### PR TITLE
Adding an Sdk section to global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,6 +2,9 @@
   "tools": {
     "dotnet": "3.0.100-preview-009784"
   },
+  "sdk": {
+    "version": "3.0.100-preview-009784"
+  },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.18605.3"
   }


### PR DESCRIPTION
Adding an Sdk section to global.json. This is needed to ensure that CI servers deterministically use the version of .NET Core 3.0 Sdk specified here to build the projects in the repo.