### PR TITLE
Port the ArrayEditor from the classic framework and add unit test.

### DIFF
--- a/src/System.Windows.Forms.Design.Editors/src/System/ComponentModel/Design/ArrayEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/ComponentModel/Design/ArrayEditor.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+namespace System.ComponentModel.Design
+{
+    /// <summary>
+    /// Edits an array of values.
+    /// </summary>
+    public class ArrayEditor : CollectionEditor
+    {
+
+        /// <summary>
+        /// Initializes a new instance of <see cref='System.ComponentModel.Design.ArrayEditor'/> 
+        /// using the specified type for the array.
+        /// </summary>
+        public ArrayEditor(Type type) : base(type)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the data type this collection contains.
+        /// </summary>
+        protected override Type CreateCollectionItemType() => CollectionType.GetElementType();
+
+        /// <summary>
+        /// Gets the items in the array.
+        /// </summary>
+        /// <param name="editValue"></param>
+        protected override object[] GetItems(object editValue)
+        {
+            if (editValue is Array)
+            {
+                Array valueArray = (Array)editValue;
+                object[] items = new object[valueArray.GetLength(0)];
+                Array.Copy(valueArray, items, items.Length);
+                return items;
+            }
+            else
+            {
+                return new object[0];
+            }
+        }
+
+        /// <summary>
+        /// Sets the items in the array.
+        /// </summary>
+        protected override object SetItems(object editValue, object[] value)
+        {
+            if (editValue is Array || editValue == null)
+            {
+                Array newArray = Array.CreateInstance(CollectionItemType, value.Length);
+                Array.Copy(value, newArray, value.Length);
+                return newArray;
+            }
+            return editValue;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design.Editors/tests/UnitTests/ArrayEditorTests.cs
+++ b/src/System.Windows.Forms.Design.Editors/tests/UnitTests/ArrayEditorTests.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Globalization;
+using System.Reflection;
+using Xunit;
+
+namespace System.ComponentModel.Design.Tests
+{
+    public class ArrayEditorTests
+    {
+        [Fact]
+        public void ArrayEditor_Constructor()
+        {
+            var underTest = GetNewEditor();
+            Assert.NotNull(underTest);
+        }
+
+        [Fact]
+        public void ArrayEditor_Getters()
+        {
+            var underTest = GetNewEditor();
+            Assert.Equal(typeof(string), underTest.GetCollectionType());
+            Assert.True(underTest.CanSelectMultiple());
+            Assert.True(underTest.CanRemove("some string"));
+            Assert.True(underTest.CanRemove(1234));
+            Assert.Equal("net.ComponentModel.CollectionEditor", underTest.GetHelpTopic());
+            Assert.Equal("my string", underTest.GetItemDisplayText("my string"));
+        }
+
+        private TestArrayEditor GetNewEditor()
+        {
+            return new TestArrayEditor(typeof(string));
+        }
+
+        private class TestArrayEditor : ArrayEditor
+        {
+            public TestArrayEditor(Type type) : base(type)
+            {
+            }
+
+            public Type GetCollectionType()
+            {
+                return base.CollectionType;
+            }
+
+            public bool CanSelectMultiple()
+            {
+                return base.CanSelectMultipleInstances();
+            }
+
+            public bool CanRemove(object value)
+            {
+                return base.CanRemoveInstance(value);
+            }
+
+            public string GetHelpTopic()
+            {
+                return base.HelpTopic;
+            }
+
+            public string GetItemDisplayText(object value)
+            {
+                return base.GetDisplayText(value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The ArrayEditor is needed to enable runtime designer functionality for the Chart control (WinForms Core DataVisualization).