### PR TITLE
fix: Incorrect parent assignment

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
@@ -217,14 +217,7 @@ namespace System.Windows.Forms.Design
 
                     if (editor is WindowsFormsComponentEditor winEditor)
                     {
-                        IWin32Window parent = null;
-                        if (obj is IWin32Window)
-                        {
-#pragma warning disable 1717 // assignment to self
-                            parent = (IWin32Window)parent;
-#pragma warning restore 1717
-                        }
-                        success = winEditor.EditComponent(obj, parent);
+                        success = winEditor.EditComponent(obj, obj as IWin32Window);
                     }
                     else
                     {


### PR DESCRIPTION
As discovered in #1079 `parent` is incorrectly set, that essentially means it is always set to `null`.

The fix removes the redundant incorrect assignment.

Closes #1079.