### PR TITLE
Fix 1353 Accessibility: Removing 'button' text from PrintButton accessible name of PrintPreviewDialog

### DIFF
--- a/src/System.Windows.Forms/src/Resources/System/Windows/Forms/PrintPreviewDialog.resx
+++ b/src/System.Windows.Forms/src/Resources/System/Windows/Forms/PrintPreviewDialog.resx
@@ -125,7 +125,7 @@
     <value xml:space="preserve">Print the document</value>
   </data>
   <data name="printToolStripButton.AccessibleName">
-    <value xml:space="preserve">Print Button</value>
+    <value xml:space="preserve">Print</value>
   </data>
   <data name="printToolStripButton.Text">
     <value xml:space="preserve">Print</value>

--- a/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.cs.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.AccessibleName">
-        <source>Print Button</source>
-        <target state="translated">Tlačítko pro tisk</target>
+        <source>Print</source>
+        <target state="needs-review-translation">Tlačítko pro tisk</target>
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.Text">

--- a/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.de.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.AccessibleName">
-        <source>Print Button</source>
-        <target state="translated">Schaltfläche "Drucken"</target>
+        <source>Print</source>
+        <target state="needs-review-translation">Schaltfläche "Drucken"</target>
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.Text">

--- a/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.es.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.AccessibleName">
-        <source>Print Button</source>
-        <target state="translated">Botón de impresión</target>
+        <source>Print</source>
+        <target state="needs-review-translation">Botón de impresión</target>
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.Text">

--- a/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.fr.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.AccessibleName">
-        <source>Print Button</source>
-        <target state="translated">Bouton Imprimer</target>
+        <source>Print</source>
+        <target state="needs-review-translation">Bouton Imprimer</target>
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.Text">

--- a/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.it.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.AccessibleName">
-        <source>Print Button</source>
-        <target state="translated">Pulsante Stampa</target>
+        <source>Print</source>
+        <target state="needs-review-translation">Pulsante Stampa</target>
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.Text">

--- a/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.ja.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.AccessibleName">
-        <source>Print Button</source>
-        <target state="translated">印刷ボタン</target>
+        <source>Print</source>
+        <target state="needs-review-translation">印刷ボタン</target>
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.Text">

--- a/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.ko.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.AccessibleName">
-        <source>Print Button</source>
-        <target state="translated">인쇄 단추</target>
+        <source>Print</source>
+        <target state="needs-review-translation">인쇄 단추</target>
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.Text">

--- a/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.pl.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.AccessibleName">
-        <source>Print Button</source>
-        <target state="translated">Przycisk Drukuj</target>
+        <source>Print</source>
+        <target state="needs-review-translation">Przycisk Drukuj</target>
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.Text">

--- a/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.pt-BR.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.AccessibleName">
-        <source>Print Button</source>
-        <target state="translated">Botão Imprimir</target>
+        <source>Print</source>
+        <target state="needs-review-translation">Botão Imprimir</target>
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.Text">

--- a/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.ru.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.AccessibleName">
-        <source>Print Button</source>
-        <target state="translated">Кнопка "Печать"</target>
+        <source>Print</source>
+        <target state="needs-review-translation">Кнопка "Печать"</target>
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.Text">

--- a/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.tr.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.AccessibleName">
-        <source>Print Button</source>
-        <target state="translated">Yazdır Düğmesi</target>
+        <source>Print</source>
+        <target state="needs-review-translation">Yazdır Düğmesi</target>
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.Text">

--- a/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.zh-Hans.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.AccessibleName">
-        <source>Print Button</source>
-        <target state="translated">“打印”按钮</target>
+        <source>Print</source>
+        <target state="needs-review-translation">“打印”按钮</target>
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.Text">

--- a/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/System/Windows/Forms/xlf/PrintPreviewDialog.zh-Hant.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.AccessibleName">
-        <source>Print Button</source>
-        <target state="translated">列印按鈕</target>
+        <source>Print</source>
+        <target state="needs-review-translation">列印按鈕</target>
         <note />
       </trans-unit>
       <trans-unit id="printToolStripButton.Text">


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1353 


## Proposed changes

- Removing "button" text from PrintButton control's Accessible name to have "Print" accessible name instead of "Print button".
- Updating resource string for PrintButton AccessibleName.
- Reassigning to translators for updating localized strings.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Please see the bug #1353 

### After

![image](https://user-images.githubusercontent.com/23213980/61126850-47603000-a4b6-11e9-8308-68e395e4a2e9.png)

## Test methodology

- Manual testing
- Narrator announcement
- Inspect tool

## Accessibility testing

Narrator announces "Print button" with the fix and "Print button, button" without the fix.
Inspect shows "Print" instead of "Print button" as accessible name property.

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->

## Test environment(s)

.NET Core SDK (reflecting any global.json):
 Version:   3.0.100-preview8-012929
 Commit:    795f8aeaa8

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.18362
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\3.0.100-preview8-012929\


<!-- Mention language, UI scaling, or anything else that might be relevant -->
