### PR TITLE
Accessibility: Fixing ToolStrip shift-tab navigation

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -1263,6 +1263,7 @@ namespace System.Windows.Forms
 #if DEBUG
             Debug.WriteLineIf(ControlKeyboardRouting.TraceVerbose, "ContainerControl.ProcessDialogKey [" + keyData.ToString() + "]");
 #endif
+            LastKeyData = keyData;
             if ((keyData & (Keys.Alt | Keys.Control)) == Keys.None)
             {
                 Keys keyCode = (Keys)keyData & Keys.KeyCode;
@@ -1290,7 +1291,6 @@ namespace System.Windows.Forms
             }
             return base.ProcessDialogKey(keyData);
         }
-
 
         protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -3417,6 +3417,11 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
+        ///     Stores information about the last button or combination pressed by the user. 
+        /// </summary>
+        private protected static Keys LastKeyData { get; set; }
+
+        /// <summary>
         ///     The left coordinate of this control.
         /// </summary>
         [

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -2461,7 +2461,9 @@ namespace System.Windows.Forms
                 case ArrowDirection.Right:
                     return GetNextItemHorizontal(start, forward: true);
                 case ArrowDirection.Left:
-                    return GetNextItemHorizontal(start, forward: false);
+                    bool isRtl = RightToLeft == RightToLeft.Yes;
+                    bool forward = (LastKeyData == (Keys.Shift | Keys.Tab) && !isRtl) || (LastKeyData == Keys.Tab && isRtl);
+                    return GetNextItemHorizontal(start, forward);
                 case ArrowDirection.Down:
                     return GetNextItemVertical(start, down: true);
                 case ArrowDirection.Up:
@@ -3238,6 +3240,7 @@ namespace System.Windows.Forms
         protected override bool ProcessDialogKey(Keys keyData)
         {
             bool retVal = false;
+            LastKeyData = keyData;
 
             // Give the ToolStripItem first dibs
             ToolStripItem item = GetSelectedItem();


### PR DESCRIPTION
Fixes #1300.
## Proposed changes
- Add static `LastKeyData` variable to store information about the last button or combination pressed by the user
- Change `forward` variable when call `GetNextItemHorizontal` method for ToolStrip
## Screenshots
![image](https://user-images.githubusercontent.com/49272759/60962936-27930580-a318-11e9-830d-a12496287d27.png)

### Before
- Tab navigation: 1-2-9
- Shift-tab navigation: 9-7-1 (**8** is skipped because of it not the selectable item)
> Similarly RTL
### After
- Tab navigation: 1-2-9
- Shift-tab navigation: 9-2-1
> Similarly RTL
## Test methodology
- Manual UI testing