### PR TITLE
Fixed CodeDOM serialization of primitives

### DIFF
--- a/src/Common/tests/CommonTestHelper.cs
+++ b/src/Common/tests/CommonTestHelper.cs
@@ -163,12 +163,13 @@ namespace WinForms.Common.Tests
         }
 
         // helper method to generate theory data for a span of string values
+        private const string reasonable = nameof(reasonable);
         public static TheoryData<string> GetStringTheoryData()
         {
             var data = new TheoryData<string>
             {
                 string.Empty,
-                "reasonable"
+                reasonable
             };
             return data;
         }
@@ -179,7 +180,7 @@ namespace WinForms.Common.Tests
             {
                 null,
                 string.Empty,
-                "reasonable"
+                reasonable
             };
             return data;
         }
@@ -200,7 +201,7 @@ namespace WinForms.Common.Tests
             {
                 { null, string.Empty },
                 { string.Empty, string.Empty },
-                { "reasonable", "reasonable" }
+                { reasonable, reasonable }
             };
             return data;
         }
@@ -451,17 +452,23 @@ namespace WinForms.Common.Tests
             return data;
         }
 
-        public static TheoryData<Exception> GetSecurityOrCriticalException()
+        #endregion
+
+        #region CodeDOM
+        public static TheoryData<object> GetPrimitiveExpressionTheoryData()
         {
-            var data = new TheoryData<Exception>
+            var data = new TheoryData<object>
             {
-                new NullReferenceException(),
-                new SecurityException()
+                false,
+                "aaa",
+                'a',
+                42,
+                42F,
+                42.123
             };
             return data;
         }
-
-        #endregion        
+        #endregion CodeDOM
     }
 
     [Flags]

--- a/src/Common/tests/CommonTestHelper.cs
+++ b/src/Common/tests/CommonTestHelper.cs
@@ -164,6 +164,7 @@ namespace WinForms.Common.Tests
 
         // helper method to generate theory data for a span of string values
         private const string reasonable = nameof(reasonable);
+
         public static TheoryData<string> GetStringTheoryData()
         {
             var data = new TheoryData<string>
@@ -453,22 +454,6 @@ namespace WinForms.Common.Tests
         }
 
         #endregion
-
-        #region CodeDOM
-        public static TheoryData<object> GetPrimitiveExpressionTheoryData()
-        {
-            var data = new TheoryData<object>
-            {
-                false,
-                "aaa",
-                'a',
-                42,
-                42F,
-                42.123
-            };
-            return data;
-        }
-        #endregion CodeDOM
     }
 
     [Flags]

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/PrimitiveCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/PrimitiveCodeDomSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -49,14 +49,14 @@ namespace System.ComponentModel.Design.Serialization
 
             if (value != null)
             {
-                if (value is string)
+                if (value is string stringValue)
                 {
-                    if (value is string stringValue && stringValue.Length > 200)
+                    if (stringValue.Length > 200)
                     {
                         expression = SerializeToResourceExpression(manager, stringValue);
                     }
                 }
-                else
+                else if (!(value is bool || value is char || value is int || value is float || value is double))
                 {
                     // Generate a cast for all other types because we won't parse them properly otherwise 
                     // because we won't know to convert them to the narrow form.

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/PrimitiveCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/PrimitiveCodeDomSerializer.cs
@@ -47,21 +47,25 @@ namespace System.ComponentModel.Design.Serialization
 
             CodeExpression expression = new CodePrimitiveExpression(value);
 
-            if (value != null)
+            if (value == null)
             {
-                if (value is string stringValue)
+				return expression;
+			}
+			
+            if (value is string stringValue)
+            {
+                if (stringValue.Length > 200)
                 {
-                    if (stringValue.Length > 200)
-                    {
-                        expression = SerializeToResourceExpression(manager, stringValue);
-                    }
+                    expression = SerializeToResourceExpression(manager, stringValue);
                 }
-                else if (!(value is bool || value is char || value is int || value is float || value is double))
-                {
-                    // Generate a cast for all other types because we won't parse them properly otherwise 
-                    // because we won't know to convert them to the narrow form.
-                    expression = new CodeCastExpression(new CodeTypeReference(value.GetType()), expression);
-                }
+				return expression;
+            }
+                
+		    if (!(value is bool || value is char || value is int || value is float || value is double))
+            {
+                // Generate a cast for all other types because we won't parse them properly otherwise 
+                // because we won't know to convert them to the narrow form.
+                expression = new CodeCastExpression(new CodeTypeReference(value.GetType()), expression);
             }
 
             return expression;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/Serialization/PrimitiveCodeDomSerializerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/Serialization/PrimitiveCodeDomSerializerTests.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CodeDom;
+using System.ComponentModel.Design.Serialization;
+using System.Text;
+using WinForms.Common.Tests;
+using Xunit;
+
+namespace System.Windows.Forms.Design.Serialization.Tests
+{
+    public class PrimitiveCodeDomSerializerTests
+    {
+        [Fact]
+        public void PrimitiveCodeDomSerializerTests_Constructor()
+        {
+            var underTest = new PrimitiveCodeDomSerializer();
+            Assert.NotNull(underTest);
+        }
+
+        [Theory]
+        [CommonMemberData(nameof(CommonTestHelper.GetPrimitiveExpressionTheoryData))]
+        public void PrimitiveCodeDomSerializerTests_Serialize(object input)
+        {
+            var manager = new DesignerSerializationManager();
+            PrimitiveCodeDomSerializer underTest = PrimitiveCodeDomSerializer.Default;
+            Assert.NotNull(underTest);
+
+            var result = underTest.Serialize(manager, input) as CodePrimitiveExpression;
+            Assert.NotNull(result);
+            Assert.Equal(input, result.Value);
+            Assert.Empty(result.UserData);
+        }
+
+        [Fact]
+        public void PrimitiveCodeDomSerializerTests_Serialize_Cast()
+        {
+            var manager = new DesignerSerializationManager();
+            PrimitiveCodeDomSerializer underTest = PrimitiveCodeDomSerializer.Default;
+            Assert.NotNull(underTest);
+
+            var cast = underTest.Serialize(manager, (byte)42) as CodeCastExpression;
+
+            Assert.NotNull(cast);
+            Assert.Equal(typeof(byte).ToString(), cast.TargetType.BaseType);
+            Assert.IsType<CodePrimitiveExpression>(cast.Expression);
+            var primitive = cast.Expression as CodePrimitiveExpression;
+            Assert.Equal((byte)42, primitive.Value);
+            Assert.Empty(cast.UserData);
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/tests/UnitTests/Serialization/PrimitiveCodeDomSerializerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/Serialization/PrimitiveCodeDomSerializerTests.cs
@@ -20,7 +20,13 @@ namespace System.Windows.Forms.Design.Serialization.Tests
         }
 
         [Theory]
-        [CommonMemberData(nameof(CommonTestHelper.GetPrimitiveExpressionTheoryData))]
+        [InlineData(null)]
+        [InlineData(false)]
+        [InlineData("some string")]
+        [InlineData('c')]
+        [InlineData(42)]
+        [InlineData(42F)]
+        [InlineData(42.123)]
         public void PrimitiveCodeDomSerializerTests_Serialize(object input)
         {
             var manager = new DesignerSerializationManager();


### PR DESCRIPTION
Serializer was adding unnecessary casts to primitive expressions.
For example ((int)(42)) instead of 42.