### PR TITLE
Ported three accessibility bug fixes from .NET 4.8

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -102,8 +102,6 @@ namespace System.Windows.Forms {
 
         private Point                          mouseEnterWhenShown      = InvalidMouseEnter;
 
-        private readonly WeakReference<ToolTip> currentToolTipReference;
-
         private const int                      INSERTION_BEAM_WIDTH     = 6;
         
         internal static int                    insertionBeamWidth       = INSERTION_BEAM_WIDTH;
@@ -211,12 +209,7 @@ namespace System.Windows.Forms {
             Size defaultSize = DefaultSize;
             SetAutoSizeMode(AutoSizeMode.GrowAndShrink);
             this.ShowItemToolTips = DefaultShowItemToolTips;
-            ResumeLayout(true);
-
-            if (!AccessibilityImprovements.UseLegacyToolTipDisplay) {
-                this.currentToolTipReference = new WeakReference<ToolTip>(null);
-            }
-            
+            ResumeLayout(true);            
         }
 
         public ToolStrip(params ToolStripItem[] items) : this() {
@@ -1767,6 +1760,18 @@ namespace System.Windows.Forms {
                     showItemToolTips = value;
                     if (!showItemToolTips) {
                         UpdateToolTip(null);
+                    }
+
+                    if (!AccessibilityImprovements.UseLegacyToolTipDisplay) {
+                        ToolTip internalToolTip = this.ToolTip;
+                        foreach (ToolStripItem item in this.Items) {
+                            if (showItemToolTips) {
+                                KeyboardToolTipStateMachine.Instance.Hook(item, internalToolTip);
+                            }
+                            else {
+                                KeyboardToolTipStateMachine.Instance.Unhook(item, internalToolTip);
+                            }
+                        } 
                     }
 
                     // If the overflow button has not been created, don't check its properties
@@ -4499,7 +4504,10 @@ namespace System.Windows.Forms {
                     finally {
                          System.Security.CodeAccessPermission.RevertAssert();
                     }
-                    ToolTip.Active = false;
+
+                    if (AccessibilityImprovements.UseLegacyToolTipDisplay) {
+                        ToolTip.Active = false;
+                    }
 
                     currentlyActiveTooltipItem = item;
 
@@ -4508,7 +4516,9 @@ namespace System.Windows.Forms {
                         Cursor currentCursor = Cursor.CurrentInternal;
 
                         if (currentCursor != null) {
-                            ToolTip.Active = true;
+                            if (AccessibilityImprovements.UseLegacyToolTipDisplay) {
+                                ToolTip.Active = true;
+                            }
 
                             Point cursorLocation = Cursor.Position;
                             cursorLocation.Y += Cursor.Size.Height - currentCursor.HotSpot.Y;
@@ -4694,45 +4704,18 @@ namespace System.Windows.Forms {
             return new WindowsFormsUtils.ReadOnlyControlCollection(this, /* isReadOnly = */ !DesignMode);
         }
 
-        internal override void OnKeyboardToolTipHook(ToolTip toolTip) {
-            base.OnKeyboardToolTipHook(toolTip);
-
-            this.currentToolTipReference.SetTarget(toolTip);
-
-            if (this.toolStripItemCollection != null) {
-                foreach (ToolStripItem item in this.toolStripItemCollection) {
-                    KeyboardToolTipStateMachine.Instance.Hook(item, toolTip);
-                }
-            }
-        }
-
-        internal override void OnKeyboardToolTipUnhook(ToolTip toolTip) {
-            base.OnKeyboardToolTipUnhook(toolTip);
-
-            this.currentToolTipReference.SetTarget(null);
-
-            if (this.toolStripItemCollection != null) {
-                foreach (ToolStripItem item in this.toolStripItemCollection) {
-                    KeyboardToolTipStateMachine.Instance.Unhook(item, toolTip);
-                }
-            }
-        }
 
         internal void OnItemAddedInternal(ToolStripItem item) {
             if (!AccessibilityImprovements.UseLegacyToolTipDisplay) {
-                ToolTip currentToolTip;
-                if (this.currentToolTipReference.TryGetTarget(out currentToolTip) && currentToolTip != null) {
-                    KeyboardToolTipStateMachine.Instance.Hook(item, currentToolTip);
+                if (this.ShowItemToolTips) {
+                    KeyboardToolTipStateMachine.Instance.Hook(item, this.ToolTip);
                 }
             }
         }
 
         internal void OnItemRemovedInternal(ToolStripItem item) {
             if (!AccessibilityImprovements.UseLegacyToolTipDisplay) {
-                ToolTip currentToolTip;
-                if (this.currentToolTipReference.TryGetTarget(out currentToolTip) && currentToolTip != null) {
-                    KeyboardToolTipStateMachine.Instance.Unhook(item, currentToolTip);
-                }
+                KeyboardToolTipStateMachine.Instance.Unhook(item, this.ToolTip);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
@@ -728,6 +728,7 @@ namespace System.Windows.Forms {
         
 
     /// <include file='doc\ToolStripDropDownItem.uex' path='docs/doc[@for="ToolStripDropDownItemAccessibleObject"]/*' />
+    [System.Runtime.InteropServices.ComVisible(true)]
     public class ToolStripDropDownItemAccessibleObject : ToolStripItem.ToolStripItemAccessibleObject {
         private ToolStripDropDownItem owner;
         /// <include file='doc\ToolStripDropDownItem.uex' path='docs/doc[@for="ToolStripDropDownItemAccessibleObject.ToolStripDropDownItemAccessibleObject"]/*' />

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -175,8 +175,7 @@ namespace System.Windows.Forms {
 
         internal string GetCaptionForTool(Control tool) {
             Debug.Assert(tool != null, "tool should not be null");
-            Debug.Assert(this.tools[tool] as TipInfo != null, "There is no TipInfo with Caption for the tool");
-            return ((TipInfo)this.tools[tool]).Caption;
+            return ((TipInfo)this.tools[tool])?.Caption;
         }
 
         /// <include file='doc\ToolTip.uex' path='docs/doc[@for="ToolTip.AutoPopDelay"]/*' />


### PR DESCRIPTION
These fixes are related to the keyboard tooltips feature and the Managed Debugging Assistant ‘NonComVisibleBaseClass’ exception.

Related to #182