### PR TITLE
Cleanup VisualStyleInformation interop

### DIFF
--- a/src/Common/src/Interop/Interop.Libraries.cs
+++ b/src/Common/src/Interop/Interop.Libraries.cs
@@ -6,9 +6,10 @@ internal static partial class Interop
 {
     public static partial class Libraries
     {
-        internal const string Kernel32 = "kernel32.dll";
-        internal const string Gdi32 = "gdi32.dll";
-        internal const string User32 = "user32.dll";
-        internal const string Shell32 = "shell32.dll";
+        public const string Kernel32 = "kernel32.dll";
+        public const string Gdi32 = "gdi32.dll";
+        public const string User32 = "user32.dll";
+        public const string UxTheme = "uxtheme.dll";
+        public const string Shell32 = "shell32.dll";
     }
 }

--- a/src/Common/src/Interop/UxTheme/Interop.GetCurrentThemeName.cs
+++ b/src/Common/src/Interop/UxTheme/Interop.GetCurrentThemeName.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    public static partial class UxTheme
+    {
+        [DllImport(Libraries.UxTheme, CharSet = CharSet.Unicode)]
+        public static unsafe extern int GetCurrentThemeName(char *pszThemeFileName, int dwMaxNameChars, char *pszColorBuff, int dwMaxColorChars, char *pszSizeBuff, int cchMaxSizeChars);
+    }
+}

--- a/src/Common/src/Interop/UxTheme/Interop.GetThemeDocumentationProperty.cs
+++ b/src/Common/src/Interop/UxTheme/Interop.GetThemeDocumentationProperty.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Buffers;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    public static partial class UxTheme
+    {
+        [DllImport(Libraries.UxTheme, CharSet = CharSet.Unicode, EntryPoint = "GetThemeDocumentationProperty")]
+        private static unsafe extern int GetThemeDocumentationPropertyInternal(string pszThemeName, string pszPropertyName, char *pszValueBuff, int cchMaxValChars);
+
+        public static unsafe string GetThemeDocumentationProperty(string pszThemeName, string pszPropertyName)
+        {
+            Span<char> buffer = stackalloc char[512];
+            fixed (char *pBuffer = buffer)
+            {
+                GetThemeDocumentationPropertyInternal(pszThemeName, pszPropertyName, pBuffer, buffer.Length);
+            }
+
+            return buffer.ToString();
+        }
+
+        public static class VisualStyleDocProperty
+        {
+            public const string DisplayName = "DisplayName";
+            public const string Company = "Company";
+            public const string Author = "Author";
+            public const string Copyright = "Copyright";
+            public const string Url = "Url";
+            public const string Version = "Version";
+            public const string Description = "Description";
+        }
+    }
+}

--- a/src/Common/src/SafeNativeMethods.cs
+++ b/src/Common/src/SafeNativeMethods.cs
@@ -737,14 +737,11 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
 
         public static extern int CloseThemeData(HandleRef hTheme);
-        [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
 
-        public static extern int GetCurrentThemeName(StringBuilder pszThemeFileName, int dwMaxNameChars, StringBuilder pszColorBuff, int dwMaxColorChars, StringBuilder pszSizeBuff, int cchMaxSizeChars);
-        [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
-
+        [DllImport(ExternDll.Uxtheme, CharSet=CharSet.Auto)]
         public static extern bool IsThemePartDefined(HandleRef hTheme, int iPartId, int iStateId);
-        [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
 
+        [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
         public static extern int DrawThemeBackground(HandleRef hTheme, HandleRef hdc, int partId, int stateId, [In] NativeMethods.COMRECT pRect, [In] NativeMethods.COMRECT pClipRect);
         [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
 
@@ -795,19 +792,6 @@ namespace System.Windows.Forms
 
         public static extern int GetThemeString(HandleRef hTheme, int iPartId, int iStateId, int iPropId, StringBuilder pszBuff, int cchMaxBuffChars);
 
-        [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
-        public static extern int GetThemeDocumentationProperty([MarshalAs(UnmanagedType.LPWStr)] string pszThemeName, [MarshalAs(UnmanagedType.LPWStr)] string pszPropertyName, StringBuilder pszValueBuff, int cchMaxValChars);
-
-        public static class VisualStyleDocProperty
-        {
-            public const string DisplayName = "DisplayName";
-            public const string Company = "Company";
-            public const string Author = "Author";
-            public const string Copyright = "Copyright";
-            public const string Url = "Url";
-            public const string Version = "Version";
-            public const string Description = "Description";
-        }
 
         [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
         public static extern int GetThemeTextExtent(HandleRef hTheme, HandleRef hdc, int iPartId, int iStateId, [MarshalAs(UnmanagedType.LPWStr)] string pszText, int iCharCount, int dwTextFlags, [In] NativeMethods.COMRECT pBoundingRect, [Out] NativeMethods.COMRECT pExtentRect);

--- a/src/System.Windows.Forms/src/System.Windows.Forms.csproj
+++ b/src/System.Windows.Forms/src/System.Windows.Forms.csproj
@@ -53,6 +53,8 @@
     <Compile Include="..\..\Common\src\Interop\Shell32\Interop.SHGetSpecialFolderLocation.cs" Link="Interop\Shell32\Interop.SHGetSpecialFolderLocation.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetWindowText.cs" Link="Interop\User32\Interop.GetWindowText.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SetWindowText.cs" Link="Interop\User32\Interop.SetWindowText.cs" />
+    <Compile Include="..\..\Common\src\Interop\UxTheme\Interop.GetCurrentThemeName.cs" Link="Interop\UxTheme\Interop.GetCurrentThemeName.cs" />
+    <Compile Include="..\..\Common\src\Interop\UxTheme\Interop.GetThemeDocumentationProperty.cs" Link="Interop\UxTheme\Interop.GetCurrentThemeName.cs" />
     <Compile Include="..\..\Common\src\Microsoft\Win32\SafeHandles\CoTaskMemSafeHandle.cs" Link="Microsoft\Win32\SafeHandles\CoTaskMemSafeHandle.cs" />
   </ItemGroup>
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleInformation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleInformation.cs
@@ -45,15 +45,19 @@ namespace System.Windows.Forms.VisualStyles
         /// </summary>
         public static bool IsEnabledByUser => SafeNativeMethods.IsAppThemed();
 
-        internal static string ThemeFilename
+        internal static unsafe string ThemeFilename
         {
             get
             {
                 if (IsEnabledByUser)
                 {
-                    StringBuilder filename = new StringBuilder(512);
-                    SafeNativeMethods.GetCurrentThemeName(filename, filename.Capacity, null, 0, null, 0);
-                    return (filename.ToString());
+                    Span<char> filename = stackalloc char[512];
+                    fixed (char* pFilename = filename)
+                    {
+                        Interop.UxTheme.GetCurrentThemeName(pFilename, filename.Length, null, 0, null, 0);
+                    }
+
+                    return filename.ToString();
                 }
 
                 return string.Empty;
@@ -63,15 +67,19 @@ namespace System.Windows.Forms.VisualStyles
         /// <summary>
         ///    The current visual style's color scheme name.
         /// </summary>
-        public static string ColorScheme
+        public static unsafe string ColorScheme
         {
             get
             {
                 if (IsEnabledByUser)
                 {
-                    StringBuilder colorScheme = new StringBuilder(512);
-                    SafeNativeMethods.GetCurrentThemeName(null, 0, colorScheme, colorScheme.Capacity, null, 0);
-                    return (colorScheme.ToString());
+                    Span<char> colorScheme = stackalloc char[512];
+                    fixed (char* pColorScheme = colorScheme)
+                    {
+                        Interop.UxTheme.GetCurrentThemeName(null, 0, pColorScheme, colorScheme.Length, null, 0);
+                    }
+
+                    return colorScheme.ToString();
                 }
 
                 return string.Empty;
@@ -81,15 +89,19 @@ namespace System.Windows.Forms.VisualStyles
         /// <summary>
         ///    The current visual style's size name.
         /// </summary>
-        public static string Size
+        public static unsafe string Size
         {
             get
             {
                 if (IsEnabledByUser)
                 {
-                    StringBuilder size = new StringBuilder(512);
-                    SafeNativeMethods.GetCurrentThemeName(null, 0, null, 0, size, size.Capacity);
-                    return (size.ToString());
+                    Span<char> size = stackalloc char[512];
+                    fixed (char* pSize = size)
+                    {
+                        Interop.UxTheme.GetCurrentThemeName(null, 0, null, 0, pSize, size.Length);
+                    }
+
+                    return size.ToString();
                 }
 
                 return string.Empty;
@@ -99,15 +111,13 @@ namespace System.Windows.Forms.VisualStyles
         /// <summary>
         ///    The current visual style's display name.
         /// </summary>
-        public static string DisplayName
+        public static unsafe string DisplayName
         {
             get
             {
                 if (IsEnabledByUser)
                 {
-                    StringBuilder name = new StringBuilder(512);
-                    SafeNativeMethods.GetThemeDocumentationProperty(ThemeFilename, SafeNativeMethods.VisualStyleDocProperty.DisplayName, name, name.Capacity);
-                    return name.ToString();
+                    return Interop.UxTheme.GetThemeDocumentationProperty(ThemeFilename, Interop.UxTheme.VisualStyleDocProperty.DisplayName);
                 }
 
                 return string.Empty;
@@ -123,9 +133,7 @@ namespace System.Windows.Forms.VisualStyles
             {
                 if (IsEnabledByUser)
                 {
-                    StringBuilder company = new StringBuilder(512);
-                    SafeNativeMethods.GetThemeDocumentationProperty(ThemeFilename, SafeNativeMethods.VisualStyleDocProperty.Company, company, company.Capacity);
-                    return company.ToString();
+                    return Interop.UxTheme.GetThemeDocumentationProperty(ThemeFilename, Interop.UxTheme.VisualStyleDocProperty.Company);
                 }
 
                 return string.Empty;
@@ -141,9 +149,7 @@ namespace System.Windows.Forms.VisualStyles
             {
                 if (IsEnabledByUser)
                 {
-                    StringBuilder author = new StringBuilder(512);
-                    SafeNativeMethods.GetThemeDocumentationProperty(ThemeFilename, SafeNativeMethods.VisualStyleDocProperty.Author, author, author.Capacity);
-                    return author.ToString();
+                    return Interop.UxTheme.GetThemeDocumentationProperty(ThemeFilename, Interop.UxTheme.VisualStyleDocProperty.Author);
                 }
 
                 return string.Empty;
@@ -159,9 +165,7 @@ namespace System.Windows.Forms.VisualStyles
             {
                 if (IsEnabledByUser)
                 {
-                    StringBuilder copyright = new StringBuilder(512);
-                    SafeNativeMethods.GetThemeDocumentationProperty(ThemeFilename, SafeNativeMethods.VisualStyleDocProperty.Copyright, copyright, copyright.Capacity);
-                    return copyright.ToString();
+                    return Interop.UxTheme.GetThemeDocumentationProperty(ThemeFilename, Interop.UxTheme.VisualStyleDocProperty.Copyright);
                 }
 
                 return string.Empty;
@@ -179,9 +183,7 @@ namespace System.Windows.Forms.VisualStyles
             {
                 if (IsEnabledByUser)
                 {
-                    StringBuilder url = new StringBuilder(512);
-                    SafeNativeMethods.GetThemeDocumentationProperty(ThemeFilename, SafeNativeMethods.VisualStyleDocProperty.Url, url, url.Capacity);
-                    return url.ToString();
+                    return Interop.UxTheme.GetThemeDocumentationProperty(ThemeFilename, Interop.UxTheme.VisualStyleDocProperty.Url);
                 }
 
                 return string.Empty;
@@ -197,9 +199,7 @@ namespace System.Windows.Forms.VisualStyles
             {
                 if (IsEnabledByUser)
                 {
-                    StringBuilder version = new StringBuilder(512);
-                    SafeNativeMethods.GetThemeDocumentationProperty(ThemeFilename, SafeNativeMethods.VisualStyleDocProperty.Version, version, version.Capacity);
-                    return version.ToString();
+                    return Interop.UxTheme.GetThemeDocumentationProperty(ThemeFilename, Interop.UxTheme.VisualStyleDocProperty.Version);
                 }
 
                 return string.Empty;
@@ -215,9 +215,7 @@ namespace System.Windows.Forms.VisualStyles
             {
                 if (IsEnabledByUser)
                 {
-                    StringBuilder description = new StringBuilder(512);
-                    SafeNativeMethods.GetThemeDocumentationProperty(ThemeFilename, SafeNativeMethods.VisualStyleDocProperty.Description, description, description.Capacity);
-                    return description.ToString();
+                    return Interop.UxTheme.GetThemeDocumentationProperty(ThemeFilename, Interop.UxTheme.VisualStyleDocProperty.Description);
                 }
 
                 return string.Empty;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/VisualStyles/VisualStyleInformationTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/VisualStyles/VisualStyleInformationTests.cs
@@ -26,6 +26,17 @@ namespace System.Windows.Forms.VisualStyles.Tests
         }
 
         [Fact]
+        public void VisualStyleInformation_ColorScheme_Get_ReturnsDifferent()
+        {
+            string scheme = VisualStyleInformation.ColorScheme;
+            if (scheme != string.Empty)
+            {
+                Assert.NotEqual(scheme, VisualStyleInformation.Size);
+                Assert.NotEqual(scheme, VisualStyleInformation.Version);
+            }
+        }
+
+        [Fact]
         public void VisualStyleInformation_Company_Get_ReturnsExpected()
         {
             string company = VisualStyleInformation.Company;
@@ -97,6 +108,17 @@ namespace System.Windows.Forms.VisualStyles.Tests
         }
 
         [Fact]
+        public void VisualStyleInformation_Size_Get_ReturnsDifferent()
+        {
+            string size = VisualStyleInformation.Size;
+            if (size != string.Empty)
+            {
+                Assert.NotEqual(size, VisualStyleInformation.ColorScheme);
+                Assert.NotEqual(size, VisualStyleInformation.Version);
+            }
+        }
+
+        [Fact]
         public void VisualStyleInformation_SupportsFlatMenus_Get_ReturnsExpected()
         {
             bool supported = VisualStyleInformation.SupportsFlatMenus;
@@ -125,6 +147,17 @@ namespace System.Windows.Forms.VisualStyles.Tests
             string version = VisualStyleInformation.Version;
             Assert.NotNull(version);
             Assert.Equal(version, VisualStyleInformation.Version);
+        }
+
+        [Fact]
+        public void VisualStyleInformation_Version_Get_ReturnsDifferent()
+        {
+            string version = VisualStyleInformation.Version;
+            if (version != string.Empty)
+            {
+                Assert.NotEqual(version, VisualStyleInformation.ColorScheme);
+                Assert.NotEqual(version, VisualStyleInformation.Size);
+            }
         }
     }
 }


### PR DESCRIPTION
- Avoid allocated a large `StringBuilder`. Instead use a stackallocated span. 512 is an appropriate size for stack allocation
- Move to the `Interop.XYZ` model to match .NET Foundation interop guidelines