### PR TITLE
fix: Reduce preview font size

### DIFF
--- a/src/System.Windows.Forms.Design.Editors/src/System/Drawing/Design/FontNameEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/Drawing/Design/FontNameEditor.cs
@@ -14,6 +14,7 @@ namespace System.Drawing.Design
     [System.Security.Permissions.PermissionSetAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, Name = "FullTrust")]
     public class FontNameEditor : UITypeEditor
     {
+        private const float ScaleFactor = 1.5f;
         private static readonly FontStyle[] s_FontStyles = new[]
         {
              FontStyle.Regular,
@@ -69,8 +70,6 @@ namespace System.Drawing.Design
                         }
                     }
                 }
-
-                e.Graphics.DrawLine(SystemPens.WindowFrame, e.Bounds.Right, e.Bounds.Y, e.Bounds.Right, e.Bounds.Bottom);
             }
             catch
             {
@@ -85,10 +84,14 @@ namespace System.Drawing.Design
         /// </summary>
         private static void DrawFontSample(PaintValueEventArgs e, FontFamily fontFamily, FontStyle fontStyle)
         {
-            float fontSize = (float)(e.Bounds.Height / 1.2);
+            float fontSize = e.Bounds.Height / ScaleFactor;
             using (var font = new Font(fontFamily, fontSize, fontStyle, GraphicsUnit.Pixel))
             {
-                e.Graphics.DrawString("abcd", font, SystemBrushes.ActiveCaptionText, e.Bounds);
+                var sf = new StringFormat(StringFormatFlags.NoWrap | StringFormatFlags.NoFontFallback)
+                {
+                    LineAlignment = StringAlignment.Far 
+                };
+                e.Graphics.DrawString("abcd", font, SystemBrushes.ActiveCaptionText, e.Bounds, sf);
             }
         }
     }


### PR DESCRIPTION
* Reduce the preview font size to provide a better visual parity with NET Fx since the change of the default font in Core.
![image](https://user-images.githubusercontent.com/4403806/59574224-cd789900-90f9-11e9-811f-8dd345084503.png)


* Prefer to align the preview to the bottom, if possible
![image](https://user-images.githubusercontent.com/4403806/59574251-da958800-90f9-11e9-9ce8-18b5da6c2e8e.png)


* Remove a vertical line to the right of the preview box as it serves no purpose

Closes #1106