### PR TITLE
fix: [Loc] incorrect description text in MultilineStringEditor dropdown

### DIFF
--- a/src/System.Windows.Forms.Design.Editors/src/Resources/SR.resx
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/SR.resx
@@ -212,6 +212,7 @@
     <value>RTL_False</value>
   </data>
   <data name="MultilineStringEditorWatermark" xml:space="preserve">
-    <value>Press Enter to begin a new line.\r\nPress Ctrl+Enter to accept Text.</value>
+    <value>Press Enter to begin a new line.
+Press Ctrl+Enter to accept Text.</value>
   </data>
 </root>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.cs.xlf
@@ -128,8 +128,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
-        <source>Press Enter to begin a new line.\r\nPress Ctrl+Enter to accept Text.</source>
-        <target state="translated">Stisknutím klávesy Enter přejděte na nový řádek.\r\nStisknutím kombinace kláves Ctrl+Enter text přijmete.</target>
+        <source>Press Enter to begin a new line.
+Press Ctrl+Enter to accept Text.</source>
+        <target state="needs-review-translation">Stisknutím klávesy Enter přejděte na nový řádek.\r\nStisknutím kombinace kláves Ctrl+Enter text přijmete.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformNotSupported_WinformsDesigner">

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.de.xlf
@@ -128,8 +128,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
-        <source>Press Enter to begin a new line.\r\nPress Ctrl+Enter to accept Text.</source>
-        <target state="translated">Drücken Sie die Eingabetaste, um eine neue Zeile zu beginnen.\r\nDrücken Sie STRG+EINGABETASTE, um Text zu übernehmen.</target>
+        <source>Press Enter to begin a new line.
+Press Ctrl+Enter to accept Text.</source>
+        <target state="needs-review-translation">Drücken Sie die Eingabetaste, um eine neue Zeile zu beginnen.\r\nDrücken Sie STRG+EINGABETASTE, um Text zu übernehmen.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformNotSupported_WinformsDesigner">

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.es.xlf
@@ -128,8 +128,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
-        <source>Press Enter to begin a new line.\r\nPress Ctrl+Enter to accept Text.</source>
-        <target state="translated">Presione Entrar para comenzar una nueva línea.\r\nPresione Ctrl+Entrar para aceptar el texto.</target>
+        <source>Press Enter to begin a new line.
+Press Ctrl+Enter to accept Text.</source>
+        <target state="needs-review-translation">Presione Entrar para comenzar una nueva línea.\r\nPresione Ctrl+Entrar para aceptar el texto.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformNotSupported_WinformsDesigner">

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.fr.xlf
@@ -128,8 +128,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
-        <source>Press Enter to begin a new line.\r\nPress Ctrl+Enter to accept Text.</source>
-        <target state="translated">Appuyez sur Entrée pour commencer une nouvelle ligne.\r\nAppuyez sur Ctrl+Entrée pour valider le texte.</target>
+        <source>Press Enter to begin a new line.
+Press Ctrl+Enter to accept Text.</source>
+        <target state="needs-review-translation">Appuyez sur Entrée pour commencer une nouvelle ligne.\r\nAppuyez sur Ctrl+Entrée pour valider le texte.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformNotSupported_WinformsDesigner">

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.it.xlf
@@ -128,8 +128,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
-        <source>Press Enter to begin a new line.\r\nPress Ctrl+Enter to accept Text.</source>
-        <target state="translated">Per iniziare una nuova riga, premere INVIO.\r\nPer accettare il testo, premere CTRL+INVIO.</target>
+        <source>Press Enter to begin a new line.
+Press Ctrl+Enter to accept Text.</source>
+        <target state="needs-review-translation">Per iniziare una nuova riga, premere INVIO.\r\nPer accettare il testo, premere CTRL+INVIO.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformNotSupported_WinformsDesigner">

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ja.xlf
@@ -128,8 +128,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
-        <source>Press Enter to begin a new line.\r\nPress Ctrl+Enter to accept Text.</source>
-        <target state="translated">Enter を押して、新しい行を開始します。\r\nCtrl+Enter を押して、テキストを受け入れます。</target>
+        <source>Press Enter to begin a new line.
+Press Ctrl+Enter to accept Text.</source>
+        <target state="needs-review-translation">Enter を押して、新しい行を開始します。\r\nCtrl+Enter を押して、テキストを受け入れます。</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformNotSupported_WinformsDesigner">

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ko.xlf
@@ -128,8 +128,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
-        <source>Press Enter to begin a new line.\r\nPress Ctrl+Enter to accept Text.</source>
-        <target state="translated">새 줄을 시작하려면 &lt;Enter&gt; 키를 누릅니다.\r\n텍스트를 적용하려면 &lt;Ctrl+Enter&gt;를 누릅니다.</target>
+        <source>Press Enter to begin a new line.
+Press Ctrl+Enter to accept Text.</source>
+        <target state="needs-review-translation">새 줄을 시작하려면 &lt;Enter&gt; 키를 누릅니다.\r\n텍스트를 적용하려면 &lt;Ctrl+Enter&gt;를 누릅니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformNotSupported_WinformsDesigner">

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.pl.xlf
@@ -128,8 +128,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
-        <source>Press Enter to begin a new line.\r\nPress Ctrl+Enter to accept Text.</source>
-        <target state="translated">Naciśnij klawisz Enter, aby rozpocząć nowy wiersz.\r\nNaciśnij klawisze Ctrl+Enter, aby zaakceptować tekst.</target>
+        <source>Press Enter to begin a new line.
+Press Ctrl+Enter to accept Text.</source>
+        <target state="needs-review-translation">Naciśnij klawisz Enter, aby rozpocząć nowy wiersz.\r\nNaciśnij klawisze Ctrl+Enter, aby zaakceptować tekst.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformNotSupported_WinformsDesigner">

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.pt-BR.xlf
@@ -128,8 +128,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
-        <source>Press Enter to begin a new line.\r\nPress Ctrl+Enter to accept Text.</source>
-        <target state="translated">Pressione Enter para iniciar uma nova linha.\r\nPressione Ctrl+Enter para aceitar o Texto.</target>
+        <source>Press Enter to begin a new line.
+Press Ctrl+Enter to accept Text.</source>
+        <target state="needs-review-translation">Pressione Enter para iniciar uma nova linha.\r\nPressione Ctrl+Enter para aceitar o Texto.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformNotSupported_WinformsDesigner">

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ru.xlf
@@ -128,8 +128,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
-        <source>Press Enter to begin a new line.\r\nPress Ctrl+Enter to accept Text.</source>
-        <target state="translated">Нажмите клавишу ВВОД, чтобы начать новую строку.\r\nНажмите клавиши CTRL+ВВОД, чтобы принять текст.</target>
+        <source>Press Enter to begin a new line.
+Press Ctrl+Enter to accept Text.</source>
+        <target state="needs-review-translation">Нажмите клавишу ВВОД, чтобы начать новую строку.\r\nНажмите клавиши CTRL+ВВОД, чтобы принять текст.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformNotSupported_WinformsDesigner">

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.tr.xlf
@@ -128,8 +128,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
-        <source>Press Enter to begin a new line.\r\nPress Ctrl+Enter to accept Text.</source>
-        <target state="translated">Yeni satıra başlamak için Enter tuşuna basın.\r\nMetni kabul etmek için Ctrl+Enter tuşlarına basın.</target>
+        <source>Press Enter to begin a new line.
+Press Ctrl+Enter to accept Text.</source>
+        <target state="needs-review-translation">Yeni satıra başlamak için Enter tuşuna basın.\r\nMetni kabul etmek için Ctrl+Enter tuşlarına basın.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformNotSupported_WinformsDesigner">

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.zh-Hans.xlf
@@ -128,8 +128,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
-        <source>Press Enter to begin a new line.\r\nPress Ctrl+Enter to accept Text.</source>
-        <target state="translated">按 Enter 开始新行。\r\n按 Ctrl+Enter 接受文本。</target>
+        <source>Press Enter to begin a new line.
+Press Ctrl+Enter to accept Text.</source>
+        <target state="needs-review-translation">按 Enter 开始新行。\r\n按 Ctrl+Enter 接受文本。</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformNotSupported_WinformsDesigner">

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.zh-Hant.xlf
@@ -128,8 +128,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
-        <source>Press Enter to begin a new line.\r\nPress Ctrl+Enter to accept Text.</source>
-        <target state="translated">按 ENTER 開始新行。\r\n按 CTRL+ENTER 接受文字。</target>
+        <source>Press Enter to begin a new line.
+Press Ctrl+Enter to accept Text.</source>
+        <target state="needs-review-translation">按 ENTER 開始新行。\r\n按 CTRL+ENTER 接受文字。</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformNotSupported_WinformsDesigner">


### PR DESCRIPTION
Fixes #1076



## Proposed changes

- Add a missing new line to the resources


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![Fra](https://user-images.githubusercontent.com/49627022/58677224-b44bba80-838d-11e9-8676-b5e8bb53fd4b.PNG)


### After


![image](https://user-images.githubusercontent.com/4403806/59984128-2e5c2000-966a-11e9-8625-f0f684ce54a0.png)



## Test methodology <!-- How did you ensure quality? -->

- Build a local version of System.Windows.Forms.Design.Editors.dll
- Copy to C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App\3.0.0-preview6-27804-01
- Run the app

