### PR TITLE
Fix buffer size passed to GetClipboardFormatName in DataFormats

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -716,20 +716,15 @@ namespace System.Windows.Forms {
             }
         }
 #endif
-        internal static string WindowsFormsVersion {
-            get {
-                // Notice   : Don't never ever change this name, since window class of Winforms control is dependent on this.
-                //            And lots of partner team are related to window class of Winforms control. Changing this will introduce breaking.
-                //            If there is some reason need to change this, should take the accountability to notify partner team.
-                return "WindowsForms10";
-            }
-        }
 
-        internal static string WindowMessagesVersion {
-            get {
-                return "WindowsForms12";
-            }
-        }
+        /// <remarks>
+        /// Don't never ever change this name, since the window class and partner teams
+        /// dependent on this. Changing this will introduce breaking changes.
+        /// If there is some reason need to change this, notify any partner teams affected.
+        /// </remarks>
+        internal static string WindowsFormsVersion => "WindowsForms10";
+
+        internal static string WindowMessagesVersion => "WindowsForms12";
 
         /// <include file='doc\Application.uex' path='docs/doc[@for="Application.VisualStyleState"]/*' />
         /// <devdoc>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataFormats.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataFormats.cs
@@ -2,307 +2,266 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
+using System.Text;
+using System.Runtime.InteropServices;
 
-namespace System.Windows.Forms {
-    using System.Text;
-    using System.Configuration.Assemblies;
-    using System.Diagnostics;
-    using System;
-    using System.ComponentModel;
-    using System.Runtime.InteropServices;
-    using System.Globalization;
-
-    /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats"]/*' />
+namespace System.Windows.Forms
+{
     /// <devdoc>
-    ///    <para>Translates
-    ///       between Win Forms text-based
-    ///    <see cref='System.Windows.Forms.Clipboard'/> formats and <see langword='Microsoft.Win32'/> 32-bit signed integer-based 
-    ///       clipboard formats. Provides <see langword='static '/> methods to create new <see cref='System.Windows.Forms.Clipboard'/> formats and add
-    ///       them to the Windows Registry.</para>
+    /// Translates between WinForms text-based <see cref='System.Windows.Forms.Clipboard'/>
+    /// formats and <see langword='Microsoft.Win32'/> 32-bit signed integer-based clipboard
+    /// formats. Provides <see langword='static '/> methods to create new
+    /// <see cref='System.Windows.Forms.Clipboard'/> formats and add them to the Windows Registry.
     /// </devdoc>
-    public class DataFormats {
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.Text"]/*' />
+    public static class DataFormats
+    {
         /// <devdoc>
-        /// <para>Specifies the standard ANSI text format. This <see langword='static '/> 
-        /// field is read-only.</para>
+        /// Specifies the standard ANSI text format. This <see langword='static '/>
+        /// field is read-only.
         /// </devdoc>
-        public static readonly string Text          = "Text";
+        public static readonly string Text = "Text";
 
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.UnicodeText"]/*' />
         /// <devdoc>
-        ///    <para>Specifies the standard Windows Unicode text format. This 
-        ///    <see langword='static '/>
-        ///    field is read-only.</para>
+        /// Specifies the standard Windows Unicode text format.
+        /// This <see langword='static '/> field is read-only.
         /// </devdoc>
-        public static readonly string UnicodeText   = "UnicodeText";
+        public static readonly string UnicodeText = "UnicodeText";
 
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.Dib"]/*' />
         /// <devdoc>
-        ///    <para>Specifies the Windows Device Independent Bitmap (DIB) 
-        ///       format. This <see langword='static '/>
-        ///       field is read-only.</para>
+        /// Specifies the Windows Device Independent Bitmap (DIB) format.
+        /// This <see langword='static '/> field is read-only.
         /// </devdoc>
-        public static readonly string Dib           = "DeviceIndependentBitmap";
+        public static readonly string Dib = "DeviceIndependentBitmap";
 
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.Bitmap"]/*' />
         /// <devdoc>
-        /// <para>Specifies a Windows bitmap format. This <see langword='static '/> field is read-only.</para>
-        /// </devdoc>
-        public static readonly string Bitmap        = "Bitmap";
+        /// Specifies a Windows bitmap format.
+        /// This <see langword='static '/> field is read-only. </devdoc>
+        public static readonly string Bitmap = "Bitmap";
 
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.EnhancedMetafile"]/*' />
         /// <devdoc>
-        ///    <para>Specifies the Windows enhanced metafile format. This 
-        ///    <see langword='static '/> field is read-only.</para>
+        /// Specifies the Windows enhanced metafile format.
+        /// This <see langword='static '/> field is read-only.
         /// </devdoc>
-        public static readonly string EnhancedMetafile   = "EnhancedMetafile";
+        public static readonly string EnhancedMetafile = "EnhancedMetafile";
 
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.MetafilePict"]/*' />
         /// <devdoc>
-        ///    <para>Specifies the Windows metafile format, which Win Forms 
-        ///       does not directly use. This <see langword='static '/>
-        ///       field is read-only.</para>
+        /// Specifies the Windows metafile format, which WinForms does not directly use.
+        /// This <see langword='static '/> field is read-only.
         /// </devdoc>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")] // Would be a breaking change to rename this
-        public static readonly string MetafilePict  = "MetaFilePict";
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", Justification = "Would be a breaking change to rename this")]
+        public static readonly string MetafilePict = "MetaFilePict";
 
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.SymbolicLink"]/*' />
         /// <devdoc>
-        ///    <para>Specifies the Windows symbolic link format, which Win 
-        ///       Forms does not directly use. This <see langword='static '/>
-        ///       field is read-only.</para>
+        /// Specifies the Windows symbolic link format, which WinForms does not directly use.
+        /// This <see langword='static '/> field is read-only.
         /// </devdoc>
-        public static readonly string SymbolicLink          = "SymbolicLink";
+        public static readonly string SymbolicLink = "SymbolicLink";
 
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.Dif"]/*' />
         /// <devdoc>
-        ///    <para>Specifies the Windows data interchange format, which Win 
-        ///       Forms does not directly use. This <see langword='static '/>
-        ///       field is read-only.</para>
+        /// Specifies the Windows data interchange format, which WinForms does not directly use.
+        /// This <see langword='static '/> field is read-only.
         /// </devdoc>
-        public static readonly string Dif           = "DataInterchangeFormat";
+        public static readonly string Dif = "DataInterchangeFormat";
 
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.Tiff"]/*' />
         /// <devdoc>
-        ///    <para>Specifies the Tagged Image File Format (TIFF), which Win 
-        ///       Forms does not directly use. This <see langword='static '/>
-        ///       field is read-only.</para>
+        /// Specifies the Tagged Image File Format (TIFF), which WinForms does not directly use.
+        /// This <see langword='static '/> field is read-only.
         /// </devdoc>
-        public static readonly string Tiff          = "TaggedImageFileFormat";
+        public static readonly string Tiff = "TaggedImageFileFormat";
 
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.OemText"]/*' />
         /// <devdoc>
-        ///    <para>Specifies the standard Windows original equipment 
-        ///       manufacturer (OEM) text format. This <see langword='static '/> field is read-only.</para>
+        /// Specifies the standard Windows original equipment manufacturer (OEM) text format.
+        /// This <see langword='static '/> field is read-only.
         /// </devdoc>
-        public static readonly string OemText       = "OEMText";
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.Palette"]/*' />
+        public static readonly string OemText = "OEMText";
+
         /// <devdoc>
-        /// <para>Specifies the Windows palette format. This <see langword='static '/> 
-        /// field is read-only.</para>
+        /// Specifies the Windows palette format.
+        /// This <see langword='static '/> field is read-only.
         /// </devdoc>
-        public static readonly string Palette       = "Palette";
+        public static readonly string Palette = "Palette";
 
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.PenData"]/*' />
         /// <devdoc>
-        ///    <para>Specifies the Windows pen data format, which consists of 
-        ///       pen strokes for handwriting software; Win Forms does not use this format. This
-        ///    <see langword='static '/> 
-        ///    field is read-only.</para>
+        /// Specifies the Windows pen data format, which consists of pen strokes for handwriting
+        /// software; Win Formsdoes not use this format.
+        /// This <see langword='static '/> field is read-only.
         /// </devdoc>
-        public static readonly string PenData       = "PenData";
+        public static readonly string PenData = "PenData";
 
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.Riff"]/*' />
         /// <devdoc>
-        ///    <para>Specifies the Resource Interchange File Format (RIFF) 
-        ///       audio format, which Win Forms does not directly use. This <see langword='static '/> field is read-only.</para>
+        /// Specifies the Resource Interchange File Format (RIFF) audio format, which WinForms
+        /// does not directly use.
+        /// This <see langword='static '/> field is read-only.
         /// </devdoc>
-        public static readonly string Riff          = "RiffAudio";
+        public static readonly string Riff = "RiffAudio";
 
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.WaveAudio"]/*' />
         /// <devdoc>
-        ///    <para>Specifies the wave audio format, which Win Forms does not 
-        ///       directly use. This <see langword='static '/> field is read-only.</para>
+        /// Specifies the wave audio format, which Win Forms does not
+        ///   directly use. This <see langword='static '/> field is read-only.
         /// </devdoc>
-        public static readonly string WaveAudio          = "WaveAudio";
+        public static readonly string WaveAudio = "WaveAudio";
 
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.FileDrop"]/*' />
         /// <devdoc>
-        ///    <para>Specifies the Windows file drop format, which Win Forms 
-        ///       does not directly use. This <see langword='static '/>
-        ///       field is read-only.</para>
+        /// Specifies the Windows file drop format, which WinForms does not directly use.
+        /// This <see langword='static '/> field is read-only.
         /// </devdoc>
-        public static readonly string FileDrop         = "FileDrop";
+        public static readonly string FileDrop = "FileDrop";
 
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.Locale"]/*' />
         /// <devdoc>
-        ///    <para>Specifies the Windows culture format, which Win Forms does 
-        ///       not directly use. This <see langword='static '/> field is read-only.</para>
+        /// Specifies the Windows culture format, which WinForms does not directly use.
+        /// This <see langword='static '/> field is read-only.
         /// </devdoc>
-        public static readonly string Locale        = "Locale";
+        public static readonly string Locale = "Locale";
 
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.Html"]/*' />
         /// <devdoc>
-        ///    <para>Specifies text consisting of HTML data. This 
-        ///    <see langword='static '/> field is read-only.</para>
+        /// Specifies text consisting of HTML data.
+        /// This <see langword='static '/> field is read-only.
         /// </devdoc>
-        public static readonly string Html          = "HTML Format";
+        public static readonly string Html = "HTML Format";
 
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.Rtf"]/*' />
         /// <devdoc>
-        ///    <para>Specifies text consisting of Rich Text Format (RTF) data. This 
-        ///    <see langword='static '/> field is read-only.</para>
+        /// Specifies text consisting of Rich Text Format (RTF) data.
+        /// This <see langword='static '/> field is read-only.
         /// </devdoc>
-        public static readonly string Rtf       = "Rich Text Format";
+        public static readonly string Rtf = "Rich Text Format";
 
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.CommaSeparatedValue"]/*' />
         /// <devdoc>
-        ///    <para>Specifies a comma-separated value (CSV) format, which is a 
-        ///       common interchange format used by spreadsheets. This format is not used directly
-        ///       by Win Forms. This <see langword='static '/>
-        ///       field is read-only.</para>
+        /// Specifies a comma-separated value (CSV) format, which is a common interchange format
+        /// used by spreadsheets. This format is not used directly by WinForms.
+        /// This <see langword='static '/> field is read-only.
         /// </devdoc>
-        public static readonly string CommaSeparatedValue           = "Csv";
+        public static readonly string CommaSeparatedValue = "Csv";
 
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.StringFormat"]/*' />
         /// <devdoc>
-        ///    <para>Specifies the Win Forms string class format, which Win 
-        ///       Forms uses to store string objects. This <see langword='static '/>
-        ///       field is read-only.</para>
+        /// Specifies the Win Forms string class format, which WinForms uses to store string
+        /// objects.
+        /// This <see langword='static '/> field is read-only.
         /// </devdoc>
-        public static readonly string StringFormat   = typeof(string).FullName;
+        public static readonly string StringFormat = typeof(string).FullName;
 
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.Serializable"]/*' />
         /// <devdoc>
-        ///    <para>Specifies a format that encapsulates any type of Win Forms 
-        ///       object. This <see langword='static '/> field is read-only.</para>
+        /// Specifies a format that encapsulates any type of WinForms object.
+        /// This <see langword='static '/> field is read-only.
         /// </devdoc>
-        public static readonly string Serializable     = Application.WindowsFormsVersion + "PersistentObject";
+        public static readonly string Serializable = Application.WindowsFormsVersion + "PersistentObject";
 
-        
-        private static Format[] formatList;
-        private static int formatCount = 0;
-        
-        private static object internalSyncObject = new object();
+        private static Format[] s_formatList;
+        private static int s_formatCount = 0;
 
-        // not creatable...
-        //
-        private DataFormats() {
-        }
+        private static object s_internalSyncObject = new object();
 
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.GetFormat"]/*' />
         /// <devdoc>
-        /// <para>Gets a <see cref='System.Windows.Forms.DataFormats.Format'/> with the Windows Clipboard numeric ID and name for the specified format.</para>
+        /// Gets a <see cref='System.Windows.Forms.DataFormats.Format'/> with the Windows
+        /// Clipboard numeric ID and name for the specified format.
         /// </devdoc>
-        public static Format GetFormat(string format) {
-            lock(internalSyncObject) {
+        public static Format GetFormat(string format)
+        {
+            lock (s_internalSyncObject)
+            {
                 EnsurePredefined();
 
-                // It is much faster to do a case sensitive search here.  So do 
-                // the case sensitive compare first, then the expensive one.
-                //
-                for (int n = 0; n < formatCount; n++) {
-                    if (formatList[n].Name.Equals(format))
-                        return formatList[n];
+                // It is much faster to do a case sensitive search here.
+                // So do the case sensitive compare first, then the expensive one.
+                for (int n = 0; n < s_formatCount; n++)
+                {
+                    if (s_formatList[n].Name.Equals(format))
+                    {
+                        return s_formatList[n];
+                    }
                 }
-                
-                for (int n = 0; n < formatCount; n++) {
-                    if (string.Equals(formatList[n].Name, format, StringComparison.OrdinalIgnoreCase))
-                        return formatList[n];
+
+                for (int n = 0; n < s_formatCount; n++)
+                {
+                    if (string.Equals(s_formatList[n].Name, format, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return s_formatList[n];
+                    }
                 }
-        
-                // need to add this format string
-                //
+
+                // Need to add this format string
                 int formatId = SafeNativeMethods.RegisterClipboardFormat(format);
-                if (0 == formatId) {
+                if (formatId == 0)
+                {
                     throw new Win32Exception(Marshal.GetLastWin32Error(), SR.RegisterCFFailed);
                 }
-        
 
                 EnsureFormatSpace(1);
-                formatList[formatCount] = new Format(format, formatId);
-                return formatList[formatCount++];
+                s_formatList[s_formatCount] = new Format(format, formatId);
+                return s_formatList[s_formatCount++];
             }
         }
 
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.GetFormat1"]/*' />
         /// <devdoc>
-        /// <para>Gets a <see cref='System.Windows.Forms.DataFormats.Format'/> with the Windows Clipboard numeric
-        ///    ID and name for the specified ID.</para>
+        /// Gets a <see cref='System.Windows.Forms.DataFormats.Format'/> with the Windows
+        /// Clipboard numeric ID and name for the specified ID.
         /// </devdoc>
-        public static Format GetFormat(int id) {
+        public static Format GetFormat(int id)
+        {
             // Win32 uses an unsigned 16 bit type as a format ID, thus stripping off the leading bits.
-            // Registered format IDs are in the range 0xC000 through 0xFFFF, thus it's important 
-            // to represent format as an unsigned type.  
-            return InternalGetFormat( null, (ushort)(id & 0xFFFF));
-        }
+            // Registered format IDs are in the range 0xC000 through 0xFFFF, thus it's important
+            // to represent format as an unsigned type.
+            ushort clampedId = (ushort)(id & 0xFFFF);
 
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.InternalGetFormat"]/*' />
-        /// <devdoc>
-        ///     Allows a the new format name to be specified if the requested format is not
-        ///     in the list
-        /// </devdoc>
-        /// <internalonly/>
-        private static Format InternalGetFormat(string strName, ushort id) {
-            lock(internalSyncObject) {
+            lock (s_internalSyncObject)
+            {
                 EnsurePredefined();
 
-                for (int n = 0; n < formatCount; n++) {
-                    if (formatList[n].Id == id)
-                        return formatList[n];
+                for (int n = 0; n < s_formatCount; n++)
+                {
+                    if (s_formatList[n].Id == clampedId)
+                    {
+                        return s_formatList[n];
+                    }
                 }
 
-                StringBuilder s = new StringBuilder(128);
+                var nameBuilder = new StringBuilder(128);
 
                 // This can happen if windows adds a standard format that we don't know about,
                 // so we should play it safe.
-                //
-                if (0 == SafeNativeMethods.GetClipboardFormatName(id, s, s.Capacity)) {
-                    s.Length = 0;
-                    if (strName == null) {
-                        s.Append( "Format" ).Append( id );
-                    }
-                    else {
-                        s.Append( strName );
-                    }
+                if (SafeNativeMethods.GetClipboardFormatName(clampedId, nameBuilder, nameBuilder.Capacity) == 0)
+                {
+                    nameBuilder.Length = 0;
+                    nameBuilder.Append("Format").Append(clampedId);
                 }
 
                 EnsureFormatSpace(1);
-                formatList[formatCount] = new Format(s.ToString(), id);
+                s_formatList[s_formatCount] = new Format(nameBuilder.ToString(), clampedId);
 
-                return formatList[formatCount++];
+                return s_formatList[s_formatCount++];
             }
         }
 
-
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.EnsureFormatSpace"]/*' />
         /// <devdoc>
-        ///     ensures that we have enough room in our format list
+        /// Ensures that we have enough room in our format list
         /// </devdoc>
-        /// <internalonly/>
-        private static void EnsureFormatSpace(int size) {
-            if (null == formatList || formatList.Length <= formatCount + size) {
-                int newSize = formatCount + 20;
+        private static void EnsureFormatSpace(int size)
+        {
+            if (s_formatList == null || s_formatList.Length <= s_formatCount + size)
+            {
+                int newSize = s_formatCount + 20;
 
                 Format[] newList = new Format[newSize];
-
-                for (int n = 0; n < formatCount; n++) {
-                    newList[n] = formatList[n];
+                for (int n = 0; n < s_formatCount; n++)
+                {
+                    newList[n] = s_formatList[n];
                 }
-                formatList = newList;
-            }                   
+
+                s_formatList = newList;
+            }
         }
 
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.EnsurePredefined"]/*' />
         /// <devdoc>
-        ///     ensures that the Win32 predefined formats are setup in our format list.  This
-        ///     is called anytime we need to search the list
+        /// Ensures that the Win32 predefined formats are setup in our format list.
+        /// This is called anytime we need to search the list
         /// </devdoc>
         /// <internalonly/>
-        private static void EnsurePredefined() {
-
-            if (0 == formatCount) {
-                formatList = new Format [] {
+        private static void EnsurePredefined()
+        {
+            if (s_formatCount == 0)
+            {
+                s_formatList = new Format[]
+                {
                     //         Text name        Win32 format ID      Data stored as a Win32 handle?
                     new Format(UnicodeText,  NativeMethods.CF_UNICODETEXT),
                     new Format(Text,         NativeMethods.CF_TEXT),
@@ -322,55 +281,34 @@ namespace System.Windows.Forms {
                     new Format(Locale,       NativeMethods.CF_LOCALE)
                 };
 
-                formatCount = formatList.Length;
+                s_formatCount = s_formatList.Length;
             }
         }
 
-        /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.Format"]/*' />
         /// <devdoc>
-        ///    <para>Represents a format type.</para>
+        /// Represents a format type.
         /// </devdoc>
-        public class Format {
-            readonly string name;
-            readonly int id;
+        public class Format
+        {
+            /// <devdoc>
+            /// Initializes a new instance of the <see cref='System.Windows.Forms.DataFormats.Format'/>
+            /// class and specifies whether a <see langword='Win32 '/> handle is expected with this format.
+            /// </devdoc>
+            public Format(string name, int id)
+            {
+                Name = name;
+                Id = id;
+            }
             
-            /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.Format.Name"]/*' />
             /// <devdoc>
-            ///    <para>
-            ///       Specifies the
-            ///       name of this format. This field is read-only.
-            ///       
-            ///    </para>
+            /// Specifies the name of this format.
             /// </devdoc>
-            public string Name {
-                get {
-                    return name;
-                }
-            }
+            public string Name { get; }
 
-            /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.Format.Id"]/*' />
             /// <devdoc>
-            ///    <para>
-            ///       Specifies the ID
-            ///       number for this format. This field is read-only.
-            ///    </para>
+            /// Specifies the ID number for this format.
             /// </devdoc>
-            public int Id {
-                get {
-                    return id;
-                }
-            }
-
-            /// <include file='doc\DataFormats.uex' path='docs/doc[@for="DataFormats.Format.Format"]/*' />
-            /// <devdoc>
-            /// <para>Initializes a new instance of the <see cref='System.Windows.Forms.DataFormats.Format'/> class and specifies whether a
-            /// <see langword='Win32 '/> 
-            /// handle is expected with this format.</para>
-            /// </devdoc>
-            public Format(string name, int id) {
-                this.name = name;
-                this.id = id;
-            }
+            public int Id { get; }
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataFormats.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataFormats.cs
@@ -215,7 +215,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                var nameBuilder = new StringBuilder(128);
+                var nameBuilder = new StringBuilder(256);
 
                 // This can happen if windows adds a standard format that we don't know about,
                 // so we should play it safe.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataFormats.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataFormats.cs
@@ -215,6 +215,9 @@ namespace System.Windows.Forms
                     }
                 }
 
+                // The max length of the name of clipboard formats is equal to the max length
+                // of a Win32 Atom of 255 chars. An additional null terminator character is added,
+                // giving a required capacity of 256 chars.
                 var nameBuilder = new StringBuilder(256);
 
                 // This can happen if windows adds a standard format that we don't know about,

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataFormatsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataFormatsTests.cs
@@ -69,10 +69,12 @@ namespace System.Windows.Forms.Tests
         public void DataFormats_GetFormat_InvokeKnownString_ReturnsExpected(string format, string expectedName, int expectedId)
         {
             DataFormats.Format result = DataFormats.GetFormat(format);
-            Assert.Same(result, DataFormats.GetFormat(format));
             Assert.Same(result, DataFormats.GetFormat(format.ToLower()));
             Assert.Equal(expectedName, result.Name);
             Assert.Equal(expectedId, result.Id);
+
+            // Call again to test caching behavior.
+            Assert.Same(result, DataFormats.GetFormat(format));
         }
 
         public static IEnumerable<object[]> GetFormat_UnknownString_TestData()
@@ -93,6 +95,10 @@ namespace System.Windows.Forms.Tests
             Assert.Same(result, DataFormats.GetFormat(format));
             Assert.Same(result, DataFormats.GetFormat(format.ToLower()));
             Assert.Equal(expectedName, result.Name);
+
+            // Internally the format is registered with RegisterClipboardFormat.
+            // According to the documentation: "Registered clipboard formats are
+            // identified by values in the range 0xC000 through 0xFFFF."
             Assert.True(result.Id >= 0xC000);
             Assert.True(result.Id < 0xFFFF);
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataFormatsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataFormatsTests.cs
@@ -1,0 +1,181 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using WinForms.Common.Tests;
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    public class DataFormatsTests
+    {
+        public static IEnumerable<object[]> KnownFormats_TestData()
+        {
+            yield return new object[] { DataFormats.Bitmap, "Bitmap" };
+            yield return new object[] { DataFormats.CommaSeparatedValue, "Csv" };
+            yield return new object[] { DataFormats.Dib, "DeviceIndependentBitmap" };
+            yield return new object[] { DataFormats.Dif, "DataInterchangeFormat" };
+            yield return new object[] { DataFormats.EnhancedMetafile, "EnhancedMetafile" };
+            yield return new object[] { DataFormats.FileDrop, "FileDrop" };
+            yield return new object[] { DataFormats.Html, "HTML Format" };
+            yield return new object[] { DataFormats.Locale, "Locale" };
+            yield return new object[] { DataFormats.MetafilePict, "MetaFilePict" };
+            yield return new object[] { DataFormats.OemText, "OEMText" };
+            yield return new object[] { DataFormats.Palette, "Palette" };
+            yield return new object[] { DataFormats.PenData, "PenData" };
+            yield return new object[] { DataFormats.Riff, "RiffAudio" };
+            yield return new object[] { DataFormats.Rtf, "Rich Text Format" };
+            yield return new object[] { DataFormats.Serializable, "WindowsForms10PersistentObject" };
+            yield return new object[] { DataFormats.StringFormat, "System.String" };
+            yield return new object[] { DataFormats.SymbolicLink, "SymbolicLink" };
+            yield return new object[] { DataFormats.Text, "Text" };
+            yield return new object[] { DataFormats.Tiff, "TaggedImageFileFormat" };
+            yield return new object[] { DataFormats.UnicodeText, "UnicodeText" };
+            yield return new object[] { DataFormats.WaveAudio, "WaveAudio" };
+        }
+
+        [Theory]
+        [MemberData(nameof(KnownFormats_TestData))]
+        public void DataFormats_KnownFormat_Get_ReturnsExpected(string value, string expected)
+        {
+            Assert.Equal(expected, value);
+        }
+
+        public static IEnumerable<object[]> GetFormat_KnownString_TestData()
+        {
+            yield return new object[] { DataFormats.Bitmap, "Bitmap", 2 };
+            yield return new object[] { DataFormats.Dib, "DeviceIndependentBitmap", 8 };
+            yield return new object[] { DataFormats.Dif, "DataInterchangeFormat", 5 };
+            yield return new object[] { DataFormats.EnhancedMetafile, "EnhancedMetafile", 14 };
+            yield return new object[] { DataFormats.FileDrop, "FileDrop", 15 };
+            yield return new object[] { DataFormats.Locale, "Locale", 16 };
+            yield return new object[] { DataFormats.MetafilePict, "MetaFilePict", 3 };
+            yield return new object[] { DataFormats.OemText, "OEMText", 7 };
+            yield return new object[] { DataFormats.Palette, "Palette", 9 };
+            yield return new object[] { DataFormats.PenData, "PenData", 10 };
+            yield return new object[] { DataFormats.Riff, "RiffAudio", 11 };
+            yield return new object[] { DataFormats.SymbolicLink, "SymbolicLink", 4 };
+            yield return new object[] { DataFormats.Text, "Text", 1 };
+            yield return new object[] { DataFormats.Tiff, "TaggedImageFileFormat", 6 };
+            yield return new object[] { DataFormats.UnicodeText, "UnicodeText", 13 };
+            yield return new object[] { DataFormats.WaveAudio, "WaveAudio", 12 };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetFormat_KnownString_TestData))]
+        public void DataFormats_GetFormat_InvokeKnownString_ReturnsExpected(string format, string expectedName, int expectedId)
+        {
+            DataFormats.Format result = DataFormats.GetFormat(format);
+            Assert.Same(result, DataFormats.GetFormat(format));
+            Assert.Same(result, DataFormats.GetFormat(format.ToLower()));
+            Assert.Equal(expectedName, result.Name);
+            Assert.Equal(expectedId, result.Id);
+        }
+
+        public static IEnumerable<object[]> GetFormat_UnknownString_TestData()
+        {
+            yield return new object[] { DataFormats.CommaSeparatedValue, "Csv" };
+            yield return new object[] { DataFormats.Html, "HTML Format" };
+            yield return new object[] { DataFormats.Rtf, "Rich Text Format" };
+            yield return new object[] { DataFormats.Serializable, "WindowsForms10PersistentObject" };
+            yield return new object[] { DataFormats.StringFormat, "System.String" };
+            yield return new object[] { "Custom", "Custom" };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetFormat_UnknownString_TestData))]
+        public void DataFormats_GetFormat_InvokeUnknownFormatString_ReturnsExpected(string format, string expectedName)
+        {
+            DataFormats.Format result = DataFormats.GetFormat(format);
+            Assert.Same(result, DataFormats.GetFormat(format));
+            Assert.Same(result, DataFormats.GetFormat(format.ToLower()));
+            Assert.Equal(expectedName, result.Name);
+            Assert.True(result.Id >= 0xC000);
+            Assert.True(result.Id < 0xFFFF);
+
+            // Should register the format.
+            Assert.Same(result, DataFormats.GetFormat(result.Id));
+        }
+
+        public static IEnumerable<object[]> GetFormat_InvalidString_TestData()
+        {
+            yield return new object[] { null };
+            yield return new object[] { string.Empty };
+            yield return new object[] { new string('a', 256) };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetFormat_InvalidString_TestData))]
+        public void DataFormats_GetFormat_NullOrEmptyString_ThrowsWin32Exception(string format)
+        {
+            Assert.Throws<Win32Exception>(() => DataFormats.GetFormat(format));
+        }
+
+        [DllImport("user32.dll")]
+        private static extern int RegisterClipboardFormat(string format);
+
+        public static IEnumerable<object[]> GetFormat_Int_TestData()
+        {
+            yield return new object[] { 2, "Bitmap" };
+            yield return new object[] { 8, "DeviceIndependentBitmap" };
+            yield return new object[] { 5, "DataInterchangeFormat" };
+            yield return new object[] { 14, "EnhancedMetafile" };
+            yield return new object[] { 15, "FileDrop" };
+            yield return new object[] { 16, "Locale" };
+            yield return new object[] { 3, "MetaFilePict" };
+            yield return new object[] { 7, "OEMText" };
+            yield return new object[] { 9, "Palette" };
+            yield return new object[] { 10, "PenData" };
+            yield return new object[] { 11, "RiffAudio" };
+            yield return new object[] { 4, "SymbolicLink" };
+            yield return new object[] { 1, "Text" };
+            yield return new object[] { 6, "TaggedImageFileFormat" };
+            yield return new object[] { 13, "UnicodeText" };
+            yield return new object[] { 12, "WaveAudio" };
+            yield return new object[] { 12 & 0xFFFFFFFF, "WaveAudio" };
+
+            yield return new object[] { -1, "Format65535" };
+            yield return new object[] { 1234, "Format1234" };
+
+            int? manuallyRegisteredFormatId = null;
+            int? longManuallyRegisteredFormatId = null;
+            try
+            {
+                manuallyRegisteredFormatId = RegisterClipboardFormat("ManuallyRegisteredFormat");
+                longManuallyRegisteredFormatId = RegisterClipboardFormat(new string('a', 255));
+            }
+            catch
+            {
+            }
+
+            if (manuallyRegisteredFormatId.HasValue)
+            {
+                yield return new object[] { manuallyRegisteredFormatId, "ManuallyRegisteredFormat" };
+                yield return new object[] { longManuallyRegisteredFormatId, new string('a', 255) };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetFormat_Int_TestData))]
+        public void DataFormats_GetFormat_InvokeId_ReturnsExpected(int id, string expectedName)
+        {
+            DataFormats.Format result = DataFormats.GetFormat(id);
+            Assert.Same(result, DataFormats.GetFormat(id));
+            Assert.Equal(expectedName, result.Name);
+            Assert.Equal(id & 0xFFFF, result.Id);
+        }
+
+        [Theory]
+        [InlineData(null, -1)]
+        [InlineData("", 0)]
+        [InlineData("name", int.MaxValue)]
+        public void DataFormats_Format_Ctor_String_Int(string name, int id)
+        {
+            var format = new DataFormats.Format(name, id);
+            Assert.Same(name, format.Name);
+        }
+    }
+}


### PR DESCRIPTION
Previously, the maximum buffer size for `GetClipboardFormatName` was 128, but now it is 256. This means that we'd chop off up to half of the string when retrieving strings longer than 128. Fix this by updating the buffer size

Also cleanup the code and add complete test coverage

Fixes #696