### PR TITLE
Fix binding null refs

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBindingHelper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBindingHelper.cs
@@ -99,7 +99,8 @@ namespace System.Windows.Forms {
             else {
                 Type type;
                 // We always resolve via type in this case (not an instance)
-                if ((null == listAccessors) || (listAccessors.Length == 0)) {
+                if (listAccessors == null || listAccessors.Length == 0 || listAccessors[0] == null)
+                {
                     if (list is Type listAsType)
                     {
                         type = listAsType;
@@ -211,6 +212,11 @@ namespace System.Windows.Forms {
             }
 
             list = GetList(list);
+            if (list == null)
+            {
+                return null;
+            }
+
             Type listType = (list is Type) ? (list as Type) : list.GetType();
             object listInstance = (list is Type) ? null : list;
 
@@ -293,7 +299,16 @@ namespace System.Windows.Forms {
 
             if (typeof(Array).IsAssignableFrom(type)) {
                 // If the type is Customers[], this will return "Customers"
-                name = type.GetElementType().Name;
+                Type elementType = type.GetElementType();
+                if (elementType != null)
+                {
+                    name = elementType.Name;
+                }
+                else
+                {
+                    // Fallback to type name
+                    name = type.Name;
+                }
             }
             else if (typeof(IList).IsAssignableFrom(type)) {
                 // If the type is BindingList<T>, TCollection, TList (or equiv), this will return "T"
@@ -317,6 +332,11 @@ namespace System.Windows.Forms {
 
         private static PropertyDescriptorCollection GetListItemPropertiesByType(Type type, PropertyDescriptor[] listAccessors, int startIndex) {
             PropertyDescriptorCollection pdc = null;
+            if (listAccessors[startIndex] == null)
+            {
+                return new PropertyDescriptorCollection(null);
+            }
+
             Type subType = listAccessors[startIndex].PropertyType;
             // subType is the property type - which is not to be confused with the item type.
             // For example, if a class Customer has a property of type Orders[], then Given:
@@ -410,6 +430,11 @@ namespace System.Windows.Forms {
             // Get the value of the first listAccessor
             if (listAccessors.Length > startIndex)
             {
+                if (listAccessors[startIndex] == null)
+                {
+                    return new PropertyDescriptorCollection(null);
+                }
+
                 // Get the value (e.g. given Foo with property Bar, this gets Foo.Bar)
                 object value = listAccessors[startIndex].GetValue(target);
 
@@ -597,6 +622,10 @@ namespace System.Windows.Forms {
                 // Otherwise use the enumerator to get the first item...
                 try {
                     IEnumerator listEnumerator = enumerable.GetEnumerator();
+                    if (listEnumerator == null)
+                    {
+                        return null;
+                    }
 
                     listEnumerator.Reset();
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBindingHelper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBindingHelper.cs
@@ -198,17 +198,17 @@ namespace System.Windows.Forms {
             return GetListItemProperties(dataSource, listAccessors);
         }
 
-        /// <include file='doc\ListBindingHelper.uex' path='docs/doc[@for="ListBindingHelper.GetListItemType"]/*' />
-        public static Type GetListItemType(object list) {
-            if (list == null) {
+        public static Type GetListItemType(object list)
+        {
+            if (list == null)
+            {
                 return null;
             }
 
-            Type itemType = null;
-
             // special case for IListSource
-            if ((list is Type) && (typeof(IListSource).IsAssignableFrom(list as Type))) {
-                list = CreateInstanceOfType(list as Type);
+            if (list is Type listAsType && typeof(IListSource).IsAssignableFrom(listAsType))
+            {
+                list = CreateInstanceOfType(listAsType);
             }
 
             list = GetList(list);
@@ -220,24 +220,22 @@ namespace System.Windows.Forms {
             Type listType = (list is Type) ? (list as Type) : list.GetType();
             object listInstance = (list is Type) ? null : list;
 
-            if (typeof(Array).IsAssignableFrom(listType)) {
-                itemType = listType.GetElementType();
-            }
-            else {
-                PropertyInfo indexer = GetTypedIndexer(listType);
-
-                if (indexer != null) {
-                    itemType = indexer.PropertyType;
-                }
-                else if (listInstance is IEnumerable) {
-                    itemType = GetListItemTypeByEnumerable(listInstance as IEnumerable);
-                }
-                else {
-                    itemType = listType;
-                }
+            if (typeof(Array).IsAssignableFrom(listType))
+            {
+                return listType.GetElementType();
             }
 
-            return itemType;
+            PropertyInfo indexer = GetTypedIndexer(listType);
+            if (indexer != null)
+            {
+                return indexer.PropertyType;
+            }
+            else if (listInstance is IEnumerable enumerable)
+            {
+                return GetListItemTypeByEnumerable(enumerable);
+            }
+            
+            return listType;
         }
 
         // Create an object of the given type. Throw an exception if this fails.
@@ -424,10 +422,6 @@ namespace System.Windows.Forms {
             // At this point, things can be simplified because:
             //   We know target is _not_ a list
             //   We have an instance
-
-            PropertyDescriptorCollection pdc;
-
-            // Get the value of the first listAccessor
             if (listAccessors.Length > startIndex)
             {
                 if (listAccessors[startIndex] == null)
@@ -438,31 +432,31 @@ namespace System.Windows.Forms {
                 // Get the value (e.g. given Foo with property Bar, this gets Foo.Bar)
                 object value = listAccessors[startIndex].GetValue(target);
 
-                if (value == null) {
+                if (value == null)
+                {
                     // It's null - we can't walk down by Instance so use Type
-                    pdc = GetListItemPropertiesByType(listAccessors[startIndex].PropertyType, listAccessors, startIndex);
+                    return GetListItemPropertiesByType(listAccessors[startIndex].PropertyType, listAccessors, startIndex);
                 }
-                else {
+                else
+                {
                     PropertyDescriptor[] accessors = null;
 
-                    if (listAccessors.Length > startIndex + 1) {
+                    if (listAccessors.Length > startIndex + 1)
+                    {
                         int accessorsCount = listAccessors.Length - (startIndex + 1);
                         accessors = new PropertyDescriptor[accessorsCount];
-                        for (int i = 0; i < accessorsCount; ++i) {
+                        for (int i = 0; i < accessorsCount; ++i)
+                        {
                             accessors[i] = listAccessors[startIndex + 1 + i];
                         }
                     }
 
                     // We've got the instance of Bar - now get it's shape
-                    pdc = GetListItemProperties(value, accessors);
+                    return GetListItemProperties(value, accessors);
                 }
             }
-            else {
-                // Fallback to TypeDescriptor
-                pdc = TypeDescriptor.GetProperties(target, BrowsableAttributeList);
-            }
-
-            return pdc;
+            
+            return TypeDescriptor.GetProperties(target, BrowsableAttributeList);
         }
 
         // returns true if 'type' can be treated as a list


### PR DESCRIPTION
Fixes #388 
Fixes #389
Fixes #390
Fixes #391
Fixes #392

This is an obvious win - we now return something meaningful (and usable) in these examples rather than throwing NRE. There are no changes in exceptions, only exceptions in edge cases that are no longer an issue!