### PR TITLE
Accessibility: fixing DataGridView BoundingRectangle property for row, data cells and header cells

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -1613,7 +1613,7 @@
     <value>Editing Panel</value>
   </data>
   <data name="DataGridView_AccHorizontalScrollBarAccName" xml:space="preserve">
-    <value>Horizontal Scroll Bar</value>
+    <value>Horizontal</value>
   </data>
   <data name="DataGridView_AccLinkCellDefaultAction" xml:space="preserve">
     <value>Click</value>
@@ -1646,7 +1646,7 @@
     <value>Top Row</value>
   </data>
   <data name="DataGridView_AccVerticalScrollBarAccName" xml:space="preserve">
-    <value>Vertical Scroll Bar</value>
+    <value>Vertical</value>
   </data>
   <data name="DataGridView_AColumnHasNoCellTemplate" xml:space="preserve">
     <value>At least one of the DataGridView control's columns has no cell template.</value>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -3133,8 +3133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccHorizontalScrollBarAccName">
-        <source>Horizontal Scroll Bar</source>
-        <target state="translated">Vodorovný posuvník</target>
+        <source>Horizontal</source>
+        <target state="needs-review-translation">Vodorovný posuvník</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccLinkCellDefaultAction">
@@ -3188,8 +3188,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccVerticalScrollBarAccName">
-        <source>Vertical Scroll Bar</source>
-        <target state="translated">Svislý posuvník</target>
+        <source>Vertical</source>
+        <target state="needs-review-translation">Svislý posuvník</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AdvancedCellBorderStyleInvalid">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -3133,8 +3133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccHorizontalScrollBarAccName">
-        <source>Horizontal Scroll Bar</source>
-        <target state="translated">Horizontale Bildlaufeiste</target>
+        <source>Horizontal</source>
+        <target state="needs-review-translation">Horizontale Bildlaufeiste</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccLinkCellDefaultAction">
@@ -3188,8 +3188,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccVerticalScrollBarAccName">
-        <source>Vertical Scroll Bar</source>
-        <target state="translated">Vertikale Bildlaufleiste</target>
+        <source>Vertical</source>
+        <target state="needs-review-translation">Vertikale Bildlaufleiste</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AdvancedCellBorderStyleInvalid">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -3133,8 +3133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccHorizontalScrollBarAccName">
-        <source>Horizontal Scroll Bar</source>
-        <target state="translated">Barra de desplazamiento horizontal</target>
+        <source>Horizontal</source>
+        <target state="needs-review-translation">Barra de desplazamiento horizontal</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccLinkCellDefaultAction">
@@ -3188,8 +3188,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccVerticalScrollBarAccName">
-        <source>Vertical Scroll Bar</source>
-        <target state="translated">Barra de desplazamiento vertical</target>
+        <source>Vertical</source>
+        <target state="needs-review-translation">Barra de desplazamiento vertical</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AdvancedCellBorderStyleInvalid">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -3133,8 +3133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccHorizontalScrollBarAccName">
-        <source>Horizontal Scroll Bar</source>
-        <target state="translated">Barre de défilement horizontale</target>
+        <source>Horizontal</source>
+        <target state="needs-review-translation">Barre de défilement horizontale</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccLinkCellDefaultAction">
@@ -3188,8 +3188,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccVerticalScrollBarAccName">
-        <source>Vertical Scroll Bar</source>
-        <target state="translated">Barre de défilement verticale</target>
+        <source>Vertical</source>
+        <target state="needs-review-translation">Barre de défilement verticale</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AdvancedCellBorderStyleInvalid">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -3133,8 +3133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccHorizontalScrollBarAccName">
-        <source>Horizontal Scroll Bar</source>
-        <target state="translated">Barra di scorrimento orizzontale</target>
+        <source>Horizontal</source>
+        <target state="needs-review-translation">Barra di scorrimento orizzontale</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccLinkCellDefaultAction">
@@ -3188,8 +3188,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccVerticalScrollBarAccName">
-        <source>Vertical Scroll Bar</source>
-        <target state="translated">Barra di scorrimento verticale</target>
+        <source>Vertical</source>
+        <target state="needs-review-translation">Barra di scorrimento verticale</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AdvancedCellBorderStyleInvalid">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -3133,8 +3133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccHorizontalScrollBarAccName">
-        <source>Horizontal Scroll Bar</source>
-        <target state="translated">水平スクロール バー</target>
+        <source>Horizontal</source>
+        <target state="needs-review-translation">水平スクロール バー</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccLinkCellDefaultAction">
@@ -3188,8 +3188,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccVerticalScrollBarAccName">
-        <source>Vertical Scroll Bar</source>
-        <target state="translated">垂直スクロール バー</target>
+        <source>Vertical</source>
+        <target state="needs-review-translation">垂直スクロール バー</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AdvancedCellBorderStyleInvalid">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -3133,8 +3133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccHorizontalScrollBarAccName">
-        <source>Horizontal Scroll Bar</source>
-        <target state="translated">가로 스크롤 막대</target>
+        <source>Horizontal</source>
+        <target state="needs-review-translation">가로 스크롤 막대</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccLinkCellDefaultAction">
@@ -3188,8 +3188,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccVerticalScrollBarAccName">
-        <source>Vertical Scroll Bar</source>
-        <target state="translated">세로 스크롤 막대</target>
+        <source>Vertical</source>
+        <target state="needs-review-translation">세로 스크롤 막대</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AdvancedCellBorderStyleInvalid">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -3133,8 +3133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccHorizontalScrollBarAccName">
-        <source>Horizontal Scroll Bar</source>
-        <target state="translated">Poziomy pasek przewijania</target>
+        <source>Horizontal</source>
+        <target state="needs-review-translation">Poziomy pasek przewijania</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccLinkCellDefaultAction">
@@ -3188,8 +3188,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccVerticalScrollBarAccName">
-        <source>Vertical Scroll Bar</source>
-        <target state="translated">Pionowy pasek przewijania</target>
+        <source>Vertical</source>
+        <target state="needs-review-translation">Pionowy pasek przewijania</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AdvancedCellBorderStyleInvalid">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -3133,8 +3133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccHorizontalScrollBarAccName">
-        <source>Horizontal Scroll Bar</source>
-        <target state="translated">Barra de rolagem horizontal</target>
+        <source>Horizontal</source>
+        <target state="needs-review-translation">Barra de rolagem horizontal</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccLinkCellDefaultAction">
@@ -3188,8 +3188,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccVerticalScrollBarAccName">
-        <source>Vertical Scroll Bar</source>
-        <target state="translated">Barra de Rolagem Vertical</target>
+        <source>Vertical</source>
+        <target state="needs-review-translation">Barra de Rolagem Vertical</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AdvancedCellBorderStyleInvalid">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -3133,8 +3133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccHorizontalScrollBarAccName">
-        <source>Horizontal Scroll Bar</source>
-        <target state="translated">Горизонтальная полоса прокрутки</target>
+        <source>Horizontal</source>
+        <target state="needs-review-translation">Горизонтальная полоса прокрутки</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccLinkCellDefaultAction">
@@ -3188,8 +3188,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccVerticalScrollBarAccName">
-        <source>Vertical Scroll Bar</source>
-        <target state="translated">Вертикальная полоса прокрутки</target>
+        <source>Vertical</source>
+        <target state="needs-review-translation">Вертикальная полоса прокрутки</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AdvancedCellBorderStyleInvalid">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -3133,8 +3133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccHorizontalScrollBarAccName">
-        <source>Horizontal Scroll Bar</source>
-        <target state="translated">Yatay Kaydırma Çubuğu</target>
+        <source>Horizontal</source>
+        <target state="needs-review-translation">Yatay Kaydırma Çubuğu</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccLinkCellDefaultAction">
@@ -3188,8 +3188,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccVerticalScrollBarAccName">
-        <source>Vertical Scroll Bar</source>
-        <target state="translated">Dikey Kaydırma Çubuğu</target>
+        <source>Vertical</source>
+        <target state="needs-review-translation">Dikey Kaydırma Çubuğu</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AdvancedCellBorderStyleInvalid">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -3133,8 +3133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccHorizontalScrollBarAccName">
-        <source>Horizontal Scroll Bar</source>
-        <target state="translated">水平滚动条</target>
+        <source>Horizontal</source>
+        <target state="needs-review-translation">水平滚动条</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccLinkCellDefaultAction">
@@ -3188,8 +3188,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccVerticalScrollBarAccName">
-        <source>Vertical Scroll Bar</source>
-        <target state="translated">垂直滚动条</target>
+        <source>Vertical</source>
+        <target state="needs-review-translation">垂直滚动条</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AdvancedCellBorderStyleInvalid">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -3133,8 +3133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccHorizontalScrollBarAccName">
-        <source>Horizontal Scroll Bar</source>
-        <target state="translated">水平捲軸</target>
+        <source>Horizontal</source>
+        <target state="needs-review-translation">水平捲軸</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccLinkCellDefaultAction">
@@ -3188,8 +3188,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AccVerticalScrollBarAccName">
-        <source>Vertical Scroll Bar</source>
-        <target state="translated">垂直捲軸</target>
+        <source>Vertical</source>
+        <target state="needs-review-translation">垂直捲軸</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridView_AdvancedCellBorderStyleInvalid">

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -1444,7 +1444,7 @@ namespace System.Windows.Forms
             }
         }
 
-        private int BorderWidth 
+        internal int BorderWidth 
         {
             get 
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -3476,6 +3476,22 @@ namespace System.Windows.Forms
             }
         }
 
+        internal int HorizontalScrollBarHeight
+        {
+            get
+            {
+                return this.horizScrollBar.Height;
+            }
+        }
+
+        internal bool HorizontalScrollBarVisible
+        {
+            get
+            {
+                return this.horizScrollBar.Visible;
+            }
+        }
+
         /// <include file='doc\DataGridView.uex' path='docs/doc[@for="DataGridView.HorizontalScrollingOffset"]/*' />
         [
             Browsable(false),

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -5142,29 +5142,32 @@ namespace System.Windows.Forms
                 var cellRight = columnRect.Left + columnRect.Width;
                 var cellLeft = columnRect.Left;
 
-                int rowHeadersWidth = 0;
+                int rightToLeftRowHeadersWidth = 0;
+                int leftToRightRowHeadersWidth = 0;
                 if (this.owner.DataGridView.RowHeadersVisible)
                 {
-                    rowHeadersWidth = this.owner.DataGridView.RowHeadersWidth;
+                    if (this.owner.DataGridView.RightToLeft == RightToLeft.Yes)
+                    {
+                        rightToLeftRowHeadersWidth = this.owner.DataGridView.RowHeadersWidth;
+                    }
+                    else
+                    {
+                        leftToRightRowHeadersWidth = this.owner.DataGridView.RowHeadersWidth;
+                    }
                 }
 
-                if (cellLeft < rowRect.Left + rowHeadersWidth)
+                if (cellLeft < rowRect.Left + leftToRightRowHeadersWidth)
                 {
-                    cellRect.X = rowRect.Left + rowHeadersWidth;
+                    cellLeft = rowRect.Left + leftToRightRowHeadersWidth;
                 }
-                else
-                {
-                    cellRect.X = cellLeft;
-                }
+                cellRect.X = cellLeft;
 
-                if (cellRight > rowRect.Right)
+
+                if (cellRight > rowRect.Right - rightToLeftRowHeadersWidth)
                 {
-                    cellRect.Width = rowRect.Right - cellRect.X;
+                    cellRight = rowRect.Right - rightToLeftRowHeadersWidth;
                 }
-                else
-                {
-                    cellRect.Width = cellRight - cellRect.X;
-                }
+                cellRect.Width = cellRight - cellLeft;
 
                 return cellRect;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -76,8 +76,10 @@ namespace System.Windows.Forms
         /// </devdoc>
         protected DataGridViewCell() : base()
         {
-            if (!isScalingInitialized) {
-                if (DpiHelper.IsScalingRequired) {
+            if (!isScalingInitialized)
+            {
+                if (DpiHelper.IsScalingRequired)
+                {
                     iconsWidth = (byte)DpiHelper.LogicalToDeviceUnitsX(DATAGRIDVIEWCELL_iconsWidth);
                     iconsHeight = (byte)DpiHelper.LogicalToDeviceUnitsY(DATAGRIDVIEWCELL_iconsHeight);
                 }
@@ -89,7 +91,7 @@ namespace System.Windows.Forms
         }
 
         /// <include file='doc\DataGridViewCell.uex' path='docs/doc[@for="DataGridViewCell.Finalize"]/*' />
-        ~DataGridViewCell() 
+        ~DataGridViewCell()
         {
             Dispose(false);
         }
@@ -102,7 +104,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                AccessibleObject result = (AccessibleObject) this.Properties.GetObject(PropCellAccessibilityObject);
+                AccessibleObject result = (AccessibleObject)this.Properties.GetObject(PropCellAccessibilityObject);
                 if (result == null)
                 {
                     result = this.CreateAccessibilityInstance();
@@ -190,7 +192,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                return (byte) (this.flags & (DATAGRIDVIEWCELL_flagDataArea | DATAGRIDVIEWCELL_flagErrorArea));
+                return (byte)(this.flags & (DATAGRIDVIEWCELL_flagDataArea | DATAGRIDVIEWCELL_flagErrorArea));
             }
             set
             {
@@ -482,7 +484,7 @@ namespace System.Windows.Forms
         [
             Browsable(false)
         ]
-        public bool IsInEditMode 
+        public bool IsInEditMode
         {
             get
             {
@@ -563,7 +565,7 @@ namespace System.Windows.Forms
                 return this.propertyStore;
             }
         }
-        
+
         /// <include file='doc\DataGridViewCell.uex' path='docs/doc[@for="DataGridViewCell.ReadOnly"]/*' />
         [
             Browsable(false),
@@ -641,7 +643,7 @@ namespace System.Windows.Forms
                 }
             }
         }
-        
+
         /// <include file='doc\DataGridViewCell.uex' path='docs/doc[@for="DataGridViewCell.Resizable"]/*' />
         [
             Browsable(false)
@@ -685,7 +687,7 @@ namespace System.Windows.Forms
                 return this.owningRow.Index;
             }
         }
-        
+
         /// <include file='doc\DataGridViewCell.uex' path='docs/doc[@for="DataGridViewCell.Selected"]/*' />
         [
             Browsable(false),
@@ -820,8 +822,8 @@ namespace System.Windows.Forms
                     }
                     this.Properties.SetObject(PropCellStyle, value);
                 }
-                if (((dgvcs != null && value == null) || 
-                    (dgvcs == null && value != null) || 
+                if (((dgvcs != null && value == null) ||
+                    (dgvcs == null && value != null) ||
                     (dgvcs != null && value != null && !dgvcs.Equals(this.Style))) && this.DataGridView != null)
                 {
                     this.DataGridView.OnCellStyleChanged(this);
@@ -832,10 +834,10 @@ namespace System.Windows.Forms
         /// <include file='doc\DataGridViewCell.uex' path='docs/doc[@for="DataGridViewCell.Tag"]/*' />
         [
             SRCategory(nameof(SR.CatData)),
-            Localizable(false), 
-            Bindable(true), 
-            SRDescription(nameof(SR.ControlTagDescr)), 
-            DefaultValue(null), 
+            Localizable(false),
+            Bindable(true),
+            SRDescription(nameof(SR.ControlTagDescr)),
+            DefaultValue(null),
             TypeConverter(typeof(StringConverter))
         ]
         public object Tag
@@ -852,7 +854,7 @@ namespace System.Windows.Forms
                 }
             }
         }
-        
+
         /// <include file='doc\DataGridViewCell.uex' path='docs/doc[@for="DataGridViewCell.ToolTipText"]/*' />
         [
             Browsable(false),
@@ -917,7 +919,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                Type cellValueType = (Type) this.Properties.GetObject(PropCellValueType);
+                Type cellValueType = (Type)this.Properties.GetObject(PropCellValueType);
                 if (cellValueType == null && this.OwningColumn != null)
                 {
                     cellValueType = this.OwningColumn.ValueType;
@@ -1104,7 +1106,7 @@ namespace System.Windows.Forms
             Debug.Assert(this.RowIndex >= 0);
             return CellStateFromColumnRowStates(this.owningRow.State);
         }*/
-        
+
         internal DataGridViewElementStates CellStateFromColumnRowStates(DataGridViewElementStates rowState)
         {
             Debug.Assert(this.DataGridView != null);
@@ -1160,7 +1162,7 @@ namespace System.Windows.Forms
         /// <include file='doc\DataGridViewCell.uex' path='docs/doc[@for="DataGridViewCell.Clone"]/*' />
         public virtual object Clone()
         {
-            DataGridViewCell dataGridViewCell = (DataGridViewCell) System.Activator.CreateInstance(this.GetType());
+            DataGridViewCell dataGridViewCell = (DataGridViewCell)System.Activator.CreateInstance(this.GetType());
             CloneInternal(dataGridViewCell);
             return dataGridViewCell;
         }
@@ -1203,9 +1205,9 @@ namespace System.Windows.Forms
                 Debug.Assert(this is DataGridViewColumnHeaderCell, "if the row index == -1 and we have an owning column this should be a column header cell");
                 DataGridViewColumn dataGridViewColumn = this.DataGridView.Columns.GetLastColumn(DataGridViewElementStates.Visible, DataGridViewElementStates.None);
                 bool isLastVisibleColumn = (dataGridViewColumn != null && dataGridViewColumn.Index == this.ColumnIndex);
-                dgvabsEffective = this.DataGridView.AdjustColumnHeaderBorderStyle(this.DataGridView.AdvancedColumnHeadersBorderStyle, 
+                dgvabsEffective = this.DataGridView.AdjustColumnHeaderBorderStyle(this.DataGridView.AdvancedColumnHeadersBorderStyle,
                     dataGridViewAdvancedBorderStylePlaceholder,
-                    this.ColumnIndex == this.DataGridView.FirstDisplayedColumnIndex, 
+                    this.ColumnIndex == this.DataGridView.FirstDisplayedColumnIndex,
                     isLastVisibleColumn);
                 cellState = this.OwningColumn.State | this.State;
             }
@@ -1231,7 +1233,7 @@ namespace System.Windows.Forms
                 cellState = this.State;
             }
 
-            cellBounds = new Rectangle(new Point(0, 0), GetSize(rowIndex)); 
+            cellBounds = new Rectangle(new Point(0, 0), GetSize(rowIndex));
         }
 
         internal Rectangle ComputeErrorIconBounds(Rectangle cellValueBounds)
@@ -1360,7 +1362,7 @@ namespace System.Windows.Forms
             // so that the tooltip appears again on mousemove after the editing.
             this.CurrentMouseLocation = DATAGRIDVIEWCELL_flagAreaNotSet;
         }
-        
+
         /// <include file='doc\DataGridViewCell.uex' path='docs/doc[@for="DataGridViewCell.Dispose"]/*' />
         public void Dispose()
         {
@@ -1371,7 +1373,7 @@ namespace System.Windows.Forms
         /// <include file='doc\DataGridViewCell.uex' path='docs/doc[@for="DataGridViewCell.Dispose2"]/*' />
         protected virtual void Dispose(bool disposing)
         {
-            if (disposing) 
+            if (disposing)
             {
                 ContextMenuStrip contextMenuStrip = (ContextMenuStrip)this.ContextMenuStripInternal;
                 if (contextMenuStrip != null)
@@ -1508,7 +1510,7 @@ namespace System.Windows.Forms
                         break;
                     // 
                     default:
-                        #if ENTITY_ENCODE_HIGH_ASCII_CHARS
+#if ENTITY_ENCODE_HIGH_ASCII_CHARS
                         // The seemingly arbitrary 160 comes from RFC
                         if (ch >= 160 && ch < 256)
                         {
@@ -1517,7 +1519,7 @@ namespace System.Windows.Forms
                             output.Write(';');
                             break;
                         }
-                        #endif // ENTITY_ENCODE_HIGH_ASCII_CHARS
+#endif // ENTITY_ENCODE_HIGH_ASCII_CHARS
                         output.Write(ch);
                         break;
                 }
@@ -1529,9 +1531,11 @@ namespace System.Windows.Forms
         {
             Bitmap b = new Bitmap(typeof(DataGridViewCell), bitmapName);
             b.MakeTransparent();
-            if (DpiHelper.IsScalingRequired) {
+            if (DpiHelper.IsScalingRequired)
+            {
                 Bitmap scaledBitmap = DpiHelper.CreateResizedBitmap(b, new Size(iconsWidth, iconsHeight));
-                if (scaledBitmap != null) {
+                if (scaledBitmap != null)
+                {
                     b.Dispose();
                     b = scaledBitmap;
                 }
@@ -1643,11 +1647,11 @@ namespace System.Windows.Forms
             }
         }
 
-        internal object GetClipboardContentInternal(int rowIndex, 
-                                                    bool firstCell, 
-                                                    bool lastCell, 
-                                                    bool inFirstRow, 
-                                                    bool inLastRow, 
+        internal object GetClipboardContentInternal(int rowIndex,
+                                                    bool firstCell,
+                                                    bool lastCell,
+                                                    bool inFirstRow,
+                                                    bool inLastRow,
                                                     string format)
         {
             return GetClipboardContent(rowIndex, firstCell, lastCell, inFirstRow, inLastRow, format);
@@ -1834,9 +1838,9 @@ namespace System.Windows.Forms
             object objErrorText = this.Properties.GetObject(PropCellErrorText);
             if (objErrorText != null)
             {
-                errorText = (string) objErrorText;
+                errorText = (string)objErrorText;
             }
-            else if (this.DataGridView != null && 
+            else if (this.DataGridView != null &&
                      rowIndex != -1 &&
                      rowIndex != this.DataGridView.NewRowIndex &&
                      this.OwningColumn != null &&
@@ -1870,9 +1874,9 @@ namespace System.Windows.Forms
         [
             SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference")  // using ref is OK.
         ]
-        protected virtual object GetFormattedValue(object value, 
-                                                   int rowIndex, 
-                                                   ref DataGridViewCellStyle cellStyle, 
+        protected virtual object GetFormattedValue(object value,
+                                                   int rowIndex,
+                                                   ref DataGridViewCellStyle cellStyle,
                                                    TypeConverter valueTypeConverter,
                                                    TypeConverter formattedValueTypeConverter,
                                                    DataGridViewDataErrorContexts context)
@@ -2017,7 +2021,7 @@ namespace System.Windows.Forms
             {
                 return contextMenuStrip;
             }
-            
+
             if (this.owningRow != null)
             {
                 contextMenuStrip = this.owningRow.GetContextMenuStrip(rowIndex);
@@ -2200,7 +2204,7 @@ namespace System.Windows.Forms
                 if (cellStyle != null && !cellStyle.BackColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.BackColor = cellStyle.BackColor;
-                } 
+                }
                 else if (rowStyle != null && !rowStyle.BackColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.BackColor = rowStyle.BackColor;
@@ -2226,7 +2230,7 @@ namespace System.Windows.Forms
                 if (cellStyle != null && !cellStyle.ForeColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.ForeColor = cellStyle.ForeColor;
-                } 
+                }
                 else if (rowStyle != null && !rowStyle.ForeColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.ForeColor = rowStyle.ForeColor;
@@ -2252,7 +2256,7 @@ namespace System.Windows.Forms
                 if (cellStyle != null && !cellStyle.SelectionBackColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.SelectionBackColor = cellStyle.SelectionBackColor;
-                } 
+                }
                 else if (rowStyle != null && !rowStyle.SelectionBackColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.SelectionBackColor = rowStyle.SelectionBackColor;
@@ -2278,7 +2282,7 @@ namespace System.Windows.Forms
                 if (cellStyle != null && !cellStyle.SelectionForeColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.SelectionForeColor = cellStyle.SelectionForeColor;
-                } 
+                }
                 else if (rowStyle != null && !rowStyle.SelectionForeColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.SelectionForeColor = rowStyle.SelectionForeColor;
@@ -2305,7 +2309,7 @@ namespace System.Windows.Forms
             if (cellStyle != null && cellStyle.Font != null)
             {
                 inheritedCellStyleTmp.Font = cellStyle.Font;
-            } 
+            }
             else if (rowStyle != null && rowStyle.Font != null)
             {
                 inheritedCellStyleTmp.Font = rowStyle.Font;
@@ -2385,12 +2389,12 @@ namespace System.Windows.Forms
             if (cellStyle != null && cellStyle.Format.Length != 0)
             {
                 inheritedCellStyleTmp.Format = cellStyle.Format;
-            } 
+            }
             else if (rowStyle != null && rowStyle.Format.Length != 0)
             {
                 inheritedCellStyleTmp.Format = rowStyle.Format;
             }
-            else if (this.DataGridView.RowsDefaultCellStyle.Format.Length != 0 && 
+            else if (this.DataGridView.RowsDefaultCellStyle.Format.Length != 0 &&
                 (rowIndex % 2 == 0 || this.DataGridView.AlternatingRowsDefaultCellStyle.Format.Length == 0))
             {
                 inheritedCellStyleTmp.Format = this.DataGridView.RowsDefaultCellStyle.Format;
@@ -2437,12 +2441,12 @@ namespace System.Windows.Forms
             if (cellStyle != null && cellStyle.Alignment != DataGridViewContentAlignment.NotSet)
             {
                 inheritedCellStyleTmp.AlignmentInternal = cellStyle.Alignment;
-            } 
+            }
             else if (rowStyle != null && rowStyle.Alignment != DataGridViewContentAlignment.NotSet)
             {
                 inheritedCellStyleTmp.AlignmentInternal = rowStyle.Alignment;
             }
-            else if (this.DataGridView.RowsDefaultCellStyle.Alignment != DataGridViewContentAlignment.NotSet && 
+            else if (this.DataGridView.RowsDefaultCellStyle.Alignment != DataGridViewContentAlignment.NotSet &&
                 (rowIndex % 2 == 0 || this.DataGridView.AlternatingRowsDefaultCellStyle.Alignment == DataGridViewContentAlignment.NotSet))
             {
                 inheritedCellStyleTmp.AlignmentInternal = this.DataGridView.RowsDefaultCellStyle.Alignment;
@@ -2464,12 +2468,12 @@ namespace System.Windows.Forms
             if (cellStyle != null && cellStyle.WrapMode != DataGridViewTriState.NotSet)
             {
                 inheritedCellStyleTmp.WrapModeInternal = cellStyle.WrapMode;
-            } 
+            }
             else if (rowStyle != null && rowStyle.WrapMode != DataGridViewTriState.NotSet)
             {
                 inheritedCellStyleTmp.WrapModeInternal = rowStyle.WrapMode;
             }
-            else if (this.DataGridView.RowsDefaultCellStyle.WrapMode != DataGridViewTriState.NotSet && 
+            else if (this.DataGridView.RowsDefaultCellStyle.WrapMode != DataGridViewTriState.NotSet &&
                 (rowIndex % 2 == 0 || this.DataGridView.AlternatingRowsDefaultCellStyle.WrapMode == DataGridViewTriState.NotSet))
             {
                 inheritedCellStyleTmp.WrapModeInternal = this.DataGridView.RowsDefaultCellStyle.WrapMode;
@@ -2496,7 +2500,7 @@ namespace System.Windows.Forms
             {
                 inheritedCellStyleTmp.Tag = rowStyle.Tag;
             }
-            else if (this.DataGridView.RowsDefaultCellStyle.Tag != null && 
+            else if (this.DataGridView.RowsDefaultCellStyle.Tag != null &&
                 (rowIndex % 2 == 0 || this.DataGridView.AlternatingRowsDefaultCellStyle.Tag == null))
             {
                 inheritedCellStyleTmp.Tag = this.DataGridView.RowsDefaultCellStyle.Tag;
@@ -2522,7 +2526,7 @@ namespace System.Windows.Forms
             {
                 inheritedCellStyleTmp.PaddingInternal = rowStyle.Padding;
             }
-            else if (this.DataGridView.RowsDefaultCellStyle.Padding != Padding.Empty && 
+            else if (this.DataGridView.RowsDefaultCellStyle.Padding != Padding.Empty &&
                 (rowIndex % 2 == 0 || this.DataGridView.AlternatingRowsDefaultCellStyle.Padding == Padding.Empty))
             {
                 inheritedCellStyleTmp.PaddingInternal = this.DataGridView.RowsDefaultCellStyle.Padding;
@@ -2558,7 +2562,7 @@ namespace System.Windows.Forms
             }
 
             DataGridViewCellStyle dataGridViewCellStyle = GetInheritedStyle(null, rowIndex, false);
-            using( Graphics g = WindowsFormsUtils.CreateMeasurementGraphics())
+            using (Graphics g = WindowsFormsUtils.CreateMeasurementGraphics())
             {
                 return GetPreferredSize(g, dataGridViewCellStyle, rowIndex, new Size(width, 0)).Height;
             }
@@ -2846,7 +2850,7 @@ namespace System.Windows.Forms
 
             if (!DataGridViewUtilities.ValidTextFormatFlags(flags))
             {
-                throw new InvalidEnumArgumentException(nameof(flags), (int) flags, typeof(TextFormatFlags));
+                throw new InvalidEnumArgumentException(nameof(flags), (int)flags, typeof(TextFormatFlags));
             }
 
             flags &= textFormatSupportedFlags;
@@ -2879,7 +2883,7 @@ namespace System.Windows.Forms
 
             if (!DataGridViewUtilities.ValidTextFormatFlags(flags))
             {
-                throw new InvalidEnumArgumentException(nameof(flags), (int) flags, typeof(TextFormatFlags));
+                throw new InvalidEnumArgumentException(nameof(flags), (int)flags, typeof(TextFormatFlags));
             }
 
             if (string.IsNullOrEmpty(text))
@@ -2894,7 +2898,7 @@ namespace System.Windows.Forms
             }
 
             flags &= textFormatSupportedFlags;
-            float maxWidth = (float) (textOneLineSize.Width * textOneLineSize.Width) / (float) textOneLineSize.Height / maxRatio * 1.1F;
+            float maxWidth = (float)(textOneLineSize.Width * textOneLineSize.Width) / (float)textOneLineSize.Height / maxRatio * 1.1F;
             Size textSize;
             do
             {
@@ -2929,7 +2933,7 @@ namespace System.Windows.Forms
 
             if (!DataGridViewUtilities.ValidTextFormatFlags(flags))
             {
-                throw new InvalidEnumArgumentException(nameof(flags), (int) flags, typeof(TextFormatFlags));
+                throw new InvalidEnumArgumentException(nameof(flags), (int)flags, typeof(TextFormatFlags));
             }
 
             flags &= textFormatSupportedFlags;
@@ -2957,7 +2961,7 @@ namespace System.Windows.Forms
             {
                 flags &= textFormatSupportedFlags;
                 int lastFittingWidth = oneLineSize.Width;
-                float maxWidth = (float) lastFittingWidth * 0.9F;
+                float maxWidth = (float)lastFittingWidth * 0.9F;
                 Size textSize;
                 do
                 {
@@ -3095,7 +3099,7 @@ namespace System.Windows.Forms
                 Debug.Assert(this.DataGridView.IsCurrentCellInEditMode);
                 return;
             }
-            
+
             // get the tool tip string
             string toolTipText = GetToolTipText(rowIndex);
 
@@ -3545,7 +3549,7 @@ namespace System.Windows.Forms
 
             // Using system colors for non-single grid colors for now
             int y1, y2;
-            
+
             Pen penControlDark = null, penControlLightLight = null;
             Pen penBackColor = this.DataGridView.GetCachedPen(cellStyle.BackColor);
             Pen penGridColor = this.DataGridView.GridPen;
@@ -3574,10 +3578,10 @@ namespace System.Windows.Forms
                         dividerWidthColor = SystemColors.ControlDark;
                         break;
                 }
-                graphics.FillRectangle(this.DataGridView.GetCachedBrush(dividerWidthColor), 
-                                this.DataGridView.RightToLeftInternal ? bounds.X : bounds.Right - dividerThickness, 
-                                bounds.Y, 
-                                dividerThickness, 
+                graphics.FillRectangle(this.DataGridView.GetCachedBrush(dividerWidthColor),
+                                this.DataGridView.RightToLeftInternal ? bounds.X : bounds.Right - dividerThickness,
+                                bounds.Y,
+                                dividerThickness,
                                 bounds.Height);
                 if (this.DataGridView.RightToLeftInternal)
                 {
@@ -3721,7 +3725,7 @@ namespace System.Windows.Forms
                 case DataGridViewAdvancedCellBorderStyle.OutsetDouble:
                     y1 = bounds.Y + 1;
                     y2 = bounds.Bottom - 1;
-                    if (advancedBorderStyle.Top == DataGridViewAdvancedCellBorderStyle.OutsetPartial || 
+                    if (advancedBorderStyle.Top == DataGridViewAdvancedCellBorderStyle.OutsetPartial ||
                         advancedBorderStyle.Top == DataGridViewAdvancedCellBorderStyle.None)
                     {
                         y1--;
@@ -3737,7 +3741,7 @@ namespace System.Windows.Forms
                 case DataGridViewAdvancedCellBorderStyle.InsetDouble:
                     y1 = bounds.Y + 1;
                     y2 = bounds.Bottom - 1;
-                    if (advancedBorderStyle.Top == DataGridViewAdvancedCellBorderStyle.OutsetPartial || 
+                    if (advancedBorderStyle.Top == DataGridViewAdvancedCellBorderStyle.OutsetPartial ||
                         advancedBorderStyle.Top == DataGridViewAdvancedCellBorderStyle.None)
                     {
                         y1--;
@@ -3765,12 +3769,12 @@ namespace System.Windows.Forms
                     if (advancedBorderStyle.Left == DataGridViewAdvancedCellBorderStyle.OutsetDouble ||
                         advancedBorderStyle.Left == DataGridViewAdvancedCellBorderStyle.InsetDouble)
                     {
-                        x1++; 
+                        x1++;
                     }
                     if (advancedBorderStyle.Right == DataGridViewAdvancedCellBorderStyle.Inset ||
                         advancedBorderStyle.Right == DataGridViewAdvancedCellBorderStyle.Outset)
                     {
-                        x2--; 
+                        x2--;
                     }
                     graphics.DrawLine(penControlDark, x1, bounds.Y, x2, bounds.Y);
                     break;
@@ -3781,12 +3785,12 @@ namespace System.Windows.Forms
                     if (advancedBorderStyle.Left == DataGridViewAdvancedCellBorderStyle.OutsetDouble ||
                         advancedBorderStyle.Left == DataGridViewAdvancedCellBorderStyle.InsetDouble)
                     {
-                        x1++; 
+                        x1++;
                     }
                     if (advancedBorderStyle.Right == DataGridViewAdvancedCellBorderStyle.Inset ||
                         advancedBorderStyle.Right == DataGridViewAdvancedCellBorderStyle.Outset)
                     {
-                        x2--; 
+                        x2--;
                     }
                     graphics.DrawLine(penControlLightLight, x1, bounds.Y, x2, bounds.Y);
                     break;
@@ -3806,7 +3810,7 @@ namespace System.Windows.Forms
                     if (advancedBorderStyle.Right != DataGridViewAdvancedCellBorderStyle.None /* && advancedBorderStyle.Right != DataGridViewAdvancedCellBorderStyle.OutsetPartial*/)
                     {
                         x2--;
-                        if (advancedBorderStyle.Right == DataGridViewAdvancedCellBorderStyle.OutsetDouble || 
+                        if (advancedBorderStyle.Right == DataGridViewAdvancedCellBorderStyle.OutsetDouble ||
                             advancedBorderStyle.Right == DataGridViewAdvancedCellBorderStyle.InsetDouble)
                         {
                             x2--;
@@ -3869,7 +3873,7 @@ namespace System.Windows.Forms
                 case DataGridViewAdvancedCellBorderStyle.Outset:
                     x1 = bounds.X;
                     x2 = bounds.Right - 1;
-                    if (advancedBorderStyle.Right == DataGridViewAdvancedCellBorderStyle.InsetDouble || 
+                    if (advancedBorderStyle.Right == DataGridViewAdvancedCellBorderStyle.InsetDouble ||
                         advancedBorderStyle.Right == DataGridViewAdvancedCellBorderStyle.OutsetDouble)
                     {
                         x2--;
@@ -4283,7 +4287,7 @@ namespace System.Windows.Forms
         protected virtual void PaintErrorIcon(Graphics graphics, Rectangle clipBounds, Rectangle cellValueBounds, string errorText)
         {
             if (!string.IsNullOrEmpty(errorText) &&
-                cellValueBounds.Width >= DATAGRIDVIEWCELL_iconMarginWidth*2+iconsWidth &&
+                cellValueBounds.Width >= DATAGRIDVIEWCELL_iconMarginWidth * 2 + iconsWidth &&
                 cellValueBounds.Height >= DATAGRIDVIEWCELL_iconMarginHeight * 2 + iconsHeight)
             {
                 PaintErrorIcon(graphics, ComputeErrorIconBounds(cellValueBounds));
@@ -4329,10 +4333,10 @@ namespace System.Windows.Forms
             return (paintParts & DataGridViewPaintParts.Focus) != 0;
         }
 
-        static internal void PaintPadding(Graphics graphics, 
-            Rectangle bounds, 
-            DataGridViewCellStyle cellStyle, 
-            Brush br, 
+        static internal void PaintPadding(Graphics graphics,
+            Rectangle bounds,
+            DataGridViewCellStyle cellStyle,
+            Brush br,
             bool rightToLeft)
         {
             Rectangle rectPadding;
@@ -4368,9 +4372,9 @@ namespace System.Windows.Forms
             return (paintParts & DataGridViewPaintParts.SelectionBackground) != 0;
         }
 
-        internal void PaintWork(Graphics graphics, 
+        internal void PaintWork(Graphics graphics,
             Rectangle clipBounds,
-            Rectangle cellBounds, 
+            Rectangle cellBounds,
             int rowIndex,
             DataGridViewElementStates cellState,
             DataGridViewCellStyle cellStyle,
@@ -4393,11 +4397,11 @@ namespace System.Windows.Forms
             }
 
             DataGridViewCellPaintingEventArgs dgvcpe = dataGridView.CellPaintingEventArgs;
-            dgvcpe.SetProperties(graphics, 
+            dgvcpe.SetProperties(graphics,
                 clipBounds,
-                cellBounds, 
-                rowIndex, 
-                columnIndex, 
+                cellBounds,
+                rowIndex,
+                columnIndex,
                 cellState,
                 value,
                 formattedValue,
@@ -4411,21 +4415,21 @@ namespace System.Windows.Forms
                 return;
             }
 
-            Paint(graphics, 
-                  clipBounds, 
-                  cellBounds, 
-                  rowIndex, 
+            Paint(graphics,
+                  clipBounds,
+                  cellBounds,
+                  rowIndex,
                   cellState,
                   value,
                   formattedValue,
-                  errorText, 
-                  cellStyle, 
+                  errorText,
+                  cellStyle,
                   advancedBorderStyle,
                   paintParts);
         }
 
         /// <include file='doc\DataGridViewCell.uex' path='docs/doc[@for="DataGridViewCell.ParseFormattedValue"]/*' />
-        public virtual object ParseFormattedValue(object formattedValue, 
+        public virtual object ParseFormattedValue(object formattedValue,
                                                   DataGridViewCellStyle cellStyle,
                                                   TypeConverter formattedValueTypeConverter,
                                                   TypeConverter valueTypeConverter)
@@ -4461,7 +4465,7 @@ namespace System.Windows.Forms
                                          this.FormattedValueType,
                                          valueTypeConverter == null ? this.ValueTypeConverter : valueTypeConverter /*sourceConverter*/,
                                          formattedValueTypeConverter == null ? this.FormattedValueTypeConverter : formattedValueTypeConverter /*targetConverter*/,
-                                         cellStyle.FormatProvider, 
+                                         cellStyle.FormatProvider,
                                          cellStyle.NullValue,
                                          cellStyle.IsDataSourceNullValueDefault ? Formatter.GetDefaultDataSourceNullValue(valueType) : cellStyle.DataSourceNullValue);
         }
@@ -4476,17 +4480,17 @@ namespace System.Windows.Forms
             Rectangle cellBounds,
             Rectangle cellClip,
             DataGridViewCellStyle cellStyle,
-            bool singleVerticalBorderAdded, 
-            bool singleHorizontalBorderAdded, 
-            bool isFirstDisplayedColumn, 
+            bool singleVerticalBorderAdded,
+            bool singleHorizontalBorderAdded,
+            bool isFirstDisplayedColumn,
             bool isFirstDisplayedRow)
         {
-            Rectangle editingControlBounds = PositionEditingPanel(cellBounds, 
-                                                                  cellClip, 
-                                                                  cellStyle, 
-                                                                  singleVerticalBorderAdded, 
-                                                                  singleHorizontalBorderAdded, 
-                                                                  isFirstDisplayedColumn, 
+            Rectangle editingControlBounds = PositionEditingPanel(cellBounds,
+                                                                  cellClip,
+                                                                  cellStyle,
+                                                                  singleVerticalBorderAdded,
+                                                                  singleHorizontalBorderAdded,
+                                                                  isFirstDisplayedColumn,
                                                                   isFirstDisplayedRow);
             if (setLocation)
             {
@@ -4504,12 +4508,12 @@ namespace System.Windows.Forms
             SuppressMessage("Microsoft.Naming", "CA1720:AvoidTypeNamesInParameters") // singleVerticalBorderAdded/singleHorizontalBorderAdded names are OK
         ]
         // Positions the editing panel and returns the normal bounds of the editing control, within the editing panel.
-        public virtual Rectangle PositionEditingPanel(Rectangle cellBounds, 
-                                                      Rectangle cellClip, 
-                                                      DataGridViewCellStyle cellStyle, 
-                                                      bool singleVerticalBorderAdded, 
-                                                      bool singleHorizontalBorderAdded, 
-                                                      bool isFirstDisplayedColumn, 
+        public virtual Rectangle PositionEditingPanel(Rectangle cellBounds,
+                                                      Rectangle cellClip,
+                                                      DataGridViewCellStyle cellStyle,
+                                                      bool singleVerticalBorderAdded,
+                                                      bool singleHorizontalBorderAdded,
+                                                      bool isFirstDisplayedColumn,
                                                       bool isFirstDisplayedRow)
         {
             if (this.DataGridView == null)
@@ -4521,9 +4525,9 @@ namespace System.Windows.Forms
 
             dgvabsEffective = AdjustCellBorderStyle(this.DataGridView.AdvancedCellBorderStyle,
                                                     dataGridViewAdvancedBorderStylePlaceholder,
-                                                    singleVerticalBorderAdded, 
-                                                    singleHorizontalBorderAdded, 
-                                                    isFirstDisplayedColumn, 
+                                                    singleVerticalBorderAdded,
+                                                    singleHorizontalBorderAdded,
+                                                    isFirstDisplayedColumn,
                                                     isFirstDisplayedRow);
 
             Rectangle borderAndPaddingWidths = BorderWidths(dgvabsEffective);
@@ -4943,7 +4947,7 @@ namespace System.Windows.Forms
 
                     object formattedValue = this.owner.FormattedValue;
                     string formattedValueAsString = formattedValue as string;
-                    if (formattedValue == null || (formattedValueAsString  != null && string.IsNullOrEmpty(formattedValueAsString)))
+                    if (formattedValue == null || (formattedValueAsString != null && string.IsNullOrEmpty(formattedValueAsString)))
                     {
                         return string.Format(SR.DataGridView_AccNullValue);
                     }
@@ -5075,6 +5079,7 @@ namespace System.Windows.Forms
 
                 // use the accessibility bounds from the parent row acc obj
                 Rectangle rowRect = parentAccObject.Bounds;
+                Rectangle cellRect = rowRect;
                 Rectangle columnRect;
 
                 int firstVisibleColumnIndex = this.owner.DataGridView.Columns.ColumnIndexToActualDisplayIndex(this.owner.DataGridView.FirstDisplayedScrollingColumnIndex, DataGridViewElementStates.Visible);
@@ -5118,8 +5123,8 @@ namespace System.Windows.Forms
                 {
                     // Get the bounds for the cell to the LEFT
                     columnRect = parentAccObject.GetChild(visibleColumnIndex
-                                                          - 1                                       // -1 because we want the previous cell to the LEFT
-                                                          + (rowHeadersVisible ? 1 : 0)).Bounds;    // +1 but only if the row headers are visible
+                                                          - 1                                       // - 1 because we want the previous cell to the LEFT
+                                                          + (rowHeadersVisible ? 1 : 0)).Bounds;    // + 1 but only if the row headers are visible
 
                     // From the bounds of the cell to the LEFT increment the width of the owning column
                     if (this.owner.DataGridView.RightToLeft == RightToLeft.No)
@@ -5134,10 +5139,34 @@ namespace System.Windows.Forms
                     columnRect.Width = this.owner.OwningColumn.Width;
                 }
 
-                rowRect.X = columnRect.X;
-                rowRect.Width = columnRect.Width;
+                var cellRight = columnRect.Left + columnRect.Width;
+                var cellLeft = columnRect.Left;
 
-                return rowRect;
+                int rowHeadersWidth = 0;
+                if (this.owner.DataGridView.RowHeadersVisible)
+                {
+                    rowHeadersWidth = this.owner.DataGridView.RowHeadersWidth;
+                }
+
+                if (cellLeft < rowRect.Left + rowHeadersWidth)
+                {
+                    cellRect.X = rowRect.Left + rowHeadersWidth;
+                }
+                else
+                {
+                    cellRect.X = cellLeft;
+                }
+
+                if (cellRight > rowRect.Right)
+                {
+                    cellRect.Width = rowRect.Right - cellRect.X;
+                }
+                else
+                {
+                    cellRect.Width = cellRight - cellRect.X;
+                }
+
+                return cellRect;
             }
 
             private AccessibleObject GetAccessibleObjectParent()
@@ -5556,7 +5585,7 @@ namespace System.Windows.Forms
                 }
 
                 if ((patternId == NativeMethods.UIA_TableItemPatternId ||
-                    patternId == NativeMethods.UIA_GridItemPatternId) && 
+                    patternId == NativeMethods.UIA_GridItemPatternId) &&
                     // We don't want to implement patterns for header cells
                     this.owner.ColumnIndex != -1 && this.owner.RowIndex != -1)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -5109,8 +5109,12 @@ namespace System.Windows.Forms
                 {
                     cellRight = rowRect.Right - rightToLeftRowHeadersWidth;
                 }
-                cellRect.Width = cellRight - cellLeft;
-
+                
+                if ((cellRight - cellLeft) >= 0)
+                    cellRect.Width = cellRight - cellLeft;
+                else
+                    cellRect.Width = 0;
+                
                 return cellRect;
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -5077,67 +5077,9 @@ namespace System.Windows.Forms
                     return Rectangle.Empty;
                 }
 
-                // use the accessibility bounds from the parent row acc obj
                 Rectangle rowRect = parentAccObject.Bounds;
                 Rectangle cellRect = rowRect;
-                Rectangle columnRect;
-
-                int firstVisibleColumnIndex = this.owner.DataGridView.Columns.ColumnIndexToActualDisplayIndex(this.owner.DataGridView.FirstDisplayedScrollingColumnIndex, DataGridViewElementStates.Visible);
-                int visibleColumnIndex = this.owner.DataGridView.Columns.ColumnIndexToActualDisplayIndex(this.owner.ColumnIndex, DataGridViewElementStates.Visible);
-
-                bool rowHeadersVisible = this.owner.DataGridView.RowHeadersVisible;
-                if (visibleColumnIndex < firstVisibleColumnIndex)
-                {
-                    // Get the bounds for the cell to the RIGHT
-                    columnRect = parentAccObject.GetChild(visibleColumnIndex
-                                                          + 1                                       // + 1 for the next cell to the RIGHT
-                                                          + (rowHeadersVisible ? 1 : 0)).Bounds;    // + 1 but only if the row headers are visible
-
-                    // From the bounds of the cell to the RIGHT decrement the width of the owning column
-                    if (this.Owner.DataGridView.RightToLeft == RightToLeft.No)
-                    {
-                        columnRect.X -= this.owner.OwningColumn.Width;
-                    }
-                    else
-                    {
-                        columnRect.X = columnRect.Right;
-                    }
-                    columnRect.Width = this.owner.OwningColumn.Width;
-                }
-                else if (visibleColumnIndex == firstVisibleColumnIndex)
-                {
-                    columnRect = this.owner.DataGridView.GetColumnDisplayRectangle(this.owner.ColumnIndex, false /*cutOverflow*/);
-                    int negOffset = this.owner.DataGridView.FirstDisplayedScrollingColumnHiddenWidth;
-
-                    if (negOffset != 0)
-                    {
-                        if (this.owner.DataGridView.RightToLeft == RightToLeft.No)
-                        {
-                            columnRect.X -= negOffset;
-                        }
-                        columnRect.Width += negOffset;
-                    }
-                    columnRect = this.owner.DataGridView.RectangleToScreen(columnRect);
-                }
-                else
-                {
-                    // Get the bounds for the cell to the LEFT
-                    columnRect = parentAccObject.GetChild(visibleColumnIndex
-                                                          - 1                                       // - 1 because we want the previous cell to the LEFT
-                                                          + (rowHeadersVisible ? 1 : 0)).Bounds;    // + 1 but only if the row headers are visible
-
-                    // From the bounds of the cell to the LEFT increment the width of the owning column
-                    if (this.owner.DataGridView.RightToLeft == RightToLeft.No)
-                    {
-                        columnRect.X = columnRect.Right;
-                    }
-                    else
-                    {
-                        columnRect.X -= this.owner.OwningColumn.Width;
-                    }
-
-                    columnRect.Width = this.owner.OwningColumn.Width;
-                }
+                Rectangle columnRect = this.owner.DataGridView.RectangleToScreen(this.owner.DataGridView.GetColumnDisplayRectangle(this.owner.ColumnIndex, false /*cutOverflow*/));
 
                 var cellRight = columnRect.Left + columnRect.Width;
                 var cellLeft = columnRect.Left;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Code taken from ASP.NET file xsp\System\Web\httpserverutility.cs
-// Don't entity encode high chars (160 to 256)
-#define ENTITY_ENCODE_HIGH_ASCII_CHARS
-
 namespace System.Windows.Forms
 {
     using System;
@@ -1510,8 +1506,9 @@ namespace System.Windows.Forms
                         break;
                     // 
                     default:
-#if ENTITY_ENCODE_HIGH_ASCII_CHARS
                         // The seemingly arbitrary 160 comes from RFC
+                        // Code taken from ASP.NET file xsp\System\Web\httpserverutility.cs
+                        // Don't entity encode high chars (160 to 256)
                         if (ch >= 160 && ch < 256)
                         {
                             output.Write("&#");
@@ -1519,7 +1516,6 @@ namespace System.Windows.Forms
                             output.Write(';');
                             break;
                         }
-#endif // ENTITY_ENCODE_HIGH_ASCII_CHARS
                         output.Write(ch);
                         break;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
@@ -1811,17 +1811,19 @@ namespace System.Windows.Forms
 
                     Rectangle dataGridViewRect = ParentPrivate.Bounds;
 
-                    int rowRectBottom = rowRect.Bottom;
-                    if ((dataGridViewRect.Bottom - horizontalScrollBarHeight) < rowRectBottom)
-                    {
-                        rowRectBottom = dataGridViewRect.Bottom - horizontalScrollBarHeight;
-                    }
-
                     int columnHeadersHeight = 0;
                     if (this.owner.DataGridView.ColumnHeadersVisible)
                     {
                         columnHeadersHeight = this.owner.DataGridView.ColumnHeadersHeight;
                     }
+
+                    int rowRectBottom = rowRect.Bottom;
+                    if ((dataGridViewRect.Bottom - horizontalScrollBarHeight) < rowRectBottom)
+                    {
+                        rowRectBottom = dataGridViewRect.Bottom - owner.DataGridView.BorderWidth - horizontalScrollBarHeight;
+                    }
+
+                    
 
                     if ((dataGridViewRect.Top + columnHeadersHeight) > rowRect.Top)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
@@ -1796,62 +1796,13 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    Rectangle rowRect;
-
                     if (owner == null)
                     {
                         throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                     }
 
-                    if (owner.Index < owner.DataGridView.FirstDisplayedScrollingRowIndex)
-                    {
-                        // the row is scrolled off the DataGridView
-                        // get the Accessible bounds for the following visible row
-                        int visibleRowIndex = owner.DataGridView.Rows.GetRowCount(DataGridViewElementStates.Visible, 0, owner.Index);
-
-                        int additionalRows = 1; // + 1 because we want to get the bounds for the next visible row
-                        if (this.owner.DataGridView.ColumnHeadersVisible)
-                        {
-                            additionalRows += 1; // + 1 because the first acc obj in the DataGridView is the top row header
-                        }
-
-                        rowRect = ParentPrivate.GetChild(visibleRowIndex + additionalRows).Bounds;
-                        rowRect.Y -= owner.Height;
-                        rowRect.Height = owner.Height;
-
-                    }
-                    else if (owner.Index >= owner.DataGridView.FirstDisplayedScrollingRowIndex &&
-                        owner.Index < owner.DataGridView.FirstDisplayedScrollingRowIndex + owner.DataGridView.DisplayedRowCount(true /*includePartialRow*/))
-                    {
-                        rowRect = owner.DataGridView.GetRowDisplayRectangle(owner.Index, false /*cutOverflow*/);
-                        rowRect = owner.DataGridView.RectangleToScreen(rowRect);
-                    }
-                    else
-                    {
-                        // the row is scrolled off the DataGridView
-                        // use the Accessible bounds for the previous visible row
-                        int visibleRowIndex = owner.DataGridView.Rows.GetRowCount(DataGridViewElementStates.Visible, 0, owner.Index);
-
-                        // This is a tricky scenario
-                        // If Visible of Row 0 is false, then visibleRowIndex is not the previous visible row.
-                        // It turns out to be the current row, this will cause a stack overflow.
-                        // We have to prevent this.
-                        if (!owner.DataGridView.Rows[0].Visible)
-                        {
-                            visibleRowIndex--;
-                        }
-
-                        // we don't have to decrement the visible row index if the first acc obj in the data grid view is the top column header
-                        if (!owner.DataGridView.ColumnHeadersVisible)
-                        {
-                            visibleRowIndex--;
-                        }
-
-                        rowRect = ParentPrivate.GetChild(visibleRowIndex).Bounds;
-                        rowRect.Y += rowRect.Height;
-                        rowRect.Height = owner.Height;
-                    }
-
+                    Rectangle rowRect = owner.DataGridView.RectangleToScreen(owner.DataGridView.GetRowDisplayRectangle(owner.Index, false /*cutOverflow*/));
+                    
                     int horizontalScrollBarHeight = 0;
                     if (this.owner.DataGridView.HorizontalScrollBarVisible)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeaderCell.cs
@@ -25,7 +25,7 @@ namespace System.Windows.Forms
         private static readonly VisualStyleElement HeaderElement = VisualStyleElement.Header.Item.Normal;
 
         // ColorMap used to map the black color of the resource bitmaps to the fore color in use in the row header cell
-        private static ColorMap[] colorMap = new ColorMap[] {new ColorMap()};
+        private static ColorMap[] colorMap = new ColorMap[] { new ColorMap() };
 
         private static Bitmap rightArrowBmp = null;
         private static Bitmap leftArrowBmp = null;
@@ -44,7 +44,7 @@ namespace System.Windows.Forms
         private const byte DATAGRIDVIEWROWHEADERCELL_horizontalTextMarginLeft = 1;
         private const byte DATAGRIDVIEWROWHEADERCELL_horizontalTextMarginRight = 2;
         private const byte DATAGRIDVIEWROWHEADERCELL_verticalTextMargin = 1;
- 
+
         /// <include file='doc\DataGridViewRowHeaderCell.uex' path='docs/doc[@for="DataGridViewRowHeaderCell.DataGridViewRowHeaderCell"]/*' />
         public DataGridViewRowHeaderCell()
         {
@@ -162,7 +162,7 @@ namespace System.Windows.Forms
             {
                 // 
 
-                dataGridViewCell = (DataGridViewRowHeaderCell) System.Activator.CreateInstance(thisType);
+                dataGridViewCell = (DataGridViewRowHeaderCell)System.Activator.CreateInstance(thisType);
             }
             base.CloneInternal(dataGridViewCell);
             dataGridViewCell.Value = this.Value;
@@ -185,8 +185,8 @@ namespace System.Windows.Forms
             return rightToLeft ? DataGridViewRowHeaderCell.LeftArrowStarBitmap : DataGridViewRowHeaderCell.RightArrowStarBitmap;
         }
 
-        
-        
+
+
         private static Bitmap GetBitmapFromIcon(string iconName)
         {
             Size desiredSize = new Size(iconsWidth, iconsHeight);
@@ -280,13 +280,13 @@ namespace System.Windows.Forms
                     {
                         if (!inLastRow)
                         {
-                            sb.Append((char) Keys.Return);
-                            sb.Append((char) Keys.LineFeed);
+                            sb.Append((char)Keys.Return);
+                            sb.Append((char)Keys.LineFeed);
                         }
                     }
                     else
                     {
-                        sb.Append(csv ? ',' : (char) Keys.Tab);
+                        sb.Append(csv ? ',' : (char)Keys.Tab);
                     }
                     return sb.ToString();
                 }
@@ -461,7 +461,7 @@ namespace System.Windows.Forms
                 if (cellStyle != null && !cellStyle.BackColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.BackColor = cellStyle.BackColor;
-                } 
+                }
                 else if (!rowHeadersStyle.BackColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.BackColor = rowHeadersStyle.BackColor;
@@ -474,7 +474,7 @@ namespace System.Windows.Forms
                 if (cellStyle != null && !cellStyle.ForeColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.ForeColor = cellStyle.ForeColor;
-                } 
+                }
                 else if (!rowHeadersStyle.ForeColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.ForeColor = rowHeadersStyle.ForeColor;
@@ -487,7 +487,7 @@ namespace System.Windows.Forms
                 if (cellStyle != null && !cellStyle.SelectionBackColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.SelectionBackColor = cellStyle.SelectionBackColor;
-                } 
+                }
                 else if (!rowHeadersStyle.SelectionBackColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.SelectionBackColor = rowHeadersStyle.SelectionBackColor;
@@ -500,7 +500,7 @@ namespace System.Windows.Forms
                 if (cellStyle != null && !cellStyle.SelectionForeColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.SelectionForeColor = cellStyle.SelectionForeColor;
-                } 
+                }
                 else if (!rowHeadersStyle.SelectionForeColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.SelectionForeColor = rowHeadersStyle.SelectionForeColor;
@@ -514,7 +514,7 @@ namespace System.Windows.Forms
             if (cellStyle != null && cellStyle.Font != null)
             {
                 inheritedCellStyleTmp.Font = cellStyle.Font;
-            } 
+            }
             else if (rowHeadersStyle.Font != null)
             {
                 inheritedCellStyleTmp.Font = rowHeadersStyle.Font;
@@ -553,7 +553,7 @@ namespace System.Windows.Forms
             if (cellStyle != null && cellStyle.Format.Length != 0)
             {
                 inheritedCellStyleTmp.Format = cellStyle.Format;
-            } 
+            }
             else if (rowHeadersStyle.Format.Length != 0)
             {
                 inheritedCellStyleTmp.Format = rowHeadersStyle.Format;
@@ -579,7 +579,7 @@ namespace System.Windows.Forms
             if (cellStyle != null && cellStyle.Alignment != DataGridViewContentAlignment.NotSet)
             {
                 inheritedCellStyleTmp.AlignmentInternal = cellStyle.Alignment;
-            } 
+            }
             else if (rowHeadersStyle.Alignment != DataGridViewContentAlignment.NotSet)
             {
                 inheritedCellStyleTmp.AlignmentInternal = rowHeadersStyle.Alignment;
@@ -593,7 +593,7 @@ namespace System.Windows.Forms
             if (cellStyle != null && cellStyle.WrapMode != DataGridViewTriState.NotSet)
             {
                 inheritedCellStyleTmp.WrapModeInternal = cellStyle.WrapMode;
-            } 
+            }
             else if (rowHeadersStyle.WrapMode != DataGridViewTriState.NotSet)
             {
                 inheritedCellStyleTmp.WrapModeInternal = rowHeadersStyle.WrapMode;
@@ -681,13 +681,13 @@ namespace System.Windows.Forms
                 val = null;
             }
             return DataGridViewUtilities.GetPreferredRowHeaderSize(graphics,
-                                                                   (string) val, 
-                                                                   cellStyle, 
-                                                                   borderAndPaddingWidths, 
+                                                                   (string)val,
+                                                                   cellStyle,
+                                                                   borderAndPaddingWidths,
                                                                    borderAndPaddingHeights,
                                                                    this.DataGridView.ShowRowErrors,
                                                                    true /*showGlyph*/,
-                                                                   constraintSize, 
+                                                                   constraintSize,
                                                                    flags);
         }
 
@@ -828,15 +828,17 @@ namespace System.Windows.Forms
                             }
                         }
                         // Flip the column header background
-                        using (Bitmap bmFlipXPThemes = new Bitmap(backgroundBounds.Height, backgroundBounds.Width)) {
-                            using (Graphics gFlip = Graphics.FromImage(bmFlipXPThemes)) {
-                            DataGridViewRowHeaderCellRenderer.DrawHeader(gFlip, new Rectangle(0, 0, backgroundBounds.Height, backgroundBounds.Width), state);
-                            bmFlipXPThemes.RotateFlip(this.DataGridView.RightToLeftInternal ? RotateFlipType.Rotate90FlipNone : RotateFlipType.Rotate270FlipY);
+                        using (Bitmap bmFlipXPThemes = new Bitmap(backgroundBounds.Height, backgroundBounds.Width))
+                        {
+                            using (Graphics gFlip = Graphics.FromImage(bmFlipXPThemes))
+                            {
+                                DataGridViewRowHeaderCellRenderer.DrawHeader(gFlip, new Rectangle(0, 0, backgroundBounds.Height, backgroundBounds.Width), state);
+                                bmFlipXPThemes.RotateFlip(this.DataGridView.RightToLeftInternal ? RotateFlipType.Rotate90FlipNone : RotateFlipType.Rotate270FlipY);
 
-                            graphics.DrawImage(bmFlipXPThemes,
-                                               backgroundBounds,
-                                               new Rectangle(0, 0, backgroundBounds.Width, backgroundBounds.Height),
-                                               GraphicsUnit.Pixel);
+                                graphics.DrawImage(bmFlipXPThemes,
+                                                   backgroundBounds,
+                                                   new Rectangle(0, 0, backgroundBounds.Width, backgroundBounds.Height),
+                                                   GraphicsUnit.Pixel);
                             }
                         }
                     }
@@ -891,9 +893,9 @@ namespace System.Windows.Forms
                 if (!string.IsNullOrEmpty(formattedString))
                 {
                     // There is text to display
-                    if (valBounds.Width >= iconsWidth + 
+                    if (valBounds.Width >= iconsWidth +
                                            2 * DATAGRIDVIEWROWHEADERCELL_iconMarginWidth &&
-                        valBounds.Height >= iconsHeight + 
+                        valBounds.Height >= iconsHeight +
                                             2 * DATAGRIDVIEWROWHEADERCELL_iconMarginHeight)
                     {
                         if (paint && DataGridViewCell.PaintContentBackground(paintParts))
@@ -1019,7 +1021,7 @@ namespace System.Windows.Forms
                         }
                     }
                     // Third priority is the row error icon, which may be painted on top of text
-                    if (errorBounds.Width >= 3 * DATAGRIDVIEWROWHEADERCELL_iconMarginWidth + 
+                    if (errorBounds.Width >= 3 * DATAGRIDVIEWROWHEADERCELL_iconMarginWidth +
                                              2 * iconsWidth)
                     {
                         // There is enough horizontal room for the error icon and the glyph
@@ -1039,7 +1041,7 @@ namespace System.Windows.Forms
                 else
                 {
                     // There is no text to display
-                    if (valBounds.Width >= iconsWidth + 2 * DATAGRIDVIEWROWHEADERCELL_iconMarginWidth && 
+                    if (valBounds.Width >= iconsWidth + 2 * DATAGRIDVIEWROWHEADERCELL_iconMarginWidth &&
                         valBounds.Height >= iconsHeight + 2 * DATAGRIDVIEWROWHEADERCELL_iconMarginHeight)
                     {
                         if (paint && DataGridViewCell.PaintContentBackground(paintParts))
@@ -1101,7 +1103,7 @@ namespace System.Windows.Forms
                         }
                     }
 
-                    if (errorBounds.Width >= 3 * DATAGRIDVIEWROWHEADERCELL_iconMarginWidth + 
+                    if (errorBounds.Width >= 3 * DATAGRIDVIEWROWHEADERCELL_iconMarginWidth +
                                              2 * iconsWidth)
                     {
                         // There is enough horizontal room for the error icon
@@ -1126,10 +1128,10 @@ namespace System.Windows.Forms
 
         private void PaintIcon(Graphics g, Bitmap bmp, Rectangle bounds, Color foreColor)
         {
-            Rectangle bmpRect = new Rectangle(this.DataGridView.RightToLeftInternal ? 
+            Rectangle bmpRect = new Rectangle(this.DataGridView.RightToLeftInternal ?
                                               bounds.Right - DATAGRIDVIEWROWHEADERCELL_iconMarginWidth - iconsWidth :
                                               bounds.Left + DATAGRIDVIEWROWHEADERCELL_iconMarginWidth,
-                                              bounds.Y + (bounds.Height - iconsHeight)/2,
+                                              bounds.Y + (bounds.Height - iconsHeight) / 2,
                                               iconsWidth,
                                               iconsHeight);
             colorMap[0].NewColor = foreColor;
@@ -1145,7 +1147,7 @@ namespace System.Windows.Forms
         protected override bool SetValue(int rowIndex, object value)
         {
             object originalValue = GetValue(rowIndex);
-            if (value != null || this.Properties.ContainsObject(PropCellValue)) 
+            if (value != null || this.Properties.ContainsObject(PropCellValue))
             {
                 this.Properties.SetObject(PropCellValue, value);
             }
@@ -1213,8 +1215,14 @@ namespace System.Windows.Forms
 
                     // use the parent row acc obj bounds
                     Rectangle rowRect = this.ParentPrivate.Bounds;
-                    rowRect.Width = this.Owner.DataGridView.RowHeadersWidth;
-                    return rowRect;
+                    Rectangle cellRect = rowRect;
+                    cellRect.Width = this.Owner.DataGridView.RowHeadersWidth;
+                    if (this.Owner.DataGridView.RightToLeft == RightToLeft.Yes)
+                    {
+                        cellRect.X = rowRect.Right - cellRect.Width;
+                    }
+                    
+                    return cellRect;
                 }
             }
 
@@ -1324,7 +1332,7 @@ namespace System.Windows.Forms
             public override void DoDefaultAction()
             {
                 if ((this.Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.FullRowSelect ||
-                    this.Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.RowHeaderSelect ) &&
+                    this.Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.RowHeaderSelect) &&
                     this.Owner.OwningRow != null)
                 {
                     this.Owner.OwningRow.Selected = true;
@@ -1423,7 +1431,7 @@ namespace System.Windows.Forms
                 {
                     throw new InvalidOperationException(string.Format(SR.DataGridViewCellAccessibleObject_OwnerNotSet));
                 }
-                
+
                 DataGridViewRowHeaderCell dataGridViewCell = (DataGridViewRowHeaderCell)this.Owner;
                 DataGridView dataGridView = dataGridViewCell.DataGridView;
 

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewCellAccessibleObjectTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+using System.Threading;
 using Xunit;
 
 namespace System.Windows.Forms.Tests.AccessibleObjects
@@ -14,15 +16,17 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
         public void DataGridViewCellsAccessibleObject_Ctor_Default(RightToLeft rightToLeft)
         {
             DataGridView dataGridView = new DataGridView();
-
+            
             dataGridView.RightToLeft = rightToLeft;
             dataGridView.ColumnCount = 4;
-            dataGridView.Width = 130;
+            dataGridView.Width = 85;
 
             dataGridView.Columns[0].Width = 40;
             dataGridView.Columns[1].Width = 40;
             dataGridView.Columns[2].Width = 40;
             dataGridView.Columns[3].Width = 40;
+
+            AccessibleObject rr = dataGridView.AccessibilityObject; //it is necessary to be in time to initialize elements
 
             var accCellWidthSum = 0;
             for(int i = 0; i < 4; i++)

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewCellAccessibleObjectTests.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Windows.Forms.Tests.AccessibleObjects
+{
+    public class DataGridViewCellsAccessibleObjectTests
+    {
+        [Fact]
+        public void DataGridViewCellsAccessibleObject_Ctor_Default()
+        {
+            DataGridView dataGridView = new DataGridView();
+            
+            dataGridView.ColumnCount = 4;
+            dataGridView.Width = 130;
+
+            dataGridView.Columns[0].Width = 40;
+            dataGridView.Columns[1].Width = 40;
+            dataGridView.Columns[2].Width = 40;
+            dataGridView.Columns[3].Width = 40;
+
+            var accCellWidthSum = 0;
+            for(int i = 0; i < 4; i++)
+            {
+                accCellWidthSum += dataGridView.Rows[0].Cells[i].AccessibilityObject.BoundingRectangle.Width;
+            }
+            var accRowWidth = dataGridView.Rows[0].AccessibilityObject.BoundingRectangle.Width;
+
+            Assert.True(accCellWidthSum <= accRowWidth);
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewCellAccessibleObjectTests.cs
@@ -8,11 +8,14 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
 {
     public class DataGridViewCellsAccessibleObjectTests
     {
-        [Fact]
-        public void DataGridViewCellsAccessibleObject_Ctor_Default()
+        [Theory]
+        [InlineData(RightToLeft.No)]
+        [InlineData(RightToLeft.Yes)]
+        public void DataGridViewCellsAccessibleObject_Ctor_Default(RightToLeft rightToLeft)
         {
             DataGridView dataGridView = new DataGridView();
-            
+
+            dataGridView.RightToLeft = rightToLeft;
             dataGridView.ColumnCount = 4;
             dataGridView.Width = 130;
 
@@ -28,7 +31,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             }
             var accRowWidth = dataGridView.Rows[0].AccessibilityObject.BoundingRectangle.Width;
 
-            Assert.True(accCellWidthSum <= accRowWidth);
+            Assert.True(accCellWidthSum == accRowWidth - dataGridView.RowHeadersWidth);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewRowsAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewRowsAccessibleObjectTests.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Windows.Forms.Tests.AccessibleObjects
+{
+    public class DataGridViewRowsAccessibleObjectTests
+    {
+        [Fact]
+        public void DataGridViewRowsAccessibleObject_Ctor_Default()
+        {
+            DataGridView dataGridView = new DataGridView();
+
+            dataGridView.RowCount = 5;
+            dataGridView.Height = 65;
+
+            dataGridView.Rows[0].Height = 20;
+            dataGridView.Rows[1].Height = 20;
+            dataGridView.Rows[2].Height = 20;
+            dataGridView.Rows[3].Height = 20;
+            dataGridView.Rows[4].Height = 20;
+
+            var accRowHeightSum = 0;
+            for (int i = 0; i < 5; i++)
+            {
+                accRowHeightSum += dataGridView.Rows[i].AccessibilityObject.BoundingRectangle.Height;
+            }
+            var accDataGridViewHeight = dataGridView.AccessibilityObject.BoundingRectangle.Height;
+
+            Assert.True(accRowHeightSum <= accDataGridViewHeight);
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewRowsAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewRowsAccessibleObjectTests.cs
@@ -14,7 +14,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             DataGridView dataGridView = new DataGridView();
 
             dataGridView.RowCount = 5;
-            dataGridView.Height = 65;
+            dataGridView.Height = 87;
 
             dataGridView.Rows[0].Height = 20;
             dataGridView.Rows[1].Height = 20;
@@ -22,14 +22,17 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             dataGridView.Rows[3].Height = 20;
             dataGridView.Rows[4].Height = 20;
 
-            var accRowHeightSum = 0;
+            AccessibleObject accObject = dataGridView.AccessibilityObject; //it is necessary to be in time to initialize elements
+
+            int accRowHeightSum = 0;
             for (int i = 0; i < 5; i++)
             {
                 accRowHeightSum += dataGridView.Rows[i].AccessibilityObject.BoundingRectangle.Height;
             }
-            var accDataGridViewHeight = dataGridView.AccessibilityObject.BoundingRectangle.Height;
+            int accDataGridViewHeight = dataGridView.AccessibilityObject.BoundingRectangle.Height;
+            int borders = 2 * dataGridView.BorderWidth; //top border and bottom border
 
-            Assert.True(accRowHeightSum <= accDataGridViewHeight);
+            Assert.True(accRowHeightSum == accDataGridViewHeight - borders - dataGridView.ColumnHeadersHeight);
         }
     }
 }


### PR DESCRIPTION
The change is related to the issue #710.