### PR TITLE
Set Control.Defaultfont to SystemFonts.MessageBoxFont

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -2274,7 +2274,7 @@ namespace System.Windows.Forms
             {
                 if (defaultFont == null)
                 {
-                    defaultFont = SystemFonts.DefaultFont;
+                    defaultFont = SystemFonts.MessageBoxFont;
                     Debug.Assert(defaultFont != null, "defaultFont wasn't set!");
                 }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -375,7 +375,7 @@ namespace System.Windows.Forms.Tests
             control.FontChanged += handler;
 
             // Set different.
-            Font font1 = SystemFonts.MenuFont;
+            Font font1 = new Font("Arial", 8.25f);
             control.Font = font1;
             Assert.Same(font1, control.Font);
             Assert.Equal(1, callCount);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowTests.cs
@@ -948,7 +948,7 @@ namespace System.Windows.Forms.Tests
                     ColumnCount = 1,
                     AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.AllCells
                 },
-                22, 0, 22
+                25, 0, 25
             };
             yield return new object[] { new DataGridView { ColumnCount = 1, VirtualMode = true }, 6, 1, 5 };
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxTests.cs
@@ -376,7 +376,7 @@ namespace System.Windows.Forms.Tests
             control.FontChanged += handler;
 
             // Set different.
-            Font font1 = SystemFonts.MenuFont;
+            Font font1 = new Font("Arial", 8.25f);
             control.Font = font1;
             Assert.Same(font1, control.Font);
             Assert.Equal(1, callCount);


### PR DESCRIPTION
This change ensures Segoe UI is used by default on Windows Vista and later, while still not breaking compatibility with Windows XP or systems compatible with it. Fixes #524.

Note that while I have not yet been able to test the code in System.Design.Editors as requested in https://github.com/dotnet/winforms/issues/524#issuecomment-469832174 due to #632 not yet being merged, I have tested with the WinformsControlTest project, and all of its forms/controls (including the ThreadExceptionDialog) are sized properly to avoid clipping text, with _no_ changes needed. While I do not think any changes will be needed to the designer code either, I am willing to hold on this PR until that can be tested. Thanks!