### PR TITLE
Fix link to .NET Core roadmap

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -45,4 +45,4 @@ Guide](Documentation/contributing.md).
 
 [comment]: <> (URI Links)
 
-[core-roadmap]: roadmap.md
+[core-roadmap]: https://github.com/dotnet/core/blob/master/roadmap.md


### PR DESCRIPTION
This is currently a circular link to the wrong roadmap.