### PR TITLE
remove src/System.Drawing/tests and src/System.Design/tests from Coverage report ...

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -26,8 +26,6 @@ flags:
   test:
     paths:
       - src/Common/tests/
-      - src/System.Design/tests/
-      - src/System.Drawing/tests/
       - src/System.Drawing.Design/tests/
       - src/System.Windows.Forms/tests/
       - src/System.Windows.Forms.Design/tests/


### PR DESCRIPTION
... as they don't and won't exist