### PR TITLE
Enhance code to use Span<byte>

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
@@ -419,7 +419,7 @@ namespace System.Windows.Forms
         {
             if (audioBytes == null)
             {
-                throw new ArgumentNullException("audioBytes");
+                throw new ArgumentNullException(nameof(audioBytes));
             }
             SetAudio(new MemoryStream(audioBytes));
         }
@@ -432,7 +432,7 @@ namespace System.Windows.Forms
         {
             if (audioBytes.IsEmpty)
             {
-                throw new ArgumentNullException("audioBytes");
+                throw new ArgumentException(nameof(audioBytes));
             }
 
             var stream = new MemoryStream(audioBytes.Length);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataStreamFromComStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataStreamFromComStream.cs
@@ -2,56 +2,70 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace System.Windows.Forms {
+namespace System.Windows.Forms
+{
     using System.Runtime.InteropServices;
 
     using System.Diagnostics;
     using System;
     using System.IO;
-    
+
 
     /// <include file='doc\DataStreamFromComStream.uex' path='docs/doc[@for="DataStreamFromComStream"]/*' />
     /// <internalonly/>
     /// <devdoc>
     /// </devdoc>
-    internal class DataStreamFromComStream : Stream {
+    internal class DataStreamFromComStream : Stream
+    {
 
         private UnsafeNativeMethods.IStream comStream;
 
-        public DataStreamFromComStream(UnsafeNativeMethods.IStream comStream) : base() {
+        public DataStreamFromComStream(UnsafeNativeMethods.IStream comStream) : base()
+        {
             this.comStream = comStream;
         }
 
-        public override long Position {
-            get {
+        public override long Position
+        {
+            get
+            {
                 return Seek(0, SeekOrigin.Current);
             }
 
-            set {
+            set
+            {
                 Seek(value, SeekOrigin.Begin);
             }
         }
 
-        public override bool CanWrite {
-            get {
+        public override bool CanWrite
+        {
+            get
+            {
                 return true;
             }
         }
 
-        public override bool CanSeek {
-            get {
+        public override bool CanSeek
+        {
+            get
+            {
                 return true;
             }
         }
 
-        public override bool CanRead {
-            get {
+        public override bool CanRead
+        {
+            get
+            {
                 return true;
             }
         }
 
-        public override long Length {
-            get {
+        public override long Length
+        {
+            get
+            {
                 long curPos = this.Position;
                 long endPos = Seek(0, SeekOrigin.End);
                 this.Position = curPos;
@@ -66,101 +80,125 @@ namespace System.Windows.Forms {
         }
         */
 
-        private unsafe int _Read(void* handle, int bytes) {
+        private unsafe int _Read(void* handle, int bytes)
+        {
             return comStream.Read((IntPtr)handle, bytes);
         }
 
-        private unsafe int _Write(void* handle, int bytes) {
+        private unsafe int _Write(void* handle, int bytes)
+        {
             return comStream.Write((IntPtr)handle, bytes);
         }
 
-        public override void Flush() {
+        public override void Flush()
+        {
         }
 
-        public unsafe override int Read(byte[] buffer, int index, int count) {
+        public unsafe override int Read(byte[] buffer, int index, int count)
+        {
             int bytesRead = 0;
-            if (count > 0 && index >= 0 && (count + index) <= buffer.Length) {
-                fixed (byte* ch = buffer) {
-                    bytesRead = _Read((void*)(ch + index), count); 
+            if (count > 0 && index >= 0 && (count + index) <= buffer.Length)
+            {
+                fixed (byte* ch = buffer)
+                {
+                    bytesRead = _Read((void*)(ch + index), count);
                 }
             }
             return bytesRead;
         }
 
-        public unsafe override int Read(Span<byte> buffer) {
+        /// <summary>
+        /// Read data from the given buffer
+        /// </summary>
+        /// <param name="buffer">The buffer containing the data</param>
+        /// <returns>The number of processed bytes</returns>
+        public unsafe override int Read(Span<byte> buffer)
+        {
             int bytesRead = 0;
-            if (!buffer.IsEmpty) {
-                fixed (byte* ch = &buffer[0]) {
-                    bytesRead = _Read(ch, buffer.Length); 
+            if (!buffer.IsEmpty)
+            {
+                fixed (byte* ch = &buffer[0])
+                {
+                    bytesRead = _Read(ch, buffer.Length);
                 }
             }
             return bytesRead;
         }
 
-        public override void SetLength(long value) {
+        public override void SetLength(long value)
+        {
             comStream.SetSize(value);
         }
 
-        public override long Seek(long offset, SeekOrigin origin) {
+        public override long Seek(long offset, SeekOrigin origin)
+        {
             return comStream.Seek(offset, (int)origin);
         }
 
-        public unsafe override void Write(byte[] buffer, int index, int count) {
-            int bytesWritten = 0;
-            if (count > 0 && index >= 0 && (count + index) <= buffer.Length) {
-                try {
-                    fixed (byte* b = buffer) {
-                        bytesWritten = _Write((void*)(b + index), count);
-                    }
-                }
-                catch {
-                }
-            }
-            if (bytesWritten < count) {
-                throw new IOException(SR.DataStreamWrite);
-            }
-        }
-
-        public unsafe void Write(Span<byte> buffer)
+        public unsafe override void Write(byte[] buffer, int index, int count)
         {
             int bytesWritten = 0;
-            if (!buffer.IsEmpty)
+            if (count > 0 && index >= 0 && (count + index) <= buffer.Length)
             {
                 try
                 {
-                    fixed (byte* b = &buffer[0])
+                    fixed (byte* b = buffer)
                     {
-                        bytesWritten = _Write(b, buffer.Length);
+                        bytesWritten = _Write((void*)(b + index), count);
                     }
                 }
                 catch
                 {
                 }
             }
-            if (bytesWritten < buffer.Length)
+            if (bytesWritten < count)
             {
                 throw new IOException(SR.DataStreamWrite);
             }
         }
 
-        protected override void Dispose(bool disposing) {
-            try {               
-                if (disposing && comStream != null) {
-                    try {
+        public unsafe override void Write(ReadOnlySpan<byte> buffer)
+        {
+            if (buffer.IsEmpty)
+                return;
+
+            try
+            {
+                fixed (byte* b = &buffer[0])
+                {
+                    _Write(b, buffer.Length);
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            try
+            {
+                if (disposing && comStream != null)
+                {
+                    try
+                    {
                         comStream.Commit(NativeMethods.STGC_DEFAULT);
                     }
-                    catch(Exception) {
+                    catch (Exception)
+                    {
                     }
                 }
                 // Can't release a COM stream from the finalizer thread.
                 comStream = null;
             }
-            finally {
+            finally
+            {
                 base.Dispose(disposing);
             }
         }
 
-        ~DataStreamFromComStream() {
+        ~DataStreamFromComStream()
+        {
             Dispose(false);
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataStreamFromComStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataStreamFromComStream.cs
@@ -87,6 +87,16 @@ namespace System.Windows.Forms {
             return bytesRead;
         }
 
+        public unsafe override int Read(Span<byte> buffer) {
+            int bytesRead = 0;
+            if (!buffer.IsEmpty) {
+                fixed (byte* ch = &buffer[0]) {
+                    bytesRead = _Read(ch, buffer.Length); 
+                }
+            }
+            return bytesRead;
+        }
+
         public override void SetLength(long value) {
             comStream.SetSize(value);
         }
@@ -107,6 +117,28 @@ namespace System.Windows.Forms {
                 }
             }
             if (bytesWritten < count) {
+                throw new IOException(SR.DataStreamWrite);
+            }
+        }
+
+        public unsafe void Write(Span<byte> buffer)
+        {
+            int bytesWritten = 0;
+            if (!buffer.IsEmpty)
+            {
+                try
+                {
+                    fixed (byte* b = &buffer[0])
+                    {
+                        bytesWritten = _Write(b, buffer.Length);
+                    }
+                }
+                catch
+                {
+                }
+            }
+            if (bytesWritten < buffer.Length)
+            {
                 throw new IOException(SR.DataStreamWrite);
             }
         }


### PR DESCRIPTION
This pull request includes a couple of overloads taking Span<byte> in addition to byte[], and a couple of optimizations to avoid copying memory (thanks to Span<byte>).