### PR TITLE
WIP: Accessibility: Fixing MenuStrip items control type property

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.cs
@@ -1409,6 +1409,11 @@ namespace System.Windows.Forms
             {
                 if (propertyID == NativeMethods.UIA_ControlTypePropertyId)
                 {
+                    if (Parent.GetPropertyValue(NativeMethods.UIA_ControlTypePropertyId) as int? == NativeMethods.UIA_MenuBarControlTypeId)
+                    {
+                        return NativeMethods.UIA_MenuControlTypeId;
+                    }
+
                     return NativeMethods.UIA_MenuItemControlTypeId;
                 }
                 else if (propertyID == NativeMethods.UIA_AcceleratorKeyPropertyId)


### PR DESCRIPTION
Fixes #1328 

## Proposed changes
- Change control type property for items of first MenuStrip layer
- Change the behavior of the accessibility navigation tree like as the Notepad

## Customer Impact
- The control type has been changed, screen readers will say “menu” as the type of item for the user.

## Regression?
- No

## Risk
- None, items behavior like as in the Notepad

### Before
Menu items of first MenuStrip layer have control type property as "menu item"

### After
Menu items of first MenuStrip layer have control type property as "menu item". When item is opened and has a DrodDown, it have control type property as "menu".

## Accessibility testing  
- Used the Inspect tool to check control type property of items

## Test environment(s) 
- Microsoft Windows [Version 10.0.18362.175]
- .NET Core SDK. Version: 3.0.100-preview6-012264
