### PR TITLE
fixing tests broken in VS only

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.cs
@@ -2579,11 +2579,11 @@ namespace System.Windows.Forms.Tests
             {
                 Text = value
             };
-            Assert.Same(expected, control.Text);
+            Assert.Equal(expected, control.Text);
 
             // Set same.
             control.Text = value;
-            Assert.Same(expected, control.Text);
+            Assert.Equal(expected, control.Text);
         }
 
         [Theory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/ComponentEditorPageTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/ComponentEditorPageTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -328,13 +328,13 @@ namespace System.Windows.Forms.Design.Tests
             {
                 Text = value
             };
-            Assert.Same(expected, control.Text);
-            Assert.Same(expected, control.Title);
+            Assert.Equal(expected, control.Text);
+            Assert.Equal(expected, control.Title);
 
             // Set same.
             control.Text = value;
-            Assert.Same(expected, control.Text);
-            Assert.Same(expected, control.Title);
+            Assert.Equal(expected, control.Text);
+            Assert.Equal(expected, control.Title);
         }
 
         [Theory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PanelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PanelTests.cs
@@ -289,11 +289,11 @@ namespace System.Windows.Forms.Tests
             {
                 Text = value
             };
-            Assert.Same(expected, control.Text);
+            Assert.Equal(expected, control.Text);
 
             // Set same.
             control.Text = value;
-            Assert.Same(expected, control.Text);
+            Assert.Equal(expected, control.Text);
         }
 
         [Theory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBarTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1054,11 +1054,11 @@ namespace System.Windows.Forms.Tests
             {
                 Text = value
             };
-            Assert.Same(expected, control.Text);
+            Assert.Equal(expected, control.Text);
 
             // Set same.
             control.Text = value;
-            Assert.Same(expected, control.Text);
+            Assert.Equal(expected, control.Text);
         }
 
         [Theory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
@@ -54,7 +54,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, treeNode.StateImageIndex);
             Assert.Empty(treeNode.StateImageKey);
             Assert.Null(treeNode.Tag);
-            Assert.Same(expectedText, treeNode.Text);
+            Assert.Equal(expectedText, treeNode.Text);
             Assert.Empty(treeNode.ToolTipText);
             Assert.Same(treeView, treeNode.TreeView);
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeTests.cs
@@ -87,7 +87,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, treeNode.StateImageIndex);
             Assert.Empty(treeNode.StateImageKey);
             Assert.Null(treeNode.Tag);
-            Assert.Same(expectedText, treeNode.Text);
+            Assert.Equal(expectedText, treeNode.Text);
             Assert.Empty(treeNode.ToolTipText);
             Assert.Null(treeNode.TreeView);
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -3842,11 +3842,11 @@ namespace System.Windows.Forms.Tests
             {
                 Text = value
             };
-            Assert.Same(expected, treeView.Text);
+            Assert.Equal(expected, treeView.Text);
 
             // Set same.
             treeView.Text = value;
-            Assert.Same(expected, treeView.Text);
+            Assert.Equal(expected, treeView.Text);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes tests broken in VS only. Assert.Same does not work in VS because xUnit MemberData is populated in a different AppDomain, which means the references are not equal.

Assert.Equal should be used for string compares anyway 😉 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1434)