### PR TITLE
disable unit tests for debug config

### DIFF
--- a/eng/CIBuild.cmd
+++ b/eng/CIBuild.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0\common\Build.ps1""" -restore -build -sign -pack -publish -ci %*"

--- a/eng/ci.yml
+++ b/eng/ci.yml
@@ -23,6 +23,10 @@ jobs:
 
       variables:
 
+        # needed for testing
+        - name: _TestArgs
+          value: -test
+
         # needed for signing
         - name: _TeamName
           value: DotNetCore
@@ -80,6 +84,7 @@ jobs:
             _PublishType: none
             _SignType: test
             _DotNetPublishToBlobFeed : false
+            _TestArgs: ''
           Build_Release:
             _BuildConfig: Release
 
@@ -88,12 +93,13 @@ jobs:
         clean: true
 
       # Build, test, pack, and sign
-      - script: eng\common\cibuild.cmd
-          -configuration $(_BuildConfig) 
+      - script: eng\cibuild.cmd
+          -configuration $(_BuildConfig)
           -prepareMachine
           $(_PublishArgs)
           $(_SignArgs)
           $(_OfficialBuildIdArgs)
+          $(_TestArgs)
         displayName: Windows Build / Publish
 
       # Run component governance detection (only for release)


### PR DESCRIPTION
Fixes #277 

The problem is debug asserts are causing the xUnit runner to fail, but that failure doesn't show up as a real test failure in the debug config. So it's kind of a weird half failure that I'm not happy with. 

One solution is to get rid of debug asserts completely, but we have too many of them. So the other solution is to not run unit tests for the debug config.

eng\common\CIBuild.cmd is part of the arcade sdk (so we can't modify it), and it passes -test by default. So there are two options:

1. Pass -test:$False as an additional parameter, but only for the debug config (this is super ugly, because we're basically passing -test, then cancelling it out with -test:$False)
2. Make a new CIBuild.cmd that is not part of arcade, with the -test omitted. Then we can add it -test when appropriate (as well as -integrationTest and -performanceTest, which are also supported)

I opted for number 2 because it's cleaner. The downside is that we no longer reference the common arcade CIBuild.cmd, but that file is a one liner and hasn't changed in a very long time, so the risk is low.

Another benefit is now engineers can still write all the debug asserts they like without the risk of failing the CI build. So it's the best of both worlds. 