### PR TITLE
Fixing #1470: PageNumericUpDown accessible name is not correct

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripNumericUpDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripNumericUpDown.cs
@@ -39,6 +39,11 @@ namespace System.Windows.Forms
 
                 internal override object GetPropertyValue(int propertyID)
                 {
+                    if (propertyID == NativeMethods.UIA_NamePropertyId)
+                    {
+                        return Name;
+                    }
+
                     if (propertyID == NativeMethods.UIA_ControlTypePropertyId)
                     {
                         return NativeMethods.UIA_SpinnerControlTypeId;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1470 


## Proposed changes

- Adding accessible name providing by ToolStripNumericUpDownAccessibleObject.
- Accessible name is provided by default when we are in MSAA mode.
- In UIA mode we need to explicitly provide accessible name.
- Accessible name is stored in Name property of AccessibleObject, passed it to the main UIA entry point - GetPropertyValue method. 


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Please see #1470 

![image](https://user-images.githubusercontent.com/23213980/61881625-9c149980-aeff-11e9-849e-950fee51df75.png)


### After

![image](https://user-images.githubusercontent.com/23213980/61881696-be0e1c00-aeff-11e9-839d-63152e3f2f89.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual testing.
- Need an approval from QA team.
- Unit test to be implemented.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

.NET Core SDK (reflecting any global.json):
Version: 3.0.100-preview8-012929
Commit: 795f8aeaa8
Runtime Environment:
OS Name: Windows
OS Version: 10.0.18362
OS Platform: Windows
RID: win10-x64
Base Path: C:\Program Files\dotnet\sdk\3.0.100-preview8-012929\


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1471)