### PR TITLE
Remove attribute not being used

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridTextBox.cs
@@ -21,8 +21,7 @@ namespace System.Windows.Forms{
     ComVisible(true),
     ClassInterface(ClassInterfaceType.AutoDispatch),
     ToolboxItem(false),
-    DesignTimeVisible(false),
-    DefaultProperty("GridEditName")
+    DesignTimeVisible(false)
     ]
     public class DataGridTextBox : TextBox {
 


### PR DESCRIPTION
The `DefaultProperty` was pointing to a property that doesn't exist, and the attribute can be removed in this case. This class is not visible in the designer. Addresses #102