### PR TITLE
Remove CAS related suppressions

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -1447,7 +1447,6 @@ namespace System.Windows.Forms
         ///     This switch determines the default text rendering engine to use by some controls that support 
         ///     switching rendering engine.
         /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands")]
         public static void SetCompatibleTextRenderingDefault(bool defaultValue)
         {
             if (NativeWindow.AnyHandleCreated)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -2418,7 +2418,6 @@ namespace System.Windows.Forms
             return true;
         }
 
-        [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands")]
         internal bool IsUserMode()
         {
             ISite site = Site;
@@ -2517,13 +2516,11 @@ namespace System.Windows.Forms
             GetOleObject().DoVerb(verb, IntPtr.Zero, oleSite, -1, parent != null ? parent.Handle : IntPtr.Zero, FillInRect(new NativeMethods.COMRECT(), Bounds));
         }
 
-        [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands")]
         private bool AwaitingDefreezing()
         {
             return freezeCount > 0;
         }
 
-        [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands")]
         private void Freeze(bool v)
         {
             Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "freezing " + v.ToString());
@@ -2571,7 +2568,6 @@ namespace System.Windows.Forms
             return hr;
         }
 
-        [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands")]
         private int GetOcState()
         {
             return ocState;
@@ -3356,13 +3352,11 @@ namespace System.Windows.Forms
         ///     Returns the IUnknown pointer to the enclosed ActiveX control.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Advanced)]
-        [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands")]
         public object GetOcx()
         {
             return instance;
         }
 
-        [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands")]
         private object GetOcxCreate()
         {
             if (instance == null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -3349,7 +3349,6 @@ namespace System.Windows.Forms
         ///     Enables the AutoComplete feature for combobox depending on the properties set.
         ///     These properties are namely AutoCompleteMode, AutoCompleteSource and AutoCompleteCustomSource.
         /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands")]
         private void SetAutoComplete(bool reset, bool recreate)
         {
             if (!IsHandleCreated || childEdit == null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -5,8 +5,6 @@
 // #define DEBUG_PREFERREDSIZE
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "System.Windows.Forms.Control+ActiveXFontMarshaler..ctor()")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands", Scope = "member", Target = "System.Windows.Forms.Control.PreProcessControlMessageInternal(System.Windows.Forms.Control, System.Windows.Forms.Message):System.Windows.Forms.PreProcessControlState")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands", Scope = "member", Target = "System.Windows.Forms.Control.OnPreviewKeyDown(System.Windows.Forms.PreviewKeyDownEventArgs):System.Void")]
 
 namespace System.Windows.Forms
 {
@@ -10459,7 +10457,6 @@ namespace System.Windows.Forms
         ///         MessageNotNeeded - PreProcessMessage() returns false, and IsInputKey/Char
         ///                            return false.
         /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands")]
         internal static PreProcessControlState PreProcessControlMessageInternal(Control target, ref Message msg)
         {
             if (target == null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElement.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElement.cs
@@ -132,7 +132,6 @@ namespace System.Windows.Forms
 
         public string Id
         {
-            [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands")]
             get
             {
                 return NativeHtmlElement.GetId();
@@ -417,7 +416,6 @@ namespace System.Windows.Forms
             }
         }
 
-        [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands")]
         public string GetAttribute(string attributeName)
         {
             object oAttributeValue = NativeHtmlElement.GetAttribute(attributeName, 0);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
@@ -1515,7 +1515,6 @@ namespace System.Windows.Forms
         ///       Raises the <see cref='System.Windows.Forms.Control.OnMouseLeave'/> event.
         ///    </para>
         /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands")]
         protected override void OnMouseLeave(EventArgs e)
         {
             if (!controlToolTip && textToolTip != null && textToolTip.GetHandleCreated())
@@ -1552,7 +1551,6 @@ namespace System.Windows.Forms
         }
 
 
-        [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands")]
         protected override void OnHandleDestroyed(EventArgs e)
         {
             base.OnHandleDestroyed(e);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
@@ -21,7 +21,6 @@ namespace System.Windows.Forms
     using Microsoft.Win32;
     using System.Text;
     using System.Globalization;
-    using System.Diagnostics.CodeAnalysis;
     using System.Runtime.Versioning;
 
     /// <summary>
@@ -83,7 +82,6 @@ namespace System.Windows.Forms
         private static readonly object createWindowSyncObject = new object();
 
 #if DEBUG
-        AppDomain handleCreatedIn = null;
         string subclassStatus = "None";
 #endif
         IntPtr handle;
@@ -227,10 +225,6 @@ namespace System.Windows.Forms
         {
             get
             {
-#if DEBUG
-                Debug.Assert(handle == IntPtr.Zero || (handleCreatedIn != null && handleCreatedIn == AppDomain.CurrentDomain),
-                             "Attempt to access a handle created in a different domain");
-
                 // We cannot assert this here.  Consider the case where someone has created an HWND on a thread but
                 // never started a message pump.  When the thread is cleaned up by the OS USER will destroy all window
                 // handles. This happens long before we finalize, so when finalization does come along and we
@@ -238,7 +232,7 @@ namespace System.Windows.Forms
                 //
                 // Debug.Assert(handle == IntPtr.Zero || UnsafeNativeMethods.IsWindow(new HandleRef(this, handle)), 
                 //             "Attempt to access a non-valid handle ");
-#endif
+
                 return handle;
             }
         }
@@ -253,7 +247,6 @@ namespace System.Windows.Forms
         /// </summary>
         internal NativeWindow PreviousWindow
         {
-            [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands")]
             get
             {
                 return previousWindow;
@@ -351,7 +344,6 @@ namespace System.Windows.Forms
 
         internal static bool WndProcShouldBeDebuggable
         {
-            [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands")]
             get
             {
                 return (WndProcFlags & UseDebuggableWndProc) != 0;
@@ -633,9 +625,7 @@ namespace System.Windows.Forms
             {
                 CheckReleased();
                 Debug.Assert(handle != IntPtr.Zero, "handle is 0");
-#if DEBUG
-                handleCreatedIn = AppDomain.CurrentDomain;
-#endif
+
                 this.handle = handle;
 
                 if (userDefWindowProc == IntPtr.Zero)
@@ -987,7 +977,6 @@ namespace System.Windows.Forms
         ///    <paramref name="handle"/>.
         ///    </para>
         /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands")]
         public static NativeWindow FromHandle(IntPtr handle)
         {
             if (handle != IntPtr.Zero && handleCount > 0)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StringSource.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StringSource.cs
@@ -4,12 +4,8 @@
 
 namespace System.Windows.Forms
 {
-
     using System.Runtime.InteropServices.ComTypes;
     using System.Runtime.InteropServices;
-    using System.Collections;
-    using System.Diagnostics.CodeAnalysis;
-
 
     /// <summary>
     ///    <para> 
@@ -81,7 +77,7 @@ namespace System.Windows.Forms
             }
             return retVal;
         }
-        [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands")]
+
         public void ReleaseAutoComplete()
         {
             if (autoCompleteObject2 != null)


### PR DESCRIPTION
CA2122 was an FxCop violation related to code access security. Removing them as CAS isn't supported in .NET Core. (And all of the CAS attributes have been removed.)

Also remove a no-op debug track of the AppDomain for window handles. Multiple AppDomains aren't supported in .NET Core.