### PR TITLE
Remove dead code relating to support for themes

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/OSFeature.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OSFeature.cs
@@ -22,9 +22,6 @@ namespace System.Windows.Forms
 
         private static OSFeature _feature = null;
 
-        private static bool _themeSupportTested = false;
-        private static bool _themeSupport = false;
-
         /// <summary>
         /// Initializes a new instance of the <see cref='System.Windows.Forms.OSFeature'/> class.
         /// </summary>
@@ -43,31 +40,10 @@ namespace System.Windows.Forms
         /// </summary>
         public override Version GetVersionPresent(object feature)
         {
-            if (feature == LayeredWindows)
+            // These are always supported on platforms that .NET Core supports.
+            if (feature == LayeredWindows || feature == Themes)
             {
                 return new Version(0, 0, 0, 0);
-            }
-            else if (feature == Themes)
-            {
-                if (!_themeSupportTested)
-                {
-                    try
-                    {
-                        SafeNativeMethods.IsAppThemed();
-                        _themeSupport = true;
-                    }
-                    catch
-                    {
-                        _themeSupport = false;
-                    }
-
-                    _themeSupportTested = true;
-                }
-
-                if (_themeSupport)
-                {
-                    return new Version(0, 0, 0, 0);
-                }
             }
 
             return null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleInformation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleInformation.cs
@@ -34,36 +34,16 @@ namespace System.Windows.Forms.VisualStyles
         private static VisualStyleRenderer visualStyleRenderer = null;
 
         /// <summary>
-        ///    <para>
-        ///       Used to find whether visual styles are supported by the current OS. Same as 
-        ///       using the OSFeature class to see if themes are supported.
-        ///    </para>
+        /// Used to find whether visual styles are supported by the current OS. Same as 
+        /// using the OSFeature class to see if themes are supported.
+        /// This is always supported on platforms that .NET Core supports.
         /// </summary>
-        public static bool IsSupportedByOS
-        {
-            get
-            {
-                return (OSFeature.Feature.IsPresent(OSFeature.Themes));
-            }
-        }
+        public static bool IsSupportedByOS => true;
 
         /// <summary>
-        ///    <para> 
-        ///     Returns true if a visual style has currently been applied by the user, else false.
-        ///    </para>
+        /// Returns true if a visual style has currently been applied by the user, else false.
         /// </summary>
-        public static bool IsEnabledByUser
-        {
-            get
-            {
-                if (!IsSupportedByOS)
-                {
-                    return false;
-                }
-
-                return (SafeNativeMethods.IsAppThemed());
-            }
-        }
+        public static bool IsEnabledByUser => SafeNativeMethods.IsAppThemed();
 
         internal static string ThemeFilename
         {


### PR DESCRIPTION
The Themes feature is supported on operating systems since Windows Server 2003 (https://docs.microsoft.com/en-us/windows/desktop/api/uxtheme/nf-uxtheme-isappthemed)

Importantly, this does *not* necessarily mean that visual styles are enabled, but that they are present in the feature set.

If you look at the implementation of the `OSFeature` check for themes, we don't actually check if `IsAppThemed` returns `true`, but rather that it does not throw.. More specifically we check that it does not throw a `EntryPointNotFoundException`, which won't happen in .NET Core since we're supported since Windows 7

The actual check for whether visual styles are enabled is `VisualStyleInformation.IsEnabledByUser`