### PR TITLE
locked string "Web" because it should not be localized

### DIFF
--- a/src/System.Windows.Forms.Design.Editors/src/Resources/SR.resx
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/SR.resx
@@ -84,6 +84,7 @@
   </data>
   <data name="ColorEditorStandardTab" xml:space="preserve">
     <value>Web</value>
+    <comment>{Locked="Web"}</comment>
   </data>
   <data name="ColorEditorSystemTab" xml:space="preserve">
     <value>System</value>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.cs.xlf
@@ -75,7 +75,7 @@
       <trans-unit id="ColorEditorStandardTab">
         <source>Web</source>
         <target state="needs-review-translation">Web</target>
-        <note />
+        <note>{Locked="Web"}</note>
       </trans-unit>
       <trans-unit id="ColorEditorSystemTab">
         <source>System</source>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.de.xlf
@@ -75,7 +75,7 @@
       <trans-unit id="ColorEditorStandardTab">
         <source>Web</source>
         <target state="needs-review-translation">Web</target>
-        <note />
+        <note>{Locked="Web"}</note>
       </trans-unit>
       <trans-unit id="ColorEditorSystemTab">
         <source>System</source>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.es.xlf
@@ -75,7 +75,7 @@
       <trans-unit id="ColorEditorStandardTab">
         <source>Web</source>
         <target state="needs-review-translation">Web</target>
-        <note />
+        <note>{Locked="Web"}</note>
       </trans-unit>
       <trans-unit id="ColorEditorSystemTab">
         <source>System</source>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.fr.xlf
@@ -75,7 +75,7 @@
       <trans-unit id="ColorEditorStandardTab">
         <source>Web</source>
         <target state="needs-review-translation">Web</target>
-        <note />
+        <note>{Locked="Web"}</note>
       </trans-unit>
       <trans-unit id="ColorEditorSystemTab">
         <source>System</source>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.it.xlf
@@ -75,7 +75,7 @@
       <trans-unit id="ColorEditorStandardTab">
         <source>Web</source>
         <target state="needs-review-translation">Web</target>
-        <note />
+        <note>{Locked="Web"}</note>
       </trans-unit>
       <trans-unit id="ColorEditorSystemTab">
         <source>System</source>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ja.xlf
@@ -75,7 +75,7 @@
       <trans-unit id="ColorEditorStandardTab">
         <source>Web</source>
         <target state="needs-review-translation">Web</target>
-        <note />
+        <note>{Locked="Web"}</note>
       </trans-unit>
       <trans-unit id="ColorEditorSystemTab">
         <source>System</source>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ko.xlf
@@ -75,7 +75,7 @@
       <trans-unit id="ColorEditorStandardTab">
         <source>Web</source>
         <target state="needs-review-translation">Web</target>
-        <note />
+        <note>{Locked="Web"}</note>
       </trans-unit>
       <trans-unit id="ColorEditorSystemTab">
         <source>System</source>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.pl.xlf
@@ -75,7 +75,7 @@
       <trans-unit id="ColorEditorStandardTab">
         <source>Web</source>
         <target state="needs-review-translation">Web</target>
-        <note />
+        <note>{Locked="Web"}</note>
       </trans-unit>
       <trans-unit id="ColorEditorSystemTab">
         <source>System</source>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.pt-BR.xlf
@@ -75,7 +75,7 @@
       <trans-unit id="ColorEditorStandardTab">
         <source>Web</source>
         <target state="needs-review-translation">Web</target>
-        <note />
+        <note>{Locked="Web"}</note>
       </trans-unit>
       <trans-unit id="ColorEditorSystemTab">
         <source>System</source>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ru.xlf
@@ -75,7 +75,7 @@
       <trans-unit id="ColorEditorStandardTab">
         <source>Web</source>
         <target state="needs-review-translation">Web</target>
-        <note />
+        <note>{Locked="Web"}</note>
       </trans-unit>
       <trans-unit id="ColorEditorSystemTab">
         <source>System</source>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.tr.xlf
@@ -75,7 +75,7 @@
       <trans-unit id="ColorEditorStandardTab">
         <source>Web</source>
         <target state="needs-review-translation">Web</target>
-        <note />
+        <note>{Locked="Web"}</note>
       </trans-unit>
       <trans-unit id="ColorEditorSystemTab">
         <source>System</source>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.zh-Hans.xlf
@@ -75,7 +75,7 @@
       <trans-unit id="ColorEditorStandardTab">
         <source>Web</source>
         <target state="needs-review-translation">Web</target>
-        <note />
+        <note>{Locked="Web"}</note>
       </trans-unit>
       <trans-unit id="ColorEditorSystemTab">
         <source>System</source>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.zh-Hant.xlf
@@ -75,7 +75,7 @@
       <trans-unit id="ColorEditorStandardTab">
         <source>Web</source>
         <target state="needs-review-translation">Web</target>
-        <note />
+        <note>{Locked="Web"}</note>
       </trans-unit>
       <trans-unit id="ColorEditorSystemTab">
         <source>System</source>


### PR DESCRIPTION
This is take 2, I added a comment to resx file and the xlf files were generated by the build. This seems to be consistent with what Roslyn has in their repo.