### PR TITLE
convert all instances of new type[0] to Array.Empty<type>() except statically allocated instances required for test member data

### DIFF
--- a/src/System.Windows.Forms.Design.Editors/tests/UnitTests/System/ComponentModel/Design/ArrayEditorTests.cs
+++ b/src/System.Windows.Forms.Design.Editors/tests/UnitTests/System/ComponentModel/Design/ArrayEditorTests.cs
@@ -135,10 +135,10 @@ namespace System.ComponentModel.Design.Tests
 
         public static IEnumerable<object[]> GetItems_TestData()
         {
-            yield return new object[] { null, new object[0] };
-            yield return new object[] { new object(), new object[0] };
+            yield return new object[] { null, Array.Empty<object>() };
+            yield return new object[] { new object(), Array.Empty<object>() };
             yield return new object[] { new int[] { 1, 2, 3 }, new object[] { 1, 2, 3, } };
-            yield return new object[] { new ArrayList { 1, 2, 3 }, new object[0] };
+            yield return new object[] { new ArrayList { 1, 2, 3 }, Array.Empty<object>() };
         }
 
         [Theory]
@@ -154,7 +154,7 @@ namespace System.ComponentModel.Design.Tests
 
         public static IEnumerable<object[]> SetItems_Array_TestData()
         {
-            yield return new object[] { null, new object[0], new object[0] };
+            yield return new object[] { null, Array.Empty<object>(), Array.Empty<object>() };
             yield return new object[] { null, new object[] { 1, 2, 3 }, new object[] { 1, 2, 3 } };
             yield return new object[] { new object[] { 4, 5 }, new object[] { 1, 2, 3 }, new object[] { 1, 2, 3 } };
             yield return new object[] { new object[] { 4, 5, 6 }, new object[] { 1, 2, 3 }, new object[] { 1, 2, 3 } };
@@ -175,8 +175,8 @@ namespace System.ComponentModel.Design.Tests
         {
             var editValue = new object();
             yield return new object[] { editValue, null, editValue };
-            yield return new object[] { editValue, new object[0], editValue };
-            yield return new object[] { new object[0], null, null };
+            yield return new object[] { editValue, Array.Empty<object>(), editValue };
+            yield return new object[] { Array.Empty<object>(), null, null };
             yield return new object[] { null, null, null };
         }
 
@@ -195,8 +195,8 @@ namespace System.ComponentModel.Design.Tests
         {
             var editor = new SubArrayEditor(type);
             Assert.Null(editor.CollectionItemType);
-            Assert.Throws<ArgumentNullException>("elementType", () => editor.SetItems(null, new object[0]));
-            Assert.Throws<ArgumentNullException>("elementType", () => editor.SetItems(new object[0], new object[0]));
+            Assert.Throws<ArgumentNullException>("elementType", () => editor.SetItems(null, Array.Empty<object>()));
+            Assert.Throws<ArgumentNullException>("elementType", () => editor.SetItems(Array.Empty<object>(), Array.Empty<object>()));
         }
 
         private class SubArrayEditor : ArrayEditor

--- a/src/System.Windows.Forms.Design.Editors/tests/UnitTests/System/ComponentModel/Design/CollectionEditorTests.cs
+++ b/src/System.Windows.Forms.Design.Editors/tests/UnitTests/System/ComponentModel/Design/CollectionEditorTests.cs
@@ -835,8 +835,8 @@ namespace System.ComponentModel.Design.Tests
 
         public static IEnumerable<object[]> GetItems_TestData()
         {
-            yield return new object[] { null, new object[0] };
-            yield return new object[] { new object(), new object[0] };
+            yield return new object[] { null, Array.Empty<object>() };
+            yield return new object[] { new object(), Array.Empty<object>() };
             yield return new object[] { new int[] { 1, 2, 3 }, new object[] { 1, 2, 3, } };
             yield return new object[] { new ArrayList { 1, 2, 3 }, new object[] { 1, 2, 3, } };
         }
@@ -917,20 +917,20 @@ namespace System.ComponentModel.Design.Tests
         public static IEnumerable<object[]> SetItems_TestData()
         {
             yield return new object[] { null, new object[] { 1, 2, 3 }, null };
-            yield return new object[] { null, new object[0], null };
+            yield return new object[] { null, Array.Empty<object>(), null };
             yield return new object[] { null, null, null };
 
             var o = new object();
             yield return new object[] { o, new object[] { 1, 2, 3 }, o };
-            yield return new object[] { o, new object[0], o };
+            yield return new object[] { o, Array.Empty<object>(), o };
             yield return new object[] { o, null, o };
 
-            yield return new object[] { new int[] { 1, 2, 3 }, new object[0], new object[] { 0, 0, 0 } };
+            yield return new object[] { new int[] { 1, 2, 3 }, Array.Empty<object>(), new object[] { 0, 0, 0 } };
             yield return new object[] { new int[] { 1, 2, 3 }, null, new object[] { 0, 0, 0 } };
 
             yield return new object[] { new ArrayList { 1, 2, 3 }, new object[] { 1 }, new object[] { 1 } };
-            yield return new object[] { new ArrayList { 1, 2, 3 }, new object[0], new object[0] };
-            yield return new object[] { new ArrayList { 1, 2, 3 }, null, new object[0] };
+            yield return new object[] { new ArrayList { 1, 2, 3 }, Array.Empty<object>(), Array.Empty<object>() };
+            yield return new object[] { new ArrayList { 1, 2, 3 }, null, Array.Empty<object>() };
         }
 
         [Theory]

--- a/src/System.Windows.Forms.Design.Editors/tests/UnitTests/System/ComponentModel/Design/CollectionFormTests.cs
+++ b/src/System.Windows.Forms.Design.Editors/tests/UnitTests/System/ComponentModel/Design/CollectionFormTests.cs
@@ -58,7 +58,7 @@ namespace System.ComponentModel.Design.Tests
         public static IEnumerable<object[]> Items_Set_TestData()
         {
             yield return new object[] { null };
-            yield return new object[] { new object[0] };
+            yield return new object[] { Array.Empty<object>() };
             yield return new object[] { new object[] { 1, 2, 3 } };
         }
 
@@ -205,16 +205,16 @@ namespace System.ComponentModel.Design.Tests
             form.OnEditValueChangedCallCount = 0;
 
             form.Items = value;
-            Assert.Equal(value ?? new object[0], form.EditValue);
-            Assert.Equal(value ?? new object[0], form.Items);
+            Assert.Equal(value ?? Array.Empty<object>(), form.EditValue);
+            Assert.Equal(value ?? Array.Empty<object>(), form.Items);
             Assert.Equal(0, form.OnEditValueChangedCallCount);
             mockContext.Verify(c => c.OnComponentChanging(), Times.Once());
             mockContext.Verify(c => c.OnComponentChanged(), Times.Once());
 
             // Set same.
             form.Items = value;
-            Assert.Equal(value ?? new object[0], form.EditValue);
-            Assert.Equal(value ?? new object[0], form.Items);
+            Assert.Equal(value ?? Array.Empty<object>(), form.EditValue);
+            Assert.Equal(value ?? Array.Empty<object>(), form.Items);
             Assert.Equal(0, form.OnEditValueChangedCallCount);
             mockContext.Verify(c => c.OnComponentChanging(), Times.Exactly(2));
             mockContext.Verify(c => c.OnComponentChanged(), Times.Exactly(2));

--- a/src/System.Windows.Forms.Design.Editors/tests/UnitTests/System/Drawing/Design/ImageEditorTests.cs
+++ b/src/System.Windows.Forms.Design.Editors/tests/UnitTests/System/Drawing/Design/ImageEditorTests.cs
@@ -17,7 +17,7 @@ namespace System.Drawing.Design.Tests
         public static IEnumerable<object[]> CreateExtensionsString_TestData()
         {
             yield return new object[] { null, ",", null };
-            yield return new object[] { new string[0], ",", null };
+            yield return new object[] { Array.Empty<string>(), ",", null };
             yield return new object[] { new string[] { "a", "b", "c" }, ",", "*.a,*.b,*.c" };
             yield return new object[] { new string[] { "a", "b", "c" }, "", "*.a*.b*.c" };
             yield return new object[] { new string[] { "a", "b", "c" }, null, "*.a*.b*.c" };

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.cs
@@ -48,7 +48,7 @@ namespace System.ComponentModel.Design
         /// </summary>
         public virtual ICollection AssociatedComponents
         {
-            get => new IComponent[0];
+            get => Array.Empty<IComponent>();
         }
 
         internal virtual bool CanBeAssociatedWith(IDesigner parentDesigner) => true;
@@ -258,7 +258,7 @@ namespace System.ComponentModel.Design
             {
                 if (properties[SettingsKeyName] is PropertyDescriptor prop)
                 {
-                    properties[SettingsKeyName] = TypeDescriptor.CreateProperty(typeof(ComponentDesigner), prop, new Attribute[0]);
+                    properties[SettingsKeyName] = TypeDescriptor.CreateProperty(typeof(ComponentDesigner), prop, Array.Empty<Attribute>());
                 }
             }
         }
@@ -318,7 +318,7 @@ namespace System.ComponentModel.Design
 
                     return designers;
                 }
-                return new object[0];
+                return Array.Empty<object>();
             }
         }
 
@@ -873,7 +873,7 @@ namespace System.ComponentModel.Design
             {
                 if (properties[SettingsKeyName] is PropertyDescriptor prop)
                 {
-                    properties[SettingsKeyName] = TypeDescriptor.CreateProperty(typeof(ComponentDesigner), prop, new Attribute[0]);
+                    properties[SettingsKeyName] = TypeDescriptor.CreateProperty(typeof(ComponentDesigner), prop, Array.Empty<Attribute>());
                 }
             }
         }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurface.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurface.cs
@@ -106,7 +106,7 @@ namespace System.ComponentModel.Design
                 {
                     return _loadErrors;
                 }
-                return new object[0];
+                return Array.Empty<object>();
             }
         }
 
@@ -325,10 +325,10 @@ namespace System.ComponentModel.Design
 
             // Locate an appropriate constructor for IComponents.
             object instance = null;
-            ConstructorInfo ctor = TypeDescriptor.GetReflectionType(type).GetConstructor(new Type[0]);
+            ConstructorInfo ctor = TypeDescriptor.GetReflectionType(type).GetConstructor(Array.Empty<Type>());
             if (ctor != null)
             {
-                instance = TypeDescriptor.CreateInstance(this, type, new Type[0], new object[0]);
+                instance = TypeDescriptor.CreateInstance(this, type, Array.Empty<Type>(), Array.Empty<object>());
             }
             else
             {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ExtenderProviderService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ExtenderProviderService.cs
@@ -30,7 +30,7 @@ namespace System.ComponentModel.Design
                 _providers.CopyTo(providers, 0);
                 return providers;
             }
-            return new IExtenderProvider[0];
+            return Array.Empty<IExtenderProvider>();
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SelectionService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SelectionService.cs
@@ -363,7 +363,7 @@ namespace System.ComponentModel.Design
                 _selection.CopyTo(selectedValues, 0);
                 return selectedValues;
             }
-            return new object[0];
+            return Array.Empty<object>();
         }
 
         /// <summary>
@@ -389,7 +389,7 @@ namespace System.ComponentModel.Design
             // We always want to allow NULL arrays coming in.
             if (components == null)
             {
-                components = new object[0];
+                components = Array.Empty<object>();
             }
             // If toggle, replace, remove or add are not specifically specified, infer them from  the state of the modifer keys.  This creates the "Auto" selection type for us by default.
             if (fAuto)

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationService.cs
@@ -307,7 +307,7 @@ namespace System.ComponentModel.Design.Serialization
                 {
                     if (_errors == null)
                     {
-                        _errors = new object[0];
+                        _errors = Array.Empty<object>();
                     }
 
                     object[] errors = new object[_errors.Count];

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs
@@ -2367,11 +2367,11 @@ namespace System.ComponentModel.Design.Serialization
             }
 
             // No instance descriptor. See if we can get to a public constructor that takes no arguments
-            ConstructorInfo ctor = GetReflectionTypeHelper(manager, value).GetConstructor(new Type[0]);
+            ConstructorInfo ctor = GetReflectionTypeHelper(manager, value).GetConstructor(Array.Empty<Type>());
             if (ctor != null)
             {
                 isComplete = false;
-                return new CodeObjectCreateExpression(TypeDescriptor.GetClassName(value), new CodeExpression[0]);
+                return new CodeObjectCreateExpression(TypeDescriptor.GetClassName(value), Array.Empty<CodeExpression>());
             }
             // Nothing worked.
             return null;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CollectionCodeDomSerializer.cs
@@ -725,7 +725,7 @@ namespace System.ComponentModel.Design.Serialization
 
             if (shouldClear)
             {
-                MethodInfo clearMethod = TypeDescriptor.GetReflectionType(collection).GetMethod("Clear", BindingFlags.Public | BindingFlags.Instance, null, new Type[0], null);
+                MethodInfo clearMethod = TypeDescriptor.GetReflectionType(collection).GetMethod("Clear", BindingFlags.Public | BindingFlags.Instance, null, Array.Empty<Type>(), null);
                 if (clearMethod == null || !MethodSupportsSerialization(clearMethod))
                 {
                     shouldClear = false;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ComponentTypeCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ComponentTypeCodeDomSerializer.cs
@@ -105,7 +105,7 @@ namespace System.ComponentModel.Design.Serialization
                 }
             }
 
-            return new CodeMemberMethod[0];
+            return Array.Empty<CodeMemberMethod>();
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/DesignerSerializationManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/DesignerSerializationManager.cs
@@ -646,7 +646,7 @@ namespace System.ComponentModel.Design.Serialization
                     PropertyDescriptor[] propArray;
                     if (propObject == null)
                     {
-                        propArray = new PropertyDescriptor[0];
+                        propArray = Array.Empty<PropertyDescriptor>();
                     }
                     else
                     {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/TypeCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/TypeCodeDomSerializer.cs
@@ -397,7 +397,7 @@ namespace System.ComponentModel.Design.Serialization
                     return new CodeMemberMethod[] { ctor };
                 }
             }
-            return new CodeMemberMethod[0];
+            return Array.Empty<CodeMemberMethod>();
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DragAssistanceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DragAssistanceManager.cs
@@ -40,8 +40,8 @@ namespace System.Windows.Forms.Design.Behavior
         //T hese are cleared and populated on every mouse move.  These lists contain all the new vertical and horizontal lines we need to draw.  At the end of each mouse move - these lines are stored off in the vertLines and horzLines arrays.  This way - we can keep track of old snap lines and can avoid erasing and redrawing the same line.  HA.
         private readonly ArrayList _tempVertLines = new ArrayList();
         private readonly ArrayList _tempHorzLines = new ArrayList();
-        private Line[] _vertLines = new Line[0];
-        private Line[] _horzLines = new Line[0];
+        private Line[] _vertLines = Array.Empty<Line>();
+        private Line[] _horzLines = Array.Empty<Line>();
         // When we draw snap lines - we only draw lines from the targetControl to the control we're snapping to.  To do this, we'll keep a hashtable... format: snapLineToBounds[SnapLine]=ControlBounds.
         private readonly Hashtable _snapLineToBounds = new Hashtable();
         // We remember the last set of (vert & horz) lines we draw so that we can push them to the beh. svc.  From there, if we receive a test hook message requesting these - we got 'em
@@ -315,7 +315,7 @@ namespace System.Windows.Forms.Design.Behavior
             }
             else
             {
-                lines = new Line[0];
+                lines = Array.Empty<Line>();
             }
             return lines;
         }
@@ -335,7 +335,7 @@ namespace System.Windows.Forms.Design.Behavior
             {
                 return _recentLines;
             }
-            return new Line[0];
+            return Array.Empty<Line>();
         }
 
         private void IdentifyAndStoreValidLines(ArrayList snapLines, int[] distances, Rectangle dragBounds, int smallestDistance)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
@@ -315,7 +315,7 @@ namespace System.Windows.Forms.Design
             object[] selection = null;
             if (components == null)
             {
-                return new object[0];
+                return Array.Empty<object>();
             }
             // Mask off any selection object that doesn't adhere to the given ruleset. We can ignore this if the ruleset is zero, as all components would be accepted.
             if (selectionRules != SelectionRules.None)
@@ -334,7 +334,7 @@ namespace System.Windows.Forms.Design
                     selection = list.ToArray();
                 }
             }
-            return selection ?? (new object[0]);
+            return selection ?? (Array.Empty<object>());
         }
 
         /// <summary>
@@ -1326,7 +1326,7 @@ namespace System.Windows.Forms.Design
                         {
                             trans = host.CreateTransaction(string.Format(SR.CommandSetCutMultiple, cutCount));
                             // clear the selected components so we aren't browsing them
-                            SelectionService.SetSelectedComponents(new object[0], SelectionTypes.Replace);
+                            SelectionService.SetSelectedComponents(Array.Empty<object>(), SelectionTypes.Replace);
                             object[] selComps = new object[selectedComponents.Count];
                             selectedComponents.CopyTo(selComps, 0);
                             for (int i = 0; i < selComps.Length; i++)
@@ -1463,7 +1463,7 @@ namespace System.Windows.Forms.Design
                         try
                         {
                             trans = host.CreateTransaction(desc);
-                            SelectionService.SetSelectedComponents(new object[0], SelectionTypes.Replace);
+                            SelectionService.SetSelectedComponents(Array.Empty<object>(), SelectionTypes.Replace);
                             foreach (object obj in comps)
                             {
                                 if (!(obj is IComponent comp) || comp.Site == null)
@@ -2030,7 +2030,7 @@ namespace System.Windows.Forms.Design
                         object[] selComps;
                         if (components == null || components.Count == 0)
                         {
-                            selComps = new IComponent[0];
+                            selComps = Array.Empty<IComponent>();
                         }
                         else
                         {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComponentTray.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComponentTray.cs
@@ -1353,7 +1353,7 @@ namespace System.Windows.Forms.Design
                 }
                 else
                 {
-                    comps = new object[0];
+                    comps = Array.Empty<object>();
                 }
 
                 if (comps.Length == 0)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -1601,7 +1601,7 @@ namespace System.Windows.Forms.Design
             // Handle shadowed properties
             string[] shadowProps = new string[] { "Visible", "Enabled", "ContextMenu", "AllowDrop", "Location", "Name" };
 
-            Attribute[] empty = new Attribute[0];
+            Attribute[] empty = Array.Empty<Attribute>();
             for (int i = 0; i < shadowProps.Length; i++)
             {
                 prop = (PropertyDescriptor)properties[shadowProps[i]];

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormDocumentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormDocumentDesigner.cs
@@ -642,7 +642,7 @@ namespace System.Windows.Forms.Design
             base.PreFilterProperties(properties);
             // Handle shadowed properties
             string[] shadowProps = new string[] { "Opacity", "Menu", "IsMdiContainer", "Size", "ShowInTaskBar", "WindowState", "AutoSize", "AcceptButton", "CancelButton" };
-            Attribute[] empty = new Attribute[0];
+            Attribute[] empty = Array.Empty<Attribute>();
             for (int i = 0; i < shadowProps.Length; i++)
             {
                 prop = (PropertyDescriptor)properties[shadowProps[i]];

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIService.cs
@@ -1146,7 +1146,7 @@ namespace System.Windows.Forms.Design
             object[] selection = null;
             if (components == null)
             {
-                return new object[0];
+                return Array.Empty<object>();
             }
             // Mask off any selection object that doesn't adhere to the given ruleset. We can ignore this if the ruleset is zero, as all components would be accepted.
             if (selectionRules != SelectionRules.None)
@@ -1165,7 +1165,7 @@ namespace System.Windows.Forms.Design
                 }
                 selection = (object[])list.ToArray();
             }
-            return selection ?? (new object[0]);
+            return selection ?? (Array.Empty<object>());
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
@@ -2224,7 +2224,7 @@ namespace System.Windows.Forms.Design
                "AllowDrop",
                "AllowItemReorder"
             };
-            Attribute[] empty = new Attribute[0];
+            Attribute[] empty = Array.Empty<Attribute>();
             for (int i = 0; i < shadowProps.Length; i++)
             {
                 prop = (PropertyDescriptor)properties[shadowProps[i]];

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesignerUtils.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesignerUtils.cs
@@ -276,7 +276,7 @@ namespace System.Windows.Forms.Design
                             continue;
                         }
                         // Check if we have public constructor...
-                        ConstructorInfo ctor = t.GetConstructor(new Type[0]);
+                        ConstructorInfo ctor = t.GetConstructor(Array.Empty<Type>());
                         if (ctor == null)
                         {
                             continue;
@@ -313,7 +313,7 @@ namespace System.Windows.Forms.Design
                 }
             }
             s_customToolStripItemCount = 0;
-            return new Type[0];
+            return Array.Empty<Type>();
         }
 
         /// <summary> 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDropDownDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDropDownDesigner.cs
@@ -566,7 +566,7 @@ namespace System.Windows.Forms.Design
             base.PreFilterProperties(properties);
             PropertyDescriptor prop;
             string[] shadowProps = new string[] { "AutoClose", SettingsKeyName, "RightToLeft", "AllowDrop" };
-            Attribute[] empty = new Attribute[0];
+            Attribute[] empty = Array.Empty<Attribute>();
             for (int i = 0; i < shadowProps.Length; i++)
             {
                 prop = (PropertyDescriptor)properties[shadowProps[i]];

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemDesigner.cs
@@ -1078,7 +1078,7 @@ namespace System.Windows.Forms.Design
             string[] shadowProps = new string[] { "AutoSize", "AccessibleName", "Visible", "Overflow" };
 
             PropertyDescriptor prop;
-            Attribute[] empty = new Attribute[0];
+            Attribute[] empty = Array.Empty<Attribute>();
             for (int i = 0; i < shadowProps.Length; i++)
             {
                 prop = (PropertyDescriptor)properties[shadowProps[i]];

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemDesigner.cs
@@ -2233,7 +2233,7 @@ namespace System.Windows.Forms.Design
             // Handle shadowed properties
             string[] shadowProps = new string[] { "Visible", "DoubleClickEnabled", "CheckOnClick", "DropDown" };
             PropertyDescriptor prop;
-            Attribute[] empty = new Attribute[0];
+            Attribute[] empty = Array.Empty<Attribute>();
             for (int i = 0; i < shadowProps.Length; i++)
             {
                 prop = (PropertyDescriptor)properties[shadowProps[i]];

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerActionListCollectionTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerActionListCollectionTests.cs
@@ -19,7 +19,7 @@ namespace System.ComponentModel.Design.Tests
 
         public static IEnumerable<object[]> Ctor_DesignerActionListArray_TestData()
         {
-            yield return new object[] { new DesignerActionList[0] };
+            yield return new object[] { Array.Empty<DesignerActionList>() };
             yield return new object[] { new DesignerActionList[] { new DesignerActionList(null), null } };
         }
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerCommandSetTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerCommandSetTests.cs
@@ -43,7 +43,7 @@ namespace System.ComponentModel.Design.Tests
             var mockSet = new Mock<DesignerCommandSet>(MockBehavior.Strict);
             mockSet
                 .Setup(s => s.GetCommands("Verbs"))
-                .Returns(new object[0]);
+                .Returns(Array.Empty<object>());
             Assert.Throws<InvalidCastException>(() => mockSet.Object.Verbs);
         }
 
@@ -64,7 +64,7 @@ namespace System.ComponentModel.Design.Tests
             var mockSet = new Mock<DesignerCommandSet>(MockBehavior.Strict);
             mockSet
                 .Setup(s => s.GetCommands("ActionLists"))
-                .Returns(new object[0]);
+                .Returns(Array.Empty<object>());
             Assert.Throws<InvalidCastException>(() => mockSet.Object.ActionLists);
         }
     }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerHostTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerHostTests.cs
@@ -1801,7 +1801,7 @@ namespace System.ComponentModel.Design.Tests
             var collection = new ComponentCollection(new Component[] { new Component() });
             var mockFilterService = new Mock<ContainerFilterService>(MockBehavior.Strict);
             mockFilterService
-                .Setup(f => f.FilterComponents(new ComponentCollection(new IComponent[0])))
+                .Setup(f => f.FilterComponents(new ComponentCollection(Array.Empty<IComponent>())))
                 .Returns(collection);
             var mockServiceProvider = new Mock<IServiceProvider>(MockBehavior.Strict);
             mockServiceProvider
@@ -2681,7 +2681,7 @@ namespace System.ComponentModel.Design.Tests
             var surface = new SubDesignSurface();
             IReflect reflect = Assert.IsAssignableFrom<IReflect>(surface.Host);
             Assert.Equal(typeof(IDesignerHost).GetMethod(nameof(IDesignerHost.Activate)), reflect.GetMethod(nameof(IDesignerHost.Activate), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public));
-            Assert.Equal(typeof(IDesignerHost).GetMethod(nameof(IDesignerHost.Activate)), reflect.GetMethod(nameof(IDesignerHost.Activate), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public, null, new Type[0], new ParameterModifier[0]));
+            Assert.Equal(typeof(IDesignerHost).GetMethod(nameof(IDesignerHost.Activate)), reflect.GetMethod(nameof(IDesignerHost.Activate), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public, null, Array.Empty<Type>(), Array.Empty<ParameterModifier>()));
         }
 
         [Fact]
@@ -2698,7 +2698,7 @@ namespace System.ComponentModel.Design.Tests
             var surface = new SubDesignSurface();
             IReflect reflect = Assert.IsAssignableFrom<IReflect>(surface.Host);
             Assert.Equal(typeof(IDesignerHost).GetProperty(nameof(IDesignerHost.Container)), reflect.GetProperty(nameof(IDesignerHost.Container), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public));
-            Assert.Equal(typeof(IDesignerHost).GetProperty(nameof(IDesignerHost.Container)), reflect.GetProperty(nameof(IDesignerHost.Container), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public, null, typeof(IContainer), new Type[0], new ParameterModifier[0]));
+            Assert.Equal(typeof(IDesignerHost).GetProperty(nameof(IDesignerHost.Container)), reflect.GetProperty(nameof(IDesignerHost.Container), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public, null, typeof(IContainer), Array.Empty<Type>(), Array.Empty<ParameterModifier>()));
         }
 
         [Fact]
@@ -2714,7 +2714,7 @@ namespace System.ComponentModel.Design.Tests
         {
             var surface = new SubDesignSurface();
             IReflect reflect = Assert.IsAssignableFrom<IReflect>(surface.Host);
-            Assert.Equal(surface.Host.Container, reflect.InvokeMember(nameof(IDesignerHost.Container), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.GetProperty, null, surface.Host, new object[0], new ParameterModifier[0], null, new string[0]));
+            Assert.Equal(surface.Host.Container, reflect.InvokeMember(nameof(IDesignerHost.Container), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.GetProperty, null, surface.Host, Array.Empty<object>(), Array.Empty<ParameterModifier>(), null, Array.Empty<string>()));
         }
 
         private class SubDesignSurface : DesignSurface

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/LoadedEventArgsTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/LoadedEventArgsTests.cs
@@ -13,7 +13,7 @@ namespace System.ComponentModel.Design.Tests
         public static IEnumerable<object[]> Ctor_Bool_ICollection_TestData()
         {
             yield return new object[] { true, null };
-            yield return new object[] { false, new object[0] };
+            yield return new object[] { false, Array.Empty<object>() };
             yield return new object[] { true, new object[] { null } };
         }
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ToolboxComponentsCreatedEventArgsTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ToolboxComponentsCreatedEventArgsTests.cs
@@ -13,7 +13,7 @@ namespace System.Drawing.Design.Tests
         public static IEnumerable<object[]> Ctor_IComponentArray_TestData()
         {
             yield return new object[] { null };
-            yield return new object[] { new IComponent[0] };
+            yield return new object[] { Array.Empty<IComponent>() };
             yield return new object[] { new IComponent[] { null } };
         }
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ToolboxItemTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ToolboxItemTests.cs
@@ -159,7 +159,7 @@ namespace System.Drawing.Design.Tests
         public static IEnumerable<object[]> DependentAssemblies_Set_TestData()
         {
             yield return new object[] { null };
-            yield return new object[] { new AssemblyName[0] };
+            yield return new object[] { Array.Empty<AssemblyName>() };
             yield return new object[] { new AssemblyName[] { null } };
             yield return new object[] { new AssemblyName[] { new AssemblyName() } };
         }
@@ -258,9 +258,9 @@ namespace System.Drawing.Design.Tests
 
         public static IEnumerable<object[]> Filter_Set_TestData()
         {
-            yield return new object[] { null, new object[0] };
-            yield return new object[] { new object[0], new object[0] };
-            yield return new object[] { new object[] { null }, new object[0] };
+            yield return new object[] { null, Array.Empty<object>() };
+            yield return new object[] { Array.Empty<object>(), Array.Empty<object>() };
+            yield return new object[] { new object[] { null }, Array.Empty<object>() };
             yield return new object[] { new object[] { new object(), new ToolboxItemFilterAttribute("filterString") }, new object[] { new ToolboxItemFilterAttribute("filterString") } };
         }
 
@@ -1146,7 +1146,7 @@ namespace System.Drawing.Design.Tests
             yield return new object[] { "typename", null, null, true };
 
             yield return new object[] { "Filter", null, Array.Empty<ToolboxItemFilterAttribute>(), false };
-            yield return new object[] { "Filter", new ToolboxItemFilterAttribute[0], new ToolboxItemFilterAttribute[0], true };
+            yield return new object[] { "Filter", Array.Empty<ToolboxItemFilterAttribute>(), Array.Empty<ToolboxItemFilterAttribute>(), true };
             yield return new object[] { "Filter", o, o, true };
             yield return new object[] { "filter", null, null, true };
 
@@ -1555,8 +1555,8 @@ namespace System.Drawing.Design.Tests
             yield return new object[] { "TypeName", "value", "value" };
 
             var filter = new ToolboxItemFilterAttribute("filter");
-            yield return new object[] { "Filter", null, new ToolboxItemFilterAttribute[0] };
-            yield return new object[] { "Filter", new ToolboxItemFilterAttribute[0], new ToolboxItemFilterAttribute[0] };
+            yield return new object[] { "Filter", null, Array.Empty<ToolboxItemFilterAttribute>() };
+            yield return new object[] { "Filter", Array.Empty<ToolboxItemFilterAttribute>(), Array.Empty<ToolboxItemFilterAttribute>() };
             yield return new object[] { "Filter", new object[] { null, "value", filter, filter }, new ToolboxItemFilterAttribute[] { filter, filter } };
 
             yield return new object[] { "NoSuchProperty", null, null };

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/Behavior/BehaviorDragDropEventArgsTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/Behavior/BehaviorDragDropEventArgsTests.cs
@@ -13,7 +13,7 @@ namespace System.Windows.Forms.Design.Behavior.Tests
         public static IEnumerable<object[]> Ctor_ICollection_TestData()
         {
             yield return new object[] { null };
-            yield return new object[] { new object[0] };
+            yield return new object[] { Array.Empty<object>() };
             yield return new object[] { new object[] { null } };
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -4279,7 +4279,7 @@ namespace System.Windows.Forms
 
             MethodInfo[] IReflect.GetMethods(BindingFlags bindingAttr)
             {
-                return new MethodInfo[0];
+                return Array.Empty<MethodInfo>();
             }
 
             FieldInfo IReflect.GetField(string name, BindingFlags bindingAttr)
@@ -4289,7 +4289,7 @@ namespace System.Windows.Forms
 
             FieldInfo[] IReflect.GetFields(BindingFlags bindingAttr)
             {
-                return new FieldInfo[0];
+                return Array.Empty<FieldInfo>();
             }
 
             PropertyInfo IReflect.GetProperty(string name, BindingFlags bindingAttr)
@@ -4304,17 +4304,17 @@ namespace System.Windows.Forms
 
             PropertyInfo[] IReflect.GetProperties(BindingFlags bindingAttr)
             {
-                return new PropertyInfo[0];
+                return Array.Empty<PropertyInfo>();
             }
 
             MemberInfo[] IReflect.GetMember(string name, BindingFlags bindingAttr)
             {
-                return new MemberInfo[0];
+                return Array.Empty<MemberInfo>();
             }
 
             MemberInfo[] IReflect.GetMembers(BindingFlags bindingAttr)
             {
-                return new MemberInfo[0];
+                return Array.Empty<MemberInfo>();
             }
 
             object IReflect.InvokeMember(string name, BindingFlags invokeAttr, Binder binder,
@@ -5778,7 +5778,7 @@ namespace System.Windows.Forms
 
             MethodInfo[] IReflect.GetMethods(BindingFlags bindingAttr)
             {
-                return new MethodInfo[0];
+                return Array.Empty<MethodInfo>();
             }
 
             FieldInfo IReflect.GetField(string name, BindingFlags bindingAttr)
@@ -5788,7 +5788,7 @@ namespace System.Windows.Forms
 
             FieldInfo[] IReflect.GetFields(BindingFlags bindingAttr)
             {
-                return new FieldInfo[0];
+                return Array.Empty<FieldInfo>();
             }
 
             PropertyInfo IReflect.GetProperty(string name, BindingFlags bindingAttr)
@@ -5803,17 +5803,17 @@ namespace System.Windows.Forms
 
             PropertyInfo[] IReflect.GetProperties(BindingFlags bindingAttr)
             {
-                return new PropertyInfo[0];
+                return Array.Empty<PropertyInfo>();
             }
 
             MemberInfo[] IReflect.GetMember(string name, BindingFlags bindingAttr)
             {
-                return new MemberInfo[0];
+                return Array.Empty<MemberInfo>();
             }
 
             MemberInfo[] IReflect.GetMembers(BindingFlags bindingAttr)
             {
-                return new MemberInfo[0];
+                return Array.Empty<MemberInfo>();
             }
 
             object IReflect.InvokeMember(string name, BindingFlags invokeAttr, Binder binder,
@@ -6008,7 +6008,7 @@ namespace System.Windows.Forms
                             }
                             else
                             {
-                                ctls = new Control[0];
+                                ctls = Array.Empty<Control>();
                             }
                             ctl = null;
                             break;
@@ -6992,7 +6992,7 @@ namespace System.Windows.Forms
 
                 FieldInfo[] IReflect.GetFields(BindingFlags bindingAttr)
                 {
-                    return new FieldInfo[0];
+                    return Array.Empty<FieldInfo>();
                 }
 
                 PropertyInfo IReflect.GetProperty(string name, BindingFlags bindingAttr)
@@ -7182,7 +7182,7 @@ namespace System.Windows.Forms
                     }
                     else
                     {
-                        return new byte[0];
+                        return Array.Empty<byte>();
                     }
                 }
 
@@ -8160,7 +8160,7 @@ namespace System.Windows.Forms
             private Int32CAMarshaler valueMarshaller;
             private bool arraysFetched;
 
-            public AxPerPropertyBrowsingEnum(AxPropertyDescriptor targetObject, AxHost owner, OleStrCAMarshaler names, Int32CAMarshaler values, bool allowUnknowns) : base(new string[0], new object[0], allowUnknowns)
+            public AxPerPropertyBrowsingEnum(AxPropertyDescriptor targetObject, AxHost owner, OleStrCAMarshaler names, Int32CAMarshaler values, bool allowUnknowns) : base(Array.Empty<string>(), Array.Empty<object>(), allowUnknowns)
             {
                 target = targetObject;
                 nameMarshaller = names;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingSource.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingSource.cs
@@ -1229,7 +1229,7 @@ namespace System.Windows.Forms
                 _itemConstructor = _itemType.GetConstructor(BindingFlags.Public |
                                                                     BindingFlags.Instance |
                                                                     BindingFlags.CreateInstance,
-                                                                    null, new Type[0], null);
+                                                                    null, Array.Empty<Type>(), null);
             }
 
             // Wire stuff up to the new list

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeaderConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeaderConverter.cs
@@ -78,10 +78,10 @@ namespace System.Windows.Forms
 
                 if (id == null)
                 {
-                    ctor = t.GetConstructor(new Type[0]);
+                    ctor = t.GetConstructor(Array.Empty<Type>());
                     if (ctor != null)
                     {
-                        return new InstanceDescriptor(ctor, new object[0], false);
+                        return new InstanceDescriptor(ctor, Array.Empty<object>(), false);
                     }
                     else
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -1096,7 +1096,7 @@ namespace System.Windows.Forms
                 return strings;
 
             }
-            return new string[0];
+            return Array.Empty<string>();
         }
 
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IManagedPerPropertyBrowsingHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IManagedPerPropertyBrowsingHandler.cs
@@ -67,7 +67,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
             if (hr != NativeMethods.S_OK || cItems == 0)
             {
-                return new Attribute[0];
+                return Array.Empty<Attribute>();
             }
 
             ArrayList attrs = new ArrayList();
@@ -78,7 +78,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             Debug.Assert(attrTypeNames.Length == varParams.Length, "Mismatched parameter and attribute name length");
             if (attrTypeNames.Length != varParams.Length)
             {
-                return new Attribute[0];
+                return Array.Empty<Attribute>();
             }
 
             // get the types
@@ -266,7 +266,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             }
             else
             {
-                return new string[0];
+                return Array.Empty<string>();
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IPerPropertyBrowsingHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IPerPropertyBrowsingHandler.cs
@@ -244,7 +244,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             internal bool arraysFetched;
             //private bool                 standardValuesQueried;
 
-            public Com2IPerPropertyBrowsingEnum(Com2PropertyDescriptor targetObject, Com2IPerPropertyBrowsingHandler handler, OleStrCAMarshaler names, Int32CAMarshaler values, bool allowUnknowns) : base(new string[0], new object[0], allowUnknowns)
+            public Com2IPerPropertyBrowsingEnum(Com2PropertyDescriptor targetObject, Com2IPerPropertyBrowsingHandler handler, OleStrCAMarshaler names, Int32CAMarshaler values, bool allowUnknowns) : base(Array.Empty<string>(), Array.Empty<object>(), allowUnknowns)
             {
                 target = targetObject;
                 nameMarshaller = names;
@@ -379,7 +379,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 }
                 catch (Exception ex)
                 {
-                    base.PopulateArrays(new string[0], new object[0]);
+                    base.PopulateArrays(Array.Empty<string>(), Array.Empty<object>());
                     Debug.Fail("Failed to build IPerPropertyBrowsing editor. " + ex.GetType().Name + ", " + ex.Message);
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
@@ -232,7 +232,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                     }
                     else
                     {
-                        baseAttrs = new Attribute[0];
+                        baseAttrs = Array.Empty<Attribute>();
                     }
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -16719,7 +16719,7 @@ namespace System.Windows.Forms
             }
             else
             {
-                return new Rectangle[0];
+                return Array.Empty<Rectangle>();
             }
         }
 
@@ -18854,7 +18854,7 @@ namespace System.Windows.Forms
 
                             MethodInfo method = typeof(SystemEvents).GetMethod("Shutdown",
                                                                                 BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.InvokeMethod,
-                                                                                null, new Type[0], new ParameterModifier[0]);
+                                                                                null, Array.Empty<Type>(), Array.Empty<ParameterModifier>());
                             Debug.Assert(method != null, "No Shutdown method on SystemEvents");
                             if (method != null)
                             {
@@ -18924,7 +18924,7 @@ namespace System.Windows.Forms
 
                         MethodInfo method = typeof(SystemEvents).GetMethod("Startup",
                                                                             BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.InvokeMethod,
-                                                                            null, new Type[0], new ParameterModifier[0]);
+                                                                            null, Array.Empty<Type>(), Array.Empty<ParameterModifier>());
                         Debug.Assert(method != null, "No Startup method on SystemEvents");
                         if (method != null)
                         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CursorConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CursorConverter.cs
@@ -157,7 +157,7 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    return new byte[0];
+                    return Array.Empty<byte>();
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGrid.cs
@@ -131,7 +131,7 @@ namespace System.Windows.Forms
         // ui state
         //
         // Don't use dataGridRows, use the accessor!!!
-        private DataGridRow[] dataGridRows = new DataGridRow[0];
+        private DataGridRow[] dataGridRows = Array.Empty<DataGridRow>();
         private int dataGridRowsLength = 0;
 
         // for toolTip
@@ -1502,7 +1502,7 @@ namespace System.Windows.Forms
 
             if (listManager == null)
             {
-                SetDataGridRows(new DataGridRow[0], 0);
+                SetDataGridRows(Array.Empty<DataGridRow>(), 0);
                 return;
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridState.cs
@@ -26,7 +26,7 @@ namespace System.Windows.Forms
         public object DataSource = null;
         public string DataMember = null;
         public CurrencyManager ListManager = null;
-        public DataGridRow[] DataGridRows = new DataGridRow[0];
+        public DataGridRow[] DataGridRows = Array.Empty<DataGridRow>();
         public DataGrid DataGrid;
         public int DataGridRowsLength = 0;
         public GridColumnStylesCollection GridColumnStyles = null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellConverter.cs
@@ -34,10 +34,10 @@ namespace System.Windows.Forms
 
             if (destinationType == typeof(InstanceDescriptor) && value is DataGridViewCell cell)
             {
-                ConstructorInfo ctor = cell.GetType().GetConstructor(new Type[0]);
+                ConstructorInfo ctor = cell.GetType().GetConstructor(Array.Empty<Type>());
                 if (ctor != null)
                 {
-                    return new InstanceDescriptor(ctor, new object[0], false);
+                    return new InstanceDescriptor(ctor, Array.Empty<object>(), false);
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyleConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyleConverter.cs
@@ -50,8 +50,8 @@ namespace System.Windows.Forms
 
             if (destinationType == typeof(InstanceDescriptor) && value is DataGridViewCellStyle)
             {
-                ConstructorInfo ctor = value.GetType().GetConstructor(new Type[0]);
-                return new InstanceDescriptor(ctor, new object[0], false);
+                ConstructorInfo ctor = value.GetType().GetConstructor(Array.Empty<Type>());
+                return new InstanceDescriptor(ctor, Array.Empty<object>(), false);
             }
 
             return base.ConvertTo(context, culture, value, destinationType);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnConverter.cs
@@ -60,10 +60,10 @@ namespace System.Windows.Forms
 
                 // public DataGridViewColumn()
                 // 
-                ctor = dataGridViewColumn.GetType().GetConstructor(new Type[0]);
+                ctor = dataGridViewColumn.GetType().GetConstructor(Array.Empty<Type>());
                 if (ctor != null)
                 {
-                    return new InstanceDescriptor(ctor, new object[0], false);
+                    return new InstanceDescriptor(ctor, Array.Empty<object>(), false);
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -1744,7 +1744,7 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    return new Form[0];
+                    return Array.Empty<Form>();
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageIndexConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageIndexConverter.cs
@@ -174,7 +174,7 @@ namespace System.Windows.Forms
             }
             else
             {
-                return new StandardValuesCollection(new object[0]);
+                return new StandardValuesCollection(Array.Empty<object>());
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageKeyConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageKeyConverter.cs
@@ -197,7 +197,7 @@ namespace System.Windows.Forms
             }
             else
             {
-                return new StandardValuesCollection(new object[0]);
+                return new StandardValuesCollection(Array.Empty<object>());
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/TableLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/TableLayout.cs
@@ -1679,7 +1679,7 @@ namespace System.Windows.Forms.Layout
         /// </summary>
         internal sealed class ContainerInfo
         {
-            private static readonly Strip[] emptyStrip = new Strip[0];
+            private static readonly Strip[] emptyStrip = Array.Empty<Strip>();
 
             private static readonly int stateValid = BitVector32.CreateMask();
             private static readonly int stateChildInfoValid = BitVector32.CreateMask(stateValid);
@@ -1970,7 +1970,7 @@ namespace System.Windows.Forms.Layout
                         }
                         _state[stateChildInfoValid] = true;
                     }
-                    return _childInfo ?? (new LayoutInfo[0]);
+                    return _childInfo ?? (Array.Empty<LayoutInfo>());
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
@@ -2560,7 +2560,7 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    return new Link[0].GetEnumerator();
+                    return Array.Empty<Link>().GetEnumerator();
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -7150,7 +7150,7 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    return new int[0].GetEnumerator();
+                    return Array.Empty<int>().GetEnumerator();
                 }
             }
         }
@@ -7487,7 +7487,7 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    return new ListViewItem[0].GetEnumerator();
+                    return Array.Empty<ListViewItem>().GetEnumerator();
                 }
             }
 
@@ -7784,7 +7784,7 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    return new int[0].GetEnumerator();
+                    return Array.Empty<int>().GetEnumerator();
                 }
             }
 
@@ -7871,7 +7871,7 @@ namespace System.Windows.Forms
                         }
                         else
                         {
-                            return new ListViewItem[0];
+                            return Array.Empty<ListViewItem>();
                         }
                     }
                 }
@@ -8144,7 +8144,7 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    return new ListViewItem[0].GetEnumerator();
+                    return Array.Empty<ListViewItem>().GetEnumerator();
                 }
             }
 
@@ -8826,7 +8826,7 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    return new ColumnHeader[0].GetEnumerator();
+                    return Array.Empty<ColumnHeader>().GetEnumerator();
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
@@ -1986,7 +1986,7 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    return new ListViewSubItem[0].GetEnumerator();
+                    return Array.Empty<ListViewSubItem>().GetEnumerator();
                 }
 
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItemStateImageIndexConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItemStateImageIndexConverter.cs
@@ -98,7 +98,7 @@ namespace System.Windows.Forms
             }
             else
             {
-                return new StandardValuesCollection(new object[0]);
+                return new StandardValuesCollection(Array.Empty<object>());
             }
 
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MenuItem.cs
@@ -1079,7 +1079,7 @@ namespace System.Windows.Forms
             }
             if (forms == null)
             {
-                forms = new Form[0];
+                forms = Array.Empty<Form>();
             }
 
             return forms;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
@@ -229,7 +229,7 @@ namespace System.Windows.Forms
             {
                 string[] fullPaths = FileNames;
                 if (null == fullPaths || 0 == fullPaths.Length)
-                { return new string[0]; }
+                { return Array.Empty<string>(); }
                 string[] safePaths = new string[fullPaths.Length];
                 for (int i = 0; i < safePaths.Length; ++i)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -474,7 +474,7 @@ namespace System.Windows.Forms
 
             if (document == null)
             {
-                pageInfo = new PreviewPageInfo[0];
+                pageInfo = Array.Empty<PreviewPageInfo>();
             }
             else
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -47,8 +47,8 @@ namespace System.Windows.Forms
         // our array of viewTabs
         private bool viewTabsDirty = true;
         private bool drawFlatToolBar = false;
-        private PropertyTab[] viewTabs = new PropertyTab[0];
-        private PropertyTabScope[] viewTabScopes = new PropertyTabScope[0];
+        private PropertyTab[] viewTabs = Array.Empty<PropertyTab>();
+        private PropertyTabScope[] viewTabScopes = Array.Empty<PropertyTabScope>();
         private Hashtable viewTabProps;
 
         // the tab view buttons
@@ -1220,7 +1220,7 @@ namespace System.Windows.Forms
             {
                 if (value == null)
                 {
-                    SelectedObjects = new object[0];
+                    SelectedObjects = Array.Empty<object>();
                 }
                 else
                 {
@@ -1325,7 +1325,7 @@ namespace System.Windows.Forms
 
                         if (value == null)
                         {
-                            currentObjects = new object[0];
+                            currentObjects = Array.Empty<object>();
                         }
                         else
                         {
@@ -1501,7 +1501,7 @@ namespace System.Windows.Forms
             {
                 if (currentObjects == null)
                 {
-                    return new object[0];
+                    return Array.Empty<object>();
                 }
                 return (object[])currentObjects.Clone();
             }
@@ -2694,7 +2694,7 @@ namespace System.Windows.Forms
 
             if (objs == null || objs.Length == 0)
             {
-                return new Type[0];
+                return Array.Empty<Type>();
             }
 
             Type[] tabTypes = new Type[5];
@@ -2704,7 +2704,7 @@ namespace System.Windows.Forms
 
             if (tabAttr == null)
             {
-                return new Type[0];
+                return Array.Empty<Type>();
             }
 
             // filter out all the types of the current scope
@@ -2726,7 +2726,7 @@ namespace System.Windows.Forms
 
             if (types == 0)
             {
-                return new Type[0];
+                return Array.Empty<Type>();
             }
 
             bool found;
@@ -2740,7 +2740,7 @@ namespace System.Windows.Forms
                 if (tabAttr == null)
                 {
                     // if this guy has no tabs at all, we can fail right now
-                    return new Type[0];
+                    return Array.Empty<Type>();
                 }
 
                 // make sure this guy has all the items in the array,
@@ -4408,7 +4408,7 @@ namespace System.Windows.Forms
                 // clear the component refs of the tabs
                 for (int i = 0; i < viewTabs.Length; i++)
                 {
-                    viewTabs[i].Components = new object[0];
+                    viewTabs[i].Components = Array.Empty<object>();
                 }
             }
         }
@@ -5162,7 +5162,7 @@ namespace System.Windows.Forms
 
                 if (peMain == null)
                 {
-                    currentPropEntries = new GridEntryCollection(null, new GridEntry[0]);
+                    currentPropEntries = new GridEntryCollection(null, Array.Empty<GridEntry>());
                     gridView.ClearProps();
                     return;
                 }
@@ -5652,7 +5652,7 @@ namespace System.Windows.Forms
             {
                 if (owner == null)
                 {
-                    return new PropertyTab[0].GetEnumerator();
+                    return Array.Empty<PropertyTab>().GetEnumerator();
                 }
 
                 return owner.viewTabs.GetEnumerator();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
@@ -1386,7 +1386,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
                 else
                 {
-                    childCollection = new GridEntryCollection(this, new GridEntry[0]);
+                    childCollection = new GridEntryCollection(this, Array.Empty<GridEntry>());
                 }
                 return false;
             }
@@ -1441,7 +1441,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
                 else
                 {
-                    childCollection = new GridEntryCollection(this, new GridEntry[0]);
+                    childCollection = new GridEntryCollection(this, Array.Empty<GridEntry>());
                 }
 
                 if (InternalExpanded)
@@ -2039,7 +2039,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 values.CopyTo(valueArray, 0);
                 return valueArray;
             }
-            return new object[0];
+            return Array.Empty<object>();
         }
 
         public override int GetHashCode()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MergePropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MergePropertyDescriptor.cs
@@ -553,7 +553,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
                 else
                 {
-                    return new object[0].GetEnumerator();
+                    return Array.Empty<object>().GetEnumerator();
                 }
             }
 
@@ -571,7 +571,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 if (items.Length != newCollection.Count)
                 {
-                    items = new object[0];
+                    items = Array.Empty<object>();
                     return false;
                 }
 
@@ -582,7 +582,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     if (((newItems[i] == null) != (items[i] == null)) ||
                         (items[i] != null && !items[i].Equals(newItems[i])))
                     {
-                        items = new object[0];
+                        items = Array.Empty<object>();
                         return false;
                     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -1422,7 +1422,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                int[] selTabs = new int[0];
+                int[] selTabs = Array.Empty<int>();
 
                 ForceHandleCreate();
                 NativeMethods.PARAFORMAT pf = new NativeMethods.PARAFORMAT

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
@@ -1744,7 +1744,7 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    return new StatusBarPanel[0].GetEnumerator();
+                    return Array.Empty<StatusBarPanel>().GetEnumerator();
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -2746,7 +2746,7 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    return new TabPage[0].GetEnumerator();
+                    return Array.Empty<TabPage>().GetEnumerator();
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutPanel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutPanel.cs
@@ -335,7 +335,7 @@ namespace System.Windows.Forms
             TableLayout.ContainerInfo containerInfo = TableLayout.GetContainerInfo(this);
             if (containerInfo.Columns == null)
             {
-                return new int[0];
+                return Array.Empty<int>();
             }
 
             int[] cw = new int[containerInfo.Columns.Length];
@@ -355,7 +355,7 @@ namespace System.Windows.Forms
             TableLayout.ContainerInfo containerInfo = TableLayout.GetContainerInfo(this);
             if (containerInfo.Rows == null)
             {
-                return new int[0];
+                return Array.Empty<int>();
             }
 
             int[] rh = new int[containerInfo.Rows.Length];

--- a/src/System.Windows.Forms/tests/UnitTests/ContextMenuTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/ContextMenuTests.cs
@@ -30,7 +30,7 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> Ctor_MenuItemArray_TestData()
         {
             yield return new object[] { null, false };
-            yield return new object[] { new MenuItem[0], false };
+            yield return new object[] { Array.Empty<MenuItem>(), false };
             yield return new object[] { new MenuItem[] { new MenuItem() }, true };
         }
 
@@ -39,7 +39,7 @@ namespace System.Windows.Forms.Tests
         public void ContextMenu_Ctor_MenuItemArray(MenuItem[] items, bool expectedIsParent)
         {
             var menu = new ContextMenu(items);
-            Assert.Equal(items ?? new MenuItem[0], menu.MenuItems.Cast<MenuItem>());
+            Assert.Equal(items ?? Array.Empty<MenuItem>(), menu.MenuItems.Cast<MenuItem>());
             for (int i = 0; i < (items?.Length ?? 0); i++)
             {
                 Assert.Equal(i, menu.MenuItems[i].Index);

--- a/src/System.Windows.Forms/tests/UnitTests/MainMenuTestsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/MainMenuTestsTests.cs
@@ -51,7 +51,7 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> Ctor_MenuItemArray_TestData()
         {
             yield return new object[] { null, false };
-            yield return new object[] { new MenuItem[0], false };
+            yield return new object[] { Array.Empty<MenuItem>(), false };
             yield return new object[] { new MenuItem[] { new MenuItem() }, true };
         }
 
@@ -60,7 +60,7 @@ namespace System.Windows.Forms.Tests
         public void MainMenu_Ctor_MenuItemArray(MenuItem[] items, bool expectedIsParent)
         {
             var menu = new MainMenu(items);
-            Assert.Equal(items ?? new MenuItem[0], menu.MenuItems.Cast<MenuItem>());
+            Assert.Equal(items ?? Array.Empty<MenuItem>(), menu.MenuItems.Cast<MenuItem>());
             for (int i = 0; i < (items?.Length ?? 0); i++)
             {
                 Assert.Equal(i, menu.MenuItems[i].Index);
@@ -170,7 +170,7 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> CloneMenu_TestData()
         {
-            yield return new object[] { new MenuItem[0] };
+            yield return new object[] { Array.Empty<MenuItem>() };
             yield return new object[] { new MenuItem[] { new MenuItem("text") } };
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/MenuItemCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/MenuItemCollectionTests.cs
@@ -24,7 +24,7 @@ namespace System.Windows.Forms.Tests
         [Fact]
         public void MenuItemCollection_IList_Properties_ReturnsExpected()
         {
-            var menu = new SubMenu(new MenuItem[0]);
+            var menu = new SubMenu(Array.Empty<MenuItem>());
             IList collection = new Menu.MenuItemCollection(menu);
             Assert.False(collection.IsFixedSize);
             Assert.False(collection.IsReadOnly);
@@ -36,7 +36,7 @@ namespace System.Windows.Forms.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
         public void MenuItemCollection_Add_String_Success(string caption, string expectedText)
         {
-            var menu = new SubMenu(new MenuItem[0]);
+            var menu = new SubMenu(Array.Empty<MenuItem>());
             var collection = new Menu.MenuItemCollection(menu);
             MenuItem menuItem = collection.Add(caption);
             Assert.Same(menuItem, Assert.Single(collection));
@@ -58,7 +58,7 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(Add_StringEventHandler_TestData))]
         public void MenuItemCollection_Add_StringEventHandler_Success(string caption, EventHandler onClick, string expectedText)
         {
-            var menu = new SubMenu(new MenuItem[0]);
+            var menu = new SubMenu(Array.Empty<MenuItem>());
             var collection = new Menu.MenuItemCollection(menu);
             MenuItem menuItem = collection.Add(caption, onClick);
             Assert.Same(menuItem, Assert.Single(collection));
@@ -71,7 +71,7 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> Add_StringMenuItemArray_TestData()
         {
             yield return new object[] { null, null, string.Empty };
-            yield return new object[] { string.Empty, new MenuItem[0], string.Empty };
+            yield return new object[] { string.Empty, Array.Empty<MenuItem>(), string.Empty };
             yield return new object[] { "caption", new MenuItem[] { new MenuItem() }, "caption" };
         }
 
@@ -79,12 +79,12 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(Add_StringMenuItemArray_TestData))]
         public void MenuItemCollection_Add_StringMenuItemArray_Success(string caption, MenuItem[] items, string expectedText)
         {
-            var menu = new SubMenu(new MenuItem[0]);
+            var menu = new SubMenu(Array.Empty<MenuItem>());
             var collection = new Menu.MenuItemCollection(menu);
             MenuItem menuItem = collection.Add(caption, items);
             Assert.Same(menuItem, Assert.Single(collection));
             Assert.Same(expectedText, menuItem.Text);
-            Assert.Equal(items ?? new MenuItem[0], menuItem.MenuItems.Cast<MenuItem>());
+            Assert.Equal(items ?? Array.Empty<MenuItem>(), menuItem.MenuItems.Cast<MenuItem>());
             Assert.Equal(menu, menuItem.Parent);
             Assert.Equal(0, menuItem.Index);
         }
@@ -92,7 +92,7 @@ namespace System.Windows.Forms.Tests
         [Fact]
         public void MenuItemCollection_Add_MenuItem_Success()
         {
-            var menu = new SubMenu(new MenuItem[0]);
+            var menu = new SubMenu(Array.Empty<MenuItem>());
             var collection = new Menu.MenuItemCollection(menu);
 
             var menuItem1 = new MenuItem("text1");
@@ -115,7 +115,7 @@ namespace System.Windows.Forms.Tests
         [Fact]
         public void MenuItemCollection_Add_IndexMenuItem_Success()
         {
-            var menu = new SubMenu(new MenuItem[0]);
+            var menu = new SubMenu(Array.Empty<MenuItem>());
             var collection = new Menu.MenuItemCollection(menu);
 
             var menuItem1 = new MenuItem("text1");
@@ -138,7 +138,7 @@ namespace System.Windows.Forms.Tests
         [Fact]
         public void MenuItemCollection_Add_SelfMenuItem_Nop()
         {
-            var menuItem = new MenuItem("text", new MenuItem[0]);
+            var menuItem = new MenuItem("text", Array.Empty<MenuItem>());
             var collection = new Menu.MenuItemCollection(menuItem);
             Assert.Empty(collection);
         }
@@ -148,7 +148,7 @@ namespace System.Windows.Forms.Tests
         {
             var menuItem1 = new MenuItem();
             var menuItem2 = new MenuItem();
-            var parent = new MenuItem("text", new MenuItem[0]);
+            var parent = new MenuItem("text", Array.Empty<MenuItem>());
             var collection = new Menu.MenuItemCollection(parent)
             {
                 menuItem1,
@@ -177,9 +177,9 @@ namespace System.Windows.Forms.Tests
         [Fact]
         public void MenuItemCollection_Add_AlreadyInDifferentCollection_Success()
         {
-            var oldParent = new MenuItem("text", new MenuItem[0]);
+            var oldParent = new MenuItem("text", Array.Empty<MenuItem>());
             var oldCollection = new Menu.MenuItemCollection(oldParent);
-            var newParent = new MenuItem("text", new MenuItem[0]);
+            var newParent = new MenuItem("text", Array.Empty<MenuItem>());
             var newCollection = new Menu.MenuItemCollection(newParent);
 
             var menuItem = new MenuItem();
@@ -195,7 +195,7 @@ namespace System.Windows.Forms.Tests
         [Fact]
         public void MenuItemCollection_Add_MenuItemToCreatedMenu_Success()
         {
-            using (var menu = new SubMenu(new MenuItem[0]))
+            using (var menu = new SubMenu(Array.Empty<MenuItem>()))
             {
                 Assert.NotEqual(IntPtr.Zero, menu.Handle);
 
@@ -227,7 +227,7 @@ namespace System.Windows.Forms.Tests
             {
                 Assert.NotEqual(IntPtr.Zero, otherMenu.Handle);
 
-                var menu = new SubMenu(new MenuItem[0]);
+                var menu = new SubMenu(Array.Empty<MenuItem>());
                 var collection = new Menu.MenuItemCollection(menu);
 
                 Assert.Equal(0, collection.Add(menuItem));
@@ -240,7 +240,7 @@ namespace System.Windows.Forms.Tests
         [Fact]
         public void MenuItemCollection_Add_NullMenuItem_ThrowsArgumentNullException()
         {
-            var menu = new SubMenu(new MenuItem[0]);
+            var menu = new SubMenu(Array.Empty<MenuItem>());
             var collection = new Menu.MenuItemCollection(menu);
             Assert.Throws<ArgumentNullException>("item", () => collection.Add((MenuItem)null));
             Assert.Throws<ArgumentNullException>("item", () => collection.Add(0, null));
@@ -249,7 +249,7 @@ namespace System.Windows.Forms.Tests
         [Fact]
         public void MenuItemCollection_Add_SelfWithParent_ThrowsArgumentException()
         {
-            var menuItem = new MenuItem("text", new MenuItem[0]);
+            var menuItem = new MenuItem("text", Array.Empty<MenuItem>());
             var parent = new MenuItem("parent", new MenuItem[] { menuItem });
             var collection = new Menu.MenuItemCollection(menuItem);
             Assert.Throws<ArgumentException>("item", () => collection.Add(menuItem));
@@ -271,7 +271,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(1)]
         public void MenuItemCollection_Add_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
         {
-            var menu = new SubMenu(new MenuItem[0]);
+            var menu = new SubMenu(Array.Empty<MenuItem>());
             var collection = new Menu.MenuItemCollection(menu);
             Assert.Throws<ArgumentOutOfRangeException>("index", () => collection.Add(index, new MenuItem()));
         }
@@ -282,7 +282,7 @@ namespace System.Windows.Forms.Tests
         public void MenuItemCollection_Add_AlreadyInCollection_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
         {
             var menuItem = new MenuItem();
-            var parent = new MenuItem("text", new MenuItem[0]);
+            var parent = new MenuItem("text", Array.Empty<MenuItem>());
             var collection = new Menu.MenuItemCollection(parent)
             {
                 menuItem
@@ -293,7 +293,7 @@ namespace System.Windows.Forms.Tests
         [Fact]
         public void MenuItemCollection_Add_IListMenuItem_Success()
         {
-            var menu = new SubMenu(new MenuItem[0]);
+            var menu = new SubMenu(Array.Empty<MenuItem>());
             IList collection = new Menu.MenuItemCollection(menu);
 
             var menuItem1 = new MenuItem("text1");
@@ -318,14 +318,14 @@ namespace System.Windows.Forms.Tests
         [InlineData(null)]
         public void MenuItemCollection_Add_IListNotMenuItem_ThrowsArgumentException(object value)
         {
-            var menu = new SubMenu(new MenuItem[0]);
+            var menu = new SubMenu(Array.Empty<MenuItem>());
             IList collection = new Menu.MenuItemCollection(menu);
             Assert.Throws<ArgumentException>("value", () => collection.Add(value));
         }
 
         public static IEnumerable<object[]> AddRange_TestData()
         {
-            yield return new object[] { new MenuItem[0] };
+            yield return new object[] { Array.Empty<MenuItem>() };
             yield return new object[] { new MenuItem[] { new MenuItem(), new MenuItem() } };
         }
 
@@ -333,7 +333,7 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(AddRange_TestData))]
         public void MenuItemCollection_AddRange_Invoke_Success(MenuItem[] items)
         {
-            var menu = new SubMenu(new MenuItem[0]);
+            var menu = new SubMenu(Array.Empty<MenuItem>());
             var collection = new Menu.MenuItemCollection(menu);
             collection.AddRange(items);
             Assert.Equal(items.Length, collection.Count);
@@ -343,7 +343,7 @@ namespace System.Windows.Forms.Tests
         [Fact]
         public void MenuItemCollection_AddRange_NullItems_ThrowsArgumentNullException()
         {
-            var menu = new SubMenu(new MenuItem[0]);
+            var menu = new SubMenu(Array.Empty<MenuItem>());
             var collection = new Menu.MenuItemCollection(menu);
             Assert.Throws<ArgumentNullException>("items", () => collection.AddRange(null));
         }
@@ -351,7 +351,7 @@ namespace System.Windows.Forms.Tests
         [Fact]
         public void MenuItemCollection_AddRange_NullValueInItems_ThrowsArgumentNullException()
         {
-            var menu = new SubMenu(new MenuItem[0]);
+            var menu = new SubMenu(Array.Empty<MenuItem>());
             var collection = new Menu.MenuItemCollection(menu);
             Assert.Throws<ArgumentNullException>("item", () => collection.AddRange(new MenuItem[] { null }));
         }
@@ -390,7 +390,7 @@ namespace System.Windows.Forms.Tests
         public void MenuItemCollection_CopyTo_NotEmpty_Success()
         {
             var menuItem = new MenuItem();
-            var menu = new SubMenu(new MenuItem[0]);
+            var menu = new SubMenu(Array.Empty<MenuItem>());
             var collection = new Menu.MenuItemCollection(menu)
             {
                 menuItem
@@ -403,7 +403,7 @@ namespace System.Windows.Forms.Tests
         [Fact]
         public void MenuItemCollection_CopyTo_Empty_Nop()
         {
-            var menu = new SubMenu(new MenuItem[0]);
+            var menu = new SubMenu(Array.Empty<MenuItem>());
             var collection = new Menu.MenuItemCollection(menu);
             var array = new object[] { 1, 2, 3 };
             collection.CopyTo(array, 1);
@@ -437,7 +437,7 @@ namespace System.Windows.Forms.Tests
         [Fact]
         public void MenuItemCollection_Contains_IListNotMenuItem_ReturnsMinusOne()
         {
-            var menu = new SubMenu(new MenuItem[0]);
+            var menu = new SubMenu(Array.Empty<MenuItem>());
             IList collection = new Menu.MenuItemCollection(menu);
             Assert.False(collection.Contains("value"));
         }
@@ -457,8 +457,8 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> Find_TestData()
         {
-            yield return new object[] { new MenuItem[] { new MenuItem() }, "noSuchKey", false, new MenuItem[0] };
-            yield return new object[] { new MenuItem[] { new MenuItem() }, "noSuchKey", true, new MenuItem[0] };
+            yield return new object[] { new MenuItem[] { new MenuItem() }, "noSuchKey", false, Array.Empty<MenuItem>() };
+            yield return new object[] { new MenuItem[] { new MenuItem() }, "noSuchKey", true, Array.Empty<MenuItem>() };
 
             foreach (bool searchAllChildren in new bool[] { true, false })
             {
@@ -469,14 +469,14 @@ namespace System.Windows.Forms.Tests
                 yield return new object[] { new MenuItem[] { menuItem1, menuItem2, menuItem3 }, "name", searchAllChildren, new MenuItem[] { menuItem1, menuItem2 } };
             }
 
-            yield return new object[] { new MenuItem[] { new MenuItem { Name = "name" } }, "noSuchName", true, new MenuItem[0] };
-            yield return new object[] { new MenuItem[] { new MenuItem { Name = "name" } }, "noSuchName", false, new MenuItem[0] };
-            yield return new object[] { new MenuItem[] { new MenuItem("text", new MenuItem[] { new MenuItem { Name = "name2" } }) { Name = "name" }, }, "noSuchName", true, new MenuItem[0] };
-            yield return new object[] { new MenuItem[] { new MenuItem("text", new MenuItem[] { new MenuItem { Name = "name2" } }) { Name = "name" }, }, "noSuchName", false, new MenuItem[0] };
+            yield return new object[] { new MenuItem[] { new MenuItem { Name = "name" } }, "noSuchName", true, Array.Empty<MenuItem>() };
+            yield return new object[] { new MenuItem[] { new MenuItem { Name = "name" } }, "noSuchName", false, Array.Empty<MenuItem>() };
+            yield return new object[] { new MenuItem[] { new MenuItem("text", new MenuItem[] { new MenuItem { Name = "name2" } }) { Name = "name" }, }, "noSuchName", true, Array.Empty<MenuItem>() };
+            yield return new object[] { new MenuItem[] { new MenuItem("text", new MenuItem[] { new MenuItem { Name = "name2" } }) { Name = "name" }, }, "noSuchName", false, Array.Empty<MenuItem>() };
 
             var menuItemChild = new MenuItem { Name = "name" };
             yield return new object[] { new MenuItem[] { new MenuItem("text", new MenuItem[] { menuItemChild }) }, "name", true, new MenuItem[] { menuItemChild } };
-            yield return new object[] { new MenuItem[] { new MenuItem("text", new MenuItem[] { new MenuItem { Name = "name" } }) }, "name", false, new MenuItem[0] };
+            yield return new object[] { new MenuItem[] { new MenuItem("text", new MenuItem[] { new MenuItem { Name = "name" } }) }, "name", false, Array.Empty<MenuItem>() };
         }
 
         [Theory]
@@ -493,7 +493,7 @@ namespace System.Windows.Forms.Tests
         [InlineData("")]
         public void MenuItemCollection_Find_NullOrEmptyKey_ThrowsArgumentNullException(string key)
         {
-            var menu = new SubMenu(new MenuItem[0]);
+            var menu = new SubMenu(Array.Empty<MenuItem>());
             var collection = new Menu.MenuItemCollection(menu);
             Assert.Throws<ArgumentNullException>("key", () => collection.Find(key, searchAllChildren: false));
         }
@@ -525,7 +525,7 @@ namespace System.Windows.Forms.Tests
         [Fact]
         public void MenuItemCollection_IndexOf_IListNotMenuItem_ReturnsMinusOne()
         {
-            var menu = new SubMenu(new MenuItem[0]);
+            var menu = new SubMenu(Array.Empty<MenuItem>());
             IList collection = new Menu.MenuItemCollection(menu);
             Assert.Equal(-1, collection.IndexOf("value"));
         }
@@ -550,7 +550,7 @@ namespace System.Windows.Forms.Tests
         [Fact]
         public void MenuItemCollection_Insert_IListInvoke_Success()
         {
-            var menu = new SubMenu(new MenuItem[0]);
+            var menu = new SubMenu(Array.Empty<MenuItem>());
             IList collection = new Menu.MenuItemCollection(menu);
 
             var menuItem1 = new MenuItem("text1");
@@ -575,7 +575,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(null)]
         public void MenuItemCollection_Insert_IListNotMenuItem_ThrowsArgumentException(object value)
         {
-            var menu = new SubMenu(new MenuItem[0]);
+            var menu = new SubMenu(Array.Empty<MenuItem>());
             IList collection = new Menu.MenuItemCollection(menu);
             Assert.Throws<ArgumentException>("value", () => collection.Insert(0, value));
         }

--- a/src/System.Windows.Forms/tests/UnitTests/MenuItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/MenuItemTests.cs
@@ -181,7 +181,7 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> Ctor_String_MenuItemArray_TestData()
         {
             yield return new object[] { null, null, false, string.Empty };
-            yield return new object[] { string.Empty, new MenuItem[0], false, string.Empty };
+            yield return new object[] { string.Empty, Array.Empty<MenuItem>(), false, string.Empty };
             yield return new object[] { "text", new MenuItem[] { new MenuItem() }, true, "text" };
         }
 
@@ -198,7 +198,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, menuItem.Index);
             Assert.Equal(expectedIsParent, menuItem.IsParent);
             Assert.False(menuItem.MdiList);
-            Assert.Equal(items ?? new MenuItem[0], menuItem.MenuItems.Cast<MenuItem>());
+            Assert.Equal(items ?? Array.Empty<MenuItem>(), menuItem.MenuItems.Cast<MenuItem>());
             Assert.Equal(0, menuItem.MergeOrder);
             Assert.Equal(MenuMerge.Add, menuItem.MergeType);
             Assert.Equal('\0', menuItem.Mnemonic);
@@ -222,7 +222,7 @@ namespace System.Windows.Forms.Tests
             EventHandler onSelect = (sender, e) => { };
 
             yield return new object[] { (MenuMerge)(MenuMerge.Add - 1), -1, (Shortcut)(Shortcut.None - 1), null, null, null, null, null, false, string.Empty };
-            yield return new object[] { MenuMerge.Add, 0, Shortcut.None, string.Empty, onClick, onPopup, onSelect, new MenuItem[0], false, string.Empty };
+            yield return new object[] { MenuMerge.Add, 0, Shortcut.None, string.Empty, onClick, onPopup, onSelect, Array.Empty<MenuItem>(), false, string.Empty };
             yield return new object[] { MenuMerge.MergeItems, 1, Shortcut.CtrlA, "text", onClick, onPopup, onSelect, new MenuItem[] { new MenuItem() }, true, "text" };
         }
 
@@ -239,7 +239,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, menuItem.Index);
             Assert.Equal(expectedIsParent, menuItem.IsParent);
             Assert.False(menuItem.MdiList);
-            Assert.Equal(items ?? new MenuItem[0], menuItem.MenuItems.Cast<MenuItem>());
+            Assert.Equal(items ?? Array.Empty<MenuItem>(), menuItem.MenuItems.Cast<MenuItem>());
             Assert.Equal(mergeOrder, menuItem.MergeOrder);
             Assert.Equal(mergeType, menuItem.MergeType);
             Assert.Equal('\0', menuItem.Mnemonic);
@@ -266,7 +266,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(menuItem, sender);
                 callCount++;
             };
-            menuItem = new SubMenuItem(MenuMerge.Add, 0, Shortcut.None, string.Empty, onClick, null, null, new MenuItem[0]);
+            menuItem = new SubMenuItem(MenuMerge.Add, 0, Shortcut.None, string.Empty, onClick, null, null, Array.Empty<MenuItem>());
             menuItem.OnClick(null);
             Assert.Equal(1, callCount);
         }
@@ -281,7 +281,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(menuItem, sender);
                 callCount++;
             };
-            menuItem = new SubMenuItem(MenuMerge.Add, 0, Shortcut.None, string.Empty, null, onPopup, null, new MenuItem[0]);
+            menuItem = new SubMenuItem(MenuMerge.Add, 0, Shortcut.None, string.Empty, null, onPopup, null, Array.Empty<MenuItem>());
             menuItem.OnPopup(null);
             Assert.Equal(1, callCount);
         }
@@ -296,7 +296,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(menuItem, sender);
                 callCount++;
             };
-            menuItem = new SubMenuItem(MenuMerge.Add, 0, Shortcut.None, string.Empty, null, null, onSelect, new MenuItem[0]);
+            menuItem = new SubMenuItem(MenuMerge.Add, 0, Shortcut.None, string.Empty, null, null, onSelect, Array.Empty<MenuItem>());
             menuItem.OnSelect(null);
             Assert.Equal(1, callCount);
         }
@@ -510,7 +510,7 @@ namespace System.Windows.Forms.Tests
                 yield return new object[] { new MenuItem("text", new MenuItem[] { new MenuItem() }) { MdiList = mdiList }, null, true };
             }
 
-            var disposedItem = new MenuItem("text", new MenuItem[0]);
+            var disposedItem = new MenuItem("text", Array.Empty<MenuItem>());
             disposedItem.Dispose();
             yield return new object[] { disposedItem, new SubMenu(), false };
 
@@ -1114,14 +1114,14 @@ namespace System.Windows.Forms.Tests
             var formWithNoMdiChildren = new Form { Menu = new MainMenu() };
             formWithNoMdiChildren.Controls.Add(new MdiClient());
             yield return new object[] { new SubMenuItem("text", new MenuItem[] { new MenuItem("child") }) { MdiList = true }, new MainMenu(), new string[] { "child" } };
-            yield return new object[] { new SubMenuItem("text") { MdiList = true }, formWithNoMdiChildren.Menu, new string[0] };
+            yield return new object[] { new SubMenuItem("text") { MdiList = true }, formWithNoMdiChildren.Menu, Array.Empty<string>() };
 
             var formWithNoVisibleMdiChildren = new Form { Menu = new MainMenu() };
             var formWithNoVisibleMdiChildrenClient = new MdiClient();
             formWithNoVisibleMdiChildren.Controls.Add(formWithNoVisibleMdiChildrenClient);
             formWithNoVisibleMdiChildrenClient.Controls.Add(new Form { MdiParent = formWithNoVisibleMdiChildren });
             yield return new object[] { new SubMenuItem("text", new MenuItem[] { new MenuItem("child") }) { MdiList = true }, formWithNoVisibleMdiChildren.Menu, new string[] { "child", "-" } };
-            yield return new object[] { new SubMenuItem("text"), formWithNoVisibleMdiChildren.Menu, new string[0] };
+            yield return new object[] { new SubMenuItem("text"), formWithNoVisibleMdiChildren.Menu, Array.Empty<string>() };
 
             var formWithMdiChildren = new Form { Menu = new MainMenu(), Visible = true };
             var formWithMdiChildrenClient = new MdiClient();
@@ -1311,7 +1311,7 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> CloneMenu_TestData()
         {
-            yield return new object[] { new MenuItem[0] };
+            yield return new object[] { Array.Empty<MenuItem>() };
             yield return new object[] { new MenuItem[] { new MenuItem("text") } };
         }
 
@@ -1725,7 +1725,7 @@ namespace System.Windows.Forms.Tests
         [Fact]
         public void MenuItem_Dispose_NoParentOrChildren_Success()
         {
-            var menuItem = new MenuItem("text", new MenuItem[0]);
+            var menuItem = new MenuItem("text", Array.Empty<MenuItem>());
             menuItem.Dispose();
             menuItem.Dispose();
         }

--- a/src/System.Windows.Forms/tests/UnitTests/MenuTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/MenuTests.cs
@@ -16,7 +16,7 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> Ctor_MenuItemArray_TestData()
         {
             yield return new object[] { null, false };
-            yield return new object[] { new MenuItem[0], false };
+            yield return new object[] { Array.Empty<MenuItem>(), false };
             yield return new object[] { new MenuItem[] { new MenuItem() }, true };
         }
 
@@ -25,7 +25,7 @@ namespace System.Windows.Forms.Tests
         public void Menu_Ctor_MenuItemArray(MenuItem[] items, bool expectedIsParent)
         {
             var menu = new SubMenu(items);
-            Assert.Equal(items ?? new MenuItem[0], menu.MenuItems.Cast<MenuItem>());
+            Assert.Equal(items ?? Array.Empty<MenuItem>(), menu.MenuItems.Cast<MenuItem>());
             for (int i = 0; i < (items?.Length ?? 0); i++)
             {
                 Assert.Equal(i, menu.MenuItems[i].Index);
@@ -58,7 +58,7 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> HandleMenuItems_TestData()
         {
-            yield return new object[] { new MenuItem[0] };
+            yield return new object[] { Array.Empty<MenuItem>() };
             yield return new object[]
             {
                 new MenuItem[]
@@ -138,7 +138,7 @@ namespace System.Windows.Forms.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
         public void Menu_Name_GetWithSite_ReturnsExpected(string name, string expected)
         {
-            var menu = new SubMenu(new MenuItem[0])
+            var menu = new SubMenu(Array.Empty<MenuItem>())
             {
                 Site = Mock.Of<ISite>(s => s.Name == name)
             };
@@ -149,7 +149,7 @@ namespace System.Windows.Forms.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
         public void Menu_Name_SetWithoutSite_GetReturnsExpected(string value, string expected)
         {
-            var menu = new SubMenu(new MenuItem[0])
+            var menu = new SubMenu(Array.Empty<MenuItem>())
             {
                 Name = value
             };
@@ -164,7 +164,7 @@ namespace System.Windows.Forms.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
         public void Menu_Name_SetWithSite_GetReturnsExpected(string value, string expected)
         {
-            var menu = new SubMenu(new MenuItem[0])
+            var menu = new SubMenu(Array.Empty<MenuItem>())
             {
                 Site = Mock.Of<ISite>(),
                 Name = value
@@ -178,7 +178,7 @@ namespace System.Windows.Forms.Tests
             var listItem1 = new MenuItem { MdiList = true };
             var listItem2 = new MenuItem { MdiList = true };
 
-            yield return new object[] { new MenuItem[0], null };
+            yield return new object[] { Array.Empty<MenuItem>(), null };
             yield return new object[] { new MenuItem[] { listItem1 }, listItem1 };
             yield return new object[] { new MenuItem[] { new MenuItem() }, null };
             yield return new object[] { new MenuItem[] { new MenuItem("parent", new MenuItem[] { listItem2 }) }, listItem2 };
@@ -197,7 +197,7 @@ namespace System.Windows.Forms.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetStringWithNullTheoryData))]
         public void Menu_Tag_Set_GetReturnsExpected(object value)
         {
-            var menu = new SubMenu(new MenuItem[0])
+            var menu = new SubMenu(Array.Empty<MenuItem>())
             {
                 Tag = value
             };
@@ -210,9 +210,9 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> FindMenuItem_TestData()
         {
-            yield return new object[] { new MenuItem[0], MenuItem.FindHandle, IntPtr.Zero, null };
-            yield return new object[] { new MenuItem[0], MenuItem.FindShortcut, IntPtr.Zero, null };
-            yield return new object[] { new MenuItem[0], 2, IntPtr.Zero, null };
+            yield return new object[] { Array.Empty<MenuItem>(), MenuItem.FindHandle, IntPtr.Zero, null };
+            yield return new object[] { Array.Empty<MenuItem>(), MenuItem.FindShortcut, IntPtr.Zero, null };
+            yield return new object[] { Array.Empty<MenuItem>(), 2, IntPtr.Zero, null };
 
             var menuItem1 = new MenuItem();
             var menuItem2 = new MenuItem();
@@ -369,7 +369,7 @@ namespace System.Windows.Forms.Tests
         [Fact]
         public void Menu_Dispose_NoChildren_Success()
         {
-            var menu = new SubMenu(new MenuItem[0]);
+            var menu = new SubMenu(Array.Empty<MenuItem>());
             menu.Dispose();
             menu.Dispose();
         }
@@ -424,7 +424,7 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> FindMergePosition_TestData()
         {
-            yield return new object[] { new MenuItem[0], -1, 0 };
+            yield return new object[] { Array.Empty<MenuItem>(), -1, 0 };
             yield return new object[] { new MenuItem[] { new MenuItem { MergeOrder = 10 }, new MenuItem { MergeOrder = 12 }, new MenuItem(), new MenuItem(), new MenuItem() }, 12, 5 };
             yield return new object[] { new MenuItem[] { new MenuItem { MergeOrder = 10 }, new MenuItem { MergeOrder = 12 }, new MenuItem(), new MenuItem(), new MenuItem() }, 11, 5 };
             yield return new object[] { new MenuItem[] { new MenuItem { MergeOrder = 10 }, new MenuItem { MergeOrder = 12 }, new MenuItem(), new MenuItem(), new MenuItem() }, -1, 0 };
@@ -443,7 +443,7 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> GetContextMenu_TestData()
         {
-            yield return new object[] { new SubMenu(new MenuItem[0]), null };
+            yield return new object[] { new SubMenu(Array.Empty<MenuItem>()), null };
             yield return new object[] { new MenuItem(), null };
 
             var menuItem1 = new MenuItem();
@@ -466,7 +466,7 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> GetMainMenu_TestData()
         {
-            yield return new object[] { new SubMenu(new MenuItem[0]), null };
+            yield return new object[] { new SubMenu(Array.Empty<MenuItem>()), null };
             yield return new object[] { new MenuItem(), null };
 
             var menuItem1 = new MenuItem();
@@ -631,7 +631,7 @@ namespace System.Windows.Forms.Tests
                 {
                     null,
                     null,
-                    new MenuItem[0]
+                    Array.Empty<MenuItem>()
                 };
             }
         }
@@ -649,20 +649,20 @@ namespace System.Windows.Forms.Tests
         [Fact]
         public void Menu_MergeMenu_SameSourceAndDestination_ThrowsArgumentException()
         {
-            var menu = new SubMenu(new MenuItem[0]);
+            var menu = new SubMenu(Array.Empty<MenuItem>());
             Assert.Throws<ArgumentException>("menuSrc", () => menu.MergeMenu(menu));
         }
 
         [Fact]
         public void Menu_MergeMenu_NullSource_ThrowsArgumentNullException()
         {
-            var menu = new SubMenu(new MenuItem[0]);
+            var menu = new SubMenu(Array.Empty<MenuItem>());
             Assert.Throws<ArgumentNullException>("menuSrc", () => menu.MergeMenu(null));
         }
 
         public static IEnumerable<object[]> CloneMenu_TestData()
         {
-            yield return new object[] { new MenuItem[0] };
+            yield return new object[] { Array.Empty<MenuItem>() };
             yield return new object[] { new MenuItem[] { new MenuItem("text") } };
         }
 
@@ -683,7 +683,7 @@ namespace System.Windows.Forms.Tests
         [Fact]
         public void Menu_CloneMenu_NullMenuSource_ThrowsArgumentNullException()
         {
-            var menu = new SubMenu(new MenuItem[0]);
+            var menu = new SubMenu(Array.Empty<MenuItem>());
             Assert.Throws<ArgumentNullException>("menuSrc", () => menu.CloneMenu(null));
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BaseCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BaseCollectionTests.cs
@@ -46,7 +46,7 @@ namespace System.Windows.Forms.Tests
         public void CopyTo_InvokeDefault_ThrowsNullReferenceException()
         {
             var collection = new BaseCollection();
-            Assert.Throws<NullReferenceException>(() => collection.CopyTo(new object[0], 0));
+            Assert.Throws<NullReferenceException>(() => collection.CopyTo(Array.Empty<object>(), 0));
         }
 
         [Fact]
@@ -62,7 +62,7 @@ namespace System.Windows.Forms.Tests
         public void GetEnumerator_InvokeDefault_ThrowsNullReferenceException()
         {
             var collection = new BaseCollection();
-            Assert.Throws<NullReferenceException>(() => collection.CopyTo(new object[0], 0));
+            Assert.Throws<NullReferenceException>(() => collection.CopyTo(Array.Empty<object>(), 0));
         }
 
         private class SubCollection : BaseCollection

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BindingSourceTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BindingSourceTests.cs
@@ -127,7 +127,7 @@ namespace System.Windows.Forms.Tests
                 var emptyList = new List<int> { };
                 yield return new object[] { emptyList, dataMember, true, false, emptyList };
 
-                var emptyArray = new int[0];
+                var emptyArray = Array.Empty<int>();
                 yield return new object[] { emptyArray, dataMember, false, true, emptyArray };
 
                 var mockEmptyListSource = new Mock<IListSource>(MockBehavior.Strict);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeaderConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeaderConverterTests.cs
@@ -53,8 +53,8 @@ namespace System.Windows.Forms.Tests
             yield return new object[]
             {
                 new ColumnHeader(),
-                new Type[0],
-                new object[0]
+                Array.Empty<Type>(),
+                Array.Empty<object>()
             };
             yield return new object[]
             {
@@ -71,14 +71,14 @@ namespace System.Windows.Forms.Tests
             yield return new object[]
             {
                 new PrivateIntConstructor() { ImageIndex = 1 },
-                new Type[0],
-                new object[0]
+                Array.Empty<Type>(),
+                Array.Empty<object>()
             };
             yield return new object[]
             {
                 new PrivateStringConstructor() { ImageKey = "imageKey" },
-                new Type[0],
-                new object[0]
+                Array.Empty<Type>(),
+                Array.Empty<object>()
             };
             yield return new object[]
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -262,7 +262,7 @@ namespace System.Windows.Forms.Tests
         {
             yield return new object[] { null };
             yield return new object[] { new List<int>() };
-            yield return new object[] { new int[0] };
+            yield return new object[] { Array.Empty<int>() };
 
             var mockSource = new Mock<IListSource>(MockBehavior.Strict);
             mockSource

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewAutoSizeColumnsModeEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewAutoSizeColumnsModeEventArgsTests.cs
@@ -13,7 +13,7 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> Ctor_DataGridViewAutoSizeColumnModeArray_TestData()
         {
             yield return new object[] { null };
-            yield return new object[] { new DataGridViewAutoSizeColumnMode[0] };
+            yield return new object[] { Array.Empty<DataGridViewAutoSizeColumnMode>() };
             yield return new object[] { new DataGridViewAutoSizeColumnMode[] { DataGridViewAutoSizeColumnMode.AllCells, (DataGridViewAutoSizeColumnMode)(DataGridViewAutoSizeColumnMode.None - 1) } };
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowTests.cs
@@ -2585,7 +2585,7 @@ namespace System.Windows.Forms.Tests
         {
             var row = new DataGridViewRow();
             Assert.Throws<ArgumentNullException>("dataGridView", () => row.CreateCells(null));
-            Assert.Throws<ArgumentNullException>("dataGridView", () => row.CreateCells(null, new object[0]));
+            Assert.Throws<ArgumentNullException>("dataGridView", () => row.CreateCells(null, Array.Empty<object>()));
         }
 
         [Fact]
@@ -2595,7 +2595,7 @@ namespace System.Windows.Forms.Tests
             dataGridView.Rows.Add(new DataGridViewRow());
             DataGridViewRow row = dataGridView.Rows[0];
             Assert.Throws<InvalidOperationException>(() => row.CreateCells(new DataGridView()));
-            Assert.Throws<InvalidOperationException>(() => row.CreateCells(new DataGridView(), new object[0]));
+            Assert.Throws<InvalidOperationException>(() => row.CreateCells(new DataGridView(), Array.Empty<object>()));
         }
 
         [Fact]
@@ -2606,7 +2606,7 @@ namespace System.Windows.Forms.Tests
             dataGridView.Columns[0].CellTemplate = null;
             var row = new DataGridViewRow();
             Assert.Throws<InvalidOperationException>(() => row.CreateCells(dataGridView));
-            Assert.Throws<InvalidOperationException>(() => row.CreateCells(dataGridView, new object[0]));
+            Assert.Throws<InvalidOperationException>(() => row.CreateCells(dataGridView, Array.Empty<object>()));
         }
 
         [Fact]
@@ -3471,14 +3471,14 @@ namespace System.Windows.Forms.Tests
             var dataGridView = new DataGridView { ColumnCount = 1, VirtualMode = true };
             dataGridView.Rows.Add(new DataGridViewRow());
             DataGridViewRow row = dataGridView.Rows[0];
-            Assert.Throws<InvalidOperationException>(() => row.SetValues(new object[0]));
+            Assert.Throws<InvalidOperationException>(() => row.SetValues(Array.Empty<object>()));
         }
 
         [Theory]
         [MemberData(nameof(SharedRow_TestData))]
         public void DataGridViewRow_SetValues_Shared_ThrowsInvalidOperationException(DataGridViewRow row)
         {
-            Assert.Throws<InvalidOperationException>(() => row.SetValues(new object[0]));
+            Assert.Throws<InvalidOperationException>(() => row.SetValues(Array.Empty<object>()));
         }
 
         private class SubDataGridViewCell : DataGridViewCell

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/PropertyTabTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/PropertyTabTests.cs
@@ -149,7 +149,7 @@ namespace System.Windows.Forms.Design.Tests
         {
             yield return new object[] { null, null, null };
             var mockContext = new Mock<ITypeDescriptorContext>(MockBehavior.Strict);
-            yield return new object[] { mockContext.Object, new object(), new Attribute[0] };
+            yield return new object[] { mockContext.Object, new object(), Array.Empty<Attribute>() };
         }
 
         [Theory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/TableLayoutSettingsTypeConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/TableLayoutSettingsTypeConverterTests.cs
@@ -317,7 +317,7 @@ namespace System.Windows.Forms.Layout.Tests
                 var mockDescriptor = new Mock<ICustomTypeDescriptor>(MockBehavior.Strict);
                 mockDescriptor
                     .Setup(c => c.GetProperties())
-                    .Returns(new PropertyDescriptorCollection(new PropertyDescriptor[0]));
+                    .Returns(new PropertyDescriptorCollection(Array.Empty<PropertyDescriptor>()));
                 return mockDescriptor.Object;
             }
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBindingHelperTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBindingHelperTests.cs
@@ -78,8 +78,8 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> GetList_NoSuchDataMember_TestData()
         {
             yield return new object[] { new DataClass(), "NoSuchProperty" };
-            yield return new object[] { new IEnumerableWrapper(new object[0]), "NoSuchProperty" };
-            yield return new object[] { new IEnumerableWrapper(new object[0]), "Property" };
+            yield return new object[] { new IEnumerableWrapper(Array.Empty<object>()), "NoSuchProperty" };
+            yield return new object[] { new IEnumerableWrapper(Array.Empty<object>()), "Property" };
         }
 
         [Theory]
@@ -160,7 +160,7 @@ namespace System.Windows.Forms.Tests
 
             // Type that wraps an enumerable but ONLY implements non-generic IEnumerable.
             yield return new object[] { new IEnumerableWrapper(null), typeof(object) };
-            yield return new object[] { new IEnumerableWrapper(new object[0]), typeof(object) };
+            yield return new object[] { new IEnumerableWrapper(Array.Empty<object>()), typeof(object) };
             yield return new object[] { new IEnumerableWrapper(new int[] { 1 }), typeof(int) };
             yield return new object[] { new IEnumerableWrapper(new object[] { 1 }), typeof(int) };
             yield return new object[] { new IEnumerableWrapper(new object[] { 1, string.Empty }), typeof(int) };
@@ -237,9 +237,9 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> GetListItemProperties_Object_TestData()
         {
             // Simple objects.
-            yield return new object[] { null, new string[0] };
-            yield return new object[] { 1, new string[0] };
-            yield return new object[] { typeof(int), new string[0] };
+            yield return new object[] { null, Array.Empty<string>() };
+            yield return new object[] { 1, Array.Empty<string>() };
+            yield return new object[] { typeof(int), Array.Empty<string>() };
 
             yield return new object[] { string.Empty, new string[] { "Length" } };
             yield return new object[] { typeof(string), new string[] { "Length" } };
@@ -251,26 +251,26 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { new List<DataClass>(), new string[] { "Property" } };
             yield return new object[] { typeof(IList<DataClass>), new string[] { "Property" } };
 
-            yield return new object[] { new List<ICustomTypeDescriptor>(), new string[0] };
-            yield return new object[] { typeof(IList<ICustomTypeDescriptor>), new string[0] };
+            yield return new object[] { new List<ICustomTypeDescriptor>(), Array.Empty<string>() };
+            yield return new object[] { typeof(IList<ICustomTypeDescriptor>), Array.Empty<string>() };
 
             // Array.
-            yield return new object[] { new DataClass[0], new string[] { "Property" } };
+            yield return new object[] { Array.Empty<DataClass>(), new string[] { "Property" } };
             yield return new object[] { typeof(DataClass[]), new string[] { "Property" } };
-            yield return new object[] { new object[0], new string[0] };
-            yield return new object[] { new object[] { new DataClass() }, new string[0] };
+            yield return new object[] { Array.Empty<object>(), Array.Empty<string>() };
+            yield return new object[] { new object[] { new DataClass() }, Array.Empty<string>() };
 
             // Only implements IEnumerable.
-            yield return new object[] { new IEnumerableWrapper(new object[0]), new string[0] };
+            yield return new object[] { new IEnumerableWrapper(Array.Empty<object>()), Array.Empty<string>() };
             yield return new object[] { new IEnumerableWrapper(new object[] { new DataClass() }), new string[] { "Property" } };
             yield return new object[] { new IEnumerableWrapper(new object[] { 1 }), new string[] { "Property" } };
-            yield return new object[] { new IEnumerableWrapper(new object[] { null }), new string[0] };
+            yield return new object[] { new IEnumerableWrapper(new object[] { null }), Array.Empty<string>() };
 
             // Only implements IList.
-            yield return new object[] { new ArrayList(), new string[0] };
+            yield return new object[] { new ArrayList(), Array.Empty<string>() };
             yield return new object[] { new ArrayList { new DataClass() }, new string[] { "Property" } };
-            yield return new object[] { new ArrayList { 1 }, new string[0] };
-            yield return new object[] { new ArrayList { null }, new string[0] };
+            yield return new object[] { new ArrayList { 1 }, Array.Empty<string>() };
+            yield return new object[] { new ArrayList { null }, Array.Empty<string>() };
 
             // ITypedList.
             var mockTypedList = new Mock<ITypedList>(MockBehavior.Strict);
@@ -300,24 +300,24 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, properties?.Select(p => p.Name));
 
             // Empty list accessors.
-            properties = ListBindingHelper.GetListItemProperties(list, new PropertyDescriptor[0])?.Cast<PropertyDescriptor>();
+            properties = ListBindingHelper.GetListItemProperties(list, Array.Empty<PropertyDescriptor>())?.Cast<PropertyDescriptor>();
             Assert.Equal(expected, properties?.Select(p => p.Name));
 
             // Null data member.
-            properties = ListBindingHelper.GetListItemProperties(list, null, new PropertyDescriptor[0])?.Cast<PropertyDescriptor>();
+            properties = ListBindingHelper.GetListItemProperties(list, null, Array.Empty<PropertyDescriptor>())?.Cast<PropertyDescriptor>();
             Assert.Equal(expected, properties?.Select(p => p.Name));
 
             // Empty data member.
-            properties = ListBindingHelper.GetListItemProperties(list, string.Empty, new PropertyDescriptor[0])?.Cast<PropertyDescriptor>();
+            properties = ListBindingHelper.GetListItemProperties(list, string.Empty, Array.Empty<PropertyDescriptor>())?.Cast<PropertyDescriptor>();
             Assert.Equal(expected, properties?.Select(p => p.Name));
         }
 
         public static IEnumerable<object[]> GetListItemProperties_Object_PropertyDescriptorArray_TestData()
         {
-            yield return new object[] { null, TypeDescriptor.GetProperties(typeof(DataClass)).Cast<PropertyDescriptor>().ToArray(), new string[0] };
+            yield return new object[] { null, TypeDescriptor.GetProperties(typeof(DataClass)).Cast<PropertyDescriptor>().ToArray(), Array.Empty<string>() };
 
-            yield return new object[] { new DataClass(), TypeDescriptor.GetProperties(typeof(DataClass)).Cast<PropertyDescriptor>().ToArray(), new string[0] };
-            yield return new object[] { typeof(DataClass), TypeDescriptor.GetProperties(typeof(DataClass)).Cast<PropertyDescriptor>().ToArray(), new string[0] };
+            yield return new object[] { new DataClass(), TypeDescriptor.GetProperties(typeof(DataClass)).Cast<PropertyDescriptor>().ToArray(), Array.Empty<string>() };
+            yield return new object[] { typeof(DataClass), TypeDescriptor.GetProperties(typeof(DataClass)).Cast<PropertyDescriptor>().ToArray(), Array.Empty<string>() };
 
             yield return new object[] { new ListDataClass(), TypeDescriptor.GetProperties(typeof(ListDataClass)).Cast<PropertyDescriptor>().ToArray(), new string[] { "Property" } };
             yield return new object[] { new ListDataClass() { ListProperty = new List<DataClass> { new DataClass() } }, TypeDescriptor.GetProperties(typeof(ListDataClass)).Cast<PropertyDescriptor>().ToArray(), new string[] { "Property" } };
@@ -331,12 +331,12 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { typeof(MultiListDataClass), TypeDescriptor.GetProperties(typeof(MultiListDataClass)).Cast<PropertyDescriptor>().ToArray(), new string[] { "ListProperty" } };
 
             yield return new object[] { typeof(DataClass), TypeDescriptor.GetProperties(typeof(ListDataClass)).Cast<PropertyDescriptor>().ToArray(), new string[] { "Property" } };
-            yield return new object[] { new DataClass(), new PropertyDescriptor[] { null }, new string[0] };
-            yield return new object[] { typeof(DataClass), new PropertyDescriptor[] { null }, new string[0] };
+            yield return new object[] { new DataClass(), new PropertyDescriptor[] { null }, Array.Empty<string>() };
+            yield return new object[] { typeof(DataClass), new PropertyDescriptor[] { null }, Array.Empty<string>() };
 
             // Only implements IEnumerable.
             PropertyDescriptor[] descriptors = TypeDescriptor.GetProperties(typeof(ListDataClass)).Cast<PropertyDescriptor>().ToArray();
-            yield return new object[] { new IEnumerableWrapper(new object[0]), descriptors, new string[] { "Property" } };
+            yield return new object[] { new IEnumerableWrapper(Array.Empty<object>()), descriptors, new string[] { "Property" } };
             yield return new object[] { new IEnumerableWrapper(new object[] { new ListDataClass() }), descriptors, new string[] { "Property" } };
             yield return new object[] { new IEnumerableWrapper(new object[] { new MultiListDataClass() }), inner.Take(2).ToArray(), new string[] { "Property" } };
             yield return new object[] { new IEnumerableWrapper(new object[] { null }), descriptors, new string[] { "Property" } };
@@ -351,7 +351,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { new ArrayList { new MultiListDataClass { ParentListProperty = new List<ListDataClass>() } }, inner.Take(2).ToArray(), new string[] { "Property" } };
             yield return new object[] { new ArrayList { new MultiListDataClass { ParentListProperty = new List<ListDataClass> { new ListDataClass { ListProperty = new List<DataClass> { new DataClass() } } } } }, inner.Take(0).ToArray(), new string[] { "ParentListProperty" } };
             yield return new object[] { new ArrayList { new MultiListDataClass { ParentListProperty = new List<ListDataClass> { new ListDataClass { ListProperty = new List<DataClass> { new DataClass() } } } } }, inner.Take(2).ToArray(), new string[] { "Property" } };
-            yield return new object[] { new ArrayList { new MultiListDataClass { ParentListProperty = new List<ListDataClass> { new ListDataClass { ListProperty = new List<DataClass> { new DataClass() } } } } }, inner.Take(3).ToArray(), new string[0] };
+            yield return new object[] { new ArrayList { new MultiListDataClass { ParentListProperty = new List<ListDataClass> { new ListDataClass { ListProperty = new List<DataClass> { new DataClass() } } } } }, inner.Take(3).ToArray(), Array.Empty<string>() };
             yield return new object[] { new ArrayList { null }, descriptors, new string[] { "Property" } };
 
             // ITypedList.
@@ -365,18 +365,18 @@ namespace System.Windows.Forms.Tests
 
             yield return new object[] { new EnumerableITypedListImplementor(), descriptors, new string[] { "Property" } };
             yield return new object[] { typeof(EnumerableITypedListImplementor), descriptors, new string[] { "Property" } };
-            yield return new object[] { new EnumerableITypedListImplementor[] { new EnumerableITypedListImplementor() }, TypeDescriptor.GetProperties(typeof(EnumerableITypedListImplementor)).Cast<PropertyDescriptor>().ToArray(), new string[0] };
-            yield return new object[] { new List<EnumerableITypedListImplementor> { new EnumerableITypedListImplementor() }, TypeDescriptor.GetProperties(typeof(EnumerableITypedListImplementor)).Cast<PropertyDescriptor>().ToArray(), new string[0] };
-            yield return new object[] { new ArrayList { new EnumerableITypedListImplementor() }, TypeDescriptor.GetProperties(typeof(EnumerableITypedListImplementor)).Cast<PropertyDescriptor>().ToArray(), new string[0] };
-            yield return new object[] { new IEnumerableWrapper(new object[] { new EnumerableITypedListImplementor() }), TypeDescriptor.GetProperties(typeof(EnumerableITypedListImplementor)).Cast<PropertyDescriptor>().ToArray(), new string[0] };
+            yield return new object[] { new EnumerableITypedListImplementor[] { new EnumerableITypedListImplementor() }, TypeDescriptor.GetProperties(typeof(EnumerableITypedListImplementor)).Cast<PropertyDescriptor>().ToArray(), Array.Empty<string>() };
+            yield return new object[] { new List<EnumerableITypedListImplementor> { new EnumerableITypedListImplementor() }, TypeDescriptor.GetProperties(typeof(EnumerableITypedListImplementor)).Cast<PropertyDescriptor>().ToArray(), Array.Empty<string>() };
+            yield return new object[] { new ArrayList { new EnumerableITypedListImplementor() }, TypeDescriptor.GetProperties(typeof(EnumerableITypedListImplementor)).Cast<PropertyDescriptor>().ToArray(), Array.Empty<string>() };
+            yield return new object[] { new IEnumerableWrapper(new object[] { new EnumerableITypedListImplementor() }), TypeDescriptor.GetProperties(typeof(EnumerableITypedListImplementor)).Cast<PropertyDescriptor>().ToArray(), Array.Empty<string>() };
             yield return new object[] { typeof(EnumerableITypedListImplementor[]), descriptors, new string[] { "Property" } };
 
             yield return new object[] { new NonEnumerableITypedListImplementor(), descriptors, new string[] { "Property" } };
             yield return new object[] { typeof(NonEnumerableITypedListImplementor), descriptors, new string[] { "Property" } };
-            yield return new object[] { new NonEnumerableITypedListImplementor[] { new NonEnumerableITypedListImplementor() }, TypeDescriptor.GetProperties(typeof(NonEnumerableITypedListImplementor)).Cast<PropertyDescriptor>().ToArray(), new string[0] };
-            yield return new object[] { new List<NonEnumerableITypedListImplementor> { new NonEnumerableITypedListImplementor() }, TypeDescriptor.GetProperties(typeof(NonEnumerableITypedListImplementor)).Cast<PropertyDescriptor>().ToArray(), new string[0] };
-            yield return new object[] { new ArrayList { new NonEnumerableITypedListImplementor() }, TypeDescriptor.GetProperties(typeof(NonEnumerableITypedListImplementor)).Cast<PropertyDescriptor>().ToArray(), new string[0] };
-            yield return new object[] { new IEnumerableWrapper(new object[] { new NonEnumerableITypedListImplementor() }), TypeDescriptor.GetProperties(typeof(NonEnumerableITypedListImplementor)).Cast<PropertyDescriptor>().ToArray(), new string[0] };
+            yield return new object[] { new NonEnumerableITypedListImplementor[] { new NonEnumerableITypedListImplementor() }, TypeDescriptor.GetProperties(typeof(NonEnumerableITypedListImplementor)).Cast<PropertyDescriptor>().ToArray(), Array.Empty<string>() };
+            yield return new object[] { new List<NonEnumerableITypedListImplementor> { new NonEnumerableITypedListImplementor() }, TypeDescriptor.GetProperties(typeof(NonEnumerableITypedListImplementor)).Cast<PropertyDescriptor>().ToArray(), Array.Empty<string>() };
+            yield return new object[] { new ArrayList { new NonEnumerableITypedListImplementor() }, TypeDescriptor.GetProperties(typeof(NonEnumerableITypedListImplementor)).Cast<PropertyDescriptor>().ToArray(), Array.Empty<string>() };
+            yield return new object[] { new IEnumerableWrapper(new object[] { new NonEnumerableITypedListImplementor() }), TypeDescriptor.GetProperties(typeof(NonEnumerableITypedListImplementor)).Cast<PropertyDescriptor>().ToArray(), Array.Empty<string>() };
             yield return new object[] { typeof(NonEnumerableITypedListImplementor[]), descriptors, new string[] { "Property" } };
 
             var typedListDataClass = new ITypedListDataClass { ListProperty = new List<EnumerableITypedListImplementor>() { new EnumerableITypedListImplementor() } };
@@ -425,10 +425,10 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> GetListItemProperties_Object_String_PropertyDescriptorArray_TestData()
         {
             yield return new object[] { new ListDataClass(), "ListProperty", null, new string[] { "Property" } };
-            yield return new object[] { new ListDataClass(), "listproperty", new PropertyDescriptor[0], new string[] { "Property" } };
+            yield return new object[] { new ListDataClass(), "listproperty", Array.Empty<PropertyDescriptor>(), new string[] { "Property" } };
             yield return new object[] { new MultiListDataClass(), "ParentListProperty", TypeDescriptor.GetProperties(typeof(ListDataClass)).Cast<PropertyDescriptor>().ToArray(), new string[] { "Property" } };
             yield return new object[] { typeof(ListDataClass), "ListProperty", null, new string[] { "Property" } };
-            yield return new object[] { typeof(ListDataClass), "listproperty", new PropertyDescriptor[0], new string[] { "Property" } };
+            yield return new object[] { typeof(ListDataClass), "listproperty", Array.Empty<PropertyDescriptor>(), new string[] { "Property" } };
             yield return new object[] { typeof(MultiListDataClass), "ParentListProperty", TypeDescriptor.GetProperties(typeof(ListDataClass)).Cast<PropertyDescriptor>().ToArray(), new string[] { "Property" } };
         }
 
@@ -472,14 +472,14 @@ namespace System.Windows.Forms.Tests
 
             yield return new object[] { 1, null, "Int32" };
             yield return new object[] { typeof(int), null, "Int32" };
-            yield return new object[] { 1, new PropertyDescriptor[0], "Int32" };
-            yield return new object[] { typeof(int), new PropertyDescriptor[0], "Int32" };
+            yield return new object[] { 1, Array.Empty<PropertyDescriptor>(), "Int32" };
+            yield return new object[] { typeof(int), Array.Empty<PropertyDescriptor>(), "Int32" };
             yield return new object[] { 1, new PropertyDescriptor[] { null }, "Int32" };
             yield return new object[] { typeof(int), new PropertyDescriptor[] { null }, "Int32" };
 
-            yield return new object[] { new int[0], null, "Int32" };
+            yield return new object[] { Array.Empty<int>(), null, "Int32" };
             yield return new object[] { typeof(int[]), null, "Int32" };
-            yield return new object[] { new object[0], null, "Object" };
+            yield return new object[] { Array.Empty<object>(), null, "Object" };
             yield return new object[] { typeof(object[]), null, "Object" };
 
             yield return new object[] { new List<int>(), null, "Int32" };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxTests.cs
@@ -263,7 +263,7 @@ namespace System.Windows.Forms.Tests
         {
             yield return new object[] { null };
             yield return new object[] { new List<int>() };
-            yield return new object[] { new int[0] };
+            yield return new object[] { Array.Empty<int>() };
 
             var mockSource = new Mock<IListSource>(MockBehavior.Strict);
             mockSource

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListControlTests.cs
@@ -455,7 +455,7 @@ namespace System.Windows.Forms.Tests
         {
             yield return new object[] { null };
             yield return new object[] { new List<int>() };
-            yield return new object[] { new int[0] };
+            yield return new object[] { Array.Empty<int>() };
 
             var mockSource = new Mock<IListSource>(MockBehavior.Strict);
             mockSource
@@ -945,7 +945,7 @@ namespace System.Windows.Forms.Tests
             int callCount = 0;
             EventHandler handler = (sender, e) =>
             {
-                control.DataSource = new int[0];
+                control.DataSource = Array.Empty<int>();
                 callCount++;
             };
             control.DataSourceChanged += handler;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItemTests.cs
@@ -50,7 +50,7 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> Ctor_StringArray_String_Color_Color_Font_ListViewGroup_TestData()
         {
             yield return new object[] { null, null, Color.Empty, Color.Empty, null, null, string.Empty, SystemColors.WindowText, SystemColors.Window, string.Empty };
-            yield return new object[] { new string[0], null, Color.Empty, Color.Empty, null, null, string.Empty, SystemColors.WindowText, SystemColors.Window, string.Empty };
+            yield return new object[] { Array.Empty<string>(), null, Color.Empty, Color.Empty, null, null, string.Empty, SystemColors.WindowText, SystemColors.Window, string.Empty };
             yield return new object[] { new string[] { null }, string.Empty, Color.Empty, Color.Empty, null, new ListViewGroup(), string.Empty, SystemColors.WindowText, SystemColors.Window, string.Empty };
             yield return new object[] { new string[] { "text" }, "imageKey", Color.Blue, Color.Red, SystemFonts.MenuFont, new ListViewGroup(), "imageKey", Color.Blue, Color.Red, "text" };
         }
@@ -88,7 +88,7 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> Ctor_StringArray_Int_Color_Color_Font_ListViewGroup_TestData()
         {
             yield return new object[] { null, -1, Color.Empty, Color.Empty, null, null, SystemColors.WindowText, SystemColors.Window, string.Empty };
-            yield return new object[] { new string[0], 0, Color.Empty, Color.Empty, null, null, SystemColors.WindowText, SystemColors.Window, string.Empty };
+            yield return new object[] { Array.Empty<string>(), 0, Color.Empty, Color.Empty, null, null, SystemColors.WindowText, SystemColors.Window, string.Empty };
             yield return new object[] { new string[] { null }, 1, Color.Empty, Color.Empty, null, new ListViewGroup(), SystemColors.WindowText, SystemColors.Window, string.Empty };
             yield return new object[] { new string[] { "text" }, 2, Color.Blue, Color.Red, SystemFonts.MenuFont, new ListViewGroup(), Color.Blue, Color.Red, "text" };
         }
@@ -126,7 +126,7 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> Ctor_StringArray_String_Color_Color_Font_TestData()
         {
             yield return new object[] { null, null, Color.Empty, Color.Empty, null, string.Empty, SystemColors.WindowText, SystemColors.Window, string.Empty };
-            yield return new object[] { new string[0], null, Color.Empty, Color.Empty, null, string.Empty, SystemColors.WindowText, SystemColors.Window, string.Empty };
+            yield return new object[] { Array.Empty<string>(), null, Color.Empty, Color.Empty, null, string.Empty, SystemColors.WindowText, SystemColors.Window, string.Empty };
             yield return new object[] { new string[] { null }, string.Empty, Color.Empty, Color.Empty, null, string.Empty, SystemColors.WindowText, SystemColors.Window, string.Empty };
             yield return new object[] { new string[] { "text" }, "imageKey", Color.Blue, Color.Red, SystemFonts.MenuFont, "imageKey", Color.Blue, Color.Red, "text" };
         }
@@ -164,7 +164,7 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> Ctor_StringArray_Int_Color_Color_Font_TestData()
         {
             yield return new object[] { null, -1, Color.Empty, Color.Empty, null, SystemColors.WindowText, SystemColors.Window, string.Empty };
-            yield return new object[] { new string[0], 0, Color.Empty, Color.Empty, null, SystemColors.WindowText, SystemColors.Window, string.Empty };
+            yield return new object[] { Array.Empty<string>(), 0, Color.Empty, Color.Empty, null, SystemColors.WindowText, SystemColors.Window, string.Empty };
             yield return new object[] { new string[] { null }, 1, Color.Empty, Color.Empty, null, SystemColors.WindowText, SystemColors.Window, string.Empty };
             yield return new object[] { new string[] { "text" }, 2, Color.Blue, Color.Red, SystemFonts.MenuFont, Color.Blue, Color.Red, "text" };
         }
@@ -276,7 +276,7 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> Ctor_StringArray_String_ListViewGroup_TestData()
         {
             yield return new object[] { null, null, null, string.Empty, string.Empty };
-            yield return new object[] { new string[0], null, null, string.Empty, string.Empty };
+            yield return new object[] { Array.Empty<string>(), null, null, string.Empty, string.Empty };
             yield return new object[] { new string[] { null }, string.Empty, new ListViewGroup(), string.Empty, string.Empty };
             yield return new object[] { new string[] { "text" }, "imageKey", new ListViewGroup(), "imageKey", "text" };
         }
@@ -314,7 +314,7 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> Ctor_StringArray_Int_ListViewGroup_TestData()
         {
             yield return new object[] { null, -1, null, string.Empty };
-            yield return new object[] { new string[0], 0, null, string.Empty };
+            yield return new object[] { Array.Empty<string>(), 0, null, string.Empty };
             yield return new object[] { new string[] { null }, 1, new ListViewGroup(), string.Empty };
             yield return new object[] { new string[] { "text" }, 2, new ListViewGroup(), "text" };
         }
@@ -502,7 +502,7 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> Ctor_StringArray_ListViewGroup_TestData()
         {
             yield return new object[] { null, null, string.Empty };
-            yield return new object[] { new string[0], null, string.Empty };
+            yield return new object[] { Array.Empty<string>(), null, string.Empty };
             yield return new object[] { new string[] { null }, new ListViewGroup(), string.Empty };
             yield return new object[] { new string[] { "text" }, new ListViewGroup(), "text" };
         }
@@ -540,7 +540,7 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> Ctor_StringArray_String_TestData()
         {
             yield return new object[] { null, null, string.Empty, string.Empty };
-            yield return new object[] { new string[0], null, string.Empty, string.Empty };
+            yield return new object[] { Array.Empty<string>(), null, string.Empty, string.Empty };
             yield return new object[] { new string[] { null }, string.Empty, string.Empty, string.Empty };
             yield return new object[] { new string[] { "text" }, "imageKey", "imageKey", "text" };
         }
@@ -578,7 +578,7 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> Ctor_StringArray_Int_TestData()
         {
             yield return new object[] { null, -1, string.Empty };
-            yield return new object[] { new string[0], 0, string.Empty };
+            yield return new object[] { Array.Empty<string>(), 0, string.Empty };
             yield return new object[] { new string[] { null }, 1, string.Empty };
             yield return new object[] { new string[] { "text" }, 2, "text" };
         }
@@ -767,7 +767,7 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> Ctor_StringArray_TestData()
         {
             yield return new object[] { null, string.Empty };
-            yield return new object[] { new string[0], string.Empty };
+            yield return new object[] { Array.Empty<string>(), string.Empty };
             yield return new object[] { new string[] { null }, string.Empty };
             yield return new object[] { new string[] { "text" }, "text" };
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyManagerTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyManagerTests.cs
@@ -55,7 +55,7 @@ namespace System.Windows.Forms.Tests
         /*
         public static IEnumerable<object[]> GetItemProperties_Parameterless_TestData()
         {
-            yield return new object[] { new PropertyManager(), new string[0] };
+            yield return new object[] { new PropertyManager(), Array.Empty<string>() };
 
             var singleContext = new BindingContext();
             yield return new object[] { singleContext[new DataSource()], new string[] { "Property" } };
@@ -74,8 +74,8 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> GetItemProperties_DataSourcesAndListAccessors_TestData()
         {
-            yield return new object[] { new PropertyManager(), null, null, new string[0] };
-            yield return new object[] { new PropertyManager(), new ArrayList(), new ArrayList(), new string[0] };
+            yield return new object[] { new PropertyManager(), null, null, Array.Empty<string>() };
+            yield return new object[] { new PropertyManager(), new ArrayList(), new ArrayList(), Array.Empty<string>() };
 
             var singleContext = new BindingContext();
             yield return new object[] { singleContext[new DataSource()], null, null, new string[] { "Property" } };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TableLayoutPanelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TableLayoutPanelTests.cs
@@ -949,7 +949,7 @@ namespace System.Windows.Forms.Tests
                 var mockDescriptor = new Mock<ICustomTypeDescriptor>(MockBehavior.Strict);
                 mockDescriptor
                     .Setup(c => c.GetProperties())
-                    .Returns(new PropertyDescriptorCollection(new PropertyDescriptor[0]));
+                    .Returns(new PropertyDescriptorCollection(Array.Empty<PropertyDescriptor>()));
                 return mockDescriptor.Object;
             }
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TableLayoutStyleTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TableLayoutStyleTests.cs
@@ -59,10 +59,10 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> ConvertTo_TestData()
         {
-            yield return new object[] { new RowStyle(SizeType.AutoSize, 1), typeof(RowStyle).GetConstructor(new Type[0]), new object[0] };
+            yield return new object[] { new RowStyle(SizeType.AutoSize, 1), typeof(RowStyle).GetConstructor(Array.Empty<Type>()), Array.Empty<object>() };
             yield return new object[] { new RowStyle(SizeType.Absolute, 1), typeof(RowStyle).GetConstructor(new Type[] { typeof(SizeType), typeof(int) }), new object[] { SizeType.Absolute, 1f } };
             yield return new object[] { new RowStyle(SizeType.Percent, 1), typeof(RowStyle).GetConstructor(new Type[] { typeof(SizeType), typeof(int) }), new object[] { SizeType.Percent, 1f } };
-            yield return new object[] { new ColumnStyle(SizeType.AutoSize, 1), typeof(ColumnStyle).GetConstructor(new Type[0]), new object[0] };
+            yield return new object[] { new ColumnStyle(SizeType.AutoSize, 1), typeof(ColumnStyle).GetConstructor(Array.Empty<Type>()), Array.Empty<object>() };
             yield return new object[] { new ColumnStyle(SizeType.Absolute, 1), typeof(ColumnStyle).GetConstructor(new Type[] { typeof(SizeType), typeof(int) }), new object[] { SizeType.Absolute, 1f } };
             yield return new object[] { new ColumnStyle(SizeType.Percent, 1), typeof(ColumnStyle).GetConstructor(new Type[] { typeof(SizeType), typeof(int) }), new object[] { SizeType.Percent, 1f } };
         }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1193 	

/cc @hughbe 	
