### PR TITLE
Fixing background color for MenuStrip/ContextMenuStrip/ToolStrip items

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolstripProfessionalRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolstripProfessionalRenderer.cs
@@ -584,7 +584,7 @@ namespace System.Windows.Forms
                         }
                         else
                         {
-                            using (Brush b = new SolidBrush(ColorTable.MenuItemSelected))
+                            using (Brush b = new LinearGradientBrush(bounds, ColorTable.MenuItemSelectedGradientBegin, ColorTable.MenuItemSelectedGradientEnd, LinearGradientMode.Vertical))
                             {
                                 g.FillRectangle(b, bounds);
                             }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1408

## Proposed changes

- Change background color for a drop-down menu item to a non-drop-down item background color (Change items color to the File color, see screenshots)

## Screenshots <!-- Remove this section if PR does not change UI -->

![image](https://user-images.githubusercontent.com/49272759/61867098-1d0f6900-aedf-11e9-8306-c74934debe36.png)


### Before

![image](https://user-images.githubusercontent.com/49272759/61867421-d9692f00-aedf-11e9-83f3-abbd4f601758.png)



### After

![image](https://user-images.githubusercontent.com/49272759/61867006-f18c7e80-aede-11e9-8d11-95a5e3b8bc39.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual UI testing


## Test environment(s) <!-- Remove any that don't apply -->
- .NET Core SDK (3.0.100-preview8-013392)
- Microsoft Windows [Version 10.0.18362.239]



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1468)