### PR TITLE
Fix COM interop ELEMDESC

### DIFF
--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -5397,7 +5397,7 @@ namespace System.Windows.Forms
         [StructLayout(LayoutKind.Sequential)]
         public unsafe struct tagELEMDESC
         {
-            public NativeMethods.tagTYPEDESC* tdesc;
+            public NativeMethods.tagTYPEDESC tdesc;
             public NativeMethods.tagPARAMDESC paramdesc;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2TypeInfoProcessor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2TypeInfoProcessor.cs
@@ -719,7 +719,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
                             unsafe
                             {
-                                typeDesc = *funcDesc.elemdescFunc.tdesc;
+                                typeDesc = funcDesc.elemdescFunc.tdesc;
                             }
                         }
                         else
@@ -734,7 +734,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                             ref readonly NativeMethods.tagELEMDESC ed = ref UnsafeNativeMethods.PtrToRef<NativeMethods.tagELEMDESC>(funcDesc.lprgelemdescParam);
                             unsafe
                             {
-                                typeDesc = *ed.tdesc;
+                                typeDesc = ed.tdesc;
                             }
                         }
                         pi = ProcessDataCore(typeInfo, propInfoList, funcDesc.memid, nameDispID, in typeDesc, funcDesc.wFuncFlags);
@@ -973,7 +973,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
                         unsafe
                         {
-                            PropInfo pi = ProcessDataCore(typeInfo, propInfoList, varDesc.memid, nameDispID, in *varDesc.elemdescVar.tdesc, varDesc.wVarFlags);
+                            PropInfo pi = ProcessDataCore(typeInfo, propInfoList, varDesc.memid, nameDispID, in varDesc.elemdescVar.tdesc, varDesc.wVarFlags);
                             if (pi.ReadOnly != PropInfo.ReadOnlyTrue)
                             {
                                 pi.ReadOnly = PropInfo.ReadOnlyFalse;


### PR DESCRIPTION
ELEMDESC doesn't contain a pointer. This fixes a regression introduced in #818.

Fixes #896

This particular bug is breaking Office interop on WPF and WinForms. Repro is to reference the following COM components:

- Microsoft.Office.Interop.Outlook
- Office
- stdole

 In a WPF app, add the following to the main Window xaml:

``` xml
<ComboBox ItemsSource="{Binding}" DisplayMemberPath="DisplayName" Height="27" Width="332" />
```

And the following to the code behind for Window_Loaded:

``` C#

using Microsoft.Office.Interop.Outlook;
using Outlook = Microsoft.Office.Interop.Outlook;

// ...
        private void Window_Loaded(object sender, RoutedEventArgs e)
        {
            List<Account> Accounts = new List<Account>();
            Outlook.Application outlook = new Outlook.Application();
            foreach (Account account in outlook.Session.Accounts)
            {
                Accounts.Add(account);
            }
            this.DataContext = Accounts;
        }

```

This should be considered for preview 7.

Ultimately we should use the COM types defined in CoreFX to reduce risk and cut the assembly size for WinForms, but making that change is non-trivial for 3.0. #1253

cc: @sharwell, @AaronRobinsonMSFT 