### PR TITLE
Standardize docs formatting

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,8 +1,12 @@
 # Contributing
 
-See [Contributing Guide](../Documentation/contributing.md) for information about:
+See [Contributing Guide][contributing] for information about:
 
 * Which kind of PRs we accept/reject for .NET Core 3.0 release
 * Coding style
 * PR style preferences (squashing vs. merging, etc.)
 * Developer guide for building and testing locally
+
+[comment]: <> (Links)
+
+[contributing]: ../Documentation/contributing.md

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "cSpell.words": [
+        "binlog",
+        "repos",
+        "winforms"
+    ]
+}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,4 +2,8 @@
 
 This project has adopted the code of conduct defined by the Contributor Covenant
 to clarify expected behavior in our community.
-For more information, see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
+For more information, see the [.NET Foundation Code of Conduct][dotnet-code-of-conduct].
+
+[comment]: <> (URI Links)
+
+[dotnet-code-of-conduct]: https://dotnetfoundation.org/code-of-conduct

--- a/Documentation/building.md
+++ b/Documentation/building.md
@@ -1,28 +1,33 @@
 # Building Windows Forms
 
 ## Prerequisites
+
 Follow the prerequisites listed at [Building CoreFX on Windows](https://github.com/dotnet/corefx/blob/master/Documentation/building/windows-instructions.md)
 
 ## Building from the command line
-* Run `.\build` from the repo root.
+
+* Run `.\build` from the repository root.
   * Builds the `System.Windows.Forms.sln` using the default config (Debug|Any CPU)
 * To specify a config, add `-configuration` followed by the config such as `.\build -configuration Release`
 
 If your build is successful, you should see something like this:
+
 ```console
 Build succeeded.
     0 Warning(s)
     0 Error(s)
 ```
 
-Note that this does **not** build using your machine-wide installed version of the dotnet sdk. It builds using the dotnet sdk specified in the global.json in the repo root.
+Note that this does **not** build using your machine-wide installed version of the dotnet sdk. It builds using the dotnet sdk specified in the global.json in the repository root.
 
 ## Building from Visual Studio
+
 * To build from Visual Studio, open System.Windows.Forms.sln in Visual Studio and build how you normally would.
 * Visual Studio behaves slightly differently than the command line. It uses the machine-wide installed SDK instead of the one specified in the global.json.
   * Please make sure you have the [latest .Net Core Daily Build](https://github.com/dotnet/core/blob/master/daily-builds.md) installed.
 
 ## Build outputs
+
 * All build outputs are generated under the `artifacts` folder.
 * Binaries are under `artifacts\bin`
   * For example, `System.Windows.Forms.dll` can be found under `artifacts\bin\System.Windows.Forms\Debug\netcoreapp3.0`
@@ -30,10 +35,12 @@ Note that this does **not** build using your machine-wide installed version of t
 * Packages are found under `artifacts\packages`
 
 ## Troubleshooting build errors
+
 * Most build errors are compile errors and can be dealt with accordingly.
 * Other error may be from MSBuild tasks. You need to examine the build logs to investigate.
   * The logs are generated at `artifacts\log\Debug\Build.binlog`
   * The file format is an MSBuild Binary Log. Install the [MSBuild Structured Log Viewer](http://msbuildlog.com/) to view them.
 
 ## Creating a package
+
 To create the Microsoft.Private.Winforms package, run `.\build -pack`

--- a/Documentation/building.md
+++ b/Documentation/building.md
@@ -45,7 +45,7 @@ Note that this does **not** build using your machine-wide installed version of t
 
 To create the Microsoft.Private.Winforms package, run `.\build -pack`
 
-[comment]: <> (Links)
+[comment]: <> (URI Links)
 
 [corefx-windows-instructions]: https://github.com/dotnet/corefx/blob/master/Documentation/building/windows-instructions.md
 [latest-core-build]: https://github.com/dotnet/core/blob/master/daily-builds.md

--- a/Documentation/building.md
+++ b/Documentation/building.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-Follow the prerequisites listed at [Building CoreFX on Windows](https://github.com/dotnet/corefx/blob/master/Documentation/building/windows-instructions.md)
+Follow the prerequisites listed at [Building CoreFX on Windows][corefx-windows-instructions]
 
 ## Building from the command line
 
@@ -24,7 +24,7 @@ Note that this does **not** build using your machine-wide installed version of t
 
 * To build from Visual Studio, open System.Windows.Forms.sln in Visual Studio and build how you normally would.
 * Visual Studio behaves slightly differently than the command line. It uses the machine-wide installed SDK instead of the one specified in the global.json.
-  * Please make sure you have the [latest .Net Core Daily Build](https://github.com/dotnet/core/blob/master/daily-builds.md) installed.
+  * Please make sure you have the [latest .Net Core Daily Build][latest-core-build] installed.
 
 ## Build outputs
 
@@ -39,8 +39,14 @@ Note that this does **not** build using your machine-wide installed version of t
 * Most build errors are compile errors and can be dealt with accordingly.
 * Other error may be from MSBuild tasks. You need to examine the build logs to investigate.
   * The logs are generated at `artifacts\log\Debug\Build.binlog`
-  * The file format is an MSBuild Binary Log. Install the [MSBuild Structured Log Viewer](http://msbuildlog.com/) to view them.
+  * The file format is an MSBuild Binary Log. Install the [MSBuild Structured Log Viewer][msbuild-log-viewer] to view them.
 
 ## Creating a package
 
 To create the Microsoft.Private.Winforms package, run `.\build -pack`
+
+[comment]: <> (Links)
+
+[corefx-windows-instructions]: https://github.com/dotnet/corefx/blob/master/Documentation/building/windows-instructions.md
+[latest-core-build]: https://github.com/dotnet/core/blob/master/daily-builds.md
+[msbuild-log-viewer]: http://msbuildlog.com/

--- a/Documentation/contributing.md
+++ b/Documentation/contributing.md
@@ -1,6 +1,6 @@
 # Contributing Guide
 
-The primary focus of .NET Core 3.0 release for Windows Forms is to achieve parity with .NET Framework. Priority will be given to changes that align with that goal. See the [roadmap][roadmap] to understand project goals.
+The primary focus of .NET Core 3.0 release for Windows Forms is to achieve parity with .NET Framework. Priority will be given to changes that align with that goal. See the [roadmap](roadmap.md) to understand project goals.
 
 We need the most help with the following types of changes:
 
@@ -9,7 +9,7 @@ We need the most help with the following types of changes:
 
 Please [file an issue][issues] for any larger change you would like to propose.
 
-See [Developer Guide][developer-guide] to learn how to develop changes for this repository.
+See [Developer Guide](developer-guide.md) to learn how to develop changes for this repository.
 
 This project follows the general [.NET Core Contribution Guidelines][corefx-contribution-guidelines]. Please read it before submitting PRs.
 
@@ -25,9 +25,7 @@ Most .NET Core components are cross-platform and we appreciate contributions tha
 
 Contributions must also satisfy the other published guidelines defined in this document.
 
-[comment]: <> (Links)
+[comment]: <> (URI Links)
 
-[roadmap]: roadmap.md
 [issues]: https://github.com/dotnet/winforms/issues
-[developer-guide]: developer-guide.md
 [corefx-contribution-guidelines]: https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/contributing.md

--- a/Documentation/contributing.md
+++ b/Documentation/contributing.md
@@ -1,17 +1,17 @@
 # Contributing Guide
 
-The primary focus of .NET Core 3.0 release for Windows Forms is to achieve parity with .NET Framework. Priority will be given to changes that align with that goal. See the [roadmap](../roadmap.md) to understand project goals.
+The primary focus of .NET Core 3.0 release for Windows Forms is to achieve parity with .NET Framework. Priority will be given to changes that align with that goal. See the [roadmap][roadmap] to understand project goals.
 
 We need the most help with the following types of changes:
 
 * Test fixes, test improvements, and new tests increasing code coverage.
 * Bug fixes that specifically target parity between .NET Core and .NET Framework.
 
-Please [file an issue](https://github.com/dotnet/winforms/issues) for any larger change you would like to propose.
+Please [file an issue][issues] for any larger change you would like to propose.
 
-See [Developer Guide](developer-guide.md) to learn how to develop changes for this repository.
+See [Developer Guide][developer-guide] to learn how to develop changes for this repository.
 
-This project follows the general [.NET Core Contribution Guidelines](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/contributing.md). Please read it before submitting PRs.
+This project follows the general [.NET Core Contribution Guidelines][corefx-contribution-guidelines]. Please read it before submitting PRs.
 
 The contribution bar from the general contribution guidelines is copied below.
 
@@ -24,3 +24,10 @@ Maintainers will not merge changes that have narrowly-defined benefits due to co
 Most .NET Core components are cross-platform and we appreciate contributions that either improve their feature set in a given environment or that add support for a new environment. We will typically not accept contributions that implement support for an OS-specific technology on another operating system. For example, we do not intend to create an implementation of the Windows registry for Linux or an implementation of the macOS keychain for Windows. We also do not intend to accept contributions that provide cross-platform implementations for Windows Forms or WPF.
 
 Contributions must also satisfy the other published guidelines defined in this document.
+
+[comment]: <> (Links)
+
+[roadmap]: roadmap.md
+[issues]: https://github.com/dotnet/winforms/issues
+[developer-guide]: developer-guide.md
+[corefx-contribution-guidelines]: https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/contributing.md

--- a/Documentation/contributing.md
+++ b/Documentation/contributing.md
@@ -4,12 +4,12 @@ The primary focus of .NET Core 3.0 release for Windows Forms is to achieve parit
 
 We need the most help with the following types of changes:
 
-* Test fixes, test improvements and new tests increasing code coverage.
+* Test fixes, test improvements, and new tests increasing code coverage.
 * Bug fixes that specifically target parity between .NET Core and .NET Framework.
 
 Please [file an issue](https://github.com/dotnet/winforms/issues) for any larger change you would like to propose.
 
-See [Developer Guide](developer-guide.md) to learn how to develop changes for this repo.
+See [Developer Guide](developer-guide.md) to learn how to develop changes for this repository.
 
 This project follows the general [.NET Core Contribution Guidelines](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/contributing.md). Please read it before submitting PRs.
 

--- a/Documentation/debugging.md
+++ b/Documentation/debugging.md
@@ -8,7 +8,7 @@ Once you are ready to debug your changes on an existing Windows Forms applicatio
 
 If you do not want to modify your local SDK, you may with to perform technique 2, while if you do not want to add an additional reference to your project, technique 1 may be better for you.
 
-## 1. Copy your changes into the SDK
+## (1) Copy your changes into the SDK
 
 copy the resulting assembly(-ies) from the base of the repository  
 
@@ -22,7 +22,7 @@ where **[Drive]** is your OS drive (for example, C:)  and **[path-to-repo]** is 
 
 **NOTE** that this will modify your SDK; to revert back, you will have to repair the install or reinstall. See the [dotnet Core repository][dotnet-core-repos] for more information.
 
-## 2. Point your project to your experimental binary(-ies)
+## (2) Point your project to your experimental binary(-ies)
 
 Add references to the binary(-ies) to your project ported to Core. For example, for System.Windows.Forms, you should add the following reference:
 

--- a/Documentation/debugging.md
+++ b/Documentation/debugging.md
@@ -1,6 +1,6 @@
 # Debugging
 
-There are two recommended ways to debug Windows Forms binaries. Both require that you first [build from source](https://github.com/dotnet/corefx/blob/master/Documentation/building.md).
+There are two recommended ways to debug Windows Forms binaries. Both require that you first [build from source][corefx-building].
 
 Then, you are free make your changes locally.
 
@@ -8,28 +8,33 @@ Once you are ready to debug your changes on an existing Windows Forms applicatio
 
 If you do not want to modify your local SDK, you may with to perform technique 2, while if you do not want to add an additional reference to your project, technique 1 may be better for you.
 
-### 1. Copy your changes into the SDK
+## 1. Copy your changes into the SDK
 
 copy the resulting assembly(-ies) from the base of the repository  
 
-`[path-to-repo]\winforms\artifacts\bin\System.Windows.Forms\Debug\netcoreapp3.0_ `
+`[path-to-repo]\winforms\artifacts\bin\System.Windows.Forms\Debug\netcoreapp3.0_`
 
 to your dotnet folder at:  
 
 `[Drive]:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App\[Version]`
 
-where **[Drive]** is your OS drive (for example, C:) and and **path-to-repo** is the additional path to our repository from the base drive. **[Version]** is your DesktopUI version directory (for example, 3.0.0-alpha-27017-4). Note if you have Microsoft.DesktopUI.App instead of Microsoft.WindowsDesktop.App, this is the outdated version.
+where **[Drive]** is your OS drive (for example, C:)  and **[path-to-repo]** is the additional path to our repository from the base drive. **[Version]** is your DesktopUI version directory (for example, 3.0.0-alpha-27017-4). Note if you have Microsoft.DesktopUI.App instead of Microsoft.WindowsDesktop.App, this is the outdated version.
 
-**NOTE** that this will modify your SDK; to revert back, you will have to repair the install or reinstall. See the [dotnet Core repository](https://github.com/dotnet/core) for more information.
+**NOTE** that this will modify your SDK; to revert back, you will have to repair the install or reinstall. See the [dotnet Core repository][dotnet-core-repos] for more information.
 
-### 2. Point your project to your experimental binary(-ies)
+## 2. Point your project to your experimental binary(-ies)
 
 Add references to the binary(-ies) to your project ported to Core. For example, for System.Windows.Forms, you should add the following reference:
 
 ```xml
 <ItemGroup>
-    <Reference Include="[Drive]:[path-to-repo]\winforms\artifacts\bin\System.Windows.Forms\Debug\netcoreapp3.0\System.Windows.Forms.dll" />   
+    <Reference Include="[Drive]:[path-to-repo]\winforms\artifacts\bin\System.Windows.Forms\Debug\netcoreapp3.0\System.Windows.Forms.dll" />
 </ItemGroup>
 ```
 
-where **[Drive]** is the drive you have our repository in and **path-to-repo** is the additional path to our repository from the base drive (this may be nothing). Note netcoreapp3.0 may change.
+where **[Drive]** is the drive you have our repository in and **[path-to-repo]** is the additional path to our repository from the base drive (this may be nothing). Note netcoreapp3.0 may change.
+
+[comment]: <> (Links)
+
+[corefx-building]: https://github.com/dotnet/corefx/blob/master/Documentation/building.md
+[dotnet-core-repos]: https://github.com/dotnet/core

--- a/Documentation/debugging.md
+++ b/Documentation/debugging.md
@@ -34,7 +34,7 @@ Add references to the binary(-ies) to your project ported to Core. For example, 
 
 where **[Drive]** is the drive you have our repository in and **[path-to-repo]** is the additional path to our repository from the base drive (this may be nothing). Note netcoreapp3.0 may change.
 
-[comment]: <> (Links)
+[comment]: <> (URI Links)
 
 [corefx-building]: https://github.com/dotnet/corefx/blob/master/Documentation/building.md
 [dotnet-core-repos]: https://github.com/dotnet/core

--- a/Documentation/developer-guide.md
+++ b/Documentation/developer-guide.md
@@ -6,7 +6,7 @@ The [Issue Guide][issue-guide] describes our approach to using GitHub issues.
 
 ## Machine Setup
 
-Follow the [Building CoreFX on Windows][corefx-windows-instructions] instructions.
+Follow the [Building CoreFX on Windows][corefx-windows-instructions] instructions. However, we recommend Visual Studio 2019 Preview 1.
 
 Windows Forms requires the following workloads and components be selected when installing Visual Studio:
 
@@ -24,7 +24,9 @@ We use the following workflow for building as well as testing features and fixes
 You first need to [Fork][fork] and [Clone][clone] this WinForms repository. This is a one-time task.
 
 1. [Build][building] the repository.
+
 2. [Debug][debugging] the change, as needed.
+
 3. [Test][testing] the change, to validate quality.
 
 ## More Information

--- a/Documentation/developer-guide.md
+++ b/Documentation/developer-guide.md
@@ -1,12 +1,12 @@
 # Developer Guide
 
-The following document describes the setup and workflow that is recommended for working on the Windows Forms project. It assumes that you have read the [contributing doc](contributing.md).
+The following document describes the setup and workflow that is recommended for working on the Windows Forms project. It assumes that you have read the [Contributing Document][contributing].
 
-The [Issue Guide](issue-guide.md) describes our approach to using GitHub issues.
+The [Issue Guide][issue-guide] describes our approach to using GitHub issues.
 
 ## Machine Setup
 
-Follow the [Building CoreFX on Windows](https://github.com/dotnet/corefx/blob/master/Documentation/building/windows-instructions.md) instructions.
+Follow the [Building CoreFX on Windows][corefx-windows-instructions] instructions.
 
 Windows Forms requires the following workloads and components be selected when installing Visual Studio:
 
@@ -19,17 +19,32 @@ Windows Forms requires the following workloads and components be selected when i
 
 ## Workflow
 
-We use the following workflow for building and testing features and fixes.
+We use the following workflow for building as well as testing features and fixes.
 
-You first need to [Fork](https://github.com/dotnet/corefx/wiki/Checking-out-the-code-repository#fork-the-repository) and [Clone](https://github.com/dotnet/corefx/wiki/Checking-out-the-code-repository#clone-the-repository) this WinForms repository. This is a one-time task.
+You first need to [Fork][fork] and [Clone][clone] this WinForms repository. This is a one-time task.
 
-1. [Build](building.md) the repo.
-2. [Debug](debugging.md) the change, as needed.
-3. [Test](testing.md) the change, to validate quality.
+1. [Build][building] the repository.
+2. [Debug][debugging] the change, as needed.
+3. [Test][testing] the change, to validate quality.
 
 ## More Information
 
-* [Git commands and workflow](https://github.com/dotnet/corefx/wiki/git-reference)
-* [Coding guidelines](https://github.com/dotnet/corefx/tree/master/Documentation#coding-guidelines)
-* [up-for-grabs WinForms issues](https://github.com/dotnet/winforms/issues?q=is%3Aopen+is%3Aissue+label%3Aup-for-grabs)
-* [easy WinForms issues](https://github.com/dotnet/winforms/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3Aeasy)
+* [Git commands and workflow][git-commands]
+* [Coding guidelines][corefx-coding-guidelines]
+* [up-for-grabs WinForms issues][up-for-grabs]
+* [easy WinForms issues][easy]
+
+[comment]: <> (Links)
+
+[contributing]: contributing.md
+[issue-guide]: issue-guide.md
+[corefx-windows-instructions]: https://github.com/dotnet/corefx/blob/master/Documentation/building/windows-instructions.md
+[fork]: https://github.com/dotnet/corefx/wiki/Checking-out-the-code-repository#fork-the-repository
+[clone]: https://github.com/dotnet/corefx/wiki/Checking-out-the-code-repository#clone-the-repository
+[building]: building.md
+[debugging]: debugging.md
+[testing]: testing.md
+[git-commands]: https://github.com/dotnet/corefx/wiki/git-reference
+[corefx-coding-guidelines]: https://github.com/dotnet/corefx/tree/master/Documentation#coding-guidelines
+[up-for-grabs]: https://github.com/dotnet/winforms/issues?q=is%3Aopen+is%3Aissue+label%3Aup-for-grabs
+[easy]: https://github.com/dotnet/winforms/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3Aeasy

--- a/Documentation/developer-guide.md
+++ b/Documentation/developer-guide.md
@@ -1,8 +1,8 @@
 # Developer Guide
 
-The following document describes the setup and workflow that is recommended for working on the Windows Forms project. It assumes that you have read the [Contributing Document][contributing].
+The following document describes the setup and workflow that is recommended for working on the Windows Forms project. It assumes that you have read the [Contributing Document](contributing.md).
 
-The [Issue Guide][issue-guide] describes our approach to using GitHub issues.
+The [Issue Guide](issue-guide.md) describes our approach to using GitHub issues.
 
 ## Machine Setup
 
@@ -23,11 +23,11 @@ We use the following workflow for building as well as testing features and fixes
 
 You first need to [Fork][fork] and [Clone][clone] this WinForms repository. This is a one-time task.
 
-1. [Build][building] the repository.
+1. [Build](building.md) the repository.
 
-2. [Debug][debugging] the change, as needed.
+2. [Debug](debugging.md) the change, as needed.
 
-3. [Test][testing] the change, to validate quality.
+3. [Test](testing.md)the change, to validate quality.
 
 ## More Information
 
@@ -36,16 +36,11 @@ You first need to [Fork][fork] and [Clone][clone] this WinForms repository. This
 * [up-for-grabs WinForms issues][up-for-grabs]
 * [easy WinForms issues][easy]
 
-[comment]: <> (Links)
+[comment]: <> (URI Links)
 
-[contributing]: contributing.md
-[issue-guide]: issue-guide.md
 [corefx-windows-instructions]: https://github.com/dotnet/corefx/blob/master/Documentation/building/windows-instructions.md
 [fork]: https://github.com/dotnet/corefx/wiki/Checking-out-the-code-repository#fork-the-repository
 [clone]: https://github.com/dotnet/corefx/wiki/Checking-out-the-code-repository#clone-the-repository
-[building]: building.md
-[debugging]: debugging.md
-[testing]: testing.md
 [git-commands]: https://github.com/dotnet/corefx/wiki/git-reference
 [corefx-coding-guidelines]: https://github.com/dotnet/corefx/tree/master/Documentation#coding-guidelines
 [up-for-grabs]: https://github.com/dotnet/winforms/issues?q=is%3Aopen+is%3Aissue+label%3Aup-for-grabs

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -7,7 +7,8 @@ This document describes the experience of using WinForms on .NET Core. The [Deve
 Choose one of these options:
 
 1. [.NET Core 3.0 SDK Preview 1 (recommended)][.net-core-3.0-sdk-preview-1]
-2. [.NET Core 3.0 daily build (latest changes, but less stable)][.net-core-3.0-daily]
+
+1. [.NET Core 3.0 daily build (latest changes, but less stable)][.net-core-3.0-daily]
 
 ## Creating new applications
 

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -1,6 +1,6 @@
 # Getting started with WinForms for .NET Core
 
-This document describes the experience of using WinForms on .NET Core. The [Developer Guide][developer-guide]describes how to develop features and fixes for Windows Forms.
+This document describes the experience of using WinForms on .NET Core. The [Developer Guide](developer-guide.md) describes how to develop features and fixes for Windows Forms.
 
 ## Installation
 
@@ -22,7 +22,7 @@ dotnet run
 
 ## Designing Forms
 
-WinForms Core does not yet have a dedicated Designer tool. For the time being, you can use [this workaround][winforms-designer].
+WinForms Core does not yet have a dedicated Designer tool. For the time being, you can use [this workaround](winforms-designer.md).
 
 ## Samples
 
@@ -30,13 +30,10 @@ Check out the [.NET Core 3.0 WinForms samples][.net-core-3.0-samples] for both b
 
 ## Porting existing applications
 
-To port your existing WinForms application from .NET Framework to .NET Core 3.0, refer to our [porting guidelines][porting-guidelines].
+To port your existing WinForms application from .NET Framework to .NET Core 3.0, refer to our [porting guidelines](porting-guidelines.md).
 
-[comment]: <> (Links)
+[comment]: <> (URI Links)
 
-[developer-guide]: developer-guide.md
 [.net-core-3.0-sdk-preview-1]: https://www.microsoft.com/net/download
 [.net-core-3.0-daily]: https://github.com/dotnet/core/blob/master/daily-builds.md
-[winforms-designer]: winforms-designer.md
 [.net-core-3.0-samples]: https://github.com/dotnet/samples/tree/master/windowsforms
-[porting-guidelines]: porting-guidelines.md

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -1,13 +1,13 @@
 # Getting started with WinForms for .NET Core
 
-This document describes the experience of using WinForms on .NET Core. The [Developer Guide](developer-guide.md) describes how to develop features and fixes for Windows Forms.
+This document describes the experience of using WinForms on .NET Core. The [Developer Guide][developer-guide]describes how to develop features and fixes for Windows Forms.
 
 ## Installation
 
 Choose one of these options:
 
-1. [.NET Core 3.0 SDK Preview 1 (recommended)](https://www.microsoft.com/net/download)
-2. [.NET Core 3.0 daily build (latest changes, but less stable)](https://github.com/dotnet/core/blob/master/daily-builds.md)
+1. [.NET Core 3.0 SDK Preview 1 (recommended)][.net-core-3.0-sdk-preview-1]
+2. [.NET Core 3.0 daily build (latest changes, but less stable)][.net-core-3.0-daily]
 
 ## Creating new applications
 
@@ -21,12 +21,21 @@ dotnet run
 
 ## Designing Forms
 
-WinForms Core does not yet have a dedicated Designer tool. For the time being, you can use [this workaround](winforms-designer.md).
+WinForms Core does not yet have a dedicated Designer tool. For the time being, you can use [this workaround][winforms-designer].
 
 ## Samples
 
-Check out the [.NET Core 3.0 WinForms samples](https://github.com/dotnet/samples/tree/master/windowsforms) for both basic and advanced scenarios.
+Check out the [.NET Core 3.0 WinForms samples][.net-core-3.0-samples] for both basic and advanced scenarios.
 
 ## Porting existing applications
 
-To port your existing WinForms application from .NET Framework to .NET Core 3.0, refer to our [porting guidelines](porting-guidelines.md).
+To port your existing WinForms application from .NET Framework to .NET Core 3.0, refer to our [porting guidelines][porting-guidelines].
+
+[comment]: <> (Links)
+
+[developer-guide]: developer-guide.md
+[.net-core-3.0-sdk-preview-1]: https://www.microsoft.com/net/download
+[.net-core-3.0-daily]: https://github.com/dotnet/core/blob/master/daily-builds.md
+[winforms-designer]: winforms-designer.md
+[.net-core-3.0-samples]: https://github.com/dotnet/samples/tree/master/windowsforms
+[porting-guidelines]: porting-guidelines.md

--- a/Documentation/issue-guide.md
+++ b/Documentation/issue-guide.md
@@ -114,7 +114,7 @@ Each PR has to have reviewer approval from at least one WinForms team member who
 
 1. Link PR to related issue via [auto-closing][auto-closing] (add "Fixes #12345" into your PR description).
 
-[comment]: <> (Links)
+[comment]: <> (URI Links)
 
 [corefx-api-review-process]: https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/api-review-process.md
 [corefx-api-proposal-ex]: https://github.com/dotnet/corefx/issues/271

--- a/Documentation/issue-guide.md
+++ b/Documentation/issue-guide.md
@@ -15,8 +15,8 @@ You can help us streamline our response time to your feedback and ideas by filin
 In general, try to be specific. Get straight to the main point. Leave additional details, options and alternatives to the end (hint: separate them visually). Don't write long bug reports, unless you have to.
 
 * Include a minimal repro in your bug if at all possible (chop off dependencies, remove as much code as possible). If it is not possible, say why.
-    * Note: Yes, it may take some time to minimize a repro from your larger app - but that is exactly what we would do in most cases anyway. Issues with clear small repros are easier for us to reproduce/investigate and therefore have higher chance to be addressed quickly.
-* Include callstacks, symptom description, or what is the difference between actual and expected behavior.
+  * Note: Yes, it may take some time to minimize a repro from your larger app - but that is exactly what we would do in most cases anyway. Issues with clear, small reproducing guidelines are easier for us to investigate and therefore have higher chance to be addressed quickly.
+* Include call-stacks, symptom description, or what is the difference between actual and expected behavior.
 
 ### High-quality feature and API suggestions
 
@@ -30,23 +30,23 @@ For API suggestions, check [API review process](https://github.com/dotnet/corefx
 We use GitHub [labels](https://github.com/dotnet/winforms/labels) on our issues in order to classify them. We have the following categories per issue:
 
 * **Issue Type**: These labels classify the type of issue. We use the following types:
-    * [api-suggestion](https://github.com/dotnet/winforms/labels/api-suggestion): Issues which would add new APIs (see [API Review process](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/api-review-process.md) for details).
-        * Note: WinForms API process is not finalized yet. We may need to add additional UI-specific steps to it (for example, accessibility review and [documentation](https://docs.microsoft.com/dotnet/framework/winforms) update process). Expect finalized API review version post-3.0 when we will be ready to take new APIs.
-    * [bug](https://github.com/dotnet/winforms/labels/bug), [enhancement](https://github.com/dotnet/winforms/labels/enhancement), [test-bug](https://github.com/dotnet/winforms/labels/test-bug), [test-enhancement](https://github.com/dotnet/winforms/labels/test-enhancement), [question](https://github.com/dotnet/winforms/labels/question), [documentation](https://github.com/dotnet/winforms/labels/documentation): See [label description](https://github.com/dotnet/winforms/labels) for details.
+  * [api-suggestion](https://github.com/dotnet/winforms/labels/api-suggestion): Issues which would add new APIs (see [API Review process](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/api-review-process.md) for details).
+    * Note: WinForms API process is not finalized yet. We may need to add additional UI-specific steps to it (e.g. accessibility review). Expect finalized API review version post-3.0 when we will be ready to take new APIs.
+  * [bug](https://github.com/dotnet/winforms/labels/bug), [enhancement](https://github.com/dotnet/winforms/labels/enhancement), [test-bug](https://github.com/dotnet/winforms/labels/test-bug), [test-enhancement](https://github.com/dotnet/winforms/labels/test-enhancement), [question](https://github.com/dotnet/winforms/labels/question), [documentation](https://github.com/dotnet/winforms/labels/documentation): See [label description](https://github.com/dotnet/winforms/labels) for details.
 * **Other**:
-    * [up-for-grabs](https://github.com/dotnet/winforms/labels/up-for-grabs): Smaller sections of work which we believe are well scoped. These sorts of issues are a good place to start if you are new. Anyone is free to work on these issues.
-    * [needs-more-info](https://github.com/dotnet/winforms/labels/needs-more-info): Issues which need more information to be actionable. Usually this will be because we can't reproduce a reported bug. We'll close these issues after a little bit if we haven't gotten actionable information, but we welcome folks who have acquired more information to reopen the issue.
-    * [tenet-compatibility](https://github.com/dotnet/winforms/labels/tenet-compatibility): Incompatibility between relesed versions or with WinForms for .NET Framework.
+  * [up-for-grabs](https://github.com/dotnet/winforms/labels/up-for-grabs): Smaller sections of work which we believe are well scoped. These sorts of issues are a good place to start if you are new. Anyone is free to work on these issues.
+  * [needs-more-info](https://github.com/dotnet/winforms/labels/needs-more-info): Issues which need more information to be actionable. Usually this will be because we can't reproduce a reported bug. We'll close these issues after a little bit if we haven't gotten actionable information, but we welcome folks who have acquired more information to reopen the issue.
+  * [tenet-compatibility](https://github.com/dotnet/winforms/labels/tenet-compatibility): Incompatibility between released versions or with WinForms for .NET Framework.
 
 ## Milestones
 
 We use [milestones](https://github.com/dotnet/winforms/milestones) to prioritize work for each upcoming release.
 
 * **3.0** milestone work is focused on parity with WinForms for .NET Framework. We do not plan to take contributions or address issues that are not unique to WinForms on .NET Core in 3.0 release. For example:
-    * Bugs which are present on both WinForms platforms (for .NET Core and .NET Framework) will be put into **Future** milestone and will be reviewed and prioritized after 3.0 final release.
+  * Bugs which are present on both WinForms platforms (for .NET Core and .NET Framework) will be put into **Future** milestone and will be reviewed and prioritized after 3.0 final release.
     * Requests for new APIs and features will be put into **Future** milestone and will be reviewed and prioritized after 3.0 final release.
 * **Future** milestone tracks all potential future work (which may or may not happen). When we are done with 3.0 release, we will move some of these issues into the next immediate milestone.
-    * Please do not start discussions about next post-3.0 milestone until we are close to final 3.0 release. If you want to express your opinion on prioritization, please [upvote first post of the issue](#upvotes-on-issues) instead.
+  * Please do not start discussions about next post-3.0 milestone until we are close to final 3.0 release. If you want to express your opinion on prioritization, please [up-vote first post of the issue](#upvotes-on-issues) instead.
 
 ## Assignee
 
@@ -54,20 +54,25 @@ We assign each issue to assignee, when the assignee is ready to pick up the work
 If the issue is not assigned to anyone and you want to pick it up, please say so - we will assign the issue to you.
 If the issue is already assigned to someone, please coordinate with the assignee before you start working on it.
 
-## Upvotes on issues
+## Up-votes on issues
 
-Upvotes on first post of each issue are useful hint for our prioritization.
-We can [sort issues by number of upvotes](https://github.com/dotnet/winforms/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc) and we will review the top list on regular basis.
+Up-votes on first post of each issue are useful hint for our prioritization.
+We can [sort issues by number of up-votes](https://github.com/dotnet/winforms/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc) and we will review the top list on regular basis.
 
 ## Triage rules
 
-Guidance for triaging issues for WinForms team members:
+Guidance for triage of issues for WinForms team members:
 
 1. Issue has no **Assignee**, unless someone is working on the issue at the moment.
+
 1. Use **up-for-grabs** as much as possible, ideally with a quick note about next steps / complexity of the issue.
+
 1. Set milestone to **Future**, unless you can 95%-commit you can fund the issue in specific milestone.
+
 1. Each issue has exactly one "*issue type*" label (**bug**, **enhancement**, **api-suggestion**, **test-bug**, **test-enhancement**, **question**, **documentation**, etc.).
+
 1. Don't be afraid to say no, or close issues - just explain why and be polite.
+
 1. Don't be afraid to be wrong - just be flexible when new information appears.
 
 Feel free to use other labels if it helps your triage efforts (for example, **needs-more-info**, **design-discussion**, **tenet-compatibility**, etc.).
@@ -75,27 +80,35 @@ Feel free to use other labels if it helps your triage efforts (for example, **ne
 ### Motivation for triage rules
 
 1. Issue has no **Assignee**, unless someone is working on the issue at the moment.
-    * Motivation: Observation is that contributors are less likely to grab assigned issues, no matter what the repo rules say.
+    * Motivation: Observation is that contributors are less likely to grab assigned issues, no matter what the repository rules say.
+
 1. Use **up-for-grabs** as much as possible, ideally with a quick note about next steps / complexity of the issue.
-    * Note: Per https://up-for-grabs.net, such issues should be no longer than few nights' worth of work. They should be actionable (that is, no mysterious CI failures that can't be tested in the open).
+    * Note: Per [http://up-for-grabs.net](http://up-for-grabs.net), such issues should be no longer than few nights' worth of work. They should be actionable (i.e. no mysterious CI failures that can't be tested in the open).
+
 1. Set milestone to **Future**, unless you can 95%-commit you can fund the issue in specific milestone.
     * Motivation: Helps communicate desire/timeline to community. Can spark further priority/impact discussion.
+
 1. Each issue has exactly one "*issue type*" label (**bug**, **enhancement**, **api-suggestion**, **test-bug**, **test-enhancement**, **question**, **documentation**, etc.).
     * Don't be afraid to be wrong when deciding 'bug' vs. 'test-bug' (flip a coin if you must). The most useful values for tracking are 'api-&#42;' vs. 'enhancement', 'question', and 'documentation'.
+
 1. Don't be afraid to say no, or close issues - just explain why and be polite.
+
 1. Don't be afraid to be wrong - just be flexible when new information appears.
 
-### PR guidance
+## PR guidance
 
 Each PR has to have reviewer approval from at least one WinForms team member who is not author of the change, before it can be merged.
 
 1. Please don't set any labels on PRs. 
-    * exceptions: 
+    * exceptions:
       * **request-no-squash** may be supplied by the PR author(s) to request that history not be squashed at merge; this is a request, not a requirement 
       * **NO-MERGE** may be supplied by the WinForms team in order to indicate that the PR should be halted; a reason should be given in the comments
-      * **waiting-on-testing** may be supplied by the WinForms team to inform the PR author(s) that their PR is being delayed due to internal, manual testing; this action does not require action by the author(s). 
+      * **waiting-on-testing** may be supplied by the WinForms team to inform the PR author(s) that their PR is being delayed due to internal, manual testing; this action does not require action by the author(s).
     * Motivation: All the important info (*issue type* label, API approval label, etc.) is already captured on the associated issue.
+
 1. Push PRs forward, don't let them go stale (response every 5+ days, ideally no PRs older than 2 weeks).
+
 1. Close stuck or long-term blocked PRs (for example, due to missing API approval, etc.) and reopen them once they are unstuck.
-    * Motivation: Keep only active PRs. WIP (work-in-progress) PRs should be rare and should not become stale (2+ weeks old). If a PR is stale and there is not immediate path forward, consider closing the PR until it is unblocked/unstuck.
+    * **Motivation: Keep only active PRs. WIP (work-in-progress) PRs should be rare and should not become stale (2+ weeks old). If a PR is stale and there is not immediate path forward, consider closing the PR until it is unblocked/unstuck.
+
 1. Link PR to related issue via [auto-closing](https://help.github.com/articles/closing-issues-via-commit-messages/) (add "Fixes #12345" into your PR description).

--- a/Documentation/issue-guide.md
+++ b/Documentation/issue-guide.md
@@ -23,11 +23,7 @@ In general, try to be specific. Get straight to the main point. Leave additional
 Provide clear description of your suggestion. Explain scenarios in which it would be helpful and why (motivation).
 Ideally, assume that the reader has minimal knowledge and experience with writing apps/libraries that would benefit from the feature.
 
-<<<<<<< HEAD
 For API suggestions, check [API review process][corefx-api-review-process], especially [example of good API proposals][corefx-api-proposal-ex].
-=======
-For API suggestions, check [API review process](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/api-review-process.md), especially this [example of a good API proposal](https://github.com/dotnet/corefx/issues/271).
->>>>>>> master
 
 ## Labels
 
@@ -38,15 +34,9 @@ We use GitHub [labels][labels] on our issues in order to classify them. We have 
     * Note: WinForms API process is not finalized yet. We may need to add additional UI-specific steps to it (e.g. accessibility review). Expect finalized API review version post-3.0 when we will be ready to take new APIs.
   * [bug][bug], [enhancement][enhancement], [test-bug][test-bug], [test-enhancement][test-enhancement], [question][question], [documentation][documentation]: See [label description][label-description] for details.
 * **Other**:
-<<<<<<< HEAD
   * [up-for-grabs][up-for-grabs]: Smaller sections of work which we believe are well scoped. These sorts of issues are a good place to start if you are new. Anyone is free to work on these issues.
   * [needs-more-info][needs-more-info]: Issues which need more information to be actionable. Usually this will be because we can't reproduce a reported bug. We'll close these issues after a little bit if we haven't gotten actionable information, but we welcome folks who have acquired more information to reopen the issue.
   * [tenet-compatibility][tenet-compatibility]: Incompatibility between released versions or with WinForms for .NET Framework.
-=======
-    * [up-for-grabs](https://github.com/dotnet/winforms/labels/up-for-grabs): Smaller sections of work which we believe are well scoped. These sorts of issues are a good place to start if you are new. Anyone is free to work on these issues.
-    * [needs-more-info](https://github.com/dotnet/winforms/labels/needs-more-info): Issues which need more information to be actionable. Usually this will be because we can't reproduce a reported bug. We'll close these issues after a little bit if we haven't gotten actionable information, but we welcome folks who have acquired more information to reopen the issue.
-    * [tenet-compatibility](https://github.com/dotnet/winforms/labels/tenet-compatibility): Incompatibility between previously released versions or with WinForms for .NET Framework.
->>>>>>> master
 
 ## Milestones
 
@@ -57,11 +47,7 @@ We use [milestones][milestones] to prioritize work for each upcoming release.
     * Bugs which are present on both WinForms platforms (for .NET Core and .NET Framework)
     * Requests for new APIs and features
 * **Future** milestone tracks all potential future work (which may or may not happen). When we are done with 3.0 release, we will move some of these issues into the next immediate milestone.
-<<<<<<< HEAD
   * Please do not start discussions about next post-3.0 milestone until we are close to final 3.0 release. If you want to express your opinion on prioritization, please [up-vote first post of the issue] instead.
-=======
-    * Please do not start discussions about next post-3.0 milestone until we are close to final 3.0 release. If you want to express your opinion on prioritization, please [upvote the first post of the issue](#upvotes-on-issues) instead.
->>>>>>> master
 
 ## Assignee
 
@@ -71,13 +57,8 @@ If the issue is already assigned to someone, please coordinate with the assignee
 
 ## Up-votes on issues
 
-<<<<<<< HEAD
 Up-votes on first post of each issue are useful hint for our prioritization.
 We can [sort issues by number of up-votes][up-votes], and we will review the top list on a regular basis.
-=======
-Upvotes on the first post of each issue are a useful hint for our prioritization.
-We can [sort issues by number of upvotes](https://github.com/dotnet/winforms/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc) and we will review the top list on regular basis.
->>>>>>> master
 
 ## Triage rules
 

--- a/Documentation/issue-guide.md
+++ b/Documentation/issue-guide.md
@@ -12,41 +12,42 @@ You can help us streamline our response time to your feedback and ideas by filin
 
 ### High-quality bug reports
 
-In general, try to be specific. Get straight to the main point. Leave additional details, options and alternatives to the end (hint: separate them visually). Don't write long bug reports, unless you have to.
+In general, try to be specific. Get straight to the main point. Leave additional details, options, and alternatives to the end (hint: separate them visually). Don't write long bug reports, unless you have to.
 
-* Include a minimal repro in your bug if at all possible (chop off dependencies, remove as much code as possible). If it is not possible, say why.
-  * Note: Yes, it may take some time to minimize a repro from your larger app - but that is exactly what we would do in most cases anyway. Issues with clear, small reproducing guidelines are easier for us to investigate and therefore have higher chance to be addressed quickly.
-* Include call-stacks, symptom description, or what is the difference between actual and expected behavior.
+* Include a minimal reproduction (repro) in your bug if at all possible (chop off dependencies, remove as much code as possible). If it is not possible, say why.
+  * Note: Yes, it may take some time to minimize a repro from your larger app - but that is exactly what we would do in most cases anyway. Issues with clear, concise reproduction guidelines are easier for us to investigate; such issues will have higher chance of being addressed quickly.
+* Include call-stacks, symptom descriptions, and differences between actual and expected behaviors.
 
 ### High-quality feature and API suggestions
 
 Provide clear description of your suggestion. Explain scenarios in which it would be helpful and why (motivation).
 Ideally, assume that the reader has minimal knowledge and experience with writing apps/libraries that would benefit from the feature.
 
-For API suggestions, check [API review process](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/api-review-process.md), especially [example of good API proposals](https://github.com/dotnet/corefx/issues/271).
+For API suggestions, check [API review process][corefx-api-review-process], especially [example of good API proposals][corefx-api-proposal-ex].
 
 ## Labels
 
-We use GitHub [labels](https://github.com/dotnet/winforms/labels) on our issues in order to classify them. We have the following categories per issue:
+We use GitHub [labels][labels] on our issues in order to classify them. We have the following categories per issue:
 
-* **Issue Type**: These labels classify the type of issue. We use the following types:
-  * [api-suggestion](https://github.com/dotnet/winforms/labels/api-suggestion): Issues which would add new APIs (see [API Review process](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/api-review-process.md) for details).
+* **Issue Types**: These labels classify the type of issue. We use the following types:
+  * [api-suggestion]: Issues which would add new APIs (see [API Review process][corefx-api-review-process] for details).
     * Note: WinForms API process is not finalized yet. We may need to add additional UI-specific steps to it (e.g. accessibility review). Expect finalized API review version post-3.0 when we will be ready to take new APIs.
-  * [bug](https://github.com/dotnet/winforms/labels/bug), [enhancement](https://github.com/dotnet/winforms/labels/enhancement), [test-bug](https://github.com/dotnet/winforms/labels/test-bug), [test-enhancement](https://github.com/dotnet/winforms/labels/test-enhancement), [question](https://github.com/dotnet/winforms/labels/question), [documentation](https://github.com/dotnet/winforms/labels/documentation): See [label description](https://github.com/dotnet/winforms/labels) for details.
+  * [bug][bug], [enhancement][enhancement], [test-bug][test-bug], [test-enhancement][test-enhancement], [question][question], [documentation][documentation]: See [label description][label-description] for details.
 * **Other**:
-  * [up-for-grabs](https://github.com/dotnet/winforms/labels/up-for-grabs): Smaller sections of work which we believe are well scoped. These sorts of issues are a good place to start if you are new. Anyone is free to work on these issues.
-  * [needs-more-info](https://github.com/dotnet/winforms/labels/needs-more-info): Issues which need more information to be actionable. Usually this will be because we can't reproduce a reported bug. We'll close these issues after a little bit if we haven't gotten actionable information, but we welcome folks who have acquired more information to reopen the issue.
-  * [tenet-compatibility](https://github.com/dotnet/winforms/labels/tenet-compatibility): Incompatibility between released versions or with WinForms for .NET Framework.
+  * [up-for-grabs][up-for-grabs]: Smaller sections of work which we believe are well scoped. These sorts of issues are a good place to start if you are new. Anyone is free to work on these issues.
+  * [needs-more-info][needs-more-info]: Issues which need more information to be actionable. Usually this will be because we can't reproduce a reported bug. We'll close these issues after a little bit if we haven't gotten actionable information, but we welcome folks who have acquired more information to reopen the issue.
+  * [tenet-compatibility][tenet-compatibility]: Incompatibility between released versions or with WinForms for .NET Framework.
 
 ## Milestones
 
-We use [milestones](https://github.com/dotnet/winforms/milestones) to prioritize work for each upcoming release.
+We use [milestones][milestones] to prioritize work for each upcoming release.
 
 * **3.0** milestone work is focused on parity with WinForms for .NET Framework. We do not plan to take contributions or address issues that are not unique to WinForms on .NET Core in 3.0 release. For example:
-  * Bugs which are present on both WinForms platforms (for .NET Core and .NET Framework) will be put into **Future** milestone and will be reviewed and prioritized after 3.0 final release.
-    * Requests for new APIs and features will be put into **Future** milestone and will be reviewed and prioritized after 3.0 final release.
+  * The following will be put into **Future** milestone and will be reviewed and prioritized after 3.0 final release:
+    * Bugs which are present on both WinForms platforms (for .NET Core and .NET Framework)
+    * Requests for new APIs and features
 * **Future** milestone tracks all potential future work (which may or may not happen). When we are done with 3.0 release, we will move some of these issues into the next immediate milestone.
-  * Please do not start discussions about next post-3.0 milestone until we are close to final 3.0 release. If you want to express your opinion on prioritization, please [up-vote first post of the issue](#upvotes-on-issues) instead.
+  * Please do not start discussions about next post-3.0 milestone until we are close to final 3.0 release. If you want to express your opinion on prioritization, please [up-vote first post of the issue] instead.
 
 ## Assignee
 
@@ -57,11 +58,11 @@ If the issue is already assigned to someone, please coordinate with the assignee
 ## Up-votes on issues
 
 Up-votes on first post of each issue are useful hint for our prioritization.
-We can [sort issues by number of up-votes](https://github.com/dotnet/winforms/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc) and we will review the top list on regular basis.
+We can [sort issues by number of up-votes][up-votes], and we will review the top list on a regular basis.
 
 ## Triage rules
 
-Guidance for triage of issues for WinForms team members:
+Guidance for triage of issues for Windows Forms team members:
 
 1. Issue has no **Assignee**, unless someone is working on the issue at the moment.
 
@@ -71,7 +72,7 @@ Guidance for triage of issues for WinForms team members:
 
 1. Each issue has exactly one "*issue type*" label (**bug**, **enhancement**, **api-suggestion**, **test-bug**, **test-enhancement**, **question**, **documentation**, etc.).
 
-1. Don't be afraid to say no, or close issues - just explain why and be polite.
+1. Don't be afraid to say no, or close issues — just explain why and be polite.
 
 1. Don't be afraid to be wrong - just be flexible when new information appears.
 
@@ -83,7 +84,7 @@ Feel free to use other labels if it helps your triage efforts (for example, **ne
     * Motivation: Observation is that contributors are less likely to grab assigned issues, no matter what the repository rules say.
 
 1. Use **up-for-grabs** as much as possible, ideally with a quick note about next steps / complexity of the issue.
-    * Note: Per [http://up-for-grabs.net](http://up-for-grabs.net), such issues should be no longer than few nights' worth of work. They should be actionable (i.e. no mysterious CI failures that can't be tested in the open).
+    * Note: Per [http://up-for-grabs.net][up-for-grabs-net], such issues should be no longer than few nights' worth of work. They should be actionable (i.e. no mysterious CI failures that can't be tested in the open).
 
 1. Set milestone to **Future**, unless you can 95%-commit you can fund the issue in specific milestone.
     * Motivation: Helps communicate desire/timeline to community. Can spark further priority/impact discussion.
@@ -91,15 +92,15 @@ Feel free to use other labels if it helps your triage efforts (for example, **ne
 1. Each issue has exactly one "*issue type*" label (**bug**, **enhancement**, **api-suggestion**, **test-bug**, **test-enhancement**, **question**, **documentation**, etc.).
     * Don't be afraid to be wrong when deciding 'bug' vs. 'test-bug' (flip a coin if you must). The most useful values for tracking are 'api-&#42;' vs. 'enhancement', 'question', and 'documentation'.
 
-1. Don't be afraid to say no, or close issues - just explain why and be polite.
+1. Don't be afraid to say no, or close issues — just explain why and be polite.
 
 1. Don't be afraid to be wrong - just be flexible when new information appears.
 
-## PR guidance
+## Pull Request (PR) guidance
 
 Each PR has to have reviewer approval from at least one WinForms team member who is not author of the change, before it can be merged.
 
-1. Please don't set any labels on PRs. 
+1. Please don't set any labels on PRs.
     * exceptions:
       * **request-no-squash** may be supplied by the PR author(s) to request that history not be squashed at merge; this is a request, not a requirement 
       * **NO-MERGE** may be supplied by the WinForms team in order to indicate that the PR should be halted; a reason should be given in the comments
@@ -111,4 +112,27 @@ Each PR has to have reviewer approval from at least one WinForms team member who
 1. Close stuck or long-term blocked PRs (for example, due to missing API approval, etc.) and reopen them once they are unstuck.
     * **Motivation: Keep only active PRs. WIP (work-in-progress) PRs should be rare and should not become stale (2+ weeks old). If a PR is stale and there is not immediate path forward, consider closing the PR until it is unblocked/unstuck.
 
-1. Link PR to related issue via [auto-closing](https://help.github.com/articles/closing-issues-via-commit-messages/) (add "Fixes #12345" into your PR description).
+1. Link PR to related issue via [auto-closing][auto-closing] (add "Fixes #12345" into your PR description).
+
+[comment]: <> (Links)
+
+[corefx-api-review-process]: https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/api-review-process.md
+[corefx-api-proposal-ex]: https://github.com/dotnet/corefx/issues/271
+[labels]: https://github.com/dotnet/winforms/labels
+[api-suggestion]: https://github.com/dotnet/winforms/labels/api-suggestion
+[API Review process]: https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/api-review-process.md
+[bug]: https://github.com/dotnet/winforms/labels/bug
+[enhancement]: https://github.com/dotnet/winforms/labels/enhancement
+[test-bug]: https://github.com/dotnet/winforms/labels/test-bug
+[test-enhancement]: https://github.com/dotnet/winforms/labels/test-enhancement
+[question]: https://github.com/dotnet/winforms/labels/question
+[documentation]: https://github.com/dotnet/winforms/labels/documentation
+[label-description]: https://github.com/dotnet/winforms/labels
+[up-for-grabs]: https://github.com/dotnet/winforms/labels/up-for-grabs
+[needs-more-info]: https://github.com/dotnet/winforms/labels/needs-more-info
+[tenet-compatibility]: https://github.com/dotnet/winforms/labels/tenet-compatibility
+[milestones]: https://github.com/dotnet/winforms/milestones
+[up-votes]: #upvotes-on-issues
+[sort issues by number of up-votes]: https://github.com/dotnet/winforms/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc
+[up-for-grabs-net]: http://up-for-grabs.net
+[auto-closing]: https://help.github.com/articles/closing-issues-via-commit-messages/

--- a/Documentation/porting-guidelines.md
+++ b/Documentation/porting-guidelines.md
@@ -18,9 +18,9 @@ The migration process includes two steps: **preparing your project for porting**
       .NET Core supported APIs and another with APIs not supported in .NET Core.
       Migrate only the first project.
 
-2. **Start from a working solution**. Ensure the solution opens, builds, and runs without any issues.
+1. **Start from a working solution**. Ensure the solution opens, builds, and runs without any issues.
 
-3. **Replace `packages.config` with `PackageReference`**. If your project uses
+1. **Replace `packages.config` with `PackageReference`**. If your project uses
    NuGet packages, you will need to add the same NuGet packages to the new .NET
    Core project. .NET Core projects support only `PackageReference` for adding
    NuGet packages. To move your NuGet references from `packages.config` to your
@@ -29,7 +29,7 @@ The migration process includes two steps: **preparing your project for porting**
 
    You can learn more about this migration in our [docs][pkg-config].
 
-4. **Migrate to the SDK-style .csproj file**. The new SDK-style `.csproj` format is leaner and easier to read. To be able to simply copy-paste your references from the old project to the new one, you first need to migrate your old project file to SDK-style so both project are in the same format. You can either do it by hand or use a third-party tool [CsprojToVs2017][pkg-config].
+1. **Migrate to the SDK-style .csproj file**. The new SDK-style `.csproj` format is leaner and easier to read. To be able to simply copy-paste your references from the old project to the new one, you first need to migrate your old project file to SDK-style so both project are in the same format. You can either do it by hand or use a third-party tool [CsprojToVs2017][pkg-config].
 
    After using the tool you still might need to delete some reference by hand; for example:
 
@@ -41,7 +41,7 @@ The migration process includes two steps: **preparing your project for porting**
 
    After you've migrated to the new SDK-style format, ensure your project builds and runs successfully.
 
-5. **Configure assembly file generation**. Most existing projects include an `AssemblyInfo.cs` file in the Properties folder. The new project style uses a different approach and generates the same assembly attributes as part of the build process. As a result, you might end up with two `AssemblyInfo.cs` files and your build will fail. There are two ways to resolve this problem. You can either:
+1. **Configure assembly file generation**. Most existing projects include an `AssemblyInfo.cs` file in the Properties folder. The new project style uses a different approach and generates the same assembly attributes as part of the build process. As a result, you might end up with two `AssemblyInfo.cs` files and your build will fail. There are two ways to resolve this problem. You can either:
     * Disable `AssemblyInfo.cs` generation on build by setting the property:
 
         ```xml
@@ -55,11 +55,11 @@ The migration process includes two steps: **preparing your project for porting**
 
 1. **Add .NET Core Windows Forms project**. Add a new .NET Core 3.0 Windows Forms project to the solution.
 
-2. **Add `<ProjectReference>`**. Copy the `<ProjectReference>` elements from the `.csproj` file of the original project to the new project's `.csproj` file. Note: The new project format does not use the `Name` and `ProjectGuid` elements, so you can safely delete those.
+1. **Add `<ProjectReference>`**. Copy the `<ProjectReference>` elements from the `.csproj` file of the original project to the new project's `.csproj` file. Note: The new project format does not use the `Name` and `ProjectGuid` elements, so you can safely delete those.
 
-3. **Restore/Build**. At this point, it's a good idea to restore/build to make sure all dependencies are properly configured.
+1. **Restore/Build**. At this point, it's a good idea to restore/build to make sure all dependencies are properly configured.
 
-4. **Link files**. Link all files from your existing .NET Framework WinForms project to the .NET Core 3.0 WinForms project by adding following to the `.csproj` file.
+1. **Link files**. Link all files from your existing .NET Framework WinForms project to the .NET Core 3.0 WinForms project by adding following to the `.csproj` file.
 
     ```xml
     <ItemGroup>
@@ -68,7 +68,7 @@ The migration process includes two steps: **preparing your project for porting**
     </ItemGroup>
     ```
 
-5. **Align default namespace and assembly name**. Since you're linking to designer generated files (for example, `Resources.Designer.cs`) you generally want to make sure that the .NET Core version of your application uses the same namespace and the same assembly name. Copy the following settings from your .NET Framework project:
+1. **Align default namespace and assembly name**. Since you're linking to designer generated files (for example, `Resources.Designer.cs`) you generally want to make sure that the .NET Core version of your application uses the same namespace and the same assembly name. Copy the following settings from your .NET Framework project:
 
     ```xml
     <PropertyGroup>
@@ -77,9 +77,9 @@ The migration process includes two steps: **preparing your project for porting**
     </PropertyGroup>
     ```
 
-6. **Run new project**. Set your new .NET Core project as StartUp Project and run it. Make sure everything works.
+1. **Run new project**. Set your new .NET Core project as StartUp Project and run it. Make sure everything works.
 
-7. **Copy or leave linked**. Now instead of linking the files, you can actually copy them from the old .NET Framework WinForms project to the new .NET Core 3.0 WinForms project. After that you can get rid of the old project. However, if you would like to use the Windows Forms' designer, it is not available in Visual Studio just yet. So you can stop at the step 6 and perform step 7 once designer support is available.
+1. **Copy or leave linked**. Now instead of linking the files, you can actually copy them from the old .NET Framework WinForms project to the new .NET Core 3.0 WinForms project. After that you can get rid of the old project. However, if you would like to use the Windows Forms' designer, it is not available in Visual Studio just yet. So you can stop at the step 6 and perform step 7 once designer support is available.
 
 ## Migration tips
 
@@ -102,9 +102,9 @@ differences:
 * There are [unsupported features][wcf-supported] that you should review.
 * The binding and endpoint address must be specified in the service client constructor. Otherwise, if you reuse the `ServiceReference` created by Visual Studio, you may get the following error:
 
-  ```cs
-  System.PlatformNotSupportedException: 'Configuration files are not supported.'
-  ```
+```cs
+System.PlatformNotSupportedException: 'Configuration files are not supported.'
+```
 
 [comment]: <> (Links)
 

--- a/Documentation/porting-guidelines.md
+++ b/Documentation/porting-guidelines.md
@@ -18,8 +18,7 @@ The migration process includes two steps: **preparing your project for porting**
       .NET Core supported APIs and another with APIs not supported in .NET Core.
       Migrate only the first project.
 
-2. **Start from a working solution**. Ensure the solution opens, builds, and
-   runs without any issues.
+2. **Start from a working solution**. Ensure the solution opens, builds, and runs without any issues.
 
 3. **Replace `packages.config` with `PackageReference`**. If your project uses
    NuGet packages, you will need to add the same NuGet packages to the new .NET
@@ -30,14 +29,9 @@ The migration process includes two steps: **preparing your project for porting**
 
    You can learn more about this migration in our [docs][pkg-config].
 
-4. **Migrate to the SDK-style .csproj file**. The new SDK-style `.csproj` format
-   is leaner and easier to read. To be able to simply copy-paste your references
-   from the old project to the new one, you first need to migrate your old
-   project file to SDK-style so both project are in the same format. You can
-   either do it by hand or use a third-party tool [CsprojToVs2017][pkg-config].
+4. **Migrate to the SDK-style .csproj file**. The new SDK-style `.csproj` format is leaner and easier to read. To be able to simply copy-paste your references from the old project to the new one, you first need to migrate your old project file to SDK-style so both project are in the same format. You can either do it by hand or use a third-party tool [CsprojToVs2017][pkg-config].
 
-   After using the tool you still might need to delete some reference by hand,
-   for example:
+   After using the tool you still might need to delete some reference by hand; for example:
 
     ```xml
     <Reference Include="System.Data.DataSetExtensions" />
@@ -45,42 +39,27 @@ The migration process includes two steps: **preparing your project for porting**
     <Reference Include="System.Net.Http" />
     ```
 
-   After you've migrated to the new SDK-style format, ensure your project builds
-   and runs successfully.
+   After you've migrated to the new SDK-style format, ensure your project builds and runs successfully.
 
-5. **Configure assembly file generation**. Most existing projects include an
-   `AssemblyInfo.cs` file in the Properties folder. The new project style uses a
-   different approach and generates the same assembly attributes as part of the
-   build process. As a result, you might end up with two `AssemblyInfo.cs` files
-   and your build will fail. There are two ways to resolve this problem. You can
-   either:
-
+5. **Configure assembly file generation**. Most existing projects include an `AssemblyInfo.cs` file in the Properties folder. The new project style uses a different approach and generates the same assembly attributes as part of the build process. As a result, you might end up with two `AssemblyInfo.cs` files and your build will fail. There are two ways to resolve this problem. You can either:
     * Disable `AssemblyInfo.cs` generation on build by setting the property:
+
         ```xml
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         ```
-    * Move the static values from `AssemblyInfo.cs` to properties in the new
-      `.csproj` file.
+    * Move the static values from `AssemblyInfo.cs` to properties in the new `.csproj` file.
 
-    Build and run to make sure you didn't introduce any issues while preparing
-    your project. Now it's time to port it.
+    Build and run to make sure you did not introduce any issues while preparing your project. Now it is time to port it.
 
 ## Port your project
 
-1. **Add .NET Core Windows Forms project**. Add a new .NET Core 3.0 Windows
-   Forms project to the solution.
+1. **Add .NET Core Windows Forms project**. Add a new .NET Core 3.0 Windows Forms project to the solution.
 
-2. **Add `<ProjectReference>`**. Copy the `<ProjectReference>` elements from the
-   `.csproj` file of the original project to the new project's `.csproj` file.
-   Note: The new project format does not use the `Name` and `ProjectGuid`
-   elements, so you can safely delete those.
+2. **Add `<ProjectReference>`**. Copy the `<ProjectReference>` elements from the `.csproj` file of the original project to the new project's `.csproj` file. Note: The new project format does not use the `Name` and `ProjectGuid` elements, so you can safely delete those.
 
-3. **Restore/Build**. At this point, it's a good idea to restore/build to make
-   sure all dependencies are properly configured.
+3. **Restore/Build**. At this point, it's a good idea to restore/build to make sure all dependencies are properly configured.
 
-4. **Link files**. Link all files from your existing .NET Framework WinForms
-   project to the .NET Core 3.0 WinForms project by adding following to the
-   `.csproj` file.
+4. **Link files**. Link all files from your existing .NET Framework WinForms project to the .NET Core 3.0 WinForms project by adding following to the `.csproj` file.
 
     ```xml
     <ItemGroup>
@@ -89,11 +68,7 @@ The migration process includes two steps: **preparing your project for porting**
     </ItemGroup>
     ```
 
-5. **Align default namespace and assembly name**. Since you're linking to
-   designer generated files (for example, `Resources.Designer.cs`) you generally
-   want to make sure that the .NET Core version of your application uses the
-   same namespace and the same assembly name. Copy the following settings from
-   your .NET Framework project:
+5. **Align default namespace and assembly name**. Since you're linking to designer generated files (for example, `Resources.Designer.cs`) you generally want to make sure that the .NET Core version of your application uses the same namespace and the same assembly name. Copy the following settings from your .NET Framework project:
 
     ```xml
     <PropertyGroup>
@@ -102,26 +77,15 @@ The migration process includes two steps: **preparing your project for porting**
     </PropertyGroup>
     ```
 
-6. **Run new project**. Set your new .NET Core project as StartUp Project and
-   run it. Make sure everything works.
+6. **Run new project**. Set your new .NET Core project as StartUp Project and run it. Make sure everything works.
 
-7. **Copy or leave linked**. Now instead of linking the files, you can actually
-   copy them from the old .NET Framework WinForms project to the new .NET Core
-   3.0 WinForms project. After that you can get rid of the old project. However
-   if you'd like to use WinForms designer, it is not available in Visual Studio
-   just yet. So you can stop at the step 8 and perform step 9 when the designer
-   support is available.
+7. **Copy or leave linked**. Now instead of linking the files, you can actually copy them from the old .NET Framework WinForms project to the new .NET Core 3.0 WinForms project. After that you can get rid of the old project. However, if you would like to use the Windows Forms' designer, it is not available in Visual Studio just yet. So you can stop at the step 6 and perform step 7 once designer support is available.
 
 ## Migration tips
 
 ### Include the Windows.Compatibility Pack
 
-Windows applications like Windows Forms and WPF often use APIs that aren't
-referenced by default in .NET Core. The reason is that .NET Core tries to reduce
-the risk that new applications accidentally depend on legacy technologies or on
-APIs that are Windows-only. However, when porting existing Windows applications,
-neither of these two aspects is a concern. To simplify your porting efforts, you
-can just reference the [Windows Compatibility Pack][compat-pack] which will give
+Windows applications like Windows Forms and WPF often use APIs that aren't referenced by default in .NET Core. The reason is that .NET Core tries to reduce the risk that new applications accidentally depend on legacy technologies or on APIs that are Windows-only. However, when porting existing Windows applications, neither of these two aspects is a concern. To simplify your porting efforts, you can simply reference the [Windows Compatibility Pack][compat-pack], which will give
 you access to many more APIs.
 
 ```cmd
@@ -133,16 +97,16 @@ dotnet add package Microsoft.Windows.Compatibility
 .NET Core has its own implementation of `System.ServiceModel` with some
 differences:
 
-* It's available as a set of NuGet packages (also included in the [Windows
+* It is available as a set of NuGet packages (also included in the [Windows
   Compatibility Pack][compat-pack]).
 * There are [unsupported features][wcf-supported] that you should review.
-* The binding and endpoint address must be specified in the service client
-  constructor. Otherwise, if you reuse the `ServiceReference` created by Visual
-  Studio, you may get the following error:
+* The binding and endpoint address must be specified in the service client constructor. Otherwise, if you reuse the `ServiceReference` created by Visual Studio, you may get the following error:
 
-  ```text
+  ```cs
   System.PlatformNotSupportedException: 'Configuration files are not supported.'
   ```
+
+[comment]: <> (Links)
 
 [api-port]: https://blogs.msdn.microsoft.com/dotnet/2018/08/08/are-your-windows-forms-and-wpf-applications-ready-for-net-core-3-0/
 [pkg-config]: https://docs.microsoft.com/en-us/nuget/reference/migrate-packages-config-to-package-reference

--- a/Documentation/porting-guidelines.md
+++ b/Documentation/porting-guidelines.md
@@ -106,7 +106,7 @@ differences:
 System.PlatformNotSupportedException: 'Configuration files are not supported.'
 ```
 
-[comment]: <> (Links)
+[comment]: <> (URI Links)
 
 [api-port]: https://blogs.msdn.microsoft.com/dotnet/2018/08/08/are-your-windows-forms-and-wpf-applications-ready-for-net-core-3-0/
 [pkg-config]: https://docs.microsoft.com/en-us/nuget/reference/migrate-packages-config-to-package-reference

--- a/Documentation/testing.md
+++ b/Documentation/testing.md
@@ -2,7 +2,7 @@
 
 This document describes our approach to unit testing.
 
-We are _still working on_ a scalable solution for functional testing. For now, see [Functional Testing](testing.md#functional-testing) and the [issue #183](https://github.com/dotnet/winforms/issues/183).
+We are _still working on_ a scalable solution for functional testing. For now, see [Functional Testing][functional-testing] and the [issue #183][issue-#183].
 
 ## Building tests
 
@@ -89,8 +89,8 @@ Tests are built and executed by file name convention
 
 ##### Code Coverage
 
-* In Visual Studio Test Explorer, select all tests, right click and execute 'Analyze code coverage for selected tests' command. This will run all tests and give a summary of blocks covered in 'Code Coverage Results' window. The summary can be drilled down to method level.   
-* Any code change accompanied with unit tests is expected to increase code coverage for the code modified. 
+* In Visual Studio Test Explorer, select all tests, right click and execute 'Analyze code coverage for selected tests' command. This will run all tests and give a summary of blocks covered in 'Code Coverage Results' window. The summary can be drilled down to method level.
+* Any code change accompanied with unit tests is expected to increase code coverage for the code modified.
 
 ##### Avoid duplicating tests just for different inputs
 
@@ -104,7 +104,7 @@ Tests are built and executed by file name convention
 ##### Whenever possible, mock up dependencies to run tests in isolation
   
 * For example, if your method accepts an abstraction, use Moq to mock it up
-* Search for Mock in the existing tests for examples, and see [Moq](https://github.com/Moq/moq4/wiki/Quickstart) for details on how to use Moq.
+* Search for Mock in the existing tests for examples, and see [Moq][moq] for details on how to use Moq.
 
 ## Functional Testing
 
@@ -118,7 +118,7 @@ In the console, run the following command from the base of the repository:
 .\.dotnet\dotnet.exe .\artifacts\bin\WinformsControlsTest\Debug\netcoreapp3.0\WinformsControlsTest.dll
 ```
 
-**Note:** that this will fail if the WinformsControlsTest is not built. See [Build](testing.md) for more information on how to build from source.
+**Note:** that this will fail if the WinformsControlsTest is not built. See [Build][building] for more information on how to build from source.
 
 ### The test runner
 
@@ -157,3 +157,10 @@ The execution of that command will return a 0 if all tests passed and a -1 if ev
 12/6/2018 9:42 AM: DateTimePickerButton passed.
 12/6/2018 9:42 AM: FolderBrowserDialogButton passed.
 ```
+
+[comment]: <> (Links)
+
+[functional-testing]: (testing.md#functional-testing)
+[issue-#183]: https://github.com/dotnet/winforms/issues/183
+[moq]: (https://github.com/Moq/moq4/wiki/Quickstart)
+[building]: (building.md)

--- a/Documentation/testing.md
+++ b/Documentation/testing.md
@@ -2,7 +2,7 @@
 
 This document describes our approach to unit testing.
 
-We are _still working on_ a scalable solution for functional testing. For now, see [Functional Testing][functional-testing] and the [issue #183][issue-#183].
+We are _still working on_ a scalable solution for functional testing. For now, see [Functional Testing](testing.md#functional-testing) and the [issue #183][issue-#183].
 
 ## Building tests
 
@@ -118,7 +118,7 @@ In the console, run the following command from the base of the repository:
 .\.dotnet\dotnet.exe .\artifacts\bin\WinformsControlsTest\Debug\netcoreapp3.0\WinformsControlsTest.dll
 ```
 
-**Note:** that this will fail if the WinformsControlsTest is not built. See [Build][building] for more information on how to build from source.
+**Note:** that this will fail if the WinformsControlsTest is not built. See [Build](building.md) for more information on how to build from source.
 
 ### The test runner
 
@@ -158,9 +158,7 @@ The execution of that command will return a 0 if all tests passed and a -1 if ev
 12/6/2018 9:42 AM: FolderBrowserDialogButton passed.
 ```
 
-[comment]: <> (Links)
+[comment]: <> (URI Links)
 
-[functional-testing]: (testing.md#functional-testing)
 [issue-#183]: https://github.com/dotnet/winforms/issues/183
 [moq]: (https://github.com/Moq/moq4/wiki/Quickstart)
-[building]: (building.md)

--- a/Documentation/testing.md
+++ b/Documentation/testing.md
@@ -6,7 +6,7 @@ We are _still working on_ a scalable solution for functional testing. For now, s
 
 ## Building tests
 
-Tests are automatically built when running `.\build` since all test projects are referenced in `Winforms.sln` at the repo root.
+Tests are automatically built when running `.\build` since all test projects are referenced in `Winforms.sln` at the repository root.
 
 ## Running tests
 
@@ -49,19 +49,17 @@ To test from Visual Studio, open Winforms.sln in Visual Studio and test how you 
 * When testing from Visual Studio, test errors show up as normal in the test explorer.
 * To troubleshoot, debug the selected test and set breakpoints as you normally would.
 
-## Unit Testing
-
-### Adding new unit tests
+## Adding new tests
 
 Tests are built and executed by file name convention
 
-* Every WinForms binary has its own folder under src in the repo root (src\System.Windows.Forms, for example)
+* Every WinForms binary has its own folder under src in the repository root (src\System.Windows.Forms, for example)
 * Each of those folders has a tests folder under it (src\System.Windows.Forms\tests, for example)
 * Each tests folder contains an xUnit test project (System.Windows.Forms.Tests.csproj)
   * These test projects automatically build when running .\build
   * The tests from these projects automatically execute when running .\build -test
 
-#### Therefore, you just need to put your tests in the right place in order for them to run
+### Therefore, you just need to put your tests in the right place in order for them to run
 
 * Browse to the tests folder for the binary you are testing
 * There should be one file per class being tested, and the file name should match the class name.
@@ -85,19 +83,28 @@ Tests are built and executed by file name convention
 
 #### Strategy
 
-* **Unit tests should be part of the same PR as code changes**
-  * Unit tests must be added for any change to public APIs. We will accept unit tests for internal methods as well. 
-* **Code Coverage**
-  * In Visual Studio Test Explorer, select all tests, right click and execute 'Analyze code coverage for selected tests' command. This will run all tests and give a summary of blocks covered in 'Code Coverage Results' window. The summary can be drilled down to method level.   
-  * Any code change accompanied with unit tests is expected to increase code coverage for the code modified. 
-* Avoid duplicating tests just for different inputs
-  * Use `[Theory]` for this, followed by either `[InlineData]` or `[MemberData]`. See existing tests for examples on how to use these attributes
-  * The exception to this is if the code behavior is fundamentally different based on the inputs. For example, if a method throws an ArgumentException for invalid inputs, that should be a separate test.
-* One test (or test data) per code path please
-  * The most common exception to this is when testing a property, most people test get/set together
-* Whenever possible, mock up dependencies to run tests in isolation
-  * For example, if your method accepts an abstraction, use Moq to mock it up
-  * Search for Mock in the existing tests for examples, and see [Moq](https://github.com/Moq/moq4/wiki/Quickstart) for details on how to use Moq.
+##### Unit tests should be part of the same PR as code changes
+
+* Unit tests must be added for any change to public APIs. We will accept unit tests for internal methods as well.
+
+##### Code Coverage
+
+* In Visual Studio Test Explorer, select all tests, right click and execute 'Analyze code coverage for selected tests' command. This will run all tests and give a summary of blocks covered in 'Code Coverage Results' window. The summary can be drilled down to method level.   
+* Any code change accompanied with unit tests is expected to increase code coverage for the code modified. 
+
+##### Avoid duplicating tests just for different inputs
+
+* Use `[Theory]` for this, followed by either `[InlineData]` or `[MemberData]`. See existing tests for examples on how to use these attributes
+* The exception to this is if the code behavior is fundamentally different based on the inputs. For example, if a method throws an ArgumentException for invalid inputs, that should be a separate test.
+
+##### One test (or test data) per code path please
+
+* The most common exception to this is when testing a property, most people test get/set together
+
+##### Whenever possible, mock up dependencies to run tests in isolation
+  
+* For example, if your method accepts an abstraction, use Moq to mock it up
+* Search for Mock in the existing tests for examples, and see [Moq](https://github.com/Moq/moq4/wiki/Quickstart) for details on how to use Moq.
 
 ## Functional Testing
 

--- a/Documentation/winforms-designer.md
+++ b/Documentation/winforms-designer.md
@@ -62,7 +62,7 @@ dotnet build
 
 1. Erase the existing Form files in both projects.
 
-### **Important:** The following steps you always repeat, when you need to insert a new Form or a new UserControl
+### The following steps you always repeat, when you need to insert a new Form or a new UserControl
 
 1. In the Classing Framework project, open the project's context menu, and click *Add New Item*.
 

--- a/Documentation/winforms-designer.md
+++ b/Documentation/winforms-designer.md
@@ -12,7 +12,6 @@ Visual Studio does not allow it currently to create a new WinForms Core App from
 
 Open your favorite console, and create a new folder with the application's name. The folder name will later become the project's name as well. Change to that folder.
 
-
 ```cmd
 md MyNewWinFormsProject
 cd MyNewWinFormsProject

--- a/Documentation/winforms-designer.md
+++ b/Documentation/winforms-designer.md
@@ -95,7 +95,7 @@ dotnet build
 
 Now, whenever you need to use the Designer on one of the Core Form or UserControl files, simply open the linked files in the Classic Framework project with the Classic Windows Forms Designer.
 
-[comment]: <> (Links)
+[comment]: <> (URI Links)
 
 [file-nesting-extension]: https://marketplace.visualstudio.com/items?itemName=MadsKristensen.FileNesting
 

--- a/Documentation/winforms-designer.md
+++ b/Documentation/winforms-designer.md
@@ -1,41 +1,43 @@
 # Using the Classic WinForms Designer in WinForms Core
 
-At this point, a dedicated WinForms Designer for WinForms Core is not yet available. As a workaround, you can use Visual Studio’s option to work with linked files and use its WinForms Designer for the Classic Framework. 
+At this point, a dedicated WinForms Designer for WinForms Core is not yet available. As a workaround, you can use Visual Studio's option to work with linked files and use its WinForms Designer for the Classic Framework.
 
-Here is, how it’s done:
+Here is, how it is done:
 
-**TIP:** During the process, you need to re-nest Form files in the Classic Framework WinForms project whenever you add a new Form or a new UserControl. Instead of using a text editor for patching the project file, you can use Mad Kristensen’s [File Nesting Extension]( https://marketplace.visualstudio.com/items?itemName=MadsKristensen.FileNesting), which is recommended to be installed beforehand. Please close every open instance of Visual Studio before installing this extension.
+**TIP:** During the process, you need to re-nest Form files in the Classic Framework WinForms project whenever you add a new Form or a new UserControl. Instead of using a text editor for patching the project file, you can use Mad Kristensen's [File Nesting Extension][file-nesting-extension], which is recommended to be installed beforehand. Please close every open instance of Visual Studio before installing this extension.
 
 ## Creating a WinForms Core App
 
 Visual Studio does not allow it currently to create a new WinForms Core App from within Visual Studio directly. If you want to design an WinForms Core app, you need to create the App first from the command line:
 
-Open your favorite console, and create a new folder with the app’s name. The folder name will later become the project’s name as well. Change to that folder.
-```
+Open your favorite console, and create a new folder with the application's name. The folder name will later become the project's name as well. Change to that folder.
+
+```cmd
 md MyNewWinFormsProject
 cd MyNewWinFormsProject
 ```
 
 Now, create a new WinForms application with the `dotnet new` command, using the templates for WinForms. Run:
-```
+
+```cmd
 dotnet new winforms
 ```
 
-**TIP:** You can have the folder name different from the project’s name. Use the option `-n` (or `–name`) for that when using `dotnet new`.
+**TIP:** You can have the folder name different from the project's name. Use the option `-n` (or `name`) for that when using `dotnet new`.
 
-**NOTE:** Templates for **Visual Basic** are currently in development (so `dotnet new winforms –lang VB` will eventually work!), but they are not available yet. Visual Basic, however, is already supported; as a workaround for the time being, you can create an empty Core Console VB app, and rename and patch the project files accordingly (just copy those definitions over from a C# app). Also note that the Application Framework in Visual Basic isn’t supported in this version.
+**NOTE:** Templates for **Visual Basic** are currently in development (so `dotnet new winforms lang VB` will eventually work!), but they are not available yet. Visual Basic, however, is already supported; as a workaround for the time being, you can create an empty Core Console VB app, and rename and patch the project files accordingly (just copy those definitions over from a C# app). Also note that the Application Framework in Visual Basic is not supported in this version.
 
-After creating it, you can test the App directly by starting it with
+After creating it, you can test the application directly by starting it with
 
-```
+```cmd
 dotnet run
 ```
 
-which builds and starts the App. 
+which builds and starts the application.
 
-**TIP:** If you only want to rebuild the App, use:
+**TIP:** If you only want to rebuild the application, use:
 
-```
+```cmd
 dotnet build
 ```
 
@@ -45,42 +47,56 @@ dotnet build
 2. Save the project in Visual Studio, and with that, also save the Solution file.
 3. Open the context menu of the solution (not the project!) in the Solution Explorer and chose *Add New Project*.
 
-<img src="./images/add-project-to-sln.png" alt="drawing" width="500"/>
+![add-projects-to-sln][add-projects-to-sln]
 
-4. In the *Installed Templates* section, pick *Visual C#* (this works for Visual Basic equally – see the comments for Visual Basic above, though), *Windows Desktop*, and then click *Windows Forms App (.NET Framework)* from the list of installed templates.
+4. In the *Installed Templates* section, pick *Visual C#* (this works for Visual Basic equally; see the comments for Visual Basic above), *Windows Desktop*, and then click *Windows Forms App (.NET Framework)* from the list of installed templates.
 
-<img src="./images/add-project-dialog.png" alt="drawing" width="600"/>
+![add-project-dialog][add-project-dialog]
 
-5. Name the new classic Framework project as the Core project, but add “.Designer” to it (so, for example, if your Core project is named “MyWinFormApp”, name the classic Framework App “MyWinFormsApp.Designer”).
-6. In the properties of the Classic Framework App (context menu on the project in the Solution Explorer), rename the default namespace to the Core App’s default namespace.
+5. Name the new classic Framework project as the Core project, but add `.Designer` to it (so, for example, if your Core project is named `MyWinFormApp`, name the classic Framework App `MyWinFormsApp.Designer`).
+6. In the properties of the Classic Framework App (context menu on the project in the Solution Explorer), rename the default namespace to the Core App's default namespace.
 
-<img src="./images/edit-namespace.png" alt="drawing" width="650"/>
+![edit-namespace][edit-namespace]
 
 7. Erase the existing Form files in both projects.
 
-**Important:** The following steps you always repeat, when you need to insert a new Form or a new UserControl.
+### **Important:** The following steps you always repeat, when you need to insert a new Form or a new UserControl.
 
-1. In the Classing Framework project, open the project’s context menu, and click *Add New Item*.
+1. In the Classing Framework project, open the project's context menu, and click *Add New Item*.
 
-<img src="./images/add-new-form.png" alt="drawing" width="500"/>
+![add-new-form][add-new-form]
 
 2. In the section list, click on *Windows Forms*, and chose *Windows Form* from the installed templates.
 
-<img src="./images/add-new-form-dialog.png" alt="drawing" width="650"/>
+![add-new-form-dialog][add-new-form-dialog]
 
 3. Enter the name for the new Form/User Control.
 4. Click *Add*.
+
  **IMPORTANT**: Now, cause some change in the Designer on the form. For example, resize the form for a couple of pixels, or change the Text property of the form, so the resource file for it can be generated and saved. After that, save the form.
 
 5. In the Solution Explorer, click on the form, and press (Ctrl)(x) to cut it the file.
 6. Select the Core WinForms project in the Solution Explorer, and press (Ctrl)(v) to insert the files. Check that the main form file, the .designer file and the resource file for the form are all present.
-7. Now, to have the exact same file back in the WinForms Classic Framework Designer, we need to use Visual Studio’s file link option. Remember: We can only use the Classic Designer, but we want to have only one set of files. So, the form files, of course, belong to the Core App. But we want to edit them in the context of the Classic Framework App (thus using the Classic Designer). So, we link the existing Core Form files to the classic app, and to this end, you open the context menu on the classic project in the solution explorer, and pick *Add* and *Existing Item*.
+7. Now, to have the exact same file back in the WinForms Classic Framework Designer, we need to use Visual Studio's file link option. Remember: We can only use the Classic Designer, but we want to have only one set of files. So, the form files, of course, belong to the Core App. But we want to edit them in the context of the Classic Framework App (thus using the Classic Designer). So, we link the existing Core Form files to the classic app, and to this end, you open the context menu on the classic project in the solution explorer, and pick *Add* and *Existing Item*.
 8. In the File Open Dialog, navigate to the Core app, and find the *Form.cs*, *Form.Designer.cs* and *Form.resx* files. (Replace *Form* by the name of your form.) Select all of them, but DO NOT click *Add* yet!
 
-<img src="./images/add-as-link.png" alt="drawing" width="650"/>
+![add-as-link][add-as-link]
 
 9. Open the pulldown menu of the *Add* dropdown button and click *Add as Link*.
 10. Compile the solution to see if the file references got set up correctly.
-11. As the last but important step, we need to re-nest the linked form files. If you installed the *File Nesting* Visual Studio Extension (see above), then that’s done easily: Select both the *Form.Designer.cs* and *Form.resx* file, and from the context menu click *File Nesting…* and *Nest Items*. In the dialog, pick the main form file (Form.cs), and click OK.
+11. As the last but important step, we need to re-nest the linked form files. If you installed the *File Nesting* Visual Studio Extension (see above), then that is done easily: Select both the *Form.Designer.cs* and *Form.resx* file, and from the context menu click *File Nesting* and *Nest Items*. In the dialog, pick the main form file (Form.cs), and click OK.
 
 Now, whenever you need to use the Designer on one of the Core Form or UserControl files, simply open the linked files in the Classic Framework project with the Classic Windows Forms Designer.
+
+[comment]: <> (Links)
+
+[file-nesting-extension]: https://marketplace.visualstudio.com/items?itemName=MadsKristensen.FileNesting
+
+[comment]: <> (Images)
+
+[add-projects-to-sln]: images/add-project-to-sln.png
+[add-project-dialog]: images/add-project-dialog.png
+[edit-namespace]: images/edit-namespace.png
+[add-new-form]: images/add-new-form.png
+[add-new-form-dialog]: images/add-new-form-dialog.png
+[add-as-link]: images/add-as-link.png

--- a/Documentation/winforms-designer.md
+++ b/Documentation/winforms-designer.md
@@ -44,47 +44,54 @@ dotnet build
 ## Preparing the WinForms Core App for the Classic Designer
 
 1. Start Visual Studio and open this project.
-2. Save the project in Visual Studio, and with that, also save the Solution file.
-3. Open the context menu of the solution (not the project!) in the Solution Explorer and chose *Add New Project*.
+1. Save the project in Visual Studio, and with that, also save the Solution file.
+1. Open the context menu of the solution (not the project!) in the Solution Explorer and chose *Add New Project*.
 
-![add-projects-to-sln][add-projects-to-sln]
+    ![add-projects-to-sln][add-projects-to-sln]
 
-4. In the *Installed Templates* section, pick *Visual C#* (this works for Visual Basic equally; see the comments for Visual Basic above), *Windows Desktop*, and then click *Windows Forms App (.NET Framework)* from the list of installed templates.
+1. In the *Installed Templates* section, pick *Visual C#* (this works for Visual Basic equally; see the comments for Visual Basic above), *Windows Desktop*, and then click *Windows Forms App (.NET Framework)* from the list of installed templates.
 
-![add-project-dialog][add-project-dialog]
+    ![add-project-dialog][add-project-dialog]
 
-5. Name the new classic Framework project as the Core project, but add `.Designer` to it (so, for example, if your Core project is named `MyWinFormApp`, name the classic Framework App `MyWinFormsApp.Designer`).
-6. In the properties of the Classic Framework App (context menu on the project in the Solution Explorer), rename the default namespace to the Core App's default namespace.
+1. Name the new classic Framework project as the Core project, but add `.Designer` to it (so, for example, if your Core project is named `MyWinFormApp`, name the classic Framework App `MyWinFormsApp.Designer`).
 
-![edit-namespace][edit-namespace]
+1. In the properties of the Classic Framework App (context menu on the project in the Solution Explorer), rename the default namespace to the Core App's default namespace.
 
-7. Erase the existing Form files in both projects.
+    ![edit-namespace][edit-namespace]
 
-### **Important:** The following steps you always repeat, when you need to insert a new Form or a new UserControl.
+1. Erase the existing Form files in both projects.
+
+### **Important:** The following steps you always repeat, when you need to insert a new Form or a new UserControl
 
 1. In the Classing Framework project, open the project's context menu, and click *Add New Item*.
 
-![add-new-form][add-new-form]
+    ![add-new-form][add-new-form]
 
-2. In the section list, click on *Windows Forms*, and chose *Windows Form* from the installed templates.
+1. In the section list, click on *Windows Forms*, and chose *Windows Form* from the installed templates.
 
-![add-new-form-dialog][add-new-form-dialog]
+    ![add-new-form-dialog][add-new-form-dialog]
 
-3. Enter the name for the new Form/User Control.
-4. Click *Add*.
+1. Enter the name for the new Form/User Control.
 
- **IMPORTANT**: Now, cause some change in the Designer on the form. For example, resize the form for a couple of pixels, or change the Text property of the form, so the resource file for it can be generated and saved. After that, save the form.
+1. Click *Add*.
 
-5. In the Solution Explorer, click on the form, and press (Ctrl)(x) to cut it the file.
-6. Select the Core WinForms project in the Solution Explorer, and press (Ctrl)(v) to insert the files. Check that the main form file, the .designer file and the resource file for the form are all present.
-7. Now, to have the exact same file back in the WinForms Classic Framework Designer, we need to use Visual Studio's file link option. Remember: We can only use the Classic Designer, but we want to have only one set of files. So, the form files, of course, belong to the Core App. But we want to edit them in the context of the Classic Framework App (thus using the Classic Designer). So, we link the existing Core Form files to the classic app, and to this end, you open the context menu on the classic project in the solution explorer, and pick *Add* and *Existing Item*.
-8. In the File Open Dialog, navigate to the Core app, and find the *Form.cs*, *Form.Designer.cs* and *Form.resx* files. (Replace *Form* by the name of your form.) Select all of them, but DO NOT click *Add* yet!
+   **IMPORTANT**: Now, cause some change in the Designer on the form. For example, resize the form for a couple of pixels, or change the Text property of the form, so the resource file for it can be generated and saved. After that, save the form.
 
-![add-as-link][add-as-link]
+1. In the Solution Explorer, click on the form, and press (Ctrl)(x) to cut it the file.
 
-9. Open the pulldown menu of the *Add* dropdown button and click *Add as Link*.
-10. Compile the solution to see if the file references got set up correctly.
-11. As the last but important step, we need to re-nest the linked form files. If you installed the *File Nesting* Visual Studio Extension (see above), then that is done easily: Select both the *Form.Designer.cs* and *Form.resx* file, and from the context menu click *File Nesting* and *Nest Items*. In the dialog, pick the main form file (Form.cs), and click OK.
+1. Select the Core WinForms project in the Solution Explorer, and press (Ctrl)(v) to insert the files. Check that the main form file, the .designer file and the resource file for the form are all present.
+
+1. Now, to have the exact same file back in the WinForms Classic Framework Designer, we need to use Visual Studio's file link option. Remember: We can only use the Classic Designer, but we want to have only one set of files. So, the form files, of course, belong to the Core App. But we want to edit them in the context of the Classic Framework App (thus using the Classic Designer). So, we link the existing Core Form files to the classic app, and to this end, you open the context menu on the classic project in the solution explorer, and pick *Add* and *Existing Item*.
+
+1. In the File Open Dialog, navigate to the Core app, and find the *Form.cs*, *Form.Designer.cs* and *Form.resx* files. (Replace *Form* by the name of your form.) Select all of them, but DO NOT click *Add* yet!
+
+    ![add-as-link][add-as-link]
+
+1. Open the pulldown menu of the *Add* dropdown button and click *Add as Link*.
+
+1. Compile the solution to see if the file references got set up correctly.
+
+1. As the last but important step, we need to re-nest the linked form files. If you installed the *File Nesting* Visual Studio Extension (see above), then that is done easily: Select both the *Form.Designer.cs* and *Form.resx* file, and from the context menu click *File Nesting* and *Nest Items*. In the dialog, pick the main form file (Form.cs), and click OK.
 
 Now, whenever you need to use the Designer on one of the Core Form or UserControl files, simply open the linked files in the Classic Framework project with the Classic Windows Forms Designer.
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Windows Forms (WinForms) is a UI framework for building Windows desktop applicat
 
 Windows Forms also provides one of the most productive ways to create desktop applications based on the visual designer provided in Visual Studio. It enables drag-and-drop of visual controls and other similar functionality that make it easy to build desktop applications.
 
-> Note: The Windows Forms visual designer is not yet available and will be part of a Visual Studio 2019 update. [See here for a workaround invoking the Classic Framework Designer][designer].
+> Note: The Windows Forms visual designer is not yet available and will be part of a Visual Studio 2019 update. [See here for a workaround invoking the Classic Framework Designer](winforms-designer.md).
 
-To learn about project priorities as well as status and ship dates see the [Windows Forms Roadmap][roadmap].
+To learn about project priorities as well as status and ship dates see the [Windows Forms Roadmap](roadmap.md).
 
 This repository contains WinForms for .NET Core. It does not contain the .NET Framework variant of WinForms.
 
@@ -44,7 +44,7 @@ The Visual Studio WinForms designer is not yet available and will be part of a V
 Some of the best ways to contribute are to try things out, file bugs, join in design conversations, and fix issues.
 
 * The [contributing guidelines][contributing]and the more general [.NET Core contributing guide][corefx-contributing] define contributing rules.
-* The [Developer Guide][developer-guide] defines the setup and workflow for working on this repository.
+* The [Developer Guide](developer-guide.md) defines the setup and workflow for working on this repository.
 * If you have a question or have found a bug, [file an issue][issue-new].
 * Use [daily builds][getting-started] if you want to contribute and stay up to date with the team.
 
@@ -68,7 +68,7 @@ This project uses the [.NET Foundation Code of Conduct][dotnet-code-of-conduct] 
 
 ## License
 
-.NET Core (including the Windows Forms repository) is licensed under the [MIT license][license].
+.NET Core (including the Windows Forms repository) is licensed under the [MIT license](LICENSE.TXT).
 
 ## .NET Foundation
 
@@ -76,17 +76,17 @@ This project uses the [.NET Foundation Code of Conduct][dotnet-code-of-conduct] 
 
 See the [.NET home repository][dotnet-home] to find other .NET-related projects.
 
-[comment]: <> (Links)
+[comment]: <> (Multi-use Internal Links)
 
-[designer]: winforms-designer.md
-[roadmap]: roadmap.md
-[wpf]: https://github.com/dotnet/wpf
-[.net-core-3.0-sdk-preview-1]: https://www.microsoft.com/net/download
 [getting-started]: getting-started.md
 [contributing]: contributing.md
 [porting-guidelines]: porting-guidelines.md
+
+[comment]: <> (URI Links)
+
+[wpf]: https://github.com/dotnet/wpf
+[.net-core-3.0-sdk-preview-1]: https://www.microsoft.com/net/download
 [corefx-contributing]: https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/contributing.md
-[developer-guide]: developer-guide.md
 [issue-new]: https://github.com/dotnet/winforms/issues/new
 [developer-community]: https://developercommunity.visualstudio.com/spaces/61/index.html
 [product-support]: https://support.microsoft.com/en-us/contactus?ws=support
@@ -94,6 +94,5 @@ See the [.NET home repository][dotnet-home] to find other .NET-related projects
 [bounty-dot-net-core]: https://www.microsoft.com/msrc/bounty-dot-net-core
 [update-on-net-core-3-0-and-net-framework-4-8]: https://blogs.msdn.microsoft.com/dotnet/2018/10/04/update-on-net-core-3-0-and-net-framework-4-8/
 [dotnet-code-of-conduct]: https://dotnetfoundation.org/code-of-conduct
-[license]: LICENSE.TXT
 [.net-foundation]: https://www.dotnetfoundation.org/projects
 [dotnet-home]: https://github.com/Microsoft/dotnet

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # Windows Forms
+
 [![Build Status](https://dnceng.visualstudio.com/public/_apis/build/status/dotnet/winforms/dotnet-winforms%20CI)](https://dnceng.visualstudio.com/public/_build/latest?definitionId=267&branch=master)
 
 Windows Forms (WinForms) is a UI framework for building Windows desktop applications. It is a .NET wrapper over Windows user interface libraries, such as User32 and GDI+. It also offers controls and other functionality that is unique to Windows Forms.
 
-WinForms also provides one of the most productive ways to create desktop applications based on the visual designer provided in Visual Studio. It enables drag-and-drop of visual controls and other similar functionality that make it easy to build desktop applications.
+Windows Forms also provides one of the most productive ways to create desktop applications based on the visual designer provided in Visual Studio. It enables drag-and-drop of visual controls and other similar functionality that make it easy to build desktop applications.
 
 > Note: The Windows Forms visual designer is not yet available and will be part of a Visual Studio 2019 update. [See issue #147](https://github.com/dotnet/winforms/issues/147).
 
-See the [Windows Forms Roadmap](roadmap.md) to learn about project priorities, status and ship dates.
+To learn about project priorities as well as status and ship dates see the [Windows Forms Roadmap](roadmap.md) .
 
-This repo contains WinForms for .NET Core. It does not contain the .NET Framework variant of WinForms.
+This repository contains WinForms for .NET Core. It does not contain the .NET Framework variant of WinForms.
 
-[WPF](https://github.com/dotnet/wpf) is another UI framework for building Windows desktop applications that is supported on .NET Core. WPF and WinForms applications only run on Windows. They are part of the `Microsoft.NET.Sdk.WindowsDesktop` SDK. You are recommended to use Visual Studio 2019 Preview 1 to use WPF and WinForms with .NET Core.
+[Windows Presentation Foundation](https://github.com/dotnet/wpf) (WPF) is another UI framework used to build Windows desktop applications which is supported on .NET Core. WPF and Windows Forms applications  run only on Windows operating systems. They are part of the `Microsoft.NET.Sdk.WindowsDesktop` SDK. You are recommended to use Visual Studio 2019 Preview 1 to use WPF and Windows Forms with .NET Core.
 
 ## Getting started
 
@@ -46,7 +47,7 @@ Some of the best ways to contribute are to try things out, file bugs, join in de
 
 ### .NET Framework issues
 
-Issues with .NET Framework, including WinForms, should be filed on [VS developer community](https://developercommunity.visualstudio.com/spaces/61/index.html), or [Product Support](https://support.microsoft.com/en-us/contactus?ws=support). They should not be filed on this repo.
+Issues with .NET Framework, including WinForms, should be filed on [VS developer community](https://developercommunity.visualstudio.com/spaces/61/index.html), or [Product Support](https://support.microsoft.com/en-us/contactus?ws=support). They should not be filed on this repository.
 
 ### Reporting security issues
 
@@ -64,10 +65,10 @@ This project uses the [.NET Foundation Code of Conduct](https://dotnetfoundation
 
 ## License
 
-.NET Core (including the WinForms repo) is licensed under the [MIT license](LICENSE.TXT).
+.NET Core (including the Windows Forms repository) is licensed under the [MIT license](LICENSE.TXT).
 
 ## .NET Foundation
 
 .NET Core WinForms is a [.NET Foundation](https://www.dotnetfoundation.org/projects) project.
 
-See the [.NET home repo](https://github.com/Microsoft/dotnet) to find other .NET-related projects.
+See the [.NET home repository](https://github.com/Microsoft/dotnet) to find other .NET-related projects.

--- a/README.md
+++ b/README.md
@@ -26,9 +26,12 @@ This repository contains WinForms for .NET Core. It does not contain the .NET Fr
 We are in the process of doing four projects with Windows Forms:
 
 1. Port Windows Forms to .NET Core.
-2. Publish source to GitHub.
-3. Publish (and in some cases write) tests to GitHub and enable automated testing infrastructure.
-4. Enable the Visual Studio WinForms designer to work with WinForms running on .NET Core.
+
+1. Publish source to GitHub.
+
+1. Publish (and in some cases write) tests to GitHub and enable automated testing infrastructure.
+
+1. Enable the Visual Studio WinForms designer to work with WinForms running on .NET Core.
 
 The first two tasks are well underway. Most of the source has been published to GitHub although we are still bringing the codebase up to functional and performance parity with .NET Framework.
 

--- a/README.md
+++ b/README.md
@@ -6,20 +6,20 @@ Windows Forms (WinForms) is a UI framework for building Windows desktop applicat
 
 Windows Forms also provides one of the most productive ways to create desktop applications based on the visual designer provided in Visual Studio. It enables drag-and-drop of visual controls and other similar functionality that make it easy to build desktop applications.
 
-> Note: The Windows Forms visual designer is not yet available and will be part of a Visual Studio 2019 update. [See issue #147](https://github.com/dotnet/winforms/issues/147).
+> Note: The Windows Forms visual designer is not yet available and will be part of a Visual Studio 2019 update. [See issue #147][issue-#147].
 
-To learn about project priorities as well as status and ship dates see the [Windows Forms Roadmap](roadmap.md) .
+To learn about project priorities as well as status and ship dates see the [Windows Forms Roadmap][roadmap].
 
 This repository contains WinForms for .NET Core. It does not contain the .NET Framework variant of WinForms.
 
-[Windows Presentation Foundation](https://github.com/dotnet/wpf) (WPF) is another UI framework used to build Windows desktop applications which is supported on .NET Core. WPF and Windows Forms applications  run only on Windows operating systems. They are part of the `Microsoft.NET.Sdk.WindowsDesktop` SDK. You are recommended to use Visual Studio 2019 Preview 1 to use WPF and Windows Forms with .NET Core.
+[Windows Presentation Foundation][wpf] (WPF) is another UI framework used to build Windows desktop applications which is supported on .NET Core. WPF and Windows Forms applications  run only on Windows operating systems. They are part of the `Microsoft.NET.Sdk.WindowsDesktop` SDK. You are recommended to use Visual Studio 2019 Preview 1 to use WPF and Windows Forms with .NET Core.
 
 ## Getting started
 
-* [.NET Core 3.0 SDK Preview 1](https://www.microsoft.com/net/download)
-* [Getting started instructions](Documentation/getting-started.md)
-* [Contributing guide](Documentation/contributing.md)
-* [Porting guide](Documentation/porting-guidelines.md)
+* [.NET Core 3.0 SDK Preview 1][.net-core-3.0-sdk-preview-1]
+* [Getting started instructions][getting-started]
+* [Contributing guide][contributing]
+* [Porting guide][porting-guidelines]
 
 ## Status
 
@@ -40,35 +40,57 @@ The Visual Studio WinForms designer is not yet available and will be part of a V
 
 Some of the best ways to contribute are to try things out, file bugs, join in design conversations, and fix issues.
 
-* The [contributing guidelines](Documentation/contributing.md) and the more general [.NET Core contributing guide](Documentation/project-docs/contributing.md) define contributing rules.
-* The [Developer Guide](Documentation/developer-guide.md) defines the setup and workflow for working on this repo.
-* If you have a question or have found a bug, [file an issue](https://github.com/dotnet/winforms/issues/new).
-* Use [daily builds](Documentation/getting-started.md#installation) if you want to contribute and stay up to date with the team.
+* The [contributing guidelines][contributing]and the more general [.NET Core contributing guide][corefx-contributing] define contributing rules.
+* The [Developer Guide][developer-guide] defines the setup and workflow for working on this repository.
+* If you have a question or have found a bug, [file an issue][issue-new].
+* Use [daily builds][getting-started] if you want to contribute and stay up to date with the team.
 
 ### .NET Framework issues
 
-Issues with .NET Framework, including WinForms, should be filed on [VS developer community](https://developercommunity.visualstudio.com/spaces/61/index.html), or [Product Support](https://support.microsoft.com/en-us/contactus?ws=support). They should not be filed on this repository.
+Issues with .NET Framework, including WinForms, should be filed on [VS developer community][developer-community], or [Product Support][product-support]. They should not be filed on this repository.
 
 ### Reporting security issues
 
-Security issues and bugs should be reported privately via email to the Microsoft Security Response Center (MSRC) <secure@microsoft.com>. You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Further information, including the MSRC PGP key, can be found in the [Security TechCenter](https://www.microsoft.com/msrc/faqs-report-an-issue). Also see info about related [Microsoft .NET Core and ASP.NET Core Bug Bounty Program](https://www.microsoft.com/msrc/bounty-dot-net-core).
+Security issues and bugs should be reported privately via email to the Microsoft Security Response Center (MSRC) <secure@microsoft.com>. You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Further information, including the MSRC PGP key, can be found in the [Security TechCenter][faqs-report-an-issue]. Also see info about related [Microsoft .NET Core and ASP.NET Core Bug Bounty Program][bounty-dot-net-core].
 
 ## Relationship to .NET Framework
 
 This code base is a fork of the Windows Forms code in the .NET Framework. We intend to release .NET Core 3.0 with Windows Forms having parity with the .NET Framework version. Over time, the two implementations may diverge.
 
-The [Update on .NET Core 3.0 and .NET Framework 4.8](https://blogs.msdn.microsoft.com/dotnet/2018/10/04/update-on-net-core-3-0-and-net-framework-4-8/) provides a good description of the forward-looking differences between .NET Core and .NET Framework.
+The [Update on .NET Core 3.0 and .NET Framework 4.8][update-on-net-core-3-0-and-net-framework-4-8] provides a good description of the forward-looking differences between .NET Core and .NET Framework.
 
 ## Code of Conduct
 
-This project uses the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct) to define expected conduct in our community. Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a project maintainer at conduct@dotnetfoundation.org.
+This project uses the [.NET Foundation Code of Conduct][dotnet-code-of-conduct] to define expected conduct in our community. Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a project maintainer at conduct@dotnetfoundation.org.
 
 ## License
 
-.NET Core (including the Windows Forms repository) is licensed under the [MIT license](LICENSE.TXT).
+.NET Core (including the Windows Forms repository) is licensed under the [MIT license][license].
 
 ## .NET Foundation
 
-.NET Core WinForms is a [.NET Foundation](https://www.dotnetfoundation.org/projects) project.
+.NET Core WinForms is a [.NET Foundation][.net-foundation] project.
 
-See the [.NET home repository](https://github.com/Microsoft/dotnet) to find other .NET-related projects.
+See the [.NET home repository][dotnet-home] to find other .NET-related projects.
+
+[comment]: <> (Links)
+
+[issue-#147]: https://github.com/dotnet/winforms/issues/147
+[roadmap]: roadmap.md
+[wpf]: https://github.com/dotnet/wpf
+[.net-core-3.0-sdk-preview-1]: https://www.microsoft.com/net/download
+[getting-started]: getting-started.md
+[contributing]: contributing.md
+[porting-guidelines]: porting-guidelines.md
+[corefx-contributing]: https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/contributing.md
+[developer-guide]: developer-guide.md
+[issue-new]: https://github.com/dotnet/winforms/issues/new
+[developer-community]: https://developercommunity.visualstudio.com/spaces/61/index.html
+[product-support]: https://support.microsoft.com/en-us/contactus?ws=support
+[faqs-report-an-issue]: https://www.microsoft.com/msrc/faqs-report-an-issue
+[bounty-dot-net-core]: https://www.microsoft.com/msrc/bounty-dot-net-core
+[update-on-net-core-3-0-and-net-framework-4-8]: https://blogs.msdn.microsoft.com/dotnet/2018/10/04/update-on-net-core-3-0-and-net-framework-4-8/
+[dotnet-code-of-conduct]: https://dotnetfoundation.org/code-of-conduct
+[license]: LICENSE.TXT
+[.net-foundation]: https://www.dotnetfoundation.org/projects
+[dotnet-home]: https://github.com/Microsoft/dotnet

--- a/roadmap.md
+++ b/roadmap.md
@@ -17,12 +17,12 @@ roadmap][core-roadmap].
 
 ## Timelines
 
-| Milestone | Date |
-|---|---|
-|Initial launch of WinForms on .NET Core repository |Dec 4, 2018|
-|Functional parity with .NET Framework WinForms |Q1 2019|
-|First version of WinForms on .NET Core |.NET Core 3.0 GA|
-|Designer support in Visual Studio|Update to VS 2019|
+| Milestone                                         | Date              |
+|---                                                |---                |
+|Initial launch of WinForms on .NET Core repository |Dec 4, 2018        |
+|Functional parity with .NET Framework WinForms     |Q1 2019            |
+|First version of WinForms on .NET Core             |.NET Core 3.0 GA   |
+|Designer support in Visual Studio|Update to VS 2019|                   |
 
 If you'd like to contribute to WinForms, please take a look at our [Contributing
 Guide][contributing].

--- a/roadmap.md
+++ b/roadmap.md
@@ -25,7 +25,7 @@ roadmap][core-roadmap].
 |Designer support in Visual Studio|Update to VS 2019|                   |
 
 If you'd like to contribute to WinForms, please take a look at our [Contributing
-Guide][contributing].
+Guide](contributing.md).
 
 ## Shorter-Term Feature Backlog
 
@@ -43,7 +43,6 @@ Guide][contributing].
 * Improve accessibility support for some missing UIA interfaces
 * Improve performance of WinForms runtime
 
-[comment]: <> (Links)
+[comment]: <> (URI Links)
 
 [core-roadmap]: https://github.com/dotnet/core/blob/master/roadmap.md
-[contributing]: contributing.md

--- a/roadmap.md
+++ b/roadmap.md
@@ -13,7 +13,7 @@ At present, our primary focus is enabling the following for .NET Core 3.0:
 As we complete those goals, we'll update our roadmap to include additional feature/capability areas we will focus on next.
 
 For general information regarding .NET Core plans, see [.NET Core
-roadmap](https://github.com/dotnet/core/blob/master/roadmap.md).
+roadmap][core-roadmap].
 
 ## Timelines
 
@@ -25,7 +25,7 @@ roadmap](https://github.com/dotnet/core/blob/master/roadmap.md).
 |Designer support in Visual Studio|Update to VS 2019|
 
 If you'd like to contribute to WinForms, please take a look at our [Contributing
-Guide](Documentation/contributing.md).
+Guide][contributing].
 
 ## Shorter-Term Feature Backlog
 
@@ -42,3 +42,8 @@ Guide](Documentation/contributing.md).
 * Add Data Visualization controls
 * Improve accessibility support for some missing UIA interfaces
 * Improve performance of WinForms runtime
+
+[comment]: <> (Links)
+
+[core-roadmap]: https://github.com/dotnet/core/blob/master/roadmap.md
+[contributing]: contributing.md

--- a/roadmap.md
+++ b/roadmap.md
@@ -5,8 +5,8 @@ This roadmap communicates priorities for evolving and extending the scope of Win
 At present, our primary focus is enabling the following for .NET Core 3.0:
 
 * Achieve WinForms functional and performance parity compared to .NET Framework
-* Publish remaining WinForms components to the repo
-* Publish (and write) more WinForms tests to the repo
+* Publish remaining WinForms components to the repository
+* Publish (and write) more WinForms tests to the repository
 
 > Note: There are some specific .NET Framework features will not be supported, such as hosting WinForms controls in Internet Explorer.
 
@@ -29,7 +29,7 @@ Guide](Documentation/contributing.md).
 
 ## Shorter-Term Feature Backlog
 
-* Port existing functional tests and test infrastructure to this repo
+* Port existing functional tests and test infrastructure to this repository
 * Add Application property for DPI Awareness setting
 
 ## Longer-Term Feature Backlog


### PR DESCRIPTION
Inconsistency in formatting of markdown files in the repo. I used [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) to normalize formatting in all source files and [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) to fix all current spelling errors, clarify wording, insert oxford commas, remove contractions; also move all links to bottom