### PR TITLE
VisualStyleState check is now converted in to bit-wise.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog_Vista.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog_Vista.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -24,8 +24,7 @@ namespace System.Windows.Forms
             get
             {
                 return !this.ShowHelp &&
-                        (Application.VisualStyleState == VisualStyles.VisualStyleState.ClientAreaEnabled ||
-                         Application.VisualStyleState == VisualStyles.VisualStyleState.ClientAndNonClientAreasEnabled);
+                        ((Application.VisualStyleState & VisualStyles.VisualStyleState.ClientAreaEnabled) == VisualStyles.VisualStyleState.ClientAreaEnabled );
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -47,6 +47,15 @@ namespace System.Windows.Forms.VisualStyles {
             SystemEvents.UserPreferenceChanging += new UserPreferenceChangingEventHandler(OnUserPreferenceChanging);
         }
 
+        /// <summary>
+        /// Check if visual styles is supported for client area.
+        /// </summary>
+        private static bool AreClientAreaVisualStylesSupported {
+            get {
+                return (VisualStyleInformation.IsEnabledByUser &&
+                   ((Application.VisualStyleState & VisualStyleState.ClientAreaEnabled) == VisualStyleState.ClientAreaEnabled));
+            }
+        }
 
         /// <include file='doc\VisualStyleRenderer.uex' path='docs/doc[@for="VisualStyleRenderer.IsSupported"]/*' />
         /// <devdoc>
@@ -59,11 +68,8 @@ namespace System.Windows.Forms.VisualStyles {
         /// </devdoc>
         public static bool IsSupported {
             get {
-                bool supported =  (VisualStyleInformation.IsEnabledByUser &&
-                   (Application.VisualStyleState == VisualStyleState.ClientAreaEnabled ||
-                    Application.VisualStyleState == VisualStyleState.ClientAndNonClientAreasEnabled));
+                bool supported = AreClientAreaVisualStylesSupported;
 
-                
                 if (supported) {
                     // In some cases, this check isn't enough, since the theme handle creation
                     // could fail for some other reason. Try creating a theme handle here - if successful, return true,
@@ -1051,12 +1057,6 @@ namespace System.Windows.Forms.VisualStyles {
             if (themeHandles != null) {
                 string[] classNames = new string[themeHandles.Keys.Count];
                 themeHandles.Keys.CopyTo(classNames, 0);
-
-                // We don't call IsSupported here, since that could cause RefreshCache to be called again,
-                // leading to stack overflow.
-                bool isSupported = (VisualStyleInformation.IsEnabledByUser &&
-                   (Application.VisualStyleState == VisualStyleState.ClientAreaEnabled ||
-                    Application.VisualStyleState == VisualStyleState.ClientAndNonClientAreasEnabled));
                 
                 foreach (string className in classNames) {
                     tHandle = (ThemeHandle) themeHandles[className];
@@ -1064,7 +1064,9 @@ namespace System.Windows.Forms.VisualStyles {
                         tHandle.Dispose();
                     }
 
-                    if (isSupported) {
+                    // We don't call IsSupported here, since that could cause RefreshCache to be called again,
+                    // leading to stack overflow.
+                    if (AreClientAreaVisualStylesSupported) {
                         tHandle = ThemeHandle.Create(className, false);
                         if (tHandle != null) {
                             themeHandles[className] = tHandle;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleState.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -13,6 +13,7 @@ namespace System.Windows.Forms.VisualStyles {
     ///    </para>
     /// </devdoc>
 
+    [Flags]
     public enum VisualStyleState {
         /// <include file='doc\VisualStyleState.uex' path='docs/doc[@for="VisualStyleState.NoneEnabled"]/*' />
         /// <devdoc>


### PR DESCRIPTION
Fixing GitHub issue #317. VisualstyleState was a numeric check that is broken in latest windows  version (where it added a new flag to its Enum).  Changing the state validation to bit-wise to fix it.

