### PR TITLE
Remove references to GlobalAssemblyCache

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxItem.cs
@@ -708,10 +708,6 @@ namespace System.Drawing.Design
             {
                 TypeName = type.FullName;
                 AssemblyName assemblyName = type.Assembly.GetName(true);
-                if (type.Assembly.GlobalAssemblyCache)
-                {
-                    assemblyName.CodeBase = null;
-                }
 
                 Dictionary<string, AssemblyName> parents = new Dictionary<string, AssemblyName>();
                 Type parentType = type;

--- a/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
@@ -825,13 +825,7 @@ namespace System.Resources {
             }
             
             if (result == null) {
-                // try to load it first from the gac
-#pragma warning disable 0618
-                //Although LoadWithPartialName is obsolete, we still have to call it: changing 
-                //this would be breaking in cases where people edited their resource files by
-                //hand.
-                result = Assembly.LoadWithPartialName(name.FullName);
-#pragma warning restore 0618                            
+                result = Assembly.Load(name.FullName);
                 if(result != null) {
                     cachedAssemblies[name] = result;
                 } 
@@ -882,13 +876,11 @@ namespace System.Resources {
                 return result;
             }
 
-            // Missed in cache, try to resolve the type. First try to resolve in the GAC
+            // Missed in cache, try to resolve the type from the reference assemblies.
             if(name.IndexOf(',') != -1) {
                 result = Type.GetType(name, false, ignoreCase);
             }
 
-            //
-            // Did not find it in the GAC, check the reference assemblies
             if(result == null && names != null) {
                 //
                 // If the type is assembly qualified name, we sort the assembly names
@@ -944,9 +936,9 @@ namespace System.Resources {
             }
 
             if(result != null) {
-                // Only cache types from .Net framework or GAC because they don't need to update.
+                // Only cache types from .Net framework  because they don't need to update.
                 // For simplicity, don't cache custom types
-                if (result.Assembly.GlobalAssemblyCache || IsNetFrameworkAssembly(result.Assembly.Location)) {
+                if (IsNetFrameworkAssembly(result.Assembly.Location)) {
                     cachedTypes[name] = result;
                 }
             }


### PR DESCRIPTION
The GAC is not supported in .NET Core - `Assembly.GlobalAssemblyCache` always returns false, for example.

Therefore this is all dead in .NET Core. However, there may be a breaking change. Consider that the user defines their own non-runtime assembly by directly subclassing `Assembly` instead of using `typeof(int).Assembly` for example. If they overrode `GlobalAssemblyCache` to return `true` in .NET Core then the code that I deleted would have been run. However, the entire GAC feature has been removed in .NET Core so I firstly don't see this happening and secondly the code is actually meaningless anyway.

Contributes to #485 
