### PR TITLE
Refactor ResolvedMatchingContract calculation

### DIFF
--- a/eng/FacadeAssemblies.props
+++ b/eng/FacadeAssemblies.props
@@ -12,23 +12,18 @@
     <!-- Produce a full PDB for facade assemblies -->
     <DebugType>full</DebugType>
 
-    <!-- allow desktop references -->
-    <AssetTargetFallback>net472</AssetTargetFallback>
-    <NoWarn>$(NoWarn);NU1701</NoWarn>
-    <MicrosoftTargetingPackNETFrameworkv472Package>Microsoft.TargetingPack.NETFramework.v4.7.2</MicrosoftTargetingPackNETFrameworkv472Package>
+    <MicrosoftTargetingPackNETFrameworkv472Package></MicrosoftTargetingPackNETFrameworkv472Package>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsFacadeAssembly)'=='true'">  
-    <!-- Not supported in .NET Core 3.0; don't flow package references to callers -->
-    <PackageReference Include="$(MicrosoftTargetingPackNETFrameworkv472Package)" Version="$(MicrosoftTargetingPackNETFrameworkv472PackageVersion)" PrivateAssets="All" />
+    <!-- PrivateAssets="All": don't flow package references to callers -->
+    <PackageReference Include="Microsoft.TargetingPack.NETFramework.v4.7.2" Version="$(MicrosoftTargetingPackNETFrameworkv472PackageVersion)" PrivateAssets="All" GeneratePathProperty="true" ExcludeAssets="All" />
     <PackageReference Include="Microsoft.DotNet.GenFacades" Version="$(MicrosoftDotNetGenFacadesPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
   
   <Target Condition="'$(IsFacadeAssembly)'=='true'" Name="ResolveMatchingContract" BeforeTargets="ResolveAssemblyReferences">
     <ItemGroup>
-      <_desktopReference Include="@(Reference)" Condition="'%(Reference.NuGetPackageId)' == '$(MicrosoftTargetingPackNETFrameworkv472Package)'" />
-      <Reference Remove="@(_desktopReference)" />
-      <ResolvedMatchingContract Include="@(_desktopReference)" Condition="'%(FileName)%(Extension)' == '$(AssemblyName).dll'" />
+      <ResolvedMatchingContract Include="$(PkgMicrosoft_TargetingPack_NETFramework_v4_7_2)\lib\*\$(AssemblyName).dll" />
 
       <!-- in case we're regenerating a facade that is already referenced -->
       <Reference Remove="@(Reference)"  Condition="'%(FileName)%(Extension)' == '$(AssemblyName).dll'" />


### PR DESCRIPTION
Changes to the build caused ResolveMatchingContract to run after
conflict resolution which was removing the desktop reference to
System.Drawing in preference to the one in the NETCoreApp refs.

Avoid this completely by directly setting ResolvedMatchingContract
using the path to the targeting pack package.

Alternative to https://github.com/dotnet/winforms/pull/1005 that doesn't include arcade update.