### PR TITLE
Remove unnecessary exclusions from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,15 +16,10 @@
 .tools/
 
 # Build results
-[Dd]ebug/
-[Dd]ebugPublic/
-[Rr]elease/
 [Rr]eleases/
 x64/
 x86/
 bld/
-[Bb]in/
-[Oo]bj/
 [Ll]og/
 
 # Visual Studio 2015/2017 cache/options directory


### PR DESCRIPTION
The issues with obj/ directories were a carry-over from the migration to arcade. Users were not aware that a **git clean** was required to remove the extraneous files and folders because they did not show up in source control views. After this change, it will be clear when files are left over from a checkout of an earlier revision, and a git clean operation will restore the repository to a properly working state.

Supersedes #490