### PR TITLE
Cleanup access levels in DataGridViewElement and subclasses

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -5130,7 +5130,7 @@ namespace System.Windows.Forms
             Debug.Assert(dataGridViewColumn != null);
             for (int columnIndex = dataGridViewColumn.Index; columnIndex < Columns.Count; columnIndex++)
             {
-                Columns[columnIndex].IndexInternal = Columns[columnIndex].Index - 1;
+                Columns[columnIndex].Index = Columns[columnIndex].Index - 1;
                 Debug.Assert(Columns[columnIndex].Index == columnIndex);
             }
         }
@@ -5141,7 +5141,7 @@ namespace System.Windows.Forms
             Debug.Assert(insertionCount > 0);
             for (int columnIndex = dataGridViewColumn.Index + insertionCount; columnIndex < Columns.Count; columnIndex++)
             {
-                Columns[columnIndex].IndexInternal = columnIndex;
+                Columns[columnIndex].Index = columnIndex;
             }
         }
 
@@ -5288,7 +5288,7 @@ namespace System.Windows.Forms
                 DataGridViewRow dataGridViewRow = Rows.SharedRow(rowIndex);
                 if (dataGridViewRow.Index >= 0)
                 {
-                    dataGridViewRow.IndexInternal = dataGridViewRow.Index - 1;
+                    dataGridViewRow.Index = dataGridViewRow.Index - 1;
                     Debug.Assert(dataGridViewRow.Index == rowIndex);
                 }
             }
@@ -5314,7 +5314,7 @@ namespace System.Windows.Forms
                 DataGridViewRow dataGridViewRow = Rows.SharedRow(rowIndex);
                 if (dataGridViewRow.Index >= 0)
                 {
-                    dataGridViewRow.IndexInternal = dataGridViewRow.Index + insertionCount;
+                    dataGridViewRow.Index = dataGridViewRow.Index + insertionCount;
                     Debug.Assert(dataGridViewRow.Index == rowIndex);
                 }
             }
@@ -6571,7 +6571,7 @@ namespace System.Windows.Forms
                             Debug.Assert(dataGridViewColumnTmp != null);
                             if (!dataGridViewColumnTmp.Displayed)
                             {
-                                dataGridViewColumnTmp.DisplayedInternal = true;
+                                dataGridViewColumnTmp.Displayed = true;
                             }
                             dataGridViewColumnTmp = Columns.GetNextColumn(dataGridViewColumnTmp, DataGridViewElementStates.Visible, DataGridViewElementStates.None);
                             numDisplayedScrollingCols--;
@@ -6584,7 +6584,7 @@ namespace System.Windows.Forms
                         dataGridViewColumnTmp = Columns.GetPreviousColumn(Columns[displayedBandsInfo.FirstDisplayedScrollingCol], DataGridViewElementStates.Visible, DataGridViewElementStates.Frozen);
                         while (dataGridViewColumnTmp != null && dataGridViewColumnTmp.Displayed)
                         {
-                            dataGridViewColumnTmp.DisplayedInternal = false;
+                            dataGridViewColumnTmp.Displayed = false;
                             dataGridViewColumnTmp = Columns.GetPreviousColumn(dataGridViewColumnTmp, DataGridViewElementStates.Visible, DataGridViewElementStates.Frozen);
                         }
 
@@ -6598,7 +6598,7 @@ namespace System.Windows.Forms
                     }
                     while (dataGridViewColumnTmp != null && dataGridViewColumnTmp.Displayed)
                     {
-                        dataGridViewColumnTmp.DisplayedInternal = false;
+                        dataGridViewColumnTmp.Displayed = false;
                         dataGridViewColumnTmp = Columns.GetNextColumn(dataGridViewColumnTmp, DataGridViewElementStates.Visible, DataGridViewElementStates.None);
                     }
 
@@ -6610,7 +6610,7 @@ namespace System.Windows.Forms
                         Debug.Assert(dataGridViewColumnTmp != null);
                         if (!dataGridViewColumnTmp.Displayed)
                         {
-                            dataGridViewColumnTmp.DisplayedInternal = true;
+                            dataGridViewColumnTmp.Displayed = true;
                         }
                         dataGridViewColumnTmp = Columns.GetNextColumn(dataGridViewColumnTmp, DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen, DataGridViewElementStates.None);
                         numDisplayedFrozenCols--;
@@ -6619,7 +6619,7 @@ namespace System.Windows.Forms
                     // Make sure all non-displayed frozen columns have their Displayed state set to false
                     while (dataGridViewColumnTmp != null && dataGridViewColumnTmp.Displayed)
                     {
-                        dataGridViewColumnTmp.DisplayedInternal = false;
+                        dataGridViewColumnTmp.Displayed = false;
                         dataGridViewColumnTmp = Columns.GetNextColumn(dataGridViewColumnTmp, DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen, DataGridViewElementStates.None);
                     }
 
@@ -6640,7 +6640,7 @@ namespace System.Windows.Forms
                         }
                         else
                         {
-                            dataGridViewColumnTmp.DisplayedInternal = false;
+                            dataGridViewColumnTmp.Displayed = false;
                             dataGridViewColumnTmp = Columns.GetNextColumn(dataGridViewColumnTmp, DataGridViewElementStates.Visible, DataGridViewElementStates.None);
                             columnIndexTmp = (dataGridViewColumnTmp == null) ? -1 : dataGridViewColumnTmp.Index;
                         }
@@ -6661,7 +6661,7 @@ namespace System.Windows.Forms
                             }
                             else
                             {
-                                dataGridViewColumnTmp.DisplayedInternal = false;
+                                dataGridViewColumnTmp.Displayed = false;
                                 dataGridViewColumnTmp = Columns.GetNextColumn(dataGridViewColumnTmp, DataGridViewElementStates.Visible, DataGridViewElementStates.None);
                             }
                         }
@@ -6674,7 +6674,7 @@ namespace System.Windows.Forms
                         {
                             if (dataGridViewColumnTmp.Displayed)
                             {
-                                dataGridViewColumnTmp.DisplayedInternal = false;
+                                dataGridViewColumnTmp.Displayed = false;
                             }
                             dataGridViewColumnTmp = Columns.GetPreviousColumn(dataGridViewColumnTmp, DataGridViewElementStates.Visible, DataGridViewElementStates.None);
                         }
@@ -10602,7 +10602,7 @@ namespace System.Windows.Forms
 
             if (dataGridViewColumn.HasHeaderCell)
             {
-                dataGridViewColumn.HeaderCell.DataGridViewInternal = this;
+                dataGridViewColumn.HeaderCell.DataGridView = this;
             }
 
             AdjustExpandingRows(dataGridViewColumn.Index, false /*fixedWidth*/);
@@ -10846,9 +10846,9 @@ namespace System.Windows.Forms
                             {
                                 dataGridViewCellNew.SetValueInternal(rowIndex, dataGridViewCellNew.DefaultNewRowValue);
                             }
-                            dataGridViewCellNew.DataGridViewInternal = this;
-                            dataGridViewCellNew.OwningRowInternal = dataGridViewRow;
-                            dataGridViewCellNew.OwningColumnInternal = dataGridViewColumn;
+                            dataGridViewCellNew.DataGridView = this;
+                            dataGridViewCellNew.OwningRow = dataGridViewRow;
+                            dataGridViewCellNew.OwningColumn = dataGridViewColumn;
                         }
                     }
                 }
@@ -10985,9 +10985,9 @@ namespace System.Windows.Forms
                                 {
                                     dataGridViewCellNew.Value = dataGridViewCellNew.DefaultNewRowValue;
                                 }
-                                dataGridViewCellNew.DataGridViewInternal = this;
-                                dataGridViewCellNew.OwningRowInternal = dataGridViewRow;
-                                dataGridViewCellNew.OwningColumnInternal = dataGridViewColumn;
+                                dataGridViewCellNew.DataGridView = this;
+                                dataGridViewCellNew.OwningRow = dataGridViewRow;
+                                dataGridViewCellNew.OwningColumn = dataGridViewColumn;
                             }
                         }
                     }
@@ -13374,7 +13374,7 @@ namespace System.Windows.Forms
             {
                 if (dataGridViewRow.Displayed)
                 {
-                    dataGridViewRow.DisplayedInternal = false;
+                    dataGridViewRow.Displayed = false;
                     DataGridViewRowStateChangedEventArgs dgvrsce = new DataGridViewRowStateChangedEventArgs(dataGridViewRow, DataGridViewElementStates.Displayed);
                     OnRowStateChanged(-1 /*rowIndex*/, dgvrsce);
                 }
@@ -14186,7 +14186,7 @@ namespace System.Windows.Forms
             Debug.Assert(dataGridViewColumn != null);
             if (dataGridViewColumn.Displayed)
             {
-                dataGridViewColumn.DisplayedInternal = false;
+                dataGridViewColumn.Displayed = false;
                 DataGridViewColumnStateChangedEventArgs dgvrsce = new DataGridViewColumnStateChangedEventArgs(dataGridViewColumn, DataGridViewElementStates.Displayed);
                 OnColumnStateChanged(dgvrsce);
             }
@@ -14535,7 +14535,7 @@ namespace System.Windows.Forms
                     if (!dataGridViewColumn.Visible && dataGridViewColumn.Displayed)
                     {
                         // Displayed column becomes invisible. Turns off the Displayed state.
-                        dataGridViewColumn.DisplayedInternal = false;
+                        dataGridViewColumn.Displayed = false;
                     }
 
                     // UsedFillWeight values need to be updated
@@ -15585,9 +15585,9 @@ namespace System.Windows.Forms
                             {
                                 dataGridViewCellNew.Value = dataGridViewCellNew.DefaultNewRowValue;
                             }
-                            dataGridViewCellNew.DataGridViewInternal = this;
-                            dataGridViewCellNew.OwningRowInternal = dataGridViewRow;
-                            dataGridViewCellNew.OwningColumnInternal = dataGridViewColumn;
+                            dataGridViewCellNew.DataGridView = this;
+                            dataGridViewCellNew.OwningRow = dataGridViewRow;
+                            dataGridViewCellNew.OwningColumn = dataGridViewColumn;
                         }
                     }
                 }
@@ -17034,7 +17034,7 @@ namespace System.Windows.Forms
             // Raise RowStateChanged event for Displayed state of deleted row
             if (rowDisplayed)
             {
-                dataGridViewRow.DisplayedInternal = false;
+                dataGridViewRow.Displayed = false;
                 DataGridViewRowStateChangedEventArgs dgvrsce = new DataGridViewRowStateChangedEventArgs(dataGridViewRow, DataGridViewElementStates.Displayed);
                 OnRowStateChanged(-1 /*rowIndex*/, dgvrsce);
             }
@@ -17190,7 +17190,7 @@ namespace System.Windows.Forms
             // Detach column header cell
             if (dataGridViewColumn.HasHeaderCell)
             {
-                dataGridViewColumn.HeaderCell.DataGridViewInternal = null;
+                dataGridViewColumn.HeaderCell.DataGridView = null;
             }
 
             // Reset sort related variables.
@@ -28279,7 +28279,7 @@ namespace System.Windows.Forms
                     Debug.Assert(dataGridViewColumnTmp != null);
                     if (dataGridViewColumnTmp.Displayed != displayed)
                     {
-                        dataGridViewColumnTmp.DisplayedInternal = displayed;
+                        dataGridViewColumnTmp.Displayed = displayed;
                         Debug.Assert(ColumnNeedsDisplayedState(dataGridViewColumnTmp));
                     }
                     dataGridViewColumnTmp = Columns.GetNextColumn(dataGridViewColumnTmp, DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen, DataGridViewElementStates.None);
@@ -28299,7 +28299,7 @@ namespace System.Windows.Forms
                     Debug.Assert(dataGridViewColumnTmp != null);
                     if (dataGridViewColumnTmp.Displayed != displayed)
                     {
-                        dataGridViewColumnTmp.DisplayedInternal = displayed;
+                        dataGridViewColumnTmp.Displayed = displayed;
                         Debug.Assert(ColumnNeedsDisplayedState(dataGridViewColumnTmp));
                     }
                     dataGridViewColumnTmp = Columns.GetNextColumn(dataGridViewColumnTmp, DataGridViewElementStates.Visible, DataGridViewElementStates.None);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -4748,12 +4748,12 @@ namespace System.Windows.Forms
                     if (topLeftHeaderCell != null)
                     {
                         // Detach existing header cell
-                        topLeftHeaderCell.DataGridViewInternal = null;
+                        topLeftHeaderCell.DataGridView = null;
                     }
                     topLeftHeaderCell = value;
                     if (value != null)
                     {
-                        topLeftHeaderCell.DataGridViewInternal = this;
+                        topLeftHeaderCell.DataGridView = this;
                     }
                     if (ColumnHeadersVisible && RowHeadersVisible)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBand.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBand.cs
@@ -28,7 +28,7 @@ namespace System.Windows.Forms
         private int _thickness;
         private int _minimumThickness;
         private int _bandIndex;
-        internal bool _bandIsRow;
+        private protected bool _bandIsRow;
 
         /// <summary>
         /// Initializes a new instance of the <see cref='DataGridViewBand'/> class.
@@ -164,20 +164,16 @@ namespace System.Windows.Forms
                 Debug.Assert(!_bandIsRow);
                 return (State & DataGridViewElementStates.Displayed) != 0;
             }
-        }
-
-        internal bool DisplayedInternal
-        {
-            set
+            internal set
             {
                 Debug.Assert(value != Displayed);
                 if (value)
                 {
-                    StateInternal = State | DataGridViewElementStates.Displayed;
+                    State = State | DataGridViewElementStates.Displayed;
                 }
                 else
                 {
-                    StateInternal = State & ~DataGridViewElementStates.Displayed;
+                    State = State & ~DataGridViewElementStates.Displayed;
                 }
                 if (DataGridView != null)
                 {
@@ -241,11 +237,11 @@ namespace System.Windows.Forms
                     OnStateChanging(DataGridViewElementStates.Frozen);
                     if (value)
                     {
-                        StateInternal = State | DataGridViewElementStates.Frozen;
+                        State = State | DataGridViewElementStates.Frozen;
                     }
                     else
                     {
-                        StateInternal = State & ~DataGridViewElementStates.Frozen;
+                        State = State & ~DataGridViewElementStates.Frozen;
                     }
                     OnStateChanged(DataGridViewElementStates.Frozen);
                 }
@@ -280,16 +276,16 @@ namespace System.Windows.Forms
                     Type cellType = DefaultHeaderCellType;
 
                     headerCell = (DataGridViewHeaderCell)Activator.CreateInstance(cellType);
-                    headerCell.DataGridViewInternal = DataGridView;
+                    headerCell.DataGridView = DataGridView;
                     if (_bandIsRow)
                     {
-                        headerCell.OwningRowInternal = (DataGridViewRow)this;   // may be a shared row
+                        headerCell.OwningRow = (DataGridViewRow)this;   // may be a shared row
                         Properties.SetObject(s_propHeaderCell, headerCell);
                     }
                     else
                     {
                         DataGridViewColumn dataGridViewColumn = this as DataGridViewColumn;
-                        headerCell.OwningColumnInternal = dataGridViewColumn;
+                        headerCell.OwningColumn = dataGridViewColumn;
                         // Set the headerCell in the property store before setting the SortOrder.
                         Properties.SetObject(s_propHeaderCell, headerCell);
                         if (DataGridView != null && DataGridView.SortedColumn == dataGridViewColumn)
@@ -310,14 +306,14 @@ namespace System.Windows.Forms
                 {
                     if (headerCell != null)
                     {
-                        headerCell.DataGridViewInternal = null;
+                        headerCell.DataGridView = null;
                         if (_bandIsRow)
                         {
-                            headerCell.OwningRowInternal = null;
+                            headerCell.OwningRow = null;
                         }
                         else
                         {
-                            headerCell.OwningColumnInternal = null;
+                            headerCell.OwningColumn = null;
                             ((DataGridViewColumnHeaderCell)headerCell).SortGlyphDirectionInternal = SortOrder.None;
                         }
                     }
@@ -337,7 +333,7 @@ namespace System.Windows.Forms
                                 value.OwningRow.HeaderCell = null;
                             }
                             Debug.Assert(value.OwningRow == null);
-                            value.OwningRowInternal = (DataGridViewRow)this;   // may be a shared row
+                            value.OwningRow = (DataGridViewRow)this;   // may be a shared row
                         }
                         else
                         {
@@ -353,10 +349,10 @@ namespace System.Windows.Forms
                             }
                             Debug.Assert(dataGridViewColumnHeaderCell.SortGlyphDirection == SortOrder.None);
                             Debug.Assert(value.OwningColumn == null);
-                            value.OwningColumnInternal = (DataGridViewColumn)this;
+                            value.OwningColumn = (DataGridViewColumn)this;
                         }
                         Debug.Assert(value.DataGridView == null);
-                        value.DataGridViewInternal = DataGridView;
+                        value.DataGridView = DataGridView;
                     }
 
                     Properties.SetObject(s_propHeaderCell, value);
@@ -369,11 +365,10 @@ namespace System.Windows.Forms
         }
 
         [Browsable(false)]
-        public int Index => _bandIndex;
-
-        internal int IndexInternal
+        public int Index
         {
-            set => _bandIndex = value;
+            get => _bandIndex;
+            internal set => _bandIndex = value;
         }
 
         [Browsable(false)]
@@ -483,11 +478,11 @@ namespace System.Windows.Forms
                                     }
                                 }
                             }
-                            StateInternal = State | DataGridViewElementStates.ReadOnly;
+                            State = State | DataGridViewElementStates.ReadOnly;
                         }
                         else
                         {
-                            StateInternal = State & ~DataGridViewElementStates.ReadOnly;
+                            State = State & ~DataGridViewElementStates.ReadOnly;
                         }
                     }
                 }
@@ -501,11 +496,11 @@ namespace System.Windows.Forms
                 Debug.Assert(value != ReadOnly);
                 if (value)
                 {
-                    StateInternal = State | DataGridViewElementStates.ReadOnly;
+                    State = State | DataGridViewElementStates.ReadOnly;
                 }
                 else
                 {
-                    StateInternal = State & ~DataGridViewElementStates.ReadOnly;
+                    State = State & ~DataGridViewElementStates.ReadOnly;
                 }
 
                 Debug.Assert(DataGridView != null);
@@ -540,20 +535,20 @@ namespace System.Windows.Forms
                 DataGridViewTriState oldResizable = Resizable;
                 if (value == DataGridViewTriState.NotSet)
                 {
-                    StateInternal = State & ~DataGridViewElementStates.ResizableSet;
+                    State = State & ~DataGridViewElementStates.ResizableSet;
                 }
                 else
                 {
-                    StateInternal = State | DataGridViewElementStates.ResizableSet;
+                    State = State | DataGridViewElementStates.ResizableSet;
                     if (((State & DataGridViewElementStates.Resizable) != 0) != (value == DataGridViewTriState.True))
                     {
                         if (value == DataGridViewTriState.True)
                         {
-                            StateInternal = State | DataGridViewElementStates.Resizable;
+                            State = State | DataGridViewElementStates.Resizable;
                         }
                         else
                         {
-                            StateInternal = State & ~DataGridViewElementStates.Resizable;
+                            State = State & ~DataGridViewElementStates.Resizable;
                         }
                     }
                 }
@@ -614,11 +609,11 @@ namespace System.Windows.Forms
                 Debug.Assert(value != Selected);
                 if (value)
                 {
-                    StateInternal = State | DataGridViewElementStates.Selected;
+                    State = State | DataGridViewElementStates.Selected;
                 }
                 else
                 {
-                    StateInternal = State & ~DataGridViewElementStates.Selected;
+                    State = State & ~DataGridViewElementStates.Selected;
                 }
 
                 if (DataGridView != null)
@@ -751,11 +746,11 @@ namespace System.Windows.Forms
                     OnStateChanging(DataGridViewElementStates.Visible);
                     if (value)
                     {
-                        StateInternal = State | DataGridViewElementStates.Visible;
+                        State = State | DataGridViewElementStates.Visible;
                     }
                     else
                     {
-                        StateInternal = State & ~DataGridViewElementStates.Visible;
+                        State = State & ~DataGridViewElementStates.Visible;
                     }
                     OnStateChanged(DataGridViewElementStates.Visible);
                 }
@@ -772,14 +767,14 @@ namespace System.Windows.Forms
             return band;
         }
 
-        internal void CloneInternal(DataGridViewBand dataGridViewBand)
+        private protected void CloneInternal(DataGridViewBand dataGridViewBand)
         {
             dataGridViewBand._propertyStore = new PropertyStore();
             dataGridViewBand._bandIndex = -1;
             dataGridViewBand._bandIsRow = _bandIsRow;
             if (!_bandIsRow || _bandIndex >= 0 || DataGridView == null)
             {
-                dataGridViewBand.StateInternal = State & ~(DataGridViewElementStates.Selected | DataGridViewElementStates.Displayed);
+                dataGridViewBand.State = State & ~(DataGridViewElementStates.Selected | DataGridViewElementStates.Displayed);
             }
             dataGridViewBand._thickness = Thickness;
             dataGridViewBand.MinimumThickness = MinimumThickness;
@@ -841,7 +836,7 @@ namespace System.Windows.Forms
             minimumHeight = _minimumThickness;
         }
 
-        internal void OnStateChanged(DataGridViewElementStates elementState)
+        private void OnStateChanged(DataGridViewElementStates elementState)
         {
             if (DataGridView != null)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -49,8 +49,6 @@ namespace System.Windows.Forms
         private static Bitmap errorBmp = null;
 
         private readonly PropertyStore propertyStore;          // Contains all properties that are not always set.
-        private DataGridViewRow owningRow;
-        private DataGridViewColumn owningColumn;
 
         private static readonly Type stringType = typeof(string);        // cache the string type for performance
 
@@ -101,17 +99,7 @@ namespace System.Windows.Forms
         /// <summary>
         /// Gets or sets the Index of a column in the <see cref='DataGrid'/> control.
         /// </summary>
-        public int ColumnIndex
-        {
-            get
-            {
-                if (owningColumn == null)
-                {
-                    return -1;
-                }
-                return owningColumn.Index;
-            }
-        }
+        public int ColumnIndex => OwningColumn?.Index ?? -1;
 
         [
             Browsable(false)
@@ -210,7 +198,7 @@ namespace System.Windows.Forms
                 if (RowIndex >= 0 && ColumnIndex >= 0)
                 {
                     Debug.Assert(DataGridView.Rows.GetRowState(RowIndex) == DataGridView.Rows.SharedRow(RowIndex).State);
-                    return owningColumn.Displayed && owningRow.Displayed;
+                    return OwningColumn.Displayed && OwningRow.Displayed;
                 }
 
                 return false;
@@ -367,11 +355,11 @@ namespace System.Windows.Forms
                 if (DataGridView != null && RowIndex >= 0 && ColumnIndex >= 0)
                 {
                     Debug.Assert(DataGridView.Rows.GetRowState(RowIndex) == DataGridView.Rows.SharedRow(RowIndex).State);
-                    return owningColumn.Frozen && owningRow.Frozen;
+                    return OwningColumn.Frozen && OwningRow.Frozen;
                 }
-                else if (owningRow != null && (owningRow.DataGridView == null || RowIndex >= 0))
+                else if (OwningRow != null && (OwningRow.DataGridView == null || RowIndex >= 0))
                 {
-                    return owningRow.Frozen;
+                    return OwningRow.Frozen;
                 }
                 return false;
             }
@@ -458,19 +446,11 @@ namespace System.Windows.Forms
 
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
-        public DataGridViewColumn OwningColumn
-        {
-            get => owningColumn;
-            set => owningColumn = value;
-        }
+        public DataGridViewColumn OwningColumn { get; internal set; }
 
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
-        public DataGridViewRow OwningRow
-        {
-            get => owningRow;
-            internal set => owningRow = value;
-        }
+        public DataGridViewRow OwningRow { get; internal set; }
 
         [
             Browsable(false)
@@ -503,14 +483,14 @@ namespace System.Windows.Forms
                 {
                     return true;
                 }
-                if (owningRow != null && (owningRow.DataGridView == null || RowIndex >= 0) && owningRow.ReadOnly)
+                if (OwningRow != null && (OwningRow.DataGridView == null || RowIndex >= 0) && OwningRow.ReadOnly)
                 {
                     return true;
                 }
                 if (DataGridView != null && RowIndex >= 0 && ColumnIndex >= 0)
                 {
                     Debug.Assert(DataGridView.Rows.GetRowState(RowIndex) == DataGridView.Rows.SharedRow(RowIndex).State);
-                    return owningColumn.ReadOnly;
+                    return OwningColumn.ReadOnly;
                 }
                 return false;
             }
@@ -532,17 +512,17 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    if (owningRow == null)
+                    if (OwningRow == null)
                     {
                         if (value != ReadOnly)
                         {
                             // We do not allow the read-only flag of a cell to be changed before it is added to a row.
-                            throw new InvalidOperationException(string.Format(SR.DataGridViewCell_CannotSetReadOnlyState));
+                            throw new InvalidOperationException(SR.DataGridViewCell_CannotSetReadOnlyState);
                         }
                     }
                     else
                     {
-                        owningRow.SetReadOnlyCellCore(this, value);
+                        OwningRow.SetReadOnlyCellCore(this, value);
                     }
                 }
             }
@@ -575,7 +555,7 @@ namespace System.Windows.Forms
             {
                 Debug.Assert((State & DataGridViewElementStates.Resizable) == 0);
 
-                if (owningRow != null && (owningRow.DataGridView == null || RowIndex >= 0) && owningRow.Resizable == DataGridViewTriState.True)
+                if (OwningRow != null && (OwningRow.DataGridView == null || RowIndex >= 0) && OwningRow.Resizable == DataGridViewTriState.True)
                 {
                     return true;
                 }
@@ -583,7 +563,7 @@ namespace System.Windows.Forms
                 if (DataGridView != null && RowIndex >= 0 && ColumnIndex >= 0)
                 {
                     Debug.Assert(DataGridView.Rows.GetRowState(RowIndex) == DataGridView.Rows.SharedRow(RowIndex).State);
-                    return owningColumn.Resizable == DataGridViewTriState.True;
+                    return OwningColumn.Resizable == DataGridViewTriState.True;
                 }
 
                 return false;
@@ -593,20 +573,8 @@ namespace System.Windows.Forms
         /// <summary>
         /// Gets or sets the index of a row in the <see cref='DataGrid'/> control.
         /// </summary>
-        [
-            Browsable(false)
-        ]
-        public int RowIndex
-        {
-            get
-            {
-                if (owningRow == null)
-                {
-                    return -1;
-                }
-                return owningRow.Index;
-            }
-        }
+        [Browsable(false)]
+        public int RowIndex => OwningRow?.Index ?? -1;
 
         [
             Browsable(false),
@@ -621,7 +589,7 @@ namespace System.Windows.Forms
                     return true;
                 }
 
-                if (owningRow != null && (owningRow.DataGridView == null || RowIndex >= 0) && owningRow.Selected)
+                if (OwningRow != null && (OwningRow.DataGridView == null || RowIndex >= 0) && OwningRow.Selected)
                 {
                     return true;
                 }
@@ -629,7 +597,7 @@ namespace System.Windows.Forms
                 if (DataGridView != null && RowIndex >= 0 && ColumnIndex >= 0)
                 {
                     Debug.Assert(DataGridView.Rows.GetRowState(RowIndex) == DataGridView.Rows.SharedRow(RowIndex).State);
-                    return owningColumn.Selected;
+                    return OwningColumn.Selected;
                 }
 
                 return false;
@@ -883,11 +851,11 @@ namespace System.Windows.Forms
                 if (DataGridView != null && RowIndex >= 0 && ColumnIndex >= 0)
                 {
                     Debug.Assert(DataGridView.Rows.GetRowState(RowIndex) == DataGridView.Rows.SharedRow(RowIndex).State);
-                    return owningColumn.Visible && owningRow.Visible;
+                    return OwningColumn.Visible && OwningRow.Visible;
                 }
-                else if (owningRow != null && (owningRow.DataGridView == null || RowIndex >= 0))
+                else if (OwningRow != null && (OwningRow.DataGridView == null || RowIndex >= 0))
                 {
-                    return owningRow.Visible;
+                    return OwningRow.Visible;
                 }
                 return false;
             }
@@ -996,20 +964,20 @@ namespace System.Windows.Forms
                 rect.Height++;
             }
 
-            if (owningColumn != null)
+            if (OwningColumn != null)
             {
                 if (DataGridView != null && DataGridView.RightToLeftInternal)
                 {
-                    rect.X += owningColumn.DividerWidth;
+                    rect.X += OwningColumn.DividerWidth;
                 }
                 else
                 {
-                    rect.Width += owningColumn.DividerWidth;
+                    rect.Width += OwningColumn.DividerWidth;
                 }
             }
-            if (owningRow != null)
+            if (OwningRow != null)
             {
-                rect.Height += owningRow.DividerHeight;
+                rect.Height += OwningRow.DividerHeight;
             }
 
             return rect;
@@ -1027,9 +995,9 @@ namespace System.Windows.Forms
             Debug.Assert(ColumnIndex >= 0);
             DataGridViewElementStates orFlags = DataGridViewElementStates.ReadOnly | DataGridViewElementStates.Resizable | DataGridViewElementStates.Selected;
             DataGridViewElementStates andFlags = DataGridViewElementStates.Displayed | DataGridViewElementStates.Frozen | DataGridViewElementStates.Visible;
-            DataGridViewElementStates cellState = (owningColumn.State & orFlags);
+            DataGridViewElementStates cellState = (OwningColumn.State & orFlags);
             cellState |= (rowState & orFlags);
-            cellState |= ((owningColumn.State & andFlags) & (rowState & andFlags));
+            cellState |= ((OwningColumn.State & andFlags) & (rowState & andFlags));
             return cellState;
         }
 
@@ -1869,8 +1837,9 @@ namespace System.Windows.Forms
             {
                 return -1;
             }
-            Debug.Assert(owningRow != null);
-            return owningRow.GetHeight(rowIndex);
+
+            Debug.Assert(OwningRow != null);
+            return OwningRow.GetHeight(rowIndex);
         }
 
         public virtual ContextMenuStrip GetInheritedContextMenuStrip(int rowIndex)
@@ -1894,18 +1863,18 @@ namespace System.Windows.Forms
                 return contextMenuStrip;
             }
 
-            if (owningRow != null)
+            if (OwningRow != null)
             {
-                contextMenuStrip = owningRow.GetContextMenuStrip(rowIndex);
+                contextMenuStrip = OwningRow.GetContextMenuStrip(rowIndex);
                 if (contextMenuStrip != null)
                 {
                     return contextMenuStrip;
                 }
             }
 
-            if (owningColumn != null)
+            if (OwningColumn != null)
             {
-                contextMenuStrip = owningColumn.ContextMenuStrip;
+                contextMenuStrip = OwningColumn.ContextMenuStrip;
                 if (contextMenuStrip != null)
                 {
                     return contextMenuStrip;
@@ -1933,10 +1902,10 @@ namespace System.Windows.Forms
                 {
                     throw new ArgumentException(string.Format(SR.InvalidArgument, nameof(rowIndex), rowIndex));
                 }
-                if (owningRow != null)
+                if (OwningRow != null)
                 {
-                    state |= (owningRow.GetState(-1) & (DataGridViewElementStates.Frozen | DataGridViewElementStates.ReadOnly | DataGridViewElementStates.Selected | DataGridViewElementStates.Visible));
-                    if (owningRow.GetResizable(rowIndex) == DataGridViewTriState.True)
+                    state |= (OwningRow.GetState(-1) & (DataGridViewElementStates.Frozen | DataGridViewElementStates.ReadOnly | DataGridViewElementStates.Selected | DataGridViewElementStates.Visible));
+                    if (OwningRow.GetResizable(rowIndex) == DataGridViewTriState.True)
                     {
                         state |= DataGridViewElementStates.Resizable;
                     }
@@ -1950,33 +1919,33 @@ namespace System.Windows.Forms
                 throw new ArgumentOutOfRangeException(nameof(rowIndex));
             }
 
-            Debug.Assert(owningColumn != null);
-            Debug.Assert(owningRow != null);
+            Debug.Assert(OwningColumn != null);
+            Debug.Assert(OwningRow != null);
             Debug.Assert(ColumnIndex >= 0);
 
-            if (DataGridView.Rows.SharedRow(rowIndex) != owningRow)
+            if (DataGridView.Rows.SharedRow(rowIndex) != OwningRow)
             {
                 throw new ArgumentException(string.Format(SR.InvalidArgument, nameof(rowIndex), rowIndex));
             }
 
             DataGridViewElementStates rowEffectiveState = DataGridView.Rows.GetRowState(rowIndex);
             state |= (rowEffectiveState & (DataGridViewElementStates.ReadOnly | DataGridViewElementStates.Selected));
-            state |= (owningColumn.State & (DataGridViewElementStates.ReadOnly | DataGridViewElementStates.Selected));
+            state |= (OwningColumn.State & (DataGridViewElementStates.ReadOnly | DataGridViewElementStates.Selected));
 
-            if (owningRow.GetResizable(rowIndex) == DataGridViewTriState.True ||
-                owningColumn.Resizable == DataGridViewTriState.True)
+            if (OwningRow.GetResizable(rowIndex) == DataGridViewTriState.True ||
+                OwningColumn.Resizable == DataGridViewTriState.True)
             {
                 state |= DataGridViewElementStates.Resizable;
             }
-            if (owningColumn.Visible && owningRow.GetVisible(rowIndex))
+            if (OwningColumn.Visible && OwningRow.GetVisible(rowIndex))
             {
                 state |= DataGridViewElementStates.Visible;
-                if (owningColumn.Displayed && owningRow.GetDisplayed(rowIndex))
+                if (OwningColumn.Displayed && OwningRow.GetDisplayed(rowIndex))
                 {
                     state |= DataGridViewElementStates.Displayed;
                 }
             }
-            if (owningColumn.Frozen && owningRow.GetFrozen(rowIndex))
+            if (OwningColumn.Frozen && OwningRow.GetFrozen(rowIndex))
             {
                 state |= DataGridViewElementStates.Frozen;
             }
@@ -2060,9 +2029,9 @@ namespace System.Windows.Forms
             }
 
             DataGridViewCellStyle columnStyle = null;
-            if (owningColumn.HasDefaultCellStyle)
+            if (OwningColumn.HasDefaultCellStyle)
             {
-                columnStyle = owningColumn.DefaultCellStyle;
+                columnStyle = OwningColumn.DefaultCellStyle;
                 Debug.Assert(columnStyle != null);
             }
 
@@ -2504,9 +2473,10 @@ namespace System.Windows.Forms
             {
                 throw new InvalidOperationException(string.Format(SR.DataGridView_InvalidPropertyGetOnSharedCell, "Size"));
             }
-            Debug.Assert(owningColumn != null);
-            Debug.Assert(owningRow != null);
-            return new Size(owningColumn.Thickness, owningRow.GetHeight(rowIndex));
+
+            Debug.Assert(OwningColumn != null);
+            Debug.Assert(OwningRow != null);
+            return new Size(OwningColumn.Thickness, OwningRow.GetHeight(rowIndex));
         }
 
         private string GetToolTipText(int rowIndex)
@@ -3337,7 +3307,7 @@ namespace System.Windows.Forms
 
             GetContrastedPens(cellStyle.BackColor, ref penControlDark, ref penControlLightLight);
 
-            int dividerThickness = owningColumn == null ? 0 : owningColumn.DividerWidth;
+            int dividerThickness = OwningColumn?.DividerWidth ?? 0;
             if (dividerThickness != 0)
             {
                 if (dividerThickness > bounds.Width)
@@ -3375,7 +3345,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            dividerThickness = owningRow == null ? 0 : owningRow.DividerHeight;
+            dividerThickness = OwningRow?.DividerHeight ?? 0;
             if (dividerThickness != 0)
             {
                 if (dividerThickness > bounds.Height)
@@ -3700,7 +3670,7 @@ namespace System.Windows.Forms
 
             using (WindowsGraphics windowsGraphics = WindowsGraphics.FromGraphics(graphics))
             {
-                int dividerThickness = this.owningColumn == null ? 0 : this.owningColumn.DividerWidth;
+                int dividerThickness = this.owningColumn == null ? 0 : this.OwningColumn.DividerWidth;
                 if (dividerThickness != 0)
                 {
                     if (dividerThickness > bounds.Width)
@@ -3738,7 +3708,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                dividerThickness = this.owningRow == null ? 0 : this.owningRow.DividerHeight;
+                dividerThickness = OwningRow.DividerHeight ?? 0;
                 if (dividerThickness != 0)
                 {
                     if (dividerThickness > bounds.Height)
@@ -4621,16 +4591,10 @@ namespace System.Windows.Forms
                 {
                     if (owner == null)
                     {
-                        throw new InvalidOperationException(string.Format(SR.DataGridViewCellAccessibleObject_OwnerNotSet));
+                        throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                     }
-                    if (owner.OwningRow == null)
-                    {
-                        return null;
-                    }
-                    else
-                    {
-                        return owner.OwningRow.AccessibilityObject;
-                    }
+                    
+                    return owner.OwningRow?.AccessibilityObject;
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -72,7 +72,7 @@ namespace System.Windows.Forms
             }
 
             propertyStore = new PropertyStore();
-            StateInternal = DataGridViewElementStates.None;
+            State = DataGridViewElementStates.None;
         }
 
         ~DataGridViewCell()
@@ -377,12 +377,9 @@ namespace System.Windows.Forms
             }
         }
 
-        internal bool HasErrorText
+        private bool HasErrorText
         {
-            get
-            {
-                return Properties.ContainsObject(PropCellErrorText) && Properties.GetObject(PropCellErrorText) != null;
-            }
+            get => Properties.ContainsObject(PropCellErrorText) && Properties.GetObject(PropCellErrorText) != null;
         }
 
         [Browsable(false)]
@@ -410,12 +407,9 @@ namespace System.Windows.Forms
             }
         }
 
-        internal virtual bool HasValueType
+        private protected virtual bool HasValueType
         {
-            get
-            {
-                return Properties.ContainsObject(PropCellValueType) && Properties.GetObject(PropCellValueType) != null;
-            }
+            get => Properties.ContainsObject(PropCellValueType) && Properties.GetObject(PropCellValueType) != null;
         }
 
         [Browsable(false)]
@@ -462,44 +456,20 @@ namespace System.Windows.Forms
             }
         }
 
-        [
-            Browsable(false),
-            EditorBrowsable(EditorBrowsableState.Advanced)
-        ]
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
         public DataGridViewColumn OwningColumn
         {
-            get
-            {
-                return owningColumn;
-            }
+            get => owningColumn;
+            set => owningColumn = value;
         }
 
-        internal DataGridViewColumn OwningColumnInternal
-        {
-            set
-            {
-                owningColumn = value;
-            }
-        }
-
-        [
-            Browsable(false),
-            EditorBrowsable(EditorBrowsableState.Advanced)
-        ]
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
         public DataGridViewRow OwningRow
         {
-            get
-            {
-                return owningRow;
-            }
-        }
-
-        internal DataGridViewRow OwningRowInternal
-        {
-            set
-            {
-                owningRow = value;
-            }
+            get => owningRow;
+            internal set => owningRow = value;
         }
 
         [
@@ -585,16 +555,14 @@ namespace System.Windows.Forms
                 Debug.Assert(value != ReadOnly);
                 if (value)
                 {
-                    StateInternal = State | DataGridViewElementStates.ReadOnly;
+                    State = State | DataGridViewElementStates.ReadOnly;
                 }
                 else
                 {
-                    StateInternal = State & ~DataGridViewElementStates.ReadOnly;
+                    State = State & ~DataGridViewElementStates.ReadOnly;
                 }
-                if (DataGridView != null)
-                {
-                    DataGridView.OnDataGridViewElementStateChanged(this, -1, DataGridViewElementStates.ReadOnly);
-                }
+                
+                DataGridView?.OnDataGridViewElementStateChanged(this, -1, DataGridViewElementStates.ReadOnly);
             }
         }
 
@@ -692,11 +660,11 @@ namespace System.Windows.Forms
                 Debug.Assert(value != Selected);
                 if (value)
                 {
-                    StateInternal = State | DataGridViewElementStates.Selected;
+                    State = State | DataGridViewElementStates.Selected;
                 }
                 else
                 {
-                    StateInternal = State & ~DataGridViewElementStates.Selected;
+                    State = State & ~DataGridViewElementStates.Selected;
                 }
                 if (DataGridView != null)
                 {
@@ -714,19 +682,20 @@ namespace System.Windows.Forms
             }
         }
 
-        internal Rectangle StdBorderWidths
+        private protected Rectangle StdBorderWidths
         {
             get
             {
                 if (DataGridView != null)
                 {
                     DataGridViewAdvancedBorderStyle dataGridViewAdvancedBorderStylePlaceholder = new DataGridViewAdvancedBorderStyle(), dgvabsEffective;
-                    dgvabsEffective = AdjustCellBorderStyle(DataGridView.AdvancedCellBorderStyle,
+                    dgvabsEffective = AdjustCellBorderStyle(
+                        DataGridView.AdvancedCellBorderStyle,
                         dataGridViewAdvancedBorderStylePlaceholder,
-                        false /*singleVerticalBorderAdded*/,
-                        false /*singleHorizontalBorderAdded*/,
-                        false /*isFirstDisplayedColumn*/,
-                        false /*isFirstDisplayedRow*/);
+                        singleVerticalBorderAdded: false,
+                        singleHorizontalBorderAdded: false,
+                        isFirstDisplayedColumn: false,
+                        isFirstDisplayedRow: false);
                     return BorderWidths(dgvabsEffective);
                 }
                 else
@@ -1096,7 +1065,7 @@ namespace System.Windows.Forms
             {
                 dataGridViewCell.ContextMenuStrip = ContextMenuStripInternal.Clone();
             }
-            dataGridViewCell.StateInternal = State & ~DataGridViewElementStates.Selected;
+            dataGridViewCell.State = State & ~DataGridViewElementStates.Selected;
             dataGridViewCell.Tag = Tag;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellCollection.cs
@@ -140,18 +140,18 @@ namespace System.Windows.Forms
 
                 DataGridViewCell oldDataGridViewCell = (DataGridViewCell)items[index];
                 items[index] = dataGridViewCell;
-                dataGridViewCell.OwningRowInternal = owner;
-                dataGridViewCell.StateInternal = oldDataGridViewCell.State;
+                dataGridViewCell.OwningRow = owner;
+                dataGridViewCell.State = oldDataGridViewCell.State;
                 if (owner.DataGridView != null)
                 {
-                    dataGridViewCell.DataGridViewInternal = owner.DataGridView;
-                    dataGridViewCell.OwningColumnInternal = owner.DataGridView.Columns[index];
+                    dataGridViewCell.DataGridView = owner.DataGridView;
+                    dataGridViewCell.OwningColumn = owner.DataGridView.Columns[index];
                     owner.DataGridView.OnReplacedCell(owner, index);
                 }
 
-                oldDataGridViewCell.DataGridViewInternal = null;
-                oldDataGridViewCell.OwningRowInternal = null;
-                oldDataGridViewCell.OwningColumnInternal = null;
+                oldDataGridViewCell.DataGridView = null;
+                oldDataGridViewCell.OwningRow = null;
+                oldDataGridViewCell.OwningColumn = null;
                 if (oldDataGridViewCell.ReadOnly)
                 {
                     oldDataGridViewCell.ReadOnlyInternal = false;
@@ -223,11 +223,11 @@ namespace System.Windows.Forms
         {
             Debug.Assert(!dataGridViewCell.Selected);
             int index = items.Add(dataGridViewCell);
-            dataGridViewCell.OwningRowInternal = owner;
+            dataGridViewCell.OwningRow = owner;
             DataGridView dataGridView = owner.DataGridView;
             if (dataGridView != null && dataGridView.Columns.Count > index)
             {
-                dataGridViewCell.OwningColumnInternal = dataGridView.Columns[index];
+                dataGridViewCell.OwningColumn = dataGridView.Columns[index];
             }
             OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Add, dataGridViewCell));
             return index;
@@ -273,7 +273,7 @@ namespace System.Windows.Forms
             items.AddRange(dataGridViewCells);
             foreach (DataGridViewCell dataGridViewCell in dataGridViewCells)
             {
-                dataGridViewCell.OwningRowInternal = owner;
+                dataGridViewCell.OwningRow = owner;
                 Debug.Assert(!dataGridViewCell.Selected);
             }
             OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Refresh, null));
@@ -287,7 +287,7 @@ namespace System.Windows.Forms
             }
             foreach (DataGridViewCell dataGridViewCell in items)
             {
-                dataGridViewCell.OwningRowInternal = null;
+                dataGridViewCell.OwningRow = null;
             }
             items.Clear();
             OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Refresh, null));
@@ -325,7 +325,7 @@ namespace System.Windows.Forms
             Debug.Assert(!dataGridViewCell.ReadOnly);
             Debug.Assert(!dataGridViewCell.Selected);
             items.Insert(index, dataGridViewCell);
-            dataGridViewCell.OwningRowInternal = owner;
+            dataGridViewCell.OwningRow = owner;
             OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Add, dataGridViewCell));
         }
 
@@ -333,11 +333,11 @@ namespace System.Windows.Forms
         {
             Debug.Assert(!dataGridViewCell.Selected);
             items.Insert(index, dataGridViewCell);
-            dataGridViewCell.OwningRowInternal = owner;
+            dataGridViewCell.OwningRow = owner;
             DataGridView dataGridView = owner.DataGridView;
             if (dataGridView != null && dataGridView.Columns.Count > index)
             {
-                dataGridViewCell.OwningColumnInternal = dataGridView.Columns[index];
+                dataGridViewCell.OwningColumn = dataGridView.Columns[index];
             }
             OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Add, dataGridViewCell));
         }
@@ -386,8 +386,8 @@ namespace System.Windows.Forms
         {
             DataGridViewCell dataGridViewCell = (DataGridViewCell)items[index];
             items.RemoveAt(index);
-            dataGridViewCell.DataGridViewInternal = null;
-            dataGridViewCell.OwningRowInternal = null;
+            dataGridViewCell.DataGridView = null;
+            dataGridViewCell.OwningRow = null;
             if (dataGridViewCell.ReadOnly)
             {
                 dataGridViewCell.ReadOnlyInternal = false;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnCollection.cs
@@ -236,8 +236,8 @@ namespace System.Windows.Forms
 
             InvalidateCachedColumnsOrder();
             int index = items.Add(dataGridViewColumn);
-            dataGridViewColumn.IndexInternal = index;
-            dataGridViewColumn.DataGridViewInternal = dataGridView;
+            dataGridViewColumn.Index = index;
+            dataGridViewColumn.DataGridView = dataGridView;
             UpdateColumnCaches(dataGridViewColumn, true);
             DataGridView.OnAddedColumn(dataGridViewColumn);
             OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Add, dataGridViewColumn), false /*changeIsInsertion*/, new Point(-1, -1));
@@ -325,8 +325,8 @@ namespace System.Windows.Forms
             {
                 InvalidateCachedColumnsOrder();
                 index = items.Add(dataGridViewColumn);
-                dataGridViewColumn.IndexInternal = index;
-                dataGridViewColumn.DataGridViewInternal = dataGridView;
+                dataGridViewColumn.Index = index;
+                dataGridViewColumn.DataGridView = dataGridView;
                 UpdateColumnCaches(dataGridViewColumn, true);
                 DataGridView.OnAddedColumn(dataGridViewColumn);
             }
@@ -355,11 +355,11 @@ namespace System.Windows.Forms
                 {
                     DataGridViewColumn dataGridViewColumn = this[columnIndex];
                     // Detach the column...
-                    dataGridViewColumn.DataGridViewInternal = null;
+                    dataGridViewColumn.DataGridView = null;
                     // ...and its potential header cell
                     if (dataGridViewColumn.HasHeaderCell)
                     {
-                        dataGridViewColumn.HeaderCell.DataGridViewInternal = null;
+                        dataGridViewColumn.HeaderCell.DataGridView = null;
                     }
                 }
 
@@ -922,8 +922,8 @@ namespace System.Windows.Forms
             }
             InvalidateCachedColumnsOrder();
             items.Insert(columnIndex, dataGridViewColumn);
-            dataGridViewColumn.IndexInternal = columnIndex;
-            dataGridViewColumn.DataGridViewInternal = dataGridView;
+            dataGridViewColumn.Index = columnIndex;
+            dataGridViewColumn.DataGridView = dataGridView;
             UpdateColumnCaches(dataGridViewColumn, true);
             DataGridView.OnInsertedColumn_PreNotification(dataGridViewColumn);
             OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Add, dataGridViewColumn), true /*changeIsInsertion*/, newCurrentCell);
@@ -1109,7 +1109,7 @@ namespace System.Windows.Forms
             DataGridView.OnRemovingColumn(dataGridViewColumn, out Point newCurrentCell, force);
             InvalidateCachedColumnsOrder();
             items.RemoveAt(index);
-            dataGridViewColumn.DataGridViewInternal = null;
+            dataGridViewColumn.DataGridView = null;
             UpdateColumnCaches(dataGridViewColumn, false);
             DataGridView.OnRemovedColumn_PreNotification(dataGridViewColumn);
             OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Remove, dataGridViewColumn), false /*changeIsInsertion*/, newCurrentCell);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewElement.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewElement.cs
@@ -11,7 +11,6 @@ namespace System.Windows.Forms
     /// </summary>
     public class DataGridViewElement
     {
-        private DataGridViewElementStates _state; // enabled frozen readOnly resizable selected visible
         private DataGridView _dataGridView;
 
         /// <summary>
@@ -19,23 +18,18 @@ namespace System.Windows.Forms
         /// </summary>
         public DataGridViewElement()
         {
-            _state = DataGridViewElementStates.Visible;
+            State = DataGridViewElementStates.Visible;
         }
 
         internal DataGridViewElement(DataGridViewElement dgveTemplate)
         {
             // Selected and Displayed states are not inherited
-            _state = dgveTemplate.State & (DataGridViewElementStates.Frozen | DataGridViewElementStates.ReadOnly | DataGridViewElementStates.Resizable | DataGridViewElementStates.ResizableSet | DataGridViewElementStates.Visible);
+            State = dgveTemplate.State & (DataGridViewElementStates.Frozen | DataGridViewElementStates.ReadOnly | DataGridViewElementStates.Resizable | DataGridViewElementStates.ResizableSet | DataGridViewElementStates.Visible);
         }
 
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
-        public virtual DataGridViewElementStates State => _state;
-
-        internal DataGridViewElementStates StateInternal
-        {
-            set => _state = value;
-        }
+        public virtual DataGridViewElementStates State { get; internal set; }
 
         internal bool StateIncludes(DataGridViewElementStates elementState)
         {
@@ -49,13 +43,12 @@ namespace System.Windows.Forms
 
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public DataGridView DataGridView => _dataGridView;
-
-        internal DataGridView DataGridViewInternal
+        public DataGridView DataGridView
         {
-            set
+            get => _dataGridView;
+            internal set
             {
-                if (DataGridView != value)
+                if (_dataGridView != value)
                 {
                     _dataGridView = value;
                     OnDataGridViewChanged();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
@@ -149,12 +149,9 @@ namespace System.Windows.Forms
             }
         }
 
-        internal override bool HasValueType
+        private protected override bool HasValueType
         {
-            get
-            {
-                return Properties.ContainsObject(PropValueType) && Properties.GetObject(PropValueType) != null;
-            }
+            get => Properties.ContainsObject(PropValueType) && Properties.GetObject(PropValueType) != null;
         }
 
         [

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
@@ -198,7 +198,7 @@ namespace System.Windows.Forms
             }
         }
 
-        internal bool HasErrorText
+        private bool HasErrorText
         {
             get => Properties.ContainsObject(s_propRowErrorText) && Properties.GetObject(s_propRowErrorText) != null;
         }
@@ -1120,15 +1120,15 @@ namespace System.Windows.Forms
         {
             if (DataGridView != null)
             {
-                DataGridViewInternal = null;
-                IndexInternal = -1;
+                DataGridView = null;
+                Index = -1;
                 if (HasHeaderCell)
                 {
-                    HeaderCell.DataGridViewInternal = null;
+                    HeaderCell.DataGridView = null;
                 }
                 foreach (DataGridViewCell dataGridViewCell in Cells)
                 {
-                    dataGridViewCell.DataGridViewInternal = null;
+                    dataGridViewCell.DataGridView = null;
                     if (dataGridViewCell.Selected)
                     {
                         dataGridViewCell.SelectedInternal = false;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowCollection.cs
@@ -215,8 +215,8 @@ namespace System.Windows.Forms
                     {
                         // The only row present in the grid gets unshared.
                         // Simply update the index and return the current row without cloning it.
-                        dataGridViewRow.IndexInternal = 0;
-                        dataGridViewRow.StateInternal = SharedRowState(0);
+                        dataGridViewRow.Index = 0;
+                        dataGridViewRow.State = SharedRowState(0);
                         if (DataGridView != null)
                         {
                             DataGridView.OnRowUnshared(dataGridViewRow);
@@ -226,22 +226,22 @@ namespace System.Windows.Forms
 
                     // unshare row
                     DataGridViewRow newDataGridViewRow = (DataGridViewRow)dataGridViewRow.Clone();
-                    newDataGridViewRow.IndexInternal = index;
-                    newDataGridViewRow.DataGridViewInternal = dataGridViewRow.DataGridView;
-                    newDataGridViewRow.StateInternal = SharedRowState(index);
+                    newDataGridViewRow.Index = index;
+                    newDataGridViewRow.DataGridView = dataGridViewRow.DataGridView;
+                    newDataGridViewRow.State = SharedRowState(index);
                     SharedList[index] = newDataGridViewRow;
                     int columnIndex = 0;
                     foreach (DataGridViewCell dataGridViewCell in newDataGridViewRow.Cells)
                     {
-                        dataGridViewCell.DataGridViewInternal = dataGridViewRow.DataGridView;
-                        dataGridViewCell.OwningRowInternal = newDataGridViewRow;
-                        dataGridViewCell.OwningColumnInternal = DataGridView.Columns[columnIndex];
+                        dataGridViewCell.DataGridView = dataGridViewRow.DataGridView;
+                        dataGridViewCell.OwningRow = newDataGridViewRow;
+                        dataGridViewCell.OwningColumn = DataGridView.Columns[columnIndex];
                         columnIndex++;
                     }
                     if (newDataGridViewRow.HasHeaderCell)
                     {
-                        newDataGridViewRow.HeaderCell.DataGridViewInternal = dataGridViewRow.DataGridView;
-                        newDataGridViewRow.HeaderCell.OwningRowInternal = newDataGridViewRow;
+                        newDataGridViewRow.HeaderCell.DataGridView = dataGridViewRow.DataGridView;
+                        newDataGridViewRow.HeaderCell.OwningRow = newDataGridViewRow;
                     }
                     if (DataGridView != null)
                     {
@@ -300,7 +300,7 @@ namespace System.Windows.Forms
                 // Note that we allow the 'new' row to be frozen.
                 Debug.Assert((dataGridViewRow.State & (DataGridViewElementStates.Selected | DataGridViewElementStates.Displayed)) == 0);
                 // Make sure the 'new row' is visible even when the row template isn't
-                dataGridViewRow.StateInternal = dataGridViewRow.State | DataGridViewElementStates.Visible;
+                dataGridViewRow.State = dataGridViewRow.State | DataGridViewElementStates.Visible;
                 foreach (DataGridViewCell dataGridViewCell in dataGridViewRow.Cells)
                 {
                     dataGridViewCell.Value = dataGridViewCell.DefaultNewRowValue;
@@ -324,20 +324,20 @@ namespace System.Windows.Forms
             DataGridViewElementStates rowState = dataGridViewRow.State;
             DataGridView.OnAddingRow(dataGridViewRow, rowState, true /*checkFrozenState*/);   // will throw an exception if the addition is illegal
 
-            dataGridViewRow.DataGridViewInternal = dataGridView;
+            dataGridViewRow.DataGridView = dataGridView;
             int columnIndex = 0;
             foreach (DataGridViewCell dataGridViewCell in dataGridViewRow.Cells)
             {
-                dataGridViewCell.DataGridViewInternal = dataGridView;
+                dataGridViewCell.DataGridView = dataGridView;
                 Debug.Assert(dataGridViewCell.OwningRow == dataGridViewRow);
-                dataGridViewCell.OwningColumnInternal = DataGridView.Columns[columnIndex];
+                dataGridViewCell.OwningColumn = DataGridView.Columns[columnIndex];
                 columnIndex++;
             }
 
             if (dataGridViewRow.HasHeaderCell)
             {
-                dataGridViewRow.HeaderCell.DataGridViewInternal = DataGridView;
-                dataGridViewRow.HeaderCell.OwningRowInternal = dataGridViewRow;
+                dataGridViewRow.HeaderCell.DataGridView = DataGridView;
+                dataGridViewRow.HeaderCell.OwningRow = dataGridViewRow;
             }
 
             int index = SharedList.Add(dataGridViewRow);
@@ -350,7 +350,7 @@ namespace System.Windows.Forms
 #endif
             if (values != null || !RowIsSharable(index) || RowHasValueOrToolTipText(dataGridViewRow) || IsCollectionChangedListenedTo)
             {
-                dataGridViewRow.IndexInternal = index;
+                dataGridViewRow.Index = index;
                 Debug.Assert(dataGridViewRow.State == SharedRowState(index));
             }
             OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Add, dataGridViewRow), index, 1);
@@ -456,19 +456,19 @@ namespace System.Windows.Forms
             Debug.Assert(rowTemplate.Cells.Count == DataGridView.Columns.Count);
             DataGridViewElementStates rowTemplateState = rowTemplate.State;
             Debug.Assert((rowTemplateState & (DataGridViewElementStates.Selected | DataGridViewElementStates.Displayed)) == 0);
-            rowTemplate.DataGridViewInternal = dataGridView;
+            rowTemplate.DataGridView = dataGridView;
             int columnIndex = 0;
             foreach (DataGridViewCell dataGridViewCell in rowTemplate.Cells)
             {
-                dataGridViewCell.DataGridViewInternal = dataGridView;
+                dataGridViewCell.DataGridView = dataGridView;
                 Debug.Assert(dataGridViewCell.OwningRow == rowTemplate);
-                dataGridViewCell.OwningColumnInternal = DataGridView.Columns[columnIndex];
+                dataGridViewCell.OwningColumn = DataGridView.Columns[columnIndex];
                 columnIndex++;
             }
             if (rowTemplate.HasHeaderCell)
             {
-                rowTemplate.HeaderCell.DataGridViewInternal = dataGridView;
-                rowTemplate.HeaderCell.OwningRowInternal = rowTemplate;
+                rowTemplate.HeaderCell.DataGridView = dataGridView;
+                rowTemplate.HeaderCell.OwningRow = rowTemplate;
             }
 
             if (DataGridView.NewRowIndex != -1)
@@ -525,19 +525,19 @@ namespace System.Windows.Forms
             int columnIndex = 0;
             foreach (DataGridViewCell dataGridViewCell in dataGridViewRow.Cells)
             {
-                dataGridViewCell.DataGridViewInternal = dataGridView;
+                dataGridViewCell.DataGridView = dataGridView;
                 Debug.Assert(dataGridViewCell.OwningRow == dataGridViewRow);
                 if (dataGridViewCell.ColumnIndex == -1)
                 {
-                    dataGridViewCell.OwningColumnInternal = DataGridView.Columns[columnIndex];
+                    dataGridViewCell.OwningColumn = DataGridView.Columns[columnIndex];
                 }
                 columnIndex++;
             }
 
             if (dataGridViewRow.HasHeaderCell)
             {
-                dataGridViewRow.HeaderCell.DataGridViewInternal = DataGridView;
-                dataGridViewRow.HeaderCell.OwningRowInternal = dataGridViewRow;
+                dataGridViewRow.HeaderCell.DataGridView = DataGridView;
+                dataGridViewRow.HeaderCell.OwningRow = dataGridViewRow;
             }
 
             int index = SharedList.Add(dataGridViewRow);
@@ -550,10 +550,10 @@ namespace System.Windows.Forms
             cachedRowCountsAccessAllowed = false;
 #endif
 
-            dataGridViewRow.DataGridViewInternal = dataGridView;
+            dataGridViewRow.DataGridView = dataGridView;
             if (!RowIsSharable(index) || RowHasValueOrToolTipText(dataGridViewRow) || IsCollectionChangedListenedTo)
             {
-                dataGridViewRow.IndexInternal = index;
+                dataGridViewRow.Index = index;
                 Debug.Assert(dataGridViewRow.State == SharedRowState(index));
             }
             OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Add, dataGridViewRow), index, 1);
@@ -756,8 +756,8 @@ namespace System.Windows.Forms
             Debug.Assert(DataGridView != null);
 
             DataGridViewRow dataGridViewRow = (DataGridViewRow)rowTemplate.Clone();
-            dataGridViewRow.StateInternal = DataGridViewElementStates.None;
-            dataGridViewRow.DataGridViewInternal = dataGridView;
+            dataGridViewRow.State = DataGridViewElementStates.None;
+            dataGridViewRow.DataGridView = dataGridView;
             DataGridViewCellCollection dgvcc = dataGridViewRow.Cells;
             int columnIndex = 0;
             foreach (DataGridViewCell dataGridViewCell in dgvcc)
@@ -766,15 +766,15 @@ namespace System.Windows.Forms
                 {
                     dataGridViewCell.Value = dataGridViewCell.DefaultNewRowValue;
                 }
-                dataGridViewCell.DataGridViewInternal = dataGridView;
-                dataGridViewCell.OwningColumnInternal = DataGridView.Columns[columnIndex];
+                dataGridViewCell.DataGridView = dataGridView;
+                dataGridViewCell.OwningColumn = DataGridView.Columns[columnIndex];
                 columnIndex++;
             }
             DataGridViewElementStates rowState = rowTemplate.State & ~(DataGridViewElementStates.Selected | DataGridViewElementStates.Displayed);
             if (dataGridViewRow.HasHeaderCell)
             {
-                dataGridViewRow.HeaderCell.DataGridViewInternal = dataGridView;
-                dataGridViewRow.HeaderCell.OwningRowInternal = dataGridViewRow;
+                dataGridViewRow.HeaderCell.DataGridView = dataGridView;
+                dataGridViewRow.HeaderCell.OwningRow = dataGridViewRow;
             }
 
             DataGridView.OnAddingRow(dataGridViewRow, rowState, true /*checkFrozenState*/);   // will throw an exception if the addition is illegal
@@ -833,16 +833,16 @@ namespace System.Windows.Forms
                 int columnIndex = 0;
                 foreach (DataGridViewCell dataGridViewCell in dataGridViewRow.Cells)
                 {
-                    dataGridViewCell.DataGridViewInternal = dataGridView;
+                    dataGridViewCell.DataGridView = dataGridView;
                     Debug.Assert(dataGridViewCell.OwningRow == dataGridViewRow);
-                    dataGridViewCell.OwningColumnInternal = DataGridView.Columns[columnIndex];
+                    dataGridViewCell.OwningColumn = DataGridView.Columns[columnIndex];
                     columnIndex++;
                 }
 
                 if (dataGridViewRow.HasHeaderCell)
                 {
-                    dataGridViewRow.HeaderCell.DataGridViewInternal = dataGridView;
-                    dataGridViewRow.HeaderCell.OwningRowInternal = dataGridViewRow;
+                    dataGridViewRow.HeaderCell.DataGridView = dataGridView;
+                    dataGridViewRow.HeaderCell.OwningRow = dataGridViewRow;
                 }
 
                 int index = SharedList.Add(dataGridViewRow);
@@ -853,9 +853,9 @@ namespace System.Windows.Forms
                 cachedRowHeightsAccessAllowed = false;
                 cachedRowCountsAccessAllowed = false;
 #endif
-                dataGridViewRow.IndexInternal = index;
+                dataGridViewRow.Index = index;
                 Debug.Assert(dataGridViewRow.State == SharedRowState(index));
-                dataGridViewRow.DataGridViewInternal = dataGridView;
+                dataGridViewRow.DataGridView = dataGridView;
             }
             Debug.Assert(rowStates.Count == SharedList.Count);
 
@@ -1478,19 +1478,19 @@ namespace System.Windows.Forms
             Debug.Assert(rowTemplate.Cells.Count == DataGridView.Columns.Count);
             DataGridViewElementStates rowTemplateState = rowTemplate.State;
             Debug.Assert((rowTemplateState & (DataGridViewElementStates.Selected | DataGridViewElementStates.Displayed)) == 0);
-            rowTemplate.DataGridViewInternal = dataGridView;
+            rowTemplate.DataGridView = dataGridView;
             int columnIndex = 0;
             foreach (DataGridViewCell dataGridViewCell in rowTemplate.Cells)
             {
-                dataGridViewCell.DataGridViewInternal = dataGridView;
+                dataGridViewCell.DataGridView = dataGridView;
                 Debug.Assert(dataGridViewCell.OwningRow == rowTemplate);
-                dataGridViewCell.OwningColumnInternal = DataGridView.Columns[columnIndex];
+                dataGridViewCell.OwningColumn = DataGridView.Columns[columnIndex];
                 columnIndex++;
             }
             if (rowTemplate.HasHeaderCell)
             {
-                rowTemplate.HeaderCell.DataGridViewInternal = dataGridView;
-                rowTemplate.HeaderCell.OwningRowInternal = rowTemplate;
+                rowTemplate.HeaderCell.DataGridView = dataGridView;
+                rowTemplate.HeaderCell.OwningRow = rowTemplate;
             }
 
             InsertCopiesPrivate(rowTemplate, rowTemplateState, rowIndex, count);
@@ -1569,19 +1569,19 @@ namespace System.Windows.Forms
             int columnIndex = 0;
             foreach (DataGridViewCell dataGridViewCell in dataGridViewRow.Cells)
             {
-                dataGridViewCell.DataGridViewInternal = dataGridView;
+                dataGridViewCell.DataGridView = dataGridView;
                 Debug.Assert(dataGridViewCell.OwningRow == dataGridViewRow);
                 if (dataGridViewCell.ColumnIndex == -1)
                 {
-                    dataGridViewCell.OwningColumnInternal = DataGridView.Columns[columnIndex];
+                    dataGridViewCell.OwningColumn = DataGridView.Columns[columnIndex];
                 }
                 columnIndex++;
             }
 
             if (dataGridViewRow.HasHeaderCell)
             {
-                dataGridViewRow.HeaderCell.DataGridViewInternal = DataGridView;
-                dataGridViewRow.HeaderCell.OwningRowInternal = dataGridViewRow;
+                dataGridViewRow.HeaderCell.DataGridView = DataGridView;
+                dataGridViewRow.HeaderCell.OwningRow = dataGridViewRow;
             }
 
             SharedList.Insert(rowIndex, dataGridViewRow);
@@ -1594,10 +1594,10 @@ namespace System.Windows.Forms
             cachedRowCountsAccessAllowed = false;
 #endif
 
-            dataGridViewRow.DataGridViewInternal = dataGridView;
+            dataGridViewRow.DataGridView = dataGridView;
             if (!RowIsSharable(rowIndex) || RowHasValueOrToolTipText(dataGridViewRow) || IsCollectionChangedListenedTo)
             {
-                dataGridViewRow.IndexInternal = rowIndex;
+                dataGridViewRow.Index = rowIndex;
                 Debug.Assert(dataGridViewRow.State == SharedRowState(rowIndex));
             }
             OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Add, dataGridViewRow), rowIndex, 1, false, true, false, newCurrentCell);
@@ -1753,21 +1753,21 @@ namespace System.Windows.Forms
             Debug.Assert(DataGridView != null);
 
             DataGridViewRow dataGridViewRow = (DataGridViewRow)rowTemplate.Clone();
-            dataGridViewRow.StateInternal = DataGridViewElementStates.None;
-            dataGridViewRow.DataGridViewInternal = dataGridView;
+            dataGridViewRow.State = DataGridViewElementStates.None;
+            dataGridViewRow.DataGridView = dataGridView;
             DataGridViewCellCollection dgvcc = dataGridViewRow.Cells;
             int columnIndex = 0;
             foreach (DataGridViewCell dataGridViewCell in dgvcc)
             {
-                dataGridViewCell.DataGridViewInternal = dataGridView;
-                dataGridViewCell.OwningColumnInternal = DataGridView.Columns[columnIndex];
+                dataGridViewCell.DataGridView = dataGridView;
+                dataGridViewCell.OwningColumn = DataGridView.Columns[columnIndex];
                 columnIndex++;
             }
             DataGridViewElementStates rowState = rowTemplate.State & ~(DataGridViewElementStates.Selected | DataGridViewElementStates.Displayed);
             if (dataGridViewRow.HasHeaderCell)
             {
-                dataGridViewRow.HeaderCell.DataGridViewInternal = dataGridView;
-                dataGridViewRow.HeaderCell.OwningRowInternal = dataGridViewRow;
+                dataGridViewRow.HeaderCell.DataGridView = dataGridView;
+                dataGridViewRow.HeaderCell.OwningRow = dataGridViewRow;
             }
 
             DataGridView.OnInsertingRow(indexDestination, dataGridViewRow, rowState, ref newCurrentCell, firstInsertion, 1, false /*force*/);   // will throw an exception if the insertion is illegal
@@ -1840,19 +1840,19 @@ namespace System.Windows.Forms
                 int columnIndex = 0;
                 foreach (DataGridViewCell dataGridViewCell in dataGridViewRow.Cells)
                 {
-                    dataGridViewCell.DataGridViewInternal = dataGridView;
+                    dataGridViewCell.DataGridView = dataGridView;
                     Debug.Assert(dataGridViewCell.OwningRow == dataGridViewRow);
                     if (dataGridViewCell.ColumnIndex == -1)
                     {
-                        dataGridViewCell.OwningColumnInternal = DataGridView.Columns[columnIndex];
+                        dataGridViewCell.OwningColumn = DataGridView.Columns[columnIndex];
                     }
                     columnIndex++;
                 }
 
                 if (dataGridViewRow.HasHeaderCell)
                 {
-                    dataGridViewRow.HeaderCell.DataGridViewInternal = DataGridView;
-                    dataGridViewRow.HeaderCell.OwningRowInternal = dataGridViewRow;
+                    dataGridViewRow.HeaderCell.DataGridView = DataGridView;
+                    dataGridViewRow.HeaderCell.OwningRow = dataGridViewRow;
                 }
 
                 SharedList.Insert(rowIndexInserted, dataGridViewRow);
@@ -1865,9 +1865,9 @@ namespace System.Windows.Forms
                 cachedRowCountsAccessAllowed = false;
 #endif
 
-                dataGridViewRow.IndexInternal = rowIndexInserted;
+                dataGridViewRow.Index = rowIndexInserted;
                 Debug.Assert(dataGridViewRow.State == SharedRowState(rowIndexInserted));
-                dataGridViewRow.DataGridViewInternal = dataGridView;
+                dataGridViewRow.DataGridView = dataGridView;
                 rowIndexInserted++;
             }
 
@@ -2333,7 +2333,7 @@ namespace System.Windows.Forms
                 {
                     case DataGridViewElementStates.Displayed:
                         {
-                            dataGridViewRow.DisplayedInternal = value;
+                            dataGridViewRow.Displayed = value;
                             break;
                         }
                     case DataGridViewElementStates.Selected:
@@ -2396,11 +2396,11 @@ namespace System.Windows.Forms
 
             if (dataGridViewRow1.Index != -1)
             {
-                dataGridViewRow1.IndexInternal = rowIndex2;
+                dataGridViewRow1.Index = rowIndex2;
             }
             if (dataGridViewRow2.Index != -1)
             {
-                dataGridViewRow2.IndexInternal = rowIndex1;
+                dataGridViewRow2.Index = rowIndex1;
             }
 
             if (DataGridView.VirtualMode)
@@ -2431,8 +2431,8 @@ namespace System.Windows.Forms
         // This function only adjusts the row's RowIndex and State properties - no more.
         private void UnshareRow(int rowIndex)
         {
-            SharedRow(rowIndex).IndexInternal = rowIndex;
-            SharedRow(rowIndex).StateInternal = SharedRowState(rowIndex);
+            SharedRow(rowIndex).Index = rowIndex;
+            SharedRow(rowIndex).State = SharedRowState(rowIndex);
         }
 
         private void UpdateRowCaches(int rowIndex, ref DataGridViewRow dataGridViewRow, bool adding)
@@ -2536,7 +2536,7 @@ namespace System.Windows.Forms
 
             public DefaultRowComparer(DataGridViewRowCollection dataGridViewRows)
             {
-                this.DataGridViewInternal = dataGridViewRows.DataGridView;
+                this.DataGridView = dataGridViewRows.DataGridView;
                 this.dataGridViewRows = dataGridViewRows;
                 this.dataGridViewSortedColumn = this.dataGridView.SortedColumn;
                 this.sortedColumnIndex = this.dataGridViewSortedColumn.Index;


### PR DESCRIPTION
Prefer using `internal set` rather than `XInternal` properties