### PR TITLE
The focused PropertyGrid button with 3 dots is not following HC standards on HC Black/White theme

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonBaseAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonBaseAdapter.cs
@@ -80,6 +80,11 @@ namespace System.Windows.Forms.ButtonInternal {
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected bool IsHighContrastHighlighted3() {
+            return AccessibilityImprovements.Level3 && IsHighContrastHighlightedInternal();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool IsHighContrastHighlightedInternal() {
             return SystemInformation.HighContrast && Application.RenderWithVisualStyles &&
                 (Control.Focused || Control.MouseIsOver || (Control.IsDefault && Control.Enabled));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.cs
@@ -209,7 +209,7 @@ namespace System.Windows.Forms.PropertyGridInternal {
         }
 
         internal override void DrawImageCore(Graphics graphics, Image image, Rectangle imageBounds, Point imageStart, ButtonBaseAdapter.LayoutData layout) {
-             ControlPaint.DrawImageReplaceColor(graphics, image, imageBounds, Color.Black, Control.ForeColor);
+             ControlPaint.DrawImageReplaceColor(graphics, image, imageBounds, Color.Black, SystemInformation.HighContrast && (this.Control.MouseIsOver || this.Control.Focused) ? SystemColors.HighlightText : Control.ForeColor);
              //ControlPaint.DrawImageColorized(graphics, image, imageBounds , Control.ForeColor);
         } 
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.cs
@@ -209,8 +209,7 @@ namespace System.Windows.Forms.PropertyGridInternal {
         }
 
         internal override void DrawImageCore(Graphics graphics, Image image, Rectangle imageBounds, Point imageStart, ButtonBaseAdapter.LayoutData layout) {
-             ControlPaint.DrawImageReplaceColor(graphics, image, imageBounds, Color.Black, SystemInformation.HighContrast && (this.Control.MouseIsOver || this.Control.Focused) ? SystemColors.HighlightText : Control.ForeColor);
-             //ControlPaint.DrawImageColorized(graphics, image, imageBounds , Control.ForeColor);
+             ControlPaint.DrawImageReplaceColor(graphics, image, imageBounds, Color.Black, this.IsHighContrastHighlighted3() && !this.Control.MouseIsDown ? SystemColors.HighlightText : Control.ForeColor);
         } 
     }
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/25530829/53358479-8c3d5d00-3941-11e9-84cb-87d901875ed7.png)

The appropriate color is now used for the icon's dots when the HC Black or HC White theme is enabled

After:
![image](https://user-images.githubusercontent.com/25530829/53441929-ff65d280-3a18-11e9-9420-dd4314b34a32.png)