### PR TITLE
Mark pvBuffer as In/Out

### DIFF
--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -2008,11 +2008,11 @@ namespace System.Windows.Forms
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        public class USEROBJECTFLAGS
+        public struct USEROBJECTFLAGS
         {
-            public int fInherit = 0;
-            public int fReserved = 0;
-            public int dwFlags = 0;
+            public int fInherit;
+            public int fReserved;
+            public int dwFlags;
         }
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -2007,7 +2007,6 @@ namespace System.Windows.Forms
             }
         }
 
-        [StructLayout(LayoutKind.Sequential)]
         public struct USEROBJECTFLAGS
         {
             public int fInherit;

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -1104,7 +1104,7 @@ namespace System.Windows.Forms
         public static extern IntPtr GetProcessWindowStation();
         [DllImport(ExternDll.User32, SetLastError = true)]
 
-        public static extern bool GetUserObjectInformation(HandleRef hObj, int nIndex, [MarshalAs(UnmanagedType.LPStruct)] NativeMethods.USEROBJECTFLAGS pvBuffer, int nLength, ref int lpnLengthNeeded);
+        public static extern bool GetUserObjectInformation(HandleRef hObj, int nIndex, [In, Out, MarshalAs(UnmanagedType.LPStruct)] NativeMethods.USEROBJECTFLAGS pvBuffer, int nLength, ref int lpnLengthNeeded);
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
 
         public static extern int ClientToScreen(HandleRef hWnd, [In, Out] NativeMethods.POINT pt);

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -1104,7 +1104,7 @@ namespace System.Windows.Forms
         public static extern IntPtr GetProcessWindowStation();
         [DllImport(ExternDll.User32, SetLastError = true)]
 
-        public static extern bool GetUserObjectInformation(HandleRef hObj, int nIndex, [In, Out, MarshalAs(UnmanagedType.LPStruct)] NativeMethods.USEROBJECTFLAGS pvBuffer, int nLength, ref int lpnLengthNeeded);
+        public static extern bool GetUserObjectInformation(HandleRef hObj, int nIndex, ref NativeMethods.USEROBJECTFLAGS pvBuffer, int nLength, ref int lpnLengthNeeded);
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
 
         public static extern int ClientToScreen(HandleRef hWnd, [In, Out] NativeMethods.POINT pt);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SystemInformation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SystemInformation.cs
@@ -795,7 +795,7 @@ namespace System.Windows.Forms
         /// Gets a value indicating whether the current process is running in user
         /// interactive mode.
         /// </summary>
-        public static bool UserInteractive
+        public unsafe static bool UserInteractive
         {
             get
             {
@@ -807,7 +807,7 @@ namespace System.Windows.Forms
                     int lengthNeeded = 0;
                     NativeMethods.USEROBJECTFLAGS flags = new NativeMethods.USEROBJECTFLAGS();
 
-                    if (UnsafeNativeMethods.GetUserObjectInformation(new HandleRef(null, hwinsta), NativeMethods.UOI_FLAGS, ref flags, Marshal.SizeOf<NativeMethods.USEROBJECTFLAGS>(), ref lengthNeeded))
+                    if (UnsafeNativeMethods.GetUserObjectInformation(new HandleRef(null, hwinsta), NativeMethods.UOI_FLAGS, ref flags, sizeof(NativeMethods.USEROBJECTFLAGS), ref lengthNeeded))
                     {
                         if ((flags.dwFlags & NativeMethods.WSF_VISIBLE) == 0)
                         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SystemInformation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SystemInformation.cs
@@ -807,7 +807,7 @@ namespace System.Windows.Forms
                     int lengthNeeded = 0;
                     NativeMethods.USEROBJECTFLAGS flags = new NativeMethods.USEROBJECTFLAGS();
 
-                    if (UnsafeNativeMethods.GetUserObjectInformation(new HandleRef(null, hwinsta), NativeMethods.UOI_FLAGS, flags, Marshal.SizeOf(flags), ref lengthNeeded))
+                    if (UnsafeNativeMethods.GetUserObjectInformation(new HandleRef(null, hwinsta), NativeMethods.UOI_FLAGS, ref flags, Marshal.SizeOf<NativeMethods.USEROBJECTFLAGS>(), ref lengthNeeded))
                     {
                         if ((flags.dwFlags & NativeMethods.WSF_VISIBLE) == 0)
                         {


### PR DESCRIPTION
This parameter is actually used as out. Per https://docs.microsoft.com/en-us/dotnet/framework/interop/blittable-and-non-blittable-types these parameters must be marked as such ("you must apply the InAttribute and OutAttribute attributes if you want to marshal the argument as an In/Out parameter"). The code currently works, because it's taking advantage of the pinning optimization that the CLR does, otherwise it would be treated as "in" only. It will keep working the same with the extra metadata, but the metadata will be correct.

Hit this while running on a runtime that doesn't do the pinning optimization (and this annotation is a fix for that).