### PR TITLE
Clean out Windows 9x code

### DIFF
--- a/src/System.Windows.Forms.Design.Editors/src/Misc/NativeMethods.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/Misc/NativeMethods.cs
@@ -3609,7 +3609,7 @@ namespace System.Windows.Forms.Design
         }
 #endif
         public static readonly int WM_MOUSEENTER = Util.RegisterWindowMessage("WinFormsMouseEnter");
-        public static readonly int HDN_ENDTRACK = Marshal.SystemDefaultCharSize == 1 ? HDN_ENDTRACKA : HDN_ENDTRACKW;
+        public static readonly int HDN_ENDTRACK = HDN_ENDTRACKW;
 
         public const int
             DT_CALCRECT = 0x00000400,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -751,7 +751,7 @@ namespace System.Windows.Forms {
 
                 try {
                     NativeMethods.TEXTMETRIC tm = new NativeMethods.TEXTMETRIC();
-                    SafeNativeMethods.GetTextMetrics(hdc, ref tm);
+                    SafeNativeMethods.GetTextMetricsW(hdc, ref tm);
 
                     retval.Height = tm.tmHeight;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -7842,7 +7842,7 @@ example usage
         /// </devdoc>
         private void MarshalStringToMessage(string value, ref Message m) {
             if (m.LParam == IntPtr.Zero) {
-                m.Result = (IntPtr)((value.Length + 1) * Marshal.SystemDefaultCharSize);
+                m.Result = (IntPtr)((value.Length + 1) * sizeof(char));
                 return;
             }
 
@@ -7857,19 +7857,13 @@ example usage
             byte[] nullBytes;
             byte[] bytes;
 
-            if (Marshal.SystemDefaultCharSize == 1) {
-                bytes = Encoding.Default.GetBytes(value);
-                nullBytes = Encoding.Default.GetBytes(nullChar);
-            }
-            else {
-                bytes = Encoding.Unicode.GetBytes(value);
-                nullBytes = Encoding.Unicode.GetBytes(nullChar);
-            }
+            bytes = Encoding.Unicode.GetBytes(value);
+            nullBytes = Encoding.Unicode.GetBytes(nullChar);
 
             Marshal.Copy(bytes, 0, m.LParam, bytes.Length);
             Marshal.Copy(nullBytes, 0, unchecked((IntPtr)((long)m.LParam + (long)bytes.Length)), nullBytes.Length);
 
-            m.Result = (IntPtr)((bytes.Length + nullBytes.Length)/Marshal.SystemDefaultCharSize);
+            m.Result = (IntPtr)((bytes.Length + nullBytes.Length) / sizeof(char));
         }
 
         // Used by form to notify the control that it has been "entered"
@@ -10507,60 +10501,10 @@ example usage
             else if (m.Msg == NativeMethods.WM_IME_CHAR) {
                 int charsToIgnore = this.ImeWmCharsToIgnore;
 
-                if (Marshal.SystemDefaultCharSize == 1) {
-                    // On Win9X we get either an SBCS or an  MBCS value. We must convert it to
-                    // UNICODE to use in the KeyPressEventArg.
-                    //
-                    // Convert the character in this message to UNICODE
-                    // for use in the KeyPress event, but then convert it back from UNICODE
-                    // to its source value for processing in the DefWindowProc, which will expect a
-                    // non-UNICODE character.
-                    char unicodeChar = (char)0;
-                    byte[] b = new byte[] {(byte)(unchecked((int)(long)m.WParam) >> 8), unchecked((byte)(long)m.WParam)};
-                    char[] unicodeCharArray = new char[1];
-                    int stringLength = UnsafeNativeMethods.MultiByteToWideChar(0 /*CP_ACP*/, UnsafeNativeMethods.MB_PRECOMPOSED, b, b.Length, unicodeCharArray, 0);
-                    if (stringLength > 0) {
-                        unicodeCharArray = new char[stringLength];
-                        UnsafeNativeMethods.MultiByteToWideChar(0 /*CP_ACP*/, UnsafeNativeMethods.MB_PRECOMPOSED, b, b.Length, unicodeCharArray, unicodeCharArray.Length);
+                charsToIgnore += (3 - sizeof(char));
+                this.ImeWmCharsToIgnore = charsToIgnore;
 
-                        // Per the docs for WM_IME_CHAR, the processing of this message by DefWindowProc
-                        // will produce two WM_CHAR messages if the character value is a DBCS character.
-                        // Otherwise, only one WM_CHAR message will be generated. Therefore, only ignore
-                        // one WM_CHAR message for SBCS characters and two WM_CHAR messages for DBCS
-                        // characters.
-
-                        // What type of character were we passed?
-                        if (unicodeCharArray[0] != 0) {
-                            // This was an MBCS character, so pass along the first character
-                            // from the resultant array.
-                            unicodeChar = unicodeCharArray[0];
-
-                            charsToIgnore += 2;
-                        }
-                        else if (unicodeCharArray[0] == 0 && unicodeCharArray.Length >= 2) {
-                            // This was an SBCS character, so pass along the second character
-                            // from the resultant array since the first character in the array is NULL.
-                            unicodeChar = unicodeCharArray[1];
-
-                            charsToIgnore += 1;
-                        }
-                    }
-                    else {
-                        //MultiByteToWideChar failed
-                        throw new Win32Exception();
-                    }
-
-                    this.ImeWmCharsToIgnore = charsToIgnore;
-
-                    // 
-                    kpe = new KeyPressEventArgs(unicodeChar);
-                }
-                else {
-                    charsToIgnore += (3 - Marshal.SystemDefaultCharSize);
-                    this.ImeWmCharsToIgnore = charsToIgnore;
-
-                    kpe = new KeyPressEventArgs(unchecked((char)(long)m.WParam));
-                }
+                kpe = new KeyPressEventArgs(unchecked((char)(long)m.WParam));
 
                 char preEventCharacter = kpe.KeyChar;
                 OnKeyPress(kpe);
@@ -10570,52 +10514,7 @@ example usage
                     newWParam = m.WParam;
                 }
                 else {
-                    if (Marshal.SystemDefaultCharSize == 1) {
-                        // On Win9X we work with either an SBCS or an MBCS value. Since we
-                        // already converted it to UNICODE to send it to the KeyPress event, we must now convert
-                        // it back to either MBCS or SBCS for processing by the DefWindowProc.
-                        //
-                        string keyChar = new string(new char[] { kpe.KeyChar });
-                        byte[] mbcsBytes = null;
-                        int bytesNeeded = UnsafeNativeMethods.WideCharToMultiByte(0 /*CP_ACP*/, 0, keyChar, keyChar.Length, null, 0, IntPtr.Zero, IntPtr.Zero);
-                        // GB18030 defines 4 byte characters: we shouldn't assume that the length is capped at 2.
-                        if (bytesNeeded >= 2) {
-                            // This is an MBCS character.
-                            mbcsBytes = new byte[bytesNeeded];
-                            UnsafeNativeMethods.WideCharToMultiByte(0 /*CP_ACP*/, 0, keyChar, keyChar.Length, mbcsBytes, mbcsBytes.Length, IntPtr.Zero, IntPtr.Zero);
-
-                            int sizeOfIntPtr = Marshal.SizeOf(typeof(IntPtr));
-                            if (bytesNeeded > sizeOfIntPtr) {
-                                bytesNeeded = sizeOfIntPtr; //Same again: we wouldn't be able to stuff anything larger into a WParam
-                            }
-                            long wParam = 0;
-                            for (int i = 0; i < bytesNeeded; i++) {
-                                wParam <<= 8;
-                                wParam |= (long)mbcsBytes[i];
-                            }
-                            newWParam = (IntPtr)wParam;
-                        }
-                        else if (bytesNeeded == 1) {
-                            // This is an SBCS character.
-                            mbcsBytes = new byte[bytesNeeded];
-                            UnsafeNativeMethods.WideCharToMultiByte(0 /*CP_ACP*/,
-                                                                    0,
-                                                                    keyChar,
-                                                                    keyChar.Length,
-                                                                    mbcsBytes,
-                                                                    mbcsBytes.Length,
-                                                                    IntPtr.Zero,
-                                                                    IntPtr.Zero);
-                            newWParam = (IntPtr)((int)mbcsBytes[0]);
-                        }
-                        else {
-                            //We don't know what's going on: WideCharToMultiByte failed.  We can't deal with that.
-                            newWParam = m.WParam;
-                        }
-                    }
-                    else {
-                        newWParam = (IntPtr)kpe.KeyChar;
-                    }
+                    newWParam = (IntPtr)kpe.KeyChar;
                 }
             }
             else {
@@ -14287,7 +14186,7 @@ example usage
                     WmNotifyFormat(ref m);
                     break;
                 case NativeMethods.WM_REFLECT + NativeMethods.WM_NOTIFYFORMAT:
-                    m.Result = (IntPtr)(Marshal.SystemDefaultCharSize == 1 ? NativeMethods.NFR_ANSI : NativeMethods.NFR_UNICODE);
+                    m.Result = (IntPtr)(NativeMethods.NFR_UNICODE);
                     break;
                 case NativeMethods.WM_SHOWWINDOW:
                     WmShowWindow(ref m);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataFormats.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataFormats.cs
@@ -302,22 +302,6 @@ namespace System.Windows.Forms {
         private static void EnsurePredefined() {
 
             if (0 == formatCount) {
-
-                /* not used
-                int standardText;
-
-                // We must handle text differently for Win 95 and NT.  We should put
-                // UnicodeText on the clipboard for NT, and Text for Win 95.
-                // So, we figure it out here theh first time someone asks for format info
-                //
-                if (1 == Marshal.SystemDefaultCharSize) {
-                    standardText = NativeMethods.CF_TEXT;
-                }
-                else {
-                    standardText = NativeMethods.CF_UNICODETEXT;
-                }
-                */
-
                 formatList = new Format [] {
                     //         Text name        Win32 format ID      Data stored as a Win32 handle?
                     new Format(UnicodeText,  NativeMethods.CF_UNICODETEXT),

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewMethods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewMethods.cs
@@ -8202,8 +8202,6 @@ namespace System.Windows.Forms
             byte[] sourceBytes = Encoding.Unicode.GetBytes(sbContent.ToString());
             byte[] destinationBytes = Encoding.Convert(Encoding.Unicode, Encoding.UTF8, sourceBytes);
 
-            // Marshal.SystemDefaultCharSize is 2 on WinXP Pro - so the offsets seem to be in character counts instead of bytes. 
-            // Test on JPN and Win9x machines.
             int bytecountEndOfFragment = 135 + destinationBytes.Length;
             int bytecountEndOfHtml = bytecountEndOfFragment + 36;
             string prefix = string.Format(CultureInfo.InvariantCulture, DATAGRIDVIEW_htmlPrefix, bytecountEndOfHtml.ToString("00000000", CultureInfo.InvariantCulture), bytecountEndOfFragment.ToString("00000000", CultureInfo.InvariantCulture)) + DATAGRIDVIEW_htmlStartFragment;
@@ -8216,7 +8214,7 @@ namespace System.Windows.Forms
             utf8Stream = new System.IO.MemoryStream(bytecountEndOfHtml + 1);
             utf8Stream.Write(destinationBytes, 0, bytecountEndOfHtml);
             utf8Stream.WriteByte((byte)0);
-            
+
             #if DEBUG
             Debug.Assert(destinationBytes[97] == '<');
             Debug.Assert(destinationBytes[bytecountEndOfHtml-1] == '>');

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
@@ -1066,31 +1066,16 @@ namespace System.Windows.Forms
                 return (NativeMethods.E_INVALIDARG);
             }
 
-
-            bool unicode = (Marshal.SystemDefaultCharSize != 1);
-
             IntPtr currentPtr = IntPtr.Zero;
             int baseStructSize = 4 + 8 + 4 + 4;
             int sizeInBytes = baseStructSize;
 
             // First determine the size of the array
-            //
-            if (unicode)
+            for (int i = 0; i < files.Length; i++)
             {
-                for (int i = 0; i < files.Length; i++)
-                {
-                    sizeInBytes += (files[i].Length + 1) * 2;
-                }
-                sizeInBytes += 2;
+                sizeInBytes += (files[i].Length + 1) * 2;
             }
-            else
-            {
-                for (int i = 0; i < files.Length; i++)
-                {
-                    sizeInBytes += NativeMethods.Util.GetPInvokeStringLength(files[i]) + 1;
-                }
-                sizeInBytes++;
-            }
+            sizeInBytes += 2;
 
             // Alloc the Win32 memory
             //
@@ -1112,10 +1097,7 @@ namespace System.Windows.Forms
             //
             int[] structData = new int[] { baseStructSize, 0, 0, 0, 0 };
 
-            if (unicode)
-            {
-                structData[4] = unchecked((int)0xFFFFFFFF);
-            }
+            structData[4] = unchecked((int)0xFFFFFFFF);
             Marshal.Copy(structData, 0, currentPtr, structData.Length);
             currentPtr = (IntPtr)((long)currentPtr + baseStructSize);
 
@@ -1123,35 +1105,15 @@ namespace System.Windows.Forms
             //
             for (int i = 0; i < files.Length; i++)
             {
-                if (unicode)
-                {
-
-                    // NOTE: DllLib.copy(char[]...) converts to ANSI on Windows 95...
-                    UnsafeNativeMethods.CopyMemoryW(currentPtr, files[i], files[i].Length * 2);
-                    currentPtr = (IntPtr)((long)currentPtr + (files[i].Length * 2));
-                    Marshal.Copy(new byte[] { 0, 0 }, 0, currentPtr, 2);
-                    currentPtr = (IntPtr)((long)currentPtr + 2);
-                }
-                else
-                {
-                    int pinvokeLen = NativeMethods.Util.GetPInvokeStringLength(files[i]);
-                    UnsafeNativeMethods.CopyMemoryA(currentPtr, files[i], pinvokeLen);
-                    currentPtr = (IntPtr)((long)currentPtr + pinvokeLen);
-                    Marshal.Copy(new byte[] { 0 }, 0, currentPtr, 1);
-                    currentPtr = (IntPtr)((long)currentPtr + 1);
-                }
-            }
-
-            if (unicode)
-            {
-                Marshal.Copy(new char[] { '\0' }, 0, currentPtr, 1);
+                // NOTE: DllLib.copy(char[]...) converts to ANSI on Windows 95...
+                UnsafeNativeMethods.CopyMemoryW(currentPtr, files[i], files[i].Length * 2);
+                currentPtr = (IntPtr)((long)currentPtr + (files[i].Length * 2));
+                Marshal.Copy(new byte[] { 0, 0 }, 0, currentPtr, 2);
                 currentPtr = (IntPtr)((long)currentPtr + 2);
             }
-            else
-            {
-                Marshal.Copy(new byte[] { 0 }, 0, currentPtr, 1);
-                currentPtr = (IntPtr)((long)currentPtr + 1);
-            }
+
+            Marshal.Copy(new char[] { '\0' }, 0, currentPtr, 1);
+            currentPtr = (IntPtr)((long)currentPtr + 2);
 
             UnsafeNativeMethods.GlobalUnlock(new HandleRef(null, newHandle));
             return NativeMethods.S_OK;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
@@ -353,8 +353,8 @@ namespace System.Windows.Forms
                 // Construct a BROWSEINFO
                 UnsafeNativeMethods.BROWSEINFO bi = new UnsafeNativeMethods.BROWSEINFO();
 
-                pszDisplayName = Marshal.AllocHGlobal(NativeMethods.MAX_PATH * Marshal.SystemDefaultCharSize);
-                pszSelectedPath = Marshal.AllocHGlobal((NativeMethods.MAX_PATH + 1) * Marshal.SystemDefaultCharSize);
+                pszDisplayName = Marshal.AllocHGlobal(NativeMethods.MAX_PATH * sizeof(char));
+                pszSelectedPath = Marshal.AllocHGlobal((NativeMethods.MAX_PATH + 1) * sizeof(char));
                 this.callback = new UnsafeNativeMethods.BrowseCallbackProc(this.FolderBrowserDialog_BrowseCallbackProc);
 
                 bi.pidlRoot = pidlRoot;
@@ -427,7 +427,7 @@ namespace System.Windows.Forms
                     IntPtr selectedPidl = lParam;
                     if (selectedPidl != IntPtr.Zero)
                     {
-                        IntPtr pszSelectedPath = Marshal.AllocHGlobal((NativeMethods.MAX_PATH + 1) * Marshal.SystemDefaultCharSize);
+                        IntPtr pszSelectedPath = Marshal.AllocHGlobal((NativeMethods.MAX_PATH + 1) * sizeof(char));
                         // Try to retrieve the path from the IDList
                         bool isFileSystemFolder = UnsafeNativeMethods.Shell32.SHGetPathFromIDListLongPath(selectedPidl, ref pszSelectedPath);
                         Marshal.FreeHGlobal(pszSelectedPath);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -3958,18 +3958,6 @@ namespace System.Windows.Forms {
         /// </devdoc>
         private void FillInCreateParamsStartPosition(CreateParams cp) {
 
-            //           Removed logic that forced MDI children to always be
-            //           default size and position... need to verify that
-            //           this works on Win9X
-            /*
-            if (getIsMdiChild()) {
-            cp.x = NativeMethods.CW_USEDEFAULT;
-            cp.y = NativeMethods.CW_USEDEFAULT;
-            cp.width = NativeMethods.CW_USEDEFAULT;
-            cp.height = NativeMethods.CW_USEDEFAULT;
-            }
-            else {
-            */
             if (formState[FormStateSetClientSize] != 0) {
 
                 // When computing the client window size, don't tell them that
@@ -3983,7 +3971,6 @@ namespace System.Windows.Forms {
                 }               
                 cp.Width = correct.Width;
                 cp.Height = correct.Height;
-               
             }
 
             switch ((FormStartPosition)formState[FormStateStartPos]) {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -71,8 +71,6 @@ namespace System.Windows.Forms {
         public const int DefaultItemHeight = 13; // 13 == listbox's non-ownerdraw item height.  That's with Win2k and
         // the default font; on other platforms and with other fonts, it may be different.
 
-        private const int maxWin9xHeight = 32767; //Win9x doesn't deal with height > 32K
-
         private static readonly object EVENT_SELECTEDINDEXCHANGED = new object();
         private static readonly object EVENT_DRAWITEM             = new object();
         private static readonly object EVENT_MEASUREITEM          = new object();
@@ -83,8 +81,6 @@ namespace System.Windows.Forms {
         SelectedObjectCollection selectedItems;
         SelectedIndexCollection selectedIndices;
         ObjectCollection itemsCollection;
-
-        // 
 
         int itemHeight = DefaultItemHeight;
         int columnWidth;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -6054,14 +6054,8 @@ namespace System.Windows.Forms {
                                     text = text.Substring(0, dispInfo.item.cchTextMax - 1);
                                 }
 
-                                if (Marshal.SystemDefaultCharSize == 1) {
-                                    // ANSI. Use byte
-                                    byte[] buff = System.Text.Encoding.Default.GetBytes(text + "\0");
-                                    Marshal.Copy(buff, 0, dispInfo.item.pszText, text.Length + 1);
-                                } else {
-                                    char[] buff = (text + "\0").ToCharArray();
-                                    Marshal.Copy(buff, 0, dispInfo.item.pszText, text.Length + 1);
-                                }
+                                char[] buff = (text + "\0").ToCharArray();
+                                Marshal.Copy(buff, 0, dispInfo.item.pszText, text.Length + 1);
                             }
 
                             if ((dispInfo.item.mask & NativeMethods.LVIF_IMAGE) != 0 && lvItem.ImageIndex != -1) {
@@ -6138,17 +6132,11 @@ namespace System.Windows.Forms {
                                 
                                 UnsafeNativeMethods.SendMessage(new HandleRef(this, nmhdr->hwndFrom), NativeMethods.TTM_SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
 
-                                if (Marshal.SystemDefaultCharSize == 1) {
-                                    // ANSI. Use byte.
-                                    // we need to copy the null terminator character ourselves
-                                    byte[] byteBuf = System.Text.Encoding.Default.GetBytes(lvi.ToolTipText + "\0");
-                                    Marshal.Copy(byteBuf, 0, infoTip.lpszText, Math.Min(byteBuf.Length, infoTip.cchTextMax));
-                                } else {
-                                    // UNICODE. Use char.
-                                    // we need to copy the null terminator character ourselves
-                                    char[] charBuf = (lvi.ToolTipText + "\0").ToCharArray();
-                                    Marshal.Copy(charBuf, 0, infoTip.lpszText, Math.Min(charBuf.Length, infoTip.cchTextMax));
-                                }
+                                // UNICODE. Use char.
+                                // we need to copy the null terminator character ourselves
+                                char[] charBuf = (lvi.ToolTipText + "\0").ToCharArray();
+                                Marshal.Copy(charBuf, 0, infoTip.lpszText, Math.Min(charBuf.Length, infoTip.cchTextMax));
+
                                 Marshal.StructureToPtr(infoTip, (IntPtr) m.LParam, false);
                             }
                         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -5513,8 +5513,7 @@ namespace System.Windows.Forms {
                 OnColumnClick(new ColumnClickEventArgs(columnIndex));
             }
 
-            if (nmhdr->code == NativeMethods.HDN_BEGINTRACKA ||
-                nmhdr->code == NativeMethods.HDN_BEGINTRACKW) {
+            if (nmhdr->code == NativeMethods.HDN_BEGINTRACK) {
                this.listViewState[LISTVIEWSTATE_headerControlTracking] = true;
 
                // Reset our tracking information for the new BEGINTRACK cycle.
@@ -5532,8 +5531,7 @@ namespace System.Windows.Forms {
                }
             }
 
-            if (nmhdr->code == NativeMethods.HDN_ITEMCHANGINGA || 
-                nmhdr->code == NativeMethods.HDN_ITEMCHANGINGW) {
+            if (nmhdr->code == NativeMethods.HDN_ITEMCHANGING) {
                 NativeMethods.NMHEADER nmheader = (NativeMethods.NMHEADER) m.GetLParam(typeof(NativeMethods.NMHEADER));
 
                 if (columnHeaders != null && nmheader.iItem < columnHeaders.Length &&
@@ -5567,8 +5565,7 @@ namespace System.Windows.Forms {
                 }
             }
 
-            if ((nmhdr->code == NativeMethods.HDN_ITEMCHANGEDA ||
-                nmhdr->code == NativeMethods.HDN_ITEMCHANGEDW) &&
+            if ((nmhdr->code == NativeMethods.HDN_ITEMCHANGED) &&
                 !this.listViewState[LISTVIEWSTATE_headerControlTracking]) {
                 NativeMethods.NMHEADER nmheader = (NativeMethods.NMHEADER)m.GetLParam(typeof(NativeMethods.NMHEADER));
                 if (columnHeaders != null && nmheader.iItem < columnHeaders.Length) {
@@ -5615,8 +5612,7 @@ namespace System.Windows.Forms {
                 }
             }
 
-            if (nmhdr->code == NativeMethods.HDN_ENDTRACKA || 
-                nmhdr->code == NativeMethods.HDN_ENDTRACKW) {
+            if (nmhdr->code == NativeMethods.HDN_ENDTRACK) {
                 Debug.Assert(this.listViewState[LISTVIEWSTATE_headerControlTracking], "HDN_ENDTRACK and HDN_BEGINTRACK are out of sync...");
                 this.listViewState[LISTVIEWSTATE_headerControlTracking] = false;
                 if (this.listViewState1[LISTVIEWSTATE1_cancelledColumnWidthChanging]) {
@@ -5641,9 +5637,6 @@ namespace System.Windows.Forms {
             if (nmhdr->code == NativeMethods.HDN_ENDDRAG) {
                 NativeMethods.NMHEADER header = (NativeMethods.NMHEADER) m.GetLParam(typeof(NativeMethods.NMHEADER));
                 if (header.pItem != IntPtr.Zero) {
-                    // 
-
-
 
                     NativeMethods.HDITEM2 hdItem = (NativeMethods.HDITEM2) UnsafeNativeMethods.PtrToStructure((IntPtr) header.pItem, typeof(NativeMethods.HDITEM2));
                     if ((hdItem.mask & NativeMethods.HDI_ORDER) == NativeMethods.HDI_ORDER) {
@@ -5696,8 +5689,7 @@ namespace System.Windows.Forms {
                 }
             }
 
-            if (nmhdr->code == NativeMethods.HDN_DIVIDERDBLCLICKA ||
-                nmhdr->code == NativeMethods.HDN_DIVIDERDBLCLICKW) {
+            if (nmhdr->code == NativeMethods.HDN_DIVIDERDBLCLICK) {
                 // We need to keep track that the user double clicked the column header divider
                 // so we know that the column header width is changing.
                 this.listViewState[LISTVIEWSTATE_headerDividerDblClick] = true;
@@ -5809,8 +5801,7 @@ namespace System.Windows.Forms {
                     CustomDraw(ref m);
                     break;
 
-                case NativeMethods.LVN_BEGINLABELEDITA:
-                case NativeMethods.LVN_BEGINLABELEDITW: {
+                case NativeMethods.LVN_BEGINLABELEDIT: {
                         NativeMethods.NMLVDISPINFO_NOTEXT nmlvdp = (NativeMethods.NMLVDISPINFO_NOTEXT)m.GetLParam(typeof(NativeMethods.NMLVDISPINFO_NOTEXT));
                         LabelEditEventArgs e = new LabelEditEventArgs(nmlvdp.item.iItem);
                         OnBeforeLabelEdit(e);
@@ -5826,8 +5817,7 @@ namespace System.Windows.Forms {
                         break;
                     }
 
-                case NativeMethods.LVN_ENDLABELEDITA:
-                case NativeMethods.LVN_ENDLABELEDITW: {
+                case NativeMethods.LVN_ENDLABELEDIT: {
                         listViewState[LISTVIEWSTATE_inLabelEdit] = false;
                         NativeMethods.NMLVDISPINFO nmlvdp = (NativeMethods.NMLVDISPINFO)m.GetLParam(typeof(NativeMethods.NMLVDISPINFO));
                         LabelEditEventArgs e = new LabelEditEventArgs(nmlvdp.item.iItem, nmlvdp.item.pszText);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NativeMethods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NativeMethods.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-//------------------------------------------------------------------------------
-//------------------------------------------------------------------------------
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope="type", Target="System.Windows.Forms.NativeMethods+BITMAPINFO")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope="type", Target="System.Windows.Forms.NativeMethods+BITMAPINFO_ARRAY")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope="type", Target="System.Windows.Forms.NativeMethods+CommonHandles")]
@@ -127,7 +125,6 @@ namespace System.Windows.Forms {
         R2_MERGEPEN         = 15, /* DPo      */
         R2_WHITE            = 16 /*  1       */;
 
-        
         public const int
         /* SetGraphicsMode(hdc, iMode ) */
         GM_COMPATIBLE       = 1,
@@ -135,12 +132,12 @@ namespace System.Windows.Forms {
         MWT_IDENTITY        = 1;
 
         public const int 
-        PAGE_READONLY = 0x02, 
-        PAGE_READWRITE = 0x04, 
+        PAGE_READONLY = 0x02,
+        PAGE_READWRITE = 0x04,
         PAGE_WRITECOPY = 0x08,
-		FILE_MAP_COPY = 0x0001,
-		FILE_MAP_WRITE = 0x0002,
-		FILE_MAP_READ = 0x0004;
+        FILE_MAP_COPY = 0x0001,
+        FILE_MAP_WRITE = 0x0002,
+        FILE_MAP_READ = 0x0004;
 
         public const int SHGFI_ICON = 0x000000100  ,   // get icon
         SHGFI_DISPLAYNAME       = 0x000000200,     // get display name
@@ -182,8 +179,8 @@ namespace System.Windows.Forms {
         ADVF_NODATA = 1,
         ADVF_ONLYONCE = 4,
         ADVF_PRIMEFIRST = 2; 
-		// Note: ADVF_ONLYONCE and ADVF_PRIMEFIRST values now conform with objidl.dll but are backwards from
-		// Platform SDK documentation as of 07/21/2003.
+        // Note: ADVF_ONLYONCE and ADVF_PRIMEFIRST values now conform with objidl.dll but are backwards from
+        // Platform SDK documentation as of 07/21/2003.
         // http://msdn.microsoft.com/library/default.asp?url=/library/en-us/com/htm/oen_a2z_8jxi.asp.
 
         public const int BCM_GETIDEALSIZE = 0x1601,
@@ -205,8 +202,7 @@ namespace System.Windows.Forms {
         BF_MIDDLE = 0x0800,
         BFFM_INITIALIZED = 1,
         BFFM_SELCHANGED = 2,
-        BFFM_SETSELECTIONA = 0x400 + 102,
-        BFFM_SETSELECTIONW = 0x400 + 103,
+        BFFM_SETSELECTION = 0x400 + 103,
         BFFM_ENABLEOK = 0x400 + 101,
         BS_PUSHBUTTON = 0x00000000,
         BS_DEFPUSHBUTTON = 0x00000001,
@@ -357,14 +353,10 @@ namespace System.Windows.Forms {
         CCS_NORESIZE = 0x00000004,
         CCS_NOPARENTALIGN = 0x00000008,
         CCS_NODIVIDER = 0x00000040,
-        CBEM_INSERTITEMA = (0x0400+1),
-        CBEM_GETITEMA = (0x0400+4),
-        CBEM_SETITEMA = (0x0400+5),
-        CBEM_INSERTITEMW = (0x0400+11),
-        CBEM_SETITEMW = (0x0400+12),
-        CBEM_GETITEMW = (0x0400+13),
-        CBEN_ENDEDITA = ((0-800)-5),
-        CBEN_ENDEDITW = ((0-800)-6),
+        CBEM_INSERTITEM = (0x0400+11),
+        CBEM_SETITEM = (0x0400+12),
+        CBEM_GETITEM = (0x0400+13),
+        CBEN_ENDEDIT = ((0-800)-6),
         CONNECT_E_NOCONNECTION = unchecked((int)0x80040200),
         CONNECT_E_CANNOTCONNECT = unchecked((int)0x80040202),
         CTRLINFO_EATS_RETURN    = 1,
@@ -444,8 +436,7 @@ namespace System.Windows.Forms {
         DTM_GETSYSTEMTIME = (0x1000+1),
         DTM_SETSYSTEMTIME = (0x1000+2),
         DTM_SETRANGE = (0x1000+4),
-        DTM_SETFORMATA = (0x1000+5),
-        DTM_SETFORMATW = (0x1000+50),
+        DTM_SETFORMAT = (0x1000+50),
         DTM_SETMCCOLOR = (0x1000+6),
         DTM_GETMONTHCAL = (0x1000+8),
         DTM_SETMCFONT = (0x1000+9),
@@ -455,14 +446,10 @@ namespace System.Windows.Forms {
         DTS_TIMEFORMAT = 0x0009,
         DTS_RIGHTALIGN = 0x0020,
         DTN_DATETIMECHANGE = ((0-760)+1),
-        DTN_USERSTRINGA = ((0-760)+2),
-        DTN_USERSTRINGW = ((0-760)+15),
-        DTN_WMKEYDOWNA = ((0-760)+3),
-        DTN_WMKEYDOWNW = ((0-760)+16),
-        DTN_FORMATA = ((0-760)+4),
-        DTN_FORMATW = ((0-760)+17),
-        DTN_FORMATQUERYA = ((0-760)+5),
-        DTN_FORMATQUERYW = ((0-760)+18),
+        DTN_USERSTRING = ((0-760)+15),
+        DTN_WMKEYDOWN = ((0-760)+16),
+        DTN_FORMAT = ((0-760)+17),
+        DTN_FORMATQUERY = ((0-760)+18),
         DTN_DROPDOWN = ((0-760)+6),
         DTN_CLOSEUP = ((0-760)+7),
         DVASPECT_CONTENT   = 1,
@@ -480,8 +467,7 @@ namespace System.Windows.Forms {
         INET_E_DEFAULT_ACTION = unchecked((int)0x800C0011),
         ETO_OPAQUE = 0x0002,
         ETO_CLIPPED = 0x0004,
-        EMR_POLYTEXTOUTA = 96,
-        EMR_POLYTEXTOUTW = 97,
+        EMR_POLYTEXTOUT = 97,
         EDGE_RAISED = (0x0001|0x0004),
         EDGE_SUNKEN = (0x0002|0x0008),
         EDGE_ETCHED = (0x0002|0x0004),
@@ -621,33 +607,21 @@ namespace System.Windows.Forms {
         HDI_ORDER = 0x0080,
         HDI_WIDTH = 0x0001,
         HDM_GETITEMCOUNT = (0x1200+0),
-        HDM_INSERTITEMA = (0x1200+1),
         HDM_INSERTITEMW = (0x1200+10),
-        HDM_GETITEMA = (0x1200+3),
         HDM_GETITEMW = (0x1200+11),
         HDM_LAYOUT = (0x1200+5),
-        HDM_SETITEMA = (0x1200+4),
         HDM_SETITEMW = (0x1200+12),
-        HDN_ITEMCHANGINGA = ((0-300)-0),
-        HDN_ITEMCHANGINGW = ((0-300)-20),
-        HDN_ITEMCHANGEDA = ((0-300)-1),
-        HDN_ITEMCHANGEDW = ((0-300)-21),
-        HDN_ITEMCLICKA = ((0-300)-2),
-        HDN_ITEMCLICKW = ((0-300)-22),
-        HDN_ITEMDBLCLICKA = ((0-300)-3),
-        HDN_ITEMDBLCLICKW = ((0-300)-23),
-        HDN_DIVIDERDBLCLICKA = ((0-300)-5),
-        HDN_DIVIDERDBLCLICKW = ((0-300)-25),
+        HDN_ITEMCHANGING = ((0-300)-20),
+        HDN_ITEMCHANGED = ((0-300)-21),
+        HDN_ITEMCLICK = ((0-300)-22),
+        HDN_ITEMDBLCLICK = ((0-300)-23),
+        HDN_DIVIDERDBLCLICK = ((0-300)-25),
         HDN_BEGINTDRAG = ((0-300)-10),
-        HDN_BEGINTRACKA = ((0-300)-6),
-        HDN_BEGINTRACKW = ((0-300)-26),
+        HDN_BEGINTRACK = ((0-300)-26),
         HDN_ENDDRAG = ((0-300)-11),
-        HDN_ENDTRACKA = ((0-300)-7),
-        HDN_ENDTRACKW = ((0-300)-27),
-        HDN_TRACKA = ((0-300)-8),
-        HDN_TRACKW = ((0-300)-28),
-        HDN_GETDISPINFOA = ((0-300)-9),
-        HDN_GETDISPINFOW = ((0-300)-29);
+        HDN_ENDTRACK = ((0-300)-27),
+        HDN_TRACK = ((0-300)-28),
+        HDN_GETDISPINFO = ((0-300)-29);
         // HOVER_DEFAULT = Do not use this value ever! It crashes entire servers.
 
         public const int HDS_FULLDRAG = 0x0080;
@@ -789,7 +763,7 @@ namespace System.Windows.Forms {
         LB_FINDSTRINGEXACT = 0x01A2,
         LB_ITEMFROMPOINT = 0x01A9,
         LB_SETLOCALE = 0x01A5;
-        
+
         public const int LBS_NOTIFY = 0x0001,
         LBS_MULTIPLESEL = 0x0008,
         LBS_OWNERDRAWFIXED = 0x0010,
@@ -833,8 +807,7 @@ namespace System.Windows.Forms {
         LVM_REDRAWITEMS = (0x1000+21),
         LVM_SCROLL=(0x1000+20),
         LVM_SETBKCOLOR = (0x1000+1),
-        LVM_SETBKIMAGEA = (0x1000+68),
-        LVM_SETBKIMAGEW = (0x1000+138),
+        LVM_SETBKIMAGE = (0x1000+138),
         LVM_SETCALLBACKMASK = (0x1000+11),
         LVM_GETCALLBACKMASK = (0x1000+10),
         LVM_GETCOLUMNORDERARRAY = (0x1000+59),
@@ -860,13 +833,10 @@ namespace System.Windows.Forms {
         LVIS_DROPHILITED = 0x0008,
         LVIS_OVERLAYMASK = 0x0F00,
         LVIS_STATEIMAGEMASK = 0xF000,
-        LVM_GETITEMA = (0x1000+5),
-        LVM_GETITEMW = (0x1000+75),
-        LVM_SETITEMA = (0x1000+6),
-        LVM_SETITEMW = (0x1000+76),
+        LVM_GETITEM = (0x1000+75),
+        LVM_SETITEM = (0x1000+76),
         LVM_SETITEMPOSITION32 = (0x01000 + 49),
-        LVM_INSERTITEMA = (0x1000+7),
-        LVM_INSERTITEMW = (0x1000+77),
+        LVM_INSERTITEM = (0x1000+77),
         LVM_DELETEITEM = (0x1000+8),
         LVM_DELETECOLUMN = (0x1000+28),
         LVM_DELETEALLITEMS = (0x1000+9),
@@ -878,8 +848,7 @@ namespace System.Windows.Forms {
         LVFI_NEARESTXY = 0x0040,
         LVFI_PARTIAL = 0x0008,
         LVFI_STRING = 0x0002,
-        LVM_FINDITEMA = (0x1000+13),
-        LVM_FINDITEMW = (0x1000+83),
+        LVM_FINDITEM = (0x1000+83),
         LVIR_BOUNDS = 0,
         LVIR_ICON = 1,
         LVIR_LABEL = 2,
@@ -887,8 +856,7 @@ namespace System.Windows.Forms {
         LVM_GETITEMPOSITION = (0x1000+16),
         LVM_GETITEMRECT = (0x1000+14),
         LVM_GETSUBITEMRECT = (0x1000+56),
-        LVM_GETSTRINGWIDTHA = (0x1000+17),
-        LVM_GETSTRINGWIDTHW = (0x1000+87),
+        LVM_GETSTRINGWIDTH = (0x1000+87),
         LVHT_NOWHERE = 0x0001,
         LVHT_ONITEMICON = 0x0002,
         LVHT_ONITEMLABEL = 0x0004,
@@ -906,8 +874,7 @@ namespace System.Windows.Forms {
         LVA_ALIGNTOP = 0x0002,
         LVA_SNAPTOGRID = 0x0005,
         LVM_ARRANGE = (0x1000+22),
-        LVM_EDITLABELA = (0x1000+23),
-        LVM_EDITLABELW = (0x1000+118),
+        LVM_EDITLABEL = (0x1000+118),
         LVCDI_ITEM = 0x0000,
         LVCDI_GROUP = 0x00000001,
         LVCF_FMT = 0x0001,
@@ -915,35 +882,32 @@ namespace System.Windows.Forms {
         LVCF_TEXT = 0x0004,
         LVCF_SUBITEM = 0x0008,
         LVCF_IMAGE = 0x0010,
-        LVCF_ORDER = 0x0020,        
+        LVCF_ORDER = 0x0020,
         LVCFMT_IMAGE = 0x0800,
-        LVGA_HEADER_LEFT  =  0x00000001,
-        LVGA_HEADER_CENTER = 0x00000002,
-        LVGA_HEADER_RIGHT  = 0x00000004,
-        LVGA_FOOTER_LEFT   = 0x00000008,
-        LVGA_FOOTER_CENTER = 0x00000010,
-        LVGA_FOOTER_RIGHT  = 0x00000020,
-        LVGF_NONE    =       0x00000000,
-        LVGF_HEADER   =      0x00000001,
-        LVGF_FOOTER    =     0x00000002,
-        LVGF_STATE      =    0x00000004,
-        LVGF_ALIGN       =   0x00000008,
-        LVGF_GROUPID    =    0x00000010,
-        LVGS_NORMAL    = 0x00000000,
-        LVGS_COLLAPSED  =    0x00000001,
-        LVGS_HIDDEN    =     0x00000002,
+        LVGA_HEADER_LEFT    = 0x00000001,
+        LVGA_HEADER_CENTER  = 0x00000002,
+        LVGA_HEADER_RIGHT   = 0x00000004,
+        LVGA_FOOTER_LEFT    = 0x00000008,
+        LVGA_FOOTER_CENTER  = 0x00000010,
+        LVGA_FOOTER_RIGHT   = 0x00000020,
+        LVGF_NONE           = 0x00000000,
+        LVGF_HEADER         = 0x00000001,
+        LVGF_FOOTER         = 0x00000002,
+        LVGF_STATE          = 0x00000004,
+        LVGF_ALIGN          = 0x00000008,
+        LVGF_GROUPID        = 0x00000010,
+        LVGS_NORMAL         = 0x00000000,
+        LVGS_COLLAPSED      = 0x00000001,
+        LVGS_HIDDEN         = 0x00000002,
         LVIM_AFTER = 0x00000001,
         LVTVIF_FIXEDSIZE = 0x00000003,
         LVTVIM_TILESIZE = 0x00000001,
         LVTVIM_COLUMNS = 0x00000002,
         LVM_ENABLEGROUPVIEW = (0x1000 + 157),
-        LVM_MOVEITEMTOGROUP     =       (0x1000 + 154),
-        LVM_GETCOLUMNA = (0x1000+25),
-        LVM_GETCOLUMNW = (0x1000+95),
-        LVM_SETCOLUMNA = (0x1000+26),
-        LVM_SETCOLUMNW = (0x1000+96),
-        LVM_INSERTCOLUMNA = (0x1000+27),
-        LVM_INSERTCOLUMNW = (0x1000+97),
+        LVM_MOVEITEMTOGROUP = (0x1000 + 154),
+        LVM_GETCOLUMN = (0x1000+95),
+        LVM_SETCOLUMN = (0x1000+96),
+        LVM_INSERTCOLUMN = (0x1000+97),
         LVM_INSERTGROUP = (0x1000 + 145),
         LVM_REMOVEGROUP = (0x1000 + 150),
         LVM_INSERTMARKHITTEST = (0x1000 + 168),
@@ -958,27 +922,24 @@ namespace System.Windows.Forms {
         LVM_SETITEMPOSITION = (0x1000+15),
         LVM_SETITEMSTATE = (0x1000+43),
         LVM_GETITEMSTATE = (0x1000+44),
-        LVM_GETITEMTEXTA = (0x1000+45),
-        LVM_GETITEMTEXTW = (0x1000+115),
+        LVM_GETITEMTEXT = (0x1000+115),
         LVM_GETHOTITEM = (0x1000+61),
-        LVM_SETITEMTEXTA = (0x1000+46),
-        LVM_SETITEMTEXTW = (0x1000+116),
+        LVM_SETITEMTEXT = (0x1000+116),
         LVM_SETITEMCOUNT = (0x1000+47),
-        LVM_SORTITEMS = (0x1000+48),
-        LVM_GETSELECTEDCOUNT = (0x1000+50),
-        LVM_GETISEARCHSTRINGA = (0x1000+52),
-        LVM_GETISEARCHSTRINGW = (0x1000+117),
-        LVM_SETEXTENDEDLISTVIEWSTYLE = (0x1000+54),
+        LVM_SORTITEMS = (0x1000 + 48),
+        LVM_GETSELECTEDCOUNT = (0x1000 + 50),
+        LVM_GETISEARCHSTRING = (0x1000 + 117),
+        LVM_SETEXTENDEDLISTVIEWSTYLE = (0x1000 + 54),
         LVM_SETVIEW = (0x1000 + 142),
-        LVM_GETGROUPINFO      =   (0x1000 + 149),
-        LVM_SETGROUPINFO  =       (0x1000 + 147),
+        LVM_GETGROUPINFO = (0x1000 + 149),
+        LVM_SETGROUPINFO = (0x1000 + 147),
         LVM_HASGROUP = (0x1000 + 161),
         LVM_SETTILEVIEWINFO = (0x1000 + 162),
-        LVM_GETTILEVIEWINFO = (0x1000 + 163),        
+        LVM_GETTILEVIEWINFO = (0x1000 + 163),
         LVM_GETINSERTMARK = (0x1000 + 167),
         LVM_GETINSERTMARKRECT = (0x1000 + 169),
         LVM_SETINSERTMARKCOLOR = (0x1000 + 170),
-        LVM_GETINSERTMARKCOLOR = (0x1000 + 171),        
+        LVM_GETINSERTMARKCOLOR = (0x1000 + 171),
         LVM_ISGROUPVIEWENABLED = (0x1000 + 175),
         LVS_EX_GRIDLINES = 0x00000001,
         LVS_EX_CHECKBOXES = 0x00000004,
@@ -992,24 +953,18 @@ namespace System.Windows.Forms {
         LVS_EX_DOUBLEBUFFER = 0x00010000,
         LVN_ITEMCHANGING = ((0-100)-0),
         LVN_ITEMCHANGED = ((0-100)-1),
-        LVN_BEGINLABELEDITA = ((0-100)-5),
-        LVN_BEGINLABELEDITW = ((0-100)-75),
-        LVN_ENDLABELEDITA = ((0-100)-6),
-        LVN_ENDLABELEDITW = ((0-100)-76),
+        LVN_BEGINLABELEDIT = ((0-100)-75),
+        LVN_ENDLABELEDIT = ((0-100)-76),
         LVN_COLUMNCLICK = ((0-100)-8),
         LVN_BEGINDRAG = ((0-100)-9),
         LVN_BEGINRDRAG = ((0-100)-11),
-        LVN_ODFINDITEMA = ((0-100)-52),
-        LVN_ODFINDITEMW = ((0-100)-79),
+        LVN_ODFINDITEM = ((0-100)-79),
         LVN_ITEMACTIVATE = ((0-100)-14),
-        LVN_GETDISPINFOA = ((0-100)-50),
-        LVN_GETDISPINFOW = ((0-100)-77),
+        LVN_GETDISPINFO = ((0-100)-77),
         LVN_ODCACHEHINT = ((0-100) - 13),
         LVN_ODSTATECHANGED = ((0-100) - 15),
-        LVN_SETDISPINFOA = ((0-100)-51),
-        LVN_SETDISPINFOW = ((0-100)-78),
-        LVN_GETINFOTIPA  = ((0-100)-57),
-        LVN_GETINFOTIPW  = ((0-100)- 58),
+        LVN_SETDISPINFO = ((0-100)-78),
+        LVN_GETINFOTIP  = ((0-100)- 58),
         LVN_KEYDOWN = ((0-100)-55),
         
         LWA_COLORKEY            = 0x00000001,
@@ -1451,13 +1406,12 @@ namespace System.Windows.Forms {
         SM_CMONITORS = 80,
         SM_SAMEDISPLAYFORMAT = 81,
         SM_REMOTESESSION = 0x1000;
-        
-                       
+
         public const int HLP_FILE = 1,
         HLP_KEYWORD = 2,
         HLP_NAVIGATOR = 3,
         HLP_OBJECT = 4;
-                
+
         public const int SW_SCROLLCHILDREN = 0x0001,
         SW_INVALIDATE = 0x0002,
         SW_ERASE = 0x0004,
@@ -1529,20 +1483,15 @@ namespace System.Windows.Forms {
         SPI_GETSNAPTODEFBUTTON = 95,
         SPI_GETWHEELSCROLLLINES = 104,
         SBARS_SIZEGRIP = 0x0100,
-        SB_SETTEXTA = (0x0400+1),
-        SB_SETTEXTW = (0x0400+11),
-        SB_GETTEXTA = (0x0400+2),
-        SB_GETTEXTW = (0x0400+13),
-        SB_GETTEXTLENGTHA = (0x0400+3),
-        SB_GETTEXTLENGTHW = (0x0400+12),
+        SB_SETTEXT = (0x0400+11),
+        SB_GETTEXT = (0x0400+13),
+        SB_GETTEXTLENGTH = (0x0400+12),
         SB_SETPARTS = (0x0400+4),
         SB_SIMPLE = (0x0400+9),
         SB_GETRECT = (0x0400+10),
         SB_SETICON = (0x0400+15),
-        SB_SETTIPTEXTA = (0x0400+16),
-        SB_SETTIPTEXTW = (0x0400+17),
-        SB_GETTIPTEXTA = (0x0400+18),
-        SB_GETTIPTEXTW = (0x0400+19),
+        SB_SETTIPTEXT = (0x0400+17),
+        SB_GETTIPTEXT = (0x0400+19),
         SBT_OWNERDRAW = 0x1000,
         SBT_NOBORDERS = 0x0100,
         SBT_POPOUT = 0x0200,
@@ -1598,32 +1547,24 @@ namespace System.Windows.Forms {
         TB_ENABLEBUTTON = (0x0400 + 1),
         TB_ISBUTTONCHECKED = (0x0400 + 10),
         TB_ISBUTTONINDETERMINATE = (0x0400 + 13),
-        TB_ADDBUTTONSA = (0x0400 + 20),
-        TB_ADDBUTTONSW = (0x0400 + 68),
-        TB_INSERTBUTTONA = (0x0400 + 21),
-        TB_INSERTBUTTONW = (0x0400 + 67),
+        TB_ADDBUTTONS = (0x0400 + 68),
+        TB_INSERTBUTTON = (0x0400 + 67),
         TB_DELETEBUTTON = (0x0400 + 22),
         TB_GETBUTTON = (0x0400 + 23),
-        TB_SAVERESTOREA = (0x0400 + 26),
-        TB_SAVERESTOREW = (0x0400 + 76),
-        TB_ADDSTRINGA = (0x0400 + 28),
-        TB_ADDSTRINGW = (0x0400 + 77),
+        TB_SAVERESTORE = (0x0400 + 76),
+        TB_ADDSTRING = (0x0400 + 77),
         TB_BUTTONSTRUCTSIZE = (0x0400 + 30),
         TB_SETBUTTONSIZE = (0x0400 + 31),
         TB_AUTOSIZE = (0x0400 + 33),
         TB_GETROWS = (0x0400 + 40),
-        TB_GETBUTTONTEXTA = (0x0400 + 45),
-        TB_GETBUTTONTEXTW = (0x0400 + 75),
+        TB_GETBUTTONTEXT = (0x0400 + 75),
         TB_SETIMAGELIST = (0x0400 + 48),
         TB_GETRECT = (0x0400 + 51),
         TB_GETBUTTONSIZE = (0x0400 + 58),
-        TB_GETBUTTONINFOW = (0x0400 + 63),
-        TB_SETBUTTONINFOW = (0x0400 + 64),
-        TB_GETBUTTONINFOA = (0x0400 + 65),
-        TB_SETBUTTONINFOA = (0x0400 + 66),
-        TB_MAPACCELERATORA = (0x0400 + 78),
+        TB_GETBUTTONINFO = (0x0400 + 63),
+        TB_SETBUTTONINFO = (0x0400 + 64),
         TB_SETEXTENDEDSTYLE = (0x0400 + 84),
-        TB_MAPACCELERATORW = (0x0400 + 90),
+        TB_MAPACCELERATOR = (0x0400 + 90),
         TB_GETTOOLTIPS = (0x0400 + 35),
         TB_SETTOOLTIPS = (0x0400 + 36),
         TBIF_IMAGE = 0x00000001,
@@ -1632,25 +1573,22 @@ namespace System.Windows.Forms {
         TBIF_STYLE = 0x00000008,
         TBIF_COMMAND = 0x00000020,
         TBIF_SIZE = 0x00000040,
-        TBN_GETBUTTONINFOA = ((0 - 700) - 0),
-        TBN_GETBUTTONINFOW = ((0 - 700) - 20),
+        TBN_GETBUTTONINFO = ((0 - 700) - 20),
         TBN_QUERYINSERT = ((0 - 700) - 6),
         TBN_DROPDOWN = ((0 - 700) - 10),
         TBN_HOTITEMCHANGE = ((0 - 700) - 13),
-        TBN_GETDISPINFOA = ((0 - 700) - 16),
-        TBN_GETDISPINFOW = ((0 - 700) - 17),
-        TBN_GETINFOTIPA = ((0 - 700) - 18),
-        TBN_GETINFOTIPW = ((0 - 700) - 19),
+        TBN_GETDISPINFO = ((0 - 700) - 17),
+        TBN_GETINFOTIP = ((0 - 700) - 19),
         TTS_ALWAYSTIP = 0x01,
         TTS_NOPREFIX = 0x02,
         TTS_NOANIMATE = 0x10,
         TTS_NOFADE = 0x20,
         TTS_BALLOON = 0x40,
-            //TTI_NONE                =0,
-            //TTI_INFO                =1,
-            TTI_WARNING = 2,
-            //TTI_ERROR               =3,
-            TTF_IDISHWND = 0x0001,
+        //TTI_NONE                =0,
+        //TTI_INFO                =1,
+        TTI_WARNING = 2,
+        //TTI_ERROR               =3,
+        TTF_IDISHWND = 0x0001,
         TTF_RTLREADING = 0x0004,
         TTF_TRACK = 0x0020,
         TTF_CENTERTIP = 0x0002,
@@ -1667,44 +1605,31 @@ namespace System.Windows.Forms {
         TTM_POP = (0x0400 + 28),
         TTM_ADJUSTRECT = (0x400 + 31),
         TTM_SETDELAYTIME = (0x0400 + 3),
-        TTM_SETTITLEA = (WM_USER + 32),  // wParam = TTI_*, lParam = char* szTitle
-            TTM_SETTITLEW = (WM_USER + 33), // wParam = TTI_*, lParam = wchar* szTitle
-            TTM_ADDTOOLA = (0x0400 + 4),
-        TTM_ADDTOOLW = (0x0400 + 50),
-        TTM_DELTOOLA = (0x0400 + 5),
-        TTM_DELTOOLW = (0x0400 + 51),
-        TTM_NEWTOOLRECTA = (0x0400 + 6),
-        TTM_NEWTOOLRECTW = (0x0400 + 52),
+        TTM_SETTITLE = (WM_USER + 33), // wParam = TTI_*, lParam = wchar* szTitle
+        TTM_ADDTOOL = (0x0400 + 50),
+        TTM_DELTOOL = (0x0400 + 51),
+        TTM_NEWTOOLRECT = (0x0400 + 52),
         TTM_RELAYEVENT = (0x0400 + 7),
         TTM_GETTIPBKCOLOR = (0x0400 + 22),
         TTM_SETTIPBKCOLOR = (0x0400 + 19),
         TTM_SETTIPTEXTCOLOR = (0x0400 + 20),
         TTM_GETTIPTEXTCOLOR = (0x0400 + 23),
-        TTM_GETTOOLINFOA = (0x0400 + 8),
-        TTM_GETTOOLINFOW = (0x0400 + 53),
-        TTM_SETTOOLINFOA = (0x0400 + 9),
-        TTM_SETTOOLINFOW = (0x0400 + 54),
-        TTM_HITTESTA = (0x0400 + 10),
-        TTM_HITTESTW = (0x0400 + 55),
-        TTM_GETTEXTA = (0x0400 + 11),
-        TTM_GETTEXTW = (0x0400 + 56),
+        TTM_GETTOOLINFO = (0x0400 + 53),
+        TTM_SETTOOLINFO = (0x0400 + 54),
+        TTM_HITTEST = (0x0400 + 55),
+        TTM_GETTEXT = (0x0400 + 56),
         TTM_UPDATE = (0x0400 + 29),
-        TTM_UPDATETIPTEXTA = (0x0400 + 12),
-        TTM_UPDATETIPTEXTW = (0x0400 + 57),
-        TTM_ENUMTOOLSA = (0x0400 + 14),
-        TTM_ENUMTOOLSW = (0x0400 + 58),
-        TTM_GETCURRENTTOOLA = (0x0400 + 15),
-        TTM_GETCURRENTTOOLW = (0x0400 + 59),
+        TTM_UPDATETIPTEXT = (0x0400 + 57),
+        TTM_ENUMTOOLS = (0x0400 + 58),
+        TTM_GETCURRENTTOOL = (0x0400 + 59),
         TTM_WINDOWFROMPOINT = (0x0400 + 16),
         TTM_GETDELAYTIME = (0x0400 + 21),
         TTM_SETMAXTIPWIDTH = (0x0400 + 24),
         TTM_GETBUBBLESIZE = (0x0400 + 30),
-        TTN_GETDISPINFOA = ((0 - 520) - 0),
-        TTN_GETDISPINFOW = ((0 - 520) - 10),
+        TTN_GETDISPINFO = ((0 - 520) - 10),
         TTN_SHOW = ((0 - 520) - 1),
         TTN_POP = ((0 - 520) - 2),
-        TTN_NEEDTEXTA = ((0 - 520) - 0),
-        TTN_NEEDTEXTW = ((0 - 520) - 10),
+        TTN_NEEDTEXT = ((0 - 520) - 10),
         TBS_AUTOTICKS = 0x0001,
         TBS_VERT = 0x0002,
         TBS_TOP = 0x0004,
@@ -1753,8 +1678,7 @@ namespace System.Windows.Forms {
         TVIS_STATEIMAGEMASK = 0xF000,
         TVI_ROOT = (unchecked((int)0xFFFF0000)),
         TVI_FIRST = (unchecked((int)0xFFFF0001)),
-        TVM_INSERTITEMA = (0x1100 + 0),
-        TVM_INSERTITEMW = (0x1100 + 50),
+        TVM_INSERTITEM = (0x1100 + 50),
         TVM_DELETEITEM = (0x1100 + 1),
         TVM_EXPAND = (0x1100 + 2),
         TVE_COLLAPSE = 0x0001,
@@ -1773,46 +1697,31 @@ namespace System.Windows.Forms {
         TVGN_DROPHILITE= 0x0008,
         TVGN_CARET = 0x0009,
         TVM_SELECTITEM = (0x1100 + 11),
-        TVM_GETITEMA = (0x1100 + 12),
-        TVM_GETITEMW = (0x1100 + 62),
-        TVM_SETITEMA = (0x1100 + 13),
-        TVM_SETITEMW = (0x1100 + 63),
-        TVM_EDITLABELA = (0x1100 + 14),
-        TVM_EDITLABELW = (0x1100 + 65),
+        TVM_GETITEM = (0x1100 + 62),
+        TVM_SETITEM = (0x1100 + 63),
+        TVM_EDITLABEL = (0x1100 + 65),
         TVM_GETEDITCONTROL = (0x1100 + 15),
         TVM_GETVISIBLECOUNT = (0x1100 + 16),
         TVM_HITTEST = (0x1100 + 17),
         TVM_ENSUREVISIBLE = (0x1100 + 20),
         TVM_ENDEDITLABELNOW = (0x1100 + 22),
-        TVM_GETISEARCHSTRINGA = (0x1100 + 23),
-        TVM_GETISEARCHSTRINGW = (0x1100 + 64),
+        TVM_GETISEARCHSTRING = (0x1100 + 64),
         TVM_SETITEMHEIGHT = (0x1100 + 27),
         TVM_GETITEMHEIGHT = (0x1100 + 28),
-        TVN_SELCHANGINGA = ((0 - 400) - 1),
-        TVN_SELCHANGINGW = ((0 - 400) - 50),
-        TVN_GETINFOTIPA = ((0 - 400) - 13),
-        TVN_GETINFOTIPW = ((0 - 400) - 14),
-        TVN_SELCHANGEDA = ((0 - 400) - 2),
-        TVN_SELCHANGEDW = ((0 - 400) - 51),
+        TVN_SELCHANGING = ((0 - 400) - 50),
+        TVN_GETINFOTIP = ((0 - 400) - 14),
+        TVN_SELCHANGED = ((0 - 400) - 51),
         TVC_UNKNOWN = 0x0000,
         TVC_BYMOUSE = 0x0001,
         TVC_BYKEYBOARD = 0x0002,
-        TVN_GETDISPINFOA = ((0 - 400) - 3),
-        TVN_GETDISPINFOW = ((0 - 400) - 52),
-        TVN_SETDISPINFOA = ((0 - 400) - 4),
-        TVN_SETDISPINFOW = ((0 - 400) - 53),
-        TVN_ITEMEXPANDINGA = ((0 - 400) - 5),
-        TVN_ITEMEXPANDINGW = ((0 - 400) - 54),
-        TVN_ITEMEXPANDEDA = ((0 - 400) - 6),
-        TVN_ITEMEXPANDEDW = ((0 - 400) - 55),
-        TVN_BEGINDRAGA = ((0 - 400) - 7),
-        TVN_BEGINDRAGW = ((0 - 400) - 56),
-        TVN_BEGINRDRAGA = ((0 - 400) - 8),
-        TVN_BEGINRDRAGW = ((0 - 400) - 57),
-        TVN_BEGINLABELEDITA = ((0 - 400) - 10),
-        TVN_BEGINLABELEDITW = ((0 - 400) - 59),
-        TVN_ENDLABELEDITA = ((0 - 400) - 11),
-        TVN_ENDLABELEDITW = ((0 - 400) - 60),
+        TVN_GETDISPINFO = ((0 - 400) - 52),
+        TVN_SETDISPINFO = ((0 - 400) - 53),
+        TVN_ITEMEXPANDING = ((0 - 400) - 54),
+        TVN_ITEMEXPANDED = ((0 - 400) - 55),
+        TVN_BEGINDRAG = ((0 - 400) - 56),
+        TVN_BEGINRDRAG = ((0 - 400) - 57),
+        TVN_BEGINLABELEDIT = ((0 - 400) - 59),
+        TVN_ENDLABELEDIT = ((0 - 400) - 60),
         TCS_BOTTOM = 0x0002,
         TCS_RIGHT = 0x0002,
         TCS_FLATBUTTONS = 0x0008,
@@ -1829,12 +1738,9 @@ namespace System.Windows.Forms {
         TCM_SETIMAGELIST = (0x1300 + 3),
         TCIF_TEXT = 0x0001,
         TCIF_IMAGE = 0x0002,
-        TCM_GETITEMA = (0x1300 + 5),
-        TCM_GETITEMW = (0x1300 + 60),
-        TCM_SETITEMA = (0x1300 + 6),
-        TCM_SETITEMW = (0x1300 + 61),
-        TCM_INSERTITEMA = (0x1300 + 7),
-        TCM_INSERTITEMW = (0x1300 + 62),
+        TCM_GETITEM = (0x1300 + 60),
+        TCM_SETITEM = (0x1300 + 61),
+        TCM_INSERTITEM = (0x1300 + 62),
         TCM_DELETEITEM = (0x1300 + 8),
         TCM_DELETEALLITEMS = (0x1300 + 9),
         TCM_GETITEMRECT = (0x1300 + 10),
@@ -1878,11 +1784,10 @@ namespace System.Windows.Forms {
         UISF_HIDEFOCUS = 0x1,
         UISF_HIDEACCEL = 0x2,
         USERCLASSTYPE_FULL = 1,
-        USERCLASSTYPE_SHORT = 2,                 
+        USERCLASSTYPE_SHORT = 2,
         USERCLASSTYPE_APPNAME = 3,
         UOI_FLAGS = 1;
 
-        
         public const int VIEW_E_DRAW = unchecked((int)0x80040140),
         VK_PRIOR = 0x21,
         VK_NEXT = 0x22,
@@ -2055,9 +1960,7 @@ namespace System.Windows.Forms {
         WM_XBUTTONDBLCLK               = 0x020D,
         WM_MOUSEWHEEL = 0x020A,
         WM_MOUSELAST = 0x020A;
-        
 
-        
         public const int WHEEL_DELTA = 120,
         WM_PARENTNOTIFY = 0x0210,
         WM_ENTERMENULOOP = 0x0211,
@@ -2214,199 +2117,8 @@ namespace System.Windows.Forms {
         public const int XBUTTON1    =  0x0001;
         public const int XBUTTON2    =  0x0002;
 
-
-        // These are initialized in a static constructor for speed.  That way we don't have to
-        // evaluate the char size each time.
-        //
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int BFFM_SETSELECTION;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int CBEM_GETITEM;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int CBEM_SETITEM;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int CBEN_ENDEDIT;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int CBEM_INSERTITEM;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int LVM_GETITEMTEXT;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int LVM_SETITEMTEXT;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int ACM_OPEN;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int DTM_SETFORMAT;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int DTN_USERSTRING;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int DTN_WMKEYDOWN;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int DTN_FORMAT;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int DTN_FORMATQUERY;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int EMR_POLYTEXTOUT;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int HDM_INSERTITEM;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int HDM_GETITEM;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int HDM_SETITEM;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int HDN_ITEMCHANGING;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int HDN_ITEMCHANGED;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int HDN_ITEMCLICK;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int HDN_ITEMDBLCLICK;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int HDN_DIVIDERDBLCLICK;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int HDN_BEGINTRACK;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int HDN_ENDTRACK;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int HDN_TRACK;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int HDN_GETDISPINFO;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int LVM_GETITEM;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int LVM_SETBKIMAGE;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int LVM_SETITEM;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int LVM_INSERTITEM;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int LVM_FINDITEM;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int LVM_GETSTRINGWIDTH;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int LVM_EDITLABEL;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int LVM_GETCOLUMN;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int LVM_SETCOLUMN;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int LVM_GETISEARCHSTRING;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int LVM_INSERTCOLUMN;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int LVN_BEGINLABELEDIT;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int LVN_ENDLABELEDIT;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int LVN_ODFINDITEM;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int LVN_GETDISPINFO;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int LVN_GETINFOTIP;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int LVN_SETDISPINFO;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int PSM_SETTITLE;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int PSM_SETFINISHTEXT;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int RB_INSERTBAND;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int SB_SETTEXT;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int SB_GETTEXT;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int SB_GETTEXTLENGTH;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int SB_SETTIPTEXT;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int SB_GETTIPTEXT;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TB_SAVERESTORE;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TB_ADDSTRING;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TB_GETBUTTONTEXT;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TB_MAPACCELERATOR;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TB_GETBUTTONINFO;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TB_SETBUTTONINFO;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TB_INSERTBUTTON;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TB_ADDBUTTONS;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TBN_GETBUTTONINFO;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TBN_GETINFOTIP;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TBN_GETDISPINFO;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TTM_ADDTOOL;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TTM_SETTITLE;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TTM_DELTOOL;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TTM_NEWTOOLRECT;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TTM_GETTOOLINFO;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TTM_SETTOOLINFO;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TTM_HITTEST;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TTM_GETTEXT;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TTM_UPDATETIPTEXT;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TTM_ENUMTOOLS;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TTM_GETCURRENTTOOL;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TTN_GETDISPINFO;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TTN_NEEDTEXT;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TVM_INSERTITEM;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TVM_GETITEM;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TVM_SETITEM;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TVM_EDITLABEL;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TVM_GETISEARCHSTRING;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TVN_SELCHANGING;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TVN_SELCHANGED;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TVN_GETDISPINFO;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TVN_SETDISPINFO;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TVN_ITEMEXPANDING;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TVN_ITEMEXPANDED;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TVN_BEGINDRAG;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TVN_BEGINRDRAG;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TVN_BEGINLABELEDIT;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TVN_ENDLABELEDIT;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TCM_GETITEM;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TCM_SETITEM;
-        [SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate")]
-        public static readonly int TCM_INSERTITEM;
-
         public const string TOOLTIPS_CLASS = "tooltips_class32";
-        
+
         public const string WC_DATETIMEPICK = "SysDateTimePick32",
         WC_LISTVIEW = "SysListView32",
         WC_MONTHCAL = "SysMonthCal32",
@@ -2433,110 +2145,9 @@ namespace System.Windows.Forms {
         public const string uuid_IAccessible  = "{618736E0-3C3D-11CF-810C-00AA00389B71}";
         public const string uuid_IEnumVariant = "{00020404-0000-0000-C000-000000000046}";
 
-        [SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline"),
-            SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        static NativeMethods()
-        {
-            BFFM_SETSELECTION = NativeMethods.BFFM_SETSELECTIONW;
-            CBEM_GETITEM = NativeMethods.CBEM_GETITEMW;
-            CBEM_SETITEM = NativeMethods.CBEM_SETITEMW;
-            CBEN_ENDEDIT = NativeMethods.CBEN_ENDEDITW;
-            CBEM_INSERTITEM = NativeMethods.CBEM_INSERTITEMW;
-            LVM_GETITEMTEXT = NativeMethods.LVM_GETITEMTEXTW;
-            LVM_SETITEMTEXT = NativeMethods.LVM_SETITEMTEXTW;
-            ACM_OPEN = NativeMethods.ACM_OPENW;
-            DTM_SETFORMAT = NativeMethods.DTM_SETFORMATW;
-            DTN_USERSTRING = NativeMethods.DTN_USERSTRINGW;
-            DTN_WMKEYDOWN = NativeMethods.DTN_WMKEYDOWNW;
-            DTN_FORMAT = NativeMethods.DTN_FORMATW;
-            DTN_FORMATQUERY = NativeMethods.DTN_FORMATQUERYW;
-            EMR_POLYTEXTOUT = NativeMethods.EMR_POLYTEXTOUTW;
-            HDM_INSERTITEM = NativeMethods.HDM_INSERTITEMW;
-            HDM_GETITEM = NativeMethods.HDM_GETITEMW;
-            HDM_SETITEM = NativeMethods.HDM_SETITEMW;
-            HDN_ITEMCHANGING = NativeMethods.HDN_ITEMCHANGINGW;
-            HDN_ITEMCHANGED = NativeMethods.HDN_ITEMCHANGEDW;
-            HDN_ITEMCLICK = NativeMethods.HDN_ITEMCLICKW;
-            HDN_ITEMDBLCLICK = NativeMethods.HDN_ITEMDBLCLICKW;
-            HDN_DIVIDERDBLCLICK = NativeMethods.HDN_DIVIDERDBLCLICKW;
-            HDN_BEGINTRACK = NativeMethods.HDN_BEGINTRACKW;
-            HDN_ENDTRACK = NativeMethods.HDN_ENDTRACKW;
-            HDN_TRACK = NativeMethods.HDN_TRACKW;
-            HDN_GETDISPINFO = NativeMethods.HDN_GETDISPINFOW;
-            LVM_SETBKIMAGE = NativeMethods.LVM_SETBKIMAGEW;
-            LVM_GETITEM = NativeMethods.LVM_GETITEMW;
-            LVM_SETITEM = NativeMethods.LVM_SETITEMW;
-            LVM_INSERTITEM = NativeMethods.LVM_INSERTITEMW;
-            LVM_FINDITEM = NativeMethods.LVM_FINDITEMW;
-            LVM_GETSTRINGWIDTH = NativeMethods.LVM_GETSTRINGWIDTHW;
-            LVM_EDITLABEL = NativeMethods.LVM_EDITLABELW;
-            LVM_GETCOLUMN = NativeMethods.LVM_GETCOLUMNW;
-            LVM_SETCOLUMN = NativeMethods.LVM_SETCOLUMNW;
-            LVM_GETISEARCHSTRING = NativeMethods.LVM_GETISEARCHSTRINGW;
-            LVM_INSERTCOLUMN = NativeMethods.LVM_INSERTCOLUMNW;
-            LVN_BEGINLABELEDIT = NativeMethods.LVN_BEGINLABELEDITW;
-            LVN_ENDLABELEDIT = NativeMethods.LVN_ENDLABELEDITW;
-            LVN_ODFINDITEM = NativeMethods.LVN_ODFINDITEMW;
-            LVN_GETDISPINFO = NativeMethods.LVN_GETDISPINFOW;
-            LVN_GETINFOTIP = NativeMethods.LVN_GETINFOTIPW;
-            LVN_SETDISPINFO = NativeMethods.LVN_SETDISPINFOW;
-            PSM_SETTITLE = NativeMethods.PSM_SETTITLEW;
-            PSM_SETFINISHTEXT = NativeMethods.PSM_SETFINISHTEXTW;
-            RB_INSERTBAND = NativeMethods.RB_INSERTBANDW;
-            SB_SETTEXT = NativeMethods.SB_SETTEXTW;
-            SB_GETTEXT = NativeMethods.SB_GETTEXTW;
-            SB_GETTEXTLENGTH = NativeMethods.SB_GETTEXTLENGTHW;
-            SB_SETTIPTEXT = NativeMethods.SB_SETTIPTEXTW;
-            SB_GETTIPTEXT = NativeMethods.SB_GETTIPTEXTW;
-            TB_SAVERESTORE = NativeMethods.TB_SAVERESTOREW;
-            TB_ADDSTRING = NativeMethods.TB_ADDSTRINGW;
-            TB_GETBUTTONTEXT = NativeMethods.TB_GETBUTTONTEXTW;
-            TB_MAPACCELERATOR = NativeMethods.TB_MAPACCELERATORW;
-            TB_GETBUTTONINFO = NativeMethods.TB_GETBUTTONINFOW;
-            TB_SETBUTTONINFO = NativeMethods.TB_SETBUTTONINFOW;
-            TB_INSERTBUTTON = NativeMethods.TB_INSERTBUTTONW;
-            TB_ADDBUTTONS = NativeMethods.TB_ADDBUTTONSW;
-            TBN_GETBUTTONINFO = NativeMethods.TBN_GETBUTTONINFOW;
-            TBN_GETINFOTIP = NativeMethods.TBN_GETINFOTIPW;
-            TBN_GETDISPINFO = NativeMethods.TBN_GETDISPINFOW;
-            TTM_ADDTOOL = NativeMethods.TTM_ADDTOOLW;
-            TTM_SETTITLE = NativeMethods.TTM_SETTITLEW;
-            TTM_DELTOOL = NativeMethods.TTM_DELTOOLW;
-            TTM_NEWTOOLRECT = NativeMethods.TTM_NEWTOOLRECTW;
-            TTM_GETTOOLINFO = NativeMethods.TTM_GETTOOLINFOW;
-            TTM_SETTOOLINFO = NativeMethods.TTM_SETTOOLINFOW;
-            TTM_HITTEST = NativeMethods.TTM_HITTESTW;
-            TTM_GETTEXT = NativeMethods.TTM_GETTEXTW;
-            TTM_UPDATETIPTEXT = NativeMethods.TTM_UPDATETIPTEXTW;
-            TTM_ENUMTOOLS = NativeMethods.TTM_ENUMTOOLSW;
-            TTM_GETCURRENTTOOL = NativeMethods.TTM_GETCURRENTTOOLW;
-            TTN_GETDISPINFO = NativeMethods.TTN_GETDISPINFOW;
-            TTN_NEEDTEXT = NativeMethods.TTN_NEEDTEXTW;
-            TVM_INSERTITEM = NativeMethods.TVM_INSERTITEMW;
-            TVM_GETITEM = NativeMethods.TVM_GETITEMW;
-            TVM_SETITEM = NativeMethods.TVM_SETITEMW;
-            TVM_EDITLABEL = NativeMethods.TVM_EDITLABELW;
-            TVM_GETISEARCHSTRING = NativeMethods.TVM_GETISEARCHSTRINGW;
-            TVN_SELCHANGING = NativeMethods.TVN_SELCHANGINGW;
-            TVN_SELCHANGED = NativeMethods.TVN_SELCHANGEDW;
-            TVN_GETDISPINFO = NativeMethods.TVN_GETDISPINFOW;
-            TVN_SETDISPINFO = NativeMethods.TVN_SETDISPINFOW;
-            TVN_ITEMEXPANDING = NativeMethods.TVN_ITEMEXPANDINGW;
-            TVN_ITEMEXPANDED = NativeMethods.TVN_ITEMEXPANDEDW;
-            TVN_BEGINDRAG = NativeMethods.TVN_BEGINDRAGW;
-            TVN_BEGINRDRAG = NativeMethods.TVN_BEGINRDRAGW;
-            TVN_BEGINLABELEDIT = NativeMethods.TVN_BEGINLABELEDITW;
-            TVN_ENDLABELEDIT = NativeMethods.TVN_ENDLABELEDITW;
-            TCM_GETITEM = NativeMethods.TCM_GETITEMW;
-            TCM_SETITEM = NativeMethods.TCM_SETITEMW;
-            TCM_INSERTITEM = NativeMethods.TCM_INSERTITEMW;
-        }
-
         /*
         * MISCELLANEOUS
         */
-
-
 
         [StructLayout(LayoutKind.Sequential), CLSCompliant(false)]
         public class OLECMD {
@@ -2546,7 +2157,6 @@ namespace System.Windows.Forms {
             public   int cmdf = 0;
 
         }
-
 
         [ComVisible(true), ComImport(), Guid("B722BCCB-4E68-101B-A2BC-00AA00404770"),
         InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown), CLSCompliantAttribute(false)]
@@ -2575,20 +2185,6 @@ namespace System.Windows.Forms {
                 int pvaOut);
         }
 
-        /* Unused
-        public static int SignedHIWORD(int n) {
-            int i = (int)(short)((n >> 16) & 0xffff);
-
-            return i;
-        }
-
-        public static int SignedLOWORD(int n) {
-            int i = (int)(short)(n & 0xFFFF);
-            
-            return i;
-        }
-        */
-
         /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.FONTDESC"]/*' />
         /// <devdoc>
         /// </devdoc>
@@ -2603,8 +2199,6 @@ namespace System.Windows.Forms {
             public bool     fUnderline;
             public bool     fStrikethrough;
         }
-
-
 
         /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.PICTDESCbmp"]/*' />
         /// <devdoc>
@@ -2681,13 +2275,13 @@ namespace System.Windows.Forms {
             public short wSecond2;
             public short wMilliseconds2;
         }
-        
+
         public delegate bool EnumChildrenCallback(IntPtr hwnd, IntPtr lParam);
 
         [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Auto)]
         public class HH_AKLINK {
             internal int        cbStruct=Marshal.SizeOf(typeof(HH_AKLINK));
-            internal bool      fReserved = false;            
+            internal bool      fReserved = false;
             internal string    pszKeywords = null;
             internal string    pszUrl = null;
             internal string    pszMsgText = null;
@@ -2700,7 +2294,7 @@ namespace System.Windows.Forms {
         public class HH_POPUP {
             internal int       cbStruct=Marshal.SizeOf(typeof(HH_POPUP));
             internal IntPtr    hinst = IntPtr.Zero;
-            internal int       idString = 0;            
+            internal int       idString = 0;
             internal IntPtr    pszText;
             internal POINT     pt;
             internal int       clrForeground = -1;
@@ -2743,7 +2337,7 @@ namespace System.Windows.Forms {
             internal RECT    rcWork = new RECT();
             internal int     dwFlags = 0;
         }
-        
+
         public delegate int EditStreamCallback(IntPtr dwCookie, IntPtr buf, int cb, out int transferred);
 
         [StructLayout(LayoutKind.Sequential)]
@@ -2760,44 +2354,44 @@ namespace System.Windows.Forms {
         }
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
-    	public struct DEVMODE
-    	{
-    		private const int CCHDEVICENAME = 32;
-    		private const int CCHFORMNAME = 32;
+        public struct DEVMODE
+        {
+            private const int CCHDEVICENAME = 32;
+            private const int CCHFORMNAME = 32;
 
-    		[MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCHDEVICENAME)]
-    		public string dmDeviceName;
-    		public short dmSpecVersion;
-    		public short dmDriverVersion;
-    		public short dmSize;
-    		public short dmDriverExtra;
-    		public int dmFields;
-    		public int dmPositionX;
-    		public int dmPositionY;
-    		public ScreenOrientation dmDisplayOrientation;
-    		public int dmDisplayFixedOutput;
-    		public short dmColor;
-    		public short dmDuplex;
-    		public short dmYResolution;
-    		public short dmTTOption;
-    		public short dmCollate;
-    		[MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCHFORMNAME)]
-    		public string dmFormName;
-    		public short dmLogPixels;
-    		public int dmBitsPerPel;
-    		public int dmPelsWidth;
-    		public int dmPelsHeight;
-    		public int dmDisplayFlags;
-    		public int dmDisplayFrequency;
-    		public int dmICMMethod;
-    		public int dmICMIntent;
-    		public int dmMediaType;
-    		public int dmDitherType;
-    		public int dmReserved1;
-    		public int dmReserved2;
-    		public int dmPanningWidth;
-    		public int dmPanningHeight;
-    	}
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCHDEVICENAME)]
+            public string dmDeviceName;
+            public short dmSpecVersion;
+            public short dmDriverVersion;
+            public short dmSize;
+            public short dmDriverExtra;
+            public int dmFields;
+            public int dmPositionX;
+            public int dmPositionY;
+            public ScreenOrientation dmDisplayOrientation;
+            public int dmDisplayFixedOutput;
+            public short dmColor;
+            public short dmDuplex;
+            public short dmYResolution;
+            public short dmTTOption;
+            public short dmCollate;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCHFORMNAME)]
+            public string dmFormName;
+            public short dmLogPixels;
+            public int dmBitsPerPel;
+            public int dmPelsWidth;
+            public int dmPelsHeight;
+            public int dmDisplayFlags;
+            public int dmDisplayFrequency;
+            public int dmICMMethod;
+            public int dmICMIntent;
+            public int dmMediaType;
+            public int dmDitherType;
+            public int dmReserved1;
+            public int dmReserved2;
+            public int dmPanningWidth;
+            public int dmPanningHeight;
+        }
 
         [ComImport(), Guid("0FF510A3-5FA5-49F1-8CCC-190D71083F3E"), InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown)]
         public interface IVsPerPropertyBrowsing {
@@ -2852,20 +2446,19 @@ namespace System.Windows.Forms {
             // given property.  If the return value is S_OK, the property's value will then be refreshed to the new default
             // values.
             [PreserveSig]
-            int ResetPropertyValue(int dispid);                               
+            int ResetPropertyValue(int dispid);
        }
-       
+
         [ComImport(), Guid("7494683C-37A0-11d2-A273-00C04F8EF4FF"), InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown)]
         public interface IManagedPerPropertyBrowsing {
-    
-            
+
             [PreserveSig]
             int GetPropertyAttributes(int dispid, 
                                       ref int  pcAttributes,
                                       ref IntPtr pbstrAttrNames,
                                       ref IntPtr pvariantInitValues);
         }
-        
+
         [ComImport(), Guid("33C0C1D8-33CF-11d3-BFF2-00C04F990235"), InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown)]
         public interface IProvidePropertyBuilder {
     
@@ -2919,7 +2512,7 @@ namespace System.Windows.Forms {
             public int      dwRop = 0;
             public int      fState = 0;
             public int      Frame = 0;
-            public int      crEffect = 0;            
+            public int      crEffect = 0;
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -2942,7 +2535,7 @@ namespace System.Windows.Forms {
                 public IntPtr   hwndTrack;
                 public int      dwHoverTime = 100; // Never set this to field ZERO, or to HOVER_DEFAULT, ever!
         }
-        
+
         [StructLayout(LayoutKind.Sequential)]
         public class POINT {
             public int x;
@@ -2976,8 +2569,6 @@ namespace System.Windows.Forms {
         }
 
         public delegate IntPtr WndProc(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
-
-
 
         [StructLayout(LayoutKind.Sequential)]
         public struct RECT {
@@ -3017,12 +2608,11 @@ namespace System.Windows.Forms {
             public int cxRightWidth;
             public int cyTopHeight;
             public int cyBottomHeight;
-        } 
+        }
 
         public delegate int ListViewCompareCallback(IntPtr lParam1, IntPtr lParam2, IntPtr lParamSort);
 
         public delegate int TreeViewCompareCallback(IntPtr lParam1, IntPtr lParam2, IntPtr lParamSort);
-
 
         [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Auto)]
         public class WNDCLASS_I {
@@ -3061,17 +2651,7 @@ namespace System.Windows.Forms {
             [MarshalAs(UnmanagedType.Struct)]
             public LOGFONT  lfMessageFont = null; 
         }
-/*
-        [StructLayout(LayoutKind.Sequential)]
-        public class ICONMETRICS {
-            public int      cbSize = Marshal.SizeOf(typeof(ICONMETRICS));
-            public int      iHorzSpacing;
-            public int      iVertSpacing;
-            public int      iTitleWrap;
-            [MarshalAs(UnmanagedType.Struct)]
-            public LOGFONT  lfFont; 
-        }
-*/
+
         [StructLayout(LayoutKind.Sequential)]
         [Serializable]
         public struct MSG {
@@ -3095,7 +2675,7 @@ namespace System.Windows.Forms {
             public int      rcPaint_right;
             public int      rcPaint_bottom;
             public bool     fRestore;
-            public bool     fIncUpdate;    
+            public bool     fIncUpdate;
             public int      reserved1;
             public int      reserved2;
             public int      reserved3;
@@ -3115,16 +2695,8 @@ namespace System.Windows.Forms {
             public int nPage;
             public int nPos;
             public int nTrackPos;
-            
-            public SCROLLINFO() {
-            }
 
-            public SCROLLINFO(int mask, int min, int max, int page, int pos) {
-                fMask = mask;
-                nMin = min;
-                nMax = max;
-                nPage = page;
-                nPos = pos;
+            public SCROLLINFO() {
             }
         }
 
@@ -3137,7 +2709,7 @@ namespace System.Windows.Forms {
             public int  rcExclude_right;
             public int  rcExclude_bottom;
         }
-        
+
         [StructLayout(LayoutKind.Sequential)]
         public class SIZE {
             public int cx;
@@ -3150,12 +2722,6 @@ namespace System.Windows.Forms {
                 this.cx = cx;
                 this.cy = cy;
             }
-
-            /* Unused
-            public System.Drawing.Size ToSize() {
-                return new System.Drawing.Size(cx, cy);
-            }
-            */
         }
         
         [StructLayout(LayoutKind.Sequential)]
@@ -3176,8 +2742,6 @@ namespace System.Windows.Forms {
             public int  rcNormalPosition_bottom;
         }
 
-        
-        
         [StructLayout(LayoutKind.Sequential,CharSet=CharSet.Auto)]
         public class STARTUPINFO_I {
             public int      cb = 0;
@@ -3199,7 +2763,7 @@ namespace System.Windows.Forms {
             public IntPtr   hStdOutput = IntPtr.Zero;
             public IntPtr   hStdError = IntPtr.Zero;
         }
-        
+
         [StructLayout(LayoutKind.Sequential)]
         public class PAGESETUPDLG {
             public int      lStructSize; 
@@ -3423,10 +2987,8 @@ namespace System.Windows.Forms {
         public class PRINTPAGERANGE {
             public int nFromPage = 0;
             public int nToPage = 0;
-        } 
+        }
 
-
-        
         [StructLayout(LayoutKind.Sequential)]
         public class PICTDESC
         {
@@ -3452,37 +3014,6 @@ namespace System.Windows.Forms {
                 pictdesc.picType = Ole.PICTYPE_ICON;
                 pictdesc.union1 = hicon;
                 return pictdesc;
-            }
-
-            /* Unused
-            public static PICTDESC CreateEnhMetafilePICTDESC(IntPtr hEMF) {
-                PICTDESC pictdesc = new PICTDESC();
-                pictdesc.cbSizeOfStruct = 12;
-                pictdesc.picType = Ole.PICTYPE_ENHMETAFILE;
-                pictdesc.union1 = hEMF;
-                return pictdesc;
-            }
-
-            public static PICTDESC CreateWinMetafilePICTDESC(IntPtr hmetafile, int x, int y) {
-                PICTDESC pictdesc = new PICTDESC();
-                pictdesc.cbSizeOfStruct = 20;
-                pictdesc.picType = Ole.PICTYPE_METAFILE;
-                pictdesc.union1 = hmetafile;
-                pictdesc.union2 = x;
-                pictdesc.union3 = y;
-                return pictdesc;
-            }
-            */
-
-            public virtual IntPtr GetHandle() {
-                return union1;
-            }
-
-            public virtual IntPtr GetHPal() {
-                if (picType == Ole.PICTYPE_BITMAP)
-                    return (IntPtr)((uint)union2 | (((long)union3) << 32));
-                else
-                    return IntPtr.Zero;
             }
         }
 
@@ -3524,9 +3055,9 @@ namespace System.Windows.Forms {
             public WndProc  lpfnHook;
             public string   lpTemplateName = null;
         }
-        
+
         public delegate IntPtr HookProc(int nCode, IntPtr wParam, IntPtr lParam);
-        
+
         [StructLayout(LayoutKind.Sequential)]
         // This is not our convention for managed resources.
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]        
@@ -3541,6 +3072,7 @@ namespace System.Windows.Forms {
             [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
             public IntPtr bmBits = IntPtr.Zero;
         }
+
         [StructLayout(LayoutKind.Sequential)]
         public class ICONINFO {
                 public int fIcon = 0;
@@ -3558,14 +3090,14 @@ namespace System.Windows.Forms {
             public int  lopnWidth_y = 0;
             public int  lopnColor = 0;
         }
-        
+
         [StructLayout(LayoutKind.Sequential)]
         public class LOGBRUSH {
                 public int lbStyle;
                 public int lbColor;
                 public IntPtr lbHatch;
         }
-        
+
         [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Auto)]
         public class LOGFONT {
             public LOGFONT() {
@@ -3606,56 +3138,31 @@ namespace System.Windows.Forms {
             public string   lfFaceName;
         }
 
-        [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Unicode)]
-        public struct TEXTMETRIC 
-        { 
-            public int  tmHeight; 
-            public int  tmAscent; 
-            public int  tmDescent; 
-            public int  tmInternalLeading; 
-            public int  tmExternalLeading; 
-            public int  tmAveCharWidth; 
-            public int  tmMaxCharWidth; 
-            public int  tmWeight; 
-            public int  tmOverhang; 
-            public int  tmDigitizedAspectX; 
-            public int  tmDigitizedAspectY; 
-            public char tmFirstChar; 
-            public char tmLastChar; 
-            public char tmDefaultChar; 
-            public char tmBreakChar; 
-            public byte tmItalic; 
-            public byte tmUnderlined; 
-            public byte tmStruckOut; 
-            public byte tmPitchAndFamily; 
-            public byte tmCharSet; 
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct TEXTMETRIC
+        {
+            public int tmHeight;
+            public int tmAscent;
+            public int tmDescent;
+            public int tmInternalLeading;
+            public int tmExternalLeading;
+            public int tmAveCharWidth;
+            public int tmMaxCharWidth;
+            public int tmWeight;
+            public int tmOverhang;
+            public int tmDigitizedAspectX;
+            public int tmDigitizedAspectY;
+            public char tmFirstChar;
+            public char tmLastChar;
+            public char tmDefaultChar;
+            public char tmBreakChar;
+            public byte tmItalic;
+            public byte tmUnderlined;
+            public byte tmStruckOut;
+            public byte tmPitchAndFamily;
+            public byte tmCharSet;
         }
 
-        [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Ansi)]
-        public struct TEXTMETRICA 
-        { 
-            public int  tmHeight; 
-            public int  tmAscent; 
-            public int  tmDescent; 
-            public int  tmInternalLeading; 
-            public int  tmExternalLeading; 
-            public int  tmAveCharWidth; 
-            public int  tmMaxCharWidth; 
-            public int  tmWeight; 
-            public int  tmOverhang; 
-            public int  tmDigitizedAspectX; 
-            public int  tmDigitizedAspectY; 
-            public byte tmFirstChar; 
-            public byte tmLastChar; 
-            public byte tmDefaultChar; 
-            public byte tmBreakChar; 
-            public byte tmItalic; 
-            public byte tmUnderlined; 
-            public byte tmStruckOut; 
-            public byte tmPitchAndFamily; 
-            public byte tmCharSet; 
-        }
-        
         [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Auto)]
         public class NOTIFYICONDATA {
             public int      cbSize = Marshal.SizeOf(typeof(NOTIFYICONDATA));
@@ -3712,8 +3219,6 @@ namespace System.Windows.Forms {
             public IntPtr   hbmpItem = IntPtr.Zero;  // requires WINVER > 5
         }
 
-
-
         [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Unicode)]
         public struct MSAAMENUINFO
         {
@@ -3729,7 +3234,7 @@ namespace System.Windows.Forms {
         }
 
         public delegate bool EnumThreadWindowsCallback(IntPtr hWnd, IntPtr lParam);
-        
+
         [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Auto)]
         public class OPENFILENAME_I
         {
@@ -3757,7 +3262,7 @@ namespace System.Windows.Forms {
             public int      dwReserved = 0;
             public int      FlagsEx;
         }
-        
+
         [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Auto), CLSCompliantAttribute(false)]
         public class CHOOSEFONT {
             public int      lStructSize = Marshal.SizeOf(typeof(CHOOSEFONT));   // ndirect.DllLib.sizeOf(this);
@@ -3778,7 +3283,6 @@ namespace System.Windows.Forms {
             public int      nSizeMax;
         }
 
-        
         [StructLayout(LayoutKind.Sequential)]
         public class BITMAPINFO {
             // bmiHeader was a by-value BITMAPINFOHEADER structure
@@ -3805,7 +3309,7 @@ namespace System.Windows.Forms {
                 //Added to make FxCop happy: doesn't really matter since it's internal...
             }
         }
-        
+
         [StructLayout(LayoutKind.Sequential)]
         public class BITMAPINFOHEADER {
             public int      biSize = 40;    // ndirect.DllLib.sizeOf( this );
@@ -3820,7 +3324,7 @@ namespace System.Windows.Forms {
             public int      biClrUsed = 0;
             public int      biClrImportant = 0;
         }
-        
+
         public class Ole {
             public const int PICTYPE_UNINITIALIZED = -1;
             public const int PICTYPE_NONE          =  0;
@@ -3831,7 +3335,7 @@ namespace System.Windows.Forms {
             public const int STATFLAG_DEFAULT = 0;
             public const int STATFLAG_NONAME = 1;
         }
-        
+
         [StructLayout(LayoutKind.Sequential)]
         public class STATSTG {
 
@@ -3885,9 +3389,6 @@ namespace System.Windows.Forms {
             public uint dwHighDateTime = 0;
         }
 
-
-        
-        
         [StructLayout(LayoutKind.Sequential)]
         public class SYSTEMTIME {
             public short wYear;
@@ -3906,7 +3407,7 @@ namespace System.Windows.Forms {
                 + "]";
             }
         }
-        
+
         [
         StructLayout(LayoutKind.Sequential),
         CLSCompliantAttribute(false)
@@ -3917,14 +3418,13 @@ namespace System.Windows.Forms {
 
         }
 
-        
         [StructLayout(LayoutKind.Sequential)]
         public sealed class tagSIZE {
             public   int cx = 0;
             public   int cy = 0;
 
         }
-        
+
         [StructLayout(LayoutKind.Sequential)]
         public class COMRECT {
             public int left;
@@ -3942,19 +3442,12 @@ namespace System.Windows.Forms {
                 this.bottom = r.Bottom;
             }
 
-            
             public COMRECT(int left, int top, int right, int bottom) {
                 this.left = left;
                 this.top = top;
                 this.right = right;
                 this.bottom = bottom;
             }
-
-            /* Unused
-            public RECT ToRECT() {
-                return new RECT(left, top, right, bottom);
-            }
-            */
 
             public static COMRECT FromXYWH(int x, int y, int width, int height) {
                 return new COMRECT(x, y, x + width, y + height);
@@ -3965,13 +3458,12 @@ namespace System.Windows.Forms {
             }
         }
 
-        
         [StructLayout(LayoutKind.Sequential)/*leftover(noAutoOffset)*/]
         public sealed class tagOleMenuGroupWidths {
             [MarshalAs(UnmanagedType.ByValArray, SizeConst=6)/*leftover(offset=0, widths)*/]
             public int[] widths = new int[6];
         }
-        
+
         [StructLayout(LayoutKind.Sequential)]
         [Serializable]
         public class MSOCRINFOSTRUCT {
@@ -4021,7 +3513,7 @@ namespace System.Windows.Forms {
           public int cAccelEntries;
 
         }
-        
+
         [StructLayout(LayoutKind.Sequential)]
         public struct NMLVFINDITEM
         {
@@ -4029,7 +3521,7 @@ namespace System.Windows.Forms {
             public int iStart;
             public LVFINDINFO lvfi;
         }
-    
+
         [StructLayout(LayoutKind.Sequential)]
         public struct NMHDR
         {
@@ -4037,7 +3529,7 @@ namespace System.Windows.Forms {
             public IntPtr idFrom; //This is declared as UINT_PTR in winuser.h
             public int code;
         }
-        
+
         [ComVisible(true),Guid("626FC520-A41E-11CF-A731-00A0C9082637"), InterfaceTypeAttribute(ComInterfaceType.InterfaceIsDual)]
         internal interface IHTMLDocument {
 
@@ -4076,7 +3568,7 @@ namespace System.Windows.Forms {
                 [Out]
                 VARIANT pVarOut);
         }
-        
+
         [ComImport(), Guid("4D07FC10-F931-11CE-B001-00AA006884E5"), InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown)]
         public interface ICategorizeProperties {
             
@@ -4093,16 +3585,13 @@ namespace System.Windows.Forms {
                 out string categoryName);
         }
 
-      
-        
         [StructLayout(LayoutKind.Sequential)/*leftover(noAutoOffset)*/]
         public sealed class tagSIZEL
         {
             public int cx;
             public int cy;
         }
-       
-        
+
         [StructLayout(LayoutKind.Sequential)/*leftover(noAutoOffset)*/]
         public sealed class tagOLEVERB
         {
@@ -4118,8 +3607,6 @@ namespace System.Windows.Forms {
             public int grfAttribs;
         }
 
-        
-        
         [StructLayout(LayoutKind.Sequential)/*leftover(noAutoOffset)*/]
         public sealed class tagLOGPALETTE
         {
@@ -4130,7 +3617,6 @@ namespace System.Windows.Forms {
             public short palNumEntries = 0;
         }
 
-        
         [StructLayout(LayoutKind.Sequential)/*leftover(noAutoOffset)*/]
         public sealed class tagCONTROLINFO
         {
@@ -4163,11 +3649,10 @@ namespace System.Windows.Forms {
             public short reserved2 = 0;
             [MarshalAs(UnmanagedType.I2)]
             public short reserved3 = 0;
-            
-            public IntPtr data1;
-            
-            public IntPtr data2;
 
+            public IntPtr data1;
+
+            public IntPtr data2;
 
             public bool Byref{
                 get{
@@ -4192,94 +3677,6 @@ namespace System.Windows.Forms {
                 Clear();
             }
 
-            public static VARIANT FromObject(Object var) {
-                VARIANT v = new VARIANT();
-
-                if (var == null) {
-                    v.vt = (int)tagVT.VT_EMPTY;
-                }
-                else if (Convert.IsDBNull(var)) {
-                }
-                else {
-                    Type t = var.GetType();
-
-                    if (t == typeof(bool)) {
-                        v.vt = (int)tagVT.VT_BOOL;
-                    }
-                    else if (t == typeof(byte)) {
-                        v.vt = (int)tagVT.VT_UI1;
-                        v.data1 = (IntPtr)Convert.ToByte(var, CultureInfo.InvariantCulture);
-                    }
-                    else if (t == typeof(char)) {
-                        v.vt = (int)tagVT.VT_UI2;
-                        v.data1 = (IntPtr)Convert.ToChar(var, CultureInfo.InvariantCulture);
-                    }
-                    else if (t == typeof(string)) {
-                        v.vt = (int)tagVT.VT_BSTR;
-                        v.data1 = SysAllocString(Convert.ToString(var, CultureInfo.InvariantCulture));
-                    }
-                    else if (t == typeof(short)) {
-                        v.vt = (int)tagVT.VT_I2;
-                        v.data1 = (IntPtr)Convert.ToInt16(var, CultureInfo.InvariantCulture);
-                    }
-                    else if (t == typeof(int)) {
-                        v.vt = (int)tagVT.VT_I4;
-                        v.data1 = (IntPtr)Convert.ToInt32(var, CultureInfo.InvariantCulture);
-                    }
-                    else if (t == typeof(long)) {
-                        v.vt = (int)tagVT.VT_I8;
-                        v.SetLong(Convert.ToInt64(var, CultureInfo.InvariantCulture));
-                    }
-                    else if (t == typeof(Decimal)) {
-                        v.vt = (int)tagVT.VT_CY;
-                        Decimal c = (Decimal)var;
-                        // Microsoft, it's bizzare that we need to call this as a static!
-                        v.SetLong(Decimal.ToInt64(c));
-                    }
-                    else if (t == typeof(decimal)) {
-                        v.vt = (int)tagVT.VT_DECIMAL;
-                        Decimal d = Convert.ToDecimal(var, CultureInfo.InvariantCulture);
-                        v.SetLong(Decimal.ToInt64(d));
-                    }
-                    else if (t == typeof(double)) {
-                        v.vt = (int)tagVT.VT_R8;
-                        // how do we handle double?
-                    }
-                    else if (t == typeof(float) || t == typeof(Single)) {
-                        v.vt = (int)tagVT.VT_R4;
-                        // how do we handle float?
-                    }
-                    else if (t == typeof(DateTime)) {
-                        v.vt = (int)tagVT.VT_DATE;
-                        v.SetLong(Convert.ToDateTime(var, CultureInfo.InvariantCulture).ToFileTime());
-                    }
-                    else if (t == typeof(SByte)) {
-                        v.vt = (int)tagVT.VT_I1;
-                        v.data1 = (IntPtr)Convert.ToSByte(var, CultureInfo.InvariantCulture);
-                    }
-                    else if (t == typeof(UInt16)) {
-                        v.vt = (int)tagVT.VT_UI2;
-                        v.data1 = (IntPtr)Convert.ToUInt16(var, CultureInfo.InvariantCulture);
-                    }
-                    else if (t == typeof(UInt32)) {
-                        v.vt = (int)tagVT.VT_UI4;
-                        v.data1 = (IntPtr)Convert.ToUInt32(var, CultureInfo.InvariantCulture);
-                    }
-                    else if (t == typeof(UInt64)) {
-                        v.vt = (int)tagVT.VT_UI8;
-                        v.SetLong((long)Convert.ToUInt64(var, CultureInfo.InvariantCulture));
-                    }
-                    else if (t == typeof(object) || t == typeof(UnsafeNativeMethods.IDispatch) || t.IsCOMObject) {
-                        v.vt = (t == typeof(UnsafeNativeMethods.IDispatch) ? (short)tagVT.VT_DISPATCH : (short)tagVT.VT_UNKNOWN);
-                        v.data1 = Marshal.GetIUnknownForObject(var);
-                    }
-                    else {
-                        throw new ArgumentException(string.Format(SR.ConnPointUnhandledType, t.Name));
-                    }
-                }
-                return v;
-            }
-
             [DllImport(ExternDll.Oleaut32,CharSet=CharSet.Auto)]
             [ResourceExposure(ResourceScope.None)]
             private static extern IntPtr SysAllocString([In, MarshalAs(UnmanagedType.LPWStr)]string s);
@@ -4291,17 +3688,6 @@ namespace System.Windows.Forms {
             public void SetLong(long lVal) {
                 data1 = (IntPtr)(lVal & 0xFFFFFFFF);
                 data2 = (IntPtr)((lVal >> 32) & 0xFFFFFFFF);
-            }
-
-            public IntPtr ToCoTaskMemPtr() {
-                IntPtr mem = Marshal.AllocCoTaskMem(16);
-                Marshal.WriteInt16(mem, vt);
-                Marshal.WriteInt16(mem, 2, reserved1);
-                Marshal.WriteInt16(mem, 4, reserved2);
-                Marshal.WriteInt16(mem, 6, reserved3);
-                Marshal.WriteInt32(mem, 8, (int) data1);
-                Marshal.WriteInt32(mem, 12, (int) data2);
-                return mem;
             }
 
             public object ToObject() {
@@ -4459,7 +3845,7 @@ namespace System.Windows.Forms {
                 return Marshal.ReadIntPtr(value);
             }
         }
-        
+
         [StructLayout(LayoutKind.Sequential)/*leftover(noAutoOffset)*/]
         public sealed class tagLICINFO
         {
@@ -4469,7 +3855,7 @@ namespace System.Windows.Forms {
           public int fRuntimeAvailable = 0;
           public int fLicVerified = 0;
         }
-        
+
         public enum  tagVT {
             VT_EMPTY = 0,
             VT_NULL = 1,
@@ -4521,8 +3907,7 @@ namespace System.Windows.Forms {
             VT_ILLEGALMASKED = 4095,
             VT_TYPEMASK = 4095
         }
-        
-    
+
         [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Auto)]
         public class WNDCLASS_D {
             public int      style;
@@ -4536,7 +3921,7 @@ namespace System.Windows.Forms {
             public string   lpszMenuName = null;
             public string   lpszClassName = null;
         }
-    
+
         public class MSOCM {
             // MSO Component registration flags
             public const int msocrfNeedIdleTime         = 1;
@@ -4657,7 +4042,7 @@ namespace System.Windows.Forms {
             public const int msocWindowComponent = 2;
             public const int msocWindowDlgOwner = 3;
         }
-        
+
         [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Auto)]
         public class TOOLINFO_T
         {
@@ -4671,7 +4056,6 @@ namespace System.Windows.Forms {
             public IntPtr   lParam = IntPtr.Zero;
         }
 
-
         [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Auto)]
         public class TOOLINFO_TOOLTIP
         {
@@ -4684,7 +4068,6 @@ namespace System.Windows.Forms {
             public IntPtr   lpszText;
             public IntPtr   lParam = IntPtr.Zero;
         }
-
 
         [StructLayout(LayoutKind.Sequential)]
         public sealed class tagDVTARGETDEVICE {
@@ -4700,8 +4083,6 @@ namespace System.Windows.Forms {
             public   short tdExtDevmodeOffset = 0;
         }
 
-
-        
         [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Auto)]
         public struct TV_ITEM {
             public int      mask;
@@ -4715,15 +4096,6 @@ namespace System.Windows.Forms {
             public int      cChildren;
             public IntPtr   lParam;
         }
-
-        [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Auto)]
-        public struct TVSORTCB {
-            public IntPtr                                         hParent;
-            public NativeMethods.TreeViewCompareCallback          lpfnCompare;
-            public IntPtr                                         lParam;
-        }
-        
-
 
         [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Auto)]
         public struct TV_INSERTSTRUCT {
@@ -4766,25 +4138,18 @@ namespace System.Windows.Forms {
             public IntPtr   lParam;
 
         }
-        
+
         [StructLayout(LayoutKind.Sequential)]
         public class NMTVDISPINFO
         {
             public NMHDR    hdr;
             public TV_ITEM  item;
         }
-        
+
         [StructLayout(LayoutKind.Sequential)]
         public sealed class POINTL {
             public   int x;
             public   int y;
-        }
-    
-        [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Auto)]
-        public struct HIGHCONTRAST {
-            public int cbSize;
-            public int dwFlags;
-            public string lpszDefaultScheme;
         }
 
         [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Auto)]
@@ -4814,7 +4179,7 @@ namespace System.Windows.Forms {
             public int      iImage;
             public IntPtr   lParam;
         }
-        
+
         [StructLayout(LayoutKind.Sequential)/*leftover(noAutoOffset)*/]
         public sealed class tagDISPPARAMS
         {
@@ -4825,14 +4190,14 @@ namespace System.Windows.Forms {
           [MarshalAs(UnmanagedType.U4)/*leftover(offset=12, cNamedArgs)*/]
           public int cNamedArgs;
         }
-        
+
         public enum  tagINVOKEKIND {
             INVOKE_FUNC = 1,
             INVOKE_PROPERTYGET = 2,
             INVOKE_PROPERTYPUT = 4,
             INVOKE_PROPERTYPUTREF = 8
         }
-        
+
         [StructLayout(LayoutKind.Sequential)]
         public class tagEXCEPINFO {
             [MarshalAs(UnmanagedType.U2)]
@@ -4863,7 +4228,7 @@ namespace System.Windows.Forms {
             DESCKIND_IMPLICITAPPOBJ = 4,
             DESCKIND_MAX = 5
         }
-        
+
         [StructLayout(LayoutKind.Sequential)]
         public sealed class tagFUNCDESC {
             public   int memid = 0;
@@ -4908,13 +4273,13 @@ namespace System.Windows.Forms {
             public   short wVarFlags = 0;
             public    /*NativeMethods.tagVARKIND*/ int varkind = 0;
         }
-        
+
         [StructLayout(LayoutKind.Sequential)]
         public struct  value_tagELEMDESC {
             public    NativeMethods.tagTYPEDESC tdesc;
             public    NativeMethods.tagPARAMDESC paramdesc;
         }
-        
+
         [StructLayout(LayoutKind.Sequential)]
         public struct WINDOWPOS {
             public IntPtr hwnd;
@@ -4931,7 +4296,7 @@ namespace System.Windows.Forms {
             public IntPtr       prc;        // pointer to a RECT
             public IntPtr       pwpos;      // pointer to a WINDOWPOS
         }
-        
+
         [StructLayout(LayoutKind.Sequential)]
         public class DRAWITEMSTRUCT {
             public int CtlType = 0;
@@ -4944,7 +4309,7 @@ namespace System.Windows.Forms {
             public RECT   rcItem;
             public IntPtr itemData = IntPtr.Zero;
         }
-        
+
         [StructLayout(LayoutKind.Sequential)]
         public class MEASUREITEMSTRUCT {
             public int CtlType = 0;
@@ -4954,7 +4319,7 @@ namespace System.Windows.Forms {
             public int itemHeight = 0;
             public IntPtr itemData = IntPtr.Zero;
         }
-        
+
         [StructLayout(LayoutKind.Sequential)]
         public class HELPINFO {
             public int      cbSize = Marshal.SizeOf(typeof(HELPINFO));
@@ -4964,14 +4329,14 @@ namespace System.Windows.Forms {
             public IntPtr   dwContextId = IntPtr.Zero;
             public POINT    MousePos = null;
         }
-    
+
         [StructLayout(LayoutKind.Sequential)]
         public class ACCEL {
             public byte fVirt;
             public short key;
             public short cmd;
         }
-        
+
         [StructLayout(LayoutKind.Sequential)]
         public class MINMAXINFO {
             public POINT    ptReserved = null;
@@ -4981,8 +4346,6 @@ namespace System.Windows.Forms {
             public POINT    ptMaxTrackSize = null;
         }
 
-
-    
         [ComImport(), Guid("B196B28B-BAB4-101A-B69C-00AA00341D07"), InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown)]
         public interface ISpecifyPropertyPages {
              void GetPages(
@@ -4990,7 +4353,7 @@ namespace System.Windows.Forms {
                 NativeMethods.tagCAUUID pPages);
 
         }
-        
+
         [StructLayout(LayoutKind.Sequential)/*leftover(noAutoOffset)*/]
         public sealed class tagCAUUID
         {
@@ -5033,20 +4396,7 @@ namespace System.Windows.Forms {
             public IntPtr hinst;
             public int    uFlags;
         }
-        
-        [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Ansi)]
-        public class TOOLTIPTEXTA
-        {
-            public NMHDR  hdr;
-            public string lpszText;
-            
-            [MarshalAs(UnmanagedType.ByValTStr, SizeConst=80)]
-            public string szText = null;
-            
-            public IntPtr hinst;
-            public int    uFlags;
-        }
-        
+
         [StructLayout(LayoutKind.Sequential)]
         public struct NMTBHOTITEM
         {
@@ -5066,26 +4416,6 @@ namespace System.Windows.Forms {
         public const int HICF_RESELECT          = 0x00000040;          // hot item reselected
         public const int HICF_LMOUSE            = 0x00000080;          // left mouse button selected
         public const int HICF_TOGGLEDROPDOWN    = 0x00000100;          // Toggle button's dropdown state
-
-
-    /*
-    Microsoft: dead code. Keep it in case we need an HDITEM class where the pszText is actually set.
-    [StructLayout(LayoutKind.Sequential,CharSet=CharSet.Auto)]
-    public class HDITEM
-    {
-        public int      mask = 0;
-        public int      cxy = 0;
-        public string   pszText = null;
-        public IntPtr   hbm = IntPtr.Zero;
-        public int      cchTextMax = 0;
-        public int      fmt = 0;
-        public IntPtr   lParam = IntPtr.Zero;
-        public int      iImage = 0;
-        public int      iOrder = 0;
-        public int      type = 0;
-        public IntPtr   pvFilter = IntPtr.Zero;
-    }
-    */
 
     // HDN_ITEMCHANGING will send us an HDITEM w/ pszText set to some random pointer.
     // Marshal.PtrToStructure chokes when it has to convert a random pointer to a string.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NativeMethods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NativeMethods.cs
@@ -2437,196 +2437,99 @@ namespace System.Windows.Forms {
             SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         static NativeMethods()
         {
-            if (Marshal.SystemDefaultCharSize == 1) {
-                BFFM_SETSELECTION = NativeMethods.BFFM_SETSELECTIONA;
-                CBEM_GETITEM = NativeMethods.CBEM_GETITEMA;
-                CBEM_SETITEM = NativeMethods.CBEM_SETITEMA;
-                CBEN_ENDEDIT = NativeMethods.CBEN_ENDEDITA;
-                CBEM_INSERTITEM = NativeMethods.CBEM_INSERTITEMA;
-                LVM_GETITEMTEXT = NativeMethods.LVM_GETITEMTEXTA;
-                LVM_SETITEMTEXT = NativeMethods.LVM_SETITEMTEXTA;
-                ACM_OPEN = NativeMethods.ACM_OPENA;
-                DTM_SETFORMAT = NativeMethods.DTM_SETFORMATA;
-                DTN_USERSTRING = NativeMethods.DTN_USERSTRINGA;
-                DTN_WMKEYDOWN = NativeMethods.DTN_WMKEYDOWNA;
-                DTN_FORMAT = NativeMethods.DTN_FORMATA;
-                DTN_FORMATQUERY = NativeMethods.DTN_FORMATQUERYA;
-                EMR_POLYTEXTOUT = NativeMethods.EMR_POLYTEXTOUTA;
-                HDM_INSERTITEM = NativeMethods.HDM_INSERTITEMA;
-                HDM_GETITEM = NativeMethods.HDM_GETITEMA;
-                HDM_SETITEM = NativeMethods.HDM_SETITEMA;
-                HDN_ITEMCHANGING = NativeMethods.HDN_ITEMCHANGINGA;
-                HDN_ITEMCHANGED = NativeMethods.HDN_ITEMCHANGEDA;
-                HDN_ITEMCLICK = NativeMethods.HDN_ITEMCLICKA;
-                HDN_ITEMDBLCLICK = NativeMethods.HDN_ITEMDBLCLICKA;
-                HDN_DIVIDERDBLCLICK = NativeMethods.HDN_DIVIDERDBLCLICKA;
-                HDN_BEGINTRACK = NativeMethods.HDN_BEGINTRACKA;
-                HDN_ENDTRACK = NativeMethods.HDN_ENDTRACKA;
-                HDN_TRACK = NativeMethods.HDN_TRACKA;
-                HDN_GETDISPINFO = NativeMethods.HDN_GETDISPINFOA;
-                LVM_SETBKIMAGE = NativeMethods.LVM_SETBKIMAGEA;
-                LVM_GETITEM = NativeMethods.LVM_GETITEMA;
-                LVM_SETITEM = NativeMethods.LVM_SETITEMA;
-                LVM_INSERTITEM = NativeMethods.LVM_INSERTITEMA;
-                LVM_FINDITEM = NativeMethods.LVM_FINDITEMA;
-                LVM_GETSTRINGWIDTH = NativeMethods.LVM_GETSTRINGWIDTHA;
-                LVM_EDITLABEL = NativeMethods.LVM_EDITLABELA;
-                LVM_GETCOLUMN = NativeMethods.LVM_GETCOLUMNA;
-                LVM_SETCOLUMN = NativeMethods.LVM_SETCOLUMNA;
-                LVM_GETISEARCHSTRING = NativeMethods.LVM_GETISEARCHSTRINGA;
-                LVM_INSERTCOLUMN = NativeMethods.LVM_INSERTCOLUMNA;
-                LVN_BEGINLABELEDIT = NativeMethods.LVN_BEGINLABELEDITA;
-                LVN_ENDLABELEDIT = NativeMethods.LVN_ENDLABELEDITA;
-                LVN_ODFINDITEM = NativeMethods.LVN_ODFINDITEMA;
-                LVN_GETDISPINFO = NativeMethods.LVN_GETDISPINFOA;
-                LVN_GETINFOTIP = NativeMethods.LVN_GETINFOTIPA;
-                LVN_SETDISPINFO = NativeMethods.LVN_SETDISPINFOA;
-                PSM_SETTITLE = NativeMethods.PSM_SETTITLEA;
-                PSM_SETFINISHTEXT = NativeMethods.PSM_SETFINISHTEXTA;
-                RB_INSERTBAND = NativeMethods.RB_INSERTBANDA;
-                SB_SETTEXT = NativeMethods.SB_SETTEXTA;
-                SB_GETTEXT = NativeMethods.SB_GETTEXTA;
-                SB_GETTEXTLENGTH = NativeMethods.SB_GETTEXTLENGTHA;
-                SB_SETTIPTEXT = NativeMethods.SB_SETTIPTEXTA;
-                SB_GETTIPTEXT = NativeMethods.SB_GETTIPTEXTA;
-                TB_SAVERESTORE = NativeMethods.TB_SAVERESTOREA;
-                TB_ADDSTRING = NativeMethods.TB_ADDSTRINGA;
-                TB_GETBUTTONTEXT = NativeMethods.TB_GETBUTTONTEXTA;
-                TB_MAPACCELERATOR = NativeMethods.TB_MAPACCELERATORA;
-                TB_GETBUTTONINFO = NativeMethods.TB_GETBUTTONINFOA;
-                TB_SETBUTTONINFO = NativeMethods.TB_SETBUTTONINFOA;
-                TB_INSERTBUTTON = NativeMethods.TB_INSERTBUTTONA;
-                TB_ADDBUTTONS = NativeMethods.TB_ADDBUTTONSA;
-                TBN_GETBUTTONINFO = NativeMethods.TBN_GETBUTTONINFOA;
-                TBN_GETINFOTIP = NativeMethods.TBN_GETINFOTIPA;
-                TBN_GETDISPINFO = NativeMethods.TBN_GETDISPINFOA;
-                TTM_ADDTOOL = NativeMethods.TTM_ADDTOOLA;
-                TTM_SETTITLE = NativeMethods.TTM_SETTITLEA;
-                TTM_DELTOOL = NativeMethods.TTM_DELTOOLA;
-                TTM_NEWTOOLRECT = NativeMethods.TTM_NEWTOOLRECTA;
-                TTM_GETTOOLINFO = NativeMethods.TTM_GETTOOLINFOA;
-                TTM_SETTOOLINFO = NativeMethods.TTM_SETTOOLINFOA;
-                TTM_HITTEST = NativeMethods.TTM_HITTESTA;
-                TTM_GETTEXT = NativeMethods.TTM_GETTEXTA;
-                TTM_UPDATETIPTEXT = NativeMethods.TTM_UPDATETIPTEXTA;
-                TTM_ENUMTOOLS = NativeMethods.TTM_ENUMTOOLSA;
-                TTM_GETCURRENTTOOL = NativeMethods.TTM_GETCURRENTTOOLA;
-                TTN_GETDISPINFO = NativeMethods.TTN_GETDISPINFOA;
-                TTN_NEEDTEXT = NativeMethods.TTN_NEEDTEXTA;
-                TVM_INSERTITEM = NativeMethods.TVM_INSERTITEMA;
-                TVM_GETITEM = NativeMethods.TVM_GETITEMA;
-                TVM_SETITEM = NativeMethods.TVM_SETITEMA;
-                TVM_EDITLABEL = NativeMethods.TVM_EDITLABELA;
-                TVM_GETISEARCHSTRING = NativeMethods.TVM_GETISEARCHSTRINGA;
-                TVN_SELCHANGING = NativeMethods.TVN_SELCHANGINGA;
-                TVN_SELCHANGED = NativeMethods.TVN_SELCHANGEDA;
-                TVN_GETDISPINFO = NativeMethods.TVN_GETDISPINFOA;
-                TVN_SETDISPINFO = NativeMethods.TVN_SETDISPINFOA;
-                TVN_ITEMEXPANDING = NativeMethods.TVN_ITEMEXPANDINGA;
-                TVN_ITEMEXPANDED = NativeMethods.TVN_ITEMEXPANDEDA;
-                TVN_BEGINDRAG = NativeMethods.TVN_BEGINDRAGA;
-                TVN_BEGINRDRAG = NativeMethods.TVN_BEGINRDRAGA;
-                TVN_BEGINLABELEDIT = NativeMethods.TVN_BEGINLABELEDITA;
-                TVN_ENDLABELEDIT = NativeMethods.TVN_ENDLABELEDITA;
-                TCM_GETITEM = NativeMethods.TCM_GETITEMA;
-                TCM_SETITEM = NativeMethods.TCM_SETITEMA;
-                TCM_INSERTITEM = NativeMethods.TCM_INSERTITEMA;
-            }
-            else {
-                BFFM_SETSELECTION = NativeMethods.BFFM_SETSELECTIONW;
-                CBEM_GETITEM = NativeMethods.CBEM_GETITEMW;
-                CBEM_SETITEM = NativeMethods.CBEM_SETITEMW;
-                CBEN_ENDEDIT = NativeMethods.CBEN_ENDEDITW;
-                CBEM_INSERTITEM = NativeMethods.CBEM_INSERTITEMW;
-                LVM_GETITEMTEXT = NativeMethods.LVM_GETITEMTEXTW;
-                LVM_SETITEMTEXT = NativeMethods.LVM_SETITEMTEXTW;
-                ACM_OPEN = NativeMethods.ACM_OPENW;
-                DTM_SETFORMAT = NativeMethods.DTM_SETFORMATW;
-                DTN_USERSTRING = NativeMethods.DTN_USERSTRINGW;
-                DTN_WMKEYDOWN = NativeMethods.DTN_WMKEYDOWNW;
-                DTN_FORMAT = NativeMethods.DTN_FORMATW;
-                DTN_FORMATQUERY = NativeMethods.DTN_FORMATQUERYW;
-                EMR_POLYTEXTOUT = NativeMethods.EMR_POLYTEXTOUTW;
-                HDM_INSERTITEM = NativeMethods.HDM_INSERTITEMW;
-                HDM_GETITEM = NativeMethods.HDM_GETITEMW;
-                HDM_SETITEM = NativeMethods.HDM_SETITEMW;
-                HDN_ITEMCHANGING = NativeMethods.HDN_ITEMCHANGINGW;
-                HDN_ITEMCHANGED = NativeMethods.HDN_ITEMCHANGEDW;
-                HDN_ITEMCLICK = NativeMethods.HDN_ITEMCLICKW;
-                HDN_ITEMDBLCLICK = NativeMethods.HDN_ITEMDBLCLICKW;
-                HDN_DIVIDERDBLCLICK = NativeMethods.HDN_DIVIDERDBLCLICKW;
-                HDN_BEGINTRACK = NativeMethods.HDN_BEGINTRACKW;
-                HDN_ENDTRACK = NativeMethods.HDN_ENDTRACKW;
-                HDN_TRACK = NativeMethods.HDN_TRACKW;
-                HDN_GETDISPINFO = NativeMethods.HDN_GETDISPINFOW;
-                LVM_SETBKIMAGE = NativeMethods.LVM_SETBKIMAGEW;
-                LVM_GETITEM = NativeMethods.LVM_GETITEMW;
-                LVM_SETITEM = NativeMethods.LVM_SETITEMW;
-                LVM_INSERTITEM = NativeMethods.LVM_INSERTITEMW;
-                LVM_FINDITEM = NativeMethods.LVM_FINDITEMW;
-                LVM_GETSTRINGWIDTH = NativeMethods.LVM_GETSTRINGWIDTHW;
-                LVM_EDITLABEL = NativeMethods.LVM_EDITLABELW;
-                LVM_GETCOLUMN = NativeMethods.LVM_GETCOLUMNW;
-                LVM_SETCOLUMN = NativeMethods.LVM_SETCOLUMNW;
-                LVM_GETISEARCHSTRING = NativeMethods.LVM_GETISEARCHSTRINGW;
-                LVM_INSERTCOLUMN = NativeMethods.LVM_INSERTCOLUMNW;
-                LVN_BEGINLABELEDIT = NativeMethods.LVN_BEGINLABELEDITW;
-                LVN_ENDLABELEDIT = NativeMethods.LVN_ENDLABELEDITW;
-                LVN_ODFINDITEM = NativeMethods.LVN_ODFINDITEMW;
-                LVN_GETDISPINFO = NativeMethods.LVN_GETDISPINFOW;
-                LVN_GETINFOTIP = NativeMethods.LVN_GETINFOTIPW;
-                LVN_SETDISPINFO = NativeMethods.LVN_SETDISPINFOW;
-                PSM_SETTITLE = NativeMethods.PSM_SETTITLEW;
-                PSM_SETFINISHTEXT = NativeMethods.PSM_SETFINISHTEXTW;
-                RB_INSERTBAND = NativeMethods.RB_INSERTBANDW;
-                SB_SETTEXT = NativeMethods.SB_SETTEXTW;
-                SB_GETTEXT = NativeMethods.SB_GETTEXTW;
-                SB_GETTEXTLENGTH = NativeMethods.SB_GETTEXTLENGTHW;
-                SB_SETTIPTEXT = NativeMethods.SB_SETTIPTEXTW;
-                SB_GETTIPTEXT = NativeMethods.SB_GETTIPTEXTW;
-                TB_SAVERESTORE = NativeMethods.TB_SAVERESTOREW;
-                TB_ADDSTRING = NativeMethods.TB_ADDSTRINGW;
-                TB_GETBUTTONTEXT = NativeMethods.TB_GETBUTTONTEXTW;
-                TB_MAPACCELERATOR = NativeMethods.TB_MAPACCELERATORW;
-                TB_GETBUTTONINFO = NativeMethods.TB_GETBUTTONINFOW;
-                TB_SETBUTTONINFO = NativeMethods.TB_SETBUTTONINFOW;
-                TB_INSERTBUTTON = NativeMethods.TB_INSERTBUTTONW;
-                TB_ADDBUTTONS = NativeMethods.TB_ADDBUTTONSW;
-                TBN_GETBUTTONINFO = NativeMethods.TBN_GETBUTTONINFOW;
-                TBN_GETINFOTIP = NativeMethods.TBN_GETINFOTIPW;
-                TBN_GETDISPINFO = NativeMethods.TBN_GETDISPINFOW;
-                TTM_ADDTOOL = NativeMethods.TTM_ADDTOOLW;
-                TTM_SETTITLE = NativeMethods.TTM_SETTITLEW;
-                TTM_DELTOOL = NativeMethods.TTM_DELTOOLW;
-                TTM_NEWTOOLRECT = NativeMethods.TTM_NEWTOOLRECTW;
-                TTM_GETTOOLINFO = NativeMethods.TTM_GETTOOLINFOW;
-                TTM_SETTOOLINFO = NativeMethods.TTM_SETTOOLINFOW;
-                TTM_HITTEST = NativeMethods.TTM_HITTESTW;
-                TTM_GETTEXT = NativeMethods.TTM_GETTEXTW;
-                TTM_UPDATETIPTEXT = NativeMethods.TTM_UPDATETIPTEXTW;
-                TTM_ENUMTOOLS = NativeMethods.TTM_ENUMTOOLSW;
-                TTM_GETCURRENTTOOL = NativeMethods.TTM_GETCURRENTTOOLW;
-                TTN_GETDISPINFO = NativeMethods.TTN_GETDISPINFOW;
-                TTN_NEEDTEXT = NativeMethods.TTN_NEEDTEXTW;
-                TVM_INSERTITEM = NativeMethods.TVM_INSERTITEMW;
-                TVM_GETITEM = NativeMethods.TVM_GETITEMW;
-                TVM_SETITEM = NativeMethods.TVM_SETITEMW;
-                TVM_EDITLABEL = NativeMethods.TVM_EDITLABELW;
-                TVM_GETISEARCHSTRING = NativeMethods.TVM_GETISEARCHSTRINGW;
-                TVN_SELCHANGING = NativeMethods.TVN_SELCHANGINGW;
-                TVN_SELCHANGED = NativeMethods.TVN_SELCHANGEDW;
-                TVN_GETDISPINFO = NativeMethods.TVN_GETDISPINFOW;
-                TVN_SETDISPINFO = NativeMethods.TVN_SETDISPINFOW;
-                TVN_ITEMEXPANDING = NativeMethods.TVN_ITEMEXPANDINGW;
-                TVN_ITEMEXPANDED = NativeMethods.TVN_ITEMEXPANDEDW;
-                TVN_BEGINDRAG = NativeMethods.TVN_BEGINDRAGW;
-                TVN_BEGINRDRAG = NativeMethods.TVN_BEGINRDRAGW;
-                TVN_BEGINLABELEDIT = NativeMethods.TVN_BEGINLABELEDITW;
-                TVN_ENDLABELEDIT = NativeMethods.TVN_ENDLABELEDITW;
-                TCM_GETITEM = NativeMethods.TCM_GETITEMW;
-                TCM_SETITEM = NativeMethods.TCM_SETITEMW;
-                TCM_INSERTITEM = NativeMethods.TCM_INSERTITEMW;
-            }
+            BFFM_SETSELECTION = NativeMethods.BFFM_SETSELECTIONW;
+            CBEM_GETITEM = NativeMethods.CBEM_GETITEMW;
+            CBEM_SETITEM = NativeMethods.CBEM_SETITEMW;
+            CBEN_ENDEDIT = NativeMethods.CBEN_ENDEDITW;
+            CBEM_INSERTITEM = NativeMethods.CBEM_INSERTITEMW;
+            LVM_GETITEMTEXT = NativeMethods.LVM_GETITEMTEXTW;
+            LVM_SETITEMTEXT = NativeMethods.LVM_SETITEMTEXTW;
+            ACM_OPEN = NativeMethods.ACM_OPENW;
+            DTM_SETFORMAT = NativeMethods.DTM_SETFORMATW;
+            DTN_USERSTRING = NativeMethods.DTN_USERSTRINGW;
+            DTN_WMKEYDOWN = NativeMethods.DTN_WMKEYDOWNW;
+            DTN_FORMAT = NativeMethods.DTN_FORMATW;
+            DTN_FORMATQUERY = NativeMethods.DTN_FORMATQUERYW;
+            EMR_POLYTEXTOUT = NativeMethods.EMR_POLYTEXTOUTW;
+            HDM_INSERTITEM = NativeMethods.HDM_INSERTITEMW;
+            HDM_GETITEM = NativeMethods.HDM_GETITEMW;
+            HDM_SETITEM = NativeMethods.HDM_SETITEMW;
+            HDN_ITEMCHANGING = NativeMethods.HDN_ITEMCHANGINGW;
+            HDN_ITEMCHANGED = NativeMethods.HDN_ITEMCHANGEDW;
+            HDN_ITEMCLICK = NativeMethods.HDN_ITEMCLICKW;
+            HDN_ITEMDBLCLICK = NativeMethods.HDN_ITEMDBLCLICKW;
+            HDN_DIVIDERDBLCLICK = NativeMethods.HDN_DIVIDERDBLCLICKW;
+            HDN_BEGINTRACK = NativeMethods.HDN_BEGINTRACKW;
+            HDN_ENDTRACK = NativeMethods.HDN_ENDTRACKW;
+            HDN_TRACK = NativeMethods.HDN_TRACKW;
+            HDN_GETDISPINFO = NativeMethods.HDN_GETDISPINFOW;
+            LVM_SETBKIMAGE = NativeMethods.LVM_SETBKIMAGEW;
+            LVM_GETITEM = NativeMethods.LVM_GETITEMW;
+            LVM_SETITEM = NativeMethods.LVM_SETITEMW;
+            LVM_INSERTITEM = NativeMethods.LVM_INSERTITEMW;
+            LVM_FINDITEM = NativeMethods.LVM_FINDITEMW;
+            LVM_GETSTRINGWIDTH = NativeMethods.LVM_GETSTRINGWIDTHW;
+            LVM_EDITLABEL = NativeMethods.LVM_EDITLABELW;
+            LVM_GETCOLUMN = NativeMethods.LVM_GETCOLUMNW;
+            LVM_SETCOLUMN = NativeMethods.LVM_SETCOLUMNW;
+            LVM_GETISEARCHSTRING = NativeMethods.LVM_GETISEARCHSTRINGW;
+            LVM_INSERTCOLUMN = NativeMethods.LVM_INSERTCOLUMNW;
+            LVN_BEGINLABELEDIT = NativeMethods.LVN_BEGINLABELEDITW;
+            LVN_ENDLABELEDIT = NativeMethods.LVN_ENDLABELEDITW;
+            LVN_ODFINDITEM = NativeMethods.LVN_ODFINDITEMW;
+            LVN_GETDISPINFO = NativeMethods.LVN_GETDISPINFOW;
+            LVN_GETINFOTIP = NativeMethods.LVN_GETINFOTIPW;
+            LVN_SETDISPINFO = NativeMethods.LVN_SETDISPINFOW;
+            PSM_SETTITLE = NativeMethods.PSM_SETTITLEW;
+            PSM_SETFINISHTEXT = NativeMethods.PSM_SETFINISHTEXTW;
+            RB_INSERTBAND = NativeMethods.RB_INSERTBANDW;
+            SB_SETTEXT = NativeMethods.SB_SETTEXTW;
+            SB_GETTEXT = NativeMethods.SB_GETTEXTW;
+            SB_GETTEXTLENGTH = NativeMethods.SB_GETTEXTLENGTHW;
+            SB_SETTIPTEXT = NativeMethods.SB_SETTIPTEXTW;
+            SB_GETTIPTEXT = NativeMethods.SB_GETTIPTEXTW;
+            TB_SAVERESTORE = NativeMethods.TB_SAVERESTOREW;
+            TB_ADDSTRING = NativeMethods.TB_ADDSTRINGW;
+            TB_GETBUTTONTEXT = NativeMethods.TB_GETBUTTONTEXTW;
+            TB_MAPACCELERATOR = NativeMethods.TB_MAPACCELERATORW;
+            TB_GETBUTTONINFO = NativeMethods.TB_GETBUTTONINFOW;
+            TB_SETBUTTONINFO = NativeMethods.TB_SETBUTTONINFOW;
+            TB_INSERTBUTTON = NativeMethods.TB_INSERTBUTTONW;
+            TB_ADDBUTTONS = NativeMethods.TB_ADDBUTTONSW;
+            TBN_GETBUTTONINFO = NativeMethods.TBN_GETBUTTONINFOW;
+            TBN_GETINFOTIP = NativeMethods.TBN_GETINFOTIPW;
+            TBN_GETDISPINFO = NativeMethods.TBN_GETDISPINFOW;
+            TTM_ADDTOOL = NativeMethods.TTM_ADDTOOLW;
+            TTM_SETTITLE = NativeMethods.TTM_SETTITLEW;
+            TTM_DELTOOL = NativeMethods.TTM_DELTOOLW;
+            TTM_NEWTOOLRECT = NativeMethods.TTM_NEWTOOLRECTW;
+            TTM_GETTOOLINFO = NativeMethods.TTM_GETTOOLINFOW;
+            TTM_SETTOOLINFO = NativeMethods.TTM_SETTOOLINFOW;
+            TTM_HITTEST = NativeMethods.TTM_HITTESTW;
+            TTM_GETTEXT = NativeMethods.TTM_GETTEXTW;
+            TTM_UPDATETIPTEXT = NativeMethods.TTM_UPDATETIPTEXTW;
+            TTM_ENUMTOOLS = NativeMethods.TTM_ENUMTOOLSW;
+            TTM_GETCURRENTTOOL = NativeMethods.TTM_GETCURRENTTOOLW;
+            TTN_GETDISPINFO = NativeMethods.TTN_GETDISPINFOW;
+            TTN_NEEDTEXT = NativeMethods.TTN_NEEDTEXTW;
+            TVM_INSERTITEM = NativeMethods.TVM_INSERTITEMW;
+            TVM_GETITEM = NativeMethods.TVM_GETITEMW;
+            TVM_SETITEM = NativeMethods.TVM_SETITEMW;
+            TVM_EDITLABEL = NativeMethods.TVM_EDITLABELW;
+            TVM_GETISEARCHSTRING = NativeMethods.TVM_GETISEARCHSTRINGW;
+            TVN_SELCHANGING = NativeMethods.TVN_SELCHANGINGW;
+            TVN_SELCHANGED = NativeMethods.TVN_SELCHANGEDW;
+            TVN_GETDISPINFO = NativeMethods.TVN_GETDISPINFOW;
+            TVN_SETDISPINFO = NativeMethods.TVN_SETDISPINFOW;
+            TVN_ITEMEXPANDING = NativeMethods.TVN_ITEMEXPANDINGW;
+            TVN_ITEMEXPANDED = NativeMethods.TVN_ITEMEXPANDEDW;
+            TVN_BEGINDRAG = NativeMethods.TVN_BEGINDRAGW;
+            TVN_BEGINRDRAG = NativeMethods.TVN_BEGINRDRAGW;
+            TVN_BEGINLABELEDIT = NativeMethods.TVN_BEGINLABELEDITW;
+            TVN_ENDLABELEDIT = NativeMethods.TVN_ENDLABELEDITW;
+            TCM_GETITEM = NativeMethods.TCM_GETITEMW;
+            TCM_SETITEM = NativeMethods.TCM_SETITEMW;
+            TCM_INSERTITEM = NativeMethods.TCM_INSERTITEMW;
         }
 
         /*
@@ -6052,53 +5955,22 @@ namespace System.Windows.Forms {
                 
                 return i;
             }
-    
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.Util.GetPInvokeStringLength"]/*' />
-            /// <devdoc>
-            ///     Computes the string size that should be passed to a typical Win32 call.
-            ///     This will be the character count under NT, and the ubyte count for Windows 95.
-            /// </devdoc>
-            public static int GetPInvokeStringLength(String s) {
-                if (s == null) {
-                    return 0;
-                }
-    
-                if (Marshal.SystemDefaultCharSize == 2) {
-                    return s.Length;
-                }
-                else {
-                    if (s.Length == 0) {
-                        return 0;
-                    }
-                    if (s.IndexOf('\0') > -1) {
-                        return GetEmbeddedNullStringLengthAnsi(s);
-                    }
-                    else {
-                        return lstrlen(s);
-                    }
-                }
-            }
-    
+
             private static int GetEmbeddedNullStringLengthAnsi(String s) {
                 int n = s.IndexOf('\0');
                 if (n > -1) {
                     String left = s.Substring(0, n);
                     String right = s.Substring(n+1);
-                    return GetPInvokeStringLength(left) + GetEmbeddedNullStringLengthAnsi(right) + 1;
+                    return left.Length + GetEmbeddedNullStringLengthAnsi(right) + 1;
                 }
                 else {
-                    return GetPInvokeStringLength(s);
+                    return s.Length;
                 }
             }
     
             [DllImport(ExternDll.Kernel32, CharSet=CharSet.Auto)]
             [ResourceExposure(ResourceScope.None)]
             private static extern int lstrlen(String s);
-    
-            /* Unused
-            [DllImport(ExternDll.User32, CharSet=CharSet.Auto)]
-            internal static extern int RegisterWindowMessage(string msg);
-            */
         }
     
         public enum  tagTYPEKIND {
@@ -6113,8 +5985,6 @@ namespace System.Windows.Forms {
             TKIND_MAX = 8
         }
 
-        
-    
         [StructLayout(LayoutKind.Sequential)]
         public  class  tagTYPEDESC {
             public   IntPtr unionMember;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
@@ -575,13 +575,8 @@ namespace System.Windows.Forms {
             AssignHandle(handle, true);
         }
 
-        // 
-
-
-
 
         internal void AssignHandle(IntPtr handle, bool assignUniqueID) {
-            // 
             lock (this) {
                 CheckReleased();
                 Debug.Assert(handle != IntPtr.Zero, "handle is 0");
@@ -591,7 +586,7 @@ namespace System.Windows.Forms {
                 this.handle = handle;
 
                 if (userDefWindowProc == IntPtr.Zero) {
-                    string defproc = (Marshal.SystemDefaultCharSize == 1 ? "DefWindowProcA" : "DefWindowProcW");
+                    string defproc = "DefWindowProcW";
 
                     userDefWindowProc = UnsafeNativeMethods.GetProcAddress(new HandleRef(null, UnsafeNativeMethods.GetModuleHandle("user32.dll")), defproc);
                     if (userDefWindowProc == IntPtr.Zero) {
@@ -1556,7 +1551,7 @@ namespace System.Windows.Forms {
                 NativeMethods.WNDCLASS_D wndclass = new NativeMethods.WNDCLASS_D();
 
                 if (userDefWindowProc == IntPtr.Zero) {
-                    string defproc = (Marshal.SystemDefaultCharSize == 1 ? "DefWindowProcA" : "DefWindowProcW");
+                    string defproc = "DefWindowProcW";
 
                     userDefWindowProc = UnsafeNativeMethods.GetProcAddress(new HandleRef(null, UnsafeNativeMethods.GetModuleHandle("user32.dll")), defproc);
                     if (userDefWindowProc == IntPtr.Zero) {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -3714,7 +3714,7 @@ namespace System.Windows.Forms.PropertyGridInternal {
                                 maxWidth = Math.Max((int) textSize.cx, maxWidth);
                             }
                         }
-                        SafeNativeMethods.GetTextMetrics(new HandleRef(DropDownListBox, hdc), ref tm);
+                        SafeNativeMethods.GetTextMetricsW(new HandleRef(DropDownListBox, hdc), ref tm);
                         
                         // border + padding + scrollbar
                         maxWidth += 2 + tm.tmMaxCharWidth + SystemInformation.VerticalScrollBarWidth;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SafeNativeMethods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SafeNativeMethods.cs
@@ -354,17 +354,8 @@ namespace System.Windows.Forms {
         [ResourceExposure(ResourceScope.None)]
         public static extern int GetPaletteEntries(HandleRef hpal, int iStartIndex, int nEntries, int[] lppe);
 
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
-        [ResourceExposure(ResourceScope.None)]
-        public static extern int GetTextMetricsW(HandleRef hDC, [In, Out] ref NativeMethods.TEXTMETRIC lptm);
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet = System.Runtime.InteropServices.CharSet.Ansi)]
-        [ResourceExposure(ResourceScope.None)]
-        public static extern int GetTextMetricsA(HandleRef hDC, [In, Out] ref NativeMethods.TEXTMETRICA lptm);
-
-        public static int GetTextMetrics(HandleRef hDC, ref NativeMethods.TEXTMETRIC lptm) {
-            // Unicode
-            return SafeNativeMethods.GetTextMetricsW(hDC, ref lptm);
-        }
+        [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        public static extern int GetTextMetricsW(HandleRef hDC, ref NativeMethods.TEXTMETRIC lptm);
 
         [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, EntryPoint="CreateDIBSection", CharSet=System.Runtime.InteropServices.CharSet.Auto)]
         [ResourceExposure(ResourceScope.Machine)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SafeNativeMethods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SafeNativeMethods.cs
@@ -362,40 +362,8 @@ namespace System.Windows.Forms {
         public static extern int GetTextMetricsA(HandleRef hDC, [In, Out] ref NativeMethods.TEXTMETRICA lptm);
 
         public static int GetTextMetrics(HandleRef hDC, ref NativeMethods.TEXTMETRIC lptm) {
-            if (Marshal.SystemDefaultCharSize == 1)
-            {
-                // ANSI
-                NativeMethods.TEXTMETRICA lptmA = new NativeMethods.TEXTMETRICA();
-                int retVal = SafeNativeMethods.GetTextMetricsA(hDC, ref lptmA);
-
-                lptm.tmHeight           = lptmA.tmHeight; 
-                lptm.tmAscent           = lptmA.tmAscent; 
-                lptm.tmDescent          = lptmA.tmDescent; 
-                lptm.tmInternalLeading  = lptmA.tmInternalLeading; 
-                lptm.tmExternalLeading  = lptmA.tmExternalLeading; 
-                lptm.tmAveCharWidth     = lptmA.tmAveCharWidth; 
-                lptm.tmMaxCharWidth     = lptmA.tmMaxCharWidth; 
-                lptm.tmWeight           = lptmA.tmWeight; 
-                lptm.tmOverhang         = lptmA.tmOverhang; 
-                lptm.tmDigitizedAspectX = lptmA.tmDigitizedAspectX; 
-                lptm.tmDigitizedAspectY = lptmA.tmDigitizedAspectY; 
-                lptm.tmFirstChar        = (char) lptmA.tmFirstChar; 
-                lptm.tmLastChar         = (char) lptmA.tmLastChar; 
-                lptm.tmDefaultChar      = (char) lptmA.tmDefaultChar; 
-                lptm.tmBreakChar        = (char) lptmA.tmBreakChar; 
-                lptm.tmItalic           = lptmA.tmItalic; 
-                lptm.tmUnderlined       = lptmA.tmUnderlined; 
-                lptm.tmStruckOut        = lptmA.tmStruckOut; 
-                lptm.tmPitchAndFamily   = lptmA.tmPitchAndFamily; 
-                lptm.tmCharSet          = lptmA.tmCharSet; 
-
-                return retVal;
-            }
-            else
-            {
-                // Unicode
-                return SafeNativeMethods.GetTextMetricsW(hDC, ref lptm);
-            }
+            // Unicode
+            return SafeNativeMethods.GetTextMetricsW(hDC, ref lptm);
         }
 
         [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, EntryPoint="CreateDIBSection", CharSet=System.Runtime.InteropServices.CharSet.Auto)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -2191,8 +2191,7 @@ namespace System.Windows.Forms {
                                 tabControlState[TABCONTROLSTATE_UISelection] = true;
                             }
                             break;
-                        case NativeMethods.TTN_GETDISPINFOA:
-                        case NativeMethods.TTN_GETDISPINFOW:
+                        case NativeMethods.TTN_GETDISPINFO:
                             // MSDN:
                             // Setting the max width has the added benefit of enabling Multiline
                             // tool tips!

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -1016,12 +1016,6 @@ namespace System.Windows.Forms {
                 // ditto for end
                 end = Math.Max( 0, end );
 
-                if( this.SelectionUsesDbcsOffsetsInWin9x && Marshal.SystemDefaultCharSize == 1 ) {
-                    // When processing EM_GETSEL, EDIT control returns byte offsets instead of character offsets, this 
-                    // makes a difference in unicode code pages like Japanese.  We need to adjust the offsets.
-                    ToUnicodeOffsets( WindowText, ref start, ref end );
-                }
-
                 length = end - start;
             }
 
@@ -1243,31 +1237,12 @@ namespace System.Windows.Forms {
             }
         }
 
-        /// <include file='doc\TextBoxBase.uex' path='docs/doc[@for="TextBoxBase.TextLength"]/*' />
         [Browsable(false)]
-        public virtual int TextLength {
-            get {
-                // Note: Currently Winforms does not fully support surrogates.  If 
-                // the text contains surrogate characters this property may return incorrect values.
+        public virtual int TextLength
+            // Note: Currently Winforms does not fully support surrogates.  If
+            // the text contains surrogate characters this property may return incorrect values.
 
-                if (IsHandleCreated && Marshal.SystemDefaultCharSize == 2) {
-                    return SafeNativeMethods.GetWindowTextLength(new HandleRef(this, Handle));
-                }
-                else {
-                    return Text.Length;
-                }
-            }
-        }
-
-        /// <devdoc>
-        ///     Specifies whether the control uses unicode to set/get text selection information (WM_GESEL/WM_SETSEL)
-        ///     in Win9x.
-        /// </devdoc>
-        internal virtual bool SelectionUsesDbcsOffsetsInWin9x {
-            get {
-                return true;
-            }
-        }
+            => IsHandleCreated ? SafeNativeMethods.GetWindowTextLength(new HandleRef(this, Handle)) : Text.Length;
 
         // Since setting the WindowText while the handle is created
         // generates a WM_COMMAND message, we must trap that case
@@ -2038,13 +2013,6 @@ namespace System.Windows.Forms {
                 }
                 else if (end > textLength) {
                     end = textLength;
-                }
-
-                if (this.SelectionUsesDbcsOffsetsInWin9x && Marshal.SystemDefaultCharSize == 1) {
-                    // EDIT control expects selection values to be byte offsets instead of character offsets, 
-                    // this makes a difference in unicode code pages like Japanese.  
-                    // We need to adjust the offsets.
-                    ToDbcsOffsets(WindowText, ref start, ref end);
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolBar.cs
@@ -1589,28 +1589,6 @@ namespace System.Windows.Forms {
             Marshal.StructureToPtr(ttt, m.LParam, false);
         }
 
-        private void WmNotifyNeedTextA(ref Message m) {
-
-            NativeMethods.TOOLTIPTEXTA ttt = (NativeMethods.TOOLTIPTEXTA) m.GetLParam(typeof(NativeMethods.TOOLTIPTEXTA));
-            int commandID = (int)ttt.hdr.idFrom;
-            ToolBarButton tbb = (ToolBarButton) buttons[commandID];
-
-            if (tbb != null && tbb.ToolTipText != null)
-                ttt.lpszText = tbb.ToolTipText;
-            else
-                ttt.lpszText = null;
-
-            ttt.hinst = IntPtr.Zero;
-
-            // RightToLeft reading order
-            //
-            if (RightToLeft == RightToLeft.Yes) {
-                ttt.uFlags |= NativeMethods.TTF_RTLREADING;
-            }
-
-            Marshal.StructureToPtr(ttt, m.LParam, false);
-        }
-
         // Track the currently hot item since the user might be using the tab and
         // arrow keys to navigate the toolbar and if that's the case, we'll need to know where to re-
         // position the tooltip window when the underlying toolbar control attempts to display it.
@@ -1672,16 +1650,7 @@ namespace System.Windows.Forms {
                 case NativeMethods.WM_NOTIFY + NativeMethods.WM_REFLECT:
                     NativeMethods.NMHDR note = (NativeMethods.NMHDR) m.GetLParam(typeof(NativeMethods.NMHDR));
                     switch (note.code) {
-                        case NativeMethods.TTN_NEEDTEXTA:
-                            // MSDN:
-                            // Setting the max width has the added benefit of enabling multiline
-                            // tool tips!
-
-                            WmNotifyNeedTextA(ref m);
-                            m.Result = (IntPtr)1;
-                            return;
-
-                        case NativeMethods.TTN_NEEDTEXTW:
+                        case NativeMethods.TTN_NEEDTEXT:
                             // MSDN:
                             // Setting the max width has the added benefit of enabling multiline
                             // tool tips!

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolBar.cs
@@ -1682,17 +1682,13 @@ namespace System.Windows.Forms {
                             return;
 
                         case NativeMethods.TTN_NEEDTEXTW:
-                            // On Win 98/IE 5,we still get W messages.  If we ignore them, it will send the A version.
-                            if (Marshal.SystemDefaultCharSize == 2) {
-                                // MSDN:
-                                // Setting the max width has the added benefit of enabling multiline
-                                // tool tips!
+                            // MSDN:
+                            // Setting the max width has the added benefit of enabling multiline
+                            // tool tips!
 
-                                WmNotifyNeedText(ref m);
-                                m.Result = (IntPtr)1;
-                                return;
-                            }
-                            break;
+                            WmNotifyNeedText(ref m);
+                            m.Result = (IntPtr)1;
+                            return;
                         case NativeMethods.TTN_SHOW:
                             // Prevent the tooltip from displaying in the upper left corner of the
                             // desktop when the control is nowhere near that location.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.cs
@@ -716,7 +716,7 @@ namespace System.Windows.Forms {
                 // fetch the string
                 info.cch += 1;  // according to MSDN we need to increment the count we receive by 1.
                 info.wID = nativeMenuCommandID;
-                IntPtr allocatedStringBuffer = Marshal.AllocCoTaskMem(info.cch * Marshal.SystemDefaultCharSize);
+                IntPtr allocatedStringBuffer = Marshal.AllocCoTaskMem(info.cch * sizeof(char));
                 info.dwTypeData = allocatedStringBuffer;
                 
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -2968,36 +2968,28 @@ namespace System.Windows.Forms {
                 NativeMethods.NMTREEVIEW* nmtv = (NativeMethods.NMTREEVIEW*)m.LParam;
 
                 switch (nmtv->nmhdr.code) {
-                    case NativeMethods.TVN_ITEMEXPANDINGA:
-                    case NativeMethods.TVN_ITEMEXPANDINGW:
+                    case NativeMethods.TVN_ITEMEXPANDING:
                         m.Result = TvnExpanding(nmtv);
                         break;
-                    case NativeMethods.TVN_ITEMEXPANDEDA:
-                    case NativeMethods.TVN_ITEMEXPANDEDW:
+                    case NativeMethods.TVN_ITEMEXPANDED:
                         TvnExpanded(nmtv);
                         break;
-                    case NativeMethods.TVN_SELCHANGINGA:
-                    case NativeMethods.TVN_SELCHANGINGW:
+                    case NativeMethods.TVN_SELCHANGING:
                         m.Result = TvnSelecting(nmtv);
                         break;
-                    case NativeMethods.TVN_SELCHANGEDA:
-                    case NativeMethods.TVN_SELCHANGEDW:
+                    case NativeMethods.TVN_SELCHANGED:
                         TvnSelected(nmtv);
                         break;
-                    case NativeMethods.TVN_BEGINDRAGA:
-                    case NativeMethods.TVN_BEGINDRAGW:
+                    case NativeMethods.TVN_BEGINDRAG:
                         TvnBeginDrag(MouseButtons.Left, nmtv);
                         break;
-                    case NativeMethods.TVN_BEGINRDRAGA:
-                    case NativeMethods.TVN_BEGINRDRAGW:
+                    case NativeMethods.TVN_BEGINRDRAG:
                         TvnBeginDrag(MouseButtons.Right, nmtv);
                         break;
-                    case NativeMethods.TVN_BEGINLABELEDITA:
-                    case NativeMethods.TVN_BEGINLABELEDITW:
+                    case NativeMethods.TVN_BEGINLABELEDIT:
                         m.Result = TvnBeginLabelEdit((NativeMethods.NMTVDISPINFO)m.GetLParam(typeof(NativeMethods.NMTVDISPINFO)));
                         break;
-                    case NativeMethods.TVN_ENDLABELEDITA:
-                    case NativeMethods.TVN_ENDLABELEDITW:
+                    case NativeMethods.TVN_ENDLABELEDIT:
                         m.Result = TvnEndLabelEdit((NativeMethods.NMTVDISPINFO)m.GetLParam(typeof(NativeMethods.NMTVDISPINFO)));
                         break;
                     case NativeMethods.NM_CLICK:
@@ -3165,8 +3157,7 @@ namespace System.Windows.Forms {
         case NativeMethods.WM_PRINT:
             WmPrint(ref m);
             break;
-                case NativeMethods.TVM_SETITEMA:
-                case NativeMethods.TVM_SETITEMW:
+                case NativeMethods.TVM_SETITEM:
                     base.WndProc(ref m);
                     if (this.CheckBoxes) {
                         NativeMethods.TV_ITEM item = (NativeMethods.TV_ITEM) m.GetLParam(typeof(NativeMethods.TV_ITEM));
@@ -3186,8 +3177,7 @@ namespace System.Windows.Forms {
                 case NativeMethods.WM_NOTIFY:
                     NativeMethods.NMHDR nmhdr = (NativeMethods.NMHDR) m.GetLParam(typeof(NativeMethods.NMHDR));
                     switch (nmhdr.code) {
-                        case NativeMethods.TTN_GETDISPINFOA:
-                        case NativeMethods.TTN_GETDISPINFOW:
+                        case NativeMethods.TTN_GETDISPINFO:
                             // MSDN:
                             // Setting the max width has the added benefit of enabling multiline
                             // tool tips!
@@ -3196,7 +3186,7 @@ namespace System.Windows.Forms {
                             WmNeedText(ref m);
                             m.Result = (IntPtr)1;
                             return;
-						case NativeMethods.TTN_SHOW:
+                        case NativeMethods.TTN_SHOW:
                             if (WmShowToolTip(ref m))
                             {
                                 m.Result = (IntPtr)1;
@@ -3392,7 +3382,6 @@ namespace System.Windows.Forms {
                         }
                     }
                     break;
-
 
                 default:
                     base.WndProc(ref m);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/control.ime.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/control.ime.cs
@@ -342,8 +342,6 @@ namespace System.Windows.Forms {
             // after all messages are sent, corresponding WM_CHAR messages are also sent. (in non-unicode 
             // windows two WM_CHAR messages are sent per char in the IME).  We need to keep a counter 
             // not to process each character twice or more.
-            // Marshal.SystemDefaultCharSize represents the default character size on the system; the default 
-            // is 2 for Unicode systems and 1 for ANSI systems.  This is how it is implemented in Control.
             get {
                 return Properties.GetInteger( PropImeWmCharsToIgnore );
             }

--- a/src/System.Windows.Forms/src/misc/GDI/DeviceContext2.cs
+++ b/src/System.Windows.Forms/src/misc/GDI/DeviceContext2.cs
@@ -270,14 +270,11 @@ namespace System.Experimental.Gdi
             // the measurement DC always leaves fonts selected for pref reasons.
             // in this case, we need to diposse the font since the original 
             // creator didn't fully dispose.
-            if (previousFont != null) {                
-#if DEBUG       
-                //Debug.Assert(previousFont.Hfont != IntPtr.Zero, "A font has been disposed before it was unselected from the DC.  This will leak a GDI handle on Win9x! Call ResetFont()");
-#endif 
+            if (previousFont != null) {
                 if (MeasurementDCInfo.IsMeasurementDC(this)) {
                     previousFont.Dispose();
                 }
-            }       
+            }
             
 #if OPTIMIZED_MEASUREMENTDC
             // once we've changed the font, update the last used font.

--- a/src/System.Windows.Forms/src/misc/GDI/NativeMethods.cs
+++ b/src/System.Windows.Forms/src/misc/GDI/NativeMethods.cs
@@ -26,9 +26,6 @@ namespace System.Experimental.Gdi
     internal
 #endif
     partial class IntNativeMethods     {
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
-        public const int MaxTextLengthInWin9x = 8192;
-
         public const int
         DT_TOP                      = 0x00000000,
         DT_LEFT                     = 0x00000000,

--- a/src/System.Windows.Forms/src/misc/GDI/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms/src/misc/GDI/UnsafeNativeMethods.cs
@@ -363,31 +363,9 @@ namespace System.Experimental.Gdi
 
         public static int DrawText( HandleRef hDC, string text, ref IntNativeMethods.RECT lpRect, int nFormat )
         {
-            int retVal;
-            if( Marshal.SystemDefaultCharSize == 1 )
-            {
-                // CapRectangleForWin9x(ref lpRect);
-                // we have to do this because if we pass too big of a value (<= 2^31) to win9x
-                // it fails and returns negative values as the rect in which it painted the text
-                lpRect.top = Math.Min( Int16.MaxValue, lpRect.top );
-                lpRect.left = Math.Min( Int16.MaxValue, lpRect.left );
-                lpRect.right = Math.Min( Int16.MaxValue, lpRect.right );
-                lpRect.bottom = Math.Min( Int16.MaxValue, lpRect.bottom );
+            int retVal = DrawTextW(hDC, text, text.Length, ref lpRect, nFormat);
 
-                // Convert Unicode string to ANSI.
-                int byteCount = IntUnsafeNativeMethods.WideCharToMultiByte( IntNativeMethods.CP_ACP, 0, text, text.Length, null, 0, IntPtr.Zero, IntPtr.Zero );
-                byte[] textBytes = new byte[byteCount];
-                IntUnsafeNativeMethods.WideCharToMultiByte( IntNativeMethods.CP_ACP, 0, text, text.Length, textBytes, textBytes.Length, IntPtr.Zero, IntPtr.Zero );
-
-                byteCount = Math.Min( byteCount, IntNativeMethods.MaxTextLengthInWin9x );
-                retVal = DrawTextA( hDC, textBytes, byteCount, ref lpRect, nFormat );
-            }
-            else
-            {
-                retVal = DrawTextW( hDC, text, text.Length, ref lpRect, nFormat );
-            }
-
-            DbgUtil.AssertWin32( retVal != 0, "DrawText(hdc=[0x{0:X8}], text=[{1}], rect=[{2}], flags=[{3}] failed.", hDC.Handle, text, lpRect, nFormat );
+            DbgUtil.AssertWin32(retVal != 0, "DrawText(hdc=[0x{0:X8}], text=[{1}], rect=[{2}], flags=[{3}] failed.", hDC.Handle, text, lpRect, nFormat);
             return retVal;
         }
 
@@ -401,29 +379,7 @@ namespace System.Experimental.Gdi
 
         public static int DrawTextEx(HandleRef hDC, string text, ref IntNativeMethods.RECT lpRect, int nFormat, [In, Out] IntNativeMethods.DRAWTEXTPARAMS lpDTParams)
         {
-            int retVal;
-            if( Marshal.SystemDefaultCharSize == 1)
-            {
-                // CapRectangleForWin9x(ref lpRect);
-                // we have to do this because if we pass too big of a value (<= 2^31) to win9x
-                // it fails and returns negative values as the rect in which it painted the text
-                lpRect.top    = Math.Min(Int16.MaxValue, lpRect.top);
-                lpRect.left   = Math.Min(Int16.MaxValue, lpRect.left);
-                lpRect.right  = Math.Min(Int16.MaxValue, lpRect.right);
-                lpRect.bottom = Math.Min(Int16.MaxValue, lpRect.bottom);
-
-                // Convert Unicode string to ANSI.
-                int byteCount = IntUnsafeNativeMethods.WideCharToMultiByte(IntNativeMethods.CP_ACP, 0, text, text.Length, null, 0, IntPtr.Zero, IntPtr.Zero);
-                byte[] textBytes = new byte[byteCount];
-                IntUnsafeNativeMethods.WideCharToMultiByte(IntNativeMethods.CP_ACP, 0, text, text.Length, textBytes, textBytes.Length, IntPtr.Zero, IntPtr.Zero);
-
-                byteCount = Math.Min( byteCount, IntNativeMethods.MaxTextLengthInWin9x);
-                retVal = DrawTextExA( hDC, textBytes, byteCount, ref lpRect, nFormat, lpDTParams );
-            }
-            else
-            {
-                retVal = DrawTextExW( hDC, text, text.Length, ref lpRect, nFormat, lpDTParams  );
-            }
+            int retVal = DrawTextExW(hDC, text, text.Length, ref lpRect, nFormat, lpDTParams);
 
             DbgUtil.AssertWin32(retVal != 0, "DrawTextEx(hdc=[0x{0:X8}], text=[{1}], rect=[{2}], flags=[{3}] failed.", hDC.Handle, text, lpRect, nFormat );
             return retVal;
@@ -441,25 +397,10 @@ namespace System.Experimental.Gdi
 
         public static int GetTextExtentPoint32(HandleRef hDC, string text, [In, Out] IntNativeMethods.SIZE size)
         {
-            int retVal;
             int byteCount = text.Length;
+            int retVal = GetTextExtentPoint32W(hDC, text, text.Length, size);
 
-            if( Marshal.SystemDefaultCharSize == 1)
-            {
-                // Convert Unicode string to ANSI.
-                byteCount = IntUnsafeNativeMethods.WideCharToMultiByte(IntNativeMethods.CP_ACP, 0, text, text.Length, null, 0, IntPtr.Zero, IntPtr.Zero);
-                byte[] textBytes = new byte[byteCount];
-                IntUnsafeNativeMethods.WideCharToMultiByte(IntNativeMethods.CP_ACP, 0, text, text.Length, textBytes, textBytes.Length, IntPtr.Zero, IntPtr.Zero);
-
-                byteCount = Math.Min( text.Length, IntNativeMethods.MaxTextLengthInWin9x);
-                retVal = GetTextExtentPoint32A(hDC, textBytes, byteCount, size);
-            }
-            else
-            {
-                retVal = GetTextExtentPoint32W(hDC, text, text.Length, size);
-            }
-
-            DbgUtil.AssertWin32(retVal != 0, "GetTextExtentPoint32(hdc=[0x{0:X8}], text=[{1}], size=[{2}] failed.", hDC.Handle, text, size );
+            DbgUtil.AssertWin32(retVal != 0, "GetTextExtentPoint32(hdc=[0x{0:X8}], text=[{1}], size=[{2}] failed.", hDC.Handle, text, size);
             return retVal;
         }
 
@@ -570,8 +511,6 @@ namespace System.Experimental.Gdi
             return retVal;
         }
 
-        
-
         [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
         [ResourceExposure(ResourceScope.None)]
         public static extern int GetTextMetricsW(HandleRef hDC, [In, Out] ref IntNativeMethods.TEXTMETRIC lptm);
@@ -582,42 +521,9 @@ namespace System.Experimental.Gdi
 
         public static int GetTextMetrics(HandleRef hDC, ref IntNativeMethods.TEXTMETRIC lptm) 
         {
-            int retVal;
+            int retVal = IntUnsafeNativeMethods.GetTextMetricsW(hDC, ref lptm);
 
-            if (Marshal.SystemDefaultCharSize == 1)
-            {
-                // ANSI
-                IntNativeMethods.TEXTMETRICA lptmA = new IntNativeMethods.TEXTMETRICA();
-                retVal = IntUnsafeNativeMethods.GetTextMetricsA(hDC, ref lptmA);
-
-                lptm.tmHeight           = lptmA.tmHeight; 
-                lptm.tmAscent           = lptmA.tmAscent; 
-                lptm.tmDescent          = lptmA.tmDescent; 
-                lptm.tmInternalLeading  = lptmA.tmInternalLeading; 
-                lptm.tmExternalLeading  = lptmA.tmExternalLeading; 
-                lptm.tmAveCharWidth     = lptmA.tmAveCharWidth; 
-                lptm.tmMaxCharWidth     = lptmA.tmMaxCharWidth; 
-                lptm.tmWeight           = lptmA.tmWeight; 
-                lptm.tmOverhang         = lptmA.tmOverhang; 
-                lptm.tmDigitizedAspectX = lptmA.tmDigitizedAspectX; 
-                lptm.tmDigitizedAspectY = lptmA.tmDigitizedAspectY; 
-                lptm.tmFirstChar        = (char) lptmA.tmFirstChar; 
-                lptm.tmLastChar         = (char) lptmA.tmLastChar; 
-                lptm.tmDefaultChar      = (char) lptmA.tmDefaultChar; 
-                lptm.tmBreakChar        = (char) lptmA.tmBreakChar; 
-                lptm.tmItalic           = lptmA.tmItalic; 
-                lptm.tmUnderlined       = lptmA.tmUnderlined; 
-                lptm.tmStruckOut        = lptmA.tmStruckOut; 
-                lptm.tmPitchAndFamily   = lptmA.tmPitchAndFamily; 
-                lptm.tmCharSet          = lptmA.tmCharSet; 
-            }
-            else
-            {
-                // Unicode
-                retVal = IntUnsafeNativeMethods.GetTextMetricsW(hDC, ref lptm);
-            }
-
-            DbgUtil.AssertWin32(retVal != 0, "GetTextMetrics(hdc=[0x{0:X8}], [out TEXTMETRIC] failed.", hDC.Handle );
+            DbgUtil.AssertWin32(retVal != 0, "GetTextMetrics(hdc=[0x{0:X8}], [out TEXTMETRIC] failed.", hDC.Handle);
             return retVal;
         }
 


### PR DESCRIPTION
As much as I fondly remember Windows 95/98 I don't think we need the code to support it any more. :)

This removes a large chunk of 9x specific code as well as some other dead/unused code in interop.

I have some other interop correctness and performance fixes that I'll follow this with.