### PR TITLE
fix Error CS0579: Duplicate attribute

### DIFF
--- a/pkg/Microsoft.Private.Winforms.csproj
+++ b/pkg/Microsoft.Private.Winforms.csproj
@@ -47,6 +47,11 @@
       <PrivateAssets>All</PrivateAssets>
     </ProjectReference>
   </ItemDefinitionGroup>
+  <ItemGroup>
+    <Compile Remove="obj\**" />
+    <EmbeddedResource Remove="obj\**" />
+    <None Remove="obj\**" />
+  </ItemGroup>
 
   <!-- Any projects referenced here will have their outputs automatically put into the package -->
   <!-- If you add a new csproj, and you want the outputs in the package, you must add it here -->

--- a/src/Common/tests/InternalUtilitiesForTests/InternalUtilitiesForTests.csproj
+++ b/src/Common/tests/InternalUtilitiesForTests/InternalUtilitiesForTests.csproj
@@ -8,9 +8,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="obj\**" />
+    <EmbeddedResource Remove="obj\**" />
+    <None Remove="obj\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
     <PackageReference Include="xunit.stafact" Version="$(XUnitStaFactPackageVersion)" />
-    <PackageReference Include= "Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsPackage)" />
+    <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsPackage)" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/src/System.Design/src/System.Design.Facade.csproj
+++ b/src/System.Design/src/System.Design.Facade.csproj
@@ -6,6 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="obj\**" />
+    <EmbeddedResource Remove="obj\**" />
+    <None Remove="obj\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\System.Windows.Forms.Design.Editors\ref\System.Windows.Forms.Design.Editors.Ref.csproj" />
     <ProjectReference Include="..\..\System.Windows.Forms.Design\ref\System.Windows.Forms.Design.Ref.csproj" />
   </ItemGroup>

--- a/src/System.Windows.Forms.Design.Editors/ref/System.Windows.Forms.Design.Editors.Ref.csproj
+++ b/src/System.Windows.Forms.Design.Editors/ref/System.Windows.Forms.Design.Editors.Ref.csproj
@@ -7,6 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="obj\**" />
+    <EmbeddedResource Remove="obj\**" />
+    <None Remove="obj\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonPackageVersion)" />
   </ItemGroup>
 

--- a/src/System.Windows.Forms.Design/tests/System.Windows.Forms.Design.Tests.csproj
+++ b/src/System.Windows.Forms.Design/tests/System.Windows.Forms.Design.Tests.csproj
@@ -7,6 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="obj\**" />
+    <EmbeddedResource Remove="obj\**" />
+    <None Remove="obj\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\src\System.Windows.Forms.Design.csproj" />
     <Compile Include="..\..\Common\tests\CommonTestHelper.cs" Link="Common\CommonTestHelper.cs" />
     <ProjectReference Include="..\..\Common\tests\InternalUtilitiesForTests\InternalUtilitiesForTests.csproj" />

--- a/src/System.Windows.Forms/ref/System.Windows.Forms.Ref.csproj
+++ b/src/System.Windows.Forms/ref/System.Windows.Forms.Ref.csproj
@@ -8,6 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="obj\**" />
+    <EmbeddedResource Remove="obj\**" />
+    <None Remove="obj\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Accessibility" Version="$(AccessibilityPackageVersion)" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryPackageVersion)" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" />


### PR DESCRIPTION
As reported in https://github.com/dotnet/winforms/issues/477#issuecomment-467319603 the latest master (3054d36a1aa237f25cb244742e17860980e0595e) fails to build in VS

obj folders must be excluded from projects, otherwise they cause builds
to fail with similar errors:

``` 
 \winforms\artifacts\obj\InternalUtilitiesForTests\Debug\netcoreapp3.0\InternalUtilitiesForTests.AssemblyInfo.cs(14,12):
      Error CS0579: Duplicate 'System.Reflection.AssemblyCompanyAttribute' attribute
      Error CS0579: Duplicate 'System.Reflection.AssemblyConfigurationAttribute' attribute
      Error CS0579: Duplicate 'System.Reflection.AssemblyFileVersionAttribute' attribute
      Error CS0579: Duplicate 'System.Reflection.AssemblyInformationalVersionAttribute' attribute
      Error CS0579: Duplicate 'System.Reflection.AssemblyProductAttribute' attribute
      Error CS0579: Duplicate 'System.Reflection.AssemblyTitleAttribute' attribute
      Error CS0579: Duplicate 'System.Reflection.AssemblyVersionAttribute' attribute
```