### PR TITLE
Fix COM interop ELEMDESC (#1254)

### DIFF
--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -5397,7 +5397,7 @@ namespace System.Windows.Forms
         [StructLayout(LayoutKind.Sequential)]
         public unsafe struct tagELEMDESC
         {
-            public NativeMethods.tagTYPEDESC* tdesc;
+            public NativeMethods.tagTYPEDESC tdesc;
             public NativeMethods.tagPARAMDESC paramdesc;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2TypeInfoProcessor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2TypeInfoProcessor.cs
@@ -719,7 +719,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
                             unsafe
                             {
-                                typeDesc = *funcDesc.elemdescFunc.tdesc;
+                                typeDesc = funcDesc.elemdescFunc.tdesc;
                             }
                         }
                         else
@@ -734,7 +734,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                             ref readonly NativeMethods.tagELEMDESC ed = ref UnsafeNativeMethods.PtrToRef<NativeMethods.tagELEMDESC>(funcDesc.lprgelemdescParam);
                             unsafe
                             {
-                                typeDesc = *ed.tdesc;
+                                typeDesc = ed.tdesc;
                             }
                         }
                         pi = ProcessDataCore(typeInfo, propInfoList, funcDesc.memid, nameDispID, in typeDesc, funcDesc.wFuncFlags);
@@ -973,7 +973,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
                         unsafe
                         {
-                            PropInfo pi = ProcessDataCore(typeInfo, propInfoList, varDesc.memid, nameDispID, in *varDesc.elemdescVar.tdesc, varDesc.wVarFlags);
+                            PropInfo pi = ProcessDataCore(typeInfo, propInfoList, varDesc.memid, nameDispID, in varDesc.elemdescVar.tdesc, varDesc.wVarFlags);
                             if (pi.ReadOnly != PropInfo.ReadOnlyTrue)
                             {
                                 pi.ReadOnly = PropInfo.ReadOnlyFalse;


### PR DESCRIPTION
ELEMDESC doesn't contain a pointer. This fixes a regression introduced in #818.

Fixes #896

Has been approved for preview7. CC @JeremyKuhne @danmosemsft 

Cherry-pick of https://github.com/dotnet/winforms/pull/1254