### PR TITLE
Fix GetThemeMargins p/invoke signature

### DIFF
--- a/src/Common/src/SafeNativeMethods.cs
+++ b/src/Common/src/SafeNativeMethods.cs
@@ -771,7 +771,7 @@ namespace System.Windows.Forms {
         public static extern int GetThemePosition(HandleRef hTheme, int iPartId, int iStateId, int iPropId, [Out] NativeMethods.POINT pPoint);
         [DllImport(ExternDll.Uxtheme, CharSet=CharSet.Auto)]
         
-        public static extern int GetThemeMargins(HandleRef hTheme, HandleRef hDC, int iPartId, int iStateId, int iPropId, ref NativeMethods.MARGINS margins);
+        public static extern int GetThemeMargins(HandleRef hTheme, HandleRef hDC, int iPartId, int iStateId, int iPropId, NativeMethods.COMRECT prc, ref NativeMethods.MARGINS margins);
         [DllImport(ExternDll.Uxtheme, CharSet=CharSet.Auto)]
         
         public static extern int GetThemeString(HandleRef hTheme, int iPartId, int iStateId, int iPropId, StringBuilder pszBuff, int cchMaxBuffChars);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
@@ -822,7 +822,7 @@ namespace System.Windows.Forms.VisualStyles {
 
             using( WindowsGraphicsWrapper wgr = new WindowsGraphicsWrapper( dc, AllGraphicsProperties ) ) {
                 HandleRef hdc = new HandleRef( wgr, wgr.WindowsGraphics.DeviceContext.Hdc );
-                lastHResult = SafeNativeMethods.GetThemeMargins( new HandleRef( this, Handle ), hdc, part, state, (int) prop, default(NativeMethods.COMRECT), ref margins );
+                lastHResult = SafeNativeMethods.GetThemeMargins( new HandleRef( this, Handle ), hdc, part, state, (int) prop, prc: null, ref margins );
             }
 
             return new Padding(margins.cxLeftWidth, margins.cyTopHeight, margins.cxRightWidth, margins.cyBottomHeight);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
@@ -822,7 +822,7 @@ namespace System.Windows.Forms.VisualStyles {
 
             using( WindowsGraphicsWrapper wgr = new WindowsGraphicsWrapper( dc, AllGraphicsProperties ) ) {
                 HandleRef hdc = new HandleRef( wgr, wgr.WindowsGraphics.DeviceContext.Hdc );
-                lastHResult = SafeNativeMethods.GetThemeMargins( new HandleRef( this, Handle ), hdc, part, state, (int) prop, ref margins );
+                lastHResult = SafeNativeMethods.GetThemeMargins( new HandleRef( this, Handle ), hdc, part, state, (int) prop, default(NativeMethods.COMRECT), ref margins );
             }
 
             return new Padding(margins.cxLeftWidth, margins.cyTopHeight, margins.cxRightWidth, margins.cyBottomHeight);

--- a/src/System.Windows.Forms/tests/UnitTests/VisualStyleRendererTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/VisualStyleRendererTests.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using System.Windows.Forms.VisualStyles;
+
+namespace System.Windows.Forms.Tests
+{
+    public class VisualStyleRendererTests
+    {
+        [Fact]
+        public void VisualStyleRenderer_GetMargins()
+        {
+            var renderer = new VisualStyleRenderer(VisualStyleElement.Button.PushButton.Normal);
+
+            using (var form = new System.Windows.Forms.Form())
+            using (var graphics = form.CreateGraphics())
+            {
+                // GetMargins should not throw an exception.
+                // See Issue #526 on GitHub.
+                renderer.GetMargins(graphics, MarginProperty.SizingMargins);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/VisualStyleRendererTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/VisualStyleRendererTests.cs
@@ -18,7 +18,7 @@ namespace System.Windows.Forms.Tests
             using (var graphics = form.CreateGraphics())
             {
                 // GetMargins should not throw an exception.
-                // See Issue #526 on GitHub.
+                // See https://github.com/dotnet/winforms/issues/526.
                 renderer.GetMargins(graphics, MarginProperty.SizingMargins);
             }
         }


### PR DESCRIPTION
According to the MS docs, the parameter `LPCRECT prc` is missing:
```c
THEMEAPI GetThemeMargins(
  HTHEME  hTheme,
  HDC     hdc,
  int     iPartId,
  int     iStateId,
  int     iPropId,
  LPCRECT prc,
  MARGINS *pMargins
);
```

This PR adds this missing parameter.

Fixes #526