### PR TITLE
Update class attributes to use `nameof`

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -45,7 +45,7 @@ namespace System.Windows.Forms {
     ClassInterface(ClassInterfaceType.AutoDispatch),
     ToolboxItem(false),
     DesignTimeVisible(false),
-    DefaultEvent("Enter"),
+    DefaultEvent(nameof(Enter)),
     Designer("System.Windows.Forms.Design.AxHostDesigner, " + AssemblyRef.SystemDesign),
     PermissionSet(SecurityAction.LinkDemand, Name="FullTrust"),
     PermissionSet(SecurityAction.InheritanceDemand, Name="FullTrust")

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingContext.cs
@@ -16,7 +16,7 @@ namespace System.Windows.Forms {
     /// <para>Manages the collection of System.Windows.Forms.BindingManagerBase
     /// objects for a Win Form.</para>
     /// </devdoc>
-    [DefaultEvent("CollectionChanged")]
+    [DefaultEvent(nameof(CollectionChanged))]
     public class BindingContext : ICollection {
 
         private Hashtable listManagers;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingNavigator.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingNavigator.cs
@@ -15,8 +15,8 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultProperty("BindingSource"),
-    DefaultEvent("RefreshItems"),
+    DefaultProperty(nameof(BindingSource)),
+    DefaultEvent(nameof(RefreshItems)),
     Designer("System.Windows.Forms.Design.BindingNavigatorDesigner, " + AssemblyRef.SystemDesign),
     SRDescription(nameof(SR.DescriptionBindingNavigator))
     ]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingSource.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingSource.cs
@@ -26,9 +26,9 @@ namespace System.Windows.Forms {
     using System.Text;
 
     [
-    DefaultProperty("DataSource"),
-    DefaultEvent("CurrentChanged"),
-    ComplexBindingProperties("DataSource", "DataMember"),
+    DefaultProperty(nameof(DataSource)),
+    DefaultEvent(DefaultEvent(nameof(CurrentChanged)),
+    ComplexBindingProperties(nameof(DataSource), nameof(DataMember)),
     Designer("System.Windows.Forms.Design.BindingSourceDesigner, " + AssemblyRef.SystemDesign),
     SRDescription(nameof(SR.DescriptionBindingSource)),
     System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1035:ICollectionImplementationsHaveStronglyTypedMembers"), // ICollection.CopyTo: Its just a wrapper class, it doesn't have a specific member type

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingSource.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingSource.cs
@@ -27,7 +27,7 @@ namespace System.Windows.Forms {
 
     [
     DefaultProperty(nameof(DataSource)),
-    DefaultEvent(DefaultEvent(nameof(CurrentChanged)),
+    DefaultEvent(nameof(CurrentChanged)),
     ComplexBindingProperties(nameof(DataSource), nameof(DataMember)),
     Designer("System.Windows.Forms.Design.BindingSourceDesigner, " + AssemblyRef.SystemDesign),
     SRDescription(nameof(SR.DescriptionBindingSource)),

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingsCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingsCollection.cs
@@ -14,7 +14,7 @@ namespace System.Windows.Forms {
     /// <devdoc>
     ///    <para>Represents a collection of data bindings on a control.</para>
     /// </devdoc>
-    [DefaultEvent("CollectionChanged")]
+    [DefaultEvent(nameof(CollectionChanged))]
     public class BindingsCollection : System.Windows.Forms.BaseCollection {
 
         private ArrayList list;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckBox.cs
@@ -32,9 +32,9 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultProperty("Checked"),
-    DefaultEvent("CheckedChanged"),
-    DefaultBindingProperty("CheckState"),
+    DefaultProperty(nameof(Checked)),
+    DefaultEvent(nameof(CheckedChanged)),
+    DefaultBindingProperty(nameof(CheckState)),
     ToolboxItem("System.Windows.Forms.Design.AutoSizeToolboxItem," + AssemblyRef.SystemDesign),
     SRDescription(nameof(SR.DescriptionCheckBox))
     ]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColorDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColorDialog.cs
@@ -26,7 +26,7 @@ namespace System.Windows.Forms {
     ///       controls that allow the user to define custom colors.
     ///    </para>
     /// </devdoc>
-    [DefaultProperty("Color")]
+    [DefaultProperty(nameof(Color))]
     [SRDescription(nameof(SR.DescriptionColorDialog))]
     // The only event this dialog has is HelpRequest, which isn't very useful
     public class ColorDialog : CommonDialog {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
@@ -28,7 +28,7 @@ namespace System.Windows.Forms {
     [
     ToolboxItem(false),
     DesignTimeVisible(false),
-    DefaultProperty("Text"),
+    DefaultProperty(nameof(Text)),
     TypeConverterAttribute(typeof(ColumnHeaderConverter))
     ]
     public class ColumnHeader : Component, ICloneable {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -41,9 +41,9 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultEvent("SelectedIndexChanged"),
-    DefaultProperty("Items"),
-    DefaultBindingProperty("Text"),
+    DefaultEvent(nameof(SelectedIndexChanged)),
+    DefaultProperty(nameof(Items)),
+    DefaultBindingProperty(nameof(Text)),
     Designer("System.Windows.Forms.Design.ComboBoxDesigner, " + AssemblyRef.SystemDesign),
     SRDescription(nameof(SR.DescriptionComboBox))
     ]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContextMenu.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContextMenu.cs
@@ -21,7 +21,7 @@ namespace System.Windows.Forms {
     ///     but can be set for the ContextMenu property that most controls have.
     /// </devdoc>
     [
-    DefaultEvent("Popup"),
+    DefaultEvent(nameof(Popup)),
     ]
     public class ContextMenu : Menu {
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContextMenuStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContextMenuStrip.cs
@@ -14,7 +14,7 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultEvent("Opening"),
+    DefaultEvent(nameof(Opening)),
     SRDescription(nameof(SR.DescriptionContextMenuStrip))
     ]
     public class ContextMenuStrip : ToolStripDropDownMenu {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -58,8 +58,8 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultProperty("Text"),
-    DefaultEvent("Click"),
+    DefaultProperty(nameof(Text)),
+    DefaultEvent(nameof(Click)),
     Designer("System.Windows.Forms.Design.ControlDesigner, " + AssemblyRef.SystemDesign),
     DesignerSerializer("System.Windows.Forms.Design.ControlCodeDomSerializer, " + AssemblyRef.SystemDesign, "System.ComponentModel.Design.Serialization.CodeDomSerializer, " + AssemblyRef.SystemDesign),
     ToolboxItemFilter("System.Windows.Forms")

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlBindingsCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlBindingsCollection.cs
@@ -16,7 +16,7 @@ namespace System.Windows.Forms {
     ///    <para> 
     ///       Represents the collection of data bindings for a control.</para>
     /// </devdoc>
-    [DefaultEvent("CollectionChanged"),
+    [DefaultEvent(nameof(CollectionChanged)),
      Editor("System.Drawing.Design.UITypeEditor, " + AssemblyRef.SystemDrawing, typeof(System.Drawing.Design.UITypeEditor)),
      TypeConverterAttribute("System.Windows.Forms.Design.ControlBindingsConverter, " + AssemblyRef.SystemDesign),
      ]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGrid.cs
@@ -32,9 +32,9 @@ namespace System.Windows.Forms {
         ComVisible(true),
         ClassInterface(ClassInterfaceType.AutoDispatch),
         Designer("System.Windows.Forms.Design.DataGridDesigner, " + AssemblyRef.SystemDesign),
-        DefaultProperty("DataSource"),
-        DefaultEvent("Navigate"),
-        ComplexBindingProperties("DataSource", "DataMember"),
+        DefaultProperty(nameof(DataSource)),
+        DefaultEvent(nameof(Navigate)),
+        ComplexBindingProperties(nameof(DataSource), nameof(DataMember)),
         ]
         public class DataGrid : Control, ISupportInitialize, IDataGridEditingService {
     #if DEBUG

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridColumn.cs
@@ -32,7 +32,7 @@ namespace System.Windows.Forms{
     [
     ToolboxItem(false),
     DesignTimeVisible(false),
-    DefaultProperty("Header"),
+    DefaultProperty(nameof(Header)),
     System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1012:AbstractTypesShouldNotHaveConstructors") // Shipped in Everett
     ]
     public abstract class DataGridColumnStyle : Component, IDataGridColumnStyleEditingNotificationService {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridColumn.cs
@@ -32,7 +32,7 @@ namespace System.Windows.Forms{
     [
     ToolboxItem(false),
     DesignTimeVisible(false),
-    DefaultProperty(nameof(Header)),
+    DefaultProperty(nameof(HeaderText)),
     System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1012:AbstractTypesShouldNotHaveConstructors") // Shipped in Everett
     ]
     public abstract class DataGridColumnStyle : Component, IDataGridColumnStyleEditingNotificationService {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridColumn.cs
@@ -32,7 +32,7 @@ namespace System.Windows.Forms{
     [
     ToolboxItem(false),
     DesignTimeVisible(false),
-    DefaultProperty(nameof(HeaderText)),
+    DefaultProperty("Header"),
     System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1012:AbstractTypesShouldNotHaveConstructors") // Shipped in Everett
     ]
     public abstract class DataGridColumnStyle : Component, IDataGridColumnStyleEditingNotificationService {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridTextBox.cs
@@ -22,7 +22,7 @@ namespace System.Windows.Forms{
     ClassInterface(ClassInterfaceType.AutoDispatch),
     ToolboxItem(false),
     DesignTimeVisible(false),
-    DefaultProperty(nameof(GridEditName))
+    DefaultProperty("GridEditName")
     ]
     public class DataGridTextBox : TextBox {
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridTextBox.cs
@@ -22,7 +22,7 @@ namespace System.Windows.Forms{
     ClassInterface(ClassInterfaceType.AutoDispatch),
     ToolboxItem(false),
     DesignTimeVisible(false),
-    DefaultProperty("GridEditName")
+    DefaultProperty(nameof(GridEditName))
     ]
     public class DataGridTextBox : TextBox {
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -31,8 +31,8 @@ namespace System.Windows.Forms
         ClassInterface(ClassInterfaceType.AutoDispatch),
         Designer("System.Windows.Forms.Design.DataGridViewDesigner, " + AssemblyRef.SystemDesign),
         //DefaultProperty("DataSource"),
-        DefaultEvent("CellContentClick"),
-        ComplexBindingProperties("DataSource", "DataMember"),
+        DefaultEvent(nameof(CellContentClick)),
+        ComplexBindingProperties(nameof(DataSource), nameof(DataMember)),
         Docking(DockingBehavior.Ask),
         Editor("System.Windows.Forms.Design.DataGridViewComponentEditor, " + AssemblyRef.SystemDesign, typeof(ComponentEditor)),
         SRDescription(nameof(SR.DescriptionDataGridView))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
@@ -28,9 +28,9 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultProperty("Value"),
-    DefaultEvent("ValueChanged"),
-    DefaultBindingProperty("Value"),
+    DefaultProperty(nameof(Value)),
+    DefaultEvent(nameof(ValueChanged)),
+    DefaultBindingProperty(nameof(Value)),
     Designer("System.Windows.Forms.Design.DateTimePickerDesigner, " + AssemblyRef.SystemDesign),
     SRDescription(nameof(SR.DescriptionDateTimePicker))
     ]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.cs
@@ -25,9 +25,9 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultProperty("Items"),
-    DefaultEvent("SelectedItemChanged"),
-    DefaultBindingProperty("SelectedItem"),
+    DefaultProperty(nameof(Items)),
+    DefaultEvent(nameof(SelectedItemChanged)),
+    DefaultBindingProperty(nameof(SelectedItem)),
     SRDescription(nameof(SR.DescriptionDomainUpDown))
     ]
     public class DomainUpDown : UpDownBase {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
@@ -32,7 +32,7 @@ namespace System.Windows.Forms {
     ProvideProperty("IconAlignment", typeof(Control)),
     ProvideProperty("Error", typeof(Control)),
     ToolboxItemFilter("System.Windows.Forms"),
-    ComplexBindingProperties("DataSource", "DataMember"),
+    ComplexBindingProperties(nameof(DataSource), nameof(DataMember)),
     SRDescription(nameof(SR.DescriptionErrorProvider))
     ]
     public class ErrorProvider : Component, IExtenderProvider, ISupportInitialize {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
@@ -33,8 +33,8 @@ namespace System.Windows.Forms {
     ///    </para>
     /// </devdoc>
     [
-    DefaultEvent("FileOk"),
-    DefaultProperty("FileName")
+    DefaultEvent(nameof(FileOk)),
+    DefaultProperty(nameof(FileName))
     ]
     public abstract partial class FileDialog : CommonDialog {
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FlowLayoutPanel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FlowLayoutPanel.cs
@@ -14,7 +14,7 @@ namespace System.Windows.Forms {
     [ComVisible(true)]
     [ClassInterface(ClassInterfaceType.AutoDispatch)]
     [ProvideProperty("FlowBreak", typeof(Control))]
-    [DefaultProperty("FlowDirection")]
+    [DefaultProperty(nameof(FlowDirection))]
     [Designer("System.Windows.Forms.Design.FlowLayoutPanelDesigner, " + AssemblyRef.SystemDesign)]
     [Docking(DockingBehavior.Ask)]
     [SRDescription(nameof(SR.DescriptionFlowLayoutPanel))]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FlowLayoutSettings.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FlowLayoutSettings.cs
@@ -10,7 +10,7 @@ namespace System.Windows.Forms {
     using System.Windows.Forms.Layout;
 
     /// <include file='doc\FlowLayoutSettings.uex' path='docs/doc[@for="FlowLayoutSettings"]/*' />
-    [DefaultProperty("FlowDirection")]
+    [DefaultProperty(nameof(FlowDirection))]
     public class FlowLayoutSettings : LayoutSettings {
 
         internal FlowLayoutSettings(IArrangedElement owner) : base(owner) {}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
@@ -23,8 +23,8 @@ namespace System.Windows.Forms
     ///    </para>
     /// </devdoc>
     [
-    DefaultEvent("HelpRequest"),
-    DefaultProperty("SelectedPath"),
+    DefaultEvent(nameof(HelpRequest)),
+    DefaultProperty(nameof(SelectedPath)),
     Designer("System.Windows.Forms.Design.FolderBrowserDialogDesigner, " + AssemblyRef.SystemDesign),    
     SRDescription(nameof(SR.DescriptionFolderBrowserDialog))
     ]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FontDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FontDialog.cs
@@ -27,8 +27,8 @@ namespace System.Windows.Forms {
     ///    </para>
     /// </devdoc>
     [
-    DefaultEvent("Apply"),
-    DefaultProperty("Font"),
+    DefaultEvent(nameof(Apply)),
+    DefaultProperty(nameof(Font)),
     SRDescription(nameof(SR.DescriptionFontDialog))
     ]
     public class FontDialog : CommonDialog {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -41,8 +41,8 @@ namespace System.Windows.Forms {
     DesignTimeVisible(false),
     Designer("System.Windows.Forms.Design.FormDocumentDesigner, " + AssemblyRef.SystemDesign, typeof(IRootDesigner)),
     DesignerCategory("Form"),
-    DefaultEvent("Load"),
-    InitializationEvent("Load"),
+    DefaultEvent(nameof(Load)),
+    InitializationEvent(nameof(Load)),
     ]
     public class Form : ContainerControl {
 #if DEBUG

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.cs
@@ -30,8 +30,8 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultEvent("Enter"),
-    DefaultProperty("Text"),
+    DefaultEvent(nameof(Enter)),
+    DefaultProperty(nameof(Text)),
     Designer("System.Windows.Forms.Design.GroupBoxDesigner, " + AssemblyRef.SystemDesign),
     SRDescription(nameof(SR.DescriptionGroupBox))
     ]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
@@ -34,7 +34,7 @@ namespace System.Windows.Forms {
     [
     Designer("System.Windows.Forms.Design.ImageListDesigner, " + AssemblyRef.SystemDesign),
     ToolboxItemFilter("System.Windows.Forms"),
-    DefaultProperty("Images"),
+    DefaultProperty(nameof(Images)),
     TypeConverter(typeof(ImageListConverter)),
     DesignerSerializer("System.Windows.Forms.Design.ImageListCodeDomSerializer, " + AssemblyRef.SystemDesign, "System.ComponentModel.Design.Serialization.CodeDomSerializer, " + AssemblyRef.SystemDesign),
     SRDescription(nameof(SR.DescriptionImageList))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
@@ -34,8 +34,8 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultProperty("Text"),
-    DefaultBindingProperty("Text"),
+    DefaultProperty(nameof(Text)),
+    DefaultBindingProperty(nameof(Text)),
     Designer("System.Windows.Forms.Design.LabelDesigner, " + AssemblyRef.SystemDesign),
     ToolboxItem("System.Windows.Forms.Design.AutoSizeToolboxItem," + AssemblyRef.SystemDesign),
     SRDescription(nameof(SR.DescriptionLabel))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
@@ -34,7 +34,7 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultEvent("LinkClicked"),
+    DefaultEvent(nameof(LinkClicked)),
     ToolboxItem("System.Windows.Forms.Design.AutoSizeToolboxItem," + AssemblyRef.SystemDesign),
     SRDescription(nameof(SR.DescriptionLinkLabel))
     ]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -53,9 +53,9 @@ namespace System.Windows.Forms {
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
     Designer("System.Windows.Forms.Design.ListBoxDesigner, " + AssemblyRef.SystemDesign),
-    DefaultEvent("SelectedIndexChanged"),
-    DefaultProperty("Items"),
-    DefaultBindingProperty("SelectedValue"),
+    DefaultEvent(nameof(SelectedIndexChanged)),
+    DefaultProperty(nameof(Items)),
+    DefaultBindingProperty(nameof(SelectedValue)),
     SRDescription(nameof(SR.DescriptionListBox))
     ]
     public class ListBox : ListControl {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListManagerBindingsCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListManagerBindingsCollection.cs
@@ -15,7 +15,7 @@ namespace System.Windows.Forms {
     /// BindingsCollection is a collection of bindings for a Control.  It has Add/Remove capabilities,
     /// as well as an All array property, enumeration, etc.
     /// </devdoc>
-    [DefaultEvent("CollectionChanged")]
+    [DefaultEvent(nameof(CollectionChanged))]
     internal class ListManagerBindingsCollection : BindingsCollection {
 
         private BindingManagerBase bindingManagerBase;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -37,8 +37,8 @@ namespace System.Windows.Forms {
     ClassInterface(ClassInterfaceType.AutoDispatch),
     Docking(DockingBehavior.Ask),
     Designer("System.Windows.Forms.Design.ListViewDesigner, " + AssemblyRef.SystemDesign),
-    DefaultProperty("Items"),
-    DefaultEvent("SelectedIndexChanged"),
+    DefaultProperty(nameof(Items)),
+    DefaultEvent(nameof(SelectedIndexChanged)),
     SRDescription(nameof(SR.DescriptionListView))
     ]
     public class ListView : Control {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
@@ -25,7 +25,7 @@ namespace System.Windows.Forms {
     TypeConverterAttribute(typeof(ListViewGroupConverter)),
     ToolboxItem(false),
     DesignTimeVisible(false),
-    DefaultProperty("Header"),
+    DefaultProperty(nameof(Header)),
     Serializable
     ]
     public sealed class ListViewGroup : ISerializable {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
@@ -35,7 +35,7 @@ namespace System.Windows.Forms {
     TypeConverterAttribute(typeof(ListViewItemConverter)),
     ToolboxItem(false),
     DesignTimeVisible(false),
-    DefaultProperty("Text"),
+    DefaultProperty(nameof(Text)),
     Serializable,    
     SuppressMessage("Microsoft.Usage", "CA2240:ImplementISerializableCorrectly")
     ]
@@ -1407,7 +1407,7 @@ namespace System.Windows.Forms {
             TypeConverterAttribute(typeof(ListViewSubItemConverter)),
             ToolboxItem(false),
             DesignTimeVisible(false),
-            DefaultProperty("Text"),
+            DefaultProperty(nameof(Text)),
             Serializable
         ]
         public class ListViewSubItem {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MaskedTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MaskedTextBox.cs
@@ -27,9 +27,9 @@ namespace System.Windows.Forms
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultEvent("MaskInputRejected"),
-    DefaultBindingProperty("Text"),
-    DefaultProperty("Mask"),
+    DefaultEvent(nameof(MaskInputRejected)),
+    DefaultBindingProperty(nameof(Text)),
+    DefaultProperty(nameof(Mask)),
     Designer("System.Windows.Forms.Design.MaskedTextBoxDesigner, " + AssemblyRef.SystemDesign),
     SRDescription(nameof(SR.DescriptionMaskedTextBox))
     ]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MenuItem.cs
@@ -38,8 +38,8 @@ namespace System.Windows.Forms {
     [
     ToolboxItem(false),
     DesignTimeVisible(false),
-    DefaultEvent("Click"),
-    DefaultProperty("Text")
+    DefaultEvent(nameof(Click)),
+    DefaultProperty(nameof(Text))
     ]
     public class MenuItem : Menu {
         internal const int STATE_BARBREAK   = 0x00000020;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -66,9 +66,9 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultProperty("SelectionRange"),
-    DefaultEvent("DateChanged"),
-    DefaultBindingProperty("SelectionRange"),
+    DefaultProperty(nameof(SelectionRange)),
+    DefaultEvent(nameof(DateChanged)),
+    DefaultBindingProperty(nameof(SelectionRange)),
     Designer("System.Windows.Forms.Design.MonthCalendarDesigner, " + AssemblyRef.SystemDesign),
     SRDescription(nameof(SR.DescriptionMonthCalendar))
     ]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
@@ -23,8 +23,8 @@ namespace System.Windows.Forms {
     ///    </para>
     /// </devdoc>
     [
-    DefaultProperty("Text"),
-    DefaultEvent("MouseDoubleClick"),
+    DefaultProperty(nameof(Text)),
+    DefaultEvent(nameof(MouseDoubleClick)),
     Designer("System.Windows.Forms.Design.NotifyIconDesigner, " + AssemblyRef.SystemDesign),
     ToolboxItemFilter("System.Windows.Forms"),
     SRDescription(nameof(SR.DescriptionNotifyIcon))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDown.cs
@@ -23,9 +23,9 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultProperty("Value"),
-    DefaultEvent("ValueChanged"),
-    DefaultBindingProperty("Value"),
+    DefaultProperty(nameof(Value)),
+    DefaultEvent(nameof(ValueChanged)),
+    DefaultBindingProperty(nameof(Value)),
     SRDescription(nameof(SR.DescriptionNumericUpDown))
     ]
     public class NumericUpDown : UpDownBase, ISupportInitialize {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Panel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Panel.cs
@@ -25,8 +25,8 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultProperty("BorderStyle"),
-    DefaultEvent("Paint"),
+    DefaultProperty(nameof(BorderStyle)),
+    DefaultEvent(nameof(Paint)),
     Docking(DockingBehavior.Ask),
     Designer("System.Windows.Forms.Design.PanelDesigner, " + AssemblyRef.SystemDesign),
     SRDescription(nameof(SR.DescriptionPanel))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
@@ -29,8 +29,8 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultProperty("Image"),
-    DefaultBindingProperty("Image"),
+    DefaultProperty(nameof(Image)),
+    DefaultBindingProperty(nameof(Image)),
     Docking(DockingBehavior.Ask),
     Designer("System.Windows.Forms.Design.PictureBoxDesigner, " + AssemblyRef.SystemDesign),
     SRDescription(nameof(SR.DescriptionPictureBox))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PageSetupDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PageSetupDialog.cs
@@ -20,7 +20,7 @@ namespace System.Windows.Forms {
     ///    <para> Represents
     ///       a dialog box that allows users to manipulate page settings, including margins and paper orientation.</para>
     /// </devdoc>
-    [DefaultProperty("Document")]
+    [DefaultProperty(nameof(Document))]
     [SRDescription(nameof(SR.DescriptionPageSetupDialog))]
     // The only event this dialog has is HelpRequested, which isn't very useful
     public sealed class PageSetupDialog : CommonDialog {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintDialog.cs
@@ -18,7 +18,7 @@ namespace System.Windows.Forms {
     ///    <para> Allows users to select a printer and choose which
     ///       portions of the document to print.</para>
     /// </devdoc>
-    [DefaultProperty("Document")]
+    [DefaultProperty(nameof(Document))]
     [SRDescription(nameof(SR.DescriptionPrintDialog))]
     [Designer("System.Windows.Forms.Design.PrintDialogDesigner, " + AssemblyRef.SystemDesign)]
     // The only event this dialog has is HelpRequested, which isn't very useful

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -30,7 +30,7 @@ namespace System.Windows.Forms {
     /// </devdoc>
     [ComVisible(true)]
     [ClassInterface(ClassInterfaceType.AutoDispatch)]
-    [DefaultProperty("Document")]
+    [DefaultProperty(nameof(Document))]
     [SRDescription(nameof(SR.DescriptionPrintPreviewControl))]
     public class PrintPreviewControl : Control {
         Size virtualSize = new Size(1,1);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewDialog.cs
@@ -29,7 +29,7 @@ namespace System.Windows.Forms {
     ClassInterface(ClassInterfaceType.AutoDispatch),
     Designer("System.ComponentModel.Design.ComponentDesigner, " + AssemblyRef.SystemDesign),
     DesignTimeVisible(true),
-    DefaultProperty("Document"),
+    DefaultProperty(nameof(Document)),
     ToolboxItemFilter("System.Windows.Forms.Control.TopLevel"),
     ToolboxItem(true),
     SRDescription(nameof(SR.DescriptionPrintPreviewDialog))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ProgressBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ProgressBar.cs
@@ -29,8 +29,8 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultProperty("Value"),
-    DefaultBindingProperty("Value"),
+    DefaultProperty(nameof(Value)),
+    DefaultBindingProperty(nameof(Value)),
     SRDescription(nameof(SR.DescriptionProgressBar))
     ]
     public class ProgressBar : Control {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RadioButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RadioButton.cs
@@ -33,9 +33,9 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultProperty("Checked"),
-    DefaultEvent("CheckedChanged"),
-    DefaultBindingProperty("Checked"),
+    DefaultProperty(nameof(Checked)),
+    DefaultEvent(nameof(CheckedChanged)),
+    DefaultBindingProperty(nameof(Checked)),
     ToolboxItem("System.Windows.Forms.Design.AutoSizeToolboxItem," + AssemblyRef.SystemDesign),
     Designer("System.Windows.Forms.Design.RadioButtonDesigner, " + AssemblyRef.SystemDesign),
     SRDescription(nameof(SR.DescriptionRadioButton))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.cs
@@ -27,8 +27,8 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultProperty("Value"),
-    DefaultEvent("Scroll"),
+    DefaultProperty(nameof(Value)),
+    DefaultEvent(nameof(Scroll)),
     System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1012:AbstractTypesShouldNotHaveConstructors") // Shipped in Everett
     ]
     public abstract class ScrollBar : Control {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
@@ -32,7 +32,7 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultEvent("SplitterMoved"),
+    DefaultEvent(nameof(SplitterMoved)),
     Docking(DockingBehavior.AutoDock),
     Designer("System.Windows.Forms.Design.SplitContainerDesigner, " + AssemblyRef.SystemDesign),
     SRDescription(nameof(SR.DescriptionSplitContainer))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.cs
@@ -27,8 +27,8 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultEvent("SplitterMoved"),
-    DefaultProperty("Dock"),
+    DefaultEvent(nameof(SplitterMoved)),
+    DefaultProperty(nameof(Dock)),
     SRDescription(nameof(SR.DescriptionSplitter)),
     Designer("System.Windows.Forms.Design.SplitterDesigner, " + AssemblyRef.SystemDesign)
     ]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
@@ -27,8 +27,8 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultEvent("PanelClick"),
-    DefaultProperty("Text"),
+    DefaultEvent(nameof(PanelClick)),
+    DefaultProperty(nameof(Text)),
     Designer("System.Windows.Forms.Design.StatusBarDesigner, " + AssemblyRef.SystemDesign),
     ]
     public class StatusBar : Control {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusBarPanel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusBarPanel.cs
@@ -27,7 +27,7 @@ namespace System.Windows.Forms {
     [
     ToolboxItem(false),
     DesignTimeVisible(false),
-    DefaultProperty("Text")
+    DefaultProperty(nameof(Text))
     ]
     public class StatusBarPanel : Component, ISupportInitialize {
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SysInfoForm.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SysInfoForm.cs
@@ -532,7 +532,7 @@ namespace System.Windows.Forms {
             tabControl1.Controls.Add(bugReportInfo);
         }
 
-        [DefaultProperty("CompanyName")]
+        [DefaultProperty(nameof(CompanyName))]
         public class AppInfo {
             AssemblyName assemblyName;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -33,8 +33,8 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultProperty("TabPages"),
-    DefaultEvent("SelectedIndexChanged"),
+    DefaultProperty(nameof(TabPages)),
+    DefaultEvent(nameof(SelectedIndexChanged)),
     Designer("System.Windows.Forms.Design.TabControlDesigner, " + AssemblyRef.SystemDesign),
     SRDescription(nameof(SR.DescriptionTabControl))
     ]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutPanel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutPanel.cs
@@ -21,7 +21,7 @@ namespace System.Windows.Forms {
     [ProvideProperty("Row", typeof(Control))]
     [ProvideProperty("Column", typeof(Control))]
     [ProvideProperty("CellPosition", typeof(Control))]
-    [DefaultProperty("ColumnCount")]    
+    [DefaultProperty(nameof(ColumnCount))]    
     [DesignerSerializer("System.Windows.Forms.Design.TableLayoutPanelCodeDomSerializer, " + AssemblyRef.SystemDesign, "System.ComponentModel.Design.Serialization.CodeDomSerializer, " + AssemblyRef.SystemDesign)]
     [Docking(DockingBehavior.Never)]
     [Designer("System.Windows.Forms.Design.TableLayoutPanelDesigner, " + AssemblyRef.SystemDesign)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -35,8 +35,8 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultEvent("TextChanged"),
-    DefaultBindingProperty("Text"),
+    DefaultEvent(nameof(TextChanged)),
+    DefaultBindingProperty(nameof(Text)),
     Designer("System.Windows.Forms.Design.TextBoxBaseDesigner, " + AssemblyRef.SystemDesign)
     ]
     public abstract class TextBoxBase : Control {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Timer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Timer.cs
@@ -20,8 +20,8 @@ namespace System.Windows.Forms {
     ///       applications and must be used in a window.</para>
     /// </devdoc>
     [
-    DefaultProperty("Interval"),
-    DefaultEvent("Tick"),
+    DefaultProperty(nameof(Interval)),
+    DefaultEvent(nameof(Tick)),
     ToolboxItemFilter("System.Windows.Forms"),
     SRDescription(nameof(SR.DescriptionTimer))
     ]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolBar.cs
@@ -24,9 +24,9 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultEvent("ButtonClick"),
+    DefaultEvent(nameof(ButtonClick)),
     Designer("System.Windows.Forms.Design.ToolBarDesigner, " + AssemblyRef.SystemDesign),
-    DefaultProperty("Buttons")
+    DefaultProperty(nameof(Buttons))
     ]
     public class ToolBar : Control {
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolBarButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolBarButton.cs
@@ -27,7 +27,7 @@ namespace System.Windows.Forms {
     /// </devdoc>
     [
     Designer("System.Windows.Forms.Design.ToolBarButtonDesigner, " + AssemblyRef.SystemDesign),
-    DefaultProperty("Text"),
+    DefaultProperty(nameof(Text)),
     ToolboxItem(false),
     DesignTimeVisible(false),
     ]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -34,9 +34,9 @@ namespace System.Windows.Forms {
     [ClassInterface(ClassInterfaceType.AutoDispatch)]
     [DesignerSerializer("System.Windows.Forms.Design.ToolStripCodeDomSerializer, " + AssemblyRef.SystemDesign, "System.ComponentModel.Design.Serialization.CodeDomSerializer, " + AssemblyRef.SystemDesign)]
     [Designer("System.Windows.Forms.Design.ToolStripDesigner, " + AssemblyRef.SystemDesign)]
-    [DefaultProperty("Items")]
+    [DefaultProperty(nameof(Items))]
     [SRDescription(nameof(SR.DescriptionToolStrip))]
-    [DefaultEvent("ItemClicked")]
+    [DefaultEvent(nameof(ItemClicked))]
     
 
     public class ToolStrip : System.Windows.Forms.ScrollableControl, 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripComboBox.cs
@@ -21,7 +21,7 @@ namespace System.Windows.Forms {
     /// <include file='doc\ToolStripComboBox.uex' path='docs/doc[@for="ToolStripComboBox"]/*' />
     /// <devdoc/>
     [ToolStripItemDesignerAvailability(ToolStripItemDesignerAvailability.MenuStrip | ToolStripItemDesignerAvailability.ToolStrip | ToolStripItemDesignerAvailability.ContextMenuStrip)]
-    [DefaultProperty("Items")]
+    [DefaultProperty(nameof(Items))]
     public class ToolStripComboBox : ToolStripControlHost {
 
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripContentPanel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripContentPanel.cs
@@ -16,9 +16,9 @@ namespace System.Windows.Forms {
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
     Designer("System.Windows.Forms.Design.ToolStripContentPanelDesigner, " + AssemblyRef.SystemDesign),
-    DefaultEvent("Load"),
+    DefaultEvent(nameof(Load)),
     Docking(DockingBehavior.Never),
-    InitializationEvent("Load"),
+    InitializationEvent(nameof(Load)),
     ToolboxItem(false)
     ]
     public class ToolStripContentPanel : Panel {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
@@ -16,7 +16,7 @@ namespace System.Windows.Forms {
     /// Base class for ToolStripItems that display DropDown windows.
     /// </devdoc>
     [Designer("System.Windows.Forms.Design.ToolStripMenuItemDesigner, " + AssemblyRef.SystemDesign)]
-    [DefaultProperty("DropDownItems")]
+    [DefaultProperty(nameof(DropDownItems))]
     public abstract class ToolStripDropDownItem : ToolStripItem {
 
         private ToolStripDropDown dropDown     = null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -30,9 +30,9 @@ namespace System.Windows.Forms {
     /// <devdoc/>
     [System.ComponentModel.DesignTimeVisible(false)]
     [Designer("System.Windows.Forms.Design.ToolStripItemDesigner, " + AssemblyRef.SystemDesign)]
-    [DefaultEvent("Click")]
+    [DefaultEvent(nameof(Click))]
     [ToolboxItem(false)]
-    [DefaultProperty("Text")]
+    [DefaultProperty(nameof(Text))]
     public abstract class ToolStripItem : Component, 
                               IDropTarget, 
                               ISupportOleDropSource,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripProgressBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripProgressBar.cs
@@ -12,7 +12,7 @@ namespace System.Windows.Forms {
     using System.Security.Permissions;
 
     /// <include file='doc\ToolStripProgressBar.uex' path='docs/doc[@for="ToolStripProgressBar"]/*' />
-    [DefaultProperty("Value")]
+    [DefaultProperty(nameof(Value))]
     public class ToolStripProgressBar : ToolStripControlHost {
 
         internal static readonly object EventRightToLeftLayoutChanged = new object();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSplitButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSplitButton.cs
@@ -21,7 +21,7 @@ namespace System.Windows.Forms {
     /// <devdoc/>
     [
     ToolStripItemDesignerAvailability(ToolStripItemDesignerAvailability.ToolStrip | ToolStripItemDesignerAvailability.StatusStrip),
-    DefaultEvent("ButtonClick")
+    DefaultEvent(nameof(ButtonClick))
     ]
     public class ToolStripSplitButton : ToolStripDropDownItem {
         

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -34,8 +34,8 @@ namespace System.Windows.Forms {
     ///    </para>
     /// </devdoc>
     [
-    ProvideProperty("ToolTip", typeof(Control)),
-    DefaultEvent("Popup"),
+    ProvideProperty(nameof(ToolTip), typeof(Control)),
+    DefaultEvent(nameof(Popup)),
     ToolboxItemFilter("System.Windows.Forms"),
     SRDescription(nameof(SR.DescriptionToolTip))
     ]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -31,9 +31,9 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultProperty("Value"),
-    DefaultEvent("Scroll"),
-    DefaultBindingProperty("Value"),
+    DefaultProperty(nameof(Value)),
+    DefaultEvent(nameof(Scroll)),
+    DefaultBindingProperty(nameof(Value)),
     Designer("System.Windows.Forms.Design.TrackBarDesigner, " + AssemblyRef.SystemDesign),
     SRDescription(nameof(SR.DescriptionTrackBar))
     ]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
@@ -35,7 +35,7 @@ namespace System.Windows.Forms {
     /// </devdoc>
     [
     TypeConverterAttribute(typeof(TreeNodeConverter)), Serializable,
-    DefaultProperty("Text"),    
+    DefaultProperty(nameof(Text)),    
     SuppressMessage("Microsoft.Usage", "CA2240:ImplementISerializableCorrectly")
     ]
     public class TreeNode : MarshalByRefObject, ICloneable, ISerializable {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -36,8 +36,8 @@ namespace System.Windows.Forms {
     [
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
-    DefaultProperty("Nodes"),
-    DefaultEvent("AfterSelect"),
+    DefaultProperty(nameof(Nodes)),
+    DefaultEvent(nameof(AfterSelect)),
     Docking(DockingBehavior.Ask),
     Designer("System.Windows.Forms.Design.TreeViewDesigner, " + AssemblyRef.SystemDesign),
     SRDescription(nameof(SR.DescriptionTreeView))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UserControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UserControl.cs
@@ -30,7 +30,7 @@ namespace System.Windows.Forms {
     Designer("System.Windows.Forms.Design.UserControlDocumentDesigner, " + AssemblyRef.SystemDesign, typeof(IRootDesigner)),
     Designer("System.Windows.Forms.Design.ControlDesigner, " + AssemblyRef.SystemDesign),
     DesignerCategory("UserControl"),
-    DefaultEvent("Load")
+    DefaultEvent(nameof(Load))
     ]
     public class UserControl : ContainerControl {
         private static readonly object EVENT_LOAD = new object();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.cs
@@ -29,7 +29,7 @@ namespace System.Windows.Forms {
     ClassInterface(ClassInterfaceType.AutoDispatch),
     PermissionSet(SecurityAction.LinkDemand, Name = "FullTrust"),
     PermissionSetAttribute(SecurityAction.InheritanceDemand, Name="FullTrust"),
-    DefaultProperty("Url"), DefaultEvent("DocumentCompleted"),
+    DefaultProperty(nameof(Url)), DefaultEvent(nameof(DocumentCompleted)),
     Docking(DockingBehavior.AutoDock),
     SRDescription(nameof(SR.DescriptionWebBrowser)),
     Designer("System.Windows.Forms.Design.WebBrowserDesigner, " + AssemblyRef.SystemDesign)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
@@ -48,7 +48,7 @@ namespace System.Windows.Forms {
     ClassInterface(ClassInterfaceType.AutoDispatch),
     PermissionSetAttribute(SecurityAction.LinkDemand, Name="FullTrust"),
     PermissionSetAttribute(SecurityAction.InheritanceDemand, Name="FullTrust"),
-    DefaultProperty("Name"), DefaultEvent("Enter"),
+    DefaultProperty(nameof(Name)), DefaultEvent(nameof(Enter)),
     Designer("System.Windows.Forms.Design.AxDesigner, " + AssemblyRef.SystemDesign)]
     public class WebBrowserBase : Control {
         //


### PR DESCRIPTION
There are several class attributes that uses string constants to point to members in a class. To ensure there are no typos and properties exist, this PR updates those attributes to instead use `nameof` to reference those members. This is being addressed for the attributes `DefaultEvent`, `DefaultProperty`, `ComplexBindingProperties` and `DefaultBindingProperty`,

To ensure all were found, I used a code analyzer (posted below) to find and identify them all by searching for string constants that matches a member name. In addition I used "Find all references" on each attribute type to double-check the changes, and a last double-check by searching project-wide for the use of attributes that starts with a double-quote like for instance `DefaultEvent("` .

In this process, I did find two string names that were pointing to a member that doesn't exist on that class,. I left this as a string in this PR, and I will log it as a separate bug:
- [DataGridTextBox](https://github.com/dotnet/winforms/blob/master/src/System.Windows.Forms/src/System/Windows/Forms/DataGridTextBox.cs#L25)  See issue #102
- [DataGridColumn](https://github.com/dotnet/winforms/blob/master/src/System.Windows.Forms/src/System/Windows/Forms/DataGridColumn.cs#L35) (Probably meant to be `HeaderText`) See issue #101 

It sort of also proves why the use of `nameof` is important 😎 


For reference, here's the analyzer used to identify string literals that match member names (credit goes to @adityatogani94 for this):

```cs
    [DiagnosticAnalyzer(LanguageNames.CSharp)]
    public class NameOfAnalyzer : DiagnosticAnalyzer
    {
        public const string DiagnosticId = "NAMEOF0001";
        private static readonly LocalizableString Title = "Use the 'nameof' operator";
        private static readonly LocalizableString MessageFormat = "Any string literal that shares its name with a member function should be replaced by a nameof operator";
        private static readonly LocalizableString Description = "Replace with nameof operator";
        private const string Category = "Maintainability";

        private static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);

        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }

        public override void Initialize(AnalysisContext context)
        {
            context.RegisterSyntaxNodeAction(AnalyzeSymbol, SyntaxKind.StringLiteralExpression);
        }

        private static void AnalyzeSymbol(SyntaxNodeAnalysisContext context)
        {
            var diagnostic = Diagnostic.Create(Rule, context.Node.GetLocation());
            var literal = (context.Node as LiteralExpressionSyntax).Token.ValueText;
            var container = context.Node.FirstAncestorOrSelf<ClassDeclarationSyntax>();
            
            if (container == null)
            {
                return;
            }

            var containersymbol = context.SemanticModel.GetDeclaredSymbol(container);

            if(!containersymbol.MemberNames.Contains(literal))
            {
                return;
            }

            context.ReportDiagnostic(diagnostic);
        }
    }
```
Code fixer:
```cs
    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(NameOfCodeFix)), Shared]
    public class NameOfCodeFix : CodeFixProvider
    {
        private const string title = "Use the 'nameof' operator";

        public sealed override ImmutableArray<string> FixableDiagnosticIds
        {
            get { return ImmutableArray.Create(NameOfAnalyzer.NameOfAnalyzer.DiagnosticId); }
        }

        public sealed override FixAllProvider GetFixAllProvider()
        {
            return WellKnownFixAllProviders.BatchFixer;
        }

        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
        {
            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
            var diagnostic = context.Diagnostics.First();
            var diagnosticSpan = diagnostic.Location.SourceSpan;
            var literal = root.FindToken(diagnosticSpan.Start).Parent.FirstAncestorOrSelf<LiteralExpressionSyntax>();

            context.RegisterCodeFix(
                    CodeAction.Create("Use NameOf", c => UseNameOfAsync(context.Document, literal, c)),
                    context.Diagnostics);
        }

        private async Task<Document> UseNameOfAsync(Document document, LiteralExpressionSyntax literal, CancellationToken cancellationToken)
        {
            var name = literal.Token.ValueText;
            var nameof = SyntaxFactory.IdentifierName("nameof");
            var newNode = SyntaxFactory.InvocationExpression(nameof).WithArgumentList(SyntaxFactory.ArgumentList(
                             SyntaxFactory.SingletonSeparatedList<ArgumentSyntax>(
                               SyntaxFactory.Argument(
                                    SyntaxFactory.IdentifierName(name)))));
            var root = await document.GetSyntaxRootAsync(cancellationToken);
            var newRoot = root.ReplaceNode(literal, newNode);
            return document.WithSyntaxRoot(newRoot);
        }
    }
```