### PR TITLE
Split restore/build, test, and pack/sign/publish into their own steps

### DIFF
--- a/eng/CIBuild.cmd
+++ b/eng/CIBuild.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0\common\Build.ps1""" -ci %*"

--- a/eng/ci.yml
+++ b/eng/ci.yml
@@ -87,14 +87,30 @@ jobs:
       - checkout: self
         clean: true
 
-      # Build, test, pack, and sign
-      - script: eng\common\cibuild.cmd
-          -configuration $(_BuildConfig) 
+      # Restore and build
+      - script: eng\cibuild.cmd
           -prepareMachine
-          $(_PublishArgs)
-          $(_SignArgs)
+          -configuration $(_BuildConfig) 
           $(_OfficialBuildIdArgs)
-        displayName: Windows Build / Publish
+          -restore
+          -build
+        displayName: Build
+
+      # Run unit tests
+      - script: eng\cibuild.cmd
+          -configuration $(_BuildConfig) 
+          $(_OfficialBuildIdArgs)
+          -test
+        displayName: Unit tests
+
+      # Create Nuget package, sign, and publish
+      - script: eng\cibuild.cmd
+          -configuration $(_BuildConfig) 
+          $(_OfficialBuildIdArgs)
+          -pack
+          -sign $(_SignArgs)
+          -publish $(_PublishArgs)
+        displayName: Pack, Sign, and Publish
 
       # Run component governance detection (only for release)
       - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0


### PR DESCRIPTION
- The build step currently does restore, build, test, sign, pack, and publish
- This can be difficult to troubleshoot on error at first glance
- The PR splits these tasks into different physical yaml steps
- This adds negligible build time since we still only restore and build once, we're just moving the other tasks into their own build steps