### PR TITLE
Fix NREs in Draw*EventArgs

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DrawItemEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DrawItemEventArgs.cs
@@ -31,7 +31,7 @@ namespace System.Windows.Forms
         public DrawItemEventArgs(Graphics graphics, Font font, Rectangle rect,
                                  int index, DrawItemState state)
         {
-            Graphics = graphics;
+            Graphics = graphics ?? throw new ArgumentNullException(nameof(graphics));
             Font = font;
             Bounds = rect;
             Index = index;
@@ -46,7 +46,7 @@ namespace System.Windows.Forms
         public DrawItemEventArgs(Graphics graphics, Font font, Rectangle rect,
                                  int index, DrawItemState state, Color foreColor, Color backColor)
         {
-            Graphics = graphics;
+            Graphics = graphics ?? throw new ArgumentNullException(nameof(graphics));
             Font = font;
             Bounds = rect;
             Index = index;
@@ -118,11 +118,6 @@ namespace System.Windows.Forms
         /// </summary>
         public virtual void DrawBackground()
         {
-            if (Graphics == null)
-            {
-                return;
-            }
-
             using (Brush backBrush = new SolidBrush(BackColor))
             {
                 Graphics.FillRectangle(backBrush, Bounds);
@@ -134,13 +129,7 @@ namespace System.Windows.Forms
         /// </summary>
         public virtual void DrawFocusRectangle()
         {
-            if (Graphics == null)
-            {
-                return;
-            }
-
-            if ((State & DrawItemState.Focus) == DrawItemState.Focus &&
-                (State & DrawItemState.NoFocusRect) != DrawItemState.NoFocusRect)
+            if ((State & DrawItemState.Focus) == DrawItemState.Focus && (State & DrawItemState.NoFocusRect) != DrawItemState.NoFocusRect)
             {
                 ControlPaint.DrawFocusRectangle(Graphics, Bounds, ForeColor, BackColor);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DrawItemEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DrawItemEventArgs.cs
@@ -95,6 +95,7 @@ namespace System.Windows.Forms
                 {
                     return SystemColors.HighlightText;
                 }
+
                 return _foreColor;
             }
         }
@@ -107,6 +108,7 @@ namespace System.Windows.Forms
                 {
                     return SystemColors.Highlight;
                 }
+
                 return _backColor;
             }
         }
@@ -116,9 +118,15 @@ namespace System.Windows.Forms
         /// </summary>
         public virtual void DrawBackground()
         {
-            Brush backBrush = new SolidBrush(BackColor);
-            Graphics.FillRectangle(backBrush, Bounds);
-            backBrush.Dispose();
+            if (Graphics == null)
+            {
+                return;
+            }
+
+            using (Brush backBrush = new SolidBrush(BackColor))
+            {
+                Graphics.FillRectangle(backBrush, Bounds);
+            }
         }
 
         /// <summary>
@@ -126,6 +134,11 @@ namespace System.Windows.Forms
         /// </summary>
         public virtual void DrawFocusRectangle()
         {
+            if (Graphics == null)
+            {
+                return;
+            }
+
             if ((State & DrawItemState.Focus) == DrawItemState.Focus &&
                 (State & DrawItemState.NoFocusRect) != DrawItemState.NoFocusRect)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DrawListViewColumnHeaderEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DrawListViewColumnHeaderEventArgs.cs
@@ -80,6 +80,11 @@ namespace System.Windows.Forms
         /// </summary>
         public void DrawBackground()
         {
+            if (Graphics == null)
+            {
+                return;
+            }
+
             if (Application.RenderWithVisualStyles)
             {
                 var vsr = new VisualStyleRenderer(VisualStyleElement.Header.Item.Normal);
@@ -119,6 +124,11 @@ namespace System.Windows.Forms
         /// </summary>
         public void DrawText()
         {
+            if (Graphics == null)
+            {
+                return;
+            }
+
             HorizontalAlignment hAlign = Header.TextAlign;
             TextFormatFlags flags = (hAlign == HorizontalAlignment.Left) ? TextFormatFlags.Left :
                                     ((hAlign == HorizontalAlignment.Center) ? TextFormatFlags.HorizontalCenter :
@@ -133,7 +143,12 @@ namespace System.Windows.Forms
         /// </summary>
         public void DrawText(TextFormatFlags flags)
         {
-            string text = Header.Text;
+            if (Graphics == null)
+            {
+                return;
+            }
+
+            string text = Header?.Text;
             int padding = TextRenderer.MeasureText(" ", Font).Width;
             Rectangle newBounds = Rectangle.Inflate(Bounds, -padding, 0);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DrawListViewColumnHeaderEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DrawListViewColumnHeaderEventArgs.cs
@@ -20,7 +20,7 @@ namespace System.Windows.Forms
                                                  ColumnHeader header, ListViewItemStates state,
                                                  Color foreColor, Color backColor, Font font)
         {
-            Graphics = graphics;
+            Graphics = graphics ?? throw new ArgumentNullException(nameof(graphics));
             Bounds = bounds;
             ColumnIndex = columnIndex;
             Header = header;
@@ -80,11 +80,6 @@ namespace System.Windows.Forms
         /// </summary>
         public void DrawBackground()
         {
-            if (Graphics == null)
-            {
-                return;
-            }
-
             if (Application.RenderWithVisualStyles)
             {
                 var vsr = new VisualStyleRenderer(VisualStyleElement.Header.Item.Normal);
@@ -124,12 +119,7 @@ namespace System.Windows.Forms
         /// </summary>
         public void DrawText()
         {
-            if (Graphics == null)
-            {
-                return;
-            }
-
-            HorizontalAlignment hAlign = Header.TextAlign;
+            HorizontalAlignment hAlign = Header?.TextAlign ?? HorizontalAlignment.Left;
             TextFormatFlags flags = (hAlign == HorizontalAlignment.Left) ? TextFormatFlags.Left :
                                     ((hAlign == HorizontalAlignment.Center) ? TextFormatFlags.HorizontalCenter :
                                      TextFormatFlags.Right);
@@ -143,11 +133,6 @@ namespace System.Windows.Forms
         /// </summary>
         public void DrawText(TextFormatFlags flags)
         {
-            if (Graphics == null)
-            {
-                return;
-            }
-
             string text = Header?.Text;
             int padding = TextRenderer.MeasureText(" ", Font).Width;
             Rectangle newBounds = Rectangle.Inflate(Bounds, -padding, 0);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DrawListViewItemEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DrawListViewItemEventArgs.cs
@@ -16,8 +16,8 @@ namespace System.Windows.Forms
         /// </summary>
         public DrawListViewItemEventArgs(Graphics graphics, ListViewItem item, Rectangle bounds, int itemIndex, ListViewItemStates state)
         {
-            Graphics = graphics;
-            Item = item;
+            Graphics = graphics ?? throw new ArgumentNullException(nameof(graphics));
+            Item = item ?? throw new ArgumentNullException(nameof(item));
             Bounds = bounds;
             ItemIndex = itemIndex;
             State = state;
@@ -58,11 +58,6 @@ namespace System.Windows.Forms
         /// </summary>
         public void DrawBackground()
         {
-            if (Graphics == null || Item == null)
-            {
-                return;
-            }
-
             using (var backBrush = new SolidBrush(Item.BackColor))
             {
                 Graphics.FillRectangle(backBrush, Bounds);
@@ -75,11 +70,6 @@ namespace System.Windows.Forms
         /// </summary>
         public void DrawFocusRectangle()
         {
-            if (Graphics == null || Item == null)
-            {
-                return;
-            }
-
             if ((State & ListViewItemStates.Focused) == ListViewItemStates.Focused)
             {
                 ControlPaint.DrawFocusRectangle(Graphics, UpdateBounds(Bounds, drawText: false), Item.ForeColor, Item.BackColor);
@@ -89,21 +79,13 @@ namespace System.Windows.Forms
         /// <summary>
         /// Draws the item's text (overloaded) - useful only when View != View.Details
         /// </summary>
-        public void DrawText()
-        {
-            DrawText(TextFormatFlags.Left);
-        }
+        public void DrawText() => DrawText(TextFormatFlags.Left);
 
         /// <summary>
         /// Draws the item's text (overloaded) - useful only when View != View.Details - takes a TextFormatFlags argument.
         /// </summary>
         public void DrawText(TextFormatFlags flags)
         {
-            if (Graphics == null || Item == null)
-            {
-                return;
-            }
-
             TextRenderer.DrawText(Graphics, Item.Text, Item.Font, UpdateBounds(Bounds, drawText: true), Item.ForeColor, flags);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DrawListViewItemEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DrawListViewItemEventArgs.cs
@@ -58,6 +58,11 @@ namespace System.Windows.Forms
         /// </summary>
         public void DrawBackground()
         {
+            if (Graphics == null || Item == null)
+            {
+                return;
+            }
+
             using (var backBrush = new SolidBrush(Item.BackColor))
             {
                 Graphics.FillRectangle(backBrush, Bounds);
@@ -70,6 +75,11 @@ namespace System.Windows.Forms
         /// </summary>
         public void DrawFocusRectangle()
         {
+            if (Graphics == null || Item == null)
+            {
+                return;
+            }
+
             if ((State & ListViewItemStates.Focused) == ListViewItemStates.Focused)
             {
                 ControlPaint.DrawFocusRectangle(Graphics, UpdateBounds(Bounds, drawText: false), Item.ForeColor, Item.BackColor);
@@ -89,13 +99,18 @@ namespace System.Windows.Forms
         /// </summary>
         public void DrawText(TextFormatFlags flags)
         {
+            if (Graphics == null || Item == null)
+            {
+                return;
+            }
+
             TextRenderer.DrawText(Graphics, Item.Text, Item.Font, UpdateBounds(Bounds, drawText: true), Item.ForeColor, flags);
         }
 
         private Rectangle UpdateBounds(Rectangle originalBounds, bool drawText)
         {
             Rectangle resultBounds = originalBounds;
-            if (Item.ListView.View == View.Details)
+            if (Item.ListView != null && Item.ListView.View == View.Details)
             {
                 // Note: this logic will compute the bounds so they align w/ the system drawn bounds only
                 // for the default font.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DrawListViewSubItemEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DrawListViewSubItemEventArgs.cs
@@ -18,6 +18,22 @@ namespace System.Windows.Forms
                         ListViewItem.ListViewSubItem subItem, int itemIndex, int columnIndex,
                         ColumnHeader header, ListViewItemStates itemState)
         {
+            if (graphics == null)
+            {
+                throw new ArgumentNullException(nameof(graphics));
+            }
+            if (itemIndex == -1)
+            {
+                if (item == null)
+                {
+                    throw new ArgumentNullException(nameof(item));
+                }
+            }
+            else if (subItem == null)
+            {
+                throw new ArgumentNullException(nameof(subItem));
+            }
+
             Graphics = graphics;
             Bounds = bounds;
             Item = item;
@@ -78,15 +94,6 @@ namespace System.Windows.Forms
         /// </summary>
         public void DrawBackground()
         {
-            if (Graphics == null)
-            {
-                return;
-            }
-            if ((ItemIndex == -1 && Item == null) || (ItemIndex != -1 && SubItem == null))
-            {
-                return;
-            }
-
             Color backColor = (ItemIndex == -1) ? Item.BackColor : SubItem.BackColor;
             using (var backBrush = new SolidBrush(backColor))
             {
@@ -99,7 +106,7 @@ namespace System.Windows.Forms
         /// </summary>
         public void DrawFocusRectangle(Rectangle bounds)
         {
-            if (Graphics == null || Item == null)
+            if (Item == null)
             {
                 return;
             }
@@ -130,15 +137,6 @@ namespace System.Windows.Forms
         /// </summary>
         public void DrawText(TextFormatFlags flags)
         {
-            if (Graphics == null)
-            {
-                return;
-            }
-            if ((ItemIndex == -1 && Item == null) || (ItemIndex != -1 && SubItem == null))
-            {
-                return;
-            }
-
             string text = (ItemIndex == -1) ? Item.Text : SubItem.Text;
             Font font = (ItemIndex == -1) ? Item.Font : SubItem.Font;
             Color color = (ItemIndex == -1) ? Item.ForeColor : SubItem.ForeColor;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DrawListViewSubItemEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DrawListViewSubItemEventArgs.cs
@@ -78,6 +78,15 @@ namespace System.Windows.Forms
         /// </summary>
         public void DrawBackground()
         {
+            if (Graphics == null)
+            {
+                return;
+            }
+            if ((ItemIndex == -1 && Item == null) || (ItemIndex != -1 && SubItem == null))
+            {
+                return;
+            }
+
             Color backColor = (ItemIndex == -1) ? Item.BackColor : SubItem.BackColor;
             using (var backBrush = new SolidBrush(backColor))
             {
@@ -90,6 +99,11 @@ namespace System.Windows.Forms
         /// </summary>
         public void DrawFocusRectangle(Rectangle bounds)
         {
+            if (Graphics == null || Item == null)
+            {
+                return;
+            }
+
             if ((ItemState & ListViewItemStates.Focused) == ListViewItemStates.Focused)
             {
                 ControlPaint.DrawFocusRectangle(Graphics, Rectangle.Inflate(bounds, -1, -1), Item.ForeColor, Item.BackColor);
@@ -101,8 +115,8 @@ namespace System.Windows.Forms
         /// </summary>
         public void DrawText()
         {
-            // Map the ColumnHeader::TextAlign to the TextFormatFlags.
-            HorizontalAlignment hAlign = Header.TextAlign;
+            // Map the ColumnHeader.TextAlign to the TextFormatFlags.
+            HorizontalAlignment hAlign = Header?.TextAlign ?? HorizontalAlignment.Left;
             TextFormatFlags flags = (hAlign == HorizontalAlignment.Left) ? TextFormatFlags.Left :
                                                    ((hAlign == HorizontalAlignment.Center) ? TextFormatFlags.HorizontalCenter :
                                                    TextFormatFlags.Right);
@@ -116,6 +130,15 @@ namespace System.Windows.Forms
         /// </summary>
         public void DrawText(TextFormatFlags flags)
         {
+            if (Graphics == null)
+            {
+                return;
+            }
+            if ((ItemIndex == -1 && Item == null) || (ItemIndex != -1 && SubItem == null))
+            {
+                return;
+            }
+
             string text = (ItemIndex == -1) ? Item.Text : SubItem.Text;
             Font font = (ItemIndex == -1) ? Item.Font : SubItem.Font;
             Color color = (ItemIndex == -1) ? Item.ForeColor : SubItem.ForeColor;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DrawToolTipEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DrawToolTipEventArgs.cs
@@ -20,7 +20,7 @@ namespace System.Windows.Forms
         public DrawToolTipEventArgs(Graphics graphics, IWin32Window associatedWindow, Control associatedControl, Rectangle bounds,
                                     string toolTipText, Color backColor, Color foreColor, Font font)
         {
-            Graphics = graphics;
+            Graphics = graphics ?? throw new ArgumentNullException(nameof(graphics));
             AssociatedWindow = associatedWindow;
             AssociatedControl = associatedControl;
             Bounds = bounds;
@@ -65,11 +65,6 @@ namespace System.Windows.Forms
         /// </summary>
         public void DrawBackground()
         {
-            if (Graphics == null)
-            {
-                return;
-            }
-
             using (var backBrush = new SolidBrush(_backColor))
             {
                 Graphics.FillRectangle(backBrush, Bounds);
@@ -90,11 +85,6 @@ namespace System.Windows.Forms
         /// </summary>
         public void DrawText(TextFormatFlags flags)
         {
-            if (Graphics == null)
-            {
-                return;
-            }
-
             TextRenderer.DrawText(Graphics, ToolTipText, Font, Bounds, _foreColor, flags);
         }
 
@@ -103,11 +93,6 @@ namespace System.Windows.Forms
         /// </summary>
         public void DrawBorder()
         {
-            if (Graphics == null)
-            {
-                return;
-            }
-
             ControlPaint.DrawBorder(Graphics, Bounds, SystemColors.WindowFrame, ButtonBorderStyle.Solid);
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DrawToolTipEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DrawToolTipEventArgs.cs
@@ -65,6 +65,11 @@ namespace System.Windows.Forms
         /// </summary>
         public void DrawBackground()
         {
+            if (Graphics == null)
+            {
+                return;
+            }
+
             using (var backBrush = new SolidBrush(_backColor))
             {
                 Graphics.FillRectangle(backBrush, Bounds);
@@ -85,6 +90,11 @@ namespace System.Windows.Forms
         /// </summary>
         public void DrawText(TextFormatFlags flags)
         {
+            if (Graphics == null)
+            {
+                return;
+            }
+
             TextRenderer.DrawText(Graphics, ToolTipText, Font, Bounds, _foreColor, flags);
         }
 
@@ -93,6 +103,11 @@ namespace System.Windows.Forms
         /// </summary>
         public void DrawBorder()
         {
+            if (Graphics == null)
+            {
+                return;
+            }
+
             ControlPaint.DrawBorder(Graphics, Bounds, SystemColors.WindowFrame, ButtonBorderStyle.Solid);
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DrawItemEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DrawItemEventArgsTests.cs
@@ -73,11 +73,22 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [Fact]
-        public void DrawBackground_NullGraphics_ThrowsNullReferenceException()
+        public static IEnumerable<object[]> NullGraphics_TestData()
         {
-            var e = new DrawItemEventArgs(null, SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), -1, DrawItemState.None);
-            Assert.Throws<NullReferenceException>(() => e.DrawBackground());
+            yield return new object[] { null, new Rectangle(-1, -2, -3, -4), 0, DrawItemState.None, Color.Empty, Color.Empty };
+            yield return new object[] { null, new Rectangle(-1, -2, -3, -4), 0, DrawItemState.Focus, Color.Empty, Color.Empty };
+            yield return new object[] { null, new Rectangle(-1, -2, -3, -4), 0, DrawItemState.Focus | DrawItemState.NoFocusRect, Color.Empty, Color.Empty };
+            yield return new object[] { SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), -1, DrawItemState.None, Color.Red, Color.Blue };
+            yield return new object[] { SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), -1, DrawItemState.Focus, Color.Red, Color.Blue };
+            yield return new object[] { SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), 1, DrawItemState.Focus | DrawItemState.NoFocusRect, Color.Red, Color.Blue };
+        }
+
+        [Theory]
+        [MemberData(nameof(NullGraphics_TestData))]
+        public void DrawBackground_NullGraphics_Nop(Font font, Rectangle bounds, int index, DrawItemState state, Color foreColor, Color backColor)
+        {
+            var e = new DrawItemEventArgs(null, font, bounds, index, state, foreColor, backColor);
+            e.DrawBackground();
         }
 
         [Fact]
@@ -92,19 +103,11 @@ namespace System.Windows.Forms.Tests
         }
 
         [Theory]
-        [InlineData(DrawItemState.None)]
-        [InlineData(DrawItemState.Focus | DrawItemState.NoFocusRect)]
-        public void DrawFocusRectangle_NullGraphics_Nop(DrawItemState state)
+        [MemberData(nameof(NullGraphics_TestData))]
+        public void DrawFocusRectangle_NullGraphics_Nop(Font font, Rectangle bounds, int index, DrawItemState state, Color foreColor, Color backColor)
         {
-            var e = new DrawItemEventArgs(null, SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), -1, state);
+            var e = new DrawItemEventArgs(null, font, bounds, index, state, foreColor, backColor);
             e.DrawFocusRectangle();
-        }
-
-        [Fact]
-        public void DrawFocusRectangle_NullGraphics_ThrowsArgumentNullException()
-        {
-            var e = new DrawItemEventArgs(null, SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), -1, DrawItemState.Focus);
-            Assert.Throws<ArgumentNullException>("graphics", () => e.DrawFocusRectangle());
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DrawItemEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DrawItemEventArgsTests.cs
@@ -12,28 +12,29 @@ namespace System.Windows.Forms.Tests
     {
         public static IEnumerable<object[]> Ctor_Graphics_Font_Rectangle_Int_DrawItemState_TestData()
         {
-            var image = new Bitmap(10, 10);
-            Graphics graphics = Graphics.FromImage(image);
-
-            yield return new object[] { null, null, Rectangle.Empty, -2, (DrawItemState)(DrawItemState.None - 1) };
-            yield return new object[] { graphics, SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), -1, DrawItemState.None };
-            yield return new object[] { graphics, SystemFonts.DefaultFont, new Rectangle(-1, 2, -3, -4), 0, DrawItemState.Selected };
-            yield return new object[] { graphics, SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), 1, DrawItemState.Focus };
-            yield return new object[] { graphics, SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), 1, DrawItemState.Focus | DrawItemState.NoFocusRect };
+            yield return new object[] { null, Rectangle.Empty, -2, (DrawItemState)(DrawItemState.None - 1), SystemColors.HighlightText, SystemColors.Highlight };
+            yield return new object[] { SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), -1, DrawItemState.None, SystemColors.WindowText, SystemColors.Window };
+            yield return new object[] { SystemFonts.DefaultFont, new Rectangle(-1, 2, -3, -4), 0, DrawItemState.Selected, SystemColors.HighlightText, SystemColors.Highlight };
+            yield return new object[] { SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), 1, DrawItemState.Focus, SystemColors.WindowText, SystemColors.Window };
+            yield return new object[] { SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), 1, DrawItemState.Focus | DrawItemState.NoFocusRect, SystemColors.WindowText, SystemColors.Window };
         }
 
         [Theory]
         [MemberData(nameof(Ctor_Graphics_Font_Rectangle_Int_DrawItemState_TestData))]
-        public void Ctor_Graphics_Font_Rectangle_Int_DrawItemState(Graphics graphics, Font font, Rectangle rect, int index, DrawItemState state)
+        public void DrawItemEventArgs_Ctor_Graphics_Font_Rectangle_Int_DrawItemState(Font font, Rectangle rect, int index, DrawItemState state, Color expectedForeColor, Color expectedBackColor)
         {
-            var e = new DrawItemEventArgs(graphics, font, rect, index, state);
-            Assert.Equal(graphics, e.Graphics);
-            Assert.Equal(font, e.Font);
-            Assert.Equal(rect, e.Bounds);
-            Assert.Equal(index, e.Index);
-            Assert.Equal(state, e.State);
-            Assert.Equal((state & DrawItemState.Selected) == DrawItemState.Selected ? SystemColors.HighlightText : SystemColors.WindowText, e.ForeColor);
-            Assert.Equal((state & DrawItemState.Selected) == DrawItemState.Selected ? SystemColors.Highlight : SystemColors.Window, e.BackColor);
+            using (var image = new Bitmap(10, 10))
+            using (Graphics graphics = Graphics.FromImage(image))
+            {
+                var e = new DrawItemEventArgs(graphics, font, rect, index, state);
+                Assert.Equal(graphics, e.Graphics);
+                Assert.Equal(font, e.Font);
+                Assert.Equal(rect, e.Bounds);
+                Assert.Equal(index, e.Index);
+                Assert.Equal(state, e.State);
+                Assert.Equal(expectedForeColor, e.ForeColor);
+                Assert.Equal(expectedBackColor, e.BackColor);
+            }
         }
 
         public static IEnumerable<object[]> Ctor_Graphics_Font_Rectangle_Int_DrawItemState_Color_Color_TestData()
@@ -41,7 +42,7 @@ namespace System.Windows.Forms.Tests
             var image = new Bitmap(10, 10);
             Graphics graphics = Graphics.FromImage(image);
 
-            yield return new object[] { null, null, Rectangle.Empty, -2, (DrawItemState)(DrawItemState.None - 1), Color.Empty, Color.Empty };
+            yield return new object[] { graphics, null, Rectangle.Empty, -2, (DrawItemState)(DrawItemState.None - 1), Color.Empty, Color.Empty };
             yield return new object[] { graphics, SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), -1, DrawItemState.None, Color.Red, Color.Blue };
             yield return new object[] { graphics, SystemFonts.DefaultFont, new Rectangle(-1, 2, -3, -4), 0, DrawItemState.Selected, Color.Red, Color.Blue };
             yield return new object[] { graphics, SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), 1, DrawItemState.Focus, Color.Red, Color.Blue };
@@ -50,7 +51,7 @@ namespace System.Windows.Forms.Tests
 
         [Theory]
         [MemberData(nameof(Ctor_Graphics_Font_Rectangle_Int_DrawItemState_Color_Color_TestData))]
-        public void Ctor_Graphics_Font_Rectangle_Int_DrawItemState_Color_Color(Graphics graphics, Font font, Rectangle rect, int index, DrawItemState state, Color foreColor, Color backColor)
+        public void DrawItemEventArgs_Ctor_Graphics_Font_Rectangle_Int_DrawItemState_Color_Color(Graphics graphics, Font font, Rectangle rect, int index, DrawItemState state, Color foreColor, Color backColor)
         {
             var e = new DrawItemEventArgs(graphics, font, rect, index, state, foreColor, backColor);
             Assert.Equal(graphics, e.Graphics);
@@ -63,51 +64,50 @@ namespace System.Windows.Forms.Tests
         }
 
         [Fact]
-        public void DrawBackground_HasGraphics_Success()
+        public void DrawItemEventArgs_Ctor_NullGraphics_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("graphics", () => new DrawItemEventArgs(null, SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), 0, DrawItemState.None));
+            Assert.Throws<ArgumentNullException>("graphics", () => new DrawItemEventArgs(null, SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), 0, DrawItemState.None, Color.Red, Color.Blue));
+        }
+
+        public static IEnumerable<object[]> Draw_TestData()
+        {
+            yield return new object[] { new Rectangle(1, 2, 3, 4), DrawItemState.None };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), DrawItemState.Selected };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), DrawItemState.Focus };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), DrawItemState.Focus | DrawItemState.Selected };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), DrawItemState.Focus | DrawItemState.NoFocusRect };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), DrawItemState.Focus | DrawItemState.NoFocusRect  | DrawItemState.Selected };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), DrawItemState.None };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), DrawItemState.Selected };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), DrawItemState.Focus };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), DrawItemState.Focus | DrawItemState.Selected };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), DrawItemState.Focus | DrawItemState.NoFocusRect };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), DrawItemState.Focus | DrawItemState.NoFocusRect  | DrawItemState.Selected };
+        }
+
+        [Theory]
+        [MemberData(nameof(Draw_TestData))]
+        public void DrawItemEventArgs_DrawBackground_Invoke_Success(Rectangle bounds, DrawItemState state)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                var e = new DrawItemEventArgs(graphics, SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), -1, DrawItemState.None);
+                var e = new DrawItemEventArgs(graphics, SystemFonts.DefaultFont, bounds, -1, state);
                 e.DrawBackground();
             }
         }
 
-        public static IEnumerable<object[]> NullGraphics_TestData()
-        {
-            yield return new object[] { null, new Rectangle(-1, -2, -3, -4), 0, DrawItemState.None, Color.Empty, Color.Empty };
-            yield return new object[] { null, new Rectangle(-1, -2, -3, -4), 0, DrawItemState.Focus, Color.Empty, Color.Empty };
-            yield return new object[] { null, new Rectangle(-1, -2, -3, -4), 0, DrawItemState.Focus | DrawItemState.NoFocusRect, Color.Empty, Color.Empty };
-            yield return new object[] { SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), -1, DrawItemState.None, Color.Red, Color.Blue };
-            yield return new object[] { SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), -1, DrawItemState.Focus, Color.Red, Color.Blue };
-            yield return new object[] { SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), 1, DrawItemState.Focus | DrawItemState.NoFocusRect, Color.Red, Color.Blue };
-        }
-
         [Theory]
-        [MemberData(nameof(NullGraphics_TestData))]
-        public void DrawBackground_NullGraphics_Nop(Font font, Rectangle bounds, int index, DrawItemState state, Color foreColor, Color backColor)
-        {
-            var e = new DrawItemEventArgs(null, font, bounds, index, state, foreColor, backColor);
-            e.DrawBackground();
-        }
-
-        [Fact]
-        public void DrawFocusRectangle_HasGraphics_Success()
+        [MemberData(nameof(Draw_TestData))]
+        public void DrawItemEventArgs_DrawFocusRectangle_Invoke_Success(Rectangle bounds, DrawItemState state)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                var e = new DrawItemEventArgs(graphics, SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), -1, DrawItemState.Focus);
+                var e = new DrawItemEventArgs(graphics, SystemFonts.DefaultFont, bounds, -1, state);
                 e.DrawFocusRectangle();
             }
-        }
-
-        [Theory]
-        [MemberData(nameof(NullGraphics_TestData))]
-        public void DrawFocusRectangle_NullGraphics_Nop(Font font, Rectangle bounds, int index, DrawItemState state, Color foreColor, Color backColor)
-        {
-            var e = new DrawItemEventArgs(null, font, bounds, index, state, foreColor, backColor);
-            e.DrawFocusRectangle();
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DrawListViewColumnHeaderEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DrawListViewColumnHeaderEventArgsTests.cs
@@ -50,6 +50,14 @@ namespace System.Windows.Forms.Tests
                     DrawDefault = value
                 };
                 Assert.Equal(value, e.DrawDefault);
+
+                // Set same.
+                e.DrawDefault = value;
+                Assert.Equal(value, e.DrawDefault);
+
+                // Set different.
+                e.DrawDefault = !value;
+                Assert.Equal(!value, e.DrawDefault);
             }
         }
 
@@ -64,18 +72,18 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [Fact]
-        public void DrawBackground_NullGraphics_ThrowsNullReferenceException()
+        public static IEnumerable<object[]> NullGraphics_TestData()
         {
-            var e = new DrawListViewColumnHeaderEventArgs(null, new Rectangle(1, 2, 3, 4), -1, new ColumnHeader(), ListViewItemStates.Checked, Color.Red, Color.Blue, SystemFonts.DefaultFont);
-            if (Application.RenderWithVisualStyles)
-            {
-                Assert.Throws<ArgumentNullException>("dc", () => e.DrawBackground());
-            }
-            else
-            {
-                Assert.Throws<NullReferenceException>(() => e.DrawBackground());
-            }
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), 0, null, ListViewItemStates.Default, Color.Empty, Color.Empty, null };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), -1, new ColumnHeader(), ListViewItemStates.Checked, Color.Red, Color.Blue, SystemFonts.DefaultFont };
+        }
+
+        [Theory]
+        [MemberData(nameof(NullGraphics_TestData))]
+        public void DrawBackground_NullGraphics_Nop(Rectangle bounds, int columnIndex, ColumnHeader header, ListViewItemStates state, Color foreColor, Color backColor, Font font)
+        {
+            var e = new DrawListViewColumnHeaderEventArgs(null, bounds, columnIndex, header, state, foreColor, backColor, font);
+            e.DrawBackground();
         }
 
         [Theory]
@@ -104,23 +112,30 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [Fact]
-        public void DrawText_NullGraphics_ThrowsArgumentNullException()
+        [Theory]
+        [MemberData(nameof(NullGraphics_TestData))]
+        public void DrawText_NullGraphics_Nop(Rectangle bounds, int columnIndex, ColumnHeader header, ListViewItemStates state, Color foreColor, Color backColor, Font font)
         {
-            var e = new DrawListViewColumnHeaderEventArgs(null, new Rectangle(1, 2, 3, 4), -1, new ColumnHeader(), ListViewItemStates.Checked, Color.Red, Color.Blue, SystemFonts.DefaultFont);
-            Assert.Throws<ArgumentNullException>("dc", () => e.DrawText());
-            Assert.Throws<ArgumentNullException>("dc", () => e.DrawText(TextFormatFlags.Left));
+            var e = new DrawListViewColumnHeaderEventArgs(null, bounds, columnIndex, header, state, foreColor, backColor, font);
+            e.DrawText();
         }
 
-        [Fact]
-        public void DrawText_NullHeader_ThrowsNullReferenceException()
+        public static IEnumerable<object[]> NullHeader_TestData()
+        {
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), 0, ListViewItemStates.Default, Color.Empty, Color.Empty, null };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), -1, ListViewItemStates.Checked, Color.Red, Color.Blue, SystemFonts.DefaultFont };
+        }
+
+        [Theory]
+        [MemberData(nameof(NullHeader_TestData))]
+        public void DrawText_NullHeader_Nop(Rectangle bounds, int columnIndex, ListViewItemStates state, Color foreColor, Color backColor, Font font)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                var e = new DrawListViewColumnHeaderEventArgs(graphics, new Rectangle(1, 2, 3, 4), -1, null, ListViewItemStates.Checked, Color.Red, Color.Blue, SystemFonts.DefaultFont);
-                Assert.Throws<NullReferenceException>(() => e.DrawText());
-                Assert.Throws<NullReferenceException>(() => e.DrawText(TextFormatFlags.Left));
+                var e = new DrawListViewColumnHeaderEventArgs(null, bounds, columnIndex, null, state, foreColor, backColor, font);
+                e.DrawText();
+                e.DrawText(TextFormatFlags.Left);
             }
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DrawListViewColumnHeaderEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DrawListViewColumnHeaderEventArgsTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Drawing;
+using WinForms.Common.Tests;
 using Xunit;
 
 namespace System.Windows.Forms.Tests
@@ -12,35 +13,41 @@ namespace System.Windows.Forms.Tests
     {
         public static IEnumerable<object[]> Ctor_Graphics_Rectangle_Int_ColumnHeader_ListViewItemStates_Color_Color_Font_TestData()
         {
-            var image = new Bitmap(10, 10);
-            Graphics graphics = Graphics.FromImage(image);
-
-            yield return new object[] { null, Rectangle.Empty, -2, null, (DrawItemState)(ListViewItemStates.Checked - 1), Color.Empty, Color.Empty, null };
-            yield return new object[] { graphics, new Rectangle(1, 2, 3, 4), -1, new ColumnHeader(), ListViewItemStates.Checked, Color.Red, Color.Blue, SystemFonts.DefaultFont };
-            yield return new object[] { graphics, new Rectangle(-1, 2, -3, -4), 0, new ColumnHeader(), ListViewItemStates.Checked, Color.Red, Color.Blue, SystemFonts.DefaultFont };
-            yield return new object[] { graphics, new Rectangle(1, 2, 3, 4), 1, new ColumnHeader(), ListViewItemStates.Checked, Color.Red, Color.Blue, SystemFonts.DefaultFont };
+            yield return new object[] { Rectangle.Empty, -2, null, (DrawItemState)(ListViewItemStates.Checked - 1), Color.Empty, Color.Empty, null };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), -1, new ColumnHeader(), ListViewItemStates.Checked, Color.Red, Color.Blue, SystemFonts.DefaultFont };
+            yield return new object[] { new Rectangle(-1, 2, -3, -4), 0, new ColumnHeader(), ListViewItemStates.Checked, Color.Red, Color.Blue, SystemFonts.DefaultFont };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), 1, new ColumnHeader(), ListViewItemStates.Checked, Color.Red, Color.Blue, SystemFonts.DefaultFont };
         }
 
         [Theory]
         [MemberData(nameof(Ctor_Graphics_Rectangle_Int_ColumnHeader_ListViewItemStates_Color_Color_Font_TestData))]
-        public void Ctor_Graphics_Rectangle_Int_ColumnHeader_ListViewItemStates_Color_Color_Font(Graphics graphics, Rectangle bounds, int columnIndex, ColumnHeader header, ListViewItemStates state, Color foreColor, Color backColor, Font font)
+        public void DrawListViewColumnHeaderEventArgs_Ctor_Graphics_Rectangle_Int_ColumnHeader_ListViewItemStates_Color_Color_Font(Rectangle bounds, int columnIndex, ColumnHeader header, ListViewItemStates state, Color foreColor, Color backColor, Font font)
         {
-            var e = new DrawListViewColumnHeaderEventArgs(graphics, bounds, columnIndex, header, state, foreColor, backColor, font);
-            Assert.Equal(graphics, e.Graphics);
-            Assert.Equal(bounds, e.Bounds);
-            Assert.Equal(columnIndex, e.ColumnIndex);
-            Assert.Equal(header, e.Header);
-            Assert.Equal(state, e.State);
-            Assert.Equal(foreColor, e.ForeColor);
-            Assert.Equal(backColor, e.BackColor);
-            Assert.Equal(font, e.Font);
-            Assert.False(e.DrawDefault);
+            using (var image = new Bitmap(10, 10))
+            using (Graphics graphics = Graphics.FromImage(image))
+            {
+                var e = new DrawListViewColumnHeaderEventArgs(graphics, bounds, columnIndex, header, state, foreColor, backColor, font);
+                Assert.Same(graphics, e.Graphics);
+                Assert.Equal(bounds, e.Bounds);
+                Assert.Equal(columnIndex, e.ColumnIndex);
+                Assert.Same(header, e.Header);
+                Assert.Equal(state, e.State);
+                Assert.Equal(foreColor, e.ForeColor);
+                Assert.Equal(backColor, e.BackColor);
+                Assert.Equal(font, e.Font);
+                Assert.False(e.DrawDefault);
+            }
+        }
+
+        [Fact]
+        public void DrawListViewColumnHeaderEventArgs_Ctor_NullGraphics_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("graphics", () => new DrawListViewColumnHeaderEventArgs(null, new Rectangle(1, 2, 3, 4), 0, new ColumnHeader(), ListViewItemStates.Default, Color.Red, Color.Blue, SystemFonts.DefaultFont));
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void DrawDefault_Set_GetReturnsExpected(bool value)
+        [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void DrawListViewColumnHeaderEventArgs_DrawDefault_Set_GetReturnsExpected(bool value)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -61,36 +68,30 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [Fact]
-        public void DrawBackground_HasGraphics_Success()
+        public static IEnumerable<object[]> Draw_TestData()
+        {
+            yield return new object[] { new Rectangle(1, 2, 3, 4), new ColumnHeader(), ListViewItemStates.Default, Color.Red, Color.Blue, SystemFonts.DefaultFont };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), new ColumnHeader(), ListViewItemStates.Default, Color.Red, Color.Blue, SystemFonts.DefaultFont };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), new ColumnHeader(), ListViewItemStates.Default, Color.Red, Color.Blue, SystemFonts.DefaultFont };
+        }
+
+        [Theory]
+        [MemberData(nameof(Draw_TestData))]
+        public void DrawListViewColumnHeaderEventArgs_DrawBackground_Invoke_Success(Rectangle bounds, ColumnHeader header, ListViewItemStates state, Color foreColor, Color backColor, Font font)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                var e = new DrawListViewColumnHeaderEventArgs(graphics, new Rectangle(1, 2, 3, 4), -1, new ColumnHeader(), ListViewItemStates.Checked, Color.Red, Color.Blue, SystemFonts.DefaultFont);
+                var e = new DrawListViewColumnHeaderEventArgs(graphics, bounds, -1, header, state, foreColor, backColor, font);
                 e.DrawBackground();
             }
-        }
-
-        public static IEnumerable<object[]> NullGraphics_TestData()
-        {
-            yield return new object[] { new Rectangle(-1, -2, -3, -4), 0, null, ListViewItemStates.Default, Color.Empty, Color.Empty, null };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), -1, new ColumnHeader(), ListViewItemStates.Checked, Color.Red, Color.Blue, SystemFonts.DefaultFont };
-        }
-
-        [Theory]
-        [MemberData(nameof(NullGraphics_TestData))]
-        public void DrawBackground_NullGraphics_Nop(Rectangle bounds, int columnIndex, ColumnHeader header, ListViewItemStates state, Color foreColor, Color backColor, Font font)
-        {
-            var e = new DrawListViewColumnHeaderEventArgs(null, bounds, columnIndex, header, state, foreColor, backColor, font);
-            e.DrawBackground();
         }
 
         [Theory]
         [InlineData(HorizontalAlignment.Left)]
         [InlineData(HorizontalAlignment.Center)]
         [InlineData(HorizontalAlignment.Right)]
-        public void DrawText_HasGraphicsWithoutFlags_Success(HorizontalAlignment textAlign)
+        public void DrawListViewColumnHeaderEventArgs_DrawText_Invoke_Success(HorizontalAlignment textAlign)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -102,7 +103,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [Fact]
-        public void DrawText_HasGraphicsWithFlags_Success()
+        public void DrawListViewColumnHeaderEventArgs_DrawText_InvokeTextFormatFlags_Success()
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -110,14 +111,6 @@ namespace System.Windows.Forms.Tests
                 var e = new DrawListViewColumnHeaderEventArgs(graphics, new Rectangle(1, 2, 3, 4), -1, new ColumnHeader(), ListViewItemStates.Checked, Color.Red, Color.Blue, SystemFonts.DefaultFont);
                 e.DrawText(TextFormatFlags.Bottom);
             }
-        }
-
-        [Theory]
-        [MemberData(nameof(NullGraphics_TestData))]
-        public void DrawText_NullGraphics_Nop(Rectangle bounds, int columnIndex, ColumnHeader header, ListViewItemStates state, Color foreColor, Color backColor, Font font)
-        {
-            var e = new DrawListViewColumnHeaderEventArgs(null, bounds, columnIndex, header, state, foreColor, backColor, font);
-            e.DrawText();
         }
 
         public static IEnumerable<object[]> NullHeader_TestData()
@@ -128,12 +121,12 @@ namespace System.Windows.Forms.Tests
 
         [Theory]
         [MemberData(nameof(NullHeader_TestData))]
-        public void DrawText_NullHeader_Nop(Rectangle bounds, int columnIndex, ListViewItemStates state, Color foreColor, Color backColor, Font font)
+        public void DrawListViewColumnHeaderEventArgs_DrawText_NullHeader_Success(Rectangle bounds, int columnIndex, ListViewItemStates state, Color foreColor, Color backColor, Font font)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                var e = new DrawListViewColumnHeaderEventArgs(null, bounds, columnIndex, null, state, foreColor, backColor, font);
+                var e = new DrawListViewColumnHeaderEventArgs(graphics, bounds, columnIndex, null, state, foreColor, backColor, font);
                 e.DrawText();
                 e.DrawText(TextFormatFlags.Left);
             }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DrawListViewItemEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DrawListViewItemEventArgsTests.cs
@@ -13,31 +13,49 @@ namespace System.Windows.Forms.Tests
     {
         public static IEnumerable<object[]> Ctor_Graphics_ListViewItem_Rectangle_Int_ListViewItemStates_TestData()
         {
-            var image = new Bitmap(10, 10);
-            Graphics graphics = Graphics.FromImage(image);
-
-            yield return new object[] { null, null, Rectangle.Empty, -2, (ListViewItemStates)(ListViewItemStates.Checked - 1) };
-            yield return new object[] { graphics, new ListViewItem(), new Rectangle(1, 2, 3, 4), -1, ListViewItemStates.Checked };
-            yield return new object[] { graphics, new ListViewItem(), new Rectangle(-1, 2, -3, -4), 0, ListViewItemStates.Focused };
-            yield return new object[] { graphics, new ListViewItem(), new Rectangle(1, 2, 3, 4), 1, ListViewItemStates.Checked };
+            yield return new object[] { Rectangle.Empty, -2, (ListViewItemStates)(ListViewItemStates.Checked - 1) };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), -1, ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(-1, 2, -3, -4), 0, ListViewItemStates.Focused };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), 1, ListViewItemStates.Checked };
         }
 
         [Theory]
         [MemberData(nameof(Ctor_Graphics_ListViewItem_Rectangle_Int_ListViewItemStates_TestData))]
-        public void Ctor_Graphics_ListViewItem_Rectangle_Int_ListViewItemStates(Graphics graphics, ListViewItem item, Rectangle bounds, int itemIndex, ListViewItemStates state)
+        public void DrawListViewItemEventArgs_Ctor_Graphics_ListViewItem_Rectangle_Int_ListViewItemStates(Rectangle bounds, int itemIndex, ListViewItemStates state)
         {
-            var e = new DrawListViewItemEventArgs(graphics, item, bounds, itemIndex, state);
-            Assert.Equal(graphics, e.Graphics);
-            Assert.Equal(item, e.Item);
-            Assert.Equal(bounds, e.Bounds);
-            Assert.Equal(itemIndex, e.ItemIndex);
-            Assert.Equal(state, e.State);
-            Assert.False(e.DrawDefault);
+            using (var image = new Bitmap(10, 10))
+            using (Graphics graphics = Graphics.FromImage(image))
+            {
+                var item = new ListViewItem();
+                var e = new DrawListViewItemEventArgs(graphics, item, bounds, itemIndex, state);
+                Assert.Same(graphics, e.Graphics);
+                Assert.Same(item, e.Item);
+                Assert.Equal(bounds, e.Bounds);
+                Assert.Equal(itemIndex, e.ItemIndex);
+                Assert.Equal(state, e.State);
+                Assert.False(e.DrawDefault);
+            }
+        }
+
+        [Fact]
+        public void DrawListViewItemEventArgs_Ctor_NullGraphics_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("graphics", () => new DrawListViewItemEventArgs(null, new ListViewItem(), new Rectangle(1, 2, 3, 4), 0, ListViewItemStates.Default));
+        }
+
+        [Fact]
+        public void DrawListViewItemEventArgs_Ctor_NullItem_ThrowsArgumentNullException()
+        {
+            using (var image = new Bitmap(10, 10))
+            using (Graphics graphics = Graphics.FromImage(image))
+            {
+                Assert.Throws<ArgumentNullException>("item", () => new DrawListViewItemEventArgs(graphics, null, new Rectangle(1, 2, 3, 4), 0, ListViewItemStates.Default));
+            }
         }
 
         [Theory]
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
-        public void DrawDefault_Set_GetReturnsExpected(bool value)
+        public void DrawListViewItemEventArgs_DrawDefault_Set_GetReturnsExpected(bool value)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -58,193 +76,89 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [Fact]
-        public void DrawBackground_HasGraphics_Success()
+        public static IEnumerable<object[]> Draw_TestData()
         {
-            using (var image = new Bitmap(10, 10))
-            using (Graphics graphics = Graphics.FromImage(image))
-            {
-                var e = new DrawListViewItemEventArgs(graphics, new ListViewItem(), new Rectangle(1, 2, 3, 4), -1, ListViewItemStates.Checked);
-                e.DrawBackground();
-            }
-        }
+            yield return new object[] { new ListViewItem(), new Rectangle(1, 2, 3, 4), ListViewItemStates.Default };
+            yield return new object[] { new ListViewItem(), new Rectangle(1, 2, 3, 4), ListViewItemStates.Focused };
+            yield return new object[] { new ListViewItem(), new Rectangle(1, 2, 3, 4), ListViewItemStates.Checked };
+            yield return new object[] { new ListViewItem(), Rectangle.Empty, ListViewItemStates.Default };
+            yield return new object[] { new ListViewItem(), Rectangle.Empty, ListViewItemStates.Focused };
+            yield return new object[] { new ListViewItem(), Rectangle.Empty, ListViewItemStates.Checked };
+            yield return new object[] { new ListViewItem(), new Rectangle(-1, -2, -3, -4), ListViewItemStates.Default };
+            yield return new object[] { new ListViewItem(), new Rectangle(-1, -2, -3, -4), ListViewItemStates.Focused };
+            yield return new object[] { new ListViewItem(), new Rectangle(-1, -2, -3, -4), ListViewItemStates.Checked };
 
-        public static IEnumerable<object[]> NullGraphics_TestData()
-        {
-            yield return new object[] { null, new Rectangle(-1, -2, -3, 4), -1, ListViewItemStates.Default };
-            yield return new object[] { null, new Rectangle(-1, -2, -3, 4), -1, ListViewItemStates.Checked };
-            yield return new object[] { null, new Rectangle(-1, -2, -3, 4), -1, ListViewItemStates.Focused };
-            yield return new object[] { new ListViewItem(), new Rectangle(1, 2, 3, 4), 0, ListViewItemStates.Default };
-            yield return new object[] { new ListViewItem(), new Rectangle(1, 2, 3, 4), 0, ListViewItemStates.Checked };
-            yield return new object[] { new ListViewItem(), new Rectangle(1, 2, 3, 4), 0, ListViewItemStates.Focused };
-        }
-
-        [Theory]
-        [MemberData(nameof(NullGraphics_TestData))]
-        public void DrawBackground_NullGraphics_Nop(ListViewItem item, Rectangle bounds, int itemIndex, ListViewItemStates state)
-        {
-            var e = new DrawListViewItemEventArgs(null, item, bounds, itemIndex, state);
-            e.DrawBackground();
-        }
-
-        public static IEnumerable<object[]> NullItem_TestData()
-        {
-            yield return new object[] { new Rectangle(-1, -2, -3, -4), -1, ListViewItemStates.Default };
-            yield return new object[] { new Rectangle(-1, -2, -3, -4), -1, ListViewItemStates.Checked };
-            yield return new object[] { new Rectangle(-1, -2, -3, -4), -1, ListViewItemStates.Focused };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), -1, ListViewItemStates.Default };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), -1, ListViewItemStates.Checked };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), -1, ListViewItemStates.Focused };
-        }
-
-        [Theory]
-        [MemberData(nameof(NullItem_TestData))]
-        public void DrawBackground_NullItem_Nop(Rectangle bounds, int itemIndex, ListViewItemStates state)
-        {
-            using (var image = new Bitmap(10, 10))
-            using (Graphics graphics = Graphics.FromImage(image))
-            {
-                var e = new DrawListViewItemEventArgs(graphics, null, bounds, itemIndex, state);
-                e.DrawBackground();
-            }
-        }
-
-        public static IEnumerable<object[]> ListViewItem_TestData()
-        {
             foreach (View view in new View[] { View.Details, View.List })
             {
                 var listView = new ListView { View = view };
                 var listViewItem = new ListViewItem();
                 listView.Items.Add(listViewItem);
-                yield return new object[] { listViewItem };
+                yield return new object[] { listViewItem, new Rectangle(1, 2, 3, 4), ListViewItemStates.Default };
+                yield return new object[] { listViewItem, new Rectangle(1, 2, 3, 4), ListViewItemStates.Focused };
+                yield return new object[] { listViewItem, new Rectangle(1, 2, 3, 4), ListViewItemStates.Checked };
 
                 var subItemsItem = new ListViewItem();
                 subItemsItem.SubItems.Add(new ListViewItem.ListViewSubItem());
                 listView.Items.Add(subItemsItem);
-                yield return new object[] { subItemsItem };
+                yield return new object[] { subItemsItem, new Rectangle(1, 2, 3, 4), ListViewItemStates.Default };
+                yield return new object[] { subItemsItem, new Rectangle(1, 2, 3, 4), ListViewItemStates.Focused };
+                yield return new object[] { subItemsItem, new Rectangle(1, 2, 3, 4), ListViewItemStates.Checked };
 
                 var fullRowSelectListView = new ListView { View = view, FullRowSelect = true };
                 var fullRowSelectListViewItem = new ListViewItem();
                 fullRowSelectListViewItem.SubItems.Add(new ListViewItem.ListViewSubItem());
                 fullRowSelectListView.Items.Add(fullRowSelectListViewItem);
-                yield return new object[] { fullRowSelectListViewItem };
+                yield return new object[] { fullRowSelectListViewItem, new Rectangle(1, 2, 3, 4), ListViewItemStates.Default };
+                yield return new object[] { fullRowSelectListViewItem, new Rectangle(1, 2, 3, 4), ListViewItemStates.Focused };
+                yield return new object[] { fullRowSelectListViewItem, new Rectangle(1, 2, 3, 4), ListViewItemStates.Checked };
             }
         }
 
         [Theory]
-        [MemberData(nameof(ListViewItem_TestData))]
-        public void DrawFocusRectangle_HasGraphicsFocused_Success(ListViewItem listViewItem)
+        [MemberData(nameof(Draw_TestData))]
+        public void DrawListViewItemEventArgs_DrawBackground_Invoke_Success(ListViewItem item, Rectangle bounds, ListViewItemStates state)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                var e = new DrawListViewItemEventArgs(graphics, listViewItem, new Rectangle(1, 2, 3, 4), -1, ListViewItemStates.Focused);
+                var e = new DrawListViewItemEventArgs(graphics, item, bounds, -1, state);
+                e.DrawBackground();
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Draw_TestData))]
+        public void DrawListViewItemEventArgs_DrawFocusRectangle_HasGraphicsFocused_Success(ListViewItem item, Rectangle bounds, ListViewItemStates state)
+        {
+            using (var image = new Bitmap(10, 10))
+            using (Graphics graphics = Graphics.FromImage(image))
+            {
+                var e = new DrawListViewItemEventArgs(graphics, item, bounds, -1, state);
                 e.DrawFocusRectangle();
             }
         }
 
         [Theory]
-        [MemberData(nameof(NullGraphics_TestData))]
-        public void DrawFocusRectangle_NullGraphics_Nop(ListViewItem item, Rectangle bounds, int itemIndex, ListViewItemStates state)
-        {
-            var e = new DrawListViewItemEventArgs(null, item, bounds, itemIndex, state);
-            e.DrawFocusRectangle();
-        }
-
-        [Theory]
-        [MemberData(nameof(NullItem_TestData))]
-        public void DrawFocusRectangle_NullItem_Nop(Rectangle bounds, int itemIndex, ListViewItemStates state)
+        [MemberData(nameof(Draw_TestData))]
+        public void DrawListViewItemEventArgs_DrawText_Invoke_Success(ListViewItem item, Rectangle bounds, ListViewItemStates state)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                var e = new DrawListViewItemEventArgs(graphics, null, bounds, itemIndex, state);
-                e.DrawFocusRectangle();
-            }
-        }
-
-        public static IEnumerable<object[]> ItemWithoutListView_TestData()
-        {
-            yield return new object[] { new Rectangle(-1, -2, -3, -4), -1, ListViewItemStates.Default };
-            yield return new object[] { new Rectangle(-1, -2, -3, -4), -1, ListViewItemStates.Checked };
-            yield return new object[] { new Rectangle(-1, -2, -3, -4), -1, ListViewItemStates.Focused };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), 0, ListViewItemStates.Default };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), 0, ListViewItemStates.Checked };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), 0, ListViewItemStates.Focused };
-        }
-
-        [Theory]
-        [MemberData(nameof(ItemWithoutListView_TestData))]
-        public void DrawFocusRectangle_ItemHasNoListViewNotFocused_Nop(Rectangle bounds, int itemIndex, ListViewItemStates state)
-        {
-            using (var image = new Bitmap(10, 10))
-            using (Graphics graphics = Graphics.FromImage(image))
-            {
-                var e = new DrawListViewItemEventArgs(graphics, new ListViewItem(), bounds, itemIndex, state);
-                e.DrawFocusRectangle();
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(ListViewItem_TestData))]
-        public void DrawText_HasGraphicsWithoutFlags_Success(ListViewItem listViewItem)
-        {
-            using (var image = new Bitmap(10, 10))
-            using (Graphics graphics = Graphics.FromImage(image))
-            {
-                var e = new DrawListViewItemEventArgs(graphics, listViewItem, new Rectangle(1, 2, 3, 4), -1, ListViewItemStates.Checked);
+                var e = new DrawListViewItemEventArgs(graphics, item, bounds, -1, state);
                 e.DrawText();
             }
         }
 
         [Theory]
-        [MemberData(nameof(ListViewItem_TestData))]
-        public void DrawText_HasGraphicsWithFlags_Success(ListViewItem listViewItem)
+        [MemberData(nameof(Draw_TestData))]
+        public void DrawListViewItemEventArgs_DrawText_InvokeTextFormatFlags(ListViewItem item, Rectangle bounds, ListViewItemStates state)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                var e = new DrawListViewItemEventArgs(graphics, listViewItem, new Rectangle(1, 2, 3, 4), -1, ListViewItemStates.Checked);
+                var e = new DrawListViewItemEventArgs(graphics, item, bounds, -1, state);
                 e.DrawText(TextFormatFlags.Bottom);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(NullGraphics_TestData))]
-        public void DrawText_NullGraphics_Nop(ListViewItem item, Rectangle bounds, int itemIndex, ListViewItemStates state)
-        {
-            using (var image = new Bitmap(10, 10))
-            using (Graphics graphics = Graphics.FromImage(image))
-            {
-                var e = new DrawListViewItemEventArgs(graphics, item, bounds, itemIndex, state);
-                e.DrawText();
-                e.DrawText(TextFormatFlags.Left);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(NullItem_TestData))]
-        public void DrawText_NullItem_Nop(Rectangle bounds, int itemIndex, ListViewItemStates state)
-        {
-            using (var image = new Bitmap(10, 10))
-            using (Graphics graphics = Graphics.FromImage(image))
-            {
-                var e = new DrawListViewItemEventArgs(graphics, null, bounds, itemIndex, state);
-                e.DrawText();
-                e.DrawText(TextFormatFlags.Left);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(ItemWithoutListView_TestData))]
-        public void DrawText_ItemHasNoListView_Nop(Rectangle bounds, int itemIndex, ListViewItemStates state)
-        {
-            using (var image = new Bitmap(10, 10))
-            using (Graphics graphics = Graphics.FromImage(image))
-            {
-                var e = new DrawListViewItemEventArgs(graphics, new ListViewItem(), bounds, itemIndex, state);
-                e.DrawText();
-                e.DrawText(TextFormatFlags.Left);
             }
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DrawListViewItemEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DrawListViewItemEventArgsTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Drawing;
+using WinForms.Common.Tests;
 using Xunit;
 
 namespace System.Windows.Forms.Tests
@@ -35,8 +36,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void DrawDefault_Set_GetReturnsExpected(bool value)
         {
             using (var image = new Bitmap(10, 10))
@@ -47,6 +47,14 @@ namespace System.Windows.Forms.Tests
                     DrawDefault = value
                 };
                 Assert.Equal(value, e.DrawDefault);
+
+                // Set same.
+                e.DrawDefault = value;
+                Assert.Equal(value, e.DrawDefault);
+
+                // Set different.
+                e.DrawDefault = !value;
+                Assert.Equal(!value, e.DrawDefault);
             }
         }
 
@@ -61,21 +69,43 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [Fact]
-        public void DrawBackground_NullGraphics_ThrowsNullReferenceException()
+        public static IEnumerable<object[]> NullGraphics_TestData()
         {
-            var e = new DrawListViewItemEventArgs(null, new ListViewItem(), new Rectangle(1, 2, 3, 4), -1, ListViewItemStates.Checked);
-            Assert.Throws<NullReferenceException>(() => e.DrawBackground());
+            yield return new object[] { null, new Rectangle(-1, -2, -3, 4), -1, ListViewItemStates.Default };
+            yield return new object[] { null, new Rectangle(-1, -2, -3, 4), -1, ListViewItemStates.Checked };
+            yield return new object[] { null, new Rectangle(-1, -2, -3, 4), -1, ListViewItemStates.Focused };
+            yield return new object[] { new ListViewItem(), new Rectangle(1, 2, 3, 4), 0, ListViewItemStates.Default };
+            yield return new object[] { new ListViewItem(), new Rectangle(1, 2, 3, 4), 0, ListViewItemStates.Checked };
+            yield return new object[] { new ListViewItem(), new Rectangle(1, 2, 3, 4), 0, ListViewItemStates.Focused };
         }
 
-        [Fact]
-        public void DrawBackground_NullItem_ThrowsNullReferenceException()
+        [Theory]
+        [MemberData(nameof(NullGraphics_TestData))]
+        public void DrawBackground_NullGraphics_Nop(ListViewItem item, Rectangle bounds, int itemIndex, ListViewItemStates state)
+        {
+            var e = new DrawListViewItemEventArgs(null, item, bounds, itemIndex, state);
+            e.DrawBackground();
+        }
+
+        public static IEnumerable<object[]> NullItem_TestData()
+        {
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), -1, ListViewItemStates.Default };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), -1, ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), -1, ListViewItemStates.Focused };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), -1, ListViewItemStates.Default };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), -1, ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), -1, ListViewItemStates.Focused };
+        }
+
+        [Theory]
+        [MemberData(nameof(NullItem_TestData))]
+        public void DrawBackground_NullItem_Nop(Rectangle bounds, int itemIndex, ListViewItemStates state)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                var e = new DrawListViewItemEventArgs(graphics, null, new Rectangle(1, 2, 3, 4), -1, ListViewItemStates.Focused);
-                Assert.Throws<NullReferenceException>(() => e.DrawBackground());
+                var e = new DrawListViewItemEventArgs(graphics, null, bounds, itemIndex, state);
+                e.DrawBackground();
             }
         }
 
@@ -113,65 +143,45 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [Fact]
-        public void DrawFocusRectangle_NullGraphicsNotFocused_Nop()
+        [Theory]
+        [MemberData(nameof(NullGraphics_TestData))]
+        public void DrawFocusRectangle_NullGraphics_Nop(ListViewItem item, Rectangle bounds, int itemIndex, ListViewItemStates state)
         {
-            var e = new DrawListViewItemEventArgs(null, new ListViewItem(), new Rectangle(1, 2, 3, 4), -1, ListViewItemStates.Checked);
+            var e = new DrawListViewItemEventArgs(null, item, bounds, itemIndex, state);
             e.DrawFocusRectangle();
         }
 
-        [Fact]
-        public void DrawFocusRectangle_NullGraphicsFocused_ThrowsArgumentNullException()
-        {
-            var listView = new ListView();
-            var listViewItem = new ListViewItem();
-            listView.Items.Add(listViewItem);
-
-            var e = new DrawListViewItemEventArgs(null, listViewItem, new Rectangle(1, 2, 3, 4), -1, ListViewItemStates.Focused);
-            Assert.Throws<ArgumentNullException>("graphics", () => e.DrawFocusRectangle());
-        }
-
-        [Fact]
-        public void DrawFocusRectangle_NullItemNotFocused_Nop()
+        [Theory]
+        [MemberData(nameof(NullItem_TestData))]
+        public void DrawFocusRectangle_NullItem_Nop(Rectangle bounds, int itemIndex, ListViewItemStates state)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                var e = new DrawListViewItemEventArgs(graphics, null, new Rectangle(1, 2, 3, 4), -1, ListViewItemStates.Checked);
+                var e = new DrawListViewItemEventArgs(graphics, null, bounds, itemIndex, state);
                 e.DrawFocusRectangle();
             }
         }
 
-        [Fact]
-        public void DrawFocusRectangle_NullItemFocused_ThrowsNullReferenceException()
+        public static IEnumerable<object[]> ItemWithoutListView_TestData()
         {
-            using (var image = new Bitmap(10, 10))
-            using (Graphics graphics = Graphics.FromImage(image))
-            {
-                var e = new DrawListViewItemEventArgs(graphics, null, new Rectangle(1, 2, 3, 4), -1, ListViewItemStates.Focused);
-                Assert.Throws<NullReferenceException>(() => e.DrawFocusRectangle());
-            }
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), -1, ListViewItemStates.Default };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), -1, ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), -1, ListViewItemStates.Focused };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), 0, ListViewItemStates.Default };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), 0, ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), 0, ListViewItemStates.Focused };
         }
 
-        [Fact]
-        public void DrawFocusRectangle_ItemHasNoListViewNotFocused_Nop()
+        [Theory]
+        [MemberData(nameof(ItemWithoutListView_TestData))]
+        public void DrawFocusRectangle_ItemHasNoListViewNotFocused_Nop(Rectangle bounds, int itemIndex, ListViewItemStates state)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                var e = new DrawListViewItemEventArgs(graphics, new ListViewItem(), new Rectangle(1, 2, 3, 4), -1, ListViewItemStates.Checked);
+                var e = new DrawListViewItemEventArgs(graphics, new ListViewItem(), bounds, itemIndex, state);
                 e.DrawFocusRectangle();
-            }
-        }
-
-        [Fact]
-        public void DrawFocusRectangle_ItemHasNoListViewFocused_ThrowsNullReferenceException()
-        {
-            using (var image = new Bitmap(10, 10))
-            using (Graphics graphics = Graphics.FromImage(image))
-            {
-                var e = new DrawListViewItemEventArgs(graphics, new ListViewItem(), new Rectangle(1, 2, 3, 4), -1, ListViewItemStates.Focused);
-                Assert.Throws<NullReferenceException>(() => e.DrawFocusRectangle());
             }
         }
 
@@ -199,35 +209,42 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [Fact]
-        public void DrawText_NullGraphics_ThrowsNullReferenceException()
-        {
-            var e = new DrawListViewItemEventArgs(null, new ListViewItem(), new Rectangle(1, 2, 3, 4), -1, ListViewItemStates.Checked);
-            Assert.Throws<NullReferenceException>(() => e.DrawText());
-            Assert.Throws<NullReferenceException>(() => e.DrawText(TextFormatFlags.Left));
-        }
-
-        [Fact]
-        public void DrawText_NullItem_ThrowsNullReferenceException()
+        [Theory]
+        [MemberData(nameof(NullGraphics_TestData))]
+        public void DrawText_NullGraphics_Nop(ListViewItem item, Rectangle bounds, int itemIndex, ListViewItemStates state)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                var e = new DrawListViewItemEventArgs(graphics, null, new Rectangle(1, 2, 3, 4), -1, ListViewItemStates.Checked);
-                Assert.Throws<NullReferenceException>(() => e.DrawText());
-                Assert.Throws<NullReferenceException>(() => e.DrawText(TextFormatFlags.Left));
+                var e = new DrawListViewItemEventArgs(graphics, item, bounds, itemIndex, state);
+                e.DrawText();
+                e.DrawText(TextFormatFlags.Left);
             }
         }
 
-        [Fact]
-        public void DrawText_ItemHasNoListView_ThrowsNullReferenceException()
+        [Theory]
+        [MemberData(nameof(NullItem_TestData))]
+        public void DrawText_NullItem_Nop(Rectangle bounds, int itemIndex, ListViewItemStates state)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                var e = new DrawListViewItemEventArgs(graphics, new ListViewItem(), new Rectangle(1, 2, 3, 4), -1, ListViewItemStates.Checked);
-                Assert.Throws<NullReferenceException>(() => e.DrawText());
-                Assert.Throws<NullReferenceException>(() => e.DrawText(TextFormatFlags.Left));
+                var e = new DrawListViewItemEventArgs(graphics, null, bounds, itemIndex, state);
+                e.DrawText();
+                e.DrawText(TextFormatFlags.Left);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ItemWithoutListView_TestData))]
+        public void DrawText_ItemHasNoListView_Nop(Rectangle bounds, int itemIndex, ListViewItemStates state)
+        {
+            using (var image = new Bitmap(10, 10))
+            using (Graphics graphics = Graphics.FromImage(image))
+            {
+                var e = new DrawListViewItemEventArgs(graphics, new ListViewItem(), bounds, itemIndex, state);
+                e.DrawText();
+                e.DrawText(TextFormatFlags.Left);
             }
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DrawListViewSubItemEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DrawListViewSubItemEventArgsTests.cs
@@ -23,7 +23,7 @@ namespace System.Windows.Forms.Tests
 
         [Theory]
         [MemberData(nameof(Ctor_Graphics_ListViewItem_Rectangle_Int_ListViewItemStates_TestData))]
-        public void Ctor_Graphics_ListViewItem_Rectangle_Int_ListViewItemStates(Graphics graphics, Rectangle bounds, ListViewItem item, ListViewItem.ListViewSubItem subItem, int itemIndex, int columnIndex, ColumnHeader header, ListViewItemStates itemState)
+        public void DrawListViewSubItemEventArgs_Ctor_Graphics_ListViewItem_Rectangle_Int_ListViewItemStates(Graphics graphics, Rectangle bounds, ListViewItem item, ListViewItem.ListViewSubItem subItem, int itemIndex, int columnIndex, ColumnHeader header, ListViewItemStates itemState)
         {
             var e = new DrawListViewSubItemEventArgs(graphics, bounds, item, subItem, itemIndex, columnIndex, header, itemState);
             Assert.Equal(graphics, e.Graphics);
@@ -40,7 +40,7 @@ namespace System.Windows.Forms.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void DrawDefault_Set_GetReturnsExpected(bool value)
+        public void DrawListViewSubItemEventArgs_DrawDefault_Set_GetReturnsExpected(bool value)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -50,13 +50,21 @@ namespace System.Windows.Forms.Tests
                     DrawDefault = value
                 };
                 Assert.Equal(value, e.DrawDefault);
+
+                // Set same.
+                e.DrawDefault = value;
+                Assert.Equal(value, e.DrawDefault);
+
+                // Set different.
+                e.DrawDefault = !value;
+                Assert.Equal(!value, e.DrawDefault);
             }
         }
 
         [Theory]
         [InlineData(-1)]
         [InlineData(1)]
-        public void DrawBackground_HasGraphics_Success(int itemIndex)
+        public void DrawListViewSubItemEventArgs_DrawBackground_HasGraphics_Success(int itemIndex)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -66,42 +74,62 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [Fact]
-        public void DrawBackground_NullGraphics_ThrowsNullReferenceException()
+        public static IEnumerable<object[]> NullGraphics_TestData()
         {
-            var e = new DrawListViewSubItemEventArgs(null, new Rectangle(1, 2, 3, 4), new ListViewItem(), new ListViewItem.ListViewSubItem(), 0, 0, new ColumnHeader(), ListViewItemStates.Checked);
-            Assert.Throws<NullReferenceException>(() => e.DrawBackground());
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, null, -1, -1, null, ListViewItemStates.Default };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, null, -1, -1, null, ListViewItemStates.Focused };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), null, null, 0, 0, null, ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), null, null, 0, 0, null, ListViewItemStates.Focused };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem(), new ListViewItem.ListViewSubItem(), 0, 0, new ColumnHeader(), ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem(), new ListViewItem.ListViewSubItem(), 0, 0, new ColumnHeader(), ListViewItemStates.Focused };
         }
 
         [Theory]
-        [InlineData(-2)]
-        [InlineData(0)]
-        [InlineData(1)]
-        public void DrawBackground_NullItemNonMinusOneItemIndex_Nop(int itemIndex)
+        [MemberData(nameof(NullGraphics_TestData))]
+        public void DrawListViewSubItemEventArgs_DrawBackground_NullGraphics_Nop(Rectangle bounds, ListViewItem item, ListViewItem.ListViewSubItem subItem, int itemIndex, int columnIndex, ColumnHeader header, ListViewItemStates itemState)
         {
-            using (var image = new Bitmap(10, 10))
-            using (Graphics graphics = Graphics.FromImage(image))
-            {
-                var e = new DrawListViewSubItemEventArgs(graphics, new Rectangle(1, 2, 3, 4), null, new ListViewItem.ListViewSubItem(), itemIndex, 0, new ColumnHeader(), ListViewItemStates.Checked);
-                e.DrawBackground();
-            }
+            var e = new DrawListViewSubItemEventArgs(null, bounds, item, subItem, itemIndex, columnIndex, header, itemState);
+            e.DrawBackground();
         }
 
-        [Fact]
-        public void DrawBackground_NullItemMinusOneItemIndex_ThrowsNullReferenceException()
+        public static IEnumerable<object[]> NullItemOrSubItem_TestData()
+        {
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, null, -1, 0, null, ListViewItemStates.Default };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, null, -1, 0, null, ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, null, -1, 0, null, ListViewItemStates.Focused };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, null, 0, 0, null, ListViewItemStates.Default };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, null, 0, 0, null, ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, null, 0, 0, null, ListViewItemStates.Focused };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), null, null, -2, 0, new ColumnHeader(), ListViewItemStates.Default };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), null, null, -2, 0, new ColumnHeader(), ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), null, null, -2, 0, new ColumnHeader(), ListViewItemStates.Focused };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), null, new ListViewItem.ListViewSubItem(), -1, 0, new ColumnHeader(), ListViewItemStates.Default };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), null, new ListViewItem.ListViewSubItem(), -1, 0, new ColumnHeader(), ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), null, new ListViewItem.ListViewSubItem(), -1, 0, new ColumnHeader(), ListViewItemStates.Focused };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), null, null, 0, 0, new ColumnHeader(), ListViewItemStates.Default };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), null, null, 0, 0, new ColumnHeader(), ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), null, null, 0, 0, new ColumnHeader(), ListViewItemStates.Focused };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem(), null, 0, 0, new ColumnHeader(), ListViewItemStates.Default };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem(), null, 0, 0, new ColumnHeader(), ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem(), null, 0, 0, new ColumnHeader(), ListViewItemStates.Focused };
+        }
+
+        [Theory]
+        [MemberData(nameof(NullItemOrSubItem_TestData))]
+        public void DrawListViewSubItemEventArgs_DrawBackground_NullItemOrSubItem_Nop(Rectangle bounds, ListViewItem item, ListViewItem.ListViewSubItem subItem, int itemIndex, int columnIndex, ColumnHeader header, ListViewItemStates itemStates)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                var e = new DrawListViewSubItemEventArgs(graphics, new Rectangle(1, 2, 3, 4), null, new ListViewItem.ListViewSubItem(), -1, 0, new ColumnHeader(), ListViewItemStates.Checked);
-                Assert.Throws<NullReferenceException>(() => e.DrawBackground());
+                var e = new DrawListViewSubItemEventArgs(graphics, bounds, item, subItem, itemIndex, columnIndex, header, itemStates);
+                e.DrawBackground();
             }
         }
 
         [Theory]
         [InlineData(ListViewItemStates.Checked)]
         [InlineData(ListViewItemStates.Focused)]
-        public void DrawFocusRectangle_HasGraphics_Success(ListViewItemStates itemState)
+        public void DrawListViewSubItemEventArgs_DrawFocusRectangle_HasGraphics_Success(ListViewItemStates itemState)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -111,39 +139,33 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [Fact]
-        public void DrawFocusRectangle_NullGraphicsNotFocused_Nop()
+        [Theory]
+        [MemberData(nameof(NullGraphics_TestData))]
+        public void DrawListViewSubItemEventArgs_DrawFocusRectangle_NullGraphics_Nop(Rectangle bounds, ListViewItem item, ListViewItem.ListViewSubItem subItem, int itemIndex, int columnIndex, ColumnHeader header, ListViewItemStates itemState)
         {
-            var e = new DrawListViewSubItemEventArgs(null, new Rectangle(1, 2, 3, 4), new ListViewItem(), new ListViewItem.ListViewSubItem(), 0, 0, new ColumnHeader(), ListViewItemStates.Checked);
+            var e = new DrawListViewSubItemEventArgs(null, bounds, item, subItem, itemIndex, columnIndex, header, itemState);
             e.DrawFocusRectangle(new Rectangle(1, 2, 3, 4));
         }
 
-        [Fact]
-        public void DrawFocusRectangle_NullGraphicsFocused_ThrowsArgumentNullException()
+        public static IEnumerable<object[]> NullItem_TestData()
         {
-            var e = new DrawListViewSubItemEventArgs(null, new Rectangle(1, 2, 3, 4), new ListViewItem(), new ListViewItem.ListViewSubItem(), 0, 0, new ColumnHeader(), ListViewItemStates.Focused);
-            Assert.Throws<ArgumentNullException>("graphics", () => e.DrawFocusRectangle(new Rectangle(1, 2, 3, 4)));
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, -1, -1, null, ListViewItemStates.Default };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, -1, -1, null, ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, -1, -1, null, ListViewItemStates.Focused };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem.ListViewSubItem(), 0, 0, new ColumnHeader(), ListViewItemStates.Default };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem.ListViewSubItem(), 0, 0, new ColumnHeader(), ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem.ListViewSubItem(), 0, 0, new ColumnHeader(), ListViewItemStates.Focused };
         }
 
-        [Fact]
-        public void DrawFocusRectangle_NullItemNotFocused_Nop()
+        [Theory]
+        [MemberData(nameof(NullItem_TestData))]
+        public void DrawListViewSubItemEventArgs_DrawFocusRectangle_NullItem_Nop(Rectangle bounds, ListViewItem.ListViewSubItem subItem, int itemIndex, int columnIndex, ColumnHeader header, ListViewItemStates itemState)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                var e = new DrawListViewSubItemEventArgs(graphics, new Rectangle(1, 2, 3, 4), null, new ListViewItem.ListViewSubItem(), 0, 0, new ColumnHeader(), ListViewItemStates.Checked);
+                var e = new DrawListViewSubItemEventArgs(graphics, bounds, null, subItem, itemIndex, columnIndex, header, itemState);
                 e.DrawFocusRectangle(new Rectangle(1, 2, 3, 4));
-            }
-        }
-
-        [Fact]
-        public void DrawFocusRectangle_NullItemFocused_ThrowsNullReferenceException()
-        {
-            using (var image = new Bitmap(10, 10))
-            using (Graphics graphics = Graphics.FromImage(image))
-            {
-                var e = new DrawListViewSubItemEventArgs(graphics, new Rectangle(1, 2, 3, 4), null, new ListViewItem.ListViewSubItem(), 0, 0, new ColumnHeader(), ListViewItemStates.Focused);
-                Assert.Throws<NullReferenceException>(() => e.DrawFocusRectangle(new Rectangle(1, 2, 3, 4)));
             }
         }
 
@@ -159,7 +181,7 @@ namespace System.Windows.Forms.Tests
 
         [Theory]
         [MemberData(nameof(DrawText_HasGraphicsWithoutFlags_TestData))]
-        public void DrawText_HasGraphicsWithoutFlags_Success(int itemIndex, HorizontalAlignment textAlign)
+        public void DrawListViewSubItemEventArgs_DrawText_HasGraphicsWithoutFlags_Success(int itemIndex, HorizontalAlignment textAlign)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -173,7 +195,7 @@ namespace System.Windows.Forms.Tests
         [Theory]
         [InlineData(-1)]
         [InlineData(1)]
-        public void DrawText_HasGraphicsWithFlags_Success(int itemIndex)
+        public void DrawListViewSubItemEventArgs_DrawText_HasGraphicsWithFlags_Success(int itemIndex)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -183,19 +205,20 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [Fact]
-        public void DrawText_NullGraphics_ThrowsArgumentNullException()
+        [Theory]
+        [MemberData(nameof(NullGraphics_TestData))]
+        public void DrawListViewSubItemEventArgs_DrawText_NullGraphics_Nop(Rectangle bounds, ListViewItem item, ListViewItem.ListViewSubItem subItem, int itemIndex, int columnIndex, ColumnHeader header, ListViewItemStates itemState)
         {
-            var e = new DrawListViewSubItemEventArgs(null, new Rectangle(1, 2, 3, 4), new ListViewItem(), new ListViewItem.ListViewSubItem(), 0, 0, new ColumnHeader(), ListViewItemStates.Checked);
-            Assert.Throws<ArgumentNullException>("dc", () => e.DrawText());
-            Assert.Throws<ArgumentNullException>("dc", () => e.DrawText(TextFormatFlags.Left));
+            var e = new DrawListViewSubItemEventArgs(null, bounds, item, subItem, itemIndex, columnIndex, header, itemState);
+            e.DrawText();
+            e.DrawText(TextFormatFlags.Left);
         }
 
         [Theory]
         [InlineData(-2)]
         [InlineData(0)]
         [InlineData(1)]
-        public void DrawText_NullItemNonMinusOneItemIndex_Nop(int itemIndex)
+        public void DrawListViewSubItemEventArgs_DrawText_NullItemNonMinusOneItemIndex_Nop(int itemIndex)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -206,41 +229,27 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [Fact]
-        public void DrawText_NullItemMinusOneItemIndex_ThrowsNullReferenceException()
-        {
-            using (var image = new Bitmap(10, 10))
-            using (Graphics graphics = Graphics.FromImage(image))
-            {
-                var e = new DrawListViewSubItemEventArgs(graphics, new Rectangle(1, 2, 3, 4), null, new ListViewItem.ListViewSubItem(), -1, 0, new ColumnHeader(), ListViewItemStates.Checked);
-                Assert.Throws<NullReferenceException>(() => e.DrawText());
-                Assert.Throws<NullReferenceException>(() => e.DrawText(TextFormatFlags.Left));
-            }
-        }
-
         [Theory]
-        [InlineData(-2)]
-        [InlineData(0)]
-        [InlineData(1)]
-        public void DrawText_NullSubItemNonMinusOneItemIndex_ThrowsNullReferenceException(int itemIndex)
+        [MemberData(nameof(NullItemOrSubItem_TestData))]
+        public void DrawListViewSubItemEventArgs_DrawText_NullItemOrSubItem_Nop(Rectangle bounds, ListViewItem item, ListViewItem.ListViewSubItem subItem, int itemIndex, int columnIndex, ColumnHeader header, ListViewItemStates itemStates)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                var e = new DrawListViewSubItemEventArgs(graphics, new Rectangle(1, 2, 3, 4), new ListViewItem(), null, itemIndex, 0, new ColumnHeader(), ListViewItemStates.Checked);
-                Assert.Throws<NullReferenceException>(() => e.DrawText());
-                Assert.Throws<NullReferenceException>(() => e.DrawText(TextFormatFlags.Left));
+                var e = new DrawListViewSubItemEventArgs(graphics, bounds, item, subItem, itemIndex, columnIndex, header, itemStates);
+                e.DrawText();
+                e.DrawText(TextFormatFlags.Left);
             }
         }
 
         [Fact]
-        public void DrawText_NullHeading_ThrowsNullReferenceException()
+        public void DrawListViewSubItemEventArgs_DrawText_NullHeading_Nop()
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
                 var e = new DrawListViewSubItemEventArgs(graphics, new Rectangle(1, 2, 3, 4), new ListViewItem(), new ListViewItem.ListViewSubItem(), 0, 0, null, ListViewItemStates.Checked);
-                Assert.Throws<NullReferenceException>(() => e.DrawText());
+                e.DrawText();
                 e.DrawText(TextFormatFlags.Left);
             }
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DrawListViewSubItemEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DrawListViewSubItemEventArgsTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Drawing;
+using WinForms.Common.Tests;
 using Xunit;
 
 namespace System.Windows.Forms.Tests
@@ -12,34 +13,64 @@ namespace System.Windows.Forms.Tests
     {
         public static IEnumerable<object[]> Ctor_Graphics_ListViewItem_Rectangle_Int_ListViewItemStates_TestData()
         {
-            var image = new Bitmap(10, 10);
-            Graphics graphics = Graphics.FromImage(image);
-
-            yield return new object[] { null, Rectangle.Empty, null, null, -2, -2, null, (ListViewItemStates)(ListViewItemStates.Checked - 1) };
-            yield return new object[] { graphics, new Rectangle(1, 2, 3, 4), new ListViewItem(), null, -1, -1, new ColumnHeader(), ListViewItemStates.Checked };
-            yield return new object[] { graphics, new Rectangle(-1, 2, -3, -4), new ListViewItem(), new ListViewItem.ListViewSubItem(), 0, 0, new ColumnHeader(), ListViewItemStates.Focused };
-            yield return new object[] { graphics, new Rectangle(1, 2, 3, 4), new ListViewItem(), new ListViewItem.ListViewSubItem(), 1, 2, new ColumnHeader(), ListViewItemStates.Checked };
+            yield return new object[] { Rectangle.Empty, null, new ListViewItem.ListViewSubItem(), -2, -2, null, (ListViewItemStates)(ListViewItemStates.Checked - 1) };
+            yield return new object[] { Rectangle.Empty, new ListViewItem(), new ListViewItem.ListViewSubItem(), -2, -2, null, (ListViewItemStates)(ListViewItemStates.Checked - 1) };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem(), null, -1, -1, new ColumnHeader(), ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem(), new ListViewItem.ListViewSubItem(), -1, -1, new ColumnHeader(), ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(-1, 2, -3, -4), new ListViewItem(), new ListViewItem.ListViewSubItem(), 0, 0, new ColumnHeader(), ListViewItemStates.Focused };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem(), new ListViewItem.ListViewSubItem(), 1, 2, new ColumnHeader(), ListViewItemStates.Checked };
         }
 
         [Theory]
         [MemberData(nameof(Ctor_Graphics_ListViewItem_Rectangle_Int_ListViewItemStates_TestData))]
-        public void DrawListViewSubItemEventArgs_Ctor_Graphics_ListViewItem_Rectangle_Int_ListViewItemStates(Graphics graphics, Rectangle bounds, ListViewItem item, ListViewItem.ListViewSubItem subItem, int itemIndex, int columnIndex, ColumnHeader header, ListViewItemStates itemState)
+        public void DrawListViewSubItemEventArgs_Ctor_Graphics_ListViewItem_Rectangle_Int_ListViewItemStates(Rectangle bounds, ListViewItem item, ListViewItem.ListViewSubItem subItem, int itemIndex, int columnIndex, ColumnHeader header, ListViewItemStates itemState)
         {
-            var e = new DrawListViewSubItemEventArgs(graphics, bounds, item, subItem, itemIndex, columnIndex, header, itemState);
-            Assert.Equal(graphics, e.Graphics);
-            Assert.Equal(bounds, e.Bounds);
-            Assert.Equal(item, e.Item);
-            Assert.Equal(subItem, e.SubItem);
-            Assert.Equal(itemIndex, e.ItemIndex);
-            Assert.Equal(columnIndex, e.ColumnIndex);
-            Assert.Equal(header, e.Header);
-            Assert.Equal(itemState, e.ItemState);
-            Assert.False(e.DrawDefault);
+            using (var image = new Bitmap(10, 10))
+            using (Graphics graphics = Graphics.FromImage(image))
+            {
+                var e = new DrawListViewSubItemEventArgs(graphics, bounds, item, subItem, itemIndex, columnIndex, header, itemState);
+                Assert.Same(graphics, e.Graphics);
+                Assert.Equal(bounds, e.Bounds);
+                Assert.Same(item, e.Item);
+                Assert.Same(subItem, e.SubItem);
+                Assert.Equal(itemIndex, e.ItemIndex);
+                Assert.Equal(columnIndex, e.ColumnIndex);
+                Assert.Same(header, e.Header);
+                Assert.Equal(itemState, e.ItemState);
+                Assert.False(e.DrawDefault);
+            }
+        }
+
+        [Fact]
+        public void DrawListViewSubItemEventArgs_Ctor_NullGraphics_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("graphics", () => new DrawListViewSubItemEventArgs(null, new Rectangle(1, 2, 3, 4), new ListViewItem(), new ListViewItem.ListViewSubItem(), -1, 0, new ColumnHeader(), ListViewItemStates.Default));
+        }
+
+        [Fact]
+        public void DrawListViewSubItemEventArgs_Ctor_NullItemIndexNegativeOne_ThrowsArgumentNullException()
+        {
+            using (var image = new Bitmap(10, 10))
+            using (Graphics graphics = Graphics.FromImage(image))
+            {
+                Assert.Throws<ArgumentNullException>("item", () => new DrawListViewSubItemEventArgs(graphics, new Rectangle(1, 2, 3, 4), null, new ListViewItem.ListViewSubItem(), -1, 0, new ColumnHeader(), ListViewItemStates.Default));
+            }
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [InlineData(-2)]
+        [InlineData(0)]
+        public void DrawListViewSubItemEventArgs_Ctor_NullSubItemIndexNotNegativeOne_ThrowsArgumentNullException(int itemIndex)
+        {
+            using (var image = new Bitmap(10, 10))
+            using (Graphics graphics = Graphics.FromImage(image))
+            {
+                Assert.Throws<ArgumentNullException>("subItem", () => new DrawListViewSubItemEventArgs(graphics, new Rectangle(1, 2, 3, 4), new ListViewItem(), null, itemIndex, 0, new ColumnHeader(), ListViewItemStates.Default));
+            }
+        }
+
+        [Theory]
+        [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void DrawListViewSubItemEventArgs_DrawDefault_Set_GetReturnsExpected(bool value)
         {
             using (var image = new Bitmap(10, 10))
@@ -61,112 +92,63 @@ namespace System.Windows.Forms.Tests
             }
         }
 
+        public static IEnumerable<object[]> Draw_TestData()
+        {
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), new ListViewItem(), null, -1, null, ListViewItemStates.Default };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), new ListViewItem(), null, -1, null, ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), new ListViewItem(), null, -1, null, ListViewItemStates.Focused };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), new ListViewItem(), null, -1, new ColumnHeader(), ListViewItemStates.Default };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), new ListViewItem(), null, -1, new ColumnHeader(), ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), new ListViewItem(), null, -1, new ColumnHeader(), ListViewItemStates.Focused };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem(), null, -1, null, ListViewItemStates.Default };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem(), null, -1, null, ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem(), null, -1, null, ListViewItemStates.Focused };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem(), null, -1, new ColumnHeader(), ListViewItemStates.Default };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem(), null, -1, new ColumnHeader(), ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem(), null, -1, new ColumnHeader(), ListViewItemStates.Focused };
+
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, new ListViewItem.ListViewSubItem(), 0, null, ListViewItemStates.Default };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, new ListViewItem.ListViewSubItem(), 0, null, ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, new ListViewItem.ListViewSubItem(), 0, null, ListViewItemStates.Focused };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, new ListViewItem.ListViewSubItem(), 0, new ColumnHeader(), ListViewItemStates.Default };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, new ListViewItem.ListViewSubItem(), 0, new ColumnHeader(), ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, new ListViewItem.ListViewSubItem(), 0, new ColumnHeader(), ListViewItemStates.Focused };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), null, new ListViewItem.ListViewSubItem(), 0, null, ListViewItemStates.Default };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), null, new ListViewItem.ListViewSubItem(), 0, null, ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), null, new ListViewItem.ListViewSubItem(), 0, null, ListViewItemStates.Focused };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), null, new ListViewItem.ListViewSubItem(), 0, new ColumnHeader(), ListViewItemStates.Default };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), null, new ListViewItem.ListViewSubItem(), 0, new ColumnHeader(), ListViewItemStates.Checked };
+            yield return new object[] { new Rectangle(1, 2, 3, 4), null, new ListViewItem.ListViewSubItem(), 0, new ColumnHeader(), ListViewItemStates.Focused };
+        }
+
         [Theory]
-        [InlineData(-1)]
-        [InlineData(1)]
-        public void DrawListViewSubItemEventArgs_DrawBackground_HasGraphics_Success(int itemIndex)
+        [MemberData(nameof(Draw_TestData))]
+        public void DrawListViewSubItemEventArgs_DrawBackground_HasGraphics_Success(Rectangle bounds, ListViewItem item, ListViewItem.ListViewSubItem subItem, int itemIndex, ColumnHeader header, ListViewItemStates itemState)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                var e = new DrawListViewSubItemEventArgs(graphics, new Rectangle(1, 2, 3, 4), new ListViewItem(), new ListViewItem.ListViewSubItem(), itemIndex, 0, new ColumnHeader(), ListViewItemStates.Checked);
-                e.DrawBackground();
-            }
-        }
-
-        public static IEnumerable<object[]> NullGraphics_TestData()
-        {
-            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, null, -1, -1, null, ListViewItemStates.Default };
-            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, null, -1, -1, null, ListViewItemStates.Focused };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), null, null, 0, 0, null, ListViewItemStates.Checked };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), null, null, 0, 0, null, ListViewItemStates.Focused };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem(), new ListViewItem.ListViewSubItem(), 0, 0, new ColumnHeader(), ListViewItemStates.Checked };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem(), new ListViewItem.ListViewSubItem(), 0, 0, new ColumnHeader(), ListViewItemStates.Focused };
-        }
-
-        [Theory]
-        [MemberData(nameof(NullGraphics_TestData))]
-        public void DrawListViewSubItemEventArgs_DrawBackground_NullGraphics_Nop(Rectangle bounds, ListViewItem item, ListViewItem.ListViewSubItem subItem, int itemIndex, int columnIndex, ColumnHeader header, ListViewItemStates itemState)
-        {
-            var e = new DrawListViewSubItemEventArgs(null, bounds, item, subItem, itemIndex, columnIndex, header, itemState);
-            e.DrawBackground();
-        }
-
-        public static IEnumerable<object[]> NullItemOrSubItem_TestData()
-        {
-            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, null, -1, 0, null, ListViewItemStates.Default };
-            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, null, -1, 0, null, ListViewItemStates.Checked };
-            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, null, -1, 0, null, ListViewItemStates.Focused };
-            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, null, 0, 0, null, ListViewItemStates.Default };
-            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, null, 0, 0, null, ListViewItemStates.Checked };
-            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, null, 0, 0, null, ListViewItemStates.Focused };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), null, null, -2, 0, new ColumnHeader(), ListViewItemStates.Default };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), null, null, -2, 0, new ColumnHeader(), ListViewItemStates.Checked };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), null, null, -2, 0, new ColumnHeader(), ListViewItemStates.Focused };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), null, new ListViewItem.ListViewSubItem(), -1, 0, new ColumnHeader(), ListViewItemStates.Default };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), null, new ListViewItem.ListViewSubItem(), -1, 0, new ColumnHeader(), ListViewItemStates.Checked };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), null, new ListViewItem.ListViewSubItem(), -1, 0, new ColumnHeader(), ListViewItemStates.Focused };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), null, null, 0, 0, new ColumnHeader(), ListViewItemStates.Default };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), null, null, 0, 0, new ColumnHeader(), ListViewItemStates.Checked };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), null, null, 0, 0, new ColumnHeader(), ListViewItemStates.Focused };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem(), null, 0, 0, new ColumnHeader(), ListViewItemStates.Default };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem(), null, 0, 0, new ColumnHeader(), ListViewItemStates.Checked };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem(), null, 0, 0, new ColumnHeader(), ListViewItemStates.Focused };
-        }
-
-        [Theory]
-        [MemberData(nameof(NullItemOrSubItem_TestData))]
-        public void DrawListViewSubItemEventArgs_DrawBackground_NullItemOrSubItem_Nop(Rectangle bounds, ListViewItem item, ListViewItem.ListViewSubItem subItem, int itemIndex, int columnIndex, ColumnHeader header, ListViewItemStates itemStates)
-        {
-            using (var image = new Bitmap(10, 10))
-            using (Graphics graphics = Graphics.FromImage(image))
-            {
-                var e = new DrawListViewSubItemEventArgs(graphics, bounds, item, subItem, itemIndex, columnIndex, header, itemStates);
+                var e = new DrawListViewSubItemEventArgs(graphics, bounds, item, subItem, itemIndex, 0, header, itemState);
                 e.DrawBackground();
             }
         }
 
         [Theory]
-        [InlineData(ListViewItemStates.Checked)]
-        [InlineData(ListViewItemStates.Focused)]
-        public void DrawListViewSubItemEventArgs_DrawFocusRectangle_HasGraphics_Success(ListViewItemStates itemState)
+        [MemberData(nameof(Draw_TestData))]
+        public void DrawListViewSubItemEventArgs_DrawFocusRectangle_HasGraphics_Success(Rectangle bounds, ListViewItem item, ListViewItem.ListViewSubItem subItem, int itemIndex, ColumnHeader header, ListViewItemStates itemState)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                var e = new DrawListViewSubItemEventArgs(graphics, new Rectangle(1, 2, 3, 4), new ListViewItem(), new ListViewItem.ListViewSubItem(), 0, 0, new ColumnHeader(), itemState);
+                var e = new DrawListViewSubItemEventArgs(graphics, bounds, item, subItem, itemIndex, 0, header, itemState);
                 e.DrawFocusRectangle(new Rectangle(1, 2, 3, 4));
             }
         }
 
-        [Theory]
-        [MemberData(nameof(NullGraphics_TestData))]
-        public void DrawListViewSubItemEventArgs_DrawFocusRectangle_NullGraphics_Nop(Rectangle bounds, ListViewItem item, ListViewItem.ListViewSubItem subItem, int itemIndex, int columnIndex, ColumnHeader header, ListViewItemStates itemState)
+/*
+        public static IEnumerable<object[]> _TestData()
         {
-            var e = new DrawListViewSubItemEventArgs(null, bounds, item, subItem, itemIndex, columnIndex, header, itemState);
-            e.DrawFocusRectangle(new Rectangle(1, 2, 3, 4));
-        }
-
-        public static IEnumerable<object[]> NullItem_TestData()
-        {
-            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, -1, -1, null, ListViewItemStates.Default };
-            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, -1, -1, null, ListViewItemStates.Checked };
-            yield return new object[] { new Rectangle(-1, -2, -3, -4), null, -1, -1, null, ListViewItemStates.Focused };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem.ListViewSubItem(), 0, 0, new ColumnHeader(), ListViewItemStates.Default };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem.ListViewSubItem(), 0, 0, new ColumnHeader(), ListViewItemStates.Checked };
-            yield return new object[] { new Rectangle(1, 2, 3, 4), new ListViewItem.ListViewSubItem(), 0, 0, new ColumnHeader(), ListViewItemStates.Focused };
-        }
-
-        [Theory]
-        [MemberData(nameof(NullItem_TestData))]
-        public void DrawListViewSubItemEventArgs_DrawFocusRectangle_NullItem_Nop(Rectangle bounds, ListViewItem.ListViewSubItem subItem, int itemIndex, int columnIndex, ColumnHeader header, ListViewItemStates itemState)
-        {
-            using (var image = new Bitmap(10, 10))
-            using (Graphics graphics = Graphics.FromImage(image))
-            {
-                var e = new DrawListViewSubItemEventArgs(graphics, bounds, null, subItem, itemIndex, columnIndex, header, itemState);
-                e.DrawFocusRectangle(new Rectangle(1, 2, 3, 4));
-            }
+            
         }
 
         public static IEnumerable<object[]> DrawText_HasGraphicsWithoutFlags_TestData()
@@ -204,54 +186,6 @@ namespace System.Windows.Forms.Tests
                 e.DrawText(TextFormatFlags.Bottom);
             }
         }
-
-        [Theory]
-        [MemberData(nameof(NullGraphics_TestData))]
-        public void DrawListViewSubItemEventArgs_DrawText_NullGraphics_Nop(Rectangle bounds, ListViewItem item, ListViewItem.ListViewSubItem subItem, int itemIndex, int columnIndex, ColumnHeader header, ListViewItemStates itemState)
-        {
-            var e = new DrawListViewSubItemEventArgs(null, bounds, item, subItem, itemIndex, columnIndex, header, itemState);
-            e.DrawText();
-            e.DrawText(TextFormatFlags.Left);
-        }
-
-        [Theory]
-        [InlineData(-2)]
-        [InlineData(0)]
-        [InlineData(1)]
-        public void DrawListViewSubItemEventArgs_DrawText_NullItemNonMinusOneItemIndex_Nop(int itemIndex)
-        {
-            using (var image = new Bitmap(10, 10))
-            using (Graphics graphics = Graphics.FromImage(image))
-            {
-                var e = new DrawListViewSubItemEventArgs(graphics, new Rectangle(1, 2, 3, 4), null, new ListViewItem.ListViewSubItem(), itemIndex, 0, new ColumnHeader(), ListViewItemStates.Checked);
-                e.DrawText();
-                e.DrawText(TextFormatFlags.Left);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(NullItemOrSubItem_TestData))]
-        public void DrawListViewSubItemEventArgs_DrawText_NullItemOrSubItem_Nop(Rectangle bounds, ListViewItem item, ListViewItem.ListViewSubItem subItem, int itemIndex, int columnIndex, ColumnHeader header, ListViewItemStates itemStates)
-        {
-            using (var image = new Bitmap(10, 10))
-            using (Graphics graphics = Graphics.FromImage(image))
-            {
-                var e = new DrawListViewSubItemEventArgs(graphics, bounds, item, subItem, itemIndex, columnIndex, header, itemStates);
-                e.DrawText();
-                e.DrawText(TextFormatFlags.Left);
-            }
-        }
-
-        [Fact]
-        public void DrawListViewSubItemEventArgs_DrawText_NullHeading_Nop()
-        {
-            using (var image = new Bitmap(10, 10))
-            using (Graphics graphics = Graphics.FromImage(image))
-            {
-                var e = new DrawListViewSubItemEventArgs(graphics, new Rectangle(1, 2, 3, 4), new ListViewItem(), new ListViewItem.ListViewSubItem(), 0, 0, null, ListViewItemStates.Checked);
-                e.DrawText();
-                e.DrawText(TextFormatFlags.Left);
-            }
-        }
+ */
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DrawToolTipEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DrawToolTipEventArgsTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Drawing;
+using Moq;
 using Xunit;
 
 namespace System.Windows.Forms.Tests
@@ -16,8 +17,8 @@ namespace System.Windows.Forms.Tests
             Graphics graphics = Graphics.FromImage(image);
 
             yield return new object[] { null, null, null, Rectangle.Empty, null, Color.Empty, Color.Empty, null };
-            yield return new object[] { graphics, new SubWin32Window(), new Button(), new Rectangle(1, 2, 3, 4), "", Color.Red, Color.Blue, SystemFonts.DefaultFont };
-            yield return new object[] { graphics, new SubWin32Window(), new Button(), new Rectangle(-1, -2, -3, -4), "toolTipText", Color.Red, Color.Blue, SystemFonts.DefaultFont };
+            yield return new object[] { graphics, new Mock<IWin32Window>(MockBehavior.Strict).Object, new Button(), new Rectangle(1, 2, 3, 4), "", Color.Red, Color.Blue, SystemFonts.DefaultFont };
+            yield return new object[] { graphics, new Mock<IWin32Window>(MockBehavior.Strict).Object, new Button(), new Rectangle(-1, -2, -3, -4), "toolTipText", Color.Red, Color.Blue, SystemFonts.DefaultFont };
         }
 
         [Theory]
@@ -44,18 +45,25 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [Fact]
-        public void DrawBackground_NullGraphics_ThrowsNullReferenceException()
+        public static IEnumerable<object[]> NullGraphics_TestData()
         {
-            var e = new DrawToolTipEventArgs(null, new SubWin32Window(), new Button(), new Rectangle(1, 2, 3, 4), "tooltipText", Color.Red, Color.Blue, SystemFonts.DefaultFont);
-            Assert.Throws<NullReferenceException>(() => e.DrawBackground());
+            yield return new object[] { null, null, new Rectangle(-1, -2, -3, -4), "tooltipText", Color.Empty, Color.Empty, null };
+            yield return new object[] { new Mock<IWin32Window>(MockBehavior.Strict).Object, new Control(), new Rectangle(1, 2, 3, 4), "tooltipText", Color.Red, Color.Blue, SystemFonts.DefaultFont };
+        }
+
+        [Theory]
+        [MemberData(nameof(NullGraphics_TestData))]
+        public void DrawBackground_NullGraphics_Nop(IWin32Window associatedWindow, Control associatedControl, Rectangle bounds, string toolTipText, Color backColor, Color foreColor, Font font)
+        {
+            var e = new DrawToolTipEventArgs(null, associatedWindow, associatedControl, bounds, toolTipText, backColor, foreColor, font);
+            e.DrawBackground();
         }
 
         public static IEnumerable<object[]> DrawText_TestData()
         {
             yield return new object[] { "tooltipText", SystemFonts.DefaultFont };
             yield return new object[] { "tooltipText", null };
-            yield return new object[] { "", SystemFonts.DefaultFont };
+            yield return new object[] { string.Empty, SystemFonts.DefaultFont };
             yield return new object[] { null, SystemFonts.DefaultFont };
         }
 
@@ -83,12 +91,13 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [Fact]
-        public void DrawText_NullGraphics_ThrowsArgumentNullException()
+        [Theory]
+        [MemberData(nameof(NullGraphics_TestData))]
+        public void DrawText_NullGraphics_Nop(IWin32Window associatedWindow, Control associatedControl, Rectangle bounds, string toolTipText, Color backColor, Color foreColor, Font font)
         {
-            var e = new DrawToolTipEventArgs(null, new SubWin32Window(), new Button(), new Rectangle(1, 2, 3, 4), "tooltipText", Color.Red, Color.Blue, SystemFonts.DefaultFont);
-            Assert.Throws<ArgumentNullException>("dc", () => e.DrawText());
-            Assert.Throws<ArgumentNullException>("dc", () => e.DrawText(TextFormatFlags.Left));
+            var e = new DrawToolTipEventArgs(null, associatedWindow, associatedControl, bounds, toolTipText, backColor, foreColor, font);
+            e.DrawText();
+            e.DrawText(TextFormatFlags.Left);
         }
 
         [Fact]
@@ -102,11 +111,12 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [Fact]
-        public void DrawBorder_NullGraphics_ThrowsArgumentNullException()
+        [Theory]
+        [MemberData(nameof(NullGraphics_TestData))]
+        public void DrawBorder_NullGraphics_Nop(IWin32Window associatedWindow, Control associatedControl, Rectangle bounds, string toolTipText, Color backColor, Color foreColor, Font font)
         {
-            var e = new DrawToolTipEventArgs(null, new SubWin32Window(), new Button(), new Rectangle(1, 2, 3, 4), "tooltipText", Color.Red, Color.Blue, SystemFonts.DefaultFont);
-            Assert.Throws<ArgumentNullException>("graphics", () => e.DrawBorder());
+            var e = new DrawToolTipEventArgs(null, associatedWindow, associatedControl, bounds, toolTipText, backColor, foreColor, font);
+            e.DrawBorder();
         }
 
         private class SubWin32Window : IWin32Window

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DrawToolTipEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DrawToolTipEventArgsTests.cs
@@ -13,50 +13,48 @@ namespace System.Windows.Forms.Tests
     {
         public static IEnumerable<object[]> Ctor_Graphics_IWin32Window_Control_Rectangle_String_Color_Color_Font_TestData()
         {
-            var image = new Bitmap(10, 10);
-            Graphics graphics = Graphics.FromImage(image);
-
-            yield return new object[] { null, null, null, Rectangle.Empty, null, Color.Empty, Color.Empty, null };
-            yield return new object[] { graphics, new Mock<IWin32Window>(MockBehavior.Strict).Object, new Button(), new Rectangle(1, 2, 3, 4), "", Color.Red, Color.Blue, SystemFonts.DefaultFont };
-            yield return new object[] { graphics, new Mock<IWin32Window>(MockBehavior.Strict).Object, new Button(), new Rectangle(-1, -2, -3, -4), "toolTipText", Color.Red, Color.Blue, SystemFonts.DefaultFont };
+            yield return new object[] { null, null, Rectangle.Empty, null, Color.Empty, Color.Empty, null };
+            yield return new object[] { new Mock<IWin32Window>(MockBehavior.Strict).Object, new Button(), new Rectangle(1, 2, 3, 4), "", Color.Red, Color.Blue, SystemFonts.DefaultFont };
+            yield return new object[] { new Mock<IWin32Window>(MockBehavior.Strict).Object, new Button(), new Rectangle(-1, -2, -3, -4), "toolTipText", Color.Red, Color.Blue, SystemFonts.DefaultFont };
         }
 
         [Theory]
         [MemberData(nameof(Ctor_Graphics_IWin32Window_Control_Rectangle_String_Color_Color_Font_TestData))]
-        public void Ctor_Graphics_IWin32Window_Control_Rectangle_String_Color_Color_Font(Graphics graphics, IWin32Window associatedWindow, Control associatedControl, Rectangle bounds, string toolTipText, Color backColor, Color foreColor, Font font)
-        {
-            var e = new DrawToolTipEventArgs(graphics, associatedWindow, associatedControl, bounds, toolTipText, backColor, foreColor, font);
-            Assert.Equal(graphics, e.Graphics);
-            Assert.Equal(associatedWindow, e.AssociatedWindow);
-            Assert.Equal(associatedControl, e.AssociatedControl);
-            Assert.Equal(bounds, e.Bounds);
-            Assert.Equal(toolTipText, e.ToolTipText);
-            Assert.Equal(font, e.Font);
-        }
-
-        [Fact]
-        public void DrawBackground_Invoke_Success()
+        public void Ctor_Graphics_IWin32Window_Control_Rectangle_String_Color_Color_Font(IWin32Window associatedWindow, Control associatedControl, Rectangle bounds, string toolTipText, Color backColor, Color foreColor, Font font)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                var e = new DrawToolTipEventArgs(graphics, new SubWin32Window(), new Button(), new Rectangle(1, 2, 3, 4), "tooltipText", Color.Red, Color.Blue, SystemFonts.DefaultFont);
-                e.DrawBackground();
+                var e = new DrawToolTipEventArgs(graphics, associatedWindow, associatedControl, bounds, toolTipText, backColor, foreColor, font);
+                Assert.Same(graphics, e.Graphics);
+                Assert.Same(associatedWindow, e.AssociatedWindow);
+                Assert.Same(associatedControl, e.AssociatedControl);
+                Assert.Equal(bounds, e.Bounds);
+                Assert.Equal(toolTipText, e.ToolTipText);
+                Assert.Same(font, e.Font);
             }
         }
 
-        public static IEnumerable<object[]> NullGraphics_TestData()
+        public static IEnumerable<object[]> Draw_TestData()
         {
+            yield return new object[] { null, null, new Rectangle(-1, -2, -3, -4), null, Color.Empty, Color.Empty, null };
+            yield return new object[] { null, null, new Rectangle(-1, -2, -3, -4), string.Empty, Color.Empty, Color.Empty, null };
             yield return new object[] { null, null, new Rectangle(-1, -2, -3, -4), "tooltipText", Color.Empty, Color.Empty, null };
-            yield return new object[] { new Mock<IWin32Window>(MockBehavior.Strict).Object, new Control(), new Rectangle(1, 2, 3, 4), "tooltipText", Color.Red, Color.Blue, SystemFonts.DefaultFont };
+            yield return new object[] { new SubWin32Window(), new Button(), new Rectangle(1, 2, 3, 4), null, Color.Red, Color.Blue, SystemFonts.DefaultFont };
+            yield return new object[] { new SubWin32Window(), new Button(), new Rectangle(1, 2, 3, 4), string.Empty, Color.Red, Color.Blue, SystemFonts.DefaultFont };
+            yield return new object[] { new SubWin32Window(), new Button(), new Rectangle(1, 2, 3, 4), "tooltipText", Color.Red, Color.Blue, SystemFonts.DefaultFont };
         }
 
         [Theory]
-        [MemberData(nameof(NullGraphics_TestData))]
-        public void DrawBackground_NullGraphics_Nop(IWin32Window associatedWindow, Control associatedControl, Rectangle bounds, string toolTipText, Color backColor, Color foreColor, Font font)
+        [MemberData(nameof(Draw_TestData))]
+        public void DrawBackground_Invoke_Success(IWin32Window associatedWindow, Control associatedControl, Rectangle bounds, string toolTipText, Color backColor, Color foreColor, Font font)
         {
-            var e = new DrawToolTipEventArgs(null, associatedWindow, associatedControl, bounds, toolTipText, backColor, foreColor, font);
-            e.DrawBackground();
+            using (var image = new Bitmap(10, 10))
+            using (Graphics graphics = Graphics.FromImage(image))
+            {
+                var e = new DrawToolTipEventArgs(graphics, associatedWindow, associatedControl, bounds, toolTipText, backColor, foreColor, font);
+                e.DrawBackground();
+            }
         }
 
         public static IEnumerable<object[]> DrawText_TestData()
@@ -68,55 +66,39 @@ namespace System.Windows.Forms.Tests
         }
 
         [Theory]
-        [MemberData(nameof(DrawText_TestData))]
-        public void DrawText_HasGraphicsWithoutFlags_Success(string tooltipText, Font font)
+        [MemberData(nameof(Draw_TestData))]
+        public void DrawText_Invoke_Success(IWin32Window associatedWindow, Control associatedControl, Rectangle bounds, string toolTipText, Color backColor, Color foreColor, Font font)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                var e = new DrawToolTipEventArgs(graphics, new SubWin32Window(), new Button(), new Rectangle(1, 2, 3, 4), tooltipText, Color.Red, Color.Blue, font);
+                var e = new DrawToolTipEventArgs(graphics, associatedWindow, associatedControl, bounds, toolTipText, backColor, foreColor, font);
                 e.DrawText();
             }
         }
 
         [Theory]
-        [MemberData(nameof(DrawText_TestData))]
-        public void DrawText_HasGraphicsWithFlags_Success(string tooltipText, Font font)
+        [MemberData(nameof(Draw_TestData))]
+        public void DrawText_InvokeTextFormatFlags_Success(IWin32Window associatedWindow, Control associatedControl, Rectangle bounds, string toolTipText, Color backColor, Color foreColor, Font font)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                var e = new DrawToolTipEventArgs(graphics, new SubWin32Window(), new Button(), new Rectangle(1, 2, 3, 4), tooltipText, Color.Red, Color.Blue, font);
+                var e = new DrawToolTipEventArgs(graphics, associatedWindow, associatedControl, bounds, toolTipText, backColor, foreColor, font);
                 e.DrawText(TextFormatFlags.Bottom);
             }
         }
 
         [Theory]
-        [MemberData(nameof(NullGraphics_TestData))]
-        public void DrawText_NullGraphics_Nop(IWin32Window associatedWindow, Control associatedControl, Rectangle bounds, string toolTipText, Color backColor, Color foreColor, Font font)
-        {
-            var e = new DrawToolTipEventArgs(null, associatedWindow, associatedControl, bounds, toolTipText, backColor, foreColor, font);
-            e.DrawText();
-            e.DrawText(TextFormatFlags.Left);
-        }
-
-        [Fact]
-        public void DrawBorder_Invoke_Success()
+        [MemberData(nameof(Draw_TestData))]
+        public void DrawBorder_Invoke_Success(IWin32Window associatedWindow, Control associatedControl, Rectangle bounds, string toolTipText, Color backColor, Color foreColor, Font font)
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                var e = new DrawToolTipEventArgs(graphics, new SubWin32Window(), new Button(), new Rectangle(1, 2, 3, 4), "tooltipText", Color.Red, Color.Blue, SystemFonts.DefaultFont);
+                var e = new DrawToolTipEventArgs(graphics, associatedWindow, associatedControl, bounds, toolTipText, backColor, foreColor, font);
                 e.DrawBorder();
             }
-        }
-
-        [Theory]
-        [MemberData(nameof(NullGraphics_TestData))]
-        public void DrawBorder_NullGraphics_Nop(IWin32Window associatedWindow, Control associatedControl, Rectangle bounds, string toolTipText, Color backColor, Color foreColor, Font font)
-        {
-            var e = new DrawToolTipEventArgs(null, associatedWindow, associatedControl, bounds, toolTipText, backColor, foreColor, font);
-            e.DrawBorder();
         }
 
         private class SubWin32Window : IWin32Window

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/StatusBarDrawItemEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/StatusBarDrawItemEventArgsTests.cs
@@ -12,56 +12,58 @@ namespace System.Windows.Forms.Tests
     {
         public static IEnumerable<object[]> Ctor_Graphics_Font_Rectangle_Int_DrawItemState_StatusBarPanel_TestData()
         {
-            var image = new Bitmap(10, 10);
-            Graphics graphics = Graphics.FromImage(image);
-
-            yield return new object[] { null, null, Rectangle.Empty, -2, (DrawItemState)(DrawItemState.None - 1), null };
-            yield return new object[] { graphics, SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), -1, DrawItemState.None, new StatusBarPanel() };
-            yield return new object[] { graphics, SystemFonts.DefaultFont, new Rectangle(-1, 2, -3, -4), 0, DrawItemState.Selected, new StatusBarPanel() };
-            yield return new object[] { graphics, SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), 1, DrawItemState.Focus, new StatusBarPanel() };
-            yield return new object[] { graphics, SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), 1, DrawItemState.Focus | DrawItemState.NoFocusRect, new StatusBarPanel() };
+            yield return new object[] { null, Rectangle.Empty, -2, (DrawItemState)(DrawItemState.None - 1), null, SystemColors.HighlightText, SystemColors.Highlight };
+            yield return new object[] { SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), -1, DrawItemState.None, new StatusBarPanel(), SystemColors.WindowText, SystemColors.Window };
+            yield return new object[] { SystemFonts.DefaultFont, new Rectangle(-1, 2, -3, -4), 0, DrawItemState.Selected, new StatusBarPanel(), SystemColors.HighlightText, SystemColors.Highlight };
+            yield return new object[] { SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), 1, DrawItemState.Focus, new StatusBarPanel(), SystemColors.WindowText, SystemColors.Window };
+            yield return new object[] { SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), 1, DrawItemState.Focus | DrawItemState.NoFocusRect, new StatusBarPanel(), SystemColors.WindowText, SystemColors.Window };
         }
 
         [Theory]
         [MemberData(nameof(Ctor_Graphics_Font_Rectangle_Int_DrawItemState_StatusBarPanel_TestData))]
-        public void Ctor_Graphics_Font_Rectangle_Int_DrawItemState_StatusBarPanel(Graphics graphics, Font font, Rectangle rect, int index, DrawItemState state, StatusBarPanel panel)
+        public void StatusBarDrawItemEventArgs_Ctor_Graphics_Font_Rectangle_Int_DrawItemState_StatusBarPanel(Font font, Rectangle rect, int index, DrawItemState state, StatusBarPanel panel, Color expectedForeColor, Color expectedBackColor)
         {
-            var e = new StatusBarDrawItemEventArgs(graphics, font, rect, index, state, panel);
-            Assert.Equal(graphics, e.Graphics);
-            Assert.Equal(font, e.Font);
-            Assert.Equal(rect, e.Bounds);
-            Assert.Equal(index, e.Index);
-            Assert.Equal(state, e.State);
-            Assert.Equal(panel, e.Panel);
-            Assert.Equal((state & DrawItemState.Selected) == DrawItemState.Selected ? SystemColors.HighlightText : SystemColors.WindowText, e.ForeColor);
-            Assert.Equal((state & DrawItemState.Selected) == DrawItemState.Selected ? SystemColors.Highlight : SystemColors.Window, e.BackColor);
+            using (var image = new Bitmap(10, 10))
+            using (Graphics graphics = Graphics.FromImage(image))
+            {
+                var e = new StatusBarDrawItemEventArgs(graphics, font, rect, index, state, panel);
+                Assert.Same(graphics, e.Graphics);
+                Assert.Same(font, e.Font);
+                Assert.Equal(rect, e.Bounds);
+                Assert.Equal(index, e.Index);
+                Assert.Equal(state, e.State);
+                Assert.Same(panel, e.Panel);
+                Assert.Equal(expectedForeColor, e.ForeColor);
+                Assert.Equal(expectedBackColor, e.BackColor);
+            }
         }
 
         public static IEnumerable<object[]> Ctor_Graphics_Font_Rectangle_Int_DrawItemState_StatusBarPanel_Color_Color_TestData()
         {
-            var image = new Bitmap(10, 10);
-            Graphics graphics = Graphics.FromImage(image);
-
-            yield return new object[] { null, null, Rectangle.Empty, -2, (DrawItemState)(DrawItemState.None - 1), null, Color.Empty, Color.Empty };
-            yield return new object[] { graphics, SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), -1, DrawItemState.None, new StatusBarPanel(), Color.Red, Color.Blue };
-            yield return new object[] { graphics, SystemFonts.DefaultFont, new Rectangle(-1, 2, -3, -4), 0, DrawItemState.Selected, new StatusBarPanel(), Color.Red, Color.Blue };
-            yield return new object[] { graphics, SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), 1, DrawItemState.Focus, new StatusBarPanel(), Color.Red, Color.Blue };
-            yield return new object[] { graphics, SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), 1, DrawItemState.Focus | DrawItemState.NoFocusRect, new StatusBarPanel(), Color.Red, Color.Blue };
+            yield return new object[] { null, Rectangle.Empty, -2, (DrawItemState)(DrawItemState.None - 1), null, Color.Empty, Color.Empty, SystemColors.HighlightText, SystemColors.Highlight };
+            yield return new object[] { SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), -1, DrawItemState.None, new StatusBarPanel(), Color.Red, Color.Blue, Color.Red, Color.Blue };
+            yield return new object[] { SystemFonts.DefaultFont, new Rectangle(-1, 2, -3, -4), 0, DrawItemState.Selected, new StatusBarPanel(), Color.Red, Color.Blue, SystemColors.HighlightText, SystemColors.Highlight };
+            yield return new object[] { SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), 1, DrawItemState.Focus, new StatusBarPanel(), Color.Red, Color.Blue, Color.Red, Color.Blue };
+            yield return new object[] { SystemFonts.DefaultFont, new Rectangle(1, 2, 3, 4), 1, DrawItemState.Focus | DrawItemState.NoFocusRect, new StatusBarPanel(), Color.Red, Color.Blue, Color.Red, Color.Blue };
         }
 
         [Theory]
         [MemberData(nameof(Ctor_Graphics_Font_Rectangle_Int_DrawItemState_StatusBarPanel_Color_Color_TestData))]
-        public void Ctor_Graphics_Font_Rectangle_Int_DrawItemState_StatusBarPanel_Color_Color(Graphics graphics, Font font, Rectangle rect, int index, DrawItemState state, StatusBarPanel panel, Color foreColor, Color backColor)
+        public void StatusBarDrawItemEventArgs_Ctor_Graphics_Font_Rectangle_Int_DrawItemState_StatusBarPanel_Color_Color(Font font, Rectangle rect, int index, DrawItemState state, StatusBarPanel panel, Color foreColor, Color backColor, Color expectedForeColor, Color expectedBackColor)
         {
-            var e = new StatusBarDrawItemEventArgs(graphics, font, rect, index, state, panel, foreColor, backColor);
-            Assert.Equal(graphics, e.Graphics);
-            Assert.Equal(font, e.Font);
-            Assert.Equal(rect, e.Bounds);
-            Assert.Equal(index, e.Index);
-            Assert.Equal(state, e.State);
-            Assert.Equal(panel, e.Panel);
-            Assert.Equal((state & DrawItemState.Selected) == DrawItemState.Selected ? SystemColors.HighlightText : foreColor, e.ForeColor);
-            Assert.Equal((state & DrawItemState.Selected) == DrawItemState.Selected ? SystemColors.Highlight : backColor, e.BackColor);
+            using (var image = new Bitmap(10, 10))
+            using (Graphics graphics = Graphics.FromImage(image))
+            {
+                var e = new StatusBarDrawItemEventArgs(graphics, font, rect, index, state, panel, foreColor, backColor);
+                Assert.Same(graphics, e.Graphics);
+                Assert.Same(font, e.Font);
+                Assert.Equal(rect, e.Bounds);
+                Assert.Equal(index, e.Index);
+                Assert.Equal(state, e.State);
+                Assert.Same(panel, e.Panel);
+                Assert.Equal(expectedForeColor, e.ForeColor);
+                Assert.Equal(expectedBackColor, e.BackColor);
+            }
         }
     }
 }


### PR DESCRIPTION
We would throw NREs in all DrawXYZ methods.

Discussion of alternatives which I am very happy to consider
- Return (i.e. nop) if Graphics is null
- Throws ANE in the constructor of the event args
- Throw something like an InvalidOperationException in the draw methods

I preferred to do a `nop`, as it appears to me the intention would be not to draw anything if you don't pass any graphics to the event args


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1453)