### PR TITLE
Make WebBrowserUriTypeConverter secure by default

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserUriTypeConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserUriTypeConverter.cs
@@ -12,17 +12,17 @@ namespace System.Windows.Forms
         public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
         {
             //The UriTypeConverter gives back a relative Uri for things like "www.microsoft.com".  If 
-            //the Uri is relative, we'll try sticking "http://" on the front to see whether that fixes it up.
+            //the Uri is relative, we'll try sticking "https://" on the front to see whether that fixes it up.
             Uri uri = base.ConvertFrom(context, culture, value) as Uri;
             if (uri != null && !string.IsNullOrEmpty(uri.OriginalString) && !uri.IsAbsoluteUri)
             {
                 try 
                 {
-                    uri = new Uri("http://" + uri.OriginalString.Trim());
+                    uri = new Uri("https://" + uri.OriginalString.Trim());
                 }
                 catch (UriFormatException) 
                 {
-                    //We can't throw "http://" on the front: just return the original (relative) Uri,
+                    //We can't throw "https://" on the front: just return the original (relative) Uri,
                     //which will throw an exception with reasonable text later.
                 }
             }


### PR DESCRIPTION
Previously, a string like `"www.microsoft.com"` would be converted to `"http://www.microsoft.com"`. This PR changes that behavior to use HTTPS.