### PR TITLE
Fix 1396 Accessibility: High Contrast - PrintPreview - The border of the PrintPreviewControl is inconsistent in the four themes of High Contrast

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -570,7 +570,8 @@ namespace System.Windows.Forms
         /// </summary>
         protected override void OnPaint(PaintEventArgs pevent)
         {
-            Brush backBrush = new SolidBrush(BackColor);
+            Color backColor = GetBackColor(SystemInformation.HighContrast);
+            Brush backBrush = new SolidBrush(backColor);
 
             try
             {
@@ -1044,6 +1045,35 @@ namespace System.Windows.Forms
         internal override bool ShouldSerializeForeColor()
         {
             return !ForeColor.Equals(Color.White);
+        }
+
+        /// <summary>
+        /// Gets back color respectively to the High Contrast theme is applied or not
+        /// and taking into account saved custom back color.
+        /// </summary>
+        /// <param name="isHighContract">Indicates whether High Contrast theme is applied or not.</param>
+        /// <returns>
+        /// Standard back color for PrintPreview control in standard theme (1),
+        /// contrasted color if there is High Contrast theme applied (2) and
+        /// custom color if this is set irrespectively to HC or not HC mode (3).
+        /// </returns>
+        private Color GetBackColor(bool isHighContract)
+        {
+            return (isHighContract && !ShouldSerializeBackColor()) ? SystemColors.ControlDark : BackColor;
+        }
+
+        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+
+        internal readonly struct TestAccessor
+        {
+            private readonly PrintPreviewControl _control;
+
+            public TestAccessor(PrintPreviewControl control)
+            {
+                _control = control;
+            }
+
+            public Color GetBackColor(bool isHighContrast) => _control.GetBackColor(isHighContrast);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Printing/PrintPreviewControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Printing/PrintPreviewControlTests.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    public class PrintPreviewControlTests
+    {
+        private const int emptyColorArgb = 0;
+        private const int blueColorArgb = -16776961;
+        private const int greenColorArgb = -16744448;
+        private const int controlDarkColorArgb = -6250336;
+        private const int appWorkSpaceNoHcColorArgb = -5526613;
+        private const int appWorkSpaceHcColorArgb = -1;
+
+        [Theory]
+        [InlineData(emptyColorArgb, false, appWorkSpaceNoHcColorArgb)]
+        [InlineData(emptyColorArgb, true, controlDarkColorArgb)]
+        [InlineData(blueColorArgb, false, blueColorArgb)]
+        [InlineData(greenColorArgb, true, greenColorArgb)]
+        public void ShowPrintPreviewControl_BackColorIsCorrect(int customBackColorArgb, bool isHighContrast, int expectedBackColorArgb)
+        {
+            var control = new PrintPreviewControl();
+
+            if (customBackColorArgb != emptyColorArgb)
+            {
+                control.BackColor = Color.FromArgb(customBackColorArgb);
+            }
+
+            int actualBackColorArgb = control.GetTestAccessor().GetBackColor(isHighContrast).ToArgb();
+            Assert.Equal(expectedBackColorArgb, actualBackColorArgb);
+
+            // Default AppWorkSpace color in HC theme does not allow to follow HC standards.
+            if (isHighContrast)
+            {
+                Assert.True(!appWorkSpaceHcColorArgb.Equals(actualBackColorArgb));
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1396 


## Proposed changes

- Changing the default value of the PrintPreviewControl back color in HC mode. For the non-HC themes default back color remains unchanged. If back color is not default and thus should be serialized, then back color will take this custom color in both HC and non-HC mode.
- Default back color for the PrintPreviewControl in HC theme is changed to ControlDark.
- ControlDark color makes the color difference between work area and control's back contrast, this also makes the color difference between form background and control's back contrast as well.


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Please see #1396 

### After

![image](https://user-images.githubusercontent.com/23213980/61298978-e99a5380-a7e7-11e9-8399-d29d609f5651.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual testing in standard and different HC themes.
- Contrast comparison.
- Evaluation in accessibility contrast analyzer:

Contrast ratio for white:
![image](https://user-images.githubusercontent.com/23213980/61298514-06825700-a7e7-11e9-90d8-4fab4067d2c0.png)

Contrast ratio for black:
![image](https://user-images.githubusercontent.com/23213980/61298651-48130200-a7e7-11e9-9fd9-9bfaf5648f36.png)


## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

.NET Core SDK (reflecting any global.json):
Version: 3.0.100-preview8-012929
Commit: 795f8aeaa8
Runtime Environment:
OS Name: Windows
OS Version: 10.0.18362
OS Platform: Windows
RID: win10-x64
Base Path: C:\Program Files\dotnet\sdk\3.0.100-preview8-012929\

<!-- Mention language, UI scaling, or anything else that might be relevant -->

- Windows with HC (high contrast) turned off.
- Windows with HC theme 1
- Windows with HC theme 2
- Windows with HC theme Black
- Windows with HC theme White