### PR TITLE
Preserve full exception when calling InvokeMarshaledCallbacks.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -7352,7 +7352,7 @@ example usage
                                 InvokeMarshaledCallback(current);
                             }
                             catch (Exception t) {
-                                current.exception = t.GetBaseException();
+                                current.exception = t;
                             }
                         }
                     }


### PR DESCRIPTION
Preserve full exception when calling `Control.InvokeMarshaledCallbacks()` so that `Application.OnThreadException` is invoked with the full exception information.

The current implementation is a real problem when working with async / TPL code. Numerous stack-overflow questions have been opened regarding this "bug". 

https://stackoverflow.com/questions/36455666/why-does-aggregateexception-thrown-from-gui-thread-get-unwrapped-in-app-except

https://stackoverflow.com/questions/347502/why-does-the-inner-exception-reach-the-threadexception-handler-and-not-the-actual

Unfortunately the connect bug report is not accessible any more: https://connect.microsoft.com/VisualStudio/feedback/ViewFeedback.aspx?FeedbackID=433765

We had to implement this crazy workaround to access the real exception:

```csharp
private Exception lastFirstChanceException;

AppDomain.CurrentDomain.FirstChanceException += (sender, e) =>
{
   lastFirstChanceException = e.Exception;
};

Application.ThreadException += (sender, e) =>
{
   if (lastFirstChanceException?.GetBaseException() == e.Exception)
   {
       var realException = lastFirstChanceException; // This is the "real" exception thrown by some code
   }
};
```
Let me know if calling `GetBaseException`  in  InvokeMarshaledCallbacks() has some hidden meaning which I am missing here. 
If this change is not acceptable because of back compat reasons, it probably would make sense to provide a static property to configure the behavior. 

Something like this:

`public static bool PreserveFullExceptionOnMarshallInvokeCallback`
