### PR TITLE
Yaml changes to support private github repo

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -49,7 +49,7 @@ phases:
             _PublishType: none
             _SignType: test
             _DotNetPublishToBlobFeed : false
-           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), not(contains(variables['Build.DefinitionName'], 'github'))) }}:
+          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), not(contains(variables['Build.DefinitionName'], 'github'))) }}:
             _PublishType: blob
             _SignType: test # set to real once our build definition has signing approval
             _DotNetPublishToBlobFeed : true


### PR DESCRIPTION
- The current build definition is in an internal VSTS project, and all the yaml logic is tied to that.
- We don't want all the "internal" stuff running for the github repo.
- These changes add a new condition that checks the build definition name. This is a total hack and will be removed once the github repo becomes public and the CI build gets moved to the public VSTS project.