### PR TITLE
Fix several issues with PlaceholderText property

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
@@ -1017,16 +1017,7 @@ namespace System.Windows.Forms
                     break;
             }
 
-            DrawPlaceholderText(ref m);
-        }
-
-        internal void DrawPlaceholderText(ref Message m)
-        {
-            if (!string.IsNullOrEmpty(PlaceholderText) &&
-                (m.Msg == Interop.WindowMessages.WM_PAINT || m.Msg == Interop.WindowMessages.WM_KILLFOCUS) &&
-                 !GetStyle(ControlStyles.UserPaint) &&
-                 !Focused &&
-                 TextLength == 0)
+            if (ShouldRenderPlaceHolderText(m))
             {
                 using (Graphics g = CreateGraphics())
                 {
@@ -1034,5 +1025,27 @@ namespace System.Windows.Forms
                 }
             }
         }
+
+        private bool ShouldRenderPlaceHolderText(in Message m) =>
+                    !string.IsNullOrEmpty(PlaceholderText) &&
+                    (m.Msg == Interop.WindowMessages.WM_PAINT || m.Msg == Interop.WindowMessages.WM_KILLFOCUS) &&
+                    !GetStyle(ControlStyles.UserPaint) &&
+                    !Focused &&
+                    TextLength == 0;
+
+        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+
+        internal readonly struct TestAccessor
+        {
+            private readonly TextBox _textBox;
+
+            public TestAccessor(TextBox textBox)
+            {
+                _textBox = textBox;
+            }
+
+            public bool ShouldRenderPlaceHolderText(in Message m) => _textBox.ShouldRenderPlaceHolderText(m);
+        }
+
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
@@ -93,7 +93,7 @@ namespace System.Windows.Forms
         private AutoCompleteStringCollection autoCompleteCustomSource;
         private bool fromHandleCreate = false;
         private StringSource stringSource = null;
-        private string placeholderText;
+        private string placeholderText = string.Empty;
 
         public TextBox()
         {
@@ -903,10 +903,10 @@ namespace System.Windows.Forms
         /// </summary>
         [
         Localizable(true),
-        DefaultValue(null),
+        DefaultValue(""),
         SRDescription(nameof(SR.TextBoxPlaceholderTextDescr))
         ]
-        public string PlaceholderText
+        public virtual string PlaceholderText
         {
             get
             {
@@ -914,10 +914,18 @@ namespace System.Windows.Forms
             }
             set
             {
+                if (value == null)
+                {
+                    value = string.Empty;
+                }
+
                 if (placeholderText != value)
                 {
                     placeholderText = value;
-                    Invalidate();
+                    if (IsHandleCreated)
+                    {
+                        Invalidate();
+                    }
                 }
             }
         }
@@ -1009,10 +1017,16 @@ namespace System.Windows.Forms
                     break;
             }
 
-            if ((m.Msg == Interop.WindowMessages.WM_PAINT || m.Msg == Interop.WindowMessages.WM_KILLFOCUS) &&
+            DrawPlaceholderText(ref m);
+        }
+
+        internal void DrawPlaceholderText(ref Message m)
+        {
+            if (!string.IsNullOrEmpty(PlaceholderText) &&
+                (m.Msg == Interop.WindowMessages.WM_PAINT || m.Msg == Interop.WindowMessages.WM_KILLFOCUS) &&
                  !GetStyle(ControlStyles.UserPaint) &&
-                   string.IsNullOrEmpty(Text) &&
-                   !Focused)
+                 !Focused &&
+                 TextLength == 0)
             {
                 using (Graphics g = CreateGraphics())
                 {
@@ -1020,20 +1034,5 @@ namespace System.Windows.Forms
                 }
             }
         }
-
-        protected override AccessibleObject CreateAccessibilityInstance()
-        {
-            if (string.IsNullOrEmpty(Text))
-            {
-                AccessibleObject accessibleObject = base.CreateAccessibilityInstance();
-                accessibleObject.Value = PlaceholderText;
-                return accessibleObject;
-            }
-            else
-            {
-                return base.CreateAccessibilityInstance();
-            }
-        }
-
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.cs
@@ -49,9 +49,45 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> TextBox_ShouldRenderPlaceHolderText_TestData()
         {
-            var textBox = new TextBox();
-            var message = new Message() { Msg = Interop.WindowMessages.WM_PAINT };
-            yield return new object[] { textBox, message, false };
+            // Test PlaceholderText
+            var tb = new SubTextBox() { PlaceholderText = "", IsUserPaint = false, IsFocused = false, TextCount = 0 };
+            var msg = new Message() { Msg = Interop.WindowMessages.WM_PAINT };
+            yield return new object[] { tb, msg, false };
+
+            // Test PlaceholderText
+            tb = new SubTextBox() { PlaceholderText = null, IsUserPaint = false, IsFocused = false, TextCount = 0 };
+            msg = new Message() { Msg = Interop.WindowMessages.WM_PAINT };
+            yield return new object[] { tb, msg, false };
+
+            // Test Message
+            msg.Msg = Interop.WindowMessages.WM_USER;
+            tb = new SubTextBox() { PlaceholderText = "Text", IsUserPaint = false, IsFocused = false, TextCount = 0 };
+            yield return new object[] { tb, msg, false };
+
+            // Test UserPaint
+            msg.Msg = Interop.WindowMessages.WM_PAINT;
+            tb = new SubTextBox() { PlaceholderText = "Text", IsUserPaint = true, IsFocused = false, TextCount = 0 };
+            yield return new object[] { tb, msg, false };
+
+            // Test Focused
+            msg.Msg = Interop.WindowMessages.WM_PAINT;
+            tb = new SubTextBox() { PlaceholderText = "Text", IsUserPaint = false, IsFocused = true, TextCount = 0 };
+            yield return new object[] { tb, msg, false };
+
+            // Test TextLength
+            msg.Msg = Interop.WindowMessages.WM_PAINT;
+            tb = new SubTextBox() { PlaceholderText = "Text", IsUserPaint = false, IsFocused = false, TextCount = 1 };
+            yield return new object[] { tb, msg, false };
+
+            // Test WM_PAINT
+            tb = new SubTextBox() { PlaceholderText = "Text", IsUserPaint = false, IsFocused = false, TextCount = 0 };
+            msg.Msg = Interop.WindowMessages.WM_PAINT;
+            yield return new object[] { tb, msg, true };
+
+            // Test WM_KILLFOCUS
+            tb = new SubTextBox() { PlaceholderText = "Text", IsUserPaint = false, IsFocused = false, TextCount = 0 };
+            msg.Msg = Interop.WindowMessages.WM_KILLFOCUS;
+            yield return new object[] { tb, msg, true };
         }
 
         [Theory]
@@ -197,6 +233,10 @@ namespace System.Windows.Forms.Tests
 
         private class SubTextBox : TextBox
         {
+            public int TextCount;
+            public bool IsFocused;
+            public bool TextAccessed;
+
             public override string PlaceholderText { get => base.PlaceholderText; set => base.PlaceholderText = value; }
 
             // used to test that PlaceholderText won't raise TextChanged event.
@@ -205,9 +245,8 @@ namespace System.Windows.Forms.Tests
                 this.CreateAccessibilityInstance();
             }
 
-            public override bool Focused => false;
-
-            public bool TextAccessed;
+            public override bool Focused => IsFocused;
+            public override int TextLength => TextCount;
 
             public override string Text
             {
@@ -217,6 +256,12 @@ namespace System.Windows.Forms.Tests
                     return base.Text;
                 }
                 set => base.Text = value;
+            }
+
+            public bool IsUserPaint
+            {
+                get => GetStyle(ControlStyles.UserPaint);
+                set => SetStyle(ControlStyles.UserPaint, value);
             }
         }
     }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1110 
Fixes #1168
Fixes #1109

## Proposed changes

- PlaceholderText default value to ""
- Make PlaceholderText virtual to keep it consistent with the other properties (#1110)
- PlaceholderText is not used by accessibility (#1168)
- Use TextLength instead Text property when drawing PlaceholderText (#1109)


### Before

- PlaceholderText default value was null which was different from Text default value.
- PlaceholderText was not virtual.
- Text property was used in WM_PAINT which breaks VMWare infrastructure client.
- Text was set when AccessibilityObject is created even when no Text or PlaceholderText was set.

### After

- PlaceholderText default value is "" to be consistent with Text default value.
- PlaceholderText is virtual.
- In WM_PAINT TextLength so Text property is not accessed.
- AccessibilityObject no longer set Text to the PlaceholderText.


## Test methodology <!-- How did you ensure quality? -->

- Testing: 

1. Added several unit-tests to cover failing scenarios
2. Used the On Screen keyboard to verify TextChanged event is not fired 
3. Verified manually that Text getter property is not called when WM_PAINT is called.


## Test environment(s) <!-- Remove any that don't apply -->

.NET Core SDK (reflecting any global.json):
 Version:   3.0.100-preview8-013255
 Commit:    5e644c189c

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.17763
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\3.0.100-preview8-013255\

/cc @merriemcgaw, @weltkante, @madewokherd, @IGMikeS, @M-Lipin, @stefanov-stefan 
