### PR TITLE
Remove unused symbols and commented code from resx code

### DIFF
--- a/src/System.Windows.Forms/src/System/Resources/IAliasResolver.cs
+++ b/src/System.Windows.Forms/src/System/Resources/IAliasResolver.cs
@@ -2,11 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if SYSTEM_WEB
-namespace System.PrivateResources {
-#else
 namespace System.Resources {
-#endif
 
     using System.Diagnostics;
     using System.Runtime.Serialization;

--- a/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
@@ -40,10 +40,6 @@ namespace System.Resources {
 
         private string name;
         private string comment;
-#if UNUSED
-        private string mimeType;
-        private string valueData;
-#endif
 
         private string typeName; // is only used when we create a resxdatanode manually with an object and contains the FQN
 
@@ -78,10 +74,7 @@ namespace System.Resources {
             result.nodeInfo = (this.nodeInfo != null) ? this.nodeInfo.Clone() : null; // nodeinfo is just made up of immutable objects, we don't need to clone it
             result.name = this.name;
             result.comment = this.comment;
-#if UNUSED            
-            result.mimeType = this.mimeType;
-            result.valueData = this.valueData;
-#endif            
+            
             result.typeName = this.typeName;
             result.fileRefFullPath = this.fileRefFullPath;
             result.fileRefType = this.fileRefType;
@@ -227,28 +220,6 @@ namespace System.Resources {
                 name = value;
             }
         }
-
-#if UNUSED
-        private string MimeType {
-            get {
-                string result = mimeType;
-                if(result == null && nodeInfo != null) {
-                    result = nodeInfo.MimeType;
-                }
-                return result;
-            }
-        }
-
-        private string ValueData {
-            get {
-                string result = valueData;
-                if(result == null && nodeInfo != null) {
-                    result = nodeInfo.ValueData;
-                }
-                return result;
-            }
-        }
-#endif
         
         /// <include file='doc\ResXDataNode.uex' path='docs/doc[@for="ResXDataNode.FileRef"]/*' />
         /// <devdoc>
@@ -302,22 +273,6 @@ namespace System.Resources {
                 return result;
             }
         }
-
-
-#if SOAP_FORMATTER
-        /// <devdoc>
-        ///     As a performance optimization, we isolate the soap class here in a separate
-        ///     function.  We don't care about the binary formatter because it lives in 
-        ///     mscorlib, which is already loaded.  The soap formatter lives in a separate
-        ///     assembly, however, so there is value in preventing it from needlessly
-        ///     being loaded.
-        /// </devdoc>
-        [MethodImplAttribute(MethodImplOptions.NoInlining)]
-        private IFormatter CreateSoapFormatter() {
-            return new System.Runtime.Serialization.Formatters.Soap.SoapFormatter();
-        }
-#endif
-
 
         private static string ToBase64WrappedString(byte[] data) {
             const int lineWrap = 80;
@@ -442,27 +397,7 @@ namespace System.Resources {
                         }
                     }
                 }
-#if SOAP_FORMATTER
-                else if (String.Equals(mimeTypeName, ResXResourceWriter.SoapSerializedObjectMimeType)
-                         || String.Equals(mimeTypeName, ResXResourceWriter.CompatSoapSerializedObjectMimeType)) {
-                    string text = dataNodeInfo.ValueData;
-                    byte[] serializedData;
-                    serializedData = FromBase64WrappedString(text);
-
-                    if (serializedData != null && serializedData.Length > 0) {
-
-                        // Performance : don't inline a new SoapFormatter here.  That will always bring in
-                        //               the soap assembly, which we don't want.  Throw this in another
-                        //               function so the class doesn't have to get loaded.
-                        //
-                        IFormatter formatter = CreateSoapFormatter();
-                        result = formatter.Deserialize(new MemoryStream(serializedData));
-                        if (result is ResXNullRef) {
-                            result = null;
-                        }
-                    }
-                }
-#endif
+                
                 else if (String.Equals(mimeTypeName, ResXResourceWriter.ByteArraySerializedObjectMimeType)) {
                     if (typeName != null && typeName.Length > 0) {
                         Type type = ResolveType(typeName, typeResolver);

--- a/src/System.Windows.Forms/src/System/Resources/ResXFileRef.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXFileRef.cs
@@ -2,12 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if SYSTEM_WEB
-namespace System.PrivateResources {
-#else
 namespace System.Resources {
-#endif
-
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
 
@@ -34,11 +29,8 @@ namespace System.Resources {
     [TypeConverterAttribute(typeof(ResXFileRef.Converter)), Serializable]
     [System.Security.Permissions.PermissionSetAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, Name="FullTrust")]
     [System.Security.Permissions.PermissionSetAttribute(System.Security.Permissions.SecurityAction.LinkDemand, Name="FullTrust")]
-#if SYSTEM_WEB
-    internal class ResXFileRef {
-#else
+
     public class ResXFileRef {
-#endif
         private string fileName;
         private string typeName;
         [OptionalField(VersionAdded = 2)]

--- a/src/System.Windows.Forms/src/System/Resources/ResXNullRef.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXNullRef.cs
@@ -2,12 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if SYSTEM_WEB
-namespace System.PrivateResources {
-#else
 namespace System.Resources {
-#endif
-
     using System.Diagnostics;
 
     using System;

--- a/src/System.Windows.Forms/src/System/Resources/ResXResourceReader.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXResourceReader.cs
@@ -2,11 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if SYSTEM_WEB
-namespace System.PrivateResources {
-#else
 namespace System.Resources {
-#endif
 
     using System.Diagnostics;
     using System.Runtime.Serialization;
@@ -25,9 +21,6 @@ namespace System.Resources {
     using System.Xml;
     using System.ComponentModel.Design;
     using System.Globalization;
-#if SYSTEM_WEB
-    using System.Web;   // This is needed to access the SR resource strings
-#endif
     
     /// <include file='doc\ResXResourceReader.uex' path='docs/doc[@for="ResXResourceReader"]/*' />
     /// <devdoc>
@@ -35,15 +28,7 @@ namespace System.Resources {
     /// </devdoc>
     [System.Security.Permissions.PermissionSetAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, Name="FullTrust")]
     [System.Security.Permissions.PermissionSetAttribute(System.Security.Permissions.SecurityAction.LinkDemand, Name="FullTrust")]
-#if SYSTEM_WEB
-    internal class ResXResourceReader : IResourceReader {
-#else
     public class ResXResourceReader : IResourceReader {
-#endif
-
-        //static readonly char[] SpecialChars = new char[]{' ', '\r', '\n'};
-
-        //IFormatter binaryFormatter = null;
         string fileName = null;
         TextReader reader = null;
         Stream stream = null;
@@ -170,27 +155,6 @@ namespace System.Resources {
                 basePath = value;
             }
         }
-
-#if UNUSED
-        /// <devdoc>
-        ///     Retrieves the resource data set. This will demand load it.
-        /// </devdoc>
-        private ListDictionary ResData {
-            get {
-                EnsureResData();
-                return resData;
-            }
-        }
-
-        /// <devdoc>
-        ///     Returns the typeResolver used to find types defined in the ResX contents.
-        /// </devdoc>
-        private ITypeResolutionService TypeResolver {
-            get {
-                return this.typeResolver;
-            }
-        }
-#endif
 
         /// <include file='doc\ResXResourceReader.uex' path='docs/doc[@for="ResXResourceReader.ResXResourceReader5"]/*' />
         /// <devdoc>
@@ -452,18 +416,12 @@ namespace System.Resources {
                     writerTypeName = writerTypeName.Split(new char[] {','})[0].Trim();
                 }
 
-// Don't check validity, since our reader/writer classes are in System.Web.Compilation,
-// while the file format has them in System.Resources.  
-#if SYSTEM_WEB
-                validFile = true;
-#else
                 if (readerTypeName != null && 
                     writerTypeName != null && 
                     readerTypeName.Equals(readerType.FullName) && 
                     writerTypeName.Equals(writerType.FullName)) {
                     validFile = true;
                 }
-#endif
             }
 
             if (!validFile) {
@@ -554,13 +512,6 @@ namespace System.Resources {
                 }
             }
         }
-
-#if UNUSED
-        private string GetSimpleName(string typeName) {
-             int indexStart = typeName.IndexOf(",");
-             return typeName.Substring(0, indexStart); 
-        }
-#endif
 
         private void ParseAssemblyNode(XmlReader reader, bool isMetaData)
         {

--- a/src/System.Windows.Forms/src/System/Resources/ResXResourceSet.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXResourceSet.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if !SYSTEM_WEB
-
 namespace System.Resources {
 
     using System.Diagnostics;
@@ -66,5 +64,3 @@ namespace System.Resources {
         }
     }
 }
-
-#endif // !SYSTEM_WEB

--- a/src/System.Windows.Forms/src/System/Resources/ResXResourceWriter.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXResourceWriter.cs
@@ -2,11 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if SYSTEM_WEB
-namespace System.PrivateResources {
-#else
 namespace System.Resources {
-#endif
 
     using System.Diagnostics;
     using System.Reflection;
@@ -22,9 +18,6 @@ namespace System.Resources {
     using System.Xml;
     using System.Runtime.Serialization;
     using System.Diagnostics.CodeAnalysis;
-#if SYSTEM_WEB
-    using System.Web;   // This is needed to access the SR resource strings
-#endif
 
     /// <include file='doc\ResXResourceWriter.uex' path='docs/doc[@for="ResXResourceWriter"]/*' />
     /// <devdoc>
@@ -33,11 +26,7 @@ namespace System.Resources {
     /// </devdoc>
     [System.Security.Permissions.PermissionSetAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, Name="FullTrust")]
     [System.Security.Permissions.PermissionSetAttribute(System.Security.Permissions.SecurityAction.LinkDemand, Name="FullTrust")]
-#if SYSTEM_WEB
-    internal class ResXResourceWriter : IResourceWriter {
-#else
     public class ResXResourceWriter : IResourceWriter {
-#endif
         internal const string TypeStr = "type";
         internal const string NameStr = "name";
         internal const string DataStr = "data";
@@ -679,35 +668,7 @@ namespace System.Resources {
              if(indexStart == -1)
                 return null;
              return typeName.Substring(indexStart + 2);
-        }
-
-#if UNUSED
-        private string GetSimpleName(string typeName) {
-             int indexStart = typeName.IndexOf(",");
-             int indexEnd =  typeName.IndexOf(",", indexStart + 1);
-             return typeName.Substring(indexStart + 2, indexEnd - indexStart  - 3); 
-        }
-
-        static string StripVersionInformation(string typeName) {
-            int indexStart = typeName.IndexOf(" Version=");
-            if(indexStart ==-1)
-                indexStart = typeName.IndexOf("Version=");
-            if(indexStart ==-1)
-                indexStart = typeName.IndexOf("version=");
-            int indexEnd = -1;
-            string result = typeName;
-            if(indexStart != -1) {
-                // foudn version
-                indexEnd = typeName.IndexOf(",", indexStart);
-                if(indexEnd != -1) {
-                    result = typeName.Remove(indexStart, indexEnd-indexStart+1);
-                }
-            }
-            return result;
-            
-        }
-#endif
-        
+        }    
 
         static string ToBase64WrappedString(byte[] data) {
             const int lineWrap = 80;


### PR DESCRIPTION
SYSTEM_WEB, UNUSED, SOAP_FORMATTER, aren't set anywhere. SoapFormatter is obsolete since .NET 2.0, and there is no System.Web in .NET Core :)