### PR TITLE
Fix bug in CodeDomSerializerBase that only occurs in Release config

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs
@@ -23,7 +23,7 @@ namespace System.ComponentModel.Design.Serialization
         private static readonly Attribute[] runTimeProperties = new Attribute[] { DesignOnlyAttribute.No };
         private static readonly CodeThisReferenceExpression thisRef = new CodeThisReferenceExpression();
         private static TraceSwitch traceSerialization = new TraceSwitch("DesignerSerialization", "Trace design time serialization");
-        private static Stack traceScope;
+        private static Stack traceScope = null;
 
         /// <summary>
         ///     Internal constructor so only we can derive from this class.
@@ -461,8 +461,8 @@ namespace System.ComponentModel.Design.Serialization
         }
         internal static IDisposable TraceScope(string name)
         {
-            if (traceScope == null) traceScope = new Stack();
 #if DEBUG
+            if (traceScope == null) traceScope = new Stack();
             Trace(name);
             traceScope.Push(name);
 #endif


### PR DESCRIPTION
In DEBUG, `CodeDomSerializerBase.TraceScope(...)` initializes the field `traceScope` with a new stack and pushes a string to it. Later , in `TracingScope.Dispose()`, there is call to `traceScope.Pop()` if `traceScope` isn't null. However, the line to initialize `traceScope` was left outside of the `#if DEBUG` block while the call to `traceScope.Push(...)` was left inside. So, `TracingScope.Dispose()` attempts to pop the stack that has nothing in it.

It looks like this was just a simple misport. Moving the line back under DEBUG introduces an uninitialized field warning, and I suspect that's why it was moved out of DEBUG in the first place. However, setting the field to null in its initializer is the proper fix for that warning.