### PR TITLE
Add Ctrl+Backspace handler

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -228,8 +228,7 @@ namespace System.Windows.Forms {
 
             if (!this.ReadOnly && (keyData == (Keys.Control | Keys.Back) || keyData == (Keys.Control | Keys.Shift | Keys.Back))) {
                 if (this.SelectionLength != 0) {
-                    // effectively send Ctrl+Delete, deleting the selection
-                    SendKeydownMessage(msg.HWnd, Keys.Delete);
+                    this.SetSelectedTextInternal("", false);
                 }
                 else {
                     var state = new byte[256];

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -230,7 +230,7 @@ namespace System.Windows.Forms {
                 if (this.SelectionLength != 0) {
                     this.SetSelectedTextInternal("", false);
                 }
-                else {
+                else if (this.SelectionStart != 0) {
                     var state = new byte[256];
                     UnsafeNativeMethods.GetKeyboardState(state);
                     bool shiftDown = state[(int)Keys.ShiftKey] >> 7 == 1;
@@ -240,7 +240,7 @@ namespace System.Windows.Forms {
                         state[(int)Keys.ShiftKey] = state[(int)Keys.LShiftKey] = 0b10000000;
                         UnsafeNativeMethods.SetKeyboardState(state);
                     }
-                    // effecitvely send Ctrl+Shift+Left, creating a selection
+                    // effectively send Ctrl+Shift+Left, creating a selection
                     SendKeydownMessage(msg.HWnd, Keys.Left);
                     if (!shiftDown)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -226,7 +226,50 @@ namespace System.Windows.Forms {
                 }
             }
 
+            if (!this.ReadOnly && (keyData == (Keys.Control | Keys.Back) || keyData == (Keys.Control | Keys.Shift | Keys.Back))) {
+                if (this.SelectionLength != 0) {
+                    this.SelectedText = "";
+                }
+                else {
+                    DeletePrecedingWord();
+                }
+                return true;
+            }
+
             return returnedValue;
+        }
+
+        /// <devdoc>
+        ///     Send Ctrl+Shift+Left, Delete to delete the word preceding the cursor.
+        ///     This is called when Ctrl+Backspace is pressed, so the Ctrl key is always active.
+        /// </devdoc>
+        /// <internalonly/>
+        private void DeletePrecedingWord() {
+            var inputs = new NativeMethods.INPUT[6];
+
+            inputs[0].type = NativeMethods.INPUT_KEYBOARD;
+            inputs[0].inputUnion.ki.wVk = (short)Keys.ShiftKey;
+
+            inputs[1].type = NativeMethods.INPUT_KEYBOARD;
+            inputs[1].inputUnion.ki.wVk = (short)Keys.Left;
+            inputs[1].inputUnion.ki.dwFlags = NativeMethods.KEYEVENTF_EXTENDEDKEY;
+
+            inputs[2].type = NativeMethods.INPUT_KEYBOARD;
+            inputs[2].inputUnion.ki.wVk = (short)Keys.Left;
+            inputs[2].inputUnion.ki.dwFlags = NativeMethods.KEYEVENTF_EXTENDEDKEY | NativeMethods.KEYEVENTF_KEYUP;
+
+            inputs[3].type = NativeMethods.INPUT_KEYBOARD;
+            inputs[3].inputUnion.ki.wVk = (short)Keys.ShiftKey;
+            inputs[3].inputUnion.ki.dwFlags = NativeMethods.KEYEVENTF_KEYUP;
+
+            inputs[4].type = NativeMethods.INPUT_KEYBOARD;
+            inputs[4].inputUnion.ki.wVk = (short)Keys.Delete;
+
+            inputs[5].type = NativeMethods.INPUT_KEYBOARD;
+            inputs[5].inputUnion.ki.wVk = (short)Keys.Delete;
+            inputs[5].inputUnion.ki.dwFlags = NativeMethods.KEYEVENTF_KEYUP;
+
+            UnsafeNativeMethods.SendInput((uint)inputs.Length, inputs, Marshal.SizeOf(typeof(NativeMethods.INPUT)));
         }
 
         /// <include file='doc\TextBoxBase.uex' path='docs/doc[@for="TextBoxBase.AutoSize"]/*' />

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -229,7 +229,7 @@ namespace System.Windows.Forms {
             if (!this.ReadOnly && (keyData == (Keys.Control | Keys.Back) || keyData == (Keys.Control | Keys.Shift | Keys.Back))) {
                 if (this.SelectionLength != 0) {
                     // effectively send Ctrl+Delete, deleting the selection
-                    SendKeydownMessage(msg.HWnd, Keys.Delete, 0x530001);
+                    SendKeydownMessage(msg.HWnd, Keys.Delete);
                 }
                 else {
                     var state = new byte[256];
@@ -242,7 +242,7 @@ namespace System.Windows.Forms {
                         UnsafeNativeMethods.SetKeyboardState(state);
                     }
                     // effecitvely send Ctrl+Shift+Left, creating a selection
-                    SendKeydownMessage(msg.HWnd, Keys.Left, 0x14B0001);
+                    SendKeydownMessage(msg.HWnd, Keys.Left);
                     if (!shiftDown)
                     {
                         // "unpress" shift if user is not actually pressing it
@@ -250,7 +250,7 @@ namespace System.Windows.Forms {
                         UnsafeNativeMethods.SetKeyboardState(state);
                     }
                     // effectively send Ctrl+Delete, deleting the selection
-                    SendKeydownMessage(msg.HWnd, Keys.Delete, 0x530001);
+                    SendKeydownMessage(msg.HWnd, Keys.Delete);
                 }
                 return true;
             }
@@ -258,7 +258,7 @@ namespace System.Windows.Forms {
             return returnedValue;
         }
 
-        private void SendKeydownMessage(IntPtr hwnd, Keys keys, int lparam)
+        private void SendKeydownMessage(IntPtr hwnd, Keys keys)
         {
             bool unicodeWindow = false;
             if (hwnd != IntPtr.Zero && SafeNativeMethods.IsWindowUnicode(new HandleRef(null, hwnd)))
@@ -269,7 +269,9 @@ namespace System.Windows.Forms {
             msg.hwnd = hwnd;
             msg.message = NativeMethods.WM_KEYDOWN;
             msg.wParam = (IntPtr)keys;
-            msg.lParam = (IntPtr)lparam;
+            // the key's scan code and extended flag can be omitted from lParam as long as wParam has the VK code.
+            // the 1 we're passing is just the repeat count (occupying bits 0-15).
+            msg.lParam = (IntPtr)1;
             if (unicodeWindow)
             {
                 UnsafeNativeMethods.DispatchMessageW(ref msg);


### PR DESCRIPTION
Add new handler to `ProcessCmdKey` of `TextBoxBase` and `ComboBox` controls which intercepts `Ctrl+Backspace` (or `Ctrl+Shift+Backspace`) and sends keystrokes to select and delete the word immediately preceding the text cursor.

Previously, for [weird historical reasons](https://blogs.msdn.microsoft.com/oldnewthing/20071011-00/?p=24823), the win32 API implicitly gave `Ctrl+Backspace` this kind of behavior only in single-line, autocomplete-enabled `TextBox` controls. In other cases, it would insert an ASCII `DELETE` character instead.

If a text selection is present, only the selection is deleted. This behavior is consistent with the `Ctrl+Delete` shortcut.

(OUTDATED) Some notes on this implementation:
* Using `SendKeys` does not suffice.
    * If `^+{LEFT}{BACKSPACE}` were sent, the Control key would be considered released afterward. If the user continued holding Control and pressed Backspace a second time, it would act as a normal Backspace.
    * If `+{LEFT}{BACKSAPCE}` were sent (with the safe assumption of the Control key already being active), then nothing would actually happen until the user *released* the Control key.
* Since the Control key must be held to initiate this shortcut, we only send `Shift+Left`, not `Ctrl+Shift+Left`.
* Since the Control key is held, we can't send `Backspace` to do the deletion or we would trigger the shortcut recursively. `Delete` is sent instead, which actually becomes `Ctrl+Delete`. Luckily, the `Ctrl+Delete` shortcut already has the behavior of just deleting the current selection if one exists.
* `DeletePrecedingWord` is currently duplicated as I'm not sure of a good common location for it.

Resolves #259.