### PR TITLE
common unsafe unit tests & fixes to code that unit tests revealed

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UnsafeNativeMethods.cs
@@ -1142,7 +1142,7 @@ namespace System.Windows.Forms {
         /// <param name="dpi">dpi requested</param>
         /// <returns>returns system metrics for dpi</returns>
         public static int TryGetSystemMetricsForDpi(int nIndex, uint dpi) {
-            if (ApiHelper.IsApiAvailable(ExternDll.User32, "GetSystemMetricsForDpi")) {
+            if (ApiHelper.IsApiAvailable(ExternDll.User32, nameof(UnsafeNativeMethods.GetSystemMetricsForDpi))) {
                 return GetSystemMetricsForDpi(nIndex, dpi);
             }
             else {
@@ -1176,7 +1176,7 @@ namespace System.Windows.Forms {
         /// Tries to get system parameter info for the dpi. dpi is ignored if "SystemParametersInfoForDpi()" API is not available on the OS that this application is running.
         /// </summary>
         public static bool TrySystemParametersInfoForDpi(int nAction, int nParam, [In, Out] NativeMethods.NONCLIENTMETRICS metrics, int nUpdate, uint dpi) {
-            if(ApiHelper.IsApiAvailable(ExternDll.User32, "SystemParametersInfoForDpi")) {
+            if(ApiHelper.IsApiAvailable(ExternDll.User32, nameof(UnsafeNativeMethods.SystemParametersInfoForDpi))) {
                 return SystemParametersInfoForDpi(nAction,  nParam, metrics,  nUpdate,  dpi);
             }
             else {

--- a/src/System.Windows.Forms/src/misc/CommonUnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms/src/misc/CommonUnsafeNativeMethods.cs
@@ -93,7 +93,11 @@ namespace System.Windows.Forms
         /// <returns>true/false</returns>
         public static bool TryFindDpiAwarenessContextsEqual(DpiAwarenessContext dpiContextA, DpiAwarenessContext dpiContextB)
         {
-            if (ApiHelper.IsApiAvailable(ExternDll.User32, "AreDpiAwarenessContextsEqual"))
+            if(dpiContextA == DpiAwarenessContext.DPI_AWARENESS_CONTEXT_UNSPECIFIED && dpiContextB == DpiAwarenessContext.DPI_AWARENESS_CONTEXT_UNSPECIFIED)
+            {
+                return true;
+            }
+            if (ApiHelper.IsApiAvailable(ExternDll.User32, nameof(CommonUnsafeNativeMethods.AreDpiAwarenessContextsEqual)))
             {
                 return AreDpiAwarenessContextsEqual(dpiContextA, dpiContextB);
             }
@@ -107,7 +111,7 @@ namespace System.Windows.Forms
         /// <returns> returns thread dpi awareness context if API is available in this version of OS. otherwise, return IntPtr.Zero.</returns>
         public static DpiAwarenessContext TryGetThreadDpiAwarenessContext()
         {
-            if (ApiHelper.IsApiAvailable(ExternDll.User32, "GetThreadDpiAwarenessContext"))
+            if (ApiHelper.IsApiAvailable(ExternDll.User32, nameof(CommonUnsafeNativeMethods.GetThreadDpiAwarenessContext)))
             {
                 return GetThreadDpiAwarenessContext();
             }
@@ -122,11 +126,15 @@ namespace System.Windows.Forms
         /// Tries to set thread dpi awareness context
         /// </summary>
         /// <returns> returns old thread dpi awareness context if API is available in this version of OS. otherwise, return IntPtr.Zero.</returns>
-        public static DpiAwarenessContext TrySetThreadDpiAwarenessContext(DpiAwarenessContext dpiCOntext)
+        public static DpiAwarenessContext TrySetThreadDpiAwarenessContext(DpiAwarenessContext dpiContext)
         {
-            if (ApiHelper.IsApiAvailable(ExternDll.User32, "SetThreadDpiAwarenessContext"))
+            if (ApiHelper.IsApiAvailable(ExternDll.User32, nameof(CommonUnsafeNativeMethods.SetThreadDpiAwarenessContext)))
             {
-                return SetThreadDpiAwarenessContext(dpiCOntext);
+                if (dpiContext == DpiAwarenessContext.DPI_AWARENESS_CONTEXT_UNSPECIFIED)
+                {
+                    throw new ArgumentException(nameof(dpiContext), dpiContext.ToString());
+                }
+                return SetThreadDpiAwarenessContext(dpiContext);
             }
             else
             {

--- a/src/System.Windows.Forms/src/misc/DpiHelper.DpiAwarenessContext.cs
+++ b/src/System.Windows.Forms/src/misc/DpiHelper.DpiAwarenessContext.cs
@@ -54,7 +54,7 @@ namespace System.Windows.Forms
             {
                 try
                 {
-                    if (!CommonUnsafeNativeMethods.AreDpiAwarenessContextsEqual(awareness, DpiAwarenessContext.DPI_AWARENESS_CONTEXT_UNSPECIFIED))
+                    if (!CommonUnsafeNativeMethods.TryFindDpiAwarenessContextsEqual(awareness, DpiAwarenessContext.DPI_AWARENESS_CONTEXT_UNSPECIFIED))
                     {
                         originalAwareness = CommonUnsafeNativeMethods.GetThreadDpiAwarenessContext();
 

--- a/src/System.Windows.Forms/tests/UnitTests/CommonUnsafenativeMethods.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/CommonUnsafenativeMethods.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    public class CommonUnsafeNativeMethodsTests
+    {
+        
+
+        /// <summary>
+        /// Data for the TryFindDpiAwarenessContextsEqual test
+        /// </summary>
+        public static TheoryData TryFindDpiAwarenessContextsEqualData =>
+            TestHelper.GetEnumTheoryData<DpiAwarenessContext>();
+        
+
+        [Theory]
+        [MemberData(nameof(TryFindDpiAwarenessContextsEqualData))]
+        internal void CommonUnsafeNativeMathods_TryFindDpiAwarenessContextsEqual(DpiAwarenessContext item)
+        { 
+            Assert.True(CommonUnsafeNativeMethods.TryFindDpiAwarenessContextsEqual(item, item));
+        }
+    
+
+        [Fact]
+        public void CommonUnsafeNativeMethods_AreDpiAwarenessContextsEqualNotForUnspecified()
+        {
+            Assert.False(CommonUnsafeNativeMethods.AreDpiAwarenessContextsEqual(DpiAwarenessContext.DPI_AWARENESS_CONTEXT_UNSPECIFIED, DpiAwarenessContext.DPI_AWARENESS_CONTEXT_UNSPECIFIED));
+        }
+
+        /// <summary>
+        /// Data for the TrySetThreadDpiAwarenessContextGetSet test
+        /// </summary>
+        public static TheoryData TrySetThreadDpiAwarenessContextGetSetData =>
+            TestHelper.GetEnumTheoryData<DpiAwarenessContext>();
+
+        [Theory]
+        [MemberData(nameof(TrySetThreadDpiAwarenessContextGetSetData))]
+        internal void CommonUnsafeNativeMethods_TrySetThreadDpiAwarenessContextGetSet(DpiAwarenessContext item)
+        {
+            if (item != DpiAwarenessContext.DPI_AWARENESS_CONTEXT_UNSPECIFIED)
+            {
+                CommonUnsafeNativeMethods.TrySetThreadDpiAwarenessContext(item);
+
+                Assert.True(CommonUnsafeNativeMethods.TryFindDpiAwarenessContextsEqual(item, CommonUnsafeNativeMethods.TryGetThreadDpiAwarenessContext()));
+            }
+            else
+            {
+                var ex = Assert.Throws<ArgumentException>(() => CommonUnsafeNativeMethods.TrySetThreadDpiAwarenessContext(DpiAwarenessContext.DPI_AWARENESS_CONTEXT_UNSPECIFIED));
+                Assert.Equal(DpiAwarenessContext.DPI_AWARENESS_CONTEXT_UNSPECIFIED.ToString(), ex.ParamName);
+            }
+        }
+
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/DpiHelper.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/DpiHelper.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using System.Drawing;
+
+namespace System.Windows.Forms.Tests
+{
+    public class DpiHelperTests
+    {
+
+        /// <summary>
+        /// Data for the LogicalToDeviceUnits test
+        /// </summary>
+        public static TheoryData<int> LogicalToDeviceUnitsData =>
+            TestHelper.GetIntTheoryData();
+
+        [Theory]
+        [MemberData(nameof(LogicalToDeviceUnitsData))]
+        public void DpiHelper_LogicalToDeviceUnits(int value)
+        {
+            var expected = Math.Round(value * (DpiHelper.DeviceDpi / DpiHelper.LogicalDpi));
+
+            Assert.Equal(expected, DpiHelper.LogicalToDeviceUnits(value));
+        }
+
+        /// <summary>
+        /// Data for the LogicalToDeviceUnitsSize test
+        /// </summary>
+        public static TheoryData<Size> LogicalToDeviceUnitsSizeData =>
+            TestHelper.GetSizeTheoryData();
+
+        [Theory]
+        [MemberData(nameof(LogicalToDeviceUnitsSizeData))]
+        public void DpiHelper_LogicalToDeviceUnitsSize(Size value)
+        {
+            var expected = new Size ((int)Math.Round(value.Width * (DpiHelper.DeviceDpi / DpiHelper.LogicalDpi)),
+                                     (int)Math.Round(value.Height * (DpiHelper.DeviceDpi / DpiHelper.LogicalDpi)));
+
+            Assert.Equal(expected, DpiHelper.LogicalToDeviceUnits(value));
+        }
+    }
+}


### PR DESCRIPTION
* changes to src
  - UnsafeNativeMethods use nameof instead of string to find, will throw at compile in method name changes
  - CommonUnsafeNativeMethods use nameof instead of string to find, will throw at compile in method name changes
  - CommonUnsafeNativeMethods fix for equality check now that windows confirms if the enum is a member of theirs, throws if attempt to set thread dpi context to unspecified as windows will refuse to do this
  - change to DpiHelper.DpiAwarenessContext to use TryFindDpiAwarenessContextsEqual middle-man method

* Some tests for CommonUnsafeNativeMethods and for DpiHelper to catch recent bugs fixes should they appear again. 