### PR TITLE
Update TextBox.cs

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
@@ -93,7 +93,7 @@ namespace System.Windows.Forms
         private AutoCompleteStringCollection autoCompleteCustomSource;
         private bool fromHandleCreate = false;
         private StringSource stringSource = null;
-        private string placeholderText;
+        private string placeholderText = "";
 
         public TextBox()
         {
@@ -903,10 +903,10 @@ namespace System.Windows.Forms
         /// </summary>
         [
         Localizable(true),
-        DefaultValue(null),
+        DefaultValue(""),
         SRDescription(nameof(SR.TextBoxPlaceholderTextDescr))
         ]
-        public string PlaceholderText
+        public virtual string PlaceholderText
         {
             get
             {
@@ -914,10 +914,18 @@ namespace System.Windows.Forms
             }
             set
             {
+                if (value == null)
+                {
+                    value = string.Empty;
+                }
+
                 if (placeholderText != value)
                 {
                     placeholderText = value;
-                    Invalidate();
+                    if (IsHandleCreated)
+                    {
+                        Invalidate();
+                    }
                 }
             }
         }
@@ -1009,10 +1017,11 @@ namespace System.Windows.Forms
                     break;
             }
 
-            if ((m.Msg == Interop.WindowMessages.WM_PAINT || m.Msg == Interop.WindowMessages.WM_KILLFOCUS) &&
-                 !GetStyle(ControlStyles.UserPaint) &&
-                   string.IsNullOrEmpty(Text) &&
-                   !Focused)
+            if (!string.IsNullOrEmpty(PlaceholderText) &&
+                (m.Msg == Interop.WindowMessages.WM_PAINT || m.Msg == Interop.WindowMessages.WM_KILLFOCUS) &&
+                 !GetStyle(ControlStyles.UserPaint) && 
+                 !Focused &&
+                 TextLength == 0)
             {
                 using (Graphics g = CreateGraphics())
                 {
@@ -1020,20 +1029,5 @@ namespace System.Windows.Forms
                 }
             }
         }
-
-        protected override AccessibleObject CreateAccessibilityInstance()
-        {
-            if (string.IsNullOrEmpty(Text))
-            {
-                AccessibleObject accessibleObject = base.CreateAccessibilityInstance();
-                accessibleObject.Value = PlaceholderText;
-                return accessibleObject;
-            }
-            else
-            {
-                return base.CreateAccessibilityInstance();
-            }
-        }
-
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1110 
Fixes #1168
Fixes #1109

## Proposed changes

- PlaceholderText default value to ""
- Make PlaceholderText virtual to keep it consistent with the other properties (#1110)
- PlaceholderText is not used by accessibility (#1168)
- Use TextLength instead Text property when drawing PlaceholderText (#1109)


### Before

- PlaceholderText default value was null which was different from Text default value.
- PlaceholderText was not virtual.
- Text property was used in WM_PAINT which breaks VMWare infrastructure client.
- Text was set when AccessibilityObject is created even when no Text or PlaceholderText was set.

### After

- PlaceholderText default value is "" to be consistent with Text default value.
- PlaceholderText is virtual.
- In WM_PAINT TextLength so Text property is not accessed.
- AccessibilityObject no longer set Text to the PlaceholderText.


## Test methodology <!-- How did you ensure quality? -->

- Manual testing: 

1. Used the On Screen keyboard to verify TextChanged event is not fired 
2. Verified manually that Text getter property is not called when WM_PAINT is called.


## Test environment(s) <!-- Remove any that don't apply -->

.NET Core SDK (reflecting any global.json):
 Version:   3.0.100-preview8-013008
 Commit:    6db6a68871

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.17763
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\3.0.100-preview8-013008\

/cc @merriemcgaw, @weltkante, @madewokherd, @IGMikeS, @M-Lipin, @stefanov-stefan 
