### PR TITLE
Remove dead ctor checks in ListItemConverter

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListItemConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListItemConverter.cs
@@ -60,24 +60,16 @@ namespace System.Windows.Forms {
                     if (item.SubItems[i].CustomStyle) {
                         if (!string.IsNullOrEmpty(item.ImageKey)) {
                             ctor = typeof(ListViewItem).GetConstructor(new Type[] { typeof(ListViewItem.ListViewSubItem[]), typeof(string)});
-                            if (ctor != null) {
-                                ListViewItem.ListViewSubItem[] subItemArray = new ListViewItem.ListViewSubItem[item.SubItems.Count];
-                                ((ICollection)item.SubItems).CopyTo(subItemArray, 0);
-                                return new InstanceDescriptor(ctor, new object[] {subItemArray, item.ImageKey}, false);
-                            }       
-                            else {
-                                break;
-                            }
+                            Debug.Assert(ctor != null, "Expected the constructor to exist.");
+                            ListViewItem.ListViewSubItem[] subItemArray = new ListViewItem.ListViewSubItem[item.SubItems.Count];
+                            ((ICollection)item.SubItems).CopyTo(subItemArray, 0);
+                            return new InstanceDescriptor(ctor, new object[] {subItemArray, item.ImageKey}, false);
                         } else {
                             ctor = typeof(ListViewItem).GetConstructor(new Type[] { typeof(ListViewItem.ListViewSubItem[]), typeof(int)});
-                            if (ctor != null) {
-                                ListViewItem.ListViewSubItem[] subItemArray = new ListViewItem.ListViewSubItem[item.SubItems.Count];
-                                ((ICollection)item.SubItems).CopyTo(subItemArray, 0);
-                                return new InstanceDescriptor(ctor, new object[] {subItemArray, item.ImageIndex}, false);
-                            }       
-                            else {
-                                break;
-                            }
+                            Debug.Assert(ctor != null, "Expected the constructor to exist.");
+                            ListViewItem.ListViewSubItem[] subItemArray = new ListViewItem.ListViewSubItem[item.SubItems.Count];
+                            ((ICollection)item.SubItems).CopyTo(subItemArray, 0);
+                            return new InstanceDescriptor(ctor, new object[] {subItemArray, item.ImageIndex}, false);
                         }
                     }
                 }                
@@ -99,15 +91,14 @@ namespace System.Windows.Forms {
                             typeof(Color),
                             typeof(Color),
                             typeof(Font)});
-                        if (ctor != null) {
-                            return new InstanceDescriptor(ctor, new object[] {
-                                subItems,
-                                item.ImageKey,
-                                item.SubItems[0].CustomForeColor ? item.ForeColor : Color.Empty,
-                                item.SubItems[0].CustomBackColor ? item.BackColor : Color.Empty,
-                                item.SubItems[0].CustomFont ? item.Font : null
-                                }, false);
-                        }
+                        Debug.Assert(ctor != null, "Expected the constructor to exist.");
+                        return new InstanceDescriptor(ctor, new object[] {
+                            subItems,
+                            item.ImageKey,
+                            item.SubItems[0].CustomForeColor ? item.ForeColor : Color.Empty,
+                            item.SubItems[0].CustomBackColor ? item.BackColor : Color.Empty,
+                            item.SubItems[0].CustomFont ? item.Font : null
+                            }, false);
                     } else {
                         ctor = typeof(ListViewItem).GetConstructor(new Type[] {
                             typeof(string[]),
@@ -115,15 +106,14 @@ namespace System.Windows.Forms {
                             typeof(Color),
                             typeof(Color),
                             typeof(Font)});
-                        if (ctor != null) {
-                            return new InstanceDescriptor(ctor, new object[] {
-                                subItems,
-                                item.ImageIndex,
-                                item.SubItems[0].CustomForeColor ? item.ForeColor : Color.Empty,
-                                item.SubItems[0].CustomBackColor ? item.BackColor : Color.Empty,
-                                item.SubItems[0].CustomFont ? item.Font : null
-                                }, false);
-                        }
+                        Debug.Assert(ctor != null, "Expected the constructor to exist.");
+                        return new InstanceDescriptor(ctor, new object[] {
+                            subItems,
+                            item.ImageIndex,
+                            item.SubItems[0].CustomForeColor ? item.ForeColor : Color.Empty,
+                            item.SubItems[0].CustomBackColor ? item.BackColor : Color.Empty,
+                            item.SubItems[0].CustomFont ? item.Font : null
+                            }, false);
                     }
                 }
 
@@ -131,9 +121,7 @@ namespace System.Windows.Forms {
                 //
                 if (item.ImageIndex == -1 && string.IsNullOrEmpty(item.ImageKey) && item.SubItems.Count <= 1) {
                     ctor = typeof(ListViewItem).GetConstructor(new Type[] {typeof(string)});
-                    if (ctor != null) {
-                        return new InstanceDescriptor(ctor, new object[] {item.Text}, false);
-                    }
+                    return new InstanceDescriptor(ctor, new object[] {item.Text}, false);
                 }
                 
                 // Text and Image
@@ -143,16 +131,14 @@ namespace System.Windows.Forms {
                         ctor = typeof(ListViewItem).GetConstructor(new Type[] {
                             typeof(string),
                             typeof(string)});
-                        if (ctor != null) {
-                            return new InstanceDescriptor(ctor, new object[] {item.Text, item.ImageKey}, false);
-                        }
+                        Debug.Assert(ctor != null, "Expected the constructor to exist.");
+                        return new InstanceDescriptor(ctor, new object[] {item.Text, item.ImageKey}, false);
                     } else {
                         ctor = typeof(ListViewItem).GetConstructor(new Type[] {
                             typeof(string),
                             typeof(int)});
-                        if (ctor != null) {
-                            return new InstanceDescriptor(ctor, new object[] {item.Text, item.ImageIndex}, false);
-                        }
+                        Debug.Assert(ctor != null, "Expected the constructor to exist.");
+                        return new InstanceDescriptor(ctor, new object[] {item.Text, item.ImageIndex}, false);
                     }
                 }
 
@@ -162,16 +148,13 @@ namespace System.Windows.Forms {
                     ctor = typeof(ListViewItem).GetConstructor(new Type[] {
                         typeof(string[]),
                         typeof(string)});
-                    if (ctor != null) {
-                        return new InstanceDescriptor(ctor, new object[] {subItems, item.ImageKey}, false);
-                    }
+                    return new InstanceDescriptor(ctor, new object[] {subItems, item.ImageKey}, false);
                 } else {
                     ctor = typeof(ListViewItem).GetConstructor(new Type[] {
                         typeof(string[]),
                         typeof(int)});
-                    if (ctor != null) {
-                        return new InstanceDescriptor(ctor, new object[] {subItems, item.ImageIndex}, false);
-                    }
+                    Debug.Assert(ctor != null, "Expected the constructor to exist.");
+                    return new InstanceDescriptor(ctor, new object[] {subItems, item.ImageIndex}, false);
                 }
             }
             
@@ -206,22 +189,20 @@ namespace System.Windows.Forms {
                         typeof(Color),
                         typeof(Color),
                         typeof(Font)});
-                    if (ctor != null) {
-                        return new InstanceDescriptor(ctor, new object[] {
-                            null,
-                            item.Text,
-                            item.ForeColor,
-                            item.BackColor,
-                            item.Font}, true);
-                    }
+                    Debug.Assert(ctor != null, "Expected the constructor to exist.");
+                    return new InstanceDescriptor(ctor, new object[] {
+                        null,
+                        item.Text,
+                        item.ForeColor,
+                        item.BackColor,
+                        item.Font}, true);
                 }
 
                 // Otherwise, just use the text constructor
                 //
                 ctor = typeof(ListViewItem.ListViewSubItem).GetConstructor(new Type[] {typeof(ListViewItem), typeof(string)});
-                if (ctor != null) {
-                    return new InstanceDescriptor(ctor, new object[] {null, item.Text}, true);
-                }
+                Debug.Assert(ctor != null, "Expected the constructor to exist.");
+                return new InstanceDescriptor(ctor, new object[] {null, item.Text}, true);
             }
             
             return base.ConvertTo(context, culture, value, destinationType);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListItemConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListItemConverter.cs
@@ -2,211 +2,241 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
+using System.Drawing;
+using System.ComponentModel;
+using System.ComponentModel.Design.Serialization;
+using System.Diagnostics;
+using System.Globalization;
+using System.Reflection;
 
-namespace System.Windows.Forms {
-    using System.Runtime.Serialization.Formatters;
-    using System.Runtime.Remoting;
-    using System.Runtime.InteropServices;
-
-    using Microsoft.Win32;
-    using System.Collections;
-    using System.ComponentModel;
-    using System.ComponentModel.Design.Serialization;
-    using System.Drawing;
-    using System.Diagnostics;
-    using System.Globalization;
-    using System.Reflection;
-
-    /// <include file='doc\ListItemConverter.uex' path='docs/doc[@for="ListViewItemConverter"]/*' />
+namespace System.Windows.Forms
+{
     /// <devdoc>
-    ///      ListViewItemConverter is a class that can be used to convert
-    ///      ListViewItem objects from one data type to another.  Access this
-    ///      class through the TypeDescriptor.
+    /// ListViewItemConverter is a class that can be used to convert
+    /// ListViewItem objects from one data type to another.  Access this
+    /// class through the TypeDescriptor.
     /// </devdoc>
-    public class ListViewItemConverter : ExpandableObjectConverter {
-    
-        /// <include file='doc\ListItemConverter.uex' path='docs/doc[@for="ListViewItemConverter.CanConvertTo"]/*' />
+    public class ListViewItemConverter : ExpandableObjectConverter
+    {
         /// <devdoc>
-        ///    <para>Gets a value indicating whether this converter can
-        ///       convert an object to the given destination type using the context.</para>
+        /// Gets a value indicating whether this converter can convert an object to the given
+        /// destination type using the context.
         /// </devdoc>
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType) {
-            if (destinationType == typeof(InstanceDescriptor)) {
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            if (destinationType == typeof(InstanceDescriptor))
+            {
                 return true;
             }
+
             return base.CanConvertTo(context, destinationType);
         }
-        
-        /// <include file='doc\ListItemConverter.uex' path='docs/doc[@for="ListViewItemConverter.ConvertTo"]/*' />
+
         /// <devdoc>
-        ///      Converts the given object to another type.  The most common types to convert
-        ///      are to and from a string object.  The default implementation will make a call
-        ///      to ToString on the object if the object is valid and if the destination
-        ///      type is string.  If this cannot convert to the desitnation type, this will
-        ///      throw a NotSupportedException.
+        /// Converts the given object to another type. The most common types to convert
+        /// are to and from a string object. The default implementation will make a call
+        /// to ToString on the object if the object is valid and if the destination
+        /// type is string. If this cannot convert to the desitnation type, this will
+        /// throw a NotSupportedException.
         /// </devdoc>
-        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType) {
-            if (destinationType == null) {
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == null)
+            {
                 throw new ArgumentNullException(nameof(destinationType));
             }
 
-            if (destinationType == typeof(InstanceDescriptor) && value is ListViewItem) {
-                ListViewItem item = (ListViewItem)value;
+            if (destinationType == typeof(InstanceDescriptor) && value is ListViewItem item)
+            {
                 ConstructorInfo ctor;
-                
                 // Should we use the subitem constructor?
-                //
-                for(int i=1; i < item.SubItems.Count; ++i) {
-                    if (item.SubItems[i].CustomStyle) {
-                        if (!string.IsNullOrEmpty(item.ImageKey)) {
+                for(int i = 1; i < item.SubItems.Count; ++i)
+                {
+                    if (item.SubItems[i].CustomStyle)
+                    {
+                        if (!string.IsNullOrEmpty(item.ImageKey))
+                        {
                             ctor = typeof(ListViewItem).GetConstructor(new Type[] { typeof(ListViewItem.ListViewSubItem[]), typeof(string)});
                             Debug.Assert(ctor != null, "Expected the constructor to exist.");
                             ListViewItem.ListViewSubItem[] subItemArray = new ListViewItem.ListViewSubItem[item.SubItems.Count];
                             ((ICollection)item.SubItems).CopyTo(subItemArray, 0);
-                            return new InstanceDescriptor(ctor, new object[] {subItemArray, item.ImageKey}, false);
-                        } else {
+                            return new InstanceDescriptor(ctor, new object[] { subItemArray, item.ImageKey }, false);
+                        }
+                        else
+                        {
                             ctor = typeof(ListViewItem).GetConstructor(new Type[] { typeof(ListViewItem.ListViewSubItem[]), typeof(int)});
                             Debug.Assert(ctor != null, "Expected the constructor to exist.");
                             ListViewItem.ListViewSubItem[] subItemArray = new ListViewItem.ListViewSubItem[item.SubItems.Count];
                             ((ICollection)item.SubItems).CopyTo(subItemArray, 0);
-                            return new InstanceDescriptor(ctor, new object[] {subItemArray, item.ImageIndex}, false);
+                            return new InstanceDescriptor(ctor, new object[] { subItemArray, item.ImageIndex }, false);
                         }
                     }
-                }                
-                
+                }
+
                 // Convert SubItem array to string array
-                //
                 string[] subItems = new string[item.SubItems.Count];
-                for(int i=0; i < subItems.Length; ++i) {
+                for(int i=0; i < subItems.Length; ++i)
+                {
                     subItems[i] = item.SubItems[i].Text;
                 }
-                
+
                 // ForeColor, BackColor or ItemFont set
-                //
-                if (item.SubItems[0].CustomStyle) {
-                    if (!string.IsNullOrEmpty(item.ImageKey)) {
-                        ctor = typeof(ListViewItem).GetConstructor(new Type[] {
+                if (item.SubItems[0].CustomStyle)
+                {
+                    if (!string.IsNullOrEmpty(item.ImageKey))
+                    {
+                        ctor = typeof(ListViewItem).GetConstructor(new Type[]
+                        {
                             typeof(string[]),
                             typeof(string),
                             typeof(Color),
                             typeof(Color),
-                            typeof(Font)});
+                            typeof(Font)
+                        });
                         Debug.Assert(ctor != null, "Expected the constructor to exist.");
-                        return new InstanceDescriptor(ctor, new object[] {
+                        return new InstanceDescriptor(ctor, new object[]
+                        {
                             subItems,
                             item.ImageKey,
                             item.SubItems[0].CustomForeColor ? item.ForeColor : Color.Empty,
                             item.SubItems[0].CustomBackColor ? item.BackColor : Color.Empty,
                             item.SubItems[0].CustomFont ? item.Font : null
-                            }, false);
-                    } else {
-                        ctor = typeof(ListViewItem).GetConstructor(new Type[] {
+                        }, false);
+                    }
+                    else
+                    {
+                        ctor = typeof(ListViewItem).GetConstructor(new Type[]
+                        {
                             typeof(string[]),
                             typeof(int),
                             typeof(Color),
                             typeof(Color),
-                            typeof(Font)});
+                            typeof(Font)
+                        });
                         Debug.Assert(ctor != null, "Expected the constructor to exist.");
-                        return new InstanceDescriptor(ctor, new object[] {
+                        return new InstanceDescriptor(ctor, new object[]
+                        {
                             subItems,
                             item.ImageIndex,
                             item.SubItems[0].CustomForeColor ? item.ForeColor : Color.Empty,
                             item.SubItems[0].CustomBackColor ? item.BackColor : Color.Empty,
                             item.SubItems[0].CustomFont ? item.Font : null
-                            }, false);
+                        }, false);
                     }
                 }
 
                 // Text
-                //
-                if (item.ImageIndex == -1 && string.IsNullOrEmpty(item.ImageKey) && item.SubItems.Count <= 1) {
-                    ctor = typeof(ListViewItem).GetConstructor(new Type[] {typeof(string)});
-                    return new InstanceDescriptor(ctor, new object[] {item.Text}, false);
+                if (item.ImageIndex == -1 && string.IsNullOrEmpty(item.ImageKey) && item.SubItems.Count <= 1)
+                {
+                    ctor = typeof(ListViewItem).GetConstructor(new Type[] { typeof(string) });
+                    Debug.Assert(ctor != null, "Expected the constructor to exist.");
+                    return new InstanceDescriptor(ctor, new object[] { item.Text }, false);
                 }
-                
+
                 // Text and Image
-                //
-                if (item.SubItems.Count <= 1) {
-                    if (!string.IsNullOrEmpty(item.ImageKey)) {
-                        ctor = typeof(ListViewItem).GetConstructor(new Type[] {
+                if (item.SubItems.Count <= 1)
+                {
+                    if (!string.IsNullOrEmpty(item.ImageKey))
+                    {
+                        ctor = typeof(ListViewItem).GetConstructor(new Type[]
+                        {
                             typeof(string),
-                            typeof(string)});
+                            typeof(string)
+                        });
                         Debug.Assert(ctor != null, "Expected the constructor to exist.");
-                        return new InstanceDescriptor(ctor, new object[] {item.Text, item.ImageKey}, false);
-                    } else {
-                        ctor = typeof(ListViewItem).GetConstructor(new Type[] {
+                        return new InstanceDescriptor(ctor, new object[] { item.Text, item.ImageKey }, false);
+                    }
+                    else
+                    {
+                        ctor = typeof(ListViewItem).GetConstructor(new Type[]
+                        {
                             typeof(string),
-                            typeof(int)});
+                            typeof(int)
+                        });
                         Debug.Assert(ctor != null, "Expected the constructor to exist.");
-                        return new InstanceDescriptor(ctor, new object[] {item.Text, item.ImageIndex}, false);
+                        return new InstanceDescriptor(ctor, new object[] { item.Text, item.ImageIndex }, false);
                     }
                 }
 
                 // Text, Image and SubItems
-                //
-                if (!string.IsNullOrEmpty(item.ImageKey)) {
-                    ctor = typeof(ListViewItem).GetConstructor(new Type[] {
+                if (!string.IsNullOrEmpty(item.ImageKey))
+                {
+                    ctor = typeof(ListViewItem).GetConstructor(new Type[]
+                    {
                         typeof(string[]),
-                        typeof(string)});
-                    return new InstanceDescriptor(ctor, new object[] {subItems, item.ImageKey}, false);
-                } else {
-                    ctor = typeof(ListViewItem).GetConstructor(new Type[] {
-                        typeof(string[]),
-                        typeof(int)});
+                        typeof(string)
+                    });
                     Debug.Assert(ctor != null, "Expected the constructor to exist.");
-                    return new InstanceDescriptor(ctor, new object[] {subItems, item.ImageIndex}, false);
+                    return new InstanceDescriptor(ctor, new object[] { subItems, item.ImageKey }, false);
+                }
+                else
+                {
+                    ctor = typeof(ListViewItem).GetConstructor(new Type[]
+                    {
+                        typeof(string[]),
+                        typeof(int)
+                    });
+                    return new InstanceDescriptor(ctor, new object[] { subItems, item.ImageIndex }, false);
                 }
             }
-            
+
             return base.ConvertTo(context, culture, value, destinationType);
         }
-    }    
+    }
 
-    internal class ListViewSubItemConverter : ExpandableObjectConverter {
-    
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType) {
-            if (destinationType == typeof(InstanceDescriptor)) {
+    internal class ListViewSubItemConverter : ExpandableObjectConverter
+    {
+
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            if (destinationType == typeof(InstanceDescriptor))
+            {
                 return true;
             }
+
             return base.CanConvertTo(context, destinationType);
         }
-        
-        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType) {
-            if (destinationType == null) {
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == null)
+            {
                 throw new ArgumentNullException(nameof(destinationType));
             }
 
-            if (destinationType == typeof(InstanceDescriptor) && value is ListViewItem.ListViewSubItem) {
-                ListViewItem.ListViewSubItem item = (ListViewItem.ListViewSubItem)value;
+            if (destinationType == typeof(InstanceDescriptor) && value is ListViewItem.ListViewSubItem item)
+            {
                 ConstructorInfo ctor;
-                
+
                 // Subitem has custom style
-                //
-                if (item.CustomStyle) {
-                    ctor = typeof(ListViewItem.ListViewSubItem).GetConstructor(new Type[] {
+                if (item.CustomStyle)
+                {
+                    ctor = typeof(ListViewItem.ListViewSubItem).GetConstructor(new Type[]
+                    {
                         typeof(ListViewItem),
                         typeof(string),
                         typeof(Color),
                         typeof(Color),
-                        typeof(Font)});
+                        typeof(Font)
+                    });
                     Debug.Assert(ctor != null, "Expected the constructor to exist.");
                     return new InstanceDescriptor(ctor, new object[] {
                         null,
                         item.Text,
                         item.ForeColor,
                         item.BackColor,
-                        item.Font}, true);
+                        item.Font
+                    }, true);
                 }
 
                 // Otherwise, just use the text constructor
-                //
-                ctor = typeof(ListViewItem.ListViewSubItem).GetConstructor(new Type[] {typeof(ListViewItem), typeof(string)});
+                ctor = typeof(ListViewItem.ListViewSubItem).GetConstructor(new Type[] { typeof(ListViewItem), typeof(string) });
                 Debug.Assert(ctor != null, "Expected the constructor to exist.");
                 return new InstanceDescriptor(ctor, new object[] {null, item.Text}, true);
             }
-            
+
             return base.ConvertTo(context, culture, value, destinationType);
         }
     }
 }
-

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupConverter.cs
@@ -101,9 +101,8 @@ namespace System.Windows.Forms {
                 // Header
                 //
                 ctor = typeof(ListViewGroup).GetConstructor(new Type[] {typeof(string), typeof(HorizontalAlignment)});
-                if (ctor != null) {
-                    return new InstanceDescriptor(ctor, new object[] { group.Header, group.HeaderAlignment }, false);
-                }
+                Debug.Assert(ctor != null, "Expected the constructor to exist.");
+                return new InstanceDescriptor(ctor, new object[] { group.Header, group.HeaderAlignment }, false);
             }
 
             if (destinationType == typeof(string) && value == null) {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupConverter.cs
@@ -2,159 +2,157 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
+using System.ComponentModel;
+using System.ComponentModel.Design.Serialization;
+using System.Diagnostics;
+using System.Globalization;
+using System.Reflection;
 
-namespace System.Windows.Forms {
-    using System.Runtime.Serialization.Formatters;
-    using System.Runtime.Remoting;
-    using System.Runtime.InteropServices;
-
-    using Microsoft.Win32;
-    using System.Collections;
-    using System.ComponentModel;
-    using System.ComponentModel.Design.Serialization;
-    using System.Drawing;
-    using System.Diagnostics;
-    using System.Globalization;
-    using System.Reflection;
-
-    /// <include file='doc\ListItemConverter.uex' path='docs/doc[@for="ListViewGroupConverter"]/*' />
+namespace System.Windows.Forms
+{
     /// <devdoc>
-    ///      ListViewGroupConverter is a class that can be used to convert
-    ///      ListViewGroup objects from one data type to another.  Access this
-    ///      class through the TypeDescriptor.
+    /// ListViewGroupConverter is a class that can be used to convert  ListViewGroup objects
+    /// from one data type to another. Access this class through the TypeDescriptor.
     /// </devdoc>
-    internal class ListViewGroupConverter : TypeConverter {
-    
-        /// <include file='doc\ListViewGroupConverter.uex' path='docs/doc[@for="CursorConverter.CanConvertFrom"]/*' />
+    internal class ListViewGroupConverter : TypeConverter
+    {
         /// <devdoc>
-        ///      Determines if this converter can convert an object in the given source
-        ///      type to the native type of the converter.
+        /// Determines if this converter can convert an object in the given source type to
+        /// the native type of the converter.
         /// </devdoc>
-        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType) {
-            if (sourceType == typeof(string) && context != null && context.Instance is ListViewItem) {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            if (sourceType == typeof(string) && context != null && context.Instance is ListViewItem)
+            {
                 return true;
             }
+
             return base.CanConvertFrom(context, sourceType);
         }
 
-        /// <include file='doc\ListViewGroupConverter.uex' path='docs/doc[@for="ListViewGroupConverter.CanConvertTo"]/*' />
         /// <devdoc>
-        ///    <para>Gets a value indicating whether this converter can
-        ///       convert an object to the given destination type using the context.</para>
+        /// Gets a value indicating whether this converter can convert an object to the given
+        /// destination type using the context.</para>
         /// </devdoc>
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType) {
-            if (destinationType == typeof(InstanceDescriptor)) {
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            if (destinationType == typeof(InstanceDescriptor))
+            {
                 return true;
             }
-            if (destinationType == typeof(string) && context != null && context.Instance is ListViewItem) {
+            if (destinationType == typeof(string) && context != null && context.Instance is ListViewItem)
+            {
                 return true;
             }
+
             return base.CanConvertTo(context, destinationType);
         }
 
-        /// <include file='doc\ListViewGroupConverter.uex' path='docs/doc[@for="ListViewGroupConverter.ConvertFrom"]/*' />
         /// <devdoc>
-        ///      Converts the given object to the converter's native type.
+        /// Converts the given object to the converter's native type.
         /// </devdoc>
-        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value) {
-        
-            if (value is string) {
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is string)
+            {
                 string text = ((string)value).Trim();
-
-                if (context != null && context.Instance != null) {
+                if (context != null && context.Instance != null)
+                {
                     ListViewItem item = context.Instance as ListViewItem;
-                    if (item != null && item.ListView != null) {
-                        
-                        foreach(ListViewGroup group in item.ListView.Groups) {
-                            if (group.Header == text) {
+                    if (item != null && item.ListView != null)
+                    {
+                        foreach(ListViewGroup group in item.ListView.Groups)
+                        {
+                            if (group.Header == text)
+                            {
                                 return group;
                             }
                         }
                     }
                 }
-            }                        
+            }
 
-            if (value == null || value.Equals(SR.toStringNone)) {
+            if (value == null || value.Equals(SR.toStringNone))
+            {
                 return null;
             }
 
             return base.ConvertFrom(context, culture, value);
         }
-        
-        /// <include file='doc\ListViewGroupConverter.uex' path='docs/doc[@for="ListViewGroupConverter.ConvertTo"]/*' />
+
         /// <devdoc>
-        ///      Converts the given object to another type.  The most common types to convert
-        ///      are to and from a string object.  The default implementation will make a call
-        ///      to ToString on the object if the object is valid and if the destination
-        ///      type is string.  If this cannot convert to the desitnation type, this will
-        ///      throw a NotSupportedException.
+        /// Converts the given object to another type. The most common types to convert
+        /// are to and from a string object. The default implementation will make a call
+        /// to ToString on the object if the object is valid and if the destination
+        /// type is string. If this cannot convert to the desitnation type, this will
+        /// throw a NotSupportedException.
         /// </devdoc>
-        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType) {
-            if (destinationType == null) {
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == null)
+            {
                 throw new ArgumentNullException(nameof(destinationType));
             }
 
-            if (destinationType == typeof(InstanceDescriptor) && value is ListViewGroup) {
+            if (destinationType == typeof(InstanceDescriptor) && value is ListViewGroup)
+            {
                 ListViewGroup group = (ListViewGroup)value;
                 ConstructorInfo ctor;
-                
+
                 // Header
-                //
                 ctor = typeof(ListViewGroup).GetConstructor(new Type[] {typeof(string), typeof(HorizontalAlignment)});
                 Debug.Assert(ctor != null, "Expected the constructor to exist.");
                 return new InstanceDescriptor(ctor, new object[] { group.Header, group.HeaderAlignment }, false);
             }
 
-            if (destinationType == typeof(string) && value == null) {
+            if (destinationType == typeof(string) && value == null)
+            {
                 return SR.toStringNone;
             }
-            
+
             return base.ConvertTo(context, culture, value, destinationType);
         }
 
-        /// <include file='doc\ListViewGroupConverter.uex' path='docs/doc[@for="ListViewGroupConverter.GetStandardValues"]/*' />
         /// <devdoc>
-        ///      Retrieves a collection containing a set of standard values
-        ///      for the data type this validator is designed for.  This
-        ///      will return null if the data type does not support a
-        ///      standard set of values.
+        /// Retrieves a collection containing a set of standard values for the data type this
+        /// validator is designed for. This will return null if the data type does not support
+        /// a standard set of values.
         /// </devdoc>
-        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context) {
-            if (context != null && context.Instance != null) {
-                ListViewItem item = context.Instance as ListViewItem;
-                if (item != null && item.ListView != null) {
-                    ArrayList list = new ArrayList();
-                    foreach (ListViewGroup group in item.ListView.Groups) {
-                        list.Add(group);
-                    }
-                    list.Add(null);
-                    return new StandardValuesCollection(list);
+        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+        {
+            if (context != null && context.Instance is ListViewItem item && item.ListView != null)
+            {
+                var list = new ArrayList();
+                foreach (ListViewGroup group in item.ListView.Groups)
+                {
+                    list.Add(group);
                 }
+                list.Add(null);
+                return new StandardValuesCollection(list);
             }
             return null;
         }
 
         /// <include file='doc\ListViewGroupConverter.uex' path='docs/doc[@for="ListViewGroupConverter.GetStandardValuesExclusive"]/*' />
         /// <devdoc>
-        ///      Determines if the list of standard values returned from
-        ///      GetStandardValues is an exclusive list.  If the list
-        ///      is exclusive, then no other values are valid, such as
-        ///      in an enum data type.  If the list is not exclusive,
-        ///      then there are other valid values besides the list of
-        ///      standard values GetStandardValues provides.
+        /// Determines if the list of standard values returned from GetStandardValues is an
+        /// exclusive list.  If the list is exclusive, then no other values are valid, such as
+        /// in an enum data type.  If the list is not exclusive, then there are other valid values
+        /// besides the list of standard values GetStandardValues provides.
         /// </devdoc>
-        public override bool GetStandardValuesExclusive(ITypeDescriptorContext context) {
+        public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
+        {
             return true;
         }
 
-        /// <include file='doc\ListViewGroupConverter.uex' path='docs/doc[@for="ListViewGroupConverter.GetStandardValuesSupported"]/*' />
         /// <devdoc>
-        ///      Determines if this object supports a standard set of values
-        ///      that can be picked from a list.
+        /// Determines if this object supports a standard set of values that can be picked
+        /// from a list.
         /// </devdoc>
-        public override bool GetStandardValuesSupported(ITypeDescriptorContext context) {
+        public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+        {
             return true;
         }
-    }    
+    }
 }
-


### PR DESCRIPTION
`ctor` is never null when getting the instancedescriptor

the other changes are formatting cleanups