### PR TITLE
Exclude documentation files from NuGet package

### DIFF
--- a/pkg/Microsoft.Private.Winforms.csproj
+++ b/pkg/Microsoft.Private.Winforms.csproj
@@ -132,10 +132,11 @@
         <PackagePath>$(_packagePath)</PackagePath>
       </TfmSpecificPackageFile>
 
+      <!-- Commenting out until we decide to use XML files in the package -->
       <!-- Get xml files -->
-      <TfmSpecificPackageFile Include="$(_baseDirectory)**\$(_baseFileName).xml">
+      <!--<TfmSpecificPackageFile Include="$(_baseDirectory)**\$(_baseFileName).xml">
         <PackagePath>$(_packagePath)%(RecursiveDir)</PackagePath>
-      </TfmSpecificPackageFile>
+      </TfmSpecificPackageFile>-->
 
       <!-- commenting out until we decide to use them in the WindowsDesktop package -->
       <!-- Get resource dlls -->


### PR DESCRIPTION
@zsd4yr requested that XML files produced during the build not be included in the NuGet package produced for the repository. This change implements that request.

If this request was documented by an issue, please feel free to link it. 👍 