### PR TITLE
Remove redundant defines

### DIFF
--- a/src/Common/src/CompModSwitches.cs
+++ b/src/Common/src/CompModSwitches.cs
@@ -6,10 +6,10 @@
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope="member", Target="System.ComponentModel.CompModSwitches.get_LayoutPerformance():System.Diagnostics.TraceSwitch")]
 
 namespace System.ComponentModel {
-    using System.Diagnostics;  
-    
+    using System.Diagnostics;
+
     internal static class CompModSwitches {
-#if WINDOWS_FORMS_SWITCHES
+
         private static TraceSwitch activeX;
         private static TraceSwitch flowLayout;
         private static TraceSwitch dataCursor;
@@ -18,17 +18,17 @@ namespace System.ComponentModel {
         private static TraceSwitch dataGridKeys;
         private static TraceSwitch dataGridLayout;
         private static TraceSwitch dataGridPainting;
-        private static TraceSwitch dataGridParents;        
+        private static TraceSwitch dataGridParents;
         private static TraceSwitch dataGridScrolling;
-        private static TraceSwitch dataGridSelection;           
-        private static TraceSwitch dataObject;        
+        private static TraceSwitch dataGridSelection;
+        private static TraceSwitch dataObject;
         private static TraceSwitch dataView;
         private static TraceSwitch debugGridView;
-        private static TraceSwitch dgCaptionPaint;     
-        private static TraceSwitch dgEditColumnEditing;                                                                
+        private static TraceSwitch dgCaptionPaint;
+        private static TraceSwitch dgEditColumnEditing;
         private static TraceSwitch dgRelationShpRowLayout;
         private static TraceSwitch dgRelationShpRowPaint;
-        private static TraceSwitch dgRowPaint;        
+        private static TraceSwitch dgRowPaint;
         private static TraceSwitch dragDrop;
         private static TraceSwitch imeMode;
         private static TraceSwitch msaa;
@@ -39,7 +39,7 @@ namespace System.ComponentModel {
         private static TraceSwitch setBounds;
 
         private static BooleanSwitch lifetimeTracing;
-        
+
         private static TraceSwitch s_handleLeak;
         private static BooleanSwitch s_traceCollect;
         private static BooleanSwitch s_commonDesignerServices;
@@ -51,7 +51,7 @@ namespace System.ComponentModel {
                 }
                 return activeX;
             }
-        }         
+        }
 
         public static TraceSwitch DataCursor {
             get {
@@ -88,7 +88,7 @@ namespace System.ComponentModel {
                 return dataGridKeys;
             }
         }
-                
+
         public static TraceSwitch DataGridLayout {
             get {
                 if (dataGridLayout == null) {
@@ -106,7 +106,7 @@ namespace System.ComponentModel {
                 return dataGridPainting;
             }
         }
-                                                                                        
+
         public static TraceSwitch DataGridParents {
             get {
                 if (dataGridParents == null) {
@@ -133,7 +133,7 @@ namespace System.ComponentModel {
                 return dataGridSelection;
             }
         }
-                                                                                
+
         public static TraceSwitch DataObject {
             get {
                 if (dataObject == null) {
@@ -150,7 +150,7 @@ namespace System.ComponentModel {
                 }
                 return dataView;
             }
-        }        
+        }
 
         public static TraceSwitch DebugGridView {
             get {
@@ -159,8 +159,8 @@ namespace System.ComponentModel {
                 }
                 return debugGridView;
             }
-        }        
-        
+        }
+
         public static TraceSwitch DGCaptionPaint {
             get {
                 if (dgCaptionPaint == null) {
@@ -169,7 +169,7 @@ namespace System.ComponentModel {
                 return dgCaptionPaint;
             }
         }
-        
+
         public static TraceSwitch DGEditColumnEditing {
             get {
                 if (dgEditColumnEditing == null) {
@@ -178,7 +178,7 @@ namespace System.ComponentModel {
                 return dgEditColumnEditing;
             }
         }
-        
+
         public static TraceSwitch DGRelationShpRowLayout {
             get {
                 if (dgRelationShpRowLayout == null) {
@@ -187,7 +187,7 @@ namespace System.ComponentModel {
                 return dgRelationShpRowLayout;
             }
         }
-                                                                            
+
         public static TraceSwitch DGRelationShpRowPaint {
             get {
                 if (dgRelationShpRowPaint == null) {
@@ -195,8 +195,8 @@ namespace System.ComponentModel {
                 }
                 return dgRelationShpRowPaint;
             }
-        }    
-        
+        }
+
         public static TraceSwitch DGRowPaint {
             get {
                 if (dgRowPaint == null) {
@@ -222,8 +222,8 @@ namespace System.ComponentModel {
                 }
                 return flowLayout;
             }
-        }       
-                
+        }
+
         public static TraceSwitch ImeMode {
             get {
                 if (imeMode == null) {
@@ -241,7 +241,7 @@ namespace System.ComponentModel {
                 return layoutPerformance;
             }
         }
-                                
+
         public static TraceSwitch LayoutSuspendResume {
             get {
                 if (layoutSuspendResume == null) {
@@ -259,7 +259,7 @@ namespace System.ComponentModel {
                 return lifetimeTracing;
             }
         }
-        
+
         public static TraceSwitch MSAA {
             get {
                 if (msaa == null) {
@@ -268,7 +268,7 @@ namespace System.ComponentModel {
                 return msaa;
             }
         }
-        
+
         public static TraceSwitch MSOComponentManager {
             get {
                 if (msoComponentManager == null) {
@@ -277,7 +277,7 @@ namespace System.ComponentModel {
                 return msoComponentManager;
             }
         }
-                                
+
         public static TraceSwitch RichLayout {
             get {
                 if (richLayout == null) {
@@ -295,7 +295,6 @@ namespace System.ComponentModel {
                 return setBounds;
             }
         }
-#endif
 
         public static TraceSwitch HandleLeak {
             get {

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -10,7 +10,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!--the obsolete usage in public surface can't be removed-->
     <NoWarn>$(NoWarn);618</NoWarn>
-    <DefineConstants>$(DefineConstants);DRAWING_DESIGN_NAMESPACE;WINDOWS_FORMS_SWITCHES;</DefineConstants>
+    <DefineConstants>$(DefineConstants);DRAWING_DESIGN_NAMESPACE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/src/System.Windows.Forms.csproj
+++ b/src/System.Windows.Forms/src/System.Windows.Forms.csproj
@@ -8,7 +8,7 @@
     <CLSCompliant>true</CLSCompliant>
     <!--the obsolete usage in public surface can't be removed-->
     <NoWarn>$(NoWarn);618</NoWarn>
-    <DefineConstants>$(DefineConstants);WIN95_SUPPORT;WINDOWS_FORMS_SWITCHES;DRAWING_DESIGN_NAMESPACE;OPTIMIZED_MEASUREMENTDC;</DefineConstants>
+    <DefineConstants>$(DefineConstants);WINDOWS_FORMS_SWITCHES;DRAWING_DESIGN_NAMESPACE;OPTIMIZED_MEASUREMENTDC;</DefineConstants>
     <Win32Manifest>Resources\System\Windows\Forms\XPThemes.manifest</Win32Manifest>
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/src/System.Windows.Forms/src/System.Windows.Forms.csproj
+++ b/src/System.Windows.Forms/src/System.Windows.Forms.csproj
@@ -8,7 +8,7 @@
     <CLSCompliant>true</CLSCompliant>
     <!--the obsolete usage in public surface can't be removed-->
     <NoWarn>$(NoWarn);618</NoWarn>
-    <DefineConstants>$(DefineConstants);WINDOWS_FORMS_SWITCHES;DRAWING_DESIGN_NAMESPACE;OPTIMIZED_MEASUREMENTDC;</DefineConstants>
+    <DefineConstants>$(DefineConstants);DRAWING_DESIGN_NAMESPACE;OPTIMIZED_MEASUREMENTDC;</DefineConstants>
     <Win32Manifest>Resources\System\Windows\Forms\XPThemes.manifest</Win32Manifest>
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -282,17 +282,15 @@ namespace System.Windows.Forms {
         internal static readonly object EventPaddingChanged           = new object();
         private static readonly object EventPreviewKeyDown            = new object();
 
-        #if WIN95_SUPPORT
         private static int mouseWheelMessage = Interop.WindowMessages.WM_MOUSEWHEEL;
         private static bool mouseWheelRoutingNeeded;
         private static bool mouseWheelInit;
-        #endif
 
         private static int threadCallbackMessage;
 
         // Initially check for illegal multithreading based on whether the
         // debugger is attached.
-        
+
         private static bool checkForIllegalCrossThreadCalls = Debugger.IsAttached;
         private static ContextCallback invokeMarshaledCallbackHelperDelegate;
 
@@ -494,9 +492,7 @@ example usage
                      ControlStyles.UseTextForAccessibility |
                      ControlStyles.Selectable,true);
 
-#if WIN95_SUPPORT
             InitMouseWheelSupport();
-#endif
 
             // We baked the "default default" margin and min size into CommonProperties
             // so that in the common case the PropertyStore would be empty.  If, however,
@@ -6912,7 +6908,6 @@ example usage
             }
         }
 
-        #if WIN95_SUPPORT
         /// <devdoc>
         ///     Initializes mouse wheel support. This may involve registering some windows
         ///     messages on older operating systems.
@@ -6949,7 +6944,6 @@ example usage
                 mouseWheelInit = true;
             }
         }
-        #endif
 
         /// <include file='doc\Control.uex' path='docs/doc[@for="Control.Invalidate"]/*' />
         /// <devdoc>
@@ -13776,7 +13770,6 @@ example usage
                         return;
                     }
 
-                    #if WIN95_SUPPORT
                     // If we have to route the mousewheel messages, do it (this logic was taken
                     // from the MFC sources...)
                     //
@@ -13805,7 +13798,6 @@ example usage
                             }
                         }
                     }
-                    #endif
 
                     if (m.Msg == NativeMethods.WM_MOUSEENTER) {
                         WmMouseEnter(ref m);


### PR DESCRIPTION
WIN95_SUPPORT - It is always defined in this project, which contains the only use of it.
WINDOWS_FORMS_SWITCHES - It is always defined, and build fails if it is not defined.

Relates to #39