### PR TITLE
Add GetLParam<T> and GetLParamRef<T>

### DIFF
--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -4044,7 +4044,7 @@ namespace System.Windows.Forms
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        public unsafe struct HDLAYOUT {
+        public struct HDLAYOUT {
             public IntPtr       prc;        // pointer to a RECT
             public IntPtr       pwpos;      // pointer to a WINDOWPOS
         }
@@ -4374,7 +4374,7 @@ namespace System.Windows.Forms
             public int      cColumns; // tile view columns
             public IntPtr   puColumns;
 
-            public unsafe void Reset() {
+            public void Reset() {
                 pszText = null;
                 mask = 0;
                 iItem = 0;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -13089,27 +13089,27 @@ example usage
         ///     Handles the WM_WINDOWPOSCHANGING message
         /// </devdoc>
         /// <internalonly/>
-        private unsafe void WmWindowPosChanging(ref Message m) {
+        private void WmWindowPosChanging(ref Message m) {
 
             // We let this fall through to defwndproc unless we are being surfaced as
             // an ActiveX control.  In that case, we must let the ActiveX side of things
             // manipulate our bounds here.
             //
             if (IsActiveX) {
-                NativeMethods.WINDOWPOS* wp = (NativeMethods.WINDOWPOS *)m.LParam;
+                ref NativeMethods.WINDOWPOS wp = ref m.GetLParamRef<NativeMethods.WINDOWPOS>();
                 // Only call UpdateBounds if the new bounds are different.
                 //
                 bool different = false;
 
-                if ((wp->flags & NativeMethods.SWP_NOMOVE) == 0 && (wp->x != Left || wp->y != Top)) {
+                if ((wp.flags & NativeMethods.SWP_NOMOVE) == 0 && (wp.x != Left || wp.y != Top)) {
                     different = true;
                 }
-                if ((wp->flags & NativeMethods.SWP_NOSIZE) == 0 && (wp->cx != Width || wp->cy != Height)) {
+                if ((wp.flags & NativeMethods.SWP_NOSIZE) == 0 && (wp.cx != Width || wp.cy != Height)) {
                     different = true;
                 }
 
                 if (different) {
-                    ActiveXUpdateBounds(ref wp->x, ref wp->y, ref wp->cx, ref wp->cy, wp->flags);
+                    ActiveXUpdateBounds(ref wp.x, ref wp.y, ref wp.cx, ref wp.cy, wp.flags);
                 }
             }
 
@@ -13323,15 +13323,15 @@ example usage
         ///     Handles the WM_WINDOWPOSCHANGED message
         /// </devdoc>
         /// <internalonly/>
-        private unsafe void WmWindowPosChanged(ref Message m) {
+        private void WmWindowPosChanged(ref Message m) {
             DefWndProc(ref m);
             // Update new size / position
             UpdateBounds();
             if (parent != null && UnsafeNativeMethods.GetParent(new HandleRef(window, InternalHandle)) == parent.InternalHandle &&
                 (state & STATE_NOZORDER) == 0) {
 
-                NativeMethods.WINDOWPOS* wp = (NativeMethods.WINDOWPOS *)m.LParam;
-                if ((wp->flags & NativeMethods.SWP_NOZORDER) == 0) {
+                ref readonly NativeMethods.WINDOWPOS wp = ref m.GetLParamRef<NativeMethods.WINDOWPOS>();
+                if ((wp.flags & NativeMethods.SWP_NOZORDER) == 0) {
                     parent.UpdateChildControlIndex(this);
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -12842,15 +12842,15 @@ example usage
         ///     Handles the WM_NOTIFY message
         /// </devdoc>
         /// <internalonly/>
-        private unsafe void WmNotify(ref Message m) {
-            NativeMethods.NMHDR* nmhdr = (NativeMethods.NMHDR*)m.LParam;
-            if (!ReflectMessage(nmhdr->hwndFrom,ref m)) {
-                if(nmhdr->code == NativeMethods.TTN_SHOW) {
-                    m.Result = UnsafeNativeMethods.SendMessage(new HandleRef(null, nmhdr->hwndFrom), Interop.WindowMessages.WM_REFLECT + m.Msg, m.WParam, m.LParam);
+        private void WmNotify(ref Message m) {
+            ref readonly NativeMethods.NMHDR nmhdr = ref m.GetLParamRef<NativeMethods.NMHDR>();
+            if (!ReflectMessage(nmhdr.hwndFrom,ref m)) {
+                if(nmhdr.code == NativeMethods.TTN_SHOW) {
+                    m.Result = UnsafeNativeMethods.SendMessage(new HandleRef(null, nmhdr.hwndFrom), Interop.WindowMessages.WM_REFLECT + m.Msg, m.WParam, m.LParam);
                     return;
                 }
-                if(nmhdr->code == NativeMethods.TTN_POP) {
-                    UnsafeNativeMethods.SendMessage(new HandleRef(null, nmhdr->hwndFrom), Interop.WindowMessages.WM_REFLECT + m.Msg, m.WParam, m.LParam);
+                if(nmhdr.code == NativeMethods.TTN_POP) {
+                    UnsafeNativeMethods.SendMessage(new HandleRef(null, nmhdr.hwndFrom), Interop.WindowMessages.WM_REFLECT + m.Msg, m.WParam, m.LParam);
                 }
                 
                 DefWndProc(ref m);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewMethods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewMethods.cs
@@ -29802,22 +29802,22 @@ namespace System.Windows.Forms
             }
         }
 
-        private unsafe bool WmNotify(ref Message m)
+        private bool WmNotify(ref Message m)
         {
             if (m.LParam == IntPtr.Zero)
             {
                 return false;
             }
 
-            NativeMethods.NMHDR* nmhdr = (NativeMethods.NMHDR *)m.LParam;
-            if (nmhdr->code == NativeMethods.TTN_GETDISPINFO && !DesignMode)
+            ref readonly NativeMethods.NMHDR nmhdr = ref m.GetLParamRef<NativeMethods.NMHDR>();
+            if (nmhdr.code == NativeMethods.TTN_GETDISPINFO && !DesignMode)
             {
                 string toolTip = this.ToolTipPrivate;
 
                 if (!string.IsNullOrEmpty(toolTip))
                 {
                     // MSDN: Setting the max width has the added benefit of enabling multiline tool tips!
-                    UnsafeNativeMethods.SendMessage(new HandleRef(this, nmhdr->hwndFrom), NativeMethods.TTM_SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
+                    UnsafeNativeMethods.SendMessage(new HandleRef(this, nmhdr.hwndFrom), NativeMethods.TTM_SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
                     NativeMethods.TOOLTIPTEXT ttt = (NativeMethods.TOOLTIPTEXT) m.GetLParam(typeof(NativeMethods.TOOLTIPTEXT));
 
                     ttt.lpszText = toolTip;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
@@ -1621,7 +1621,7 @@ namespace System.Windows.Forms {
         private void WmReflectCommand(ref Message m) {
             if (m.HWnd == Handle) {
 
-                NativeMethods.NMHDR nmhdr = (NativeMethods.NMHDR)m.GetLParam(typeof(NativeMethods.NMHDR));
+                ref readonly NativeMethods.NMHDR nmhdr = ref m.GetLParamRef<NativeMethods.NMHDR>();
                 switch (nmhdr.code) {
                     case NativeMethods.DTN_CLOSEUP:
                         WmCloseUp(ref m);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.cs
@@ -840,7 +840,7 @@ namespace System.Windows.Forms.Design {
 
             protected override void WndProc(ref Message m) {
                 if (m.Msg == Interop.WindowMessages.WM_REFLECT + Interop.WindowMessages.WM_NOTIFY) {
-                    NativeMethods.NMHDR nmh = (NativeMethods.NMHDR)m.GetLParam(typeof(NativeMethods.NMHDR));
+                    ref readonly NativeMethods.NMHDR nmh = ref m.GetLParamRef<NativeMethods.NMHDR>();
                     if (nmh.code == NativeMethods.NM_CUSTOMDRAW) {
                         OnCustomDraw(ref m);
                         return;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DpiChangedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DpiChangedEventArgs.cs
@@ -5,7 +5,6 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
-using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms
 {
@@ -22,7 +21,7 @@ namespace System.Windows.Forms
             DeviceDpiOld = old;
             DeviceDpiNew = NativeMethods.Util.SignedLOWORD(m.WParam);
             Debug.Assert(NativeMethods.Util.SignedHIWORD(m.WParam) == DeviceDpiNew, "Non-square pixels!");
-            NativeMethods.RECT suggestedRect = Marshal.PtrToStructure<NativeMethods.RECT>(m.LParam);
+            ref readonly NativeMethods.RECT suggestedRect = ref m.GetLParamRef<NativeMethods.RECT>();
             SuggestedRectangle = Rectangle.FromLTRB(suggestedRect.left, suggestedRect.top, suggestedRect.right, suggestedRect.bottom);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
@@ -1254,7 +1254,7 @@ namespace System.Windows.Forms {
             protected override void WndProc(ref Message m) {
                 switch (m.Msg) {
                     case Interop.WindowMessages.WM_NOTIFY:
-                        NativeMethods.NMHDR nmhdr = (NativeMethods.NMHDR)m.GetLParam(typeof(NativeMethods.NMHDR));
+                        ref readonly NativeMethods.NMHDR nmhdr = ref m.GetLParamRef<NativeMethods.NMHDR>();
                         if (nmhdr.code == NativeMethods.TTN_SHOW || nmhdr.code == NativeMethods.TTN_POP)
                         {
                             OnToolTipVisibilityChanging(nmhdr.idFrom, nmhdr.code == NativeMethods.TTN_SHOW);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
@@ -627,21 +627,19 @@ namespace System.Windows.Forms {
             // do the actual copy
             int offsetSrc = 0;
             int offsetDest = 0;
-            unsafe {
-                for (int i = 0; i < targetData.Height; i++)
-                {
-                    IntPtr srcPtr, destPtr;
-                    if (IntPtr.Size == 4) {
-                        srcPtr = new IntPtr(sourceData.Scan0.ToInt32() + offsetSrc);
-                        destPtr = new IntPtr(targetData.Scan0.ToInt32() + offsetDest);
-                    } else {
-                        srcPtr = new IntPtr(sourceData.Scan0.ToInt64() + offsetSrc);
-                        destPtr = new IntPtr(targetData.Scan0.ToInt64() + offsetDest);
-                    }
-                    UnsafeNativeMethods.CopyMemory(new HandleRef(this, destPtr), new HandleRef(this, srcPtr), Math.Abs(targetData.Stride)); 
-                    offsetSrc += sourceData.Stride;
-                    offsetDest += targetData.Stride;
+            for (int i = 0; i < targetData.Height; i++)
+            {
+                IntPtr srcPtr, destPtr;
+                if (IntPtr.Size == 4) {
+                    srcPtr = new IntPtr(sourceData.Scan0.ToInt32() + offsetSrc);
+                    destPtr = new IntPtr(targetData.Scan0.ToInt32() + offsetDest);
+                } else {
+                    srcPtr = new IntPtr(sourceData.Scan0.ToInt64() + offsetSrc);
+                    destPtr = new IntPtr(targetData.Scan0.ToInt64() + offsetDest);
                 }
+                UnsafeNativeMethods.CopyMemory(new HandleRef(this, destPtr), new HandleRef(this, srcPtr), Math.Abs(targetData.Stride)); 
+                offsetSrc += sourceData.Stride;
+                offsetDest += targetData.Stride;
             }
         }
         

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -5930,7 +5930,7 @@ namespace System.Windows.Forms {
                     }
                     else if (nmhdr.code == NativeMethods.LVN_ODFINDITEM) {
                         if (VirtualMode) {
-                            NativeMethods.NMLVFINDITEM nmlvif = (NativeMethods.NMLVFINDITEM) m.GetLParam(typeof(NativeMethods.NMLVFINDITEM));
+                            NativeMethods.NMLVFINDITEM nmlvif = m.GetLParam<NativeMethods.NMLVFINDITEM>();
 
                             if ((nmlvif.lvfi.flags & NativeMethods.LVFI_PARAM) != 0) {
                                 m.Result = (IntPtr) (-1);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -4412,7 +4412,7 @@ namespace System.Windows.Forms {
                 eh(this, e);
         }
 
-        private unsafe void PositionHeader() {
+        private void PositionHeader() {
             IntPtr hdrHWND = UnsafeNativeMethods.GetWindow(new HandleRef(this, this.Handle), NativeMethods.GW_CHILD);
             if (hdrHWND != IntPtr.Zero) {
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -5274,10 +5274,10 @@ namespace System.Windows.Forms {
         }
 
         private unsafe bool WmNotify(ref Message m) {
-            NativeMethods.NMHDR* nmhdr = (NativeMethods.NMHDR*)m.LParam;
+            ref readonly NativeMethods.NMHDR nmhdr = ref m.GetLParamRef<NativeMethods.NMHDR>();
 
             // column header custom draw message handling
-            if (nmhdr->code == NativeMethods.NM_CUSTOMDRAW && OwnerDraw)
+            if (nmhdr.code == NativeMethods.NM_CUSTOMDRAW && OwnerDraw)
             {
                 try
                 {
@@ -5339,12 +5339,12 @@ namespace System.Windows.Forms {
             }
 
 
-            if (nmhdr->code == NativeMethods.NM_RELEASEDCAPTURE && listViewState[LISTVIEWSTATE_columnClicked]) {
+            if (nmhdr.code == NativeMethods.NM_RELEASEDCAPTURE && listViewState[LISTVIEWSTATE_columnClicked]) {
                 listViewState[LISTVIEWSTATE_columnClicked] = false;
                 OnColumnClick(new ColumnClickEventArgs(columnIndex));
             }
 
-            if (nmhdr->code == NativeMethods.HDN_BEGINTRACK) {
+            if (nmhdr.code == NativeMethods.HDN_BEGINTRACK) {
                this.listViewState[LISTVIEWSTATE_headerControlTracking] = true;
 
                // Reset our tracking information for the new BEGINTRACK cycle.
@@ -5362,7 +5362,7 @@ namespace System.Windows.Forms {
                }
             }
 
-            if (nmhdr->code == NativeMethods.HDN_ITEMCHANGING) {
+            if (nmhdr.code == NativeMethods.HDN_ITEMCHANGING) {
                 NativeMethods.NMHEADER nmheader = (NativeMethods.NMHEADER) m.GetLParam(typeof(NativeMethods.NMHEADER));
 
                 if (columnHeaders != null && nmheader.iItem < columnHeaders.Length &&
@@ -5396,7 +5396,7 @@ namespace System.Windows.Forms {
                 }
             }
 
-            if ((nmhdr->code == NativeMethods.HDN_ITEMCHANGED) &&
+            if ((nmhdr.code == NativeMethods.HDN_ITEMCHANGED) &&
                 !this.listViewState[LISTVIEWSTATE_headerControlTracking]) {
                 NativeMethods.NMHEADER nmheader = (NativeMethods.NMHEADER)m.GetLParam(typeof(NativeMethods.NMHEADER));
                 if (columnHeaders != null && nmheader.iItem < columnHeaders.Length) {
@@ -5443,7 +5443,7 @@ namespace System.Windows.Forms {
                 }
             }
 
-            if (nmhdr->code == NativeMethods.HDN_ENDTRACK) {
+            if (nmhdr.code == NativeMethods.HDN_ENDTRACK) {
                 Debug.Assert(this.listViewState[LISTVIEWSTATE_headerControlTracking], "HDN_ENDTRACK and HDN_BEGINTRACK are out of sync...");
                 this.listViewState[LISTVIEWSTATE_headerControlTracking] = false;
                 if (this.listViewState1[LISTVIEWSTATE1_cancelledColumnWidthChanging]) {
@@ -5465,7 +5465,7 @@ namespace System.Windows.Forms {
                 }
             }
 
-            if (nmhdr->code == NativeMethods.HDN_ENDDRAG) {
+            if (nmhdr.code == NativeMethods.HDN_ENDDRAG) {
                 NativeMethods.NMHEADER header = (NativeMethods.NMHEADER) m.GetLParam(typeof(NativeMethods.NMHEADER));
                 if (header.pItem != IntPtr.Zero) {
 
@@ -5520,7 +5520,7 @@ namespace System.Windows.Forms {
                 }
             }
 
-            if (nmhdr->code == NativeMethods.HDN_DIVIDERDBLCLICK) {
+            if (nmhdr.code == NativeMethods.HDN_DIVIDERDBLCLICK) {
                 // We need to keep track that the user double clicked the column header divider
                 // so we know that the column header width is changing.
                 this.listViewState[LISTVIEWSTATE_headerDividerDblClick] = true;
@@ -5624,9 +5624,9 @@ namespace System.Windows.Forms {
         [SuppressMessage("Microsoft.Performance", "CA1808:AvoidCallsThatBoxValueTypes")]
         private unsafe void WmReflectNotify(ref Message m) {
 
-            NativeMethods.NMHDR* nmhdr = (NativeMethods.NMHDR*)m.LParam;
+            ref readonly NativeMethods.NMHDR nmhdr = ref m.GetLParamRef<NativeMethods.NMHDR>();
 
-            switch (nmhdr->code) {
+            switch (nmhdr.code) {
                 case NativeMethods.NM_CUSTOMDRAW:
                     CustomDraw(ref m);
                     break;
@@ -5779,7 +5779,7 @@ namespace System.Windows.Forms {
                     NativeMethods.LVHITTESTINFO lvhi = new NativeMethods.LVHITTESTINFO();
                     int displayIndex = GetIndexOfClickedItem(lvhi);
 
-                    MouseButtons button = nmhdr->code == NativeMethods.NM_CLICK ? MouseButtons.Left : MouseButtons.Right;
+                    MouseButtons button = nmhdr.code == NativeMethods.NM_CLICK ? MouseButtons.Left : MouseButtons.Right;
                     Point pos = Cursor.Position;
                     pos = PointToClient(pos);
 
@@ -5840,7 +5840,7 @@ namespace System.Windows.Forms {
                     break;
 
                 default:
-                    if (nmhdr->code == NativeMethods.LVN_GETDISPINFO) {
+                    if (nmhdr.code == NativeMethods.LVN_GETDISPINFO) {
                         // we use the LVN_GETDISPINFO message only in virtual mode
                         if (this.VirtualMode && m.LParam != IntPtr.Zero) {
                             NativeMethods.NMLVDISPINFO_NOTEXT dispInfo= (NativeMethods.NMLVDISPINFO_NOTEXT) m.GetLParam(typeof(NativeMethods.NMLVDISPINFO_NOTEXT));
@@ -5892,7 +5892,7 @@ namespace System.Windows.Forms {
 
                         }
                     }
-                    else if (nmhdr->code == NativeMethods.LVN_ODSTATECHANGED) {
+                    else if (nmhdr.code == NativeMethods.LVN_ODSTATECHANGED) {
                         if (VirtualMode && m.LParam != IntPtr.Zero) {
                             NativeMethods.NMLVODSTATECHANGE odStateChange = (NativeMethods.NMLVODSTATECHANGE) m.GetLParam(typeof(NativeMethods.NMLVODSTATECHANGE));
                             bool selectedChanged = (odStateChange.uNewState & NativeMethods.LVIS_SELECTED) != (odStateChange.uOldState & NativeMethods.LVIS_SELECTED);
@@ -5906,7 +5906,7 @@ namespace System.Windows.Forms {
                             }
                         }
                     }
-                    else if (nmhdr->code == NativeMethods.LVN_GETINFOTIP) {
+                    else if (nmhdr.code == NativeMethods.LVN_GETINFOTIP) {
                         if (ShowItemToolTips && m.LParam != IntPtr.Zero) {
                             NativeMethods.NMLVGETINFOTIP infoTip = (NativeMethods.NMLVGETINFOTIP) m.GetLParam(typeof(NativeMethods.NMLVGETINFOTIP));
                             ListViewItem lvi = Items[infoTip.item];
@@ -5917,7 +5917,7 @@ namespace System.Windows.Forms {
                                 // tool tips!
                                 //
                                 
-                                UnsafeNativeMethods.SendMessage(new HandleRef(this, nmhdr->hwndFrom), NativeMethods.TTM_SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
+                                UnsafeNativeMethods.SendMessage(new HandleRef(this, nmhdr.hwndFrom), NativeMethods.TTM_SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
 
                                 // UNICODE. Use char.
                                 // we need to copy the null terminator character ourselves
@@ -5928,7 +5928,7 @@ namespace System.Windows.Forms {
                             }
                         }
                     }
-                    else if (nmhdr->code == NativeMethods.LVN_ODFINDITEM) {
+                    else if (nmhdr.code == NativeMethods.LVN_ODFINDITEM) {
                         if (VirtualMode) {
                             NativeMethods.NMLVFINDITEM nmlvif = (NativeMethods.NMLVFINDITEM) m.GetLParam(typeof(NativeMethods.NMLVFINDITEM));
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -3914,7 +3914,7 @@ namespace System.Windows.Forms {
             }
         }
 
-        private void LvnBeginDrag(MouseButtons buttons, NativeMethods.NMLISTVIEW nmlv) {
+        private void LvnBeginDrag(MouseButtons buttons, in NativeMethods.NMLISTVIEW nmlv) {
             ListViewItem item = Items[nmlv.iItem];
             OnItemDrag(new ItemDragEventArgs(buttons, item));
         }
@@ -5622,7 +5622,7 @@ namespace System.Windows.Forms {
         /// </devdoc>
         /// <internalonly/>
         [SuppressMessage("Microsoft.Performance", "CA1808:AvoidCallsThatBoxValueTypes")]
-        private unsafe void WmReflectNotify(ref Message m) {
+        private void WmReflectNotify(ref Message m) {
 
             ref readonly NativeMethods.NMHDR nmhdr = ref m.GetLParamRef<NativeMethods.NMHDR>();
 
@@ -5641,7 +5641,7 @@ namespace System.Windows.Forms {
                     }
 
                 case NativeMethods.LVN_COLUMNCLICK: {
-                        NativeMethods.NMLISTVIEW nmlv = (NativeMethods.NMLISTVIEW)m.GetLParam(typeof(NativeMethods.NMLISTVIEW));
+                        ref readonly NativeMethods.NMLISTVIEW nmlv = ref m.GetLParamRef<NativeMethods.NMLISTVIEW>();
                         listViewState[LISTVIEWSTATE_columnClicked] = true;
                         columnIndex = nmlv.iSubItem;
                         break;
@@ -5670,8 +5670,8 @@ namespace System.Windows.Forms {
                     // so don't tell the user about this operation...
                     // 
                     if (!this.ItemCollectionChangedInMouseDown) {
-                        NativeMethods.NMLISTVIEW nmlv = (NativeMethods.NMLISTVIEW)m.GetLParam(typeof(NativeMethods.NMLISTVIEW));
-                        LvnBeginDrag(MouseButtons.Left, nmlv);
+                        ref readonly NativeMethods.NMLISTVIEW nmlv = ref m.GetLParamRef<NativeMethods.NMLISTVIEW>();
+                        LvnBeginDrag(MouseButtons.Left, in nmlv);
                     }
 
                     break;
@@ -5683,23 +5683,23 @@ namespace System.Windows.Forms {
                     // so don't tell the user about this operation...
                     // 
                     if (!this.ItemCollectionChangedInMouseDown) {
-                        NativeMethods.NMLISTVIEW nmlv = (NativeMethods.NMLISTVIEW)m.GetLParam(typeof(NativeMethods.NMLISTVIEW));
-                        LvnBeginDrag(MouseButtons.Right, nmlv);
+                        ref readonly NativeMethods.NMLISTVIEW nmlv = ref m.GetLParamRef<NativeMethods.NMLISTVIEW>();
+                        LvnBeginDrag(MouseButtons.Right, in nmlv);
                     }
                     break;
                 }
 
 
                 case NativeMethods.LVN_ITEMCHANGING: {
-                        NativeMethods.NMLISTVIEW* nmlv = (NativeMethods.NMLISTVIEW*)m.LParam;
-                        if ((nmlv->uChanged & NativeMethods.LVIF_STATE) != 0) {
+                        ref readonly NativeMethods.NMLISTVIEW nmlv = ref m.GetLParamRef<NativeMethods.NMLISTVIEW>();
+                        if ((nmlv.uChanged & NativeMethods.LVIF_STATE) != 0) {
                             // Because the state image mask is 1-based, a value of 1 means unchecked,
                             // anything else means checked.  We convert this to the more standard 0 or 1
-                            CheckState oldState = (CheckState)(((nmlv->uOldState & NativeMethods.LVIS_STATEIMAGEMASK) >> 12) == 1 ? 0 : 1);
-                            CheckState newState = (CheckState)(((nmlv->uNewState & NativeMethods.LVIS_STATEIMAGEMASK) >> 12) == 1 ? 0 : 1);
+                            CheckState oldState = (CheckState)(((nmlv.uOldState & NativeMethods.LVIS_STATEIMAGEMASK) >> 12) == 1 ? 0 : 1);
+                            CheckState newState = (CheckState)(((nmlv.uNewState & NativeMethods.LVIS_STATEIMAGEMASK) >> 12) == 1 ? 0 : 1);
 
                             if (oldState != newState) {
-                                ItemCheckEventArgs e = new ItemCheckEventArgs(nmlv->iItem, newState, oldState);
+                                ItemCheckEventArgs e = new ItemCheckEventArgs(nmlv.iItem, newState, oldState);
                                 OnItemCheck(e);
                                 m.Result = (IntPtr)(((int)e.NewValue == 0 ? 0 : 1) == (int)oldState ? 1 : 0);
                             }
@@ -5708,24 +5708,24 @@ namespace System.Windows.Forms {
                     }
 
                 case NativeMethods.LVN_ITEMCHANGED: {
-                        NativeMethods.NMLISTVIEW* nmlv = (NativeMethods.NMLISTVIEW*)m.LParam;
+                        ref readonly NativeMethods.NMLISTVIEW nmlv = ref m.GetLParamRef<NativeMethods.NMLISTVIEW>();
                         // Check for state changes to the selected state...
-                        if ((nmlv->uChanged & NativeMethods.LVIF_STATE) != 0) {
+                        if ((nmlv.uChanged & NativeMethods.LVIF_STATE) != 0) {
                             // Because the state image mask is 1-based, a value of 1 means unchecked,
                             // anything else means checked.  We convert this to the more standard 0 or 1
-                            CheckState oldValue = (CheckState)(((nmlv->uOldState & NativeMethods.LVIS_STATEIMAGEMASK) >> 12) == 1 ? 0 : 1);
-                            CheckState newValue = (CheckState)(((nmlv->uNewState & NativeMethods.LVIS_STATEIMAGEMASK) >> 12) == 1 ? 0 : 1);
+                            CheckState oldValue = (CheckState)(((nmlv.uOldState & NativeMethods.LVIS_STATEIMAGEMASK) >> 12) == 1 ? 0 : 1);
+                            CheckState newValue = (CheckState)(((nmlv.uNewState & NativeMethods.LVIS_STATEIMAGEMASK) >> 12) == 1 ? 0 : 1);
 
                             if (newValue != oldValue) {
-                                ItemCheckedEventArgs e = new ItemCheckedEventArgs(Items[nmlv->iItem]);
+                                ItemCheckedEventArgs e = new ItemCheckedEventArgs(Items[nmlv.iItem]);
                                 OnItemChecked(e);
                                 
-                                AccessibilityNotifyClients(AccessibleEvents.StateChange, nmlv->iItem);
-                                AccessibilityNotifyClients(AccessibleEvents.NameChange, nmlv->iItem);
+                                AccessibilityNotifyClients(AccessibleEvents.StateChange, nmlv.iItem);
+                                AccessibilityNotifyClients(AccessibleEvents.NameChange, nmlv.iItem);
                             }
 
-                            int oldState = nmlv->uOldState & NativeMethods.LVIS_SELECTED;
-                            int newState = nmlv->uNewState & NativeMethods.LVIS_SELECTED;
+                            int oldState = nmlv.uOldState & NativeMethods.LVIS_SELECTED;
+                            int newState = nmlv.uNewState & NativeMethods.LVIS_SELECTED;
                             // Windows common control always fires
                             // this event twice, once with newState, oldState, and again with
                             // oldState, newState.
@@ -5733,7 +5733,7 @@ namespace System.Windows.Forms {
                             // fires the event on a Deselct of an Items from multiple selections.
                             // So leave it as it is...
                             if (newState != oldState) {
-                                if (this.VirtualMode && nmlv->iItem == -1)
+                                if (this.VirtualMode && nmlv.iItem == -1)
                                 {
                                     if (this.VirtualListSize > 0) {
                                         ListViewVirtualItemsSelectionRangeChangedEventArgs lvvisrce = new ListViewVirtualItemsSelectionRangeChangedEventArgs(0, this.VirtualListSize-1, newState != 0);
@@ -5749,8 +5749,8 @@ namespace System.Windows.Forms {
                                     // And that may cause GetItemAt to throw an out of bounds exception.
 
                                     if (this.Items.Count > 0) {
-                                        ListViewItemSelectionChangedEventArgs lvisce = new ListViewItemSelectionChangedEventArgs(this.Items[nmlv->iItem],
-                                                                                                                                 nmlv->iItem,
+                                        ListViewItemSelectionChangedEventArgs lvisce = new ListViewItemSelectionChangedEventArgs(this.Items[nmlv.iItem],
+                                                                                                                                 nmlv.iItem,
                                                                                                                                  newState != 0);
                                         OnItemSelectionChanged(lvisce);
                                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Message.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Message.cs
@@ -40,6 +40,22 @@ namespace System.Windows.Forms
         public object GetLParam(Type cls) => Marshal.PtrToStructure(LParam, cls);
 
         /// <summary>
+        /// Gets the <see cref='Message.lparam'/> value, and converts the value to an object of type
+        /// <typeparamref name="T"/>.
+        /// </summary>
+        internal T GetLParam<T>() => Marshal.PtrToStructure<T>(LParam);
+
+        /// <summary>
+        /// Gets a reference to the structure of type <typeparamref name="T"/> pointed to by the
+        /// <see cref='Message.lparam'/> value.
+        /// </summary>
+        internal ref T GetLParamRef<T>()
+            where T : unmanaged
+        {
+            return ref UnsafeNativeMethods.PtrToRef<T>(LParam);
+        }
+
+        /// <summary>
         /// Creates a new <see cref='System.Windows.Forms.Message'/> object.
         /// </summary>
         public static Message Create(IntPtr hWnd, int msg, IntPtr wparam, IntPtr lparam)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -2280,7 +2280,7 @@ namespace System.Windows.Forms {
         /// <internalonly/>
         private void WmReflectCommand(ref Message m) {
             if (m.HWnd == Handle) {
-                NativeMethods.NMHDR nmhdr = (NativeMethods.NMHDR)m.GetLParam(typeof(NativeMethods.NMHDR));
+                ref readonly NativeMethods.NMHDR nmhdr = ref m.GetLParamRef<NativeMethods.NMHDR>();
                 switch (nmhdr.code) {
                     case NativeMethods.MCN_SELECT:
                         WmDateSelected(ref m);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -5181,12 +5181,12 @@ namespace System.Windows.Forms.PropertyGridInternal {
             }
         }
         
-        private unsafe bool WmNotify(ref Message m) {
+        private bool WmNotify(ref Message m) {
             if (m.LParam != IntPtr.Zero) {
-                NativeMethods.NMHDR* nmhdr = (NativeMethods.NMHDR*)m.LParam;
+                ref readonly NativeMethods.NMHDR nmhdr = ref m.GetLParamRef<NativeMethods.NMHDR>();
             
-                if (nmhdr->hwndFrom == ToolTip.Handle) {
-                    switch (nmhdr->code) {
+                if (nmhdr.hwndFrom == ToolTip.Handle) {
+                    switch (nmhdr.code) {
                         case NativeMethods.TTN_POP:
                             break;
                         case NativeMethods.TTN_SHOW:
@@ -6704,13 +6704,13 @@ namespace System.Windows.Forms.PropertyGridInternal {
                 return psheet.WantsTab(forward);
             }
       
-            private unsafe bool WmNotify(ref Message m) {
+            private bool WmNotify(ref Message m) {
                 
                 if (m.LParam != IntPtr.Zero) {
-                   NativeMethods.NMHDR* nmhdr = (NativeMethods.NMHDR*)m.LParam;
+                   ref readonly NativeMethods.NMHDR nmhdr = ref m.GetLParamRef<NativeMethods.NMHDR>();
                    
-                   if (nmhdr->hwndFrom == psheet.ToolTip.Handle) {
-                       switch (nmhdr->code) {
+                   if (nmhdr.hwndFrom == psheet.ToolTip.Handle) {
+                       switch (nmhdr.code) {
                           case NativeMethods.TTN_SHOW:
                              PropertyGridView.PositionTooltip(this, psheet.ToolTip, ClientRectangle);
                              m.Result = (IntPtr)1;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -3261,7 +3261,7 @@ namespace System.Windows.Forms {
         /// <internalonly/>
         internal void WmReflectNotify(ref Message m) {
             if (m.HWnd == Handle) {
-                NativeMethods.NMHDR nmhdr = (NativeMethods.NMHDR)m.GetLParam(typeof(NativeMethods.NMHDR));
+                ref readonly NativeMethods.NMHDR nmhdr = ref m.GetLParamRef<NativeMethods.NMHDR>();
                 switch (nmhdr.code) {
                     case RichTextBoxConstants.EN_LINK:
                         EnLinkMsgHandler(ref m);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
@@ -1160,7 +1160,7 @@ namespace System.Windows.Forms {
                     break;
                 case Interop.WindowMessages.WM_NOTIFY:
                 case Interop.WindowMessages.WM_NOTIFY + Interop.WindowMessages.WM_REFLECT:
-                    NativeMethods.NMHDR note = (NativeMethods.NMHDR)m.GetLParam(typeof(NativeMethods.NMHDR));
+                    ref readonly NativeMethods.NMHDR note = ref m.GetLParamRef<NativeMethods.NMHDR>();
                     switch (note.code) {
                         case NativeMethods.NM_CLICK:
                         case NativeMethods.NM_RCLICK:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
@@ -1039,7 +1039,7 @@ namespace System.Windows.Forms {
         /// <internalonly/>
         /// <devdoc>
         /// </devdoc>
-        private void WmNotifyNMClick(NativeMethods.NMHDR note) {
+        private void WmNotifyNMClick(in NativeMethods.NMHDR note) {
 
             if (!showPanels) {
                 return;
@@ -1166,7 +1166,7 @@ namespace System.Windows.Forms {
                         case NativeMethods.NM_RCLICK:
                         case NativeMethods.NM_DBLCLK:
                         case NativeMethods.NM_RDBLCLK:
-                            WmNotifyNMClick(note);
+                            WmNotifyNMClick(in note);
                             break;
                         default:
                             base.WndProc(ref m);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -2086,7 +2086,7 @@ namespace System.Windows.Forms {
 
                 case Interop.WindowMessages.WM_NOTIFY:
                 case Interop.WindowMessages.WM_REFLECT + Interop.WindowMessages.WM_NOTIFY:
-                    NativeMethods.NMHDR nmhdr = (NativeMethods.NMHDR) m.GetLParam(typeof(NativeMethods.NMHDR));
+                    ref readonly NativeMethods.NMHDR nmhdr = ref m.GetLParamRef<NativeMethods.NMHDR>();
                     switch (nmhdr.code) {
                         // new switch added to prevent the TabControl from changing to next TabPage ...
                         //in case of validation cancelled...

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolBar.cs
@@ -1583,7 +1583,7 @@ namespace System.Windows.Forms {
         // position the tooltip window when the underlying toolbar control attempts to display it.
         private void WmNotifyHotItemChange(ref Message m) {
             // Should we set the hot item?
-            NativeMethods.NMTBHOTITEM nmTbHotItem = (NativeMethods.NMTBHOTITEM)m.GetLParam(typeof(NativeMethods.NMTBHOTITEM));
+            ref readonly NativeMethods.NMTBHOTITEM nmTbHotItem = ref m.GetLParamRef<NativeMethods.NMTBHOTITEM>();
             if (NativeMethods.HICF_ENTERING == (nmTbHotItem.dwFlags & NativeMethods.HICF_ENTERING))
                 this.hotItem = nmTbHotItem.idNew;
             else if (NativeMethods.HICF_LEAVING == (nmTbHotItem.dwFlags & NativeMethods.HICF_LEAVING))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolBar.cs
@@ -1515,7 +1515,7 @@ namespace System.Windows.Forms {
         /// </devdoc>
         /// <internalonly/>
         private void WmNotifyDropDown(ref Message m) {
-            NativeMethods.NMTOOLBAR nmTB = (NativeMethods.NMTOOLBAR)m.GetLParam(typeof(NativeMethods.NMTOOLBAR));
+            ref readonly NativeMethods.NMTOOLBAR nmTB = ref m.GetLParamRef<NativeMethods.NMTOOLBAR>();
 
             ToolBarButton tbb = (ToolBarButton)buttons[nmTB.iItem];
             if (tbb == null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolBar.cs
@@ -1636,7 +1636,7 @@ namespace System.Windows.Forms {
 
                 case Interop.WindowMessages.WM_NOTIFY:
                 case Interop.WindowMessages.WM_NOTIFY + Interop.WindowMessages.WM_REFLECT:
-                    NativeMethods.NMHDR note = (NativeMethods.NMHDR) m.GetLParam(typeof(NativeMethods.NMHDR));
+                    ref readonly NativeMethods.NMHDR note = ref m.GetLParamRef<NativeMethods.NMHDR>();
                     switch (note.code) {
                         case NativeMethods.TTN_NEEDTEXT:
                             // MSDN:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.cs
@@ -1362,17 +1362,17 @@ namespace System.Windows.Forms {
                     }
                 }
 
-                private unsafe IntPtr MessageHookProc(int nCode, IntPtr wparam, IntPtr lparam) {
+                private IntPtr MessageHookProc(int nCode, IntPtr wparam, IntPtr lparam) {
                     if (nCode == NativeMethods.HC_ACTION)  {
                         if (isHooked && (int)wparam == NativeMethods.PM_REMOVE /*only process GetMessage, not PeekMessage*/) {
                             // only process messages we've pulled off the queue
-                            NativeMethods.MSG* msg = (NativeMethods.MSG*)lparam;
-                            if (msg != null) {
+                            if (lparam != IntPtr.Zero) {
+                                ref NativeMethods.MSG msg = ref UnsafeNativeMethods.PtrToRef<NativeMethods.MSG>(lparam);
                                 //Debug.WriteLine("Got " + Message.Create(msg->hwnd, msg->message, wparam, lparam).ToString());
                                 // call pretranslate on the message - this should execute
                                 // the message filters and preprocess message.
-                                if (Application.ThreadContext.FromCurrent().PreTranslateMessage(ref *msg)) {
-                                    msg->message = Interop.WindowMessages.WM_NULL;
+                                if (Application.ThreadContext.FromCurrent().PreTranslateMessage(ref msg)) {
+                                    msg.message = Interop.WindowMessages.WM_NULL;
                                 }
                             }
                         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -2498,7 +2498,7 @@ namespace System.Windows.Forms {
             switch (msg.Msg) {
 
             case Interop.WindowMessages.WM_REFLECT + Interop.WindowMessages.WM_NOTIFY:
-                 NativeMethods.NMHDR nmhdr = (NativeMethods.NMHDR) msg.GetLParam(typeof(NativeMethods.NMHDR));
+                 ref readonly NativeMethods.NMHDR nmhdr = ref msg.GetLParamRef<NativeMethods.NMHDR>();
                  if (nmhdr.code == NativeMethods.TTN_SHOW && !trackPosition) {
                      WmShow();
                  }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -2335,13 +2335,13 @@ namespace System.Windows.Forms {
         ///     Handles the WM_WINDOWPOSCHANGING message.
         /// </devdoc>
         /// <internalonly/>
-        private unsafe void WmWindowPosChanging(ref Message m) {
+        private void WmWindowPosChanging(ref Message m) {
             if (cancelled || isDisposing)
             {
             	return;
             }
 
-            NativeMethods.WINDOWPOS* wp = (NativeMethods.WINDOWPOS *)m.LParam;
+            ref NativeMethods.WINDOWPOS wp = ref m.GetLParamRef<NativeMethods.WINDOWPOS>();
             
             Cursor currentCursor = Cursor.CurrentInternal;
             Point cursorPos = Cursor.Position;
@@ -2380,7 +2380,7 @@ namespace System.Windows.Forms {
                 }
 
                 if (IsBalloon) {
-                   wp->cx += 2*XBALLOONOFFSET;
+                   wp.cx += 2*XBALLOONOFFSET;
                    return;
                 }
 
@@ -2395,31 +2395,31 @@ namespace System.Windows.Forms {
                    Screen screen = Screen.FromPoint(cursorPos);
                    if (currentCursor != null)
                    {
-                        wp->x = cursorPos.X;
-                        wp->y = cursorPos.Y;
-                        if (wp->y + wp->cy + currentCursor.Size.Height - currentCursor.HotSpot.Y > screen.WorkingArea.Bottom) {
-                            wp->y = cursorPos.Y - wp->cy;
+                        wp.x = cursorPos.X;
+                        wp.y = cursorPos.Y;
+                        if (wp.y + wp.cy + currentCursor.Size.Height - currentCursor.HotSpot.Y > screen.WorkingArea.Bottom) {
+                            wp.y = cursorPos.Y - wp.cy;
                         }
                         else {
-                            wp->y = cursorPos.Y + currentCursor.Size.Height - currentCursor.HotSpot.Y;
+                            wp.y = cursorPos.Y + currentCursor.Size.Height - currentCursor.HotSpot.Y;
                         }
                    }
-                   if (wp->x + wp->cx >screen.WorkingArea.Right) {
-                      wp->x = screen.WorkingArea.Right - wp->cx;
+                   if (wp.x + wp.cx >screen.WorkingArea.Right) {
+                      wp.x = screen.WorkingArea.Right - wp.cx;
                    }
 
                 }
                 else if ((tt.TipType & TipInfo.Type.SemiAbsolute) != 0 && tt.Position != Point.Empty) {
 
                    Screen screen = Screen.FromPoint(tt.Position);
-                   wp->x = tt.Position.X;
-                   if (wp->x + wp->cx >screen.WorkingArea.Right) {
-                      wp->x = screen.WorkingArea.Right - wp->cx;
+                   wp.x = tt.Position.X;
+                   if (wp.x + wp.cx >screen.WorkingArea.Right) {
+                      wp.x = screen.WorkingArea.Right - wp.cx;
                    }
-                   wp->y = tt.Position.Y;
+                   wp.y = tt.Position.Y;
                    
-                   if (wp->y + wp->cy > screen.WorkingArea.Bottom) {
-                        wp->y = screen.WorkingArea.Bottom - wp->cy;
+                   if (wp.y + wp.cy > screen.WorkingArea.Bottom) {
+                        wp.y = screen.WorkingArea.Bottom - wp.cy;
                    }
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -2396,8 +2396,8 @@ namespace System.Windows.Forms {
             return s;
         }
 
-        private unsafe void TvnBeginDrag(MouseButtons buttons, NativeMethods.NMTREEVIEW* nmtv) {
-            ref readonly NativeMethods.TV_ITEM item = ref nmtv->itemNew;
+        private void TvnBeginDrag(MouseButtons buttons, in NativeMethods.NMTREEVIEW nmtv) {
+            ref readonly NativeMethods.TV_ITEM item = ref nmtv.itemNew;
 
             // Check for invalid node handle
             if (item.hItem == IntPtr.Zero) {
@@ -2409,8 +2409,8 @@ namespace System.Windows.Forms {
             OnItemDrag(new ItemDragEventArgs(buttons, node));
         }
 
-        private unsafe IntPtr TvnExpanding(NativeMethods.NMTREEVIEW* nmtv) {
-            ref readonly NativeMethods.TV_ITEM item = ref nmtv->itemNew;
+        private IntPtr TvnExpanding(in NativeMethods.NMTREEVIEW nmtv) {
+            ref readonly NativeMethods.TV_ITEM item = ref nmtv.itemNew;
 
             // Check for invalid node handle
             if (item.hItem == IntPtr.Zero) {
@@ -2429,8 +2429,8 @@ namespace System.Windows.Forms {
             return (IntPtr)(e.Cancel? 1: 0);
         }
 
-        private unsafe void TvnExpanded(NativeMethods.NMTREEVIEW* nmtv) {
-            ref readonly NativeMethods.TV_ITEM item = ref nmtv->itemNew;
+        private void TvnExpanded(in NativeMethods.NMTREEVIEW nmtv) {
+            ref readonly NativeMethods.TV_ITEM item = ref nmtv.itemNew;
 
             // Check for invalid node handle
             if (item.hItem == IntPtr.Zero) {
@@ -2451,20 +2451,20 @@ namespace System.Windows.Forms {
             }
         }
 
-        private unsafe IntPtr TvnSelecting(NativeMethods.NMTREEVIEW* nmtv) {
+        private IntPtr TvnSelecting(in NativeMethods.NMTREEVIEW nmtv) {
             if (treeViewState[ TREEVIEWSTATE_ignoreSelects])
             {
                 return (IntPtr)1;
             }
             // Check for invalid node handle
-            if (nmtv->itemNew.hItem == IntPtr.Zero) {
+            if (nmtv.itemNew.hItem == IntPtr.Zero) {
                 return IntPtr.Zero;
             }
 
-            TreeNode node = NodeFromHandle(nmtv->itemNew.hItem);
+            TreeNode node = NodeFromHandle(nmtv.itemNew.hItem);
 
             TreeViewAction action = TreeViewAction.Unknown;
-            switch(nmtv->action) {
+            switch(nmtv.action) {
                 case NativeMethods.TVC_BYKEYBOARD:
                     action = TreeViewAction.ByKeyboard;
                     break;
@@ -2479,14 +2479,14 @@ namespace System.Windows.Forms {
             return (IntPtr)(e.Cancel? 1: 0);
         }
 
-        private unsafe void TvnSelected(NativeMethods.NMTREEVIEW* nmtv) {
+        private unsafe void TvnSelected(in NativeMethods.NMTREEVIEW nmtv) {
             if (nodesCollectionClear) //if called thru the Clear( ) of treeNodeCollection then just return...
             {
                 return;
             }
-            if (nmtv->itemNew.hItem != IntPtr.Zero) {
+            if (nmtv.itemNew.hItem != IntPtr.Zero) {
                 TreeViewAction action = TreeViewAction.Unknown;
-                switch(nmtv->action) {
+                switch(nmtv.action) {
                     case NativeMethods.TVC_BYKEYBOARD:
                         action = TreeViewAction.ByKeyboard;
                         break;
@@ -2494,15 +2494,15 @@ namespace System.Windows.Forms {
                         action = TreeViewAction.ByMouse;
                         break;
                 }
-                OnAfterSelect(new TreeViewEventArgs(NodeFromHandle(nmtv->itemNew.hItem), action));
+                OnAfterSelect(new TreeViewEventArgs(NodeFromHandle(nmtv.itemNew.hItem), action));
             }
 
             // TreeView doesn't properly revert back to the unselected image
             // if the unselected image is blank.
             //
             NativeMethods.RECT rc = new NativeMethods.RECT();
-            *((IntPtr *) &rc.left) = nmtv->itemOld.hItem;
-            if (nmtv->itemOld.hItem != IntPtr.Zero) {
+            *((IntPtr *) &rc.left) = nmtv.itemOld.hItem;
+            if (nmtv.itemOld.hItem != IntPtr.Zero) {
                 if (unchecked( (int) (long)UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TVM_GETITEMRECT, 1, ref rc)) != 0)
                     SafeNativeMethods.InvalidateRect(new HandleRef(this, Handle), ref rc, true);
             }
@@ -2888,7 +2888,7 @@ namespace System.Windows.Forms {
         }
 
 
-        private unsafe void WmNotify(ref Message m) {
+        private void WmNotify(ref Message m) {
             ref readonly NativeMethods.NMHDR nmhdr = ref m.GetLParamRef<NativeMethods.NMHDR>();
             
             // Custom draw code is handled separately.
@@ -2898,26 +2898,26 @@ namespace System.Windows.Forms {
             }
             else {
                 
-                NativeMethods.NMTREEVIEW* nmtv = (NativeMethods.NMTREEVIEW*)m.LParam;
+                ref readonly NativeMethods.NMTREEVIEW nmtv = ref m.GetLParamRef<NativeMethods.NMTREEVIEW>();
 
-                switch (nmtv->nmhdr.code) {
+                switch (nmtv.nmhdr.code) {
                     case NativeMethods.TVN_ITEMEXPANDING:
-                        m.Result = TvnExpanding(nmtv);
+                        m.Result = TvnExpanding(in nmtv);
                         break;
                     case NativeMethods.TVN_ITEMEXPANDED:
                         TvnExpanded(nmtv);
                         break;
                     case NativeMethods.TVN_SELCHANGING:
-                        m.Result = TvnSelecting(nmtv);
+                        m.Result = TvnSelecting(in nmtv);
                         break;
                     case NativeMethods.TVN_SELCHANGED:
-                        TvnSelected(nmtv);
+                        TvnSelected(in nmtv);
                         break;
                     case NativeMethods.TVN_BEGINDRAG:
-                        TvnBeginDrag(MouseButtons.Left, nmtv);
+                        TvnBeginDrag(MouseButtons.Left, in nmtv);
                         break;
                     case NativeMethods.TVN_BEGINRDRAG:
-                        TvnBeginDrag(MouseButtons.Right, nmtv);
+                        TvnBeginDrag(MouseButtons.Right, in nmtv);
                         break;
                     case NativeMethods.TVN_BEGINLABELEDIT:
                         m.Result = TvnBeginLabelEdit((NativeMethods.NMTVDISPINFO)m.GetLParam(typeof(NativeMethods.NMTVDISPINFO)));
@@ -2935,16 +2935,16 @@ namespace System.Windows.Forms {
                         tvhip.pt_x = pos.X;
                         tvhip.pt_y = pos.Y;
                         IntPtr hnode = UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TVM_HITTEST, 0, tvhip);
-                        if (nmtv->nmhdr.code != NativeMethods.NM_CLICK
+                        if (nmtv.nmhdr.code != NativeMethods.NM_CLICK
                                     || (tvhip.flags & NativeMethods.TVHT_ONITEM) != 0) {
-                                button = nmtv->nmhdr.code == NativeMethods.NM_CLICK
+                                button = nmtv.nmhdr.code == NativeMethods.NM_CLICK
                                     ? MouseButtons.Left : MouseButtons.Right;
                         }
 
                         // The treeview's WndProc doesn't get the WM_LBUTTONUP messages when
                         // LBUTTONUP happens on TVHT_ONITEM. This is a comctl quirk.
                         // We work around that by calling OnMouseUp here.
-                        if (nmtv->nmhdr.code != NativeMethods.NM_CLICK
+                        if (nmtv.nmhdr.code != NativeMethods.NM_CLICK
                             || (tvhip.flags & NativeMethods.TVHT_ONITEM) != 0 || FullRowSelect) {
                             if (hnode != IntPtr.Zero && !ValidationCancelled) {
                                 OnNodeMouseClick(new TreeNodeMouseClickEventArgs(NodeFromHandle(hnode), button, 1, pos.X, pos.Y));
@@ -2953,7 +2953,7 @@ namespace System.Windows.Forms {
 
                             }
                         }
-                        if (nmtv->nmhdr.code == NativeMethods.NM_RCLICK) {
+                        if (nmtv.nmhdr.code == NativeMethods.NM_RCLICK) {
                             TreeNode treeNode = NodeFromHandle(hnode);
                             if (treeNode != null && (treeNode.ContextMenu != null || treeNode.ContextMenuStrip != null)) {
                                 ShowContextMenu(treeNode);
@@ -2967,7 +2967,7 @@ namespace System.Windows.Forms {
                         }
 
                         if (!treeViewState[TREEVIEWSTATE_mouseUpFired]) {
-                            if (nmtv->nmhdr.code != NativeMethods.NM_CLICK
+                            if (nmtv.nmhdr.code != NativeMethods.NM_CLICK
                             || (tvhip.flags & NativeMethods.TVHT_ONITEM) != 0) {
                                 // The treeview's WndProc doesn't get the WM_LBUTTONUP messages when
                                 // LBUTTONUP happens on TVHT_ONITEM. This is a comctl quirk.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -2817,10 +2817,10 @@ namespace System.Windows.Forms {
             return retval;
         }
 
-        private unsafe bool WmShowToolTip(ref Message m)
+        private bool WmShowToolTip(ref Message m)
         {
-            NativeMethods.NMHDR* nmhdr = (NativeMethods.NMHDR*)m.LParam;
-            IntPtr tooltipHandle = nmhdr->hwndFrom;
+            ref readonly NativeMethods.NMHDR nmhdr = ref m.GetLParamRef<NativeMethods.NMHDR>();
+            IntPtr tooltipHandle = nmhdr.hwndFrom;
             
                 
             NativeMethods.TV_HITTESTINFO tvhip = new NativeMethods.TV_HITTESTINFO();
@@ -2889,11 +2889,11 @@ namespace System.Windows.Forms {
 
 
         private unsafe void WmNotify(ref Message m) {
-            NativeMethods.NMHDR* nmhdr = (NativeMethods.NMHDR *)m.LParam;
+            ref readonly NativeMethods.NMHDR nmhdr = ref m.GetLParamRef<NativeMethods.NMHDR>();
             
             // Custom draw code is handled separately.
             //
-            if ((nmhdr->code ==  NativeMethods.NM_CUSTOMDRAW)) {
+            if ((nmhdr.code ==  NativeMethods.NM_CUSTOMDRAW)) {
                 CustomDraw(ref m);
             }
             else {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -3101,7 +3101,7 @@ namespace System.Windows.Forms {
                     }
                     break;
                 case Interop.WindowMessages.WM_NOTIFY:
-                    NativeMethods.NMHDR nmhdr = (NativeMethods.NMHDR) m.GetLParam(typeof(NativeMethods.NMHDR));
+                    ref readonly NativeMethods.NMHDR nmhdr = ref m.GetLParamRef<NativeMethods.NMHDR>();
                     switch (nmhdr.code) {
                         case NativeMethods.TTN_GETDISPINFO:
                             // MSDN:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -2397,7 +2397,7 @@ namespace System.Windows.Forms {
         }
 
         private unsafe void TvnBeginDrag(MouseButtons buttons, NativeMethods.NMTREEVIEW* nmtv) {
-            NativeMethods.TV_ITEM item = nmtv->itemNew;
+            ref readonly NativeMethods.TV_ITEM item = ref nmtv->itemNew;
 
             // Check for invalid node handle
             if (item.hItem == IntPtr.Zero) {
@@ -2410,7 +2410,7 @@ namespace System.Windows.Forms {
         }
 
         private unsafe IntPtr TvnExpanding(NativeMethods.NMTREEVIEW* nmtv) {
-            NativeMethods.TV_ITEM item = nmtv->itemNew;
+            ref readonly NativeMethods.TV_ITEM item = ref nmtv->itemNew;
 
             // Check for invalid node handle
             if (item.hItem == IntPtr.Zero) {
@@ -2430,7 +2430,7 @@ namespace System.Windows.Forms {
         }
 
         private unsafe void TvnExpanded(NativeMethods.NMTREEVIEW* nmtv) {
-            NativeMethods.TV_ITEM item = nmtv->itemNew;
+            ref readonly NativeMethods.TV_ITEM item = ref nmtv->itemNew;
 
             // Check for invalid node handle
             if (item.hItem == IntPtr.Zero) {
@@ -3086,7 +3086,7 @@ namespace System.Windows.Forms {
                 case NativeMethods.TVM_SETITEM:
                     base.WndProc(ref m);
                     if (this.CheckBoxes) {
-                        NativeMethods.TV_ITEM item = (NativeMethods.TV_ITEM) m.GetLParam(typeof(NativeMethods.TV_ITEM));
+                        ref readonly NativeMethods.TV_ITEM item = ref m.GetLParamRef<NativeMethods.TV_ITEM>();
                         // Check for invalid node handle
                         if (item.hItem != IntPtr.Zero) {
                             NativeMethods.TV_ITEM item1 = new NativeMethods.TV_ITEM();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
@@ -1937,18 +1937,18 @@ namespace System.Windows.Forms
                 }
             }
 
-            private unsafe void WmWindowPosChanging(ref Message m) {
-                NativeMethods.WINDOWPOS* wp = (NativeMethods.WINDOWPOS *)m.LParam;
-                wp->x = 0;
-                wp->y = 0;
+            private void WmWindowPosChanging(ref Message m) {
+                ref NativeMethods.WINDOWPOS wp = ref m.GetLParamRef<NativeMethods.WINDOWPOS>();
+                wp.x = 0;
+                wp.y = 0;
                 Size s = WebBrowserBase.webBrowserBaseChangingSize;
                 if (s.Width == -1) {   // Invalid value. Use WebBrowserBase.Bounds instead, when this is the case.
-                    wp->cx = WebBrowserBase.Width;
-                    wp->cy = WebBrowserBase.Height;
+                    wp.cx = WebBrowserBase.Width;
+                    wp.cy = WebBrowserBase.Height;
                 }
                 else {
-                    wp->cx = s.Width;
-                    wp->cy = s.Height;
+                    wp.cx = s.Width;
+                    wp.cy = s.Height;
                 }
                 m.Result = (IntPtr)0;
             }


### PR DESCRIPTION
This pull request implements the new `GetLParam<T>` and `GetLParamRef<T>` (#792) as internal methods, and uses them to avoid marshaling overhead for existing value types.

The first commit is shared with #818.