### PR TITLE
Fix CollectionEditor min/max

### DIFF
--- a/src/System.Windows.Forms.Design.Editors/src/System/ComponentModel/Design/CollectionEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/ComponentModel/Design/CollectionEditor.cs
@@ -915,7 +915,7 @@ namespace System.ComponentModel.Design
 
             private int CalcItemWidth(Graphics g, ListItem item)
             {
-                int c = Math.Min(2, _listbox.Items.Count);
+                int c = Math.Max(2, _listbox.Items.Count);
                 SizeF sizeW = g.MeasureString(c.ToString(CultureInfo.CurrentCulture), _listbox.Font);
 
                 int charactersInNumber = ((int)(Math.Log((double)(c - 1)) / s_log10) + 1);


### PR DESCRIPTION
Previously the code was:
```cs
                int c = _listbox.Items.Count;
                if (c < 2)
                {
                    c = 2;  //for c-1 should be greater than zero.
                }
```

This was incorrectly cleaned up to `Min`, but should be `Max`.

Will resist the urge to clean cases like this up in future