### PR TITLE
System.Windows.Forms.Design.Tests.FolderNameEditorTests+FolderBrowser…

### DIFF
--- a/src/System.Windows.Forms.Design.Editors/tests/UnitTests/System/Windows/Forms/Design/FolderNameEditorTests.cs
+++ b/src/System.Windows.Forms.Design.Editors/tests/UnitTests/System/Windows/Forms/Design/FolderNameEditorTests.cs
@@ -47,11 +47,11 @@ namespace System.Windows.Forms.Design.Tests
                 {
                     Description = value
                 };
-                Assert.Same(expected, browser.Description);
+                Assert.Equal(expected, browser.Description);
 
                 // Set same.
                 browser.Description = value;
-                Assert.Same(expected, browser.Description);
+                Assert.Equal(expected, browser.Description);
             }
 
             [Theory]


### PR DESCRIPTION
Currently this test is failing. Please check the attached screenshot. 
It seems that it is failing because of the use of Assert.Same().

Replacing it with Assert.Equal() as in other tests fixes it.

![FailingTest](https://user-images.githubusercontent.com/48907761/59420134-fbe23580-8dd4-11e9-97a9-65dccd585c58.JPG)
