### PR TITLE
disable helix dialog handler in ci builds

### DIFF
--- a/eng/ci.yml
+++ b/eng/ci.yml
@@ -122,11 +122,12 @@ jobs:
       - powershell: eng\pre-build.ps1
         displayName: Pre-Build - Set VSO Variables
 
+      # see env vars, for debugging only, remove once the next step is working
+      - script: set
+
       # disable helix dialog handler which breaks some of our UI tests
-      - script: $env:HELIX_PYTHONPATH -c 'from helix_test_execution import disable_dialog_handler; disable_dialog_handler()'
+      - script: %HELIX_PYTHONPATH% -c 'from helix_test_execution import disable_dialog_handler; disable_dialog_handler()'
         displayName: Disable dialog handler
-        env: 
-          HELIX_PYTHONPATH: $(HELIX_PYTHONPATH)
 
       # Build and rename binlog
       # Note: The /p:Coverage argument is passed here since some build properties change to accommodate running with

--- a/eng/ci.yml
+++ b/eng/ci.yml
@@ -126,7 +126,7 @@ jobs:
       - script: set
 
       # disable helix dialog handler which breaks some of our UI tests
-      - script: $(HELIX_PYTHONPATH) -c 'from helix_test_execution import disable_dialog_handler; disable_dialog_handler()'
+      - script: $(HELIX_PYTHONPATH) -c from helix_test_execution import disable_dialog_handler; disable_dialog_handler()
         displayName: Disable dialog handler
 
       # Build and rename binlog

--- a/eng/ci.yml
+++ b/eng/ci.yml
@@ -126,7 +126,7 @@ jobs:
       - script: set
 
       # disable helix dialog handler which breaks some of our UI tests
-      - script: %HELIX_PYTHONPATH% -c 'from helix_test_execution import disable_dialog_handler; disable_dialog_handler()'
+      - script: $(HELIX_PYTHONPATH) -c 'from helix_test_execution import disable_dialog_handler; disable_dialog_handler()'
         displayName: Disable dialog handler
 
       # Build and rename binlog

--- a/eng/ci.yml
+++ b/eng/ci.yml
@@ -122,9 +122,6 @@ jobs:
       - powershell: eng\pre-build.ps1
         displayName: Pre-Build - Set VSO Variables
 
-      # see env vars, for debugging only, remove once the next step is working
-      - script: set
-
       # disable helix dialog handler which breaks some of our UI tests
       - script: $(HELIX_PYTHONPATH) -c "from helix_test_execution import disable_dialog_handler; disable_dialog_handler()"
         displayName: Disable dialog handler

--- a/eng/ci.yml
+++ b/eng/ci.yml
@@ -126,7 +126,7 @@ jobs:
       - script: set
 
       # disable helix dialog handler which breaks some of our UI tests
-      - script: $(HELIX_PYTHONPATH) -c from helix_test_execution import disable_dialog_handler; disable_dialog_handler()
+      - script: $(HELIX_PYTHONPATH) -c "from helix_test_execution import disable_dialog_handler; disable_dialog_handler()"
         displayName: Disable dialog handler
 
       # Build and rename binlog

--- a/eng/ci.yml
+++ b/eng/ci.yml
@@ -122,6 +122,12 @@ jobs:
       - powershell: eng\pre-build.ps1
         displayName: Pre-Build - Set VSO Variables
 
+      # disable helix dialog handler which breaks some of our UI tests
+      - script: $env:HELIX_PYTHONPATH -c 'from helix_test_execution import disable_dialog_handler; disable_dialog_handler()'
+        displayName: Disable dialog handler
+        env: 
+          HELIX_PYTHONPATH: $(HELIX_PYTHONPATH)
+
       # Build and rename binlog
       # Note: The /p:Coverage argument is passed here since some build properties change to accommodate running with
       #       coverage. This is part of the workarounds for https://github.com/tonerdo/coverlet/issues/362 and


### PR DESCRIPTION
The dialog handler is most likely responsible for sporadically causing our unit tests to time out, since many of our tests open UI windows. The suggestion from dnceng was to disable it in this way.