### PR TITLE
Add License badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Windows Forms
-[![Build Status](https://dnceng.visualstudio.com/public/_apis/build/status/dotnet/winforms/dotnet-winforms%20CI)](https://dnceng.visualstudio.com/public/_build/latest?definitionId=267&branch=master)
+[![Build Status](https://dnceng.visualstudio.com/public/_apis/build/status/dotnet/winforms/dotnet-winforms%20CI)](https://dnceng.visualstudio.com/public/_build/latest?definitionId=267&branch=master) 
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/dotnet/winforms/blob/master/LICENSE.TXT)
 
 Windows Forms (WinForms) is a UI framework for building Windows desktop applications. It is a .NET wrapper over Windows user interface libraries, such as User32 and GDI+. It also offers controls and other functionality that is unique to Windows Forms.
 


### PR DESCRIPTION
There was no license badge in the readme; it is common practice among github repositories to have this, especially among popular repos. 

examples:
- https://github.com/hyperium/hyper
- https://github.com/GokuMohandas/practicalAI