### PR TITLE
Porting bug fix: Smart Tag window does not render at all\correctly on secondary monitor when PMA is enabled

### DIFF
--- a/src/Common/src/CommonUnsafeNativeMethods.cs
+++ b/src/Common/src/CommonUnsafeNativeMethods.cs
@@ -146,20 +146,13 @@ namespace System.Windows.Forms
         {
             DpiAwarenessContext dpiAwarenessContext = DpiAwarenessContext.DPI_AWARENESS_CONTEXT_UNSPECIFIED;
 
-            try
+            if (ApiHelper.IsApiAvailable(ExternDll.User32, "GetWindowDpiAwarenessContext") &&
+                ApiHelper.IsApiAvailable(ExternDll.User32, "GetAwarenessFromDpiAwarenessContext"))
             {
-                if (ApiHelper.IsApiAvailable(ExternDll.User32, "GetWindowDpiAwarenessContext") &&
-                    ApiHelper.IsApiAvailable(ExternDll.User32, "GetAwarenessFromDpiAwarenessContext"))
-                {
-                    // Works only >= Windows 10/1607
-                    IntPtr awarenessContext = GetWindowDpiAwarenessContext(hWnd);
-                    DPI_AWARENESS awareness = GetAwarenessFromDpiAwarenessContext(awarenessContext);
-                    dpiAwarenessContext = ConvertToDpiAwarenessContext(awareness);
-                }
-            }
-            catch
-            {
-                // swallow all exceptions
+                // Works only >= Windows 10/1607
+                IntPtr awarenessContext = GetWindowDpiAwarenessContext(hWnd);
+                DPI_AWARENESS awareness = GetAwarenessFromDpiAwarenessContext(awarenessContext);
+                dpiAwarenessContext = ConvertToDpiAwarenessContext(awareness);
             }
 
             return dpiAwarenessContext;

--- a/src/Common/src/CommonUnsafeNativeMethods.cs
+++ b/src/Common/src/CommonUnsafeNativeMethods.cs
@@ -70,6 +70,12 @@ namespace System.Windows.Forms
         internal static extern DpiAwarenessContext SetThreadDpiAwarenessContext(DpiAwarenessContext dpiContext);
 
         [DllImport(ExternDll.User32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
+        internal static extern IntPtr GetWindowDpiAwarenessContext(IntPtr hWnd);
+
+        [DllImport(ExternDll.User32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
+        internal static extern DPI_AWARENESS GetAwarenessFromDpiAwarenessContext(IntPtr dpiAwarenessContext);
+
+        [DllImport(ExternDll.User32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
         internal static extern bool AreDpiAwarenessContextsEqual(DpiAwarenessContext dpiContextA, DpiAwarenessContext dpiContextB);
 
         /// <summary>
@@ -135,6 +141,60 @@ namespace System.Windows.Forms
                 public static readonly DPI_AWARENESS_CONTEXT DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE = (-3);
                 public static readonly DPI_AWARENESS_CONTEXT DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 = (-4);
                 public static readonly DPI_AWARENESS_CONTEXT DPI_AWARENESS_CONTEXT_UNSPECIFIED = (0);*/
+
+        internal static DpiAwarenessContext GetDpiAwarenessContextForWindow(IntPtr hWnd)
+        {
+            DpiAwarenessContext dpiAwarenessContext = DpiAwarenessContext.DPI_AWARENESS_CONTEXT_UNSPECIFIED;
+
+            try
+            {
+                if (ApiHelper.IsApiAvailable(ExternDll.User32, "GetWindowDpiAwarenessContext") &&
+                    ApiHelper.IsApiAvailable(ExternDll.User32, "GetAwarenessFromDpiAwarenessContext"))
+                {
+                    // Works only >= Windows 10/1607
+                    IntPtr awarenessContext = GetWindowDpiAwarenessContext(hWnd);
+                    DPI_AWARENESS awareness = GetAwarenessFromDpiAwarenessContext(awarenessContext);
+                    dpiAwarenessContext = ConvertToDpiAwarenessContext(awareness);
+                }
+            }
+            catch
+            {
+                // swallow all exceptions
+            }
+
+            return dpiAwarenessContext;
+        }
+
         #endregion
+
+        #region Private Methods
+
+        private static DpiAwarenessContext ConvertToDpiAwarenessContext(DPI_AWARENESS dpiAwareness)
+        {
+            switch (dpiAwareness)
+            {
+                case DPI_AWARENESS.DPI_AWARENESS_UNAWARE:
+                    return DpiAwarenessContext.DPI_AWARENESS_CONTEXT_UNAWARE;
+
+                case DPI_AWARENESS.DPI_AWARENESS_SYSTEM_AWARE:
+                    return DpiAwarenessContext.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE;
+
+                case DPI_AWARENESS.DPI_AWARENESS_PER_MONITOR_AWARE:
+                    return DpiAwarenessContext.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2;
+
+                default:
+                    return DpiAwarenessContext.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE;
+            }
+        }
+
+        #endregion
+
+        internal enum DPI_AWARENESS
+        {
+            DPI_AWARENESS_INVALID = -1,
+            DPI_AWARENESS_UNAWARE = 0,
+            DPI_AWARENESS_SYSTEM_AWARE = 1,
+            DPI_AWARENESS_PER_MONITOR_AWARE = 2
+        }
     }
 }


### PR DESCRIPTION
**Issue:** When PMA mode is enabled, smart tag window does not render correctly or some of the options in the window are not accessible through mouse. It happens because of DPI awareness context mismatch between the control window and its corresponding mouse hook.

**Fix**: Determine DPI awareness context of the control window and set it in its mouse hook.

**Note:** This fix is a port from net fx runtime

**Testing done:** Since smart tags is a design time feature and is not supported by netcore designer yet, it cannot be tested. However I ran few sample netcore apps and ensured that there is no regression.