### PR TITLE
Remove artifacts subfolders from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,15 +18,10 @@
 .packages/
 
 # Build results
-[Dd]ebug/
-[Dd]ebugPublic/
-[Rr]elease/
 [Rr]eleases/
 x64/
 x86/
 bld/
-[Bb]in/
-[Oo]bj/
 [Ll]og/
 
 # Visual Studio 2015/2017 cache/options directory


### PR DESCRIPTION
These exclusions are covered by an existing exclusion of the artifacts top-level folder. Subfolders are intentionally omitted from .gitignore, since the appearance of a file in such a location outside of artifacts
indicates a wider failure of the build structure.