### PR TITLE
Remove part of remoting goo

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -7,7 +7,6 @@ namespace System.Windows.Forms {
     using System.Text;
     using System.Threading;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
     using System.Runtime.ConstrainedExecution;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -2909,13 +2909,6 @@ namespace System.Windows.Forms {
                 return(threadState & bit) != 0;
             }
 
-            /// <devdoc>
-            ///     Keep the object alive forever.
-            /// </devdoc>
-            public override object InitializeLifetimeService() {
-                return null;
-            }
-
             /// <summary>
             /// A method of determining whether we are handling messages that does not demand register
             /// the componentmanager

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -21,7 +21,6 @@ namespace System.Windows.Forms {
     using System.IO;
     using System.Reflection;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
     using System.Runtime.Serialization.Formatters.Binary;
     using System.Runtime.Serialization;
     using System.Threading;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Button.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Button.cs
@@ -5,7 +5,6 @@
 
 namespace System.Windows.Forms {
     using System.Runtime.Serialization.Formatters;
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
 
     using System.Diagnostics;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckBox.cs
@@ -5,7 +5,6 @@
 
 namespace System.Windows.Forms {
     using System.Runtime.Serialization.Formatters;
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
 
     using System.Diagnostics;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
@@ -7,7 +7,6 @@ namespace System.Windows.Forms {
     using Accessibility;
 
     using System.Text;
-    using System.Runtime.Remoting;
 
     using System.Diagnostics;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
@@ -13,7 +13,6 @@ namespace System.Windows.Forms {
     using System.Drawing;
     using System.IO;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
     using System.Windows.Forms;    
     using System.Globalization;
     

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeaderConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeaderConverter.cs
@@ -5,7 +5,6 @@
 
 namespace System.Windows.Forms {
     using System.Runtime.Serialization.Formatters;
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
 
     using Microsoft.Win32;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -7,7 +7,6 @@ namespace System.Windows.Forms {
     using Accessibility;
     using System.Runtime.Serialization.Formatters;
     using System.Threading;
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
     using System.Diagnostics;
     using System;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentManagerBroker.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentManagerBroker.cs
@@ -148,13 +148,6 @@ namespace System.Windows.Forms {
             _proxy = null;
         }
 
-        /// <devdoc>
-        ///     Keep the object alive forever.
-        /// </devdoc>
-        public override object InitializeLifetimeService() {
-            return null;
-        }
-
         #region Instance API only callable from a proxied object
         
         /// <devdoc>
@@ -273,13 +266,6 @@ namespace System.Windows.Forms {
                 _refCount = 0;
                 _broker.ClearComponentManager();
             }
-        }
-
-        /// <devdoc>
-        ///     Keep the object alive forever.
-        /// </devdoc>
-        public override object InitializeLifetimeService() {
-            return null;
         }
 
         private bool RevokeComponent() {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentManagerBroker.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentManagerBroker.cs
@@ -13,7 +13,6 @@ namespace System.Windows.Forms {
     using System.Diagnostics;
     using System.Drawing;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting.Lifetime;
     using System.Runtime.Serialization.Formatters;
     using System.Runtime.Versioning;
     using System.Threading;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentManagerBroker.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentManagerBroker.cs
@@ -204,29 +204,12 @@ namespace System.Windows.Forms {
                     if (domain == AppDomain.CurrentDomain) {
                         _broker = new ComponentManagerBroker();
                     }
-                    else {
-                        _broker = GetRemotedComponentManagerBroker(domain);
-                    }
                 }
             }
 
             // However we got here, we got here.  What's important is that we have a proxied instance to the broker object
             // and we can now call on it.
             return _broker.GetProxy((long)pOriginal);
-        }
-
-        /// <devdoc>
-        ///     This method is factored out of GetComponentManager so we can prevent System.Runtime.Remoting from being
-        ///     loaded into the process if we are using a single domain.
-        /// </devdoc>
-        private static ComponentManagerBroker GetRemotedComponentManagerBroker(AppDomain domain) {
-#if REMOTING
-            Type ourType = typeof(ComponentManagerBroker);
-            ComponentManagerBroker broker = (ComponentManagerBroker)domain.CreateInstanceAndUnwrap(ourType.Assembly.FullName, ourType.FullName);
-            return broker.Singleton;
-#else
-            return _broker;
-#endif
         }
         #endregion
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/BaseCAMarshaler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/BaseCAMarshaler.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 namespace System.Windows.Forms.ComponentModel.Com2Interop {
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
     using System.ComponentModel;
     using System.Diagnostics;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ComponentEditor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ComponentEditor.cs
@@ -4,7 +4,6 @@
 
 namespace System.Windows.Forms.ComponentModel.Com2Interop {
 
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
     using System.ComponentModel;
     using System.Diagnostics;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IPerPropertyBrowsingHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IPerPropertyBrowsingHandler.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 namespace System.Windows.Forms.ComponentModel.Com2Interop {
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
     using System.ComponentModel;
     using System.Diagnostics;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2Properties.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2Properties.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 namespace System.Windows.Forms.ComponentModel.Com2Interop {
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
     using System.ComponentModel;
     using System.Diagnostics;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.cs
@@ -4,7 +4,6 @@
 
 namespace System.Windows.Forms.ComponentModel.Com2Interop {
     using System.Runtime.Serialization.Formatters;
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
     using System.ComponentModel;
     using System.Diagnostics;
@@ -258,7 +257,8 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop {
                    // first walk the list looking for items that need to be
                    // cleaned out.
                    //
-                   foreach(DictionaryEntry de in nativeProps) {
+                   foreach(DictionaryEntry de in nativeProps) {
+
                         entry = de.Value as Com2Properties;
 
                         if (entry != null && entry.TooOld) {
@@ -398,7 +398,8 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop {
         /// <devdoc>
         /// Fired when the property info gets disposed.
         /// </devdoc>        
-        private void OnPropsInfoDisposed(object sender, EventArgs e) {
+        private void OnPropsInfoDisposed(object sender, EventArgs e) {
+
             Com2Properties propsInfo = sender as Com2Properties;
 
             if (propsInfo != null) {
@@ -409,12 +410,14 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop {
                     // find the key
                     object key = propsInfo.TargetObject;
 
-                    if (key == null && nativeProps.ContainsValue(propsInfo)) {
+                    if (key == null && nativeProps.ContainsValue(propsInfo)) {
+
                         // need to find it - the target object has probably been cleaned out
                         // of the Com2Properties object already, so we run through the
                         // hashtable looking for the value, so we know what key to remove.
                         //
-                        foreach (DictionaryEntry de in nativeProps) {
+                        foreach (DictionaryEntry de in nativeProps) {
+
                             if (de.Value == propsInfo) {
                                 key = de.Key;
                                 break;                                    

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -6,7 +6,6 @@
 namespace System.Windows.Forms {
     using System.Threading;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
     using System.Collections.Specialized;
     using System.ComponentModel;
     using System.Diagnostics;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContextMenu.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContextMenu.cs
@@ -10,7 +10,6 @@ namespace System.Windows.Forms {
     using System.Diagnostics;
     using System.Drawing;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
 
     /// <include file='doc\ContextMenu.uex' path='docs/doc[@for="ContextMenu"]/*' />
     /// <devdoc>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -28,7 +28,6 @@ namespace System.Windows.Forms {
     using System.Reflection;
     using System.Runtime.InteropServices;
     using System.Runtime.InteropServices.ComTypes;
-    using System.Runtime.Remoting;
     using System.Runtime.Serialization;
     using System.Runtime.Serialization.Formatters;
     using System.Runtime.Serialization.Formatters.Binary;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGrid.cs
@@ -6,7 +6,6 @@ namespace System.Windows.Forms {
         using System.Text;
         using System.Runtime.Serialization.Formatters;
         using System.Runtime.InteropServices;
-        using System.Runtime.Remoting;
         using System.ComponentModel;
         using System;
         using System.Collections;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridAddNewRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridAddNewRow.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 namespace System.Windows.Forms {
-    using System.Runtime.Remoting;
 
     using System.Diagnostics;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridColumnCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridColumnCollection.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 namespace System.Windows.Forms {
-    using System.Runtime.Remoting;
 
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridDefaultColumnWidthTypeConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridDefaultColumnWidthTypeConverter.cs
@@ -4,7 +4,6 @@
 
 namespace System.Windows.Forms {
     using System.Runtime.Serialization.Formatters;
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
     using System;
     using System.IO;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridParentRows.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridParentRows.cs
@@ -4,7 +4,6 @@
 
 namespace System.Windows.Forms {
     using System.Text;
-    using System.Runtime.Remoting;
     using System;
     using System.Collections;
     using System.Windows.Forms;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridRelationshipRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridRelationshipRow.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 namespace System.Windows.Forms {
-    using System.Runtime.Remoting;
 
     using System;
     using System.Runtime.InteropServices;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridRow.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 namespace System.Windows.Forms {
-    using System.Runtime.Remoting;
     using System.Runtime.Versioning;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridTextBox.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 namespace System.Windows.Forms{
-    using System.Runtime.Remoting;
     using System;
     using System.Windows.Forms;
     using System.ComponentModel;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridTextBoxColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridTextBoxColumn.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 namespace System.Windows.Forms {
-    using System.Runtime.Remoting;
 
     using System;
     

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridToolTip.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 namespace System.Windows.Forms {
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
     using System.Drawing;
     

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -6,7 +6,6 @@ namespace System.Windows.Forms
 {
     using System.Text;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
     using System.ComponentModel;
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyleConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyleConverter.cs
@@ -5,7 +5,6 @@
 
 namespace System.Windows.Forms {
     using System.Runtime.Serialization.Formatters;
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
 
     using Microsoft.Win32;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnConverter.cs
@@ -5,7 +5,6 @@
 
 namespace System.Windows.Forms {
     using System.Runtime.Serialization.Formatters;
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
 
     using Microsoft.Win32;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewMethods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewMethods.cs
@@ -6,7 +6,6 @@ namespace System.Windows.Forms
 {
     using System.Text;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
     using System.ComponentModel;
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
@@ -5,7 +5,6 @@
 
 namespace System.Windows.Forms {
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
 
     using System.Diagnostics;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.cs
@@ -4,7 +4,6 @@
 
 namespace System.Windows.Forms.Design {
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
     using System.ComponentModel;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorPage.cs
@@ -5,7 +5,6 @@
 
 
 namespace System.Windows.Forms.Design {
-    using System.Runtime.Remoting;
     using System.ComponentModel;
 
     using System.Diagnostics;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
@@ -4,7 +4,6 @@
 
 namespace System.Windows.Forms {
     using System.Threading;
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
     using System.ComponentModel;
     using System.ComponentModel.Design;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -19,7 +19,6 @@ namespace System.Windows.Forms {
     using System.Net;
     using System.Reflection;
     using System.Runtime.Serialization.Formatters;
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
     using System.Threading;
     using System.Windows.Forms.Design;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.cs
@@ -13,7 +13,6 @@ namespace System.Windows.Forms {
     using System.Windows.Forms.Internal;
     using System.Drawing.Text;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
     using System.Windows.Forms.VisualStyles;
     using System.Windows.Forms.Layout;
     using System.Diagnostics.CodeAnalysis;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
@@ -14,7 +14,6 @@ namespace System.Windows.Forms {
     using System.Drawing.Design;
     using System.Drawing.Imaging;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
     using System.Runtime.Serialization.Formatters;
     using System.Windows.Forms.Layout;
     using Microsoft.Win32;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
@@ -12,7 +12,6 @@ namespace System.Windows.Forms {
     using System.Drawing.Text;
     using System.Drawing;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
     using System.Runtime.Serialization.Formatters;
     using System.Text;
     using System.Windows.Forms.ComponentModel;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -5,7 +5,6 @@
 
 namespace System.Windows.Forms {
     using System.Runtime.Serialization.Formatters;
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
 
     using System.Diagnostics;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -16,7 +16,6 @@ namespace System.Windows.Forms {
     using System.Drawing.Design;
     using System.Globalization;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
     using System.Runtime.Serialization.Formatters;
     using System.Windows.Forms.Internal;
     using System.Windows.Forms.Layout;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MDIClient.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MDIClient.cs
@@ -14,7 +14,6 @@ namespace System.Windows.Forms {
     using System.Drawing;
     using System.Globalization;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
     using System.Threading;
     using System.Windows.Forms;
     

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MessageBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MessageBox.cs
@@ -10,7 +10,6 @@ namespace System.Windows.Forms {
     using System.ComponentModel;
     using System.Diagnostics;
     using System.Drawing;
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
     using System.Windows.Forms;
     using System.Collections;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -6,7 +6,6 @@
 
 namespace System.Windows.Forms {
     using System.Runtime.Serialization.Formatters;
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
 
     using System.Diagnostics;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
@@ -7,7 +7,6 @@ namespace System.Windows.Forms
 {
     using System.Threading;
     using System.Configuration.Assemblies;
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
     using System.Runtime.ConstrainedExecution;
     using System.Runtime.CompilerServices;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 namespace System.Windows.Forms {
-    using System.Runtime.Remoting;
     using System.ComponentModel;
     using System.ComponentModel.Design;
     using System.Diagnostics;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -9,7 +9,6 @@
 namespace System.Windows.Forms {
     using System.Runtime.Serialization.Formatters;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
     using System.Diagnostics;
     using System;
     using System.Drawing;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewDialog.cs
@@ -12,7 +12,6 @@ namespace System.Windows.Forms {
     using System.Drawing;
     using System.Drawing.Design;
     using System.Drawing.Printing;
-    using System.Runtime.Remoting;
     using System.Windows.Forms.Design;
     using System.Runtime.InteropServices;
     using System.Runtime.Versioning;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ProgressBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ProgressBar.cs
@@ -5,7 +5,6 @@
 
 namespace System.Windows.Forms {
     using System.Runtime.Serialization.Formatters;
-    using System.Runtime.Remoting;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
@@ -6,7 +6,6 @@
 
 namespace System.Windows.Forms.PropertyGridInternal {
     using System.Runtime.Serialization.Formatters;
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
     using System.ComponentModel;
     using System.Diagnostics;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridErrorDlg.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridErrorDlg.cs
@@ -6,7 +6,6 @@ namespace System.Windows.Forms.PropertyGridInternal {
     using System.Runtime.Serialization.Formatters;
     using System.Threading;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
     using System.ComponentModel;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
@@ -5,7 +5,6 @@
 
 namespace System.Windows.Forms.PropertyGridInternal {
     using System.Runtime.Serialization.Formatters;
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
     using System.ComponentModel;
     using System.Diagnostics;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -7,7 +7,6 @@ namespace System.Windows.Forms.PropertyGridInternal {
     using System.Runtime.Serialization.Formatters;
     using System.Threading;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
     using System.Runtime.Versioning;
     using System.ComponentModel;
     using System.Diagnostics;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -14,7 +14,6 @@ namespace System.Windows.Forms {
     using System.Globalization;
     using System.IO;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
     using System.Runtime.Serialization.Formatters;
     using System.Text;
     using System.Windows.Forms.ComponentModel;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollableControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollableControl.cs
@@ -5,7 +5,6 @@
 
 namespace System.Windows.Forms {
     using System.Runtime.Serialization.Formatters;
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
 
     using System.Diagnostics;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SelectionRangeConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SelectionRangeConverter.cs
@@ -5,7 +5,6 @@
 
 namespace System.Windows.Forms {
     using System.Runtime.Serialization.Formatters;
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
 
     using Microsoft.Win32;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
@@ -12,7 +12,6 @@ namespace System.Windows.Forms {
     using System.Diagnostics.CodeAnalysis;
     using System.Drawing;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
     using System.Windows.Forms;
     using System.Collections;
     using System.Drawing.Drawing2D;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.cs
@@ -11,7 +11,6 @@ namespace System.Windows.Forms {
     using System.Diagnostics;
     using System.Drawing;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
     using System.Windows.Forms;
     using System.Globalization;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
@@ -6,7 +6,6 @@
 namespace System.Windows.Forms {
     using System.Runtime.Serialization.Formatters;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
     using System.ComponentModel;
     using System.Diagnostics;
     using System;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusBarPanel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusBarPanel.cs
@@ -5,7 +5,6 @@
 
 namespace System.Windows.Forms {
     using System.Runtime.Serialization.Formatters;
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
     using System.ComponentModel;
     using System.ComponentModel.Design;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SystemInformation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SystemInformation.cs
@@ -7,7 +7,6 @@ namespace System.Windows.Forms {
     using System.Text;
     using System.Configuration.Assemblies;
     using System.Threading;
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
 
     using System.Diagnostics;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -18,7 +18,6 @@ namespace System.Windows.Forms {
     using System.Drawing;
     using System.Drawing.Design;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
     using System.Runtime.Serialization.Formatters;
     using System.Windows.Forms.Layout;
     using System.Globalization;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
@@ -4,7 +4,6 @@
 
 
 namespace System.Windows.Forms {
-    using System.Runtime.Remoting;
     using System.ComponentModel;
     using System.Diagnostics;
     using System;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -7,7 +7,6 @@ namespace System.Windows.Forms {
     using System.Text;
     using System.Runtime.Serialization.Formatters;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolBar.cs
@@ -5,7 +5,6 @@
 
 namespace System.Windows.Forms {
     using System.Runtime.Serialization.Formatters;
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
     using System.ComponentModel;
     using System.Diagnostics;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolBarButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolBarButton.cs
@@ -6,7 +6,6 @@
 namespace System.Windows.Forms {
     using System.Runtime.Serialization.Formatters;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
     using System.ComponentModel;
     using System.ComponentModel.Design;
     using System.Diagnostics;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -6,7 +6,6 @@
 namespace System.Windows.Forms {
     using System.Runtime.Serialization.Formatters;
     using System.Threading;
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
     using System.ComponentModel;
     using System.ComponentModel.Design;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -6,7 +6,6 @@
 namespace System.Windows.Forms {
     using System.Runtime.Serialization.Formatters;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
 
     using System.Diagnostics;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
@@ -9,7 +9,6 @@ namespace System.Windows.Forms {
     using System.Runtime.Serialization;
     using System.Runtime.Serialization.Formatters;
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeConverter.cs
@@ -5,7 +5,6 @@
 
 namespace System.Windows.Forms {
     using System.Runtime.Serialization.Formatters;
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
 
     using Microsoft.Win32;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -4,7 +4,6 @@
 
 
 namespace System.Windows.Forms {
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
@@ -5,7 +5,6 @@
 namespace System.Windows.Forms {
     using System.Runtime.Serialization.Formatters;
     using System.Threading;
-    using System.Runtime.Remoting;
     using System.Runtime.InteropServices;
     using System.ComponentModel;
     using System.Diagnostics;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UserControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UserControl.cs
@@ -13,7 +13,6 @@ namespace System.Windows.Forms {
     using System.Diagnostics;
     using System.Drawing;    
     using System.Runtime.InteropServices;
-    using System.Runtime.Remoting;
     using System.Windows.Forms.Design;
     using System.Windows.Forms.Layout;
 

--- a/src/System.Windows.Forms/src/workarounds.cs
+++ b/src/System.Windows.Forms/src/workarounds.cs
@@ -1,7 +1,0 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-namespace System.Runtime.Remoting { }
-namespace System.Runtime.Remoting.Lifetime { }
-


### PR DESCRIPTION
Remove using statements, and the MarshalByRefObject derivations and lifetime override methods.

Contributes to https://github.com/dotnet/winforms/issues/839

There is more left: quite a bit related to app domains certainly.