### PR TITLE
Update SDK, remove NoBuild (now deprecated), and fix tests for InstanceDescriptor Conversion

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,4 +37,9 @@
   <Target Name="InstrumentModulesAfterBuild" />
   <Target Name="GenerateCoverageResult" />
 
+  <!-- workaround for package downgrade in Microsoft.NetCore.Platforms -->
+  <PropertyGroup>
+    <DisableImplicitNETCorePlatformsReference>true</DisableImplicitNETCorePlatformsReference>
+  </PropertyGroup>
+
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,7 +6,7 @@
   <Import Project="$(RepositoryEngineeringDir)versioning.targets" />
   <!-- to prevent using MS.NC.Platforms from SDK, which is lagging behind the version that WinForms gets from the CoreFx packages -->
   <ItemGroup>
-    <PackageReference Update="Microsoft.NETCore.Platforms" Version="$(MicrosoftNETCorePlatformsPackageVersion)" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="$(MicrosoftNETCorePlatformsPackageVersion)" />
   </ItemGroup>
 
   <!-- Set code coverage properties that reference properties not available in Directory.Build.props -->

--- a/eng/packageContent.targets
+++ b/eng/packageContent.targets
@@ -25,4 +25,6 @@
     </ItemGroup>
   </Target>
 
+  <!-- xml files can be added here for intellisense -->
+
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview3-010436",
+    "dotnet": "3.0.100-preview4-010924",
     "vs": {
       "version": "16.0"
     }
   },
   "sdk": {
-    "version": "3.0.100-preview3-010436"
+    "version": "3.0.100-preview4-010924"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19162.7",

--- a/pkg/Microsoft.Private.Winforms.csproj
+++ b/pkg/Microsoft.Private.Winforms.csproj
@@ -18,6 +18,7 @@
 
     <!-- Don't include this project in the build output -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <PublishWindowsPdb>false</PublishWindowsPdb>
     <IncludeSymbols>false</IncludeSymbols>
 
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/pkg/Microsoft.Private.Winforms.csproj
+++ b/pkg/Microsoft.Private.Winforms.csproj
@@ -16,9 +16,7 @@
 
   <PropertyGroup>
 
-    <!-- Don't build this project -->
-    <!-- Todo: this doesn't seem to work, find another way to prevent build outputs -->
-    <NoBuild>true</NoBuild>
+    <!-- Don't include this project in the build output -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>
 

--- a/src/Common/tests/CommonTestHelper.cs
+++ b/src/Common/tests/CommonTestHelper.cs
@@ -247,6 +247,17 @@ namespace WinForms.Common.Tests
             return data;
         }
 
+        public static TheoryData<Type, bool> GetConvertFromTheoryData()
+        {
+            var data = new TheoryData<Type, bool>();
+            data.Add(typeof(bool), false);
+            data.Add(typeof(System.ComponentModel.Design.Serialization.InstanceDescriptor), true);
+            data.Add(typeof(int), false);
+            data.Add(typeof(double), false);
+            data.Add(null, false);
+            return data;
+        }
+
         #endregion        
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeaderConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeaderConverterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -14,12 +14,12 @@ namespace System.Windows.Forms.Tests
 {
     public class ColumnHeaderConverterTests
     {
+        public static TheoryData<Type, bool> CanConvertFromData =>
+            CommonTestHelper.GetConvertFromTheoryData();
+
         [Theory]
-        [InlineData(typeof(string), false)]
-        [InlineData(typeof(InstanceDescriptor), false)]
+        [MemberData(nameof(CanConvertFromData))]
         [InlineData(typeof(ColumnHeader), false)]
-        [InlineData(typeof(int), false)]
-        [InlineData(null, false)]
         public void ColumnHeaderConverter_CanConvertFrom_Invoke_ReturnsExpected(Type sourceType, bool expected)
         {
             var converter = new ColumnHeaderConverter();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/TableLayoutSettingsTypeConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/TableLayoutSettingsTypeConverterTests.cs
@@ -6,18 +6,20 @@ using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
 using System.Xml;
 using Moq;
+using WinForms.Common.Tests;
 using Xunit;
 
 namespace System.Windows.Forms.Layout.Tests
 {
     public class TableLayoutSettingsTypeConverterTests
     {
+        public static TheoryData<Type, bool> CanConvertFromData =>
+            CommonTestHelper.GetConvertFromTheoryData();
+
         [Theory]
-        [InlineData(typeof(string), true)]
-        [InlineData(typeof(InstanceDescriptor), false)]
+        [MemberData(nameof(CanConvertFromData))]
         [InlineData(typeof(TableLayoutSettings), false)]
-        [InlineData(typeof(int), false)]
-        [InlineData(null, false)]
+        [InlineData(typeof(string), true)]
         public void TableLayoutSettingsTypeConverter_CanConvertFrom_Invoke_ReturnsExpected(Type sourceType, bool expected)
         {
             var converter = new TableLayoutSettingsTypeConverter();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupConverterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -14,12 +14,13 @@ namespace System.Windows.Forms.Tests
 {
     public class ListViewGroupConverterTests
     {
+        public static TheoryData<Type, bool> CanConvertFromData =>
+            CommonTestHelper.GetConvertFromTheoryData();
+
         [Theory]
-        [InlineData(typeof(string), false)]
-        [InlineData(typeof(InstanceDescriptor), false)]
+        [MemberData(nameof(CanConvertFromData))]
         [InlineData(typeof(ListViewGroup), false)]
-        [InlineData(typeof(int), false)]
-        [InlineData(null, false)]
+        [InlineData(typeof(string), false)]
         public void ListViewGroupConverter_CanConvertFrom_Invoke_ReturnsExpected(Type sourceType, bool expected)
         {
             TypeConverter converter = TypeDescriptor.GetConverter(typeof(ListViewGroup));

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItemConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItemConverterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -14,12 +14,13 @@ namespace System.Windows.Forms.Tests
 {
     public class ListViewItemConverterTests
     {
+        public static TheoryData<Type, bool> CanConvertFromData =>
+            CommonTestHelper.GetConvertFromTheoryData();
+
         [Theory]
-        [InlineData(typeof(string), false)]
-        [InlineData(typeof(InstanceDescriptor), false)]
+        [MemberData(nameof(CanConvertFromData))]
         [InlineData(typeof(ListViewItem), false)]
-        [InlineData(typeof(int), false)]
-        [InlineData(null, false)]
+        [InlineData(typeof(string), false)]
         public void ListViewItemConverter_CanConvertFrom_Invoke_ReturnsExpected(Type sourceType, bool expected)
         {
             var converter = new ListViewItemConverter();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewSubItemConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewSubItemConverterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -14,12 +14,13 @@ namespace System.Windows.Forms.Tests
 {
     public class ListViewSubItemConverterTests
     {
+        public static TheoryData<Type, bool> CanConvertFromData =>
+            CommonTestHelper.GetConvertFromTheoryData();
+
         [Theory]
-        [InlineData(typeof(string), false)]
-        [InlineData(typeof(InstanceDescriptor), false)]
+        [MemberData(nameof(CanConvertFromData))]
         [InlineData(typeof(ListViewItem.ListViewSubItem), false)]
-        [InlineData(typeof(int), false)]
-        [InlineData(null, false)]
+        [InlineData(typeof(string), false)]
         public void ListViewSubItemConverter_CanConvertFrom_Invoke_ReturnsExpected(Type sourceType, bool expected)
         {
             TypeConverter converter = TypeDescriptor.GetConverter(typeof(ListViewItem.ListViewSubItem));

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/OpacityConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/OpacityConverterTests.cs
@@ -8,18 +8,19 @@ using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
 using System.Globalization;
 using Moq;
+using WinForms.Common.Tests;
 using Xunit;
 
 namespace System.Windows.Forms.Tests
 {
     public class OpacityConverterTests
     {
+        public static TheoryData<Type, bool> CanConvertFromData =>
+            CommonTestHelper.GetConvertFromTheoryData();
+
         [Theory]
+        [MemberData(nameof(CanConvertFromData))]
         [InlineData(typeof(string), true)]
-        [InlineData(typeof(InstanceDescriptor), false)]
-        [InlineData(typeof(double), false)]
-        [InlineData(typeof(int), false)]
-        [InlineData(null, false)]
         public void OpacityConverter_CanConvertFrom_Invoke_ReturnsExpected(Type sourceType, bool expected)
         {
             var converter = new OpacityConverter();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PaddingConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PaddingConverterTests.cs
@@ -6,20 +6,22 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
-using System.Globalization;
 using Moq;
+using WinForms.Common.Tests;
 using Xunit;
 
 namespace System.Windows.Forms.Tests
 {
     public class PaddingConverterTests
     {
+
+        public static TheoryData<Type,bool> CanConvertFromData =>
+            CommonTestHelper.GetConvertFromTheoryData();
+
         [Theory]
-        [InlineData(typeof(string), true)]
-        [InlineData(typeof(InstanceDescriptor), false)]
+        [MemberData(nameof(CanConvertFromData))]
         [InlineData(typeof(Padding), false)]
-        [InlineData(typeof(int), false)]
-        [InlineData(null, false)]
+        [InlineData(typeof(string), true)]
         public void PaddingConverter_CanConvertFrom_Invoke_ReturnsExpected(Type sourceType, bool expected)
         {
             var converter = new PaddingConverter();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TableLayoutPanelCellPositionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TableLayoutPanelCellPositionTests.cs
@@ -96,12 +96,13 @@ namespace System.Windows.Forms.Tests
             Assert.Equal("1,2", position.ToString());
         }
 
+        public static TheoryData<Type, bool> CanConvertFromData =>
+            CommonTestHelper.GetConvertFromTheoryData();
+
         [Theory]
-        [InlineData(typeof(string), true)]
-        [InlineData(typeof(InstanceDescriptor), false)]
+        [MemberData(nameof(CanConvertFromData))]
         [InlineData(typeof(TableLayoutSettings), false)]
-        [InlineData(typeof(int), false)]
-        [InlineData(null, false)]
+        [InlineData(typeof(string), true)]
         public void TableLayoutPanelCellPosition_ConverterCanConvertFrom_Invoke_ReturnsExpected(Type sourceType, bool expected)
         {
             TypeConverter converter = TypeDescriptor.GetConverter(typeof(TableLayoutPanelCellPosition));


### PR DESCRIPTION
fixes

```diff
- E:\winforms\.dotnet\sdk\3.0.100-preview4-010924\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.targets(115,5): error NETSDK1085: The 'NoBuild' property was set to true but the 'Build' targetcrosoft.NET.Sdk.targets(115,5): error NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked. [E:\winforms\pkg\Microsoft.Private.Winforms.csproj]
```