### PR TITLE
Add intellisense blob as part of native toolset restore and integrate xmls into package

### DIFF
--- a/Documentation/intellisense.md
+++ b/Documentation/intellisense.md
@@ -1,0 +1,44 @@
+# Intellisense XML Incorporation into Ref-Pack
+
+
+Intellisense XML's are produced in the `dotnet/dotnet-api-docs` repo. They are currently **not** published to a NuGet package or another easily consumable artifact. Thus, the process of ingestion of these XML files is a manual one at this time. 
+
+1. Go to OPS build site at https://ops.microsoft.com/#/sites/Docs/docsets/dotnet-api-docs?tabName=builds and obtain the latest build artifacts
+   - Filter by `Build Type = Intellisense`
+    - Download latest package (it's a `zip` file)
+2. Extract the zip contents and retain only the contents of `_intellisense\netcore-3.0` subfolder
+   - Copy these contents over to a new folder hierarchy that looks like this: 
+  
+    ```
+    DOTNET-API-DOCS_NETCOREAPP3.0-0.0.0.1-WIN32-X86
+    \---_intellisense
+        \---netcore-3.0
+    ```
+
+    - Create `version.txt` directly under the top-level folder, and save the commit-sha of the build obtained from the OPS site. 
+
+ 3. Repeat the process (using the same files) and create `dotnet-api-docs_netcoreapp3.0-0.0.0.1-win64-x64\` folder. 
+
+*FUTURE NOTE: 
+	The version number `0.0.0.1` would change for each subsequent update to a new value, like `0.0.0.2`, etc.* 
+
+
+4. Compress each of the above folders like this: 
+
+  ```PowerShell
+  Compress-Archive -Path .\dotnet-api-docs_netcoreapp3.0-0.0.0.1-win32-x86\* -DestinationPath .\dotnet-api-docs_netcoreapp3.0-0.0.0.1-win32-x86.zip
+  Compress-Archive -path .\dotnet-api-docs_netcoreapp3.0-0.0.0.1-win64-x64\* -DestinationPath .\dotnet-api-docs_netcoreapp3.0-0.0.0.1-win64-x64.zip
+  ```
+
+   - It's very important to use Powershell, and no other tools, to create these zip files. 
+
+5. Upload the zip files using Azure Storage Explorer to `netcorenativeassets` blob store under this path: 
+  - `resource-packages -> external -> windows -> dotnet-api-docs_netcoreapp3.0` 
+6. Update the versions
+    - `global.json` for `native-tools.dotnet-api-docs_netcoreapp3.0`
+    - `ReferenceAssembly.targets` for `DotNetApiDocsNetCoreApp30` property
+    - Also update `global.json` in `dotnet-wpf-int` repository (if applicable).
+
+**Note:** 
+ - This blob is currently owned by [WPF](https://github.com/dotnet/wpf). Please coordinate with @dotnet/wpf-developers if there is ever a need to update this blob. 
+ - This file is a copy of https://github.com/dotnet/wpf/blob/master/Documentation/intellisense.md

--- a/Restore.cmd
+++ b/Restore.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\common\Build.ps1""" -restore %*"

--- a/eng/configure-toolset.ps1
+++ b/eng/configure-toolset.ps1
@@ -1,0 +1,2 @@
+$DoNotAbortNativeToolsInstallationOnFailure = $true
+. $PsScriptRoot\common\init-tools-native.ps1 -InstallDirectory $PSScriptRoot\..\.tools\native -GlobalJsonFile $PSScriptRoot\..\global.json

--- a/eng/packageContent.targets
+++ b/eng/packageContent.targets
@@ -11,50 +11,54 @@
     <PackagePath Condition="'$(IsFacadeAssembly)' == 'true'">lib/$(TargetFramework);$(RefPackagePath)</PackagePath>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Also in global.json -->
+    <DotNetApiDocsNetCoreApp30>0.0.0.1</DotNetApiDocsNetCoreApp30>
+    <IntellisenseXmlDir>$(RepositoryToolsDir)native\bin\dotnet-api-docs_netcoreapp3.0\$(DotNetApiDocsNetCoreApp30)\_intellisense\netcore-3.0\</IntellisenseXmlDir>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <IntellisenseXmlFileSource>$(IntellisenseXmlDir)$(AssemblyName).xml</IntellisenseXmlFileSource>
+    
+    <IntellisenseXml Condition="'$(ProduceReferenceAssembly)' == 'true' And '$(PackageAsRefAndLib)' != 'true'" >$([System.IO.Path]::ChangeExtension('$(TargetRefPath)', '.xml'))</IntellisenseXml>
+    <IntellisenseXml Condition="'$(PackageAsRefAndLib)' == 'true'" >$([System.IO.Path]::ChangeExtension('$(TargetPath)', '.xml'))</IntellisenseXml>
+
+    <IntellisenseXmlDir Condition="'$(IntellisenseXml)' != ''">$([System.IO.Path]::GetDirectoryName('$(IntellisenseXml)'))</IntellisenseXmlDir>
+  </PropertyGroup>
+  
   <Target Name="GetPackageContent"
           DependsOnTargets="SatelliteDllsProjectOutputGroup"
           Returns="@(PackageFile)">
-    <PropertyGroup>
-      <IntellisenseXml Condition="'$(ProduceReferenceAssembly)' == 'true'" >$([System.IO.Path]::ChangeExtension('$(TargetRefPath)', '.xml'))</IntellisenseXml>
-    </PropertyGroup>
     <ItemGroup>
       <PackageFile Include="$(TargetPath)" PackagePath="$(PackagePath)" />
       <PackageFile Condition="'$(IncludePdbInPackage)' == 'true'" Include="$(TargetDir)$(TargetName).pdb" PackagePath="$(PackagePath)" />
       <PackageFile Condition="'$(ProduceReferenceAssembly)' == 'true'" Include="$(TargetRefPath)" PackagePath="$(RefPackagePath)" />
-      <PackageFile Condition="'$(ProduceReferenceAssembly)' == 'true'" Include="$(IntellisenseXml)" PackagePath="$(RefPackagePath)" />
+      <PackageFile Condition="'$(ProduceReferenceAssembly)' == 'true' Or '$(PackageAsRefAndLib)' == 'true'" 
+                   Include="$(IntellisenseXml)" 
+                   PackagePath="$(RefPackagePath)" />
       <PackageFile Condition="'$(PackageAsRefAndLib)' == 'true'" Include="$(TargetPath)" PackagePath="$(RefPackagePath)" />
       <PackageFile Condition="'$(IncludeResourcesInPackage)' == 'true'"
                    Include="@(SatelliteDllsProjectOutputGroupOutput->'%(FinalOutputPath)')"
                    PackagePath="$(PackagePath)/%(SatelliteDllsProjectOutputGroupOutput.Culture)" />
     </ItemGroup>
   </Target>
-
-  <PropertyGroup>
-    <!-- Also in global.json -->
-    <DotNetApiDocsNetCoreApp30>0.0.0.1</DotNetApiDocsNetCoreApp30>
-    <IntellisenseXmlDir>$(RepositoryToolsDir)native\bin\dotnet-api-docs_netcoreapp3.0\$(DotNetApiDocsNetCoreApp30)\_intellisense\netcore-3.0\</IntellisenseXmlDir>
-  </PropertyGroup>
   
   <!-- xml files can be added here for intellisense -->
   <Target Name="CopyIntellisenseXmlsToTargetRefPath"
-          AfterTargets="CoreCompile"
-          Inputs="$(IntellisenseXmlDir)$(AssemblyName).xml"
-          Outputs="$([System.IO.Path]::ChangeExtension('$(TargetRefPath)', '.xml'))"
-          Condition="'$(ProduceReferenceAssembly)' == 'true'">
-
-    <PropertyGroup>
-      <IntellisenseXmlFileSource>$(IntellisenseXmlDir)$(AssemblyName).xml</IntellisenseXmlFileSource>
-    </PropertyGroup>
+          AfterTargets="Build"
+          Inputs="$(IntellisenseXmlFileSource)"
+          Outputs="$(IntellisenseXml)"
+          Condition="'$(ProduceReferenceAssembly)' == 'true' Or '$(PackageAsRefAndLib)' == 'true'">
     
     <Message Condition="!Exists('$(IntellisenseXmlFileSource)')"
              Text="$(IntellisenseXmlFileSource) is missing" />
 
-    <MakeDir Condition="!Exists('$(_targetRefDir)')"
-             Directories="$([System.IO.Path]::GetDirectoryName('$(TargetRefPath)'))" />
+    <MakeDir Condition="!Exists('$(IntellisenseXmlDir)')"
+             Directories="$([System.IO.Path]::GetDirectoryName('$(IntellisenseXml)'))" />
     
     <Copy SourceFiles="$(IntellisenseXmlFileSource)"
-          Condition="Exists('$(IntellisenseXmlDir)$(AssemblyName).xml')"
-          DestinationFiles="$([System.IO.Path]::ChangeExtension('$(TargetRefPath)', '.xml'))"
+          Condition="Exists('$(IntellisenseXmlFileSource)')"
+          DestinationFiles="$(IntellisenseXml)"
           SkipUnchangedFiles="true" />
   </Target>
 </Project>

--- a/eng/packageContent.targets
+++ b/eng/packageContent.targets
@@ -14,10 +14,14 @@
   <Target Name="GetPackageContent"
           DependsOnTargets="SatelliteDllsProjectOutputGroup"
           Returns="@(PackageFile)">
+    <PropertyGroup>
+      <IntellisenseXml Condition="'$(ProduceReferenceAssembly)' == 'true'" >$([System.IO.Path]::ChangeExtension('$(TargetRefPath)', '.xml'))</IntellisenseXml>
+    </PropertyGroup>
     <ItemGroup>
       <PackageFile Include="$(TargetPath)" PackagePath="$(PackagePath)" />
       <PackageFile Condition="'$(IncludePdbInPackage)' == 'true'" Include="$(TargetDir)$(TargetName).pdb" PackagePath="$(PackagePath)" />
       <PackageFile Condition="'$(ProduceReferenceAssembly)' == 'true'" Include="$(TargetRefPath)" PackagePath="$(RefPackagePath)" />
+      <PackageFile Condition="'$(ProduceReferenceAssembly)' == 'true'" Include="$(IntellisenseXml)" PackagePath="$(RefPackagePath)" />
       <PackageFile Condition="'$(PackageAsRefAndLib)' == 'true'" Include="$(TargetPath)" PackagePath="$(RefPackagePath)" />
       <PackageFile Condition="'$(IncludeResourcesInPackage)' == 'true'"
                    Include="@(SatelliteDllsProjectOutputGroupOutput->'%(FinalOutputPath)')"
@@ -25,6 +29,32 @@
     </ItemGroup>
   </Target>
 
+  <PropertyGroup>
+    <!-- Also in global.json -->
+    <DotNetApiDocsNetCoreApp30>0.0.0.1</DotNetApiDocsNetCoreApp30>
+    <IntellisenseXmlDir>$(RepositoryToolsDir)native\bin\dotnet-api-docs_netcoreapp3.0\$(DotNetApiDocsNetCoreApp30)\_intellisense\netcore-3.0\</IntellisenseXmlDir>
+  </PropertyGroup>
+  
   <!-- xml files can be added here for intellisense -->
+  <Target Name="CopyIntellisenseXmlsToTargetRefPath"
+          AfterTargets="CoreCompile"
+          Inputs="$(IntellisenseXmlDir)$(AssemblyName).xml"
+          Outputs="$([System.IO.Path]::ChangeExtension('$(TargetRefPath)', '.xml'))"
+          Condition="'$(ProduceReferenceAssembly)' == 'true'">
 
+    <PropertyGroup>
+      <IntellisenseXmlFileSource>$(IntellisenseXmlDir)$(AssemblyName).xml</IntellisenseXmlFileSource>
+    </PropertyGroup>
+    
+    <Message Condition="!Exists('$(IntellisenseXmlFileSource)')"
+             Text="$(IntellisenseXmlFileSource) is missing" />
+
+    <MakeDir Condition="!Exists('$(_targetRefDir)')"
+             Directories="$([System.IO.Path]::GetDirectoryName('$(TargetRefPath)'))" />
+    
+    <Copy SourceFiles="$(IntellisenseXmlFileSource)"
+          Condition="Exists('$(IntellisenseXmlDir)$(AssemblyName).xml')"
+          DestinationFiles="$([System.IO.Path]::ChangeExtension('$(TargetRefPath)', '.xml'))"
+          SkipUnchangedFiles="true" />
+  </Target>
 </Project>

--- a/global.json
+++ b/global.json
@@ -18,5 +18,8 @@
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19323.4",
     "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19323.4",
     "Microsoft.NET.Sdk.IL": "3.0.0-preview7.19323.2"
+  },
+  "native-tools": {
+    "dotnet-api-docs_netcoreapp3.0": "0.0.0.1"
   }
 }


### PR DESCRIPTION
@AdamYoblick Here is a basic outline that on-boards the intellisense blob to your build process. You can build on top of this and add relevant targets to integrate the right xmls into your transport package. 

Feel free to close the PR and cherry-pick the relevant commit directly, or use the change shown here however you want. 