### PR TITLE
Modernize folderdialog

### DIFF
--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -8,4 +8,35 @@ bring it to our attention. Post an issue or email us:
 
 The attached notices are provided for information only.
 
-No notices are provided at this time.
+License notice for Ookie.Dialogs
+--------------------------------
+
+http://www.ookii.org/software/dialogs/
+
+Copyright © Sven Groot (Ookii.org) 2009
+All rights reserved.
+
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+1) Redistributions of source code must retain the above copyright notice, 
+   this list of conditions and the following disclaimer. 
+2) Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution. 
+3) Neither the name of the ORGANIZATION nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/System.Windows.Forms/ref/System.Windows.Forms.cs
+++ b/src/System.Windows.Forms/ref/System.Windows.Forms.cs
@@ -6963,6 +6963,8 @@ namespace System.Windows.Forms
     public sealed partial class FolderBrowserDialog : System.Windows.Forms.CommonDialog
     {
         public FolderBrowserDialog() { }
+        [System.ComponentModel.DefaultValueAttribute(true)]
+        public bool AutoUpgradeEnabled { get { throw null; } set { } }
         [System.ComponentModel.BrowsableAttribute(true)]
         [System.ComponentModel.DefaultValueAttribute("")]
         [System.ComponentModel.LocalizableAttribute(true)]
@@ -6979,6 +6981,10 @@ namespace System.Windows.Forms
         [System.ComponentModel.DefaultValueAttribute(true)]
         [System.ComponentModel.LocalizableAttribute(false)]
         public bool ShowNewFolderButton { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(true)]
+        [System.ComponentModel.DefaultValueAttribute(false)]
+        [System.ComponentModel.LocalizableAttribute(true)]
+        public bool UseDescriptionForTitle { get{ throw null; } set { } }
         [System.ComponentModel.BrowsableAttribute(false)]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public new event System.EventHandler HelpRequest { add { } remove { } }

--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -3163,7 +3163,7 @@
     <value>Application does not support Windows Forms just-in-time (JIT)\r\ndebugging. Contact the application author for more\r\ninformation.\r\n</value>
   </data>
   <data name="ExDlgMsgFooterSwitchable" xml:space="preserve">
-    <value>To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n<configuration>\r\n    <system.windows.forms jitDebugging="true" />\r\n</configuration>\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</value>
+    <value />
   </data>
   <data name="ExDlgMsgHeaderNonSwitchable" xml:space="preserve">
     <value>Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</value>
@@ -7376,5 +7376,8 @@
   </data>
   <data name="UnexpectedTypeForClipboardFormat" xml:space="preserve">
     <value>The specified Clipboard format is not compatible with '{0}' type.</value>
+  </data>
+  <data name="FolderBrowserDialogUseDescriptionForTitle" xml:space="preserve">
+    <value>A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</value>
   </data>
 </root>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -5092,11 +5092,6 @@
         <target state="new">Application does not support Windows Forms just-in-time (JIT)\r\ndebugging. Contact the application author for more\r\ninformation.\r\n</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExDlgMsgFooterSwitchable">
-        <source>To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</source>
-        <target state="new">To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExDlgMsgHeaderNonSwitchable">
         <source>Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</source>
         <target state="new">Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</target>
@@ -5420,6 +5415,11 @@
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="new">Include the New Folder button in the dialog box.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
+        <source>A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</source>
+        <target state="new">A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</target>
         <note />
       </trans-unit>
       <trans-unit id="FormAcceptButtonDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -5092,11 +5092,6 @@
         <target state="new">Application does not support Windows Forms just-in-time (JIT)\r\ndebugging. Contact the application author for more\r\ninformation.\r\n</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExDlgMsgFooterSwitchable">
-        <source>To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</source>
-        <target state="new">To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExDlgMsgHeaderNonSwitchable">
         <source>Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</source>
         <target state="new">Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</target>
@@ -5420,6 +5415,11 @@
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="new">Include the New Folder button in the dialog box.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
+        <source>A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</source>
+        <target state="new">A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</target>
         <note />
       </trans-unit>
       <trans-unit id="FormAcceptButtonDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -5092,11 +5092,6 @@
         <target state="new">Application does not support Windows Forms just-in-time (JIT)\r\ndebugging. Contact the application author for more\r\ninformation.\r\n</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExDlgMsgFooterSwitchable">
-        <source>To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</source>
-        <target state="new">To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExDlgMsgHeaderNonSwitchable">
         <source>Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</source>
         <target state="new">Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</target>
@@ -5420,6 +5415,11 @@
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="new">Include the New Folder button in the dialog box.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
+        <source>A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</source>
+        <target state="new">A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</target>
         <note />
       </trans-unit>
       <trans-unit id="FormAcceptButtonDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -5092,11 +5092,6 @@
         <target state="new">Application does not support Windows Forms just-in-time (JIT)\r\ndebugging. Contact the application author for more\r\ninformation.\r\n</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExDlgMsgFooterSwitchable">
-        <source>To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</source>
-        <target state="new">To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExDlgMsgHeaderNonSwitchable">
         <source>Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</source>
         <target state="new">Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</target>
@@ -5420,6 +5415,11 @@
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="new">Include the New Folder button in the dialog box.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
+        <source>A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</source>
+        <target state="new">A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</target>
         <note />
       </trans-unit>
       <trans-unit id="FormAcceptButtonDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -5092,11 +5092,6 @@
         <target state="new">Application does not support Windows Forms just-in-time (JIT)\r\ndebugging. Contact the application author for more\r\ninformation.\r\n</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExDlgMsgFooterSwitchable">
-        <source>To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</source>
-        <target state="new">To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExDlgMsgHeaderNonSwitchable">
         <source>Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</source>
         <target state="new">Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</target>
@@ -5420,6 +5415,11 @@
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="new">Include the New Folder button in the dialog box.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
+        <source>A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</source>
+        <target state="new">A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</target>
         <note />
       </trans-unit>
       <trans-unit id="FormAcceptButtonDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -5092,11 +5092,6 @@
         <target state="new">Application does not support Windows Forms just-in-time (JIT)\r\ndebugging. Contact the application author for more\r\ninformation.\r\n</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExDlgMsgFooterSwitchable">
-        <source>To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</source>
-        <target state="new">To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExDlgMsgHeaderNonSwitchable">
         <source>Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</source>
         <target state="new">Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</target>
@@ -5420,6 +5415,11 @@
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="new">Include the New Folder button in the dialog box.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
+        <source>A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</source>
+        <target state="new">A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</target>
         <note />
       </trans-unit>
       <trans-unit id="FormAcceptButtonDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -5092,11 +5092,6 @@
         <target state="new">Application does not support Windows Forms just-in-time (JIT)\r\ndebugging. Contact the application author for more\r\ninformation.\r\n</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExDlgMsgFooterSwitchable">
-        <source>To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</source>
-        <target state="new">To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExDlgMsgHeaderNonSwitchable">
         <source>Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</source>
         <target state="new">Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</target>
@@ -5420,6 +5415,11 @@
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="new">Include the New Folder button in the dialog box.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
+        <source>A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</source>
+        <target state="new">A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</target>
         <note />
       </trans-unit>
       <trans-unit id="FormAcceptButtonDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -5092,11 +5092,6 @@
         <target state="new">Application does not support Windows Forms just-in-time (JIT)\r\ndebugging. Contact the application author for more\r\ninformation.\r\n</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExDlgMsgFooterSwitchable">
-        <source>To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</source>
-        <target state="new">To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExDlgMsgHeaderNonSwitchable">
         <source>Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</source>
         <target state="new">Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</target>
@@ -5420,6 +5415,11 @@
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="new">Include the New Folder button in the dialog box.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
+        <source>A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</source>
+        <target state="new">A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</target>
         <note />
       </trans-unit>
       <trans-unit id="FormAcceptButtonDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -5092,11 +5092,6 @@
         <target state="new">Application does not support Windows Forms just-in-time (JIT)\r\ndebugging. Contact the application author for more\r\ninformation.\r\n</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExDlgMsgFooterSwitchable">
-        <source>To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</source>
-        <target state="new">To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExDlgMsgHeaderNonSwitchable">
         <source>Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</source>
         <target state="new">Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</target>
@@ -5420,6 +5415,11 @@
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="new">Include the New Folder button in the dialog box.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
+        <source>A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</source>
+        <target state="new">A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</target>
         <note />
       </trans-unit>
       <trans-unit id="FormAcceptButtonDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -5092,11 +5092,6 @@
         <target state="new">Application does not support Windows Forms just-in-time (JIT)\r\ndebugging. Contact the application author for more\r\ninformation.\r\n</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExDlgMsgFooterSwitchable">
-        <source>To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</source>
-        <target state="new">To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExDlgMsgHeaderNonSwitchable">
         <source>Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</source>
         <target state="new">Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</target>
@@ -5420,6 +5415,11 @@
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="new">Include the New Folder button in the dialog box.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
+        <source>A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</source>
+        <target state="new">A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</target>
         <note />
       </trans-unit>
       <trans-unit id="FormAcceptButtonDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -5092,11 +5092,6 @@
         <target state="new">Application does not support Windows Forms just-in-time (JIT)\r\ndebugging. Contact the application author for more\r\ninformation.\r\n</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExDlgMsgFooterSwitchable">
-        <source>To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</source>
-        <target state="new">To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExDlgMsgHeaderNonSwitchable">
         <source>Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</source>
         <target state="new">Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</target>
@@ -5420,6 +5415,11 @@
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="new">Include the New Folder button in the dialog box.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
+        <source>A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</source>
+        <target state="new">A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</target>
         <note />
       </trans-unit>
       <trans-unit id="FormAcceptButtonDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -5092,11 +5092,6 @@
         <target state="new">Application does not support Windows Forms just-in-time (JIT)\r\ndebugging. Contact the application author for more\r\ninformation.\r\n</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExDlgMsgFooterSwitchable">
-        <source>To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</source>
-        <target state="new">To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExDlgMsgHeaderNonSwitchable">
         <source>Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</source>
         <target state="new">Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</target>
@@ -5420,6 +5415,11 @@
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="new">Include the New Folder button in the dialog box.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
+        <source>A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</source>
+        <target state="new">A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</target>
         <note />
       </trans-unit>
       <trans-unit id="FormAcceptButtonDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -5092,11 +5092,6 @@
         <target state="new">Application does not support Windows Forms just-in-time (JIT)\r\ndebugging. Contact the application author for more\r\ninformation.\r\n</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExDlgMsgFooterSwitchable">
-        <source>To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</source>
-        <target state="new">To enable just-in-time (JIT) debugging, the .config file for this\r\napplication or computer (machine.config) must have the\r\njitDebugging value set in the system.windows.forms section.\r\nThe application must also be compiled with debugging\r\nenabled.\r\n\r\nFor example:\r\n\r\n\r\n    \r\n\r\n\r\nWhen JIT debugging is enabled, any unhandled exception\r\nwill be sent to the JIT debugger registered on the computer\r\nrather than be handled by this dialog box.\r\n</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExDlgMsgHeaderNonSwitchable">
         <source>Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</source>
         <target state="new">Application does not support just-in-time (JIT)\r\ndebugging. See the end of this message for details.\r\n</target>
@@ -5420,6 +5415,11 @@
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="new">Include the New Folder button in the dialog box.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
+        <source>A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</source>
+        <target state="new">A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.</target>
         <note />
       </trans-unit>
       <trans-unit id="FormAcceptButtonDescr">

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog_Vista_Interop.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog_Vista_Interop.cs
@@ -431,7 +431,7 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.Shell32, CharSet = CharSet.Unicode)]
         private static extern int SHCreateItemFromParsingName([MarshalAs(UnmanagedType.LPWStr)] string pszPath, IntPtr pbc, ref Guid riid, [MarshalAs(UnmanagedType.Interface)] out object ppv);
 
-        public static IShellItem CreateItemFromParsingName(string path)
+        internal static IShellItem CreateItemFromParsingName(string path)
         {
             Guid guid = new Guid(IIDGuid.IShellItem);
             int hr = SHCreateItemFromParsingName(path, IntPtr.Zero, ref guid, out object item);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog_Vista_Interop.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog_Vista_Interop.cs
@@ -47,6 +47,7 @@ namespace System.Windows.Forms
             internal const string IFileOpenDialog = "d57c7288-d4ad-4768-be02-9d969532d960";
             internal const string IFileSaveDialog = "84bccd23-5fde-4cdb-aea4-af64b83d78ab";
             internal const string IFileDialogEvents = "973510DB-7D7F-452B-8975-74A85828D354";
+            internal const string IFileDialogCustomize = "e6fdd21a-163f-4975-9c8c-a69f1ba37034";
             internal const string IShellItem = "43826D1E-E718-42EE-BC55-A1E261C37BFE";
             internal const string IShellItemArray = "B63EA76D-1F85-456F-A19C-48159EFA858B";
         }
@@ -310,6 +311,40 @@ namespace System.Windows.Forms
         }
 
         [ComImport,
+        Guid(IIDGuid.IFileDialogCustomize),
+        InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        internal interface IFileDialogCustomize
+        {
+            void EnableOpenDropDown([In] int dwIDCtl);
+
+            void AddMenu([In] int dwIDCtl, [In, MarshalAs(UnmanagedType.LPWStr)] string pszLabel);
+            void AddPushButton([In] int dwIDCtl, [In, MarshalAs(UnmanagedType.LPWStr)] string pszLabel);
+            void AddComboBox([In] int dwIDCtl);
+            void AddRadioButtonList([In] int dwIDCtl);
+            void AddCheckButton([In] int dwIDCtl, [In, MarshalAs(UnmanagedType.LPWStr)] string pszLabel, [In] bool bChecked);
+            void AddEditBox([In] int dwIDCtl, [In, MarshalAs(UnmanagedType.LPWStr)] string pszText);
+            void AddSeparator([In] int dwIDCtl);
+            void AddText([In] int dwIDCtl, [In, MarshalAs(UnmanagedType.LPWStr)] string pszText);
+            void SetControlLabel([In] int dwIDCtl, [In, MarshalAs(UnmanagedType.LPWStr)] string pszLabel);
+            void GetControlState([In] int dwIDCtl, [Out] out CDCONTROLSTATE pdwState);
+            void SetControlState([In] int dwIDCtl, [In] CDCONTROLSTATE dwState);
+            void GetEditBoxText([In] int dwIDCtl, [Out] IntPtr ppszText);
+            void SetEditBoxText([In] int dwIDCtl, [In, MarshalAs(UnmanagedType.LPWStr)] string pszText);
+            void GetCheckButtonState([In] int dwIDCtl, [Out] out bool pbChecked);
+            void SetCheckButtonState([In] int dwIDCtl, [In] bool bChecked);
+            void AddControlItem([In] int dwIDCtl, [In] int dwIDItem, [In, MarshalAs(UnmanagedType.LPWStr)] string pszLabel);
+            void RemoveControlItem([In] int dwIDCtl, [In] int dwIDItem);
+            void RemoveAllControlItems([In] int dwIDCtl);
+            void GetControlItemState([In] int dwIDCtl, [In] int dwIDItem, [Out] out CDCONTROLSTATE pdwState);
+            void SetControlItemState([In] int dwIDCtl, [In] int dwIDItem, [In] CDCONTROLSTATE dwState);
+            void GetSelectedControlItem([In] int dwIDCtl, [Out] out int pdwIDItem);
+            void SetSelectedControlItem([In] int dwIDCtl, [In] int dwIDItem); // Not valid for OpenDropDown
+            void StartVisualGroup([In] int dwIDCtl, [In, MarshalAs(UnmanagedType.LPWStr)] string pszLabel);
+            void EndVisualGroup();
+            void MakeProminent([In] int dwIDCtl);
+        }
+
+        [ComImport,
         Guid(IIDGuid.IShellItem),
         InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
         internal interface IShellItem
@@ -372,6 +407,13 @@ namespace System.Windows.Forms
             FOS_DEFAULTNOMINIMODE = 0x20000000
         }
 
+        internal enum CDCONTROLSTATE
+        {
+            CDCS_INACTIVE = 0x00000000,
+            CDCS_ENABLED = 0x00000001,
+            CDCS_VISIBLE = 0x00000002
+        }
+
         internal enum FDE_SHAREVIOLATION_RESPONSE
         {
             FDESVR_DEFAULT = 0x00000000,
@@ -384,6 +426,18 @@ namespace System.Windows.Forms
             FDEOR_DEFAULT = 0x00000000,
             FDEOR_ACCEPT = 0x00000001,
             FDEOR_REFUSE = 0x00000002
+        }
+
+        [DllImport(ExternDll.Shell32, CharSet = CharSet.Unicode)]
+        private static extern int SHCreateItemFromParsingName([MarshalAs(UnmanagedType.LPWStr)] string pszPath, IntPtr pbc, ref Guid riid, [MarshalAs(UnmanagedType.Interface)] out object ppv);
+
+        public static IShellItem CreateItemFromParsingName(string path)
+        {
+            Guid guid = new Guid(IIDGuid.IShellItem);
+            int hr = SHCreateItemFromParsingName(path, IntPtr.Zero, ref guid, out object item);
+            if (hr != 0)
+                throw new System.ComponentModel.Win32Exception(hr);
+            return (IShellItem)item;
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
@@ -212,7 +212,13 @@ namespace System.Windows.Forms
         /// </summary>
         /// <value><see langword="true" /> to indicate that the value of the <see cref="Description" /> property is used as dialog title; <see langword="false" />
         /// to indicate the value is added as additional text to the dialog. The default is <see langword="false" />.</value>
-        [Category("Folder Browsing"), DefaultValue(false), Description("A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.")]
+        [
+        Browsable(true),
+        DefaultValue(false),
+        Localizable(true),
+        Category("Folder Browsing"),
+        Description("A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.")
+        ]
         public bool UseDescriptionForTitle { get; set; }
 
         internal bool UseVistaDialogInternal

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
@@ -46,13 +46,6 @@ namespace System.Windows.Forms
         // Show the 'New Folder' button?
         private bool showNewFolderButton;
 
-        // set to True when selectedPath is set after the dialog box returns
-        // set to False when selectedPath is set via the SelectedPath property.
-        // Warning! Be careful about race conditions when touching this variable.
-        // This variable is determining if the PathDiscovery security check should
-        // be bypassed or not.
-        private bool selectedPathNeedsCheck;
-
         // Callback function for the folder browser dialog
         private UnsafeNativeMethods.BrowseCallbackProc callback;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
@@ -41,8 +41,6 @@ namespace System.Windows.Forms
         // Folder picked by the user.
         private string selectedPath;
 
-        private bool autoUpgradeEnabled = true;
-
         // Show the 'New Folder' button?
         private bool showNewFolderButton;
 
@@ -67,17 +65,8 @@ namespace System.Windows.Forms
         [
             DefaultValue(true)
         ]
-        public bool AutoUpgradeEnabled
-        {
-            get
-            {
-                return autoUpgradeEnabled;
-            }
-            set
-            {
-                autoUpgradeEnabled = value;
-            }
-        }
+        public bool AutoUpgradeEnabled { get; set; } = true;
+
         /// <include file='doc\FolderBrowserDialog.uex' path='docs/doc[@for="FolderBrowserDialog.HelpRequest"]/*' />
         /// <internalonly/>
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
@@ -218,9 +207,9 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (autoUpgradeEnabled)
+                if (AutoUpgradeEnabled)
                 {
-                    return SystemInformation.BootMode == BootMode.Normal; // see DDB#169589 // TODO: How should this be doc'd?
+                    return SystemInformation.BootMode == BootMode.Normal; 
                 }
 
                 return false;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
@@ -198,8 +198,8 @@ namespace System.Windows.Forms
         Browsable(true),
         DefaultValue(false),
         Localizable(true),
-        Category("Folder Browsing"),
-        Description("A value that indicates whether to use the value of the Description property as the dialog title for Vista style dialogs. This property has no effect on old style dialogs.")
+        SRCategory(nameof(SR.CatFolderBrowsing)),
+        Description(nameof(SR.FolderBrowserDialogUseDescriptionForTitle))
         ]
         public bool UseDescriptionForTitle { get; set; }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NativeMethods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NativeMethods.cs
@@ -4890,7 +4890,16 @@ namespace System.Windows.Forms {
             public int dwFlags;
             public IntPtr lpszDefaultScheme;
         }
-        
+
+        public enum HRESULT : long
+        {
+            S_FALSE = 0x0001,
+            S_OK = 0x0000,
+            E_INVALIDARG = 0x80070057,
+            E_OUTOFMEMORY = 0x8007000E,
+            ERROR_CANCELLED = 0x800704C7
+        }
+
         [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Auto)]
         public class TCITEM_T
         {

--- a/src/System.Windows.Forms/tests/UnitTests/FolderBrowserDialog.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/FolderBrowserDialog.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    public class FolderBrowserDialogTests
+    {
+        [Fact]
+        public void FolderBrowserDialog_Constructor()
+        {
+            var dialog = new FolderBrowserDialog();
+
+            Assert.Equal(string.Empty, dialog.SelectedPath);
+            Assert.True(dialog.AutoUpgradeEnabled);
+            Assert.Equal(string.Empty, dialog.Description);
+            Assert.False(dialog.UseDescriptionForTitle);
+        }
+
+        [Fact]
+        public void FolderBrowserDialog_Reset()
+        {
+            var dialog = new FolderBrowserDialog
+            {
+                Description = "A description",
+                UseDescriptionForTitle = true,
+                SelectedPath = @"C:\"
+            };
+
+            dialog.Reset();
+
+            Assert.Equal(string.Empty, dialog.SelectedPath);
+            Assert.True(dialog.AutoUpgradeEnabled);
+            Assert.Equal(string.Empty, dialog.Description);
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/functests/Runner_WinformsControlsTest/run_individual_exe.ps1
+++ b/src/System.Windows.Forms/tests/functests/Runner_WinformsControlsTest/run_individual_exe.ps1
@@ -156,6 +156,8 @@ If ($testInner -eq $true)
     $overall = ((OpenTabTimesEnter -p $p -tabs 12 -nameOfTest 'ListView' -enters 1) -eq 0) -and $overall
 
     $overall = ((OpenTabTimesEnter -p $p -tabs 13 -nameOfTest 'DateTimePickerButton' -enters 1) -eq 0) -and $overall
+    
+    $overall = ((OpenTabTimesEnter -p $p -tabs 14 -nameOfTest 'FolderBrowserDialogButton' -enters 1) -eq 0) -and $overall
 }
 
 if ($overall -eq $true)

--- a/src/System.Windows.Forms/tests/functests/WinformsControlsTest/MainForm.Designer.cs
+++ b/src/System.Windows.Forms/tests/functests/WinformsControlsTest/MainForm.Designer.cs
@@ -48,6 +48,7 @@ namespace WinformsControlsTest
             this.propertyGrid = new System.Windows.Forms.Button();
             this.listViewButton = new System.Windows.Forms.Button();
             this.DateTimePickerButton = new System.Windows.Forms.Button();
+            this.FolderBrowserDialogButton = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // buttonsButton
@@ -210,11 +211,22 @@ namespace WinformsControlsTest
             this.DateTimePickerButton.UseVisualStyleBackColor = true;
             this.DateTimePickerButton.Click += new System.EventHandler(this.button1_Click_1);
             // 
+            // FolderBrowserDialogButton
+            // 
+            this.FolderBrowserDialogButton.Location = new System.Drawing.Point(13, 223);
+            this.FolderBrowserDialogButton.Name = "FolderBrowserDialogButton";
+            this.FolderBrowserDialogButton.Size = new System.Drawing.Size(259, 23);
+            this.FolderBrowserDialogButton.TabIndex = 18;
+            this.FolderBrowserDialogButton.Text = "FolderBrowserDialog";
+            this.FolderBrowserDialogButton.UseVisualStyleBackColor = true;
+            this.FolderBrowserDialogButton.Click += new System.EventHandler(this.folderBrowserDialogButton_Click);
+            // 
             // MenuForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(578, 402);
+            this.Controls.Add(this.FolderBrowserDialogButton);
             this.Controls.Add(this.DateTimePickerButton);
             this.Controls.Add(this.listViewButton);
             this.Controls.Add(this.propertyGrid);
@@ -258,6 +270,7 @@ namespace WinformsControlsTest
         private System.Windows.Forms.Button propertyGrid;
         private System.Windows.Forms.Button listViewButton;
         private System.Windows.Forms.Button DateTimePickerButton;
+        private System.Windows.Forms.Button FolderBrowserDialogButton;
     }
 }
 

--- a/src/System.Windows.Forms/tests/functests/WinformsControlsTest/MainForm.cs
+++ b/src/System.Windows.Forms/tests/functests/WinformsControlsTest/MainForm.cs
@@ -100,5 +100,11 @@ namespace WinformsControlsTest
         {
             (new DateTimePicker()).Show();
         }
+
+        private void folderBrowserDialogButton_Click(object sender, EventArgs e)
+        {
+            var dialog = new FolderBrowserDialog();
+            dialog.ShowDialog();
+        }
     }
 }


### PR DESCRIPTION
This PR fixes #1 by implementing a Vista-style folder dialog.

Current dialog:
![image](https://user-images.githubusercontent.com/1427284/49414964-2d51b880-f743-11e8-933d-f6c6bdda3cc9.png)

With this PR, the Vista-style dialog:
![image](https://user-images.githubusercontent.com/1427284/49414985-3a6ea780-f743-11e8-8e8e-a4dda20473b1.png)
