### PR TITLE
Use Unsafe.AsRef to implement UnsafeNativeMethods.PtrToRef

### DIFF
--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -68,6 +68,7 @@ using System.Runtime.Versioning;
 namespace System.Windows.Forms {
 
     using Accessibility;
+    using System.Runtime.CompilerServices;
     using System.Runtime.InteropServices;
     using System.Runtime.InteropServices.ComTypes;
     using System.Runtime.ConstrainedExecution;
@@ -1583,7 +1584,7 @@ namespace System.Windows.Forms {
         {
             unsafe
             {
-                return ref *(T*)ptr;
+                return ref Unsafe.AsRef<T>(ptr.ToPointer());
             }
         }
 


### PR DESCRIPTION
Follow-up to #818, per a request in https://github.com/dotnet/winforms/pull/835#discussion_r277804970.