### PR TITLE
Fix DataGridViewBand.DefaultCellStyle setter

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBand.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBand.cs
@@ -115,8 +115,8 @@ namespace System.Windows.Forms
                 }
 
                 if (DataGridView != null &&
-                   (style != null ^ value != null) ||
-                   (style != null && value != null && !style.Equals(DefaultCellStyle)))
+                   ((style != null ^ value != null) ||
+                   (style != null && value != null && !style.Equals(DefaultCellStyle))))
                 {
                     DataGridView.OnBandDefaultCellStyleChanged(this);
                 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowTests.cs
@@ -245,17 +245,27 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> DefaultCellStyle_Set_TestData()
         {
-            yield return new object[] { new DataGridViewRow(), null, new DataGridViewCellStyle() };
-
             var style = new DataGridViewCellStyle { Alignment = DataGridViewContentAlignment.BottomRight };
-            var dataGridView = new DataGridView { ColumnCount = 1 };
-            dataGridView.Rows.Add(new DataGridViewRow());
-            yield return new object[] { dataGridView.Rows[0], style, style };
+
+            yield return new object[] { new DataGridViewRow(), null, new DataGridViewCellStyle() };
+            yield return new object[] { new DataGridViewRow(), style, style };
+
+            var dataGridView1 = new DataGridView { ColumnCount = 1 };
+            dataGridView1.Rows.Add(new DataGridViewRow());
+            var dataGridView2 = new DataGridView { ColumnCount = 1 };
+            dataGridView2.Rows.Add(new DataGridViewRow());
+            yield return new object[] { dataGridView1.Rows[0], null, new DataGridViewCellStyle() };
+            yield return new object[] { dataGridView2.Rows[0], style, style };
+
+            var templateDataGridView1 = new DataGridView();
+            var templateDataGridView2 = new DataGridView();
+            yield return new object[] { templateDataGridView1.RowTemplate, null, new DataGridViewCellStyle() };
+            yield return new object[] { templateDataGridView2.RowTemplate, style, style };
         }
 
         [Theory]
         [MemberData(nameof(DefaultCellStyle_Set_TestData))]
-        public void DataGridViewRow_DefaultCellStyle_Set_GetReturnsExpected(DataGridViewRow row, DataGridViewCellStyle value, DataGridViewCellStyle expected)
+        public void DataGridViewRow_DefaultCellStyle_SetWithNullOldValue_GetReturnsExpected(DataGridViewRow row, DataGridViewCellStyle value, DataGridViewCellStyle expected)
         {
             row.DefaultCellStyle = value;
             Assert.Equal(expected, row.DefaultCellStyle);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
@@ -9,11 +9,11 @@ namespace System.Windows.Forms.Tests
     public class DataGridViewTests
     {
         [Fact]
-        public void DataGridView_Constructor()
+        public void DataGridView_Ctor_Default()
         {
-            var dgv = new DataGridView();
-
-            Assert.NotNull(dgv);
+            var dataGridView = new DataGridView();
+            Assert.NotNull(dataGridView.RowTemplate);
+            Assert.Same(dataGridView.RowTemplate, dataGridView.RowTemplate);
         }
     }
 }


### PR DESCRIPTION
Fixes #879 

Problem was the order of precedence between `&&` and `||`

/cc @zsd4yr @Amy-Li02