### PR TITLE
Break up Control class

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/CheckableControlBaseAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/CheckableControlBaseAdapter.cs
@@ -89,8 +89,7 @@ namespace System.Windows.Forms.ButtonInternal
             if (DpiHelper.IsPerMonitorV2Awareness
                 && control != null && control.IsHandleCreated)
             {
-
-                return control.deviceDpi / DpiHelper.LogicalDpi;
+                return control._deviceDpi / DpiHelper.LogicalDpi;
             }
 
             if (g == null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -6317,7 +6317,7 @@ namespace System.Windows.Forms
                 Offset2Pixels = comboBox.LogicalToDeviceUnits(OFFSET_2PIXELS);
 
                 clientRect = comboBox.ClientRectangle;
-                int dropDownButtonWidth = SystemInformation.GetHorizontalScrollBarArrowWidthForDpi(comboBox.deviceDpi);
+                int dropDownButtonWidth = SystemInformation.GetHorizontalScrollBarArrowWidthForDpi(comboBox._deviceDpi);
                 outerBorder = new Rectangle(clientRect.Location, new Size(clientRect.Width - 1, clientRect.Height - 1));
                 innerBorder = new Rectangle(outerBorder.X + 1, outerBorder.Y + 1, outerBorder.Width - dropDownButtonWidth - 2, outerBorder.Height - 2);
                 innerInnerBorder = new Rectangle(innerBorder.X + 1, innerBorder.Y + 1, innerBorder.Width - 2, innerBorder.Height - 2);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -319,7 +319,7 @@ namespace System.Windows.Forms
                             // Screen Dpi
                             if (DpiHelper.IsPerMonitorV2Awareness)
                             {
-                                _currentAutoScaleDimensions = new SizeF((float)deviceDpi, (float)deviceDpi);
+                                _currentAutoScaleDimensions = new SizeF((float)_deviceDpi, (float)_deviceDpi);
                             }
                             else
                             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXFontMarshaler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXFontMarshaler.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using System.Runtime.InteropServices;
+
+namespace System.Windows.Forms
+{
+    public partial class Control
+    {
+        /// <summary>
+        ///  This is a marshaler object that knows how to marshal IFont to Font
+        ///  and back.
+        /// </summary>
+        private class ActiveXFontMarshaler : ICustomMarshaler
+        {
+            private static ActiveXFontMarshaler s_instance;
+
+            public void CleanUpManagedData(object obj)
+            {
+            }
+
+            public void CleanUpNativeData(IntPtr pObj)
+            {
+                Marshal.Release(pObj);
+            }
+
+            internal static ICustomMarshaler GetInstance(string cookie)
+            {
+                if (s_instance == null)
+                {
+                    s_instance = new ActiveXFontMarshaler();
+                }
+                return s_instance;
+            }
+
+            public int GetNativeDataSize()
+                => -1; // not a value type, so use -1
+
+            public IntPtr MarshalManagedToNative(object obj)
+            {
+                Font font = (Font)obj;
+                NativeMethods.tagFONTDESC fontDesc = new NativeMethods.tagFONTDESC();
+                NativeMethods.LOGFONTW logFont = NativeMethods.LOGFONTW.FromFont(font);
+
+                fontDesc.lpstrName = font.Name;
+                fontDesc.cySize = (long)(font.SizeInPoints * 10000);
+                fontDesc.sWeight = (short)logFont.lfWeight;
+                fontDesc.sCharset = logFont.lfCharSet;
+                fontDesc.fItalic = font.Italic;
+                fontDesc.fUnderline = font.Underline;
+                fontDesc.fStrikethrough = font.Strikeout;
+
+                Guid iid = typeof(UnsafeNativeMethods.IFont).GUID;
+
+                UnsafeNativeMethods.IFont oleFont = UnsafeNativeMethods.OleCreateFontIndirect(fontDesc, ref iid);
+                IntPtr pFont = Marshal.GetIUnknownForObject(oleFont);
+
+                int hr = Marshal.QueryInterface(pFont, ref iid, out IntPtr pIFont);
+
+                Marshal.Release(pFont);
+
+                if (NativeMethods.Failed(hr))
+                {
+                    Marshal.ThrowExceptionForHR(hr);
+                }
+
+                return pIFont;
+            }
+
+            public object MarshalNativeToManaged(IntPtr pObj)
+            {
+                UnsafeNativeMethods.IFont nativeFont = (UnsafeNativeMethods.IFont)Marshal.GetObjectForIUnknown(pObj);
+                IntPtr hfont = nativeFont.GetHFont();
+
+                Font font;
+                try
+                {
+                    font = Font.FromHfont(hfont);
+                }
+                catch (Exception e)
+                {
+                    if (ClientUtils.IsSecurityOrCriticalException(e))
+                    {
+                        throw;
+                    }
+
+                    font = DefaultFont;
+                }
+
+                return font;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -1,0 +1,2607 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Drawing;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Text;
+using Microsoft.Win32;
+
+namespace System.Windows.Forms
+{
+    public partial class Control
+    {
+        /// <summary>
+        ///  This class holds all of the state data for an ActiveX control and
+        ///  supplies the implementation for many of the non-trivial methods.
+        /// </summary>
+        private class ActiveXImpl : MarshalByRefObject, IWindowTarget
+        {
+            private const int HiMetricPerInch = 2540;
+            private static readonly int s_viewAdviseOnlyOnce = BitVector32.CreateMask();
+            private static readonly int s_viewAdvisePrimeFirst = BitVector32.CreateMask(s_viewAdviseOnlyOnce);
+            private static readonly int s_eventsFrozen = BitVector32.CreateMask(s_viewAdvisePrimeFirst);
+            private static readonly int s_changingExtents = BitVector32.CreateMask(s_eventsFrozen);
+            private static readonly int s_saving = BitVector32.CreateMask(s_changingExtents);
+            private static readonly int s_isDirty = BitVector32.CreateMask(s_saving);
+            private static readonly int s_inPlaceActive = BitVector32.CreateMask(s_isDirty);
+            private static readonly int s_inPlaceVisible = BitVector32.CreateMask(s_inPlaceActive);
+            private static readonly int s_uiActive = BitVector32.CreateMask(s_inPlaceVisible);
+            private static readonly int s_uiDead = BitVector32.CreateMask(s_uiActive);
+            private static readonly int s_adjustingRect = BitVector32.CreateMask(s_uiDead);
+
+            private static Point s_logPixels = Point.Empty;
+            private static NativeMethods.tagOLEVERB[] s_axVerbs;
+
+            private static int s_globalActiveXCount = 0;
+            private static bool s_checkedIE;
+            private static bool s_isIE;
+
+            private readonly Control _control;
+            private readonly IWindowTarget _controlWindowTarget;
+            private IntPtr _clipRegion;
+            private UnsafeNativeMethods.IOleClientSite _clientSite;
+            private UnsafeNativeMethods.IOleInPlaceUIWindow _inPlaceUiWindow;
+            private UnsafeNativeMethods.IOleInPlaceFrame _inPlaceFrame;
+            private readonly ArrayList _adviseList;
+            private IAdviseSink _viewAdviseSink;
+            private BitVector32 _activeXState;
+            private readonly AmbientProperty[] _ambientProperties;
+            private IntPtr _accelTable;
+            private short _accelCount = -1;
+            private NativeMethods.COMRECT _adjustRect; // temporary rect used during OnPosRectChange && SetObjectRects
+
+            /// <summary>
+            ///  Creates a new ActiveXImpl.
+            /// </summary>
+            internal ActiveXImpl(Control control)
+            {
+                _control = control;
+
+                // We replace the control's window target with our own.  We
+                // do this so we can handle the UI Dead ambient property.
+                _controlWindowTarget = control.WindowTarget;
+                control.WindowTarget = this;
+
+                _adviseList = new ArrayList();
+                _activeXState = new BitVector32();
+                _ambientProperties = new AmbientProperty[] {
+                    new AmbientProperty("Font", NativeMethods.ActiveX.DISPID_AMBIENT_FONT),
+                    new AmbientProperty("BackColor", NativeMethods.ActiveX.DISPID_AMBIENT_BACKCOLOR),
+                    new AmbientProperty("ForeColor", NativeMethods.ActiveX.DISPID_AMBIENT_FORECOLOR)
+                };
+            }
+
+            /// <summary>
+            ///  Retrieves the ambient back color for the control.
+            /// </summary>
+            [Browsable(false), EditorBrowsable(EditorBrowsableState.Advanced), DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+            internal Color AmbientBackColor
+            {
+                get
+                {
+                    AmbientProperty prop = LookupAmbient(NativeMethods.ActiveX.DISPID_AMBIENT_BACKCOLOR);
+
+                    if (prop.Empty)
+                    {
+                        object obj = null;
+                        if (GetAmbientProperty(NativeMethods.ActiveX.DISPID_AMBIENT_BACKCOLOR, ref obj))
+                        {
+                            if (obj != null)
+                            {
+                                try
+                                {
+                                    Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Object color type=" + obj.GetType().FullName);
+                                    prop.Value = ColorTranslator.FromOle(Convert.ToInt32(obj, CultureInfo.InvariantCulture));
+                                }
+                                catch (Exception e)
+                                {
+                                    Debug.Fail("Failed to massage ambient back color to a Color", e.ToString());
+
+                                    if (ClientUtils.IsSecurityOrCriticalException(e))
+                                    {
+                                        throw;
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if (prop.Value == null)
+                    {
+                        return Color.Empty;
+                    }
+                    else
+                    {
+                        return (Color)prop.Value;
+                    }
+                }
+            }
+
+            /// <summary>
+            ///  Retrieves the ambient font for the control.
+            /// </summary>
+            [Browsable(false), EditorBrowsable(EditorBrowsableState.Advanced), DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+            internal Font AmbientFont
+            {
+                get
+                {
+                    AmbientProperty prop = LookupAmbient(NativeMethods.ActiveX.DISPID_AMBIENT_FONT);
+
+                    if (prop.Empty)
+                    {
+                        object obj = null;
+                        if (GetAmbientProperty(NativeMethods.ActiveX.DISPID_AMBIENT_FONT, ref obj))
+                        {
+                            try
+                            {
+                                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Object font type=" + obj.GetType().FullName);
+                                Debug.Assert(obj != null, "GetAmbientProperty failed");
+                                IntPtr hfont = IntPtr.Zero;
+
+                                UnsafeNativeMethods.IFont ifont = (UnsafeNativeMethods.IFont)obj;
+                                Font font = null;
+                                hfont = ifont.GetHFont();
+                                font = Font.FromHfont(hfont);
+                                prop.Value = font;
+                            }
+                            catch (Exception e)
+                            {
+                                if (ClientUtils.IsSecurityOrCriticalException(e))
+                                {
+                                    throw;
+                                }
+
+                                // Do NULL, so we just defer to the default font
+                                prop.Value = null;
+                            }
+                        }
+                    }
+
+                    return (Font)prop.Value;
+                }
+            }
+
+            /// <summary>
+            ///  Retrieves the ambient back color for the control.
+            /// </summary>
+            [Browsable(false), EditorBrowsable(EditorBrowsableState.Advanced), DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+            internal Color AmbientForeColor
+            {
+                get
+                {
+                    AmbientProperty prop = LookupAmbient(NativeMethods.ActiveX.DISPID_AMBIENT_FORECOLOR);
+
+                    if (prop.Empty)
+                    {
+                        object obj = null;
+                        if (GetAmbientProperty(NativeMethods.ActiveX.DISPID_AMBIENT_FORECOLOR, ref obj))
+                        {
+                            if (obj != null)
+                            {
+                                try
+                                {
+                                    Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Object color type=" + obj.GetType().FullName);
+                                    prop.Value = ColorTranslator.FromOle(Convert.ToInt32(obj, CultureInfo.InvariantCulture));
+                                }
+                                catch (Exception e)
+                                {
+                                    Debug.Fail("Failed to massage ambient fore color to a Color", e.ToString());
+
+                                    if (ClientUtils.IsSecurityOrCriticalException(e))
+                                    {
+                                        throw;
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if (prop.Value == null)
+                    {
+                        return Color.Empty;
+                    }
+                    else
+                    {
+                        return (Color)prop.Value;
+                    }
+                }
+            }
+
+            /// <summary>
+            ///  Determines if events should be frozen.
+            /// </summary>
+            [Browsable(false), EditorBrowsable(EditorBrowsableState.Advanced), DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+            internal bool EventsFrozen
+            {
+                get
+                {
+                    return _activeXState[s_eventsFrozen];
+                }
+                set
+                {
+                    _activeXState[s_eventsFrozen] = value;
+                }
+            }
+
+            /// <summary>
+            ///  Provides access to the parent window handle
+            ///  when we are UI active
+            /// </summary>
+            internal IntPtr HWNDParent { get; private set; }
+
+            /// <summary>
+            ///  Returns true if this app domain is running inside of IE.  The
+            ///  control must be sited for this to succeed (it will assert and
+            ///  return false if the control is not sited).
+            /// </summary>
+            internal bool IsIE
+            {
+                get
+                {
+                    if (!s_checkedIE)
+                    {
+                        if (_clientSite == null)
+                        {
+                            Debug.Fail("Do not reference IsIE property unless control is sited.");
+                            return false;
+                        }
+
+                        // First, is this a managed EXE?  If so, it will correctly shut down
+                        // the runtime.
+                        if (Assembly.GetEntryAssembly() == null)
+                        {
+                            // Now check for IHTMLDocument2
+
+                            if (NativeMethods.Succeeded(_clientSite.GetContainer(out UnsafeNativeMethods.IOleContainer container)) && container is NativeMethods.IHTMLDocument)
+                            {
+                                s_isIE = true;
+                                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceVerbose, "AxSource:IsIE running under IE");
+                            }
+
+                            if (container != null && Marshal.IsComObject(container))
+                            {
+                                Marshal.ReleaseComObject(container);
+                            }
+                        }
+
+                        s_checkedIE = true;
+                    }
+
+                    return s_isIE;
+                }
+            }
+
+            /// <summary>
+            ///  Retrieves the number of logical pixels per inch on the
+            ///  primary monitor.
+            /// </summary>
+            private Point LogPixels
+            {
+                get
+                {
+                    if (s_logPixels.IsEmpty)
+                    {
+                        s_logPixels = new Point();
+                        using ScreenDC dc = ScreenDC.Create();
+                        s_logPixels.X = Interop.Gdi32.GetDeviceCaps(dc, Interop.Gdi32.DeviceCapability.LOGPIXELSX);
+                        s_logPixels.Y = Interop.Gdi32.GetDeviceCaps(dc, Interop.Gdi32.DeviceCapability.LOGPIXELSY);
+                    }
+                    return s_logPixels;
+                }
+            }
+
+            /// <summary>
+            ///  Implements IOleObject::Advise
+            /// </summary>
+            internal int Advise(IAdviseSink pAdvSink)
+            {
+                _adviseList.Add(pAdvSink);
+                return _adviseList.Count;
+            }
+
+            /// <summary>
+            ///  Implements IOleObject::Close
+            /// </summary>
+            internal void Close(int dwSaveOption)
+            {
+                if (_activeXState[s_inPlaceActive])
+                {
+                    InPlaceDeactivate();
+                }
+
+                if ((dwSaveOption == NativeMethods.OLECLOSE_SAVEIFDIRTY ||
+                     dwSaveOption == NativeMethods.OLECLOSE_PROMPTSAVE) &&
+                    _activeXState[s_isDirty])
+                {
+
+                    if (_clientSite != null)
+                    {
+                        _clientSite.SaveObject();
+                    }
+                    SendOnSave();
+                }
+            }
+
+            /// <summary>
+            ///  Implements IOleObject::DoVerb
+            /// </summary>
+            internal void DoVerb(int iVerb, IntPtr lpmsg, UnsafeNativeMethods.IOleClientSite pActiveSite, int lindex, IntPtr hwndParent, NativeMethods.COMRECT lprcPosRect)
+            {
+                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceVerbose, "AxSource:ActiveXImpl:DoVerb(" + iVerb + ")");
+                switch (iVerb)
+                {
+                    case NativeMethods.OLEIVERB_SHOW:
+                    case NativeMethods.OLEIVERB_INPLACEACTIVATE:
+                    case NativeMethods.OLEIVERB_UIACTIVATE:
+                    case NativeMethods.OLEIVERB_PRIMARY:
+                        Debug.WriteLineIf(CompModSwitches.ActiveX.TraceVerbose, "DoVerb:Show, InPlaceActivate, UIActivate");
+                        InPlaceActivate(iVerb);
+
+                        // Now that we're active, send the lpmsg to the control if it
+                        // is valid.
+                        if (lpmsg != IntPtr.Zero)
+                        {
+                            NativeMethods.MSG msg = Marshal.PtrToStructure<NativeMethods.MSG>(lpmsg);
+                            Control target = _control;
+
+                            if (msg.hwnd != _control.Handle && msg.message >= Interop.WindowMessages.WM_MOUSEFIRST && msg.message <= Interop.WindowMessages.WM_MOUSELAST)
+                            {
+                                // Must translate message coordniates over to our HWND.  We first try
+                                IntPtr hwndMap = msg.hwnd == IntPtr.Zero ? hwndParent : msg.hwnd;
+                                NativeMethods.POINT pt = new NativeMethods.POINT
+                                {
+                                    x = NativeMethods.Util.LOWORD(msg.lParam),
+                                    y = NativeMethods.Util.HIWORD(msg.lParam)
+                                };
+                                UnsafeNativeMethods.MapWindowPoints(new HandleRef(null, hwndMap), new HandleRef(_control, _control.Handle), pt, 1);
+
+                                // check to see if this message should really go to a child
+                                //  control, and if so, map the point into that child's window
+                                //  coordinates
+                                Control realTarget = target.GetChildAtPoint(new Point(pt.x, pt.y));
+                                if (realTarget != null && realTarget != target)
+                                {
+                                    UnsafeNativeMethods.MapWindowPoints(new HandleRef(target, target.Handle), new HandleRef(realTarget, realTarget.Handle), pt, 1);
+                                    target = realTarget;
+                                }
+
+                                msg.lParam = NativeMethods.Util.MAKELPARAM(pt.x, pt.y);
+                            }
+
+#if DEBUG
+                            if (CompModSwitches.ActiveX.TraceVerbose)
+                            {
+                                Message m = Message.Create(msg.hwnd, msg.message, msg.wParam, msg.lParam);
+                                Debug.WriteLine("Valid message pointer passed, sending to control: " + m.ToString());
+                            }
+#endif
+
+                            if (msg.message == Interop.WindowMessages.WM_KEYDOWN && msg.wParam == (IntPtr)NativeMethods.VK_TAB)
+                            {
+                                target.SelectNextControl(null, Control.ModifierKeys != Keys.Shift, true, true, true);
+                            }
+                            else
+                            {
+                                target.SendMessage(msg.message, msg.wParam, msg.lParam);
+                            }
+                        }
+                        break;
+
+                    // These affect our visibility
+                    case NativeMethods.OLEIVERB_HIDE:
+                        Debug.WriteLineIf(CompModSwitches.ActiveX.TraceVerbose, "DoVerb:Hide");
+                        UIDeactivate();
+                        InPlaceDeactivate();
+                        if (_activeXState[s_inPlaceVisible])
+                        {
+                            SetInPlaceVisible(false);
+                        }
+                        break;
+
+                    // All other verbs are notimpl.
+                    default:
+                        Debug.WriteLineIf(CompModSwitches.ActiveX.TraceVerbose, "DoVerb:Other");
+                        ThrowHr(NativeMethods.E_NOTIMPL);
+                        break;
+                }
+            }
+
+            /// <summary>
+            ///  Implements IViewObject2::Draw.
+            /// </summary>
+            internal void Draw(int dwDrawAspect, int lindex, IntPtr pvAspect, NativeMethods.tagDVTARGETDEVICE ptd,
+                             IntPtr hdcTargetDev, IntPtr hdcDraw, NativeMethods.COMRECT prcBounds, NativeMethods.COMRECT lprcWBounds,
+                             IntPtr pfnContinue, int dwContinue)
+            {
+
+                // support the aspects required for multi-pass drawing
+                //
+                switch (dwDrawAspect)
+                {
+                    case NativeMethods.DVASPECT_CONTENT:
+                    case NativeMethods.DVASPECT_OPAQUE:
+                    case NativeMethods.DVASPECT_TRANSPARENT:
+                        break;
+                    default:
+                        ThrowHr(NativeMethods.DV_E_DVASPECT);
+                        break;
+                }
+
+                // We can paint to an enhanced metafile, but not all GDI / GDI+ is
+                // supported on classic metafiles.  We throw VIEW_E_DRAW in the hope that
+                // the caller figures it out and sends us a different DC.
+                //
+                int hdcType = UnsafeNativeMethods.GetObjectType(new HandleRef(null, hdcDraw));
+                if (hdcType == NativeMethods.OBJ_METADC)
+                {
+                    ThrowHr(NativeMethods.VIEW_E_DRAW);
+                }
+
+                Interop.RECT rc;
+                NativeMethods.POINT pVp = new NativeMethods.POINT();
+                NativeMethods.POINT pW = new NativeMethods.POINT();
+                NativeMethods.SIZE sWindowExt = new NativeMethods.SIZE();
+                NativeMethods.SIZE sViewportExt = new NativeMethods.SIZE();
+                int iMode = NativeMethods.MM_TEXT;
+
+                if (!_control.IsHandleCreated)
+                {
+                    _control.CreateHandle();
+                }
+
+                // if they didn't give us a rectangle, just copy over ours
+                //
+                if (prcBounds != null)
+                {
+                    rc = new Interop.RECT(prcBounds.left, prcBounds.top, prcBounds.right, prcBounds.bottom);
+
+                    // To draw to a given rect, we scale the DC in such a way as to
+                    // make the values it takes match our own happy MM_TEXT.  Then,
+                    // we back-convert prcBounds so that we convert it to this coordinate
+                    // system.  This puts us in the most similar coordinates as we currently
+                    // use.
+                    SafeNativeMethods.LPtoDP(new HandleRef(null, hdcDraw), ref rc, 2);
+
+                    iMode = SafeNativeMethods.SetMapMode(new HandleRef(null, hdcDraw), NativeMethods.MM_ANISOTROPIC);
+                    SafeNativeMethods.SetWindowOrgEx(new HandleRef(null, hdcDraw), 0, 0, pW);
+                    SafeNativeMethods.SetWindowExtEx(new HandleRef(null, hdcDraw), _control.Width, _control.Height, sWindowExt);
+                    SafeNativeMethods.SetViewportOrgEx(new HandleRef(null, hdcDraw), rc.left, rc.top, pVp);
+                    SafeNativeMethods.SetViewportExtEx(new HandleRef(null, hdcDraw), rc.right - rc.left, rc.bottom - rc.top, sViewportExt);
+                }
+
+                // Now do the actual drawing.  We must ask all of our children to draw as well.
+                try
+                {
+                    IntPtr flags = (IntPtr)(NativeMethods.PRF_CHILDREN
+                                    | NativeMethods.PRF_CLIENT
+                                    | NativeMethods.PRF_ERASEBKGND
+                                    | NativeMethods.PRF_NONCLIENT);
+
+                    if (hdcType != NativeMethods.OBJ_ENHMETADC)
+                    {
+                        _control.SendMessage(Interop.WindowMessages.WM_PRINT, hdcDraw, flags);
+                    }
+                    else
+                    {
+                        _control.PrintToMetaFile(new HandleRef(null, hdcDraw), flags);
+                    }
+                }
+                finally
+                {
+                    // And clean up the DC
+                    if (prcBounds != null)
+                    {
+                        SafeNativeMethods.SetWindowOrgEx(new HandleRef(null, hdcDraw), pW.x, pW.y, null);
+                        SafeNativeMethods.SetWindowExtEx(new HandleRef(null, hdcDraw), sWindowExt.cx, sWindowExt.cy, null);
+                        SafeNativeMethods.SetViewportOrgEx(new HandleRef(null, hdcDraw), pVp.x, pVp.y, null);
+                        SafeNativeMethods.SetViewportExtEx(new HandleRef(null, hdcDraw), sViewportExt.cx, sViewportExt.cy, null);
+                        SafeNativeMethods.SetMapMode(new HandleRef(null, hdcDraw), iMode);
+                    }
+                }
+            }
+
+            /// <summary>
+            ///  Returns a new verb enumerator.
+            /// </summary>
+            internal static int EnumVerbs(out UnsafeNativeMethods.IEnumOLEVERB e)
+            {
+                if (s_axVerbs == null)
+                {
+                    NativeMethods.tagOLEVERB verbShow = new NativeMethods.tagOLEVERB();
+                    NativeMethods.tagOLEVERB verbInplaceActivate = new NativeMethods.tagOLEVERB();
+                    NativeMethods.tagOLEVERB verbUIActivate = new NativeMethods.tagOLEVERB();
+                    NativeMethods.tagOLEVERB verbHide = new NativeMethods.tagOLEVERB();
+                    NativeMethods.tagOLEVERB verbPrimary = new NativeMethods.tagOLEVERB();
+                    NativeMethods.tagOLEVERB verbProperties = new NativeMethods.tagOLEVERB();
+
+                    verbShow.lVerb = NativeMethods.OLEIVERB_SHOW;
+                    verbInplaceActivate.lVerb = NativeMethods.OLEIVERB_INPLACEACTIVATE;
+                    verbUIActivate.lVerb = NativeMethods.OLEIVERB_UIACTIVATE;
+                    verbHide.lVerb = NativeMethods.OLEIVERB_HIDE;
+                    verbPrimary.lVerb = NativeMethods.OLEIVERB_PRIMARY;
+                    verbProperties.lVerb = NativeMethods.OLEIVERB_PROPERTIES;
+                    verbProperties.lpszVerbName = SR.AXProperties;
+                    verbProperties.grfAttribs = NativeMethods.ActiveX.OLEVERBATTRIB_ONCONTAINERMENU;
+
+                    s_axVerbs = new NativeMethods.tagOLEVERB[] {
+                        verbShow,
+                        verbInplaceActivate,
+                        verbUIActivate,
+                        verbHide,
+                        verbPrimary
+                    };
+                }
+
+                e = new ActiveXVerbEnum(s_axVerbs);
+                return NativeMethods.S_OK;
+            }
+
+            /// <summary>
+            ///  Converts the given string to a byte array.
+            /// </summary>
+            private static byte[] FromBase64WrappedString(string text)
+            {
+                if (text.IndexOfAny(new char[] { ' ', '\r', '\n' }) != -1)
+                {
+                    StringBuilder sb = new StringBuilder(text.Length);
+                    for (int i = 0; i < text.Length; i++)
+                    {
+                        switch (text[i])
+                        {
+                            case ' ':
+                            case '\r':
+                            case '\n':
+                                break;
+                            default:
+                                sb.Append(text[i]);
+                                break;
+                        }
+                    }
+                    return Convert.FromBase64String(sb.ToString());
+                }
+                else
+                {
+                    return Convert.FromBase64String(text);
+                }
+            }
+
+            /// <summary>
+            ///  Implements IViewObject2::GetAdvise.
+            /// </summary>
+            internal void GetAdvise(int[] paspects, int[] padvf, IAdviseSink[] pAdvSink)
+            {
+                // if they want it, give it to them
+                if (paspects != null)
+                {
+                    paspects[0] = NativeMethods.DVASPECT_CONTENT;
+                }
+
+                if (padvf != null)
+                {
+                    padvf[0] = 0;
+
+                    if (_activeXState[s_viewAdviseOnlyOnce])
+                    {
+                        padvf[0] |= NativeMethods.ADVF_ONLYONCE;
+                    }
+
+                    if (_activeXState[s_viewAdvisePrimeFirst])
+                    {
+                        padvf[0] |= NativeMethods.ADVF_PRIMEFIRST;
+                    }
+                }
+
+                if (pAdvSink != null)
+                {
+                    pAdvSink[0] = _viewAdviseSink;
+                }
+            }
+
+            /// <summary>
+            ///  Helper function to retrieve an ambient property.  Returns false if the
+            ///  property wasn't found.
+            /// </summary>
+            private bool GetAmbientProperty(int dispid, ref object obj)
+            {
+                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:GetAmbientProperty");
+                Debug.Indent();
+
+                if (_clientSite is UnsafeNativeMethods.IDispatch)
+                {
+                    Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "clientSite implements IDispatch");
+
+                    UnsafeNativeMethods.IDispatch disp = (UnsafeNativeMethods.IDispatch)_clientSite;
+                    object[] pvt = new object[1];
+                    Guid g = Guid.Empty;
+                    int hr = disp.Invoke(dispid, ref g, NativeMethods.LOCALE_USER_DEFAULT,
+                                        NativeMethods.DISPATCH_PROPERTYGET, new NativeMethods.tagDISPPARAMS(),
+                                        pvt, null, null);
+                    if (NativeMethods.Succeeded(hr))
+                    {
+                        Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "IDispatch::Invoke succeeded. VT=" + pvt[0].GetType().FullName);
+                        obj = pvt[0];
+                        Debug.Unindent();
+                        return true;
+                    }
+                    else
+                    {
+                        Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "IDispatch::Invoke failed. HR: 0x" + string.Format(CultureInfo.CurrentCulture, "{0:X}", hr));
+                    }
+                }
+
+                Debug.Unindent();
+                return false;
+            }
+
+            /// <summary>
+            ///  Implements IOleObject::GetClientSite.
+            /// </summary>
+            internal UnsafeNativeMethods.IOleClientSite GetClientSite()
+            {
+                return _clientSite;
+            }
+
+            internal int GetControlInfo(NativeMethods.tagCONTROLINFO pCI)
+            {
+                if (_accelCount == -1)
+                {
+                    ArrayList mnemonicList = new ArrayList();
+                    GetMnemonicList(_control, mnemonicList);
+
+                    _accelCount = (short)mnemonicList.Count;
+
+                    if (_accelCount > 0)
+                    {
+                        int accelSize = Marshal.SizeOf<NativeMethods.ACCEL>();
+
+                        // In the worst case we may have two accelerators per mnemonic:  one lower case and
+                        // one upper case, hence the * 2 below.
+                        //
+                        IntPtr accelBlob = Marshal.AllocHGlobal(accelSize * _accelCount * 2);
+
+                        try
+                        {
+                            NativeMethods.ACCEL accel = new NativeMethods.ACCEL
+                            {
+                                cmd = 0
+                            };
+
+                            Debug.Indent();
+
+                            _accelCount = 0;
+
+                            foreach (char ch in mnemonicList)
+                            {
+                                IntPtr structAddr = (IntPtr)((long)accelBlob + _accelCount * accelSize);
+
+                                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Mnemonic: " + ch.ToString());
+
+                                if (ch >= 'A' && ch <= 'Z')
+                                {
+                                    // Lower case letter
+                                    accel.fVirt = NativeMethods.FALT | NativeMethods.FVIRTKEY;
+                                    accel.key = (short)(UnsafeNativeMethods.VkKeyScan(ch) & 0x00FF);
+                                    Marshal.StructureToPtr(accel, structAddr, false);
+
+                                    // Upper case letter
+                                    _accelCount++;
+                                    structAddr = (IntPtr)((long)structAddr + accelSize);
+                                    accel.fVirt = NativeMethods.FALT | NativeMethods.FVIRTKEY | NativeMethods.FSHIFT;
+                                    Marshal.StructureToPtr(accel, structAddr, false);
+                                }
+                                else
+                                {
+                                    // Some non-printable character.
+                                    accel.fVirt = NativeMethods.FALT | NativeMethods.FVIRTKEY;
+                                    short scan = (short)(UnsafeNativeMethods.VkKeyScan(ch));
+                                    if ((scan & 0x0100) != 0)
+                                    {
+                                        accel.fVirt |= NativeMethods.FSHIFT;
+                                    }
+                                    accel.key = (short)(scan & 0x00FF);
+                                    Marshal.StructureToPtr(accel, structAddr, false);
+                                }
+
+                                accel.cmd++;
+                                _accelCount++;
+                            }
+
+                            Debug.Unindent();
+
+                            // Now create an accelerator table and then free our memory.
+
+                            if (_accelTable != IntPtr.Zero)
+                            {
+                                UnsafeNativeMethods.DestroyAcceleratorTable(new HandleRef(this, _accelTable));
+                                _accelTable = IntPtr.Zero;
+                            }
+
+                            _accelTable = UnsafeNativeMethods.CreateAcceleratorTable(new HandleRef(null, accelBlob), _accelCount);
+                        }
+                        finally
+                        {
+                            if (accelBlob != IntPtr.Zero)
+                            {
+                                Marshal.FreeHGlobal(accelBlob);
+                            }
+                        }
+                    }
+                }
+
+                pCI.cAccel = _accelCount;
+                pCI.hAccel = _accelTable;
+                return NativeMethods.S_OK;
+            }
+
+            /// <summary>
+            ///  Implements IOleObject::GetExtent.
+            /// </summary>
+            internal void GetExtent(int dwDrawAspect, NativeMethods.tagSIZEL pSizel)
+            {
+                if ((dwDrawAspect & NativeMethods.DVASPECT_CONTENT) != 0)
+                {
+                    Size size = _control.Size;
+
+                    Point pt = PixelToHiMetric(size.Width, size.Height);
+                    pSizel.cx = pt.X;
+                    pSizel.cy = pt.Y;
+                }
+                else
+                {
+                    ThrowHr(NativeMethods.DV_E_DVASPECT);
+                }
+            }
+
+            /// <summary>
+            ///  Searches the control hierarchy of the given control and adds
+            ///  the mnemonics for each control to mnemonicList.  Each mnemonic
+            ///  is added as a char to the list.
+            /// </summary>
+            private void GetMnemonicList(Control control, ArrayList mnemonicList)
+            {
+                // Get the mnemonic for our control
+                char mnemonic = WindowsFormsUtils.GetMnemonic(control.Text, true);
+                if (mnemonic != 0)
+                {
+                    mnemonicList.Add(mnemonic);
+                }
+
+                // And recurse for our children.
+                foreach (Control c in control.Controls)
+                {
+                    if (c != null)
+                    {
+                        GetMnemonicList(c, mnemonicList);
+                    }
+                }
+            }
+
+            /// <summary>
+            ///  Name to use for a stream: use the control's type name (max 31 chars, use the end chars
+            ///  if it's longer than that)
+            /// </summary>
+            private string GetStreamName()
+            {
+                string streamName = _control.GetType().FullName;
+                int len = streamName.Length;
+                if (len > 31)
+                {
+                    // The max allowed length of the stream name is 31.
+                    streamName = streamName.Substring(len - 31);
+                }
+                return streamName;
+            }
+
+            /// <summary>
+            ///  Implements IOleWindow::GetWindow
+            /// </summary>
+            internal int GetWindow(out IntPtr hwnd)
+            {
+                if (!_activeXState[s_inPlaceActive])
+                {
+                    hwnd = IntPtr.Zero;
+                    return NativeMethods.E_FAIL;
+                }
+                hwnd = _control.Handle;
+                return NativeMethods.S_OK;
+            }
+
+            /// <summary>
+            ///  Converts coordinates in HiMetric to pixels.  Used for ActiveX sourcing.
+            /// </summary>
+            private Point HiMetricToPixel(int x, int y)
+            {
+                Point pt = new Point
+                {
+                    X = (LogPixels.X * x + HiMetricPerInch / 2) / HiMetricPerInch,
+                    Y = (LogPixels.Y * y + HiMetricPerInch / 2) / HiMetricPerInch
+                };
+                return pt;
+            }
+
+            /// <summary>
+            ///  In place activates this Object.
+            /// </summary>
+            internal void InPlaceActivate(int verb)
+            {
+                // If we don't have a client site, then there's not much to do.
+                // We also punt if this isn't an in-place site, since we can't
+                // go active then.
+                if (!(_clientSite is UnsafeNativeMethods.IOleInPlaceSite inPlaceSite))
+                {
+                    return;
+                }
+
+                // If we're not already active, go and do it.
+                if (!_activeXState[s_inPlaceActive])
+                {
+                    Debug.WriteLineIf(CompModSwitches.ActiveX.TraceVerbose, "\tActiveXImpl:InPlaceActivate --> inplaceactive");
+
+                    int hr = inPlaceSite.CanInPlaceActivate();
+
+                    if (hr != NativeMethods.S_OK)
+                    {
+                        if (NativeMethods.Succeeded(hr))
+                        {
+                            hr = NativeMethods.E_FAIL;
+                        }
+                        ThrowHr(hr);
+                    }
+
+                    inPlaceSite.OnInPlaceActivate();
+
+                    _activeXState[s_inPlaceActive] = true;
+                }
+
+                // And if we're not visible, do that too.
+                if (!_activeXState[s_inPlaceVisible])
+                {
+                    Debug.WriteLineIf(CompModSwitches.ActiveX.TraceVerbose, "\tActiveXImpl:InPlaceActivate --> inplacevisible");
+                    NativeMethods.tagOIFI inPlaceFrameInfo = new NativeMethods.tagOIFI
+                    {
+                        cb = Marshal.SizeOf<NativeMethods.tagOIFI>()
+                    };
+                    IntPtr hwndParent = IntPtr.Zero;
+
+                    // We are entering a secure context here.
+                    hwndParent = inPlaceSite.GetWindow();
+
+                    NativeMethods.COMRECT posRect = new NativeMethods.COMRECT();
+                    NativeMethods.COMRECT clipRect = new NativeMethods.COMRECT();
+
+                    if (_inPlaceUiWindow != null && Marshal.IsComObject(_inPlaceUiWindow))
+                    {
+                        Marshal.ReleaseComObject(_inPlaceUiWindow);
+                        _inPlaceUiWindow = null;
+                    }
+
+                    if (_inPlaceFrame != null && Marshal.IsComObject(_inPlaceFrame))
+                    {
+                        Marshal.ReleaseComObject(_inPlaceFrame);
+                        _inPlaceFrame = null;
+                    }
+
+                    inPlaceSite.GetWindowContext(out UnsafeNativeMethods.IOleInPlaceFrame pFrame, out UnsafeNativeMethods.IOleInPlaceUIWindow pWindow, posRect, clipRect, inPlaceFrameInfo);
+
+                    SetObjectRects(posRect, clipRect);
+
+                    _inPlaceFrame = pFrame;
+                    _inPlaceUiWindow = pWindow;
+
+                    // We are parenting ourselves
+                    // directly to the host window.  The host must
+                    // implement the ambient property
+                    // DISPID_AMBIENT_MESSAGEREFLECT.
+                    // If it doesn't, that means that the host
+                    // won't reflect messages back to us.
+                    HWNDParent = hwndParent;
+                    UnsafeNativeMethods.SetParent(new HandleRef(_control, _control.Handle), new HandleRef(null, hwndParent));
+
+                    // Now create our handle if it hasn't already been done.
+                    _control.CreateControl();
+
+                    _clientSite.ShowObject();
+
+                    SetInPlaceVisible(true);
+                    Debug.Assert(_activeXState[s_inPlaceVisible], "Failed to set inplacevisible");
+                }
+
+                // if we weren't asked to UIActivate, then we're done.
+                if (verb != NativeMethods.OLEIVERB_PRIMARY && verb != NativeMethods.OLEIVERB_UIACTIVATE)
+                {
+                    Debug.WriteLineIf(CompModSwitches.ActiveX.TraceVerbose, "\tActiveXImpl:InPlaceActivate --> not becoming UIActive");
+                    return;
+                }
+
+                // if we're not already UI active, do sow now.
+                if (!_activeXState[s_uiActive])
+                {
+                    Debug.WriteLineIf(CompModSwitches.ActiveX.TraceVerbose, "\tActiveXImpl:InPlaceActivate --> uiactive");
+                    _activeXState[s_uiActive] = true;
+
+                    // inform the container of our intent
+                    inPlaceSite.OnUIActivate();
+
+                    // take the focus  [which is what UI Activation is all about !]
+                    if (!_control.ContainsFocus)
+                    {
+                        _control.Focus();
+                    }
+
+                    // set ourselves up in the host.
+                    Debug.Assert(_inPlaceFrame != null, "Setting us to visible should have created the in place frame");
+                    _inPlaceFrame.SetActiveObject(_control, null);
+                    if (_inPlaceUiWindow != null)
+                    {
+                        _inPlaceUiWindow.SetActiveObject(_control, null);
+                    }
+
+                    // we have to explicitly say we don't wany any border space.
+                    int hr = _inPlaceFrame.SetBorderSpace(null);
+                    if (NativeMethods.Failed(hr) && hr != NativeMethods.OLE_E_INVALIDRECT &&
+                        hr != NativeMethods.INPLACE_E_NOTOOLSPACE && hr != NativeMethods.E_NOTIMPL)
+                    {
+                        Marshal.ThrowExceptionForHR(hr);
+                    }
+
+                    if (_inPlaceUiWindow != null)
+                    {
+                        hr = _inPlaceFrame.SetBorderSpace(null);
+                        if (NativeMethods.Failed(hr) && hr != NativeMethods.OLE_E_INVALIDRECT &&
+                            hr != NativeMethods.INPLACE_E_NOTOOLSPACE && hr != NativeMethods.E_NOTIMPL)
+                        {
+                            Marshal.ThrowExceptionForHR(hr);
+                        }
+                    }
+                }
+                else
+                {
+                    Debug.WriteLineIf(CompModSwitches.ActiveX.TraceVerbose, "\tActiveXImpl:InPlaceActivate --> already uiactive");
+                }
+            }
+
+            /// <summary>
+            ///  Implements IOleInPlaceObject::InPlaceDeactivate.
+            /// </summary>
+            internal void InPlaceDeactivate()
+            {
+                // Only do this if we're already in place active.
+                if (!_activeXState[s_inPlaceActive])
+                {
+                    return;
+                }
+
+                // Deactivate us if we're UI active
+                if (_activeXState[s_uiActive])
+                {
+                    UIDeactivate();
+                }
+
+                // Some containers may call into us to save, and if we're still
+                // active we will try to deactivate and recurse back into the container.
+                // So, set the state bits here first.
+                _activeXState[s_inPlaceActive] = false;
+                _activeXState[s_inPlaceVisible] = false;
+
+                // Notify our site of our deactivation.
+                if (_clientSite is UnsafeNativeMethods.IOleInPlaceSite oleClientSite)
+                {
+                    oleClientSite.OnInPlaceDeactivate();
+                }
+
+                _control.Visible = false;
+                HWNDParent = IntPtr.Zero;
+
+                if (_inPlaceUiWindow != null && Marshal.IsComObject(_inPlaceUiWindow))
+                {
+                    Marshal.ReleaseComObject(_inPlaceUiWindow);
+                    _inPlaceUiWindow = null;
+                }
+
+                if (_inPlaceFrame != null && Marshal.IsComObject(_inPlaceFrame))
+                {
+                    Marshal.ReleaseComObject(_inPlaceFrame);
+                    _inPlaceFrame = null;
+                }
+            }
+
+            /// <summary>
+            ///  Implements IPersistStreamInit::IsDirty.
+            /// </summary>
+            internal int IsDirty()
+            {
+                if (_activeXState[s_isDirty])
+                {
+                    return NativeMethods.S_OK;
+                }
+                else
+                {
+                    return NativeMethods.S_FALSE;
+                }
+            }
+
+            /// <summary>
+            ///  Looks at the property to see if it should be loaded / saved as a resource or
+            ///  through a type converter.
+            /// </summary>
+            private bool IsResourceProp(PropertyDescriptor prop)
+            {
+                TypeConverter converter = prop.Converter;
+                Type[] convertTypes = new Type[] {
+                    typeof(string),
+                    typeof(byte[])
+                    };
+
+                foreach (Type t in convertTypes)
+                {
+                    if (converter.CanConvertTo(t) && converter.CanConvertFrom(t))
+                    {
+                        return false;
+                    }
+                }
+
+                // Finally, if the property can be serialized, it is a resource property.
+                return (prop.GetValue(_control) is ISerializable);
+            }
+
+            /// <summary>
+            ///  Implements IPersistStorage::Load
+            /// </summary>
+            internal void Load(UnsafeNativeMethods.IStorage stg)
+            {
+                UnsafeNativeMethods.IStream stream;
+                try
+                {
+                    stream = stg.OpenStream(GetStreamName(), IntPtr.Zero, NativeMethods.STGM_READ | NativeMethods.STGM_SHARE_EXCLUSIVE, 0);
+                }
+                catch (COMException e)
+                {
+                    if (e.ErrorCode == NativeMethods.STG_E_FILENOTFOUND)
+                    {
+                        // For backward compatibility: We were earlier using GetType().FullName
+                        // as the stream name in v1. Lets see if a stream by that name exists.
+                        stream = stg.OpenStream(GetType().FullName, IntPtr.Zero, NativeMethods.STGM_READ | NativeMethods.STGM_SHARE_EXCLUSIVE, 0);
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+
+                Load(stream);
+                if (Marshal.IsComObject(stg))
+                {
+                    Marshal.ReleaseComObject(stg);
+                }
+            }
+
+            /// <summary>
+            ///  Implements IPersistStreamInit::Load
+            /// </summary>
+            internal void Load(UnsafeNativeMethods.IStream stream)
+            {
+                // We do everything through property bags because we support full fidelity
+                // in them.  So, load through that method.
+                PropertyBagStream bag = new PropertyBagStream();
+                bag.Read(stream);
+                Load(bag, null);
+
+                if (Marshal.IsComObject(stream))
+                {
+                    Marshal.ReleaseComObject(stream);
+                }
+            }
+
+            /// <summary>
+            ///  Implements IPersistPropertyBag::Load
+            /// </summary>
+            internal void Load(UnsafeNativeMethods.IPropertyBag pPropBag, UnsafeNativeMethods.IErrorLog pErrorLog)
+            {
+                PropertyDescriptorCollection props = TypeDescriptor.GetProperties(_control,
+                    new Attribute[] { DesignerSerializationVisibilityAttribute.Visible });
+
+                for (int i = 0; i < props.Count; i++)
+                {
+                    Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Loading property " + props[i].Name);
+
+                    try
+                    {
+                        object obj = null;
+                        int hr = pPropBag.Read(props[i].Name, ref obj, pErrorLog);
+
+                        if (NativeMethods.Succeeded(hr) && obj != null)
+                        {
+                            Debug.Indent();
+                            Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Property was in bag");
+
+                            string errorString = null;
+                            int errorCode = 0;
+
+                            try
+                            {
+                                if (obj.GetType() != typeof(string))
+                                {
+                                    Debug.Fail("Expected property " + props[i].Name + " to be stored in IPropertyBag as a string.  Attempting to coerce");
+                                    obj = Convert.ToString(obj, CultureInfo.InvariantCulture);
+                                }
+
+                                // Determine if this is a resource property or was persisted via a type converter.
+                                if (IsResourceProp(props[i]))
+                                {
+                                    Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "It's a resource property");
+
+                                    // Resource property.  We encode these as base 64 strings.  To load them, we convert
+                                    // to a binary blob and then de-serialize.
+                                    byte[] bytes = Convert.FromBase64String(obj.ToString());
+                                    MemoryStream stream = new MemoryStream(bytes);
+                                    BinaryFormatter formatter = new BinaryFormatter();
+                                    props[i].SetValue(_control, formatter.Deserialize(stream));
+                                }
+                                else
+                                {
+                                    Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "It's a standard property");
+
+                                    // Not a resource property.  Use TypeConverters to convert the string back to the data type.  We do
+                                    // not check for CanConvertFrom here -- we the conversion fails the type converter will throw,
+                                    // and we will log it into the COM error log.
+                                    TypeConverter converter = props[i].Converter;
+                                    Debug.Assert(converter != null, "No type converter for property '" + props[i].Name + "' on class " + _control.GetType().FullName);
+
+                                    // Check to see if the type converter can convert from a string.  If it can,.
+                                    // use that as it is the best format for IPropertyBag.  Otherwise, check to see
+                                    // if it can convert from a byte array.  If it can, get the string, decode it
+                                    // to a byte array, and then set the value.
+                                    object value = null;
+
+                                    if (converter.CanConvertFrom(typeof(string)))
+                                    {
+                                        value = converter.ConvertFromInvariantString(obj.ToString());
+                                    }
+                                    else if (converter.CanConvertFrom(typeof(byte[])))
+                                    {
+                                        string objString = obj.ToString();
+                                        value = converter.ConvertFrom(null, CultureInfo.InvariantCulture, FromBase64WrappedString(objString));
+                                    }
+                                    Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Converter returned " + value);
+                                    props[i].SetValue(_control, value);
+                                }
+                            }
+                            catch (Exception e)
+                            {
+                                errorString = e.ToString();
+                                if (e is ExternalException)
+                                {
+                                    errorCode = ((ExternalException)e).ErrorCode;
+                                }
+                                else
+                                {
+                                    errorCode = NativeMethods.E_FAIL;
+                                }
+                            }
+                            if (errorString != null)
+                            {
+                                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Exception converting property: " + errorString);
+                                if (pErrorLog != null)
+                                {
+                                    NativeMethods.tagEXCEPINFO err = new NativeMethods.tagEXCEPINFO
+                                    {
+                                        bstrSource = _control.GetType().FullName,
+                                        bstrDescription = errorString,
+                                        scode = errorCode
+                                    };
+                                    pErrorLog.AddError(props[i].Name, err);
+                                }
+                            }
+                            Debug.Unindent();
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.Fail("Unexpected failure reading property", ex.ToString());
+
+                        if (ClientUtils.IsSecurityOrCriticalException(ex))
+                        {
+                            throw;
+                        }
+                    }
+                }
+                if (Marshal.IsComObject(pPropBag))
+                {
+                    Marshal.ReleaseComObject(pPropBag);
+                }
+            }
+
+            /// <summary>
+            ///  Simple lookup to find the AmbientProperty corresponding to the given
+            ///  dispid.
+            /// </summary>
+            private AmbientProperty LookupAmbient(int dispid)
+            {
+                for (int i = 0; i < _ambientProperties.Length; i++)
+                {
+                    if (_ambientProperties[i].DispID == dispid)
+                    {
+                        return _ambientProperties[i];
+                    }
+                }
+                Debug.Fail("No ambient property for dispid " + dispid.ToString(CultureInfo.InvariantCulture));
+                return _ambientProperties[0];
+            }
+
+            /// <summary>
+            ///  Merges the input region with the current clipping region.
+            ///  The output is always a region that can be fed directly
+            ///  to SetWindowRgn.  The region does not have to be destroyed.
+            ///  The original region is destroyed if a new region is returned.
+            /// </summary>
+            internal IntPtr MergeRegion(IntPtr region)
+            {
+                if (_clipRegion == IntPtr.Zero)
+                {
+                    return region;
+                }
+
+                if (region == IntPtr.Zero)
+                {
+                    return _clipRegion;
+                }
+
+                IntPtr newRegion = Interop.Gdi32.CreateRectRgn(0, 0, 0, 0);
+                Interop.Gdi32.CombineRgn(newRegion, region, _clipRegion, Interop.Gdi32.CombineMode.RGN_DIFF);
+                Interop.Gdi32.DeleteObject(region);
+                return newRegion;
+            }
+
+            private void CallParentPropertyChanged(Control control, string propName)
+            {
+                switch (propName)
+                {
+                    case "BackColor":
+                        control.OnParentBackColorChanged(EventArgs.Empty);
+                        break;
+                    case "BackgroundImage":
+                        control.OnParentBackgroundImageChanged(EventArgs.Empty);
+                        break;
+                    case "BindingContext":
+                        control.OnParentBindingContextChanged(EventArgs.Empty);
+                        break;
+                    case "Enabled":
+                        control.OnParentEnabledChanged(EventArgs.Empty);
+                        break;
+                    case "Font":
+                        control.OnParentFontChanged(EventArgs.Empty);
+                        break;
+                    case "ForeColor":
+                        control.OnParentForeColorChanged(EventArgs.Empty);
+                        break;
+                    case "RightToLeft":
+                        control.OnParentRightToLeftChanged(EventArgs.Empty);
+                        break;
+                    case "Visible":
+                        control.OnParentVisibleChanged(EventArgs.Empty);
+                        break;
+                    default:
+                        Debug.Fail("There is no property change notification for: " + propName + " on Control.");
+                        break;
+                }
+            }
+
+            /// <summary>
+            ///  Implements IOleControl::OnAmbientPropertyChanged
+            /// </summary>
+            internal void OnAmbientPropertyChange(int dispID)
+            {
+                if (dispID != NativeMethods.ActiveX.DISPID_UNKNOWN)
+                {
+                    // Look for a specific property that has changed.
+                    for (int i = 0; i < _ambientProperties.Length; i++)
+                    {
+                        if (_ambientProperties[i].DispID == dispID)
+                        {
+                            _ambientProperties[i].ResetValue();
+                            CallParentPropertyChanged(_control, _ambientProperties[i].Name);
+                            return;
+                        }
+                    }
+
+                    // Special properties that we care about
+                    object obj = new object();
+
+                    switch (dispID)
+                    {
+                        case NativeMethods.ActiveX.DISPID_AMBIENT_UIDEAD:
+                            if (GetAmbientProperty(NativeMethods.ActiveX.DISPID_AMBIENT_UIDEAD, ref obj))
+                            {
+                                _activeXState[s_uiDead] = (bool)obj;
+                            }
+                            break;
+
+                        case NativeMethods.ActiveX.DISPID_AMBIENT_DISPLAYASDEFAULT:
+                            if (_control is IButtonControl ibuttonControl && GetAmbientProperty(NativeMethods.ActiveX.DISPID_AMBIENT_DISPLAYASDEFAULT, ref obj))
+                            {
+                                ibuttonControl.NotifyDefault((bool)obj);
+                            }
+                            break;
+                    }
+                }
+                else
+                {
+                    // Invalidate all properties.  Ideally we should be checking each one, but
+                    // that's pretty expensive too.
+                    for (int i = 0; i < _ambientProperties.Length; i++)
+                    {
+                        _ambientProperties[i].ResetValue();
+                        CallParentPropertyChanged(_control, _ambientProperties[i].Name);
+                    }
+                }
+            }
+
+            /// <summary>
+            ///  Implements IOleInPlaceActiveObject::OnDocWindowActivate.
+            /// </summary>
+            internal void OnDocWindowActivate(int fActivate)
+            {
+                if (_activeXState[s_uiActive] && fActivate != 0 && _inPlaceFrame != null)
+                {
+                    // we have to explicitly say we don't wany any border space.
+                    int hr = _inPlaceFrame.SetBorderSpace(null);
+
+                    if (NativeMethods.Failed(hr) && hr != NativeMethods.INPLACE_E_NOTOOLSPACE && hr != NativeMethods.E_NOTIMPL)
+                    {
+                        Marshal.ThrowExceptionForHR(hr);
+                    }
+                }
+            }
+
+            /// <summary>
+            ///  Called by Control when it gets the focus.
+            /// </summary>
+            internal void OnFocus(bool focus)
+            {
+                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AXSource: SetFocus:  " + focus.ToString());
+                if (_activeXState[s_inPlaceActive] && _clientSite is UnsafeNativeMethods.IOleControlSite)
+                {
+                    ((UnsafeNativeMethods.IOleControlSite)_clientSite).OnFocus(focus ? 1 : 0);
+                }
+
+                if (focus && _activeXState[s_inPlaceActive] && !_activeXState[s_uiActive])
+                {
+                    InPlaceActivate(NativeMethods.OLEIVERB_UIACTIVATE);
+                }
+            }
+
+            /// <summary>
+            ///  Converts coordinates in pixels to HiMetric.
+            /// </summary>
+            private Point PixelToHiMetric(int x, int y)
+            {
+                Point pt = new Point
+                {
+                    X = (HiMetricPerInch * x + (LogPixels.X >> 1)) / LogPixels.X,
+                    Y = (HiMetricPerInch * y + (LogPixels.Y >> 1)) / LogPixels.Y
+                };
+                return pt;
+            }
+
+            /// <summary>
+            ///  Our implementation of IQuickActivate::QuickActivate
+            /// </summary>
+            internal void QuickActivate(UnsafeNativeMethods.tagQACONTAINER pQaContainer, UnsafeNativeMethods.tagQACONTROL pQaControl)
+            {
+                // Hookup our ambient colors
+                AmbientProperty prop = LookupAmbient(NativeMethods.ActiveX.DISPID_AMBIENT_BACKCOLOR);
+                prop.Value = ColorTranslator.FromOle(unchecked((int)pQaContainer.colorBack));
+
+                prop = LookupAmbient(NativeMethods.ActiveX.DISPID_AMBIENT_FORECOLOR);
+                prop.Value = ColorTranslator.FromOle(unchecked((int)pQaContainer.colorFore));
+
+                // And our ambient font
+                if (pQaContainer.pFont != null)
+                {
+                    prop = LookupAmbient(NativeMethods.ActiveX.DISPID_AMBIENT_FONT);
+
+                    try
+                    {
+                        IntPtr hfont = IntPtr.Zero;
+                        object objfont = pQaContainer.pFont;
+                        UnsafeNativeMethods.IFont ifont = (UnsafeNativeMethods.IFont)objfont;
+                        hfont = ifont.GetHFont();
+                        Font font = Font.FromHfont(hfont);
+                        prop.Value = font;
+                    }
+                    catch (Exception e)
+                    {
+                        if (ClientUtils.IsSecurityOrCriticalException(e))
+                        {
+                            throw;
+                        }
+
+                        // Do NULL, so we just defer to the default font
+                        prop.Value = null;
+                    }
+                }
+
+                // Now use the rest of the goo that we got passed in.
+
+                pQaControl.cbSize = Marshal.SizeOf<UnsafeNativeMethods.tagQACONTROL>();
+
+                SetClientSite(pQaContainer.pClientSite);
+
+                if (pQaContainer.pAdviseSink != null)
+                {
+                    SetAdvise(NativeMethods.DVASPECT_CONTENT, 0, (IAdviseSink)pQaContainer.pAdviseSink);
+                }
+
+                ((UnsafeNativeMethods.IOleObject)_control).GetMiscStatus(NativeMethods.DVASPECT_CONTENT, out int status);
+                pQaControl.dwMiscStatus = status;
+
+                // Advise the event sink so VB6 can catch events raised from UserControls.
+                // VB6 expects the control to do this during IQuickActivate, otherwise it will not hook events at runtime.
+                // We will do this if all of the following are true:
+                //  1. The container (e.g., vb6) has supplied an event sink
+                //  2. The control is a UserControl (this is only to limit the scope of the changed behavior)
+                //  3. The UserControl has indicated it wants to expose events to COM via the ComSourceInterfacesAttribute
+                // Note that the AdviseHelper handles some non-standard COM interop that is required in order to access
+                // the events on the CLR-supplied CCW (COM-callable Wrapper.
+
+                if ((pQaContainer.pUnkEventSink != null) && (_control is UserControl))
+                {
+                    // Check if this control exposes events to COM.
+                    Type eventInterface = GetDefaultEventsInterface(_control.GetType());
+
+                    if (eventInterface != null)
+                    {
+                        try
+                        {
+                            // For the default source interface, call IConnectionPoint.Advise with the supplied event sink.
+                            // This is easier said than done. See notes in AdviseHelper.AdviseConnectionPoint.
+                            AdviseHelper.AdviseConnectionPoint(_control, pQaContainer.pUnkEventSink, eventInterface, out pQaControl.dwEventCookie);
+                        }
+                        catch (Exception e)
+                        {
+                            if (ClientUtils.IsSecurityOrCriticalException(e))
+                            {
+                                throw;
+                            }
+                        }
+                    }
+                }
+
+                if (pQaContainer.pPropertyNotifySink != null && Marshal.IsComObject(pQaContainer.pPropertyNotifySink))
+                {
+                    Marshal.ReleaseComObject(pQaContainer.pPropertyNotifySink);
+                }
+
+                if (pQaContainer.pUnkEventSink != null && Marshal.IsComObject(pQaContainer.pUnkEventSink))
+                {
+                    Marshal.ReleaseComObject(pQaContainer.pUnkEventSink);
+                }
+            }
+
+            /// <summary>
+            ///  Helper class. Calls IConnectionPoint.Advise to hook up a native COM event sink
+            ///  to a manage .NET event interface.
+            ///  The events are exposed to COM by the CLR-supplied COM-callable Wrapper (CCW).
+            /// </summary>
+            internal static class AdviseHelper
+            {
+                /// <summary>
+                ///  Get the COM connection point container from the CLR's CCW and advise for the given event id.
+                /// </summary>
+                public static bool AdviseConnectionPoint(object connectionPoint, object sink, Type eventInterface, out int cookie)
+                {
+                    // Note that we cannot simply cast the connectionPoint object to
+                    // System.Runtime.InteropServices.ComTypes.IConnectionPointContainer because the .NET
+                    // object doesn't implement it directly. When the object is exposed to COM, the CLR
+                    // implements IConnectionPointContainer on the proxy object called the CCW or COM-callable wrapper.
+                    // We use the helper class ComConnectionPointContainer to get to the CCW directly
+                    // to to call the interface.
+                    // It is critical to call Dispose to ensure that the IUnknown is released.
+
+                    using (ComConnectionPointContainer cpc = new ComConnectionPointContainer(connectionPoint, true))
+                    {
+                        return AdviseConnectionPoint(cpc, sink, eventInterface, out cookie);
+                    }
+                }
+
+                /// <summary>
+                ///  Find the COM connection point and call Advise for the given event id.
+                /// </summary>
+                internal static bool AdviseConnectionPoint(ComConnectionPointContainer cpc, object sink, Type eventInterface, out int cookie)
+                {
+                    // Note that we cannot simply cast the returned IConnectionPoint to
+                    // System.Runtime.InteropServices.ComTypes.IConnectionPoint because the .NET
+                    // object doesn't implement it directly. When the object is exposed to COM, the CLR
+                    // implements IConnectionPoint for the proxy object via the CCW or COM-callable wrapper.
+                    // We use the helper class ComConnectionPoint to get to the CCW directly to to call the interface.
+                    // It is critical to call Dispose to ensure that the IUnknown is released.
+                    using (ComConnectionPoint cp = cpc.FindConnectionPoint(eventInterface))
+                    {
+                        using (SafeIUnknown punkEventsSink = new SafeIUnknown(sink, true))
+                        {
+                            // Finally...we can call IConnectionPoint.Advise to hook up a native COM event sink
+                            // to a managed .NET event interface.
+                            return cp.Advise(punkEventsSink.DangerousGetHandle(), out cookie);
+                        }
+                    }
+                }
+
+                /// <summary>
+                ///  Wraps a native IUnknown in a SafeHandle.
+                ///  See similar implementaton in the <see cref='Transactions.SafeIUnknown'/> class.
+                /// </summary>
+                internal class SafeIUnknown : SafeHandle
+                {
+                    /// <summary>
+                    ///  Wrap an incomoing unknown or get the unknown for the CCW (COM-callable wrapper).
+                    /// </summary>
+                    public SafeIUnknown(object obj, bool addRefIntPtr)
+                        : this(obj, addRefIntPtr, Guid.Empty)
+                    {
+                    }
+
+                    /// <summary>
+                    ///  Wrap an incomoing unknown or get the unknown for the CCW (COM-callable wrapper).
+                    ///  If an iid is supplied, QI for the interface and wrap that unknonwn instead.
+                    /// </summary>
+                    public SafeIUnknown(object obj, bool addRefIntPtr, Guid iid)
+                        : base(IntPtr.Zero, true)
+                    {
+                        RuntimeHelpers.PrepareConstrainedRegions();
+                        try
+                        {
+                            // Set this.handle in a finally block to ensure the com ptr is set in the SafeHandle
+                            // even if the runtime throws a exception (such as ThreadAbortException) during the call.
+                            // This ensures that the finalizer will clean up the COM reference.
+                        }
+                        finally
+                        {
+                            // Get a raw IUnknown for this object.
+                            // We are responsible for releasing the IUnknown ourselves.
+                            IntPtr unknown;
+
+                            if (obj is IntPtr)
+                            {
+                                unknown = (IntPtr)obj;
+
+                                // The incoming IntPtr may already be reference counted or not, depending on
+                                // where it came from. The caller needs to tell us whether to add-ref or not.
+                                if (addRefIntPtr)
+                                {
+                                    Marshal.AddRef(unknown);
+                                }
+                            }
+                            else
+                            {
+                                // GetIUnknownForObject will return a reference-counted object
+                                unknown = Marshal.GetIUnknownForObject(obj);
+                            }
+
+                            // Attempt QueryInterface if an iid is specified.
+                            if (iid != Guid.Empty)
+                            {
+                                IntPtr oldUnknown = unknown;
+                                try
+                                {
+                                    unknown = InternalQueryInterface(unknown, ref iid);
+                                }
+                                finally
+                                {
+                                    // It is critical to release the original unknown if
+                                    // InternalQueryInterface throws out so we don't leak ref counts.
+                                    Marshal.Release(oldUnknown);
+                                }
+                            }
+
+                            // Preserve the com ptr in the SafeHandle.
+                            handle = unknown;
+                        }
+                    }
+
+                    /// <summary>
+                    ///  Helper function for QueryInterface.
+                    /// </summary>
+                    private static IntPtr InternalQueryInterface(IntPtr pUnk, ref Guid iid)
+                    {
+                        int hresult = Marshal.QueryInterface(pUnk, ref iid, out IntPtr ppv);
+                        if (hresult != 0 || ppv == IntPtr.Zero)
+                        {
+                            throw new InvalidCastException(SR.AxInterfaceNotSupported);
+                        }
+                        return ppv;
+                    }
+
+                    /// <summary>
+                    ///  Return whether the handle is invalid.
+                    /// </summary>
+                    public sealed override bool IsInvalid
+                    {
+                        get
+                        {
+                            if (!IsClosed)
+                            {
+                                return (IntPtr.Zero == handle);
+                            }
+                            return true;
+                        }
+                    }
+
+                    /// <summary>
+                    ///  Release the IUnknown.
+                    /// </summary>
+                    protected sealed override bool ReleaseHandle()
+                    {
+                        IntPtr ptr1 = handle;
+                        handle = IntPtr.Zero;
+                        if (IntPtr.Zero != ptr1)
+                        {
+                            Marshal.Release(ptr1);
+                        }
+                        return true;
+                    }
+
+                    /// <summary>
+                    ///  Helper function to load a COM v-table from a com object pointer.
+                    /// </summary>
+                    protected V LoadVtable<V>()
+                    {
+                        IntPtr vtblptr = Marshal.ReadIntPtr(handle, 0);
+                        return Marshal.PtrToStructure<V>(vtblptr);
+                    }
+                }
+
+                /// <summary>
+                ///  Helper class to access IConnectionPointContainer from a .NET COM-callable wrapper.
+                ///  The IConnectionPointContainer COM pointer is wrapped in a SafeHandle.
+                /// </summary>
+                internal sealed class ComConnectionPointContainer
+                    : SafeIUnknown
+                {
+                    public ComConnectionPointContainer(object obj, bool addRefIntPtr)
+                        : base(obj, addRefIntPtr, typeof(IConnectionPointContainer).GUID)
+                    {
+                        _vtbl = LoadVtable<VTABLE>();
+                    }
+
+                    private readonly VTABLE _vtbl;
+
+                    [StructLayout(LayoutKind.Sequential)]
+                    private class VTABLE
+                    {
+                        public IntPtr QueryInterfacePtr;
+                        public IntPtr AddRefPtr;
+                        public IntPtr ReleasePtr;
+                        public IntPtr EnumConnectionPointsPtr;
+                        public IntPtr FindConnectionPointPtr;
+                    }
+
+                    /// <summary>
+                    ///  Call IConnectionPointContainer.FindConnectionPoint using Delegate.Invoke on the v-table slot.
+                    /// </summary>
+                    public ComConnectionPoint FindConnectionPoint(Type eventInterface)
+                    {
+                        FindConnectionPointD findConnectionPoint = (FindConnectionPointD)Marshal.GetDelegateForFunctionPointer(_vtbl.FindConnectionPointPtr, typeof(FindConnectionPointD));
+
+                        Guid iid = eventInterface.GUID;
+                        int hresult = findConnectionPoint.Invoke(handle, ref iid, out IntPtr result);
+                        if (hresult != 0 || result == IntPtr.Zero)
+                        {
+                            throw new ArgumentException(string.Format(SR.AXNoConnectionPoint, eventInterface.Name));
+                        }
+
+                        return new ComConnectionPoint(result, false);   // result is already ref-counted as an out-param so pass in false
+                    }
+
+                    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+                    private delegate int FindConnectionPointD(IntPtr This, ref Guid iid, out IntPtr ppv);
+                }
+
+                /// <summary>
+                ///  Helper class to access IConnectionPoint from a .NET COM-callable wrapper.
+                ///  The IConnectionPoint COM pointer is wrapped in a SafeHandle.
+                /// </summary>
+                internal sealed class ComConnectionPoint
+                    : SafeIUnknown
+                {
+                    public ComConnectionPoint(object obj, bool addRefIntPtr)
+                        : base(obj, addRefIntPtr, typeof(IConnectionPoint).GUID)
+                    {
+                        _vtbl = LoadVtable<VTABLE>();
+                    }
+
+                    [StructLayout(LayoutKind.Sequential)]
+                    private class VTABLE
+                    {
+                        public IntPtr QueryInterfacePtr;
+                        public IntPtr AddRefPtr;
+                        public IntPtr ReleasePtr;
+                        public IntPtr GetConnectionInterfacePtr;
+                        public IntPtr GetConnectionPointContainterPtr;
+                        public IntPtr AdvisePtr;
+                        public IntPtr UnadvisePtr;
+                        public IntPtr EnumConnectionsPtr;
+                    }
+
+                    private readonly VTABLE _vtbl;
+
+                    /// <summary>
+                    ///  Call IConnectioinPoint.Advise using Delegate.Invoke on the v-table slot.
+                    /// </summary>
+                    public bool Advise(IntPtr punkEventSink, out int cookie)
+                    {
+                        AdviseD advise = (AdviseD)Marshal.GetDelegateForFunctionPointer(_vtbl.AdvisePtr, typeof(AdviseD));
+                        if (advise.Invoke(handle, punkEventSink, out cookie) == 0)
+                        {
+                            return true;
+                        }
+                        return false;
+                    }
+
+                    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+                    private delegate int AdviseD(IntPtr This, IntPtr punkEventSink, out int cookie);
+                }
+
+            }
+
+            /// <summary>
+            ///  Return the default COM events interface declared on a .NET class.
+            ///  This looks for the ComSourceInterfacesAttribute and returns the .NET
+            ///  interface type of the first interface declared.
+            /// </summary>
+            private static Type GetDefaultEventsInterface(Type controlType)
+            {
+                Type eventInterface = null;
+                object[] custom = controlType.GetCustomAttributes(typeof(ComSourceInterfacesAttribute), false);
+
+                if (custom.Length > 0)
+                {
+                    ComSourceInterfacesAttribute coms = (ComSourceInterfacesAttribute)custom[0];
+                    string eventName = coms.Value.Split(new char[] { '\0' })[0];
+                    eventInterface = controlType.Module.Assembly.GetType(eventName, false);
+                    if (eventInterface == null)
+                    {
+                        eventInterface = Type.GetType(eventName, false);
+                    }
+                }
+
+                return eventInterface;
+            }
+
+            /// <summary>
+            ///  Implements IPersistStorage::Save
+            /// </summary>
+            internal void Save(UnsafeNativeMethods.IStorage stg, bool fSameAsLoad)
+            {
+                UnsafeNativeMethods.IStream stream = stg.CreateStream(GetStreamName(), NativeMethods.STGM_WRITE | NativeMethods.STGM_SHARE_EXCLUSIVE | NativeMethods.STGM_CREATE, 0, 0);
+                Debug.Assert(stream != null, "Stream should be non-null, or an exception should have been thrown.");
+                Save(stream, true);
+                Marshal.ReleaseComObject(stream);
+            }
+
+            /// <summary>
+            ///  Implements IPersistStreamInit::Save
+            /// </summary>
+            internal void Save(UnsafeNativeMethods.IStream stream, bool fClearDirty)
+            {
+                // We do everything through property bags because we support full fidelity
+                // in them.  So, save through that method.
+                PropertyBagStream bag = new PropertyBagStream();
+                Save(bag, fClearDirty, false);
+                bag.Write(stream);
+
+                if (Marshal.IsComObject(stream))
+                {
+                    Marshal.ReleaseComObject(stream);
+                }
+            }
+
+            /// <summary>
+            ///  Implements IPersistPropertyBag::Save
+            /// </summary>
+            internal void Save(UnsafeNativeMethods.IPropertyBag pPropBag, bool fClearDirty, bool fSaveAllProperties)
+            {
+                PropertyDescriptorCollection props = TypeDescriptor.GetProperties(_control,
+                    new Attribute[] { DesignerSerializationVisibilityAttribute.Visible });
+
+                for (int i = 0; i < props.Count; i++)
+                {
+                    if (fSaveAllProperties || props[i].ShouldSerializeValue(_control))
+                    {
+                        Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Saving property " + props[i].Name);
+
+                        object propValue;
+
+                        if (IsResourceProp(props[i]))
+                        {
+                            // Resource property.  Save this to the bag as a 64bit encoded string.
+                            MemoryStream stream = new MemoryStream();
+                            BinaryFormatter formatter = new BinaryFormatter();
+                            formatter.Serialize(stream, props[i].GetValue(_control));
+                            byte[] bytes = new byte[(int)stream.Length];
+                            stream.Position = 0;
+                            stream.Read(bytes, 0, bytes.Length);
+                            propValue = Convert.ToBase64String(bytes);
+                            pPropBag.Write(props[i].Name, ref propValue);
+                        }
+                        else
+                        {
+                            // Not a resource property.  Persist this using standard type converters.
+                            TypeConverter converter = props[i].Converter;
+                            Debug.Assert(converter != null, "No type converter for property '" + props[i].Name + "' on class " + _control.GetType().FullName);
+
+                            if (converter.CanConvertFrom(typeof(string)))
+                            {
+                                propValue = converter.ConvertToInvariantString(props[i].GetValue(_control));
+                                pPropBag.Write(props[i].Name, ref propValue);
+                            }
+                            else if (converter.CanConvertFrom(typeof(byte[])))
+                            {
+                                byte[] data = (byte[])converter.ConvertTo(null, CultureInfo.InvariantCulture, props[i].GetValue(_control), typeof(byte[]));
+                                propValue = Convert.ToBase64String(data);
+                                pPropBag.Write(props[i].Name, ref propValue);
+                            }
+                        }
+                    }
+                }
+
+                if (Marshal.IsComObject(pPropBag))
+                {
+                    Marshal.ReleaseComObject(pPropBag);
+                }
+
+                if (fClearDirty)
+                {
+                    _activeXState[s_isDirty] = false;
+                }
+            }
+
+            /// <summary>
+            ///  Fires the OnSave event to all of our IAdviseSink
+            ///  listeners.  Used for ActiveXSourcing.
+            /// </summary>
+            private void SendOnSave()
+            {
+                int cnt = _adviseList.Count;
+                for (int i = 0; i < cnt; i++)
+                {
+                    IAdviseSink s = (IAdviseSink)_adviseList[i];
+                    Debug.Assert(s != null, "NULL in our advise list");
+                    s.OnSave();
+                }
+            }
+
+            /// <summary>
+            ///  Implements IViewObject2::SetAdvise.
+            /// </summary>
+            internal void SetAdvise(int aspects, int advf, IAdviseSink pAdvSink)
+            {
+                // if it's not a content aspect, we don't support it.
+                if ((aspects & NativeMethods.DVASPECT_CONTENT) == 0)
+                {
+                    ThrowHr(NativeMethods.DV_E_DVASPECT);
+                }
+
+                // set up some flags  [we gotta stash for GetAdvise ...]
+                _activeXState[s_viewAdvisePrimeFirst] = (advf & NativeMethods.ADVF_PRIMEFIRST) != 0 ? true : false;
+                _activeXState[s_viewAdviseOnlyOnce] = (advf & NativeMethods.ADVF_ONLYONCE) != 0 ? true : false;
+
+                if (_viewAdviseSink != null && Marshal.IsComObject(_viewAdviseSink))
+                {
+                    Marshal.ReleaseComObject(_viewAdviseSink);
+                }
+
+                _viewAdviseSink = pAdvSink;
+
+                // prime them if they want it [we need to store this so they can get flags later]
+                if (_activeXState[s_viewAdvisePrimeFirst])
+                {
+                    ViewChanged();
+                }
+            }
+
+            /// <summary>
+            ///  Implements IOleObject::SetClientSite.
+            /// </summary>
+            internal void SetClientSite(UnsafeNativeMethods.IOleClientSite value)
+            {
+                if (_clientSite != null)
+                {
+                    if (value == null)
+                    {
+                        s_globalActiveXCount--;
+
+                        if (s_globalActiveXCount == 0 && IsIE)
+                        {
+                            // This the last ActiveX control and we are
+                            // being hosted in IE.  Use private reflection
+                            // to ask SystemEvents to shutdown.  This is to
+                            // prevent a crash.
+
+                            MethodInfo method = typeof(SystemEvents).GetMethod("Shutdown",
+                                                                                BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.InvokeMethod,
+                                                                                null, Array.Empty<Type>(), Array.Empty<ParameterModifier>());
+                            Debug.Assert(method != null, "No Shutdown method on SystemEvents");
+                            if (method != null)
+                            {
+                                method.Invoke(null, null);
+                            }
+                        }
+                    }
+
+                    if (Marshal.IsComObject(_clientSite))
+                    {
+                        Marshal.FinalReleaseComObject(_clientSite);
+                    }
+                }
+
+                _clientSite = value;
+
+                if (_clientSite != null)
+                {
+                    _control.Site = new AxSourcingSite(_control, _clientSite, "ControlAxSourcingSite");
+                }
+                else
+                {
+                    _control.Site = null;
+                }
+
+                // Get the ambient properties that effect us...
+                object obj = new object();
+                if (GetAmbientProperty(NativeMethods.ActiveX.DISPID_AMBIENT_UIDEAD, ref obj))
+                {
+                    _activeXState[s_uiDead] = (bool)obj;
+                }
+
+                if (_control is IButtonControl && GetAmbientProperty(NativeMethods.ActiveX.DISPID_AMBIENT_UIDEAD, ref obj))
+                {
+                    ((IButtonControl)_control).NotifyDefault((bool)obj);
+                }
+
+                if (_clientSite == null)
+                {
+                    if (_accelTable != IntPtr.Zero)
+                    {
+                        UnsafeNativeMethods.DestroyAcceleratorTable(new HandleRef(this, _accelTable));
+                        _accelTable = IntPtr.Zero;
+                        _accelCount = -1;
+                    }
+
+                    if (IsIE)
+                    {
+                        _control.Dispose();
+                    }
+                }
+                else
+                {
+                    s_globalActiveXCount++;
+
+                    if (s_globalActiveXCount == 1 && IsIE)
+                    {
+                        // This the first ActiveX control and we are
+                        // being hosted in IE.  Use private reflection
+                        // to ask SystemEvents to start.  Startup will only
+                        // restart system events if we previously shut it down.
+                        // This is to prevent a crash.
+                        MethodInfo method = typeof(SystemEvents).GetMethod("Startup",
+                                                                            BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.InvokeMethod,
+                                                                            null, Array.Empty<Type>(), Array.Empty<ParameterModifier>());
+                        Debug.Assert(method != null, "No Startup method on SystemEvents");
+                        if (method != null)
+                        {
+                            method.Invoke(null, null);
+                        }
+                    }
+                }
+                _control.OnTopMostActiveXParentChanged(EventArgs.Empty);
+            }
+
+            /// <summary>
+            ///  Implements IOleObject::SetExtent
+            /// </summary>
+            internal void SetExtent(int dwDrawAspect, NativeMethods.tagSIZEL pSizel)
+            {
+                if ((dwDrawAspect & NativeMethods.DVASPECT_CONTENT) != 0)
+                {
+                    if (_activeXState[s_changingExtents])
+                    {
+                        return;
+                    }
+
+                    _activeXState[s_changingExtents] = true;
+
+                    try
+                    {
+                        Size size = new Size(HiMetricToPixel(pSizel.cx, pSizel.cy));
+                        Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "SetExtent : new size:" + size.ToString());
+
+                        // If we're in place active, let the in place site set our bounds.
+                        // Otherwise, just set it on our control directly.
+                        if (_activeXState[s_inPlaceActive])
+                        {
+                            if (_clientSite is UnsafeNativeMethods.IOleInPlaceSite ioleClientSite)
+                            {
+                                Rectangle bounds = _control.Bounds;
+                                bounds.Location = new Point(bounds.X, bounds.Y);
+                                Size adjusted = new Size(size.Width, size.Height);
+                                bounds.Width = adjusted.Width;
+                                bounds.Height = adjusted.Height;
+                                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "SetExtent : Announcing to in place site that our rect has changed.");
+                                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "            Announcing rect = " + bounds);
+                                Debug.Assert(_clientSite != null, "How can we setextent before we are sited??");
+
+                                ioleClientSite.OnPosRectChange(NativeMethods.COMRECT.FromXYWH(bounds.X, bounds.Y, bounds.Width, bounds.Height));
+                            }
+                        }
+
+                        _control.Size = size;
+
+                        // Check to see if the control overwrote our size with
+                        // its own values.
+                        if (!_control.Size.Equals(size))
+                        {
+                            Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "SetExtent : Control has changed size.  Setting dirty bit");
+                            _activeXState[s_isDirty] = true;
+
+                            // If we're not inplace active, then anounce that the view changed.
+                            if (!_activeXState[s_inPlaceActive])
+                            {
+                                ViewChanged();
+                            }
+
+                            // We need to call RequestNewObjectLayout
+                            // here so we visually display our new extents.
+                            if (!_activeXState[s_inPlaceActive] && _clientSite != null)
+                            {
+                                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "SetExtent : Requesting new Object layout.");
+                                _clientSite.RequestNewObjectLayout();
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        _activeXState[s_changingExtents] = false;
+                    }
+                }
+                else
+                {
+                    // We don't support any other aspects
+                    ThrowHr(NativeMethods.DV_E_DVASPECT);
+                }
+            }
+
+            /// <summary>
+            ///  Marks our state as in place visible.
+            /// </summary>
+            private void SetInPlaceVisible(bool visible)
+            {
+                _activeXState[s_inPlaceVisible] = visible;
+                _control.Visible = visible;
+            }
+
+            /// <summary>
+            ///  Implements IOleInPlaceObject::SetObjectRects.
+            /// </summary>
+            internal void SetObjectRects(NativeMethods.COMRECT lprcPosRect, NativeMethods.COMRECT lprcClipRect)
+            {
+#if DEBUG
+                if (CompModSwitches.ActiveX.TraceInfo)
+                {
+                    Debug.WriteLine("SetObjectRects:");
+                    Debug.Indent();
+
+                    if (lprcPosRect != null)
+                    {
+                        Debug.WriteLine("PosLeft:    " + lprcPosRect.left.ToString(CultureInfo.InvariantCulture));
+                        Debug.WriteLine("PosTop:     " + lprcPosRect.top.ToString(CultureInfo.InvariantCulture));
+                        Debug.WriteLine("PosRight:   " + lprcPosRect.right.ToString(CultureInfo.InvariantCulture));
+                        Debug.WriteLine("PosBottom:  " + lprcPosRect.bottom.ToString(CultureInfo.InvariantCulture));
+                    }
+
+                    if (lprcClipRect != null)
+                    {
+                        Debug.WriteLine("ClipLeft:   " + lprcClipRect.left.ToString(CultureInfo.InvariantCulture));
+                        Debug.WriteLine("ClipTop:    " + lprcClipRect.top.ToString(CultureInfo.InvariantCulture));
+                        Debug.WriteLine("ClipRight:  " + lprcClipRect.right.ToString(CultureInfo.InvariantCulture));
+                        Debug.WriteLine("ClipBottom: " + lprcClipRect.bottom.ToString(CultureInfo.InvariantCulture));
+                    }
+                    Debug.Unindent();
+                }
+#endif
+
+                Rectangle posRect = Rectangle.FromLTRB(lprcPosRect.left, lprcPosRect.top, lprcPosRect.right, lprcPosRect.bottom);
+
+                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Set control bounds: " + posRect.ToString());
+
+                // ActiveX expects to be notified when a control's bounds change, and also
+                // intends to notify us through SetObjectRects when we report that the
+                // bounds are about to change.  We implement this all on a control's Bounds
+                // property, which doesn't use this callback mechanism.  The adjustRect
+                // member handles this. If it is non-null, then we are being called in
+                // response to an OnPosRectChange call.  In this case we do not
+                // set the control bounds but set the bounds on the adjustRect.  When
+                // this returns from the container and comes back to our OnPosRectChange
+                // implementation, these new bounds will be handed back to the control
+                // for the actual window change.
+                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Old Control Bounds: " + _control.Bounds);
+                if (_activeXState[s_adjustingRect])
+                {
+                    _adjustRect.left = posRect.X;
+                    _adjustRect.top = posRect.Y;
+                    _adjustRect.right = posRect.Width + posRect.X;
+                    _adjustRect.bottom = posRect.Height + posRect.Y;
+                }
+                else
+                {
+                    _activeXState[s_adjustingRect] = true;
+                    try
+                    {
+                        _control.Bounds = posRect;
+                    }
+                    finally
+                    {
+                        _activeXState[s_adjustingRect] = false;
+                    }
+                }
+
+                bool setRegion = false;
+
+                if (_clipRegion != IntPtr.Zero)
+                {
+                    // Bad -- after calling SetWindowReg, windows owns the region.
+                    //SafeNativeMethods.DeleteObject(clipRegion);
+                    _clipRegion = IntPtr.Zero;
+                    setRegion = true;
+                }
+
+                if (lprcClipRect != null)
+                {
+                    // The container wants us to clip, so figure out if we really
+                    // need to.
+                    Rectangle clipRect = Rectangle.FromLTRB(lprcClipRect.left, lprcClipRect.top, lprcClipRect.right, lprcClipRect.bottom);
+
+                    Rectangle intersect;
+
+                    // Trident always sends an empty ClipRect... and so, we check for that and not do an
+                    // intersect in that case.
+                    if (!clipRect.IsEmpty)
+                    {
+                        intersect = Rectangle.Intersect(posRect, clipRect);
+                    }
+                    else
+                    {
+                        intersect = posRect;
+                    }
+
+                    if (!intersect.Equals(posRect))
+                    {
+                        // Offset the rectangle back to client coordinates
+                        Interop.RECT rcIntersect = intersect;
+                        IntPtr hWndParent = UnsafeNativeMethods.GetParent(new HandleRef(_control, _control.Handle));
+
+                        Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Old Intersect: " + new Rectangle(rcIntersect.left, rcIntersect.top, rcIntersect.right - rcIntersect.left, rcIntersect.bottom - rcIntersect.top));
+                        Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "New Control Bounds: " + posRect);
+
+                        UnsafeNativeMethods.MapWindowPoints(new HandleRef(null, hWndParent), new HandleRef(_control, _control.Handle), ref rcIntersect, 2);
+
+                        Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "New Intersect: " + new Rectangle(rcIntersect.left, rcIntersect.top, rcIntersect.right - rcIntersect.left, rcIntersect.bottom - rcIntersect.top));
+
+                        // Create a Win32 region for it
+                        _clipRegion = Interop.Gdi32.CreateRectRgn(rcIntersect.left, rcIntersect.top,
+                                                                 rcIntersect.right, rcIntersect.bottom);
+                        setRegion = true;
+                        Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Created clipping region");
+                    }
+                }
+
+                // If our region has changed, set the new value.  We only do this if
+                // the handle has been created, since otherwise the control will
+                // merge our region automatically.
+                if (setRegion && _control.IsHandleCreated)
+                {
+                    IntPtr finalClipRegion = _clipRegion;
+
+                    Region controlRegion = _control.Region;
+                    if (controlRegion != null)
+                    {
+                        IntPtr rgn = _control.GetHRgn(controlRegion);
+                        finalClipRegion = MergeRegion(rgn);
+                    }
+
+                    UnsafeNativeMethods.SetWindowRgn(new HandleRef(_control, _control.Handle), new HandleRef(this, finalClipRegion), SafeNativeMethods.IsWindowVisible(new HandleRef(_control, _control.Handle)));
+                }
+
+                // Yuck.  Forms^3 uses transparent overlay windows that appear to cause
+                // painting artifacts.  Flicker like a banshee.
+                _control.Invalidate();
+            }
+
+            /// <summary>
+            ///  Throws the given hresult.  This is used by ActiveX sourcing.
+            /// </summary>
+            internal static void ThrowHr(int hr)
+            {
+                ExternalException e = new ExternalException(SR.ExternalException, hr);
+                throw e;
+            }
+
+            /// <summary>
+            ///  Handles IOleControl::TranslateAccelerator
+            /// </summary>
+            internal int TranslateAccelerator(ref NativeMethods.MSG lpmsg)
+            {
+#if DEBUG
+                if (CompModSwitches.ActiveX.TraceInfo)
+                {
+                    if (!_control.IsHandleCreated)
+                    {
+                        Debug.WriteLine("AxSource: TranslateAccelerator before handle creation");
+                    }
+                    else
+                    {
+                        Message m = Message.Create(lpmsg.hwnd, lpmsg.message, lpmsg.wParam, lpmsg.lParam);
+                        Debug.WriteLine("AxSource: TranslateAccelerator : " + m.ToString());
+                    }
+                }
+#endif // DEBUG
+
+                bool needPreProcess = false;
+
+                switch (lpmsg.message)
+                {
+                    case Interop.WindowMessages.WM_KEYDOWN:
+                    case Interop.WindowMessages.WM_SYSKEYDOWN:
+                    case Interop.WindowMessages.WM_CHAR:
+                    case Interop.WindowMessages.WM_SYSCHAR:
+                        needPreProcess = true;
+                        break;
+                }
+
+                Message msg = Message.Create(lpmsg.hwnd, lpmsg.message, lpmsg.wParam, lpmsg.lParam);
+
+                if (needPreProcess)
+                {
+                    Control target = FromChildHandle(lpmsg.hwnd);
+                    if (target != null && (_control == target || _control.Contains(target)))
+                    {
+                        PreProcessControlState messageState = PreProcessControlMessageInternal(target, ref msg);
+                        switch (messageState)
+                        {
+                            case PreProcessControlState.MessageProcessed:
+                                // someone returned true from PreProcessMessage
+                                // no need to dispatch the message, its already been coped with.
+                                lpmsg.message = msg.Msg;
+                                lpmsg.wParam = msg.WParam;
+                                lpmsg.lParam = msg.LParam;
+                                return NativeMethods.S_OK;
+                            case PreProcessControlState.MessageNeeded:
+                                // Here we need to dispatch the message ourselves
+                                // otherwise the host may never send the key to our wndproc.
+
+                                // Someone returned true from IsInputKey or IsInputChar
+                                UnsafeNativeMethods.TranslateMessage(ref lpmsg);
+                                if (SafeNativeMethods.IsWindowUnicode(new HandleRef(null, lpmsg.hwnd)))
+                                {
+                                    UnsafeNativeMethods.DispatchMessageW(ref lpmsg);
+                                }
+                                else
+                                {
+                                    UnsafeNativeMethods.DispatchMessageA(ref lpmsg);
+                                }
+                                return NativeMethods.S_OK;
+                            case PreProcessControlState.MessageNotNeeded:
+                                // in this case we'll check the site to see if it wants the message.
+                                break;
+                        }
+                    }
+                }
+
+                // SITE processing.  We're not interested in the message, but the site may be.
+
+                int hr = NativeMethods.S_FALSE;
+
+                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource: Control did not process accelerator, handing to site");
+
+                if (_clientSite is UnsafeNativeMethods.IOleControlSite ioleClientSite)
+                {
+                    int keyState = 0;
+
+                    if (UnsafeNativeMethods.GetKeyState(NativeMethods.VK_SHIFT) < 0)
+                    {
+                        keyState |= 1;
+                    }
+
+                    if (UnsafeNativeMethods.GetKeyState(NativeMethods.VK_CONTROL) < 0)
+                    {
+                        keyState |= 2;
+                    }
+
+                    if (UnsafeNativeMethods.GetKeyState(NativeMethods.VK_MENU) < 0)
+                    {
+                        keyState |= 4;
+                    }
+
+                    hr = ioleClientSite.TranslateAccelerator(ref lpmsg, keyState);
+                }
+
+                return hr;
+            }
+
+            /// <summary>
+            ///  Implements IOleInPlaceObject::UIDeactivate.
+            /// </summary>
+            internal int UIDeactivate()
+            {
+                // Only do this if we're UI active
+                if (!_activeXState[s_uiActive])
+                {
+                    return NativeMethods.S_OK;
+                }
+
+                _activeXState[s_uiActive] = false;
+
+                // Notify frame windows, if appropriate, that we're no longer ui-active.
+                if (_inPlaceUiWindow != null)
+                {
+                    _inPlaceUiWindow.SetActiveObject(null, null);
+                }
+
+                // May need this for SetActiveObject & OnUIDeactivate, so leave until function return
+                Debug.Assert(_inPlaceFrame != null, "No inplace frame -- how dod we go UI active?");
+                _inPlaceFrame.SetActiveObject(null, null);
+
+                if (_clientSite is UnsafeNativeMethods.IOleInPlaceSite ioleClientSite)
+                {
+                    ioleClientSite.OnUIDeactivate(0);
+                }
+
+                return NativeMethods.S_OK;
+            }
+
+            /// <summary>
+            ///  Implements IOleObject::Unadvise
+            /// </summary>
+            internal void Unadvise(int dwConnection)
+            {
+                if (dwConnection > _adviseList.Count || _adviseList[dwConnection - 1] == null)
+                {
+                    ThrowHr(NativeMethods.OLE_E_NOCONNECTION);
+                }
+
+                IAdviseSink sink = (IAdviseSink)_adviseList[dwConnection - 1];
+                _adviseList.RemoveAt(dwConnection - 1);
+                if (sink != null && Marshal.IsComObject(sink))
+                {
+                    Marshal.ReleaseComObject(sink);
+                }
+            }
+
+            /// <summary>
+            ///  Notifies our site that we have changed our size and location.
+            /// </summary>
+            internal void UpdateBounds(ref int x, ref int y, ref int width, ref int height, int flags)
+            {
+                if (!_activeXState[s_adjustingRect] && _activeXState[s_inPlaceVisible])
+                {
+                    if (_clientSite is UnsafeNativeMethods.IOleInPlaceSite ioleClientSite)
+                    {
+                        NativeMethods.COMRECT rc = new NativeMethods.COMRECT();
+
+                        if ((flags & NativeMethods.SWP_NOMOVE) != 0)
+                        {
+                            rc.left = _control.Left;
+                            rc.top = _control.Top;
+                        }
+                        else
+                        {
+                            rc.left = x;
+                            rc.top = y;
+                        }
+
+                        if ((flags & NativeMethods.SWP_NOSIZE) != 0)
+                        {
+                            rc.right = rc.left + _control.Width;
+                            rc.bottom = rc.top + _control.Height;
+                        }
+                        else
+                        {
+                            rc.right = rc.left + width;
+                            rc.bottom = rc.top + height;
+                        }
+
+                        // This member variable may be modified by SetObjectRects by the container.
+                        _adjustRect = rc;
+                        _activeXState[s_adjustingRect] = true;
+
+                        try
+                        {
+                            ioleClientSite.OnPosRectChange(rc);
+                        }
+                        finally
+                        {
+                            _adjustRect = null;
+                            _activeXState[s_adjustingRect] = false;
+                        }
+
+                        // On output, the new bounds will be reflected in  rc
+                        if ((flags & NativeMethods.SWP_NOMOVE) == 0)
+                        {
+                            x = rc.left;
+                            y = rc.top;
+                        }
+                        if ((flags & NativeMethods.SWP_NOSIZE) == 0)
+                        {
+                            width = rc.right - rc.left;
+                            height = rc.bottom - rc.top;
+                        }
+                    }
+                }
+            }
+
+            /// <summary>
+            ///  Notifies that the accelerator table needs to be updated due to a change in a control mnemonic.
+            /// </summary>
+            internal void UpdateAccelTable()
+            {
+                // Setting the count to -1 will recreate the table on demand (when GetControlInfo is called).
+                _accelCount = -1;
+
+                if (_clientSite is UnsafeNativeMethods.IOleControlSite ioleClientSite)
+                {
+                    ioleClientSite.OnControlInfoChanged();
+                }
+            }
+
+            // Since this method is used by Reflection .. dont change the "signature"
+            internal void ViewChangedInternal()
+            {
+                ViewChanged();
+            }
+
+            /// <summary>
+            ///  Notifies our view advise sink (if it exists) that the view has
+            ///  changed.
+            /// </summary>
+            private void ViewChanged()
+            {
+                // send the view change notification to anybody listening.
+                //
+                // Note: Word2000 won't resize components correctly if an OnViewChange notification
+                //       is sent while the component is persisting it's state.  The !m_fSaving check
+                //       is to make sure we don't call OnViewChange in this case.
+                if (_viewAdviseSink != null && !_activeXState[s_saving])
+                {
+                    _viewAdviseSink.OnViewChange(NativeMethods.DVASPECT_CONTENT, -1);
+
+                    if (_activeXState[s_viewAdviseOnlyOnce])
+                    {
+                        if (Marshal.IsComObject(_viewAdviseSink))
+                        {
+                            Marshal.ReleaseComObject(_viewAdviseSink);
+                        }
+                        _viewAdviseSink = null;
+                    }
+                }
+            }
+
+            /// <summary>
+            ///  Called when the window handle of the control has changed.
+            /// </summary>
+            void IWindowTarget.OnHandleChange(IntPtr newHandle)
+            {
+                _controlWindowTarget.OnHandleChange(newHandle);
+            }
+
+            /// <summary>
+            ///  Called to do control-specific processing for this window.
+            /// </summary>
+            void IWindowTarget.OnMessage(ref Message m)
+            {
+                if (_activeXState[s_uiDead])
+                {
+                    if (m.Msg >= Interop.WindowMessages.WM_MOUSEFIRST && m.Msg <= Interop.WindowMessages.WM_MOUSELAST)
+                    {
+                        return;
+                    }
+                    if (m.Msg >= Interop.WindowMessages.WM_NCLBUTTONDOWN && m.Msg <= Interop.WindowMessages.WM_NCMBUTTONDBLCLK)
+                    {
+                        return;
+                    }
+                    if (m.Msg >= Interop.WindowMessages.WM_KEYFIRST && m.Msg <= Interop.WindowMessages.WM_KEYLAST)
+                    {
+                        return;
+                    }
+                }
+
+                _controlWindowTarget.OnMessage(ref m);
+            }
+
+            /// <summary>
+            ///  This is a property bag implementation that sits on a stream.  It can
+            ///  read and write the bag to the stream.
+            /// </summary>
+            private class PropertyBagStream : UnsafeNativeMethods.IPropertyBag
+            {
+                private Hashtable _bag = new Hashtable();
+
+                internal void Read(UnsafeNativeMethods.IStream istream)
+                {
+                    // visual basic's memory streams don't support seeking, so we have to
+                    // work around this limitation here.  We do this by copying
+                    // the contents of the stream into a MemoryStream object.
+                    Stream stream = new DataStreamFromComStream(istream);
+                    const int PAGE_SIZE = 0x1000; // one page (4096b)
+                    byte[] streamData = new byte[PAGE_SIZE];
+                    int offset = 0;
+
+                    int count = stream.Read(streamData, offset, PAGE_SIZE);
+                    int totalCount = count;
+
+                    while (count == PAGE_SIZE)
+                    {
+                        byte[] newChunk = new byte[streamData.Length + PAGE_SIZE];
+                        Array.Copy(streamData, newChunk, streamData.Length);
+                        streamData = newChunk;
+
+                        offset += PAGE_SIZE;
+                        count = stream.Read(streamData, offset, PAGE_SIZE);
+                        totalCount += count;
+                    }
+
+                    stream = new MemoryStream(streamData);
+
+                    BinaryFormatter formatter = new BinaryFormatter();
+                    try
+                    {
+                        _bag = (Hashtable)formatter.Deserialize(stream);
+                    }
+                    catch (Exception e)
+                    {
+                        if (ClientUtils.IsSecurityOrCriticalException(e))
+                        {
+                            throw;
+                        }
+
+                        // Error reading.  Just init an empty hashtable.
+                        _bag = new Hashtable();
+                    }
+                }
+
+                int UnsafeNativeMethods.IPropertyBag.Read(string pszPropName, ref object pVar, UnsafeNativeMethods.IErrorLog pErrorLog)
+                {
+                    if (!_bag.Contains(pszPropName))
+                    {
+                        return NativeMethods.E_INVALIDARG;
+                    }
+
+                    pVar = _bag[pszPropName];
+                    return NativeMethods.S_OK;
+                }
+
+                int UnsafeNativeMethods.IPropertyBag.Write(string pszPropName, ref object pVar)
+                {
+                    _bag[pszPropName] = pVar;
+                    return NativeMethods.S_OK;
+                }
+
+                internal void Write(UnsafeNativeMethods.IStream istream)
+                {
+                    Stream stream = new DataStreamFromComStream(istream);
+                    BinaryFormatter formatter = new BinaryFormatter();
+                    formatter.Serialize(stream, _bag);
+                }
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXVerbEnum.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXVerbEnum.cs
@@ -1,0 +1,92 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Diagnostics;
+
+namespace System.Windows.Forms
+{
+    public partial class Control
+    {
+        /// <summary>
+        ///  Simple verb enumerator.
+        /// </summary>
+        private class ActiveXVerbEnum : UnsafeNativeMethods.IEnumOLEVERB
+        {
+            private readonly NativeMethods.tagOLEVERB[] _verbs;
+            private int _current;
+
+            internal ActiveXVerbEnum(NativeMethods.tagOLEVERB[] verbs)
+            {
+                _verbs = verbs;
+                _current = 0;
+            }
+
+            public int Next(int celt, NativeMethods.tagOLEVERB rgelt, int[] pceltFetched)
+            {
+                int fetched = 0;
+
+                if (celt != 1)
+                {
+                    Debug.Fail("Caller of IEnumOLEVERB requested celt > 1, but clr marshalling does not support this.");
+                    celt = 1;
+                }
+
+                while (celt > 0 && _current < _verbs.Length)
+                {
+                    rgelt.lVerb = _verbs[_current].lVerb;
+                    rgelt.lpszVerbName = _verbs[_current].lpszVerbName;
+                    rgelt.fuFlags = _verbs[_current].fuFlags;
+                    rgelt.grfAttribs = _verbs[_current].grfAttribs;
+                    celt--;
+                    _current++;
+                    fetched++;
+                }
+
+                if (pceltFetched != null)
+                {
+                    pceltFetched[0] = fetched;
+                }
+
+#if DEBUG
+                if (CompModSwitches.ActiveX.TraceInfo)
+                {
+                    Debug.WriteLine($"AxSource:IEnumOLEVERB::Next returning {fetched} verbs:");
+                    Debug.Indent();
+                    for (int i = _current - fetched; i < _current; i++)
+                    {
+                        Debug.WriteLine($"{i}: {_verbs[i].lVerb} {_verbs[i].lpszVerbName ?? string.Empty}");
+                    }
+                    Debug.Unindent();
+                }
+#endif
+                return (celt == 0 ? NativeMethods.S_OK : NativeMethods.S_FALSE);
+            }
+
+            public int Skip(int celt)
+            {
+                if (_current + celt < _verbs.Length)
+                {
+                    _current += celt;
+                    return NativeMethods.S_OK;
+                }
+                else
+                {
+                    _current = _verbs.Length;
+                    return NativeMethods.S_FALSE;
+                }
+            }
+
+            public void Reset()
+            {
+                _current = 0;
+            }
+
+            public void Clone(out UnsafeNativeMethods.IEnumOLEVERB ppenum)
+            {
+                ppenum = new ActiveXVerbEnum(_verbs);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.AmbientProperty.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.AmbientProperty.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms
+{
+    public partial class Control
+    {
+        /// <summary>
+        ///  Contains a single ambient property, including DISPID, name and value.
+        /// </summary>
+        private class AmbientProperty
+        {
+            private object _value;
+
+            /// <summary>
+            ///  Creates a new, empty ambient property.
+            ///</summary>
+            internal AmbientProperty(string name, int dispID)
+            {
+                Name = name;
+                DispID = dispID;
+                _value = null;
+                Empty = true;
+            }
+
+            /// <summary>
+            ///  The windows forms property name.
+            /// </summary>
+            internal string Name { get; }
+
+            /// <summary>
+            ///  The DispID for the property.
+            /// </summary>
+            internal int DispID { get; }
+
+            /// <summary>
+            ///  Returns true if this property has not been set.
+            /// </summary>
+            internal bool Empty { get; private set; }
+
+            /// <summary>
+            ///  The current value of the property.
+            /// </summary>
+            internal object Value
+            {
+                get
+                {
+                    return _value;
+                }
+                set
+                {
+                    _value = value;
+                    Empty = false;
+                }
+            }
+
+            /// <summary>
+            ///  Resets the property.
+            /// </summary>
+            internal void ResetValue()
+            {
+                Empty = true;
+                _value = null;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.AxSourcingSite.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.AxSourcingSite.cs
@@ -33,31 +33,27 @@ namespace System.Windows.Forms
 
             public object GetService(Type service)
             {
-                object retVal = null;
-
                 if (service == typeof(HtmlDocument))
                 {
-
                     int hr = _clientSite.GetContainer(out UnsafeNativeMethods.IOleContainer iOlecontainer);
 
                     if (NativeMethods.Succeeded(hr)
-                            && (iOlecontainer is UnsafeNativeMethods.IHTMLDocument))
+                        && (iOlecontainer is UnsafeNativeMethods.IHTMLDocument))
                     {
                         if (_shimManager == null)
                         {
                             _shimManager = new HtmlShimManager();
                         }
 
-                        retVal = new HtmlDocument(_shimManager, iOlecontainer as UnsafeNativeMethods.IHTMLDocument);
+                        return new HtmlDocument(_shimManager, iOlecontainer as UnsafeNativeMethods.IHTMLDocument);
                     }
-
                 }
                 else if (_clientSite.GetType().IsAssignableFrom(service))
                 {
-                    retVal = _clientSite;
+                    return _clientSite;
                 }
 
-                return retVal;
+                return null;
             }
 
             /// <summary>
@@ -70,7 +66,7 @@ namespace System.Windows.Forms
             /// </summary>
             public string Name
             {
-                get { return _name; }
+                get => _name;
                 set
                 {
                     if (value == null || _name == null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.AxSourcingSite.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.AxSourcingSite.cs
@@ -1,0 +1,84 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+
+namespace System.Windows.Forms
+{
+    public partial class Control
+    {
+        private class AxSourcingSite : ISite
+        {
+            private readonly UnsafeNativeMethods.IOleClientSite _clientSite;
+            private string _name;
+            private HtmlShimManager _shimManager;
+
+            internal AxSourcingSite(IComponent component, UnsafeNativeMethods.IOleClientSite clientSite, string name)
+            {
+                Component = component;
+                _clientSite = clientSite;
+                _name = name;
+            }
+
+            /// <summary>
+            ///  The component sited by this component site.
+            /// </summary>
+            public IComponent Component { get; }
+
+            /// <summary>
+            ///  The container in which the component is sited.
+            /// </summary>
+            public IContainer Container => null;
+
+            public object GetService(Type service)
+            {
+                object retVal = null;
+
+                if (service == typeof(HtmlDocument))
+                {
+
+                    int hr = _clientSite.GetContainer(out UnsafeNativeMethods.IOleContainer iOlecontainer);
+
+                    if (NativeMethods.Succeeded(hr)
+                            && (iOlecontainer is UnsafeNativeMethods.IHTMLDocument))
+                    {
+                        if (_shimManager == null)
+                        {
+                            _shimManager = new HtmlShimManager();
+                        }
+
+                        retVal = new HtmlDocument(_shimManager, iOlecontainer as UnsafeNativeMethods.IHTMLDocument);
+                    }
+
+                }
+                else if (_clientSite.GetType().IsAssignableFrom(service))
+                {
+                    retVal = _clientSite;
+                }
+
+                return retVal;
+            }
+
+            /// <summary>
+            ///  Indicates whether the component is in design mode.
+            /// </summary>
+            public bool DesignMode => false;
+
+            /// <summary>
+            ///  The name of the component.
+            /// </summary>
+            public string Name
+            {
+                get { return _name; }
+                set
+                {
+                    if (value == null || _name == null)
+                    {
+                        _name = value;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
@@ -1,0 +1,559 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Windows.Forms.Automation;
+
+namespace System.Windows.Forms
+{
+    public partial class Control
+    {
+        /// <summary>
+        ///  An implementation of AccessibleChild for use with Controls
+        /// </summary>
+        [ComVisible(true)]
+        public class ControlAccessibleObject : AccessibleObject
+        {
+            private static IntPtr s_oleAccAvailable = NativeMethods.InvalidIntPtr;
+
+            // Member variables
+
+            private IntPtr _handle = IntPtr.Zero; // Associated window handle (if any)
+            private int[] _runtimeId = null; // Used by UIAutomation
+
+            // constructors
+
+            public ControlAccessibleObject(Control ownerControl)
+            {
+                Debug.Assert(ownerControl != null, "Cannot construct a ControlAccessibleObject with a null ownerControl");
+
+                Owner = ownerControl ?? throw new ArgumentNullException(nameof(ownerControl));
+                IntPtr handle = ownerControl.Handle;
+                Handle = handle;
+            }
+
+            internal ControlAccessibleObject(Control ownerControl, int accObjId)
+            {
+                Debug.Assert(ownerControl != null, "Cannot construct a ControlAccessibleObject with a null ownerControl");
+
+                AccessibleObjectId = accObjId; // ...must set this *before* setting the Handle property
+                Owner = ownerControl ?? throw new ArgumentNullException(nameof(ownerControl));
+                IntPtr handle = ownerControl.Handle;
+                Handle = handle;
+            }
+
+            /// <summary>
+            ///  For container controls only, return array of child controls sorted into
+            ///  tab index order. This gets applies to the list of child accessible objects
+            ///  as returned by the system, so that we can present a meaningful order to
+            ///  the user. The system defaults to z-order, which is bad for us because
+            ///  that is usually the reverse of tab order!
+            /// </summary>
+            internal override int[] GetSysChildOrder()
+            {
+                if (Owner.GetStyle(ControlStyles.ContainerControl))
+                {
+                    return Owner.GetChildWindowsInTabOrder();
+                }
+
+                return base.GetSysChildOrder();
+            }
+
+            /// <summary>
+            ///  Perform custom navigation between parent/child/sibling accessible objects,
+            ///  using tab index order as the guide, rather than letting the system default
+            ///  behavior do navigation based on z-order.
+            ///
+            ///  For a container control and its child controls, the accessible object tree
+            ///  looks like this...
+            ///
+            ///  [client area of container]
+            ///   [non-client area of child #1]
+            ///       [random non-client elements]
+            ///       [client area of child #1]
+            ///       [random non-client elements]
+            ///   [non-client area of child #2]
+            ///       [random non-client elements]
+            ///       [client area of child #2]
+            ///       [random non-client elements]
+            ///   [non-client area of child #3]
+            ///       [random non-client elements]
+            ///       [client area of child #3]
+            ///       [random non-client elements]
+            ///
+            ///  We need to intercept first-child / last-child navigation from the container's
+            ///  client object, and next-sibling / previous-sibling navigation from each child's
+            ///  non-client object. All other navigation operations must be allowed to fall back
+            ///  on the system's deafult behavior (provided by OLEACC.DLL).
+            ///
+            ///  When combined with the re-ordering behavior of GetSysChildOrder() above, this
+            ///  allows us to present the end user with the illusion of accessible objects in
+            ///  tab index order, even though the system behavior only supports z-order.
+            /// </summary>
+            internal override bool GetSysChild(AccessibleNavigation navdir, out AccessibleObject accessibleObject)
+            {
+                // Clear the out parameter
+                accessibleObject = null;
+
+                // Get the owning control's parent, if it has one
+                Control parentControl = Owner.ParentInternal;
+
+                // ctrls[index] will indicate the control at the destination of this navigation operation
+                int index = -1;
+                Control[] ctrls = null;
+
+                // Now handle any 'appropriate' navigation requests...
+                switch (navdir)
+                {
+                    case AccessibleNavigation.FirstChild:
+                        if (IsClientObject)
+                        {
+                            ctrls = Owner.GetChildControlsInTabOrder(true);
+                            index = 0;
+                        }
+                        break;
+                    case AccessibleNavigation.LastChild:
+                        if (IsClientObject)
+                        {
+                            ctrls = Owner.GetChildControlsInTabOrder(true);
+                            index = ctrls.Length - 1;
+                        }
+                        break;
+                    case AccessibleNavigation.Previous:
+                        if (IsNonClientObject && parentControl != null)
+                        {
+                            ctrls = parentControl.GetChildControlsInTabOrder(true);
+                            index = Array.IndexOf(ctrls, Owner);
+                            if (index != -1)
+                            {
+                                --index;
+                            }
+                        }
+                        break;
+                    case AccessibleNavigation.Next:
+                        if (IsNonClientObject && parentControl != null)
+                        {
+                            ctrls = parentControl.GetChildControlsInTabOrder(true);
+                            index = Array.IndexOf(ctrls, Owner);
+                            if (index != -1)
+                            {
+                                ++index;
+                            }
+                        }
+                        break;
+                }
+
+                // Unsupported navigation operation for this object, or unexpected error.
+                // Return false to force fall back on default system navigation behavior.
+                if (ctrls == null || ctrls.Length == 0)
+                {
+                    return false;
+                }
+
+                // If ctrls[index] is a valid control, return its non-client accessible object.
+                // If index is invalid, return null pointer meaning "end of list reached".
+                if (index >= 0 && index < ctrls.Length)
+                {
+                    accessibleObject = ctrls[index].NcAccessibilityObject;
+                }
+
+                // Return true to use the found accessible object and block default system behavior
+                return true;
+            }
+
+            public override string DefaultAction
+            {
+                get
+                {
+                    string defaultAction = Owner.AccessibleDefaultActionDescription;
+                    if (defaultAction != null)
+                    {
+                        return defaultAction;
+                    }
+                    else
+                    {
+                        return base.DefaultAction;
+                    }
+                }
+            }
+
+            // This is used only if control supports IAccessibleEx
+            internal override int[] RuntimeId
+            {
+                get
+                {
+                    if (_runtimeId == null)
+                    {
+                        _runtimeId = new int[2];
+                        _runtimeId[0] = 0x2a;
+                        _runtimeId[1] = (int)(long)Handle;
+                    }
+
+                    return _runtimeId;
+                }
+            }
+
+            public override string Description
+            {
+                get
+                {
+                    string description = Owner.AccessibleDescription;
+                    if (description != null)
+                    {
+                        return description;
+                    }
+                    else
+                    {
+                        return base.Description;
+                    }
+                }
+            }
+
+            public IntPtr Handle
+            {
+                get
+                {
+                    return _handle;
+                }
+                set
+                {
+                    if (_handle != value)
+                    {
+                        _handle = value;
+
+                        if (s_oleAccAvailable == IntPtr.Zero)
+                        {
+                            return;
+                        }
+
+                        bool freeLib = false;
+
+                        if (s_oleAccAvailable == NativeMethods.InvalidIntPtr)
+                        {
+                            s_oleAccAvailable = Interop.Kernel32.LoadLibraryFromSystemPathIfAvailable("oleacc.dll");
+                            freeLib = (s_oleAccAvailable != IntPtr.Zero);
+                        }
+
+                        // Update systemIAccessible
+                        // We need to store internally the system provided
+                        // IAccessible, because some windows forms controls use it
+                        // as the default IAccessible implementation.
+                        if (_handle != IntPtr.Zero && s_oleAccAvailable != IntPtr.Zero)
+                        {
+                            UseStdAccessibleObjects(_handle);
+                        }
+
+                        if (freeLib)
+                        {
+                            Interop.Kernel32.FreeLibrary(s_oleAccAvailable);
+                        }
+                    }
+                }
+            }
+
+            public override string Help
+            {
+                get
+                {
+                    QueryAccessibilityHelpEventHandler handler = (QueryAccessibilityHelpEventHandler)Owner.Events[EventQueryAccessibilityHelp];
+
+                    if (handler != null)
+                    {
+                        QueryAccessibilityHelpEventArgs args = new QueryAccessibilityHelpEventArgs();
+                        handler(Owner, args);
+                        return args.HelpString;
+                    }
+                    else
+                    {
+                        return base.Help;
+                    }
+                }
+            }
+
+            public override string KeyboardShortcut
+            {
+                get
+                {
+                    // For controls, the default keyboard shortcut comes directly from the accessible
+                    // name property. This matches the default behavior of OLEACC.DLL exactly.
+                    char mnemonic = WindowsFormsUtils.GetMnemonic(TextLabel, false);
+                    return (mnemonic == (char)0) ? null : ("Alt+" + mnemonic);
+                }
+            }
+
+            public override string Name
+            {
+                get
+                {
+                    // Special case: If an explicit name has been set in the AccessibleName property, use that.
+                    // Note: Any non-null value in AccessibleName overrides the default accessible name logic,
+                    // even an empty string (this is the only way to *force* the accessible name to be blank).
+                    string name = Owner.AccessibleName;
+                    if (name != null)
+                    {
+                        return name;
+                    }
+
+                    // Otherwise just return the default label string, minus any mnemonics
+                    return WindowsFormsUtils.TextWithoutMnemonics(TextLabel);
+                }
+                set
+                {
+                    // If anyone tries to set the accessible name, just cache the value in the control's
+                    // AccessibleName property. This value will then end up overriding the normal accessible
+                    // name logic, until such time as AccessibleName is set back to null.
+                    Owner.AccessibleName = value;
+                }
+            }
+
+            public override AccessibleObject Parent
+            {
+                get
+                {
+                    return base.Parent;
+                }
+            }
+
+            // Determine the text that should be used to 'label' this control for accessibility purposes.
+            //
+            // Prior to Whidbey, we just called 'base.Name' to determine the accessible name. This would end up calling
+            // OLEACC.DLL to determine the name. The rules used by OLEACC.DLL are the same as what we now have below,
+            // except that OLEACC searches for preceding labels using z-order, and we want to search for labels using
+            // TabIndex order.
+            internal string TextLabel
+            {
+                get
+                {
+                    // If owning control allows, use its Text property - but only if that Text is not empty
+                    if (Owner.GetStyle(ControlStyles.UseTextForAccessibility))
+                    {
+                        string text = Owner.Text;
+                        if (!string.IsNullOrEmpty(text))
+                        {
+                            return text;
+                        }
+                    }
+
+                    // Otherwise use the text of the preceding Label control, if there is one
+                    Label previousLabel = PreviousLabel;
+                    if (previousLabel != null)
+                    {
+                        string text = previousLabel.Text;
+                        if (!string.IsNullOrEmpty(text))
+                        {
+                            return text;
+                        }
+                    }
+
+                    // This control has no discernable MSAA name - return an empty string to indiciate 'nameless'.
+                    return null;
+                }
+            }
+
+            public Control Owner { get; } = null;
+
+            // Look for a label immediately preceeding this control in
+            // the tab order, and use its name for the accessible name.
+            //
+            // This method aims to emulate the equivalent behavior in OLEACC.DLL,
+            // but walking controls in TabIndex order rather than native z-order.
+            internal Label PreviousLabel
+            {
+                get
+                {
+                    // Try to get to the parent of this control.
+                    Control parent = Owner.ParentInternal;
+
+                    if (parent == null)
+                    {
+                        return null;
+                    }
+
+                    // Find this control's containing control
+                    if (!(parent.GetContainerControl() is ContainerControl container))
+                    {
+                        return null;
+                    }
+
+                    // Walk backwards through peer controls...
+                    for (Control previous = container.GetNextControl(Owner, false);
+                         previous != null;
+                         previous = container.GetNextControl(previous, false))
+                    {
+
+                        // Stop when we hit a Label (whether visible or invisible)
+                        if (previous is Label)
+                        {
+                            return previous as Label;
+                        }
+
+                        // Stop at any *visible* tab stop
+                        if (previous.Visible && previous.TabStop)
+                        {
+                            break;
+                        }
+                    }
+
+                    return null;
+                }
+            }
+
+            public override AccessibleRole Role
+            {
+                get
+                {
+                    AccessibleRole role = Owner.AccessibleRole;
+                    if (role != AccessibleRole.Default)
+                    {
+                        return role;
+                    }
+                    else
+                    {
+                        return base.Role;
+                    }
+
+                }
+            }
+
+            public override int GetHelpTopic(out string fileName)
+            {
+                int topic = 0;
+
+                QueryAccessibilityHelpEventHandler handler = (QueryAccessibilityHelpEventHandler)Owner.Events[EventQueryAccessibilityHelp];
+
+                if (handler != null)
+                {
+                    QueryAccessibilityHelpEventArgs args = new QueryAccessibilityHelpEventArgs();
+                    handler(Owner, args);
+
+                    fileName = args.HelpNamespace;
+
+                    try
+                    {
+                        topic = int.Parse(args.HelpKeyword, CultureInfo.InvariantCulture);
+                    }
+                    catch (Exception e)
+                    {
+                        if (ClientUtils.IsSecurityOrCriticalException(e))
+                        {
+                            throw;
+                        }
+                    }
+
+                    return topic;
+                }
+                else
+                {
+                    return base.GetHelpTopic(out fileName);
+                }
+            }
+
+            public void NotifyClients(AccessibleEvents accEvent)
+            {
+                Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, "Control.NotifyClients: this = " +
+                                  ToString() + ", accEvent = " + accEvent.ToString() + ", childID = self");
+
+                UnsafeNativeMethods.NotifyWinEvent((int)accEvent, new HandleRef(this, Handle), NativeMethods.OBJID_CLIENT, 0);
+            }
+
+            public void NotifyClients(AccessibleEvents accEvent, int childID)
+            {
+
+                Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, "Control.NotifyClients: this = " +
+                                  ToString() +
+                                  ", accEvent = " + accEvent.ToString() +
+                                  ", childID = " + childID.ToString(CultureInfo.InvariantCulture));
+
+                UnsafeNativeMethods.NotifyWinEvent((int)accEvent, new HandleRef(this, Handle), NativeMethods.OBJID_CLIENT, childID + 1);
+            }
+
+            public void NotifyClients(AccessibleEvents accEvent, int objectID, int childID)
+            {
+
+                Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, "Control.NotifyClients: this = " +
+                                  ToString() +
+                                  ", accEvent = " + accEvent.ToString() +
+                                  ", childID = " + childID.ToString(CultureInfo.InvariantCulture));
+
+                UnsafeNativeMethods.NotifyWinEvent((int)accEvent, new HandleRef(this, Handle), objectID, childID + 1);
+            }
+
+            /// <summary>
+            /// Raises the LiveRegionChanged UIA event.
+            /// To make this method effective, the control must implement System.Windows.Forms.Automation.IAutomationLiveRegion interface
+            /// and its LiveSetting property must return either AutomationLiveSetting.Polite or AutomationLiveSetting.Assertive value.
+            /// </summary>
+            /// <returns>True if operation succeeds, False otherwise.</returns>
+            public override bool RaiseLiveRegionChanged()
+            {
+                if (!(Owner is IAutomationLiveRegion))
+                {
+                    throw new InvalidOperationException(SR.OwnerControlIsNotALiveRegion);
+                }
+
+                return RaiseAutomationEvent(NativeMethods.UIA_LiveRegionChangedEventId);
+            }
+
+            internal override bool IsIAccessibleExSupported()
+            {
+                if (Owner is IAutomationLiveRegion)
+                {
+                    return true;
+                }
+
+                return base.IsIAccessibleExSupported();
+            }
+
+            internal override object GetPropertyValue(int propertyID)
+            {
+                if (propertyID == NativeMethods.UIA_LiveSettingPropertyId && Owner is IAutomationLiveRegion)
+                {
+                    return ((IAutomationLiveRegion)Owner).LiveSetting;
+                }
+
+                if (Owner.SupportsUiaProviders)
+                {
+                    switch (propertyID)
+                    {
+                        case NativeMethods.UIA_IsKeyboardFocusablePropertyId:
+                            return Owner.CanSelect;
+                        case NativeMethods.UIA_IsOffscreenPropertyId:
+                        case NativeMethods.UIA_IsPasswordPropertyId:
+                            return false;
+                        case NativeMethods.UIA_AccessKeyPropertyId:
+                            return string.Empty;
+                        case NativeMethods.UIA_HelpTextPropertyId:
+                            return Help ?? string.Empty;
+                    }
+                }
+
+                return base.GetPropertyValue(propertyID);
+            }
+
+            internal override UnsafeNativeMethods.IRawElementProviderSimple HostRawElementProvider
+            {
+                get
+                {
+                    UnsafeNativeMethods.UiaHostProviderFromHwnd(new HandleRef(this, Handle), out UnsafeNativeMethods.IRawElementProviderSimple provider);
+                    return provider;
+                }
+            }
+
+            public override string ToString()
+            {
+                if (Owner != null)
+                {
+                    return "ControlAccessibleObject: Owner = " + Owner.ToString();
+                }
+                else
+                {
+                    return "ControlAccessibleObject: Owner = null";
+                }
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlCollection.cs
@@ -1,0 +1,598 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Windows.Forms.Layout;
+
+namespace System.Windows.Forms
+{
+    public partial class Control
+    {
+        /// <summary>
+        ///  Collection of controls...
+        /// </summary>
+        [ListBindable(false), ComVisible(false)]
+        public class ControlCollection : ArrangedElementCollection, IList, ICloneable
+        {
+            /// A caching mechanism for key accessor
+            /// We use an index here rather than control so that we don't have lifetime
+            /// issues by holding on to extra references.
+            /// Note this is not Thread Safe - but WinForms has to be run in a STA anyways.
+            private int _lastAccessedIndex = -1;
+
+            public ControlCollection(Control owner)
+            {
+                Owner = owner;
+            }
+
+            /// <summary>
+            ///  Returns true if the collection contains an item with the specified key, false otherwise.
+            /// </summary>
+            public virtual bool ContainsKey(string key)
+            {
+                return IsValidIndex(IndexOfKey(key));
+            }
+
+            /// <summary>
+            ///  Adds a child control to this control. The control becomes the last control in
+            ///  the child control list. If the control is already a child of another control it
+            ///  is first removed from that control.
+            /// </summary>
+            public virtual void Add(Control value)
+            {
+                if (value == null)
+                {
+                    return;
+                }
+
+                if (value.GetTopLevel())
+                {
+                    throw new ArgumentException(SR.TopLevelControlAdd);
+                }
+
+                // Verify that the control being added is on the same thread as
+                // us...or our parent chain.
+                if (Owner.CreateThreadId != value.CreateThreadId)
+                {
+                    throw new ArgumentException(SR.AddDifferentThreads);
+                }
+
+                CheckParentingCycle(Owner, value);
+
+                if (value._parent == Owner)
+                {
+                    value.SendToBack();
+                    return;
+                }
+
+                // Remove the new control from its old parent (if any)
+                if (value._parent != null)
+                {
+                    value._parent.Controls.Remove(value);
+                }
+
+                // Add the control
+                InnerList.Add(value);
+
+                if (value._tabIndex == -1)
+                {
+                    // Find the next highest tab index
+                    int nextTabIndex = 0;
+                    for (int c = 0; c < (Count - 1); c++)
+                    {
+                        int t = this[c].TabIndex;
+                        if (nextTabIndex <= t)
+                        {
+                            nextTabIndex = t + 1;
+                        }
+                    }
+                    value._tabIndex = nextTabIndex;
+                }
+
+                // if we don't suspend layout, AssignParent will indirectly trigger a layout event
+                // before we're ready (AssignParent will fire a PropertyChangedEvent("Visible"), which calls PerformLayout)
+#if DEBUG
+                int dbgLayoutCheck = Owner.LayoutSuspendCount;
+#endif
+                Owner.SuspendLayout();
+
+                try
+                {
+                    Control oldParent = value._parent;
+                    try
+                    {
+                        // AssignParent calls into user code - this could throw, which
+                        // would make us short-circuit the rest of the reparenting logic.
+                        // you could end up with a control half reparented.
+                        value.AssignParent(Owner);
+                    }
+                    finally
+                    {
+                        if (oldParent != value._parent && (Owner._state & STATE_CREATED) != 0)
+                        {
+                            value.SetParentHandle(Owner.InternalHandle);
+                            if (value.Visible)
+                            {
+                                value.CreateControl();
+                            }
+                        }
+                    }
+
+                    value.InitLayout();
+                }
+                finally
+                {
+                    Owner.ResumeLayout(false);
+#if DEBUG
+                    Owner.AssertLayoutSuspendCount(dbgLayoutCheck);
+#endif
+                }
+
+                // Not putting in the finally block, as it would eat the original
+                // exception thrown from AssignParent if the following throws an exception.
+                LayoutTransaction.DoLayout(Owner, value, PropertyNames.Parent);
+                Owner.OnControlAdded(new ControlEventArgs(value));
+            }
+
+            int IList.Add(object control)
+            {
+                if (control is Control)
+                {
+                    Add((Control)control);
+                    return IndexOf((Control)control);
+                }
+                else
+                {
+                    throw new ArgumentException(SR.ControlBadControl, "control");
+                }
+            }
+
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+            public virtual void AddRange(Control[] controls)
+            {
+                if (controls == null)
+                {
+                    throw new ArgumentNullException(nameof(controls));
+                }
+                if (controls.Length > 0)
+                {
+#if DEBUG
+                    int dbgLayoutCheck = Owner.LayoutSuspendCount;
+#endif
+                    Owner.SuspendLayout();
+                    try
+                    {
+                        for (int i = 0; i < controls.Length; ++i)
+                        {
+                            Add(controls[i]);
+                        }
+                    }
+                    finally
+                    {
+                        Owner.ResumeLayout(true);
+                    }
+#if DEBUG
+                    Owner.AssertLayoutSuspendCount(dbgLayoutCheck);
+#endif
+                }
+            }
+
+            object ICloneable.Clone()
+            {
+                // Use CreateControlInstance so we get the same type of ControlCollection, but whack the
+                // owner so adding controls to this new collection does not affect the control we cloned from.
+                ControlCollection ccOther = Owner.CreateControlsInstance();
+
+                // We add using InnerList to prevent unnecessary parent cycle checks, etc.
+                ccOther.InnerList.AddRange(this);
+                return ccOther;
+            }
+
+            public bool Contains(Control control)
+            {
+                return InnerList.Contains(control);
+            }
+
+            /// <summary>
+            ///  Searches for Controls by their Name property, builds up an array
+            ///  of all the controls that match.
+            /// </summary>
+            public Control[] Find(string key, bool searchAllChildren)
+            {
+                if (string.IsNullOrEmpty(key))
+                {
+                    throw new ArgumentNullException(nameof(key), SR.FindKeyMayNotBeEmptyOrNull);
+                }
+
+                ArrayList foundControls = FindInternal(key, searchAllChildren, this, new ArrayList());
+
+                // Make this a stongly typed collection.
+                Control[] stronglyTypedFoundControls = new Control[foundControls.Count];
+                foundControls.CopyTo(stronglyTypedFoundControls, 0);
+
+                return stronglyTypedFoundControls;
+            }
+
+            /// <summary>
+            ///  Searches for Controls by their Name property, builds up an array list
+            ///  of all the controls that match.
+            /// </summary>
+            private ArrayList FindInternal(string key, bool searchAllChildren, ControlCollection controlsToLookIn, ArrayList foundControls)
+            {
+                if ((controlsToLookIn == null) || (foundControls == null))
+                {
+                    return null;
+                }
+
+                try
+                {
+                    // Perform breadth first search - as it's likely people will want controls belonging
+                    // to the same parent close to each other.
+                    for (int i = 0; i < controlsToLookIn.Count; i++)
+                    {
+                        if (controlsToLookIn[i] == null)
+                        {
+                            continue;
+                        }
+
+                        if (WindowsFormsUtils.SafeCompareStrings(controlsToLookIn[i].Name, key, /* ignoreCase = */ true))
+                        {
+                            foundControls.Add(controlsToLookIn[i]);
+                        }
+                    }
+
+                    // Optional recurive search for controls in child collections.
+
+                    if (searchAllChildren)
+                    {
+                        for (int i = 0; i < controlsToLookIn.Count; i++)
+                        {
+                            if (controlsToLookIn[i] == null)
+                            {
+                                continue;
+                            }
+                            if ((controlsToLookIn[i].Controls != null) && controlsToLookIn[i].Controls.Count > 0)
+                            {
+                                // if it has a valid child collecion, append those results to our collection
+                                foundControls = FindInternal(key, searchAllChildren, controlsToLookIn[i].Controls, foundControls);
+                            }
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    if (ClientUtils.IsSecurityOrCriticalException(e))
+                    {
+                        throw;
+                    }
+                }
+                return foundControls;
+            }
+
+            public override IEnumerator GetEnumerator()
+            {
+                return new ControlCollectionEnumerator(this);
+            }
+
+            public int IndexOf(Control control)
+            {
+                return InnerList.IndexOf(control);
+            }
+
+            /// <summary>
+            ///  The zero-based index of the first occurrence of value within the entire CollectionBase, if found; otherwise, -1.
+            /// </summary>
+            public virtual int IndexOfKey(string key)
+            {
+                // Step 0 - Arg validation
+                if (string.IsNullOrEmpty(key))
+                {
+                    return -1; // we dont support empty or null keys.
+                }
+
+                // step 1 - check the last cached item
+                if (IsValidIndex(_lastAccessedIndex))
+                {
+                    if (WindowsFormsUtils.SafeCompareStrings(this[_lastAccessedIndex].Name, key, /* ignoreCase = */ true))
+                    {
+                        return _lastAccessedIndex;
+                    }
+                }
+
+                // step 2 - search for the item
+                for (int i = 0; i < Count; i++)
+                {
+                    if (WindowsFormsUtils.SafeCompareStrings(this[i].Name, key, /* ignoreCase = */ true))
+                    {
+                        _lastAccessedIndex = i;
+                        return i;
+                    }
+                }
+
+                // step 3 - we didn't find it.  Invalidate the last accessed index and return -1.
+                _lastAccessedIndex = -1;
+                return -1;
+            }
+
+            /// <summary>
+            ///  Determines if the index is valid for the collection.
+            /// </summary>
+            private bool IsValidIndex(int index)
+            {
+                return ((index >= 0) && (index < Count));
+            }
+
+            /// <summary>
+            ///  Who owns this control collection.
+            /// </summary>
+            public Control Owner { get; }
+
+            /// <summary>
+            ///  Removes control from this control. Inheriting controls should call
+            ///  base.remove to ensure that the control is removed.
+            /// </summary>
+            public virtual void Remove(Control value)
+            {
+                // Sanity check parameter
+                if (value == null)
+                {
+                    return;     // Don't do anything
+                }
+
+                if (value.ParentInternal == Owner)
+                {
+                    Debug.Assert(Owner != null);
+
+                    value.SetParentHandle(IntPtr.Zero);
+
+                    // Remove the control from the internal control array
+                    //
+                    InnerList.Remove(value);
+                    value.AssignParent(null);
+                    LayoutTransaction.DoLayout(Owner, value, PropertyNames.Parent);
+                    Owner.OnControlRemoved(new ControlEventArgs(value));
+
+                    // ContainerControl needs to see it needs to find a new ActiveControl.
+                    if (Owner.GetContainerControl() is ContainerControl cc)
+                    {
+                        cc.AfterControlRemoved(value, Owner);
+                    }
+                }
+            }
+
+            void IList.Remove(object control)
+            {
+                if (control is Control)
+                {
+                    Remove((Control)control);
+                }
+            }
+
+            public void RemoveAt(int index)
+            {
+                Remove(this[index]);
+            }
+
+            /// <summary>
+            ///  Removes the child control with the specified key.
+            /// </summary>
+            public virtual void RemoveByKey(string key)
+            {
+                int index = IndexOfKey(key);
+                if (IsValidIndex(index))
+                {
+                    RemoveAt(index);
+                }
+            }
+
+            /// <summary>
+            ///  Retrieves the child control with the specified index.
+            /// </summary>
+            public new virtual Control this[int index]
+            {
+                get
+                {
+                    //do some bounds checking here...
+                    if (index < 0 || index >= Count)
+                    {
+                        throw new ArgumentOutOfRangeException(
+                            nameof(index),
+                            string.Format(SR.IndexOutOfRange, index.ToString(CultureInfo.CurrentCulture)));
+                    }
+
+                    Control control = (Control)InnerList[index];
+                    Debug.Assert(control != null, "Why are we returning null controls from a valid index?");
+                    return control;
+                }
+            }
+
+            /// <summary>
+            ///  Retrieves the child control with the specified key.
+            /// </summary>
+            public virtual Control this[string key]
+            {
+                get
+                {
+                    // We do not support null and empty string as valid keys.
+                    if (string.IsNullOrEmpty(key))
+                    {
+                        return null;
+                    }
+
+                    // Search for the key in our collection
+                    int index = IndexOfKey(key);
+                    if (IsValidIndex(index))
+                    {
+                        return this[index];
+                    }
+                    else
+                    {
+                        return null;
+                    }
+
+                }
+            }
+
+            public virtual void Clear()
+            {
+#if DEBUG
+                int layoutSuspendCount = Owner.LayoutSuspendCount;
+#endif
+                Owner.SuspendLayout();
+                // clear all preferred size caches in the tree -
+                // inherited fonts could go away, etc.
+                CommonProperties.xClearAllPreferredSizeCaches(Owner);
+
+                try
+                {
+                    while (Count != 0)
+                    {
+                        RemoveAt(Count - 1);
+                    }
+                }
+                finally
+                {
+                    Owner.ResumeLayout();
+#if DEBUG
+                    Debug.Assert(Owner.LayoutSuspendCount == layoutSuspendCount, "Suspend/Resume layout mismatch!");
+#endif
+                }
+            }
+
+            /// <summary>
+            ///  Retrieves the index of the specified
+            ///  child control in this array.  An ArgumentException
+            ///  is thrown if child is not parented to this
+            ///  Control.
+            /// </summary>
+            public int GetChildIndex(Control child)
+            {
+                return GetChildIndex(child, true);
+            }
+
+            /// <summary>
+            ///  Retrieves the index of the specified
+            ///  child control in this array.  An ArgumentException
+            ///  is thrown if child is not parented to this
+            ///  Control.
+            /// </summary>
+            public virtual int GetChildIndex(Control child, bool throwException)
+            {
+                int index = IndexOf(child);
+                if (index == -1 && throwException)
+                {
+                    throw new ArgumentException(SR.ControlNotChild);
+                }
+                return index;
+            }
+
+            /// <summary>
+            ///  This is internal virtual method so that "Readonly Collections" can override this and throw as they should not allow changing
+            ///  the child control indices.
+            /// </summary>
+            internal virtual void SetChildIndexInternal(Control child, int newIndex)
+            {
+                // Sanity check parameters
+                if (child == null)
+                {
+                    throw new ArgumentNullException(nameof(child));
+                }
+
+                int currentIndex = GetChildIndex(child);
+
+                if (currentIndex == newIndex)
+                {
+                    return;
+                }
+
+                if (newIndex >= Count || newIndex == -1)
+                {
+                    newIndex = Count - 1;
+                }
+
+                MoveElement(child, currentIndex, newIndex);
+                child.UpdateZOrder();
+
+                LayoutTransaction.DoLayout(Owner, child, PropertyNames.ChildIndex);
+
+            }
+
+            /// <summary>
+            ///  Sets the index of the specified
+            ///  child control in this array.  An ArgumentException
+            ///  is thrown if child is not parented to this
+            ///  Control.
+            /// </summary>
+            public virtual void SetChildIndex(Control child, int newIndex)
+            {
+                SetChildIndexInternal(child, newIndex);
+            }
+
+            // This is the same as WinformsUtils.ArraySubsetEnumerator
+            // however since we're no longer an array, we've gotta employ a
+            // special version of this.
+            private class ControlCollectionEnumerator : IEnumerator
+            {
+                private readonly ControlCollection controls;
+                private int current;
+                private readonly int originalCount;
+
+                public ControlCollectionEnumerator(ControlCollection controls)
+                {
+                    this.controls = controls;
+                    originalCount = controls.Count;
+                    current = -1;
+                }
+
+                public bool MoveNext()
+                {
+                    // We have to use Controls.Count here because someone could have deleted
+                    // an item from the array.
+                    //
+                    // this can happen if someone does:
+                    //     foreach (Control c in Controls) { c.Dispose(); }
+                    //
+                    // We also dont want to iterate past the original size of the collection
+                    //
+                    // this can happen if someone does
+                    //     foreach (Control c in Controls) { c.Controls.Add(new Label()); }
+
+                    if (current < controls.Count - 1 && current < originalCount - 1)
+                    {
+                        current++;
+                        return true;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+
+                public void Reset()
+                {
+                    current = -1;
+                }
+
+                public object Current
+                {
+                    get
+                    {
+                        if (current == -1)
+                        {
+                            return null;
+                        }
+                        else
+                        {
+                            return controls[current];
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlCollection.cs
@@ -264,12 +264,8 @@ namespace System.Windows.Forms
                         }
                     }
                 }
-                catch (Exception e)
+                catch (Exception e) when (!ClientUtils.IsSecurityOrCriticalException(e))
                 {
-                    if (ClientUtils.IsSecurityOrCriticalException(e))
-                    {
-                        throw;
-                    }
                 }
                 return foundControls;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlNativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlNativeWindow.cs
@@ -1,0 +1,120 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Windows.Forms
+{
+    public partial class Control
+    {
+        internal sealed class ControlNativeWindow : NativeWindow, IWindowTarget
+        {
+            private readonly Control _control;
+            private GCHandle _rootRef;   // We will root the control when we do not want to be elligible for garbage collection.
+
+            internal ControlNativeWindow(Control control)
+            {
+                _control = control;
+                WindowTarget = this;
+            }
+
+            internal Control GetControl()
+            {
+                return _control;
+            }
+
+            protected override void OnHandleChange()
+            {
+                WindowTarget.OnHandleChange(Handle);
+            }
+
+            // IWindowTarget method
+            public void OnHandleChange(IntPtr newHandle)
+            {
+                _control.SetHandle(newHandle);
+            }
+
+            internal void LockReference(bool locked)
+            {
+                if (locked)
+                {
+                    if (!_rootRef.IsAllocated)
+                    {
+                        _rootRef = GCHandle.Alloc(GetControl(), GCHandleType.Normal);
+                    }
+                }
+                else
+                {
+                    if (_rootRef.IsAllocated)
+                    {
+                        _rootRef.Free();
+                    }
+                }
+            }
+
+            protected override void OnThreadException(Exception e)
+            {
+                _control.WndProcException(e);
+            }
+
+            // IWindowTarget method
+            public void OnMessage(ref Message m)
+            {
+                _control.WndProc(ref m);
+            }
+
+            internal IWindowTarget WindowTarget { get; set; }
+
+#if DEBUG
+            // We override ToString so in debug asserts that fire for
+            // non-released controls will show what control wasn't released.
+            public override string ToString()
+            {
+                if (_control != null)
+                {
+                    return _control.GetType().FullName;
+                }
+                return base.ToString();
+            }
+#endif
+
+            protected override void WndProc(ref Message m)
+            {
+                // There are certain messages that we want to process
+                // regardless of what window target we are using.  These
+                // messages cause other messages or state transitions
+                // to occur within control.
+                switch (m.Msg)
+                {
+                    case Interop.WindowMessages.WM_MOUSELEAVE:
+                        _control.UnhookMouseEvent();
+                        break;
+
+                    case Interop.WindowMessages.WM_MOUSEMOVE:
+                        if (!_control.GetState(STATE_TRACKINGMOUSEEVENT))
+                        {
+                            _control.HookMouseEvent();
+                            if (!_control.GetState(STATE_MOUSEENTERPENDING))
+                            {
+                                _control.SendMessage(NativeMethods.WM_MOUSEENTER, 0, 0);
+                            }
+                            else
+                            {
+                                _control.SetState(STATE_MOUSEENTERPENDING, false);
+                            }
+                        }
+                        break;
+
+                    case Interop.WindowMessages.WM_MOUSEWHEEL:
+                        // TrackMouseEvent's mousehover implementation doesn't watch the wheel
+                        // correctly...
+                        _control.ResetMouseEventArgs();
+                        break;
+                }
+
+                WindowTarget.OnMessage(ref m);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlTabOrderHolder.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlTabOrderHolder.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+
+namespace System.Windows.Forms
+{
+    public partial class Control
+    {
+        /// <summary>
+        ///  This class contains a control and associates it with a z-order.
+        ///  This is used when sorting controls based on tab index first,
+        ///  z-order second.
+        /// </summary>
+        private class ControlTabOrderHolder
+        {
+            internal readonly int _oldOrder;
+            internal readonly int _newOrder;
+            internal readonly Control _control;
+
+            internal ControlTabOrderHolder(int oldOrder, int newOrder, Control control)
+            {
+                _oldOrder = oldOrder;
+                _newOrder = newOrder;
+                _control = control;
+            }
+        }
+
+        /// <summary>
+        ///  Used to sort controls based on tab index and z-order.
+        /// </summary>
+        private class ControlTabOrderComparer : IComparer
+        {
+            int IComparer.Compare(object x, object y)
+            {
+                ControlTabOrderHolder hx = (ControlTabOrderHolder)x;
+                ControlTabOrderHolder hy = (ControlTabOrderHolder)y;
+
+                int delta = hx._newOrder - hy._newOrder;
+                if (delta == 0)
+                {
+                    delta = hx._oldOrder - hy._oldOrder;
+                }
+
+                return delta;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlVersionInfo.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlVersionInfo.cs
@@ -1,0 +1,173 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Reflection;
+
+namespace System.Windows.Forms
+{
+    public partial class Control
+    {
+        private class ControlVersionInfo
+        {
+            private string _companyName = null;
+            private string _productName = null;
+            private string _productVersion = null;
+            private FileVersionInfo _versionInfo = null;
+            private readonly Control _owner;
+
+            internal ControlVersionInfo(Control owner)
+            {
+                _owner = owner;
+            }
+
+            /// <summary>
+            ///  The company name associated with the component.
+            /// </summary>
+            internal string CompanyName
+            {
+                get
+                {
+                    if (_companyName == null)
+                    {
+                        object[] attrs = _owner.GetType().Module.Assembly.GetCustomAttributes(typeof(AssemblyCompanyAttribute), false);
+                        if (attrs != null && attrs.Length > 0)
+                        {
+                            _companyName = ((AssemblyCompanyAttribute)attrs[0]).Company;
+                        }
+
+                        if (_companyName == null || _companyName.Length == 0)
+                        {
+                            _companyName = GetFileVersionInfo().CompanyName;
+                            if (_companyName != null)
+                            {
+                                _companyName = _companyName.Trim();
+                            }
+                        }
+
+                        if (_companyName == null || _companyName.Length == 0)
+                        {
+                            string ns = _owner.GetType().Namespace;
+
+                            if (ns == null)
+                            {
+                                ns = string.Empty;
+                            }
+
+                            int firstDot = ns.IndexOf('/');
+                            if (firstDot != -1)
+                            {
+                                _companyName = ns.Substring(0, firstDot);
+                            }
+                            else
+                            {
+                                _companyName = ns;
+                            }
+                        }
+                    }
+                    return _companyName;
+                }
+            }
+
+            /// <summary>
+            ///  The product name associated with this component.
+            /// </summary>
+            internal string ProductName
+            {
+                get
+                {
+                    if (_productName == null)
+                    {
+                        object[] attrs = _owner.GetType().Module.Assembly.GetCustomAttributes(typeof(AssemblyProductAttribute), false);
+                        if (attrs != null && attrs.Length > 0)
+                        {
+                            _productName = ((AssemblyProductAttribute)attrs[0]).Product;
+                        }
+
+                        if (_productName == null || _productName.Length == 0)
+                        {
+                            _productName = GetFileVersionInfo().ProductName;
+                            if (_productName != null)
+                            {
+                                _productName = _productName.Trim();
+                            }
+                        }
+
+                        if (_productName == null || _productName.Length == 0)
+                        {
+                            string ns = _owner.GetType().Namespace;
+
+                            if (ns == null)
+                            {
+                                ns = string.Empty;
+                            }
+                            int firstDot = ns.IndexOf('.');
+                            if (firstDot != -1)
+                            {
+                                _productName = ns.Substring(firstDot + 1);
+                            }
+                            else
+                            {
+                                _productName = ns;
+                            }
+                        }
+                    }
+
+                    return _productName;
+                }
+            }
+
+            /// <summary>
+            ///  The product version associated with this component.
+            /// </summary>
+            internal string ProductVersion
+            {
+                get
+                {
+                    if (_productVersion == null)
+                    {
+                        // custom attribute
+                        object[] attrs = _owner.GetType().Module.Assembly.GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false);
+                        if (attrs != null && attrs.Length > 0)
+                        {
+                            _productVersion = ((AssemblyInformationalVersionAttribute)attrs[0]).InformationalVersion;
+                        }
+
+                        // win32 version info
+                        if (_productVersion == null || _productVersion.Length == 0)
+                        {
+                            _productVersion = GetFileVersionInfo().ProductVersion;
+                            if (_productVersion != null)
+                            {
+                                _productVersion = _productVersion.Trim();
+                            }
+                        }
+
+                        // fake it
+                        if (_productVersion == null || _productVersion.Length == 0)
+                        {
+                            _productVersion = "1.0.0.0";
+                        }
+                    }
+                    return _productVersion;
+                }
+            }
+
+            /// <summary>
+            ///  Retrieves the FileVersionInfo associated with the main module for
+            ///  the component.
+            /// </summary>
+            private FileVersionInfo GetFileVersionInfo()
+            {
+                if (_versionInfo == null)
+                {
+                    string path = _owner.GetType().Module.FullyQualifiedName;
+
+                    _versionInfo = FileVersionInfo.GetVersionInfo(path);
+                }
+                return _versionInfo;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.FontHandleWrapper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.FontHandleWrapper.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Drawing;
+using System.Runtime.InteropServices;
+
+namespace System.Windows.Forms
+{
+    public partial class Control
+    {
+        // Fonts can be a pain to track, so we wrap Hfonts in this class to get a Finalize method.
+        internal sealed class FontHandleWrapper : MarshalByRefObject, IDisposable
+        {
+#if DEBUG
+            private readonly string _stackOnCreate = null;
+            private string _stackOnDispose = null;
+            private bool _finalizing = false;
+#endif
+            private IntPtr _handle;
+
+            internal FontHandleWrapper(Font font)
+            {
+#if DEBUG
+                if (CompModSwitches.LifetimeTracing.Enabled)
+                {
+                    _stackOnCreate = new StackTrace().ToString();
+                }
+#endif
+                _handle = font.ToHfont();
+            }
+
+            internal IntPtr Handle
+            {
+                get
+                {
+                    Debug.Assert(_handle != IntPtr.Zero, "FontHandleWrapper disposed, but still being accessed");
+                    return _handle;
+                }
+            }
+
+            public void Dispose()
+            {
+                Dispose(true);
+                GC.SuppressFinalize(this);
+            }
+
+            private void Dispose(bool disposing)
+            {
+#if DEBUG
+                Debug.Assert(_finalizing || this != s_defaultFontHandleWrapper, "Don't dispose the defaultFontHandleWrapper");
+#endif
+
+                if (_handle != IntPtr.Zero)
+                {
+#if DEBUG
+                    if (CompModSwitches.LifetimeTracing.Enabled)
+                    {
+                        _stackOnDispose = new StackTrace().ToString();
+                    }
+#endif
+                    Interop.Gdi32.DeleteObject(_handle);
+                    _handle = IntPtr.Zero;
+                }
+            }
+
+            ~FontHandleWrapper()
+            {
+#if DEBUG
+                _finalizing = true;
+#endif
+                Dispose(false);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.MetafileDCWrapper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.MetafileDCWrapper.cs
@@ -1,0 +1,209 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Drawing;
+using System.Runtime.InteropServices;
+
+namespace System.Windows.Forms
+{
+    public partial class Control
+    {
+        /// <summary>
+        ///  MetafileDCWrapper is used to wrap a metafile DC so that subsequent
+        ///  paint operations are rendered to a temporary bitmap.  When the
+        ///  wrapper is disposed, it copies the bitmap back to the metafile DC.
+        ///
+        ///  Example:
+        ///
+        ///  using(MetafileDCWrapper dcWrapper = new MetafileDCWrapper(hDC, size) {
+        ///  // ...use dcWrapper.HDC to do painting
+        ///  }
+        /// </summary>
+        private class MetafileDCWrapper : IDisposable
+        {
+            private IntPtr _hBitmap = IntPtr.Zero;
+            private IntPtr _hOriginalBmp = IntPtr.Zero;
+            private readonly HandleRef _hMetafileDC;
+            private Interop.RECT _destRect;
+
+            internal MetafileDCWrapper(HandleRef hOriginalDC, Size size)
+            {
+                Debug.Assert(UnsafeNativeMethods.GetObjectType(hOriginalDC) == NativeMethods.OBJ_ENHMETADC,
+                    "Why wrap a non-Enhanced MetaFile DC?");
+
+                // Security fix: make sure the size has non-negative width and height.
+                if (size.Width < 0 || size.Height < 0)
+                {
+                    throw new ArgumentException(nameof(size), SR.ControlMetaFileDCWrapperSizeInvalid);
+                }
+
+                _hMetafileDC = hOriginalDC;
+                _destRect = new Interop.RECT(0, 0, size.Width, size.Height);
+                HDC = Interop.Gdi32.CreateCompatibleDC(IntPtr.Zero);
+
+                int planes = Interop.Gdi32.GetDeviceCaps(HDC, Interop.Gdi32.DeviceCapability.PLANES);
+                int bitsPixel = Interop.Gdi32.GetDeviceCaps(HDC, Interop.Gdi32.DeviceCapability.BITSPIXEL);
+                _hBitmap = SafeNativeMethods.CreateBitmap(size.Width, size.Height, planes, bitsPixel, IntPtr.Zero);
+                _hOriginalBmp = Interop.Gdi32.SelectObject(HDC, _hBitmap);
+            }
+
+            ~MetafileDCWrapper()
+            {
+                ((IDisposable)this).Dispose();
+            }
+
+            void IDisposable.Dispose()
+            {
+                if (HDC == IntPtr.Zero || _hMetafileDC.Handle == IntPtr.Zero || _hBitmap == IntPtr.Zero)
+                {
+                    return;
+                }
+
+                bool success;
+
+                try
+                {
+                    success = DICopy(_hMetafileDC, HDC, _destRect, true);
+                    Debug.Assert(success, "DICopy() failed.");
+                    Interop.Gdi32.SelectObject(HDC, _hOriginalBmp);
+                    success = Interop.Gdi32.DeleteObject(_hBitmap) != Interop.BOOL.FALSE;
+                    Debug.Assert(success, "DeleteObject() failed.");
+                    success = Interop.Gdi32.DeleteDC(HDC);
+                    Debug.Assert(success, "DeleteObject() failed.");
+                }
+                finally
+                {
+                    // Dispose is done. Set all the handles to IntPtr.Zero so this way the Dispose method executes only once.
+                    HDC = IntPtr.Zero;
+                    _hBitmap = IntPtr.Zero;
+                    _hOriginalBmp = IntPtr.Zero;
+
+                    GC.SuppressFinalize(this);
+                }
+            }
+
+            internal IntPtr HDC { get; private set; } = IntPtr.Zero;
+
+            // ported form VB6 (Ctls\PortUtil\StdCtl.cpp:6176)
+            private unsafe bool DICopy(HandleRef hdcDest, IntPtr hdcSrc, Interop.RECT rect, bool bStretch)
+            {
+                long i;
+
+                // Get the bitmap from the DC by selecting in a 1x1 pixel temp bitmap
+                IntPtr hNullBitmap = SafeNativeMethods.CreateBitmap(1, 1, 1, 1, IntPtr.Zero);
+                if (hNullBitmap == IntPtr.Zero)
+                {
+                    return false;
+                }
+
+                try
+                {
+                    IntPtr hBitmap = Interop.Gdi32.SelectObject(hdcSrc, hNullBitmap);
+                    if (hBitmap == IntPtr.Zero)
+                    {
+                        return false;
+                    }
+
+                    // Restore original bitmap
+                    Interop.Gdi32.SelectObject(hdcSrc, hBitmap);
+
+                    NativeMethods.BITMAP bmp = new NativeMethods.BITMAP();
+                    if (UnsafeNativeMethods.GetObject(new HandleRef(null, hBitmap), Marshal.SizeOf(bmp), bmp) == 0)
+                    {
+                        return false;
+                    }
+
+                    NativeMethods.BITMAPINFO_FLAT lpbmi = new NativeMethods.BITMAPINFO_FLAT
+                    {
+                        bmiHeader_biSize = Marshal.SizeOf<NativeMethods.BITMAPINFOHEADER>(),
+                        bmiHeader_biWidth = bmp.bmWidth,
+                        bmiHeader_biHeight = bmp.bmHeight,
+                        bmiHeader_biPlanes = 1,
+                        bmiHeader_biBitCount = bmp.bmBitsPixel,
+                        bmiHeader_biCompression = NativeMethods.BI_RGB,
+                        bmiHeader_biSizeImage = 0,               //Not needed since using BI_RGB
+                        bmiHeader_biXPelsPerMeter = 0,
+                        bmiHeader_biYPelsPerMeter = 0,
+                        bmiHeader_biClrUsed = 0,
+                        bmiHeader_biClrImportant = 0,
+                        bmiColors = new byte[NativeMethods.BITMAPINFO_MAX_COLORSIZE * 4]
+                    };
+
+                    // Include the palette for 256 color bitmaps
+                    long iColors = 1 << (bmp.bmBitsPixel * bmp.bmPlanes);
+                    if (iColors <= 256)
+                    {
+                        byte[] aj = new byte[Marshal.SizeOf<NativeMethods.PALETTEENTRY>() * 256];
+                        SafeNativeMethods.GetSystemPaletteEntries(hdcSrc, 0, (int)iColors, aj);
+
+                        fixed (byte* pcolors = lpbmi.bmiColors)
+                        {
+                            fixed (byte* ppal = aj)
+                            {
+                                NativeMethods.RGBQUAD* prgb = (NativeMethods.RGBQUAD*)pcolors;
+                                NativeMethods.PALETTEENTRY* lppe = (NativeMethods.PALETTEENTRY*)ppal;
+
+                                // Convert the palette entries to RGB quad entries
+                                for (i = 0; i < (int)iColors; i++)
+                                {
+                                    prgb[i].rgbRed = lppe[i].peRed;
+                                    prgb[i].rgbBlue = lppe[i].peBlue;
+                                    prgb[i].rgbGreen = lppe[i].peGreen;
+                                }
+                            }
+                        }
+                    }
+
+                    // Allocate memory to hold the bitmap bits
+                    long bitsPerScanLine = bmp.bmBitsPixel * (long)bmp.bmWidth;
+                    long bytesPerScanLine = (bitsPerScanLine + 7) / 8;
+                    long totalBytesReqd = bytesPerScanLine * bmp.bmHeight;
+                    byte[] lpBits = new byte[totalBytesReqd];
+
+                    // Get the bitmap bits
+                    int diRet = SafeNativeMethods.GetDIBits(hdcSrc, hBitmap, 0, bmp.bmHeight, lpBits,
+                            ref lpbmi, NativeMethods.DIB_RGB_COLORS);
+                    if (diRet == 0)
+                    {
+                        return false;
+                    }
+
+                    // Set the destination coordiates depending on whether stretch-to-fit was chosen
+                    int xDest, yDest, cxDest, cyDest;
+                    if (bStretch)
+                    {
+                        xDest = rect.left;
+                        yDest = rect.top;
+                        cxDest = rect.right - rect.left;
+                        cyDest = rect.bottom - rect.top;
+                    }
+                    else
+                    {
+                        xDest = rect.left;
+                        yDest = rect.top;
+                        cxDest = bmp.bmWidth;
+                        cyDest = bmp.bmHeight;
+                    }
+
+                    // Paint the bitmap
+                    int iRet = SafeNativeMethods.StretchDIBits(hdcDest,
+                            xDest, yDest, cxDest, cyDest, 0, 0, bmp.bmWidth, bmp.bmHeight,
+                            lpBits, ref lpbmi, NativeMethods.DIB_RGB_COLORS, NativeMethods.SRCCOPY);
+
+                    if (iRet == NativeMethods.GDI_ERROR)
+                    {
+                        return false;
+                    }
+                }
+                finally
+                {
+                    Interop.Gdi32.DeleteObject(hNullBitmap);
+                }
+
+                return true;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.MultithreadSafeCallScope.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.MultithreadSafeCallScope.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms
+{
+    public partial class Control
+    {
+        private sealed class MultithreadSafeCallScope : IDisposable
+        {
+            // Use local stack variable rather than a refcount since we're
+            // guaranteed that these 'scopes' are properly nested.
+            private readonly bool _resultedInSet;
+
+            internal MultithreadSafeCallScope()
+            {
+                // Only access the thread-local stuff if we're going to be
+                // checking for illegal thread calling (no need to incur the
+                // expense otherwise).
+                if (CheckForIllegalCrossThreadCalls && !t_inCrossThreadSafeCall)
+                {
+                    t_inCrossThreadSafeCall = true;
+                    _resultedInSet = true;
+                }
+                else
+                {
+                    _resultedInSet = false;
+                }
+            }
+
+            void IDisposable.Dispose()
+            {
+                if (_resultedInSet)
+                {
+                    t_inCrossThreadSafeCall = false;
+                }
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.PrintPaintEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.PrintPaintEventArgs.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+
+namespace System.Windows.Forms
+{
+    public partial class Control
+    {
+        private sealed class PrintPaintEventArgs : PaintEventArgs
+        {
+            private Message _m;
+
+            internal PrintPaintEventArgs(Message m, IntPtr dc, Rectangle clipRect)
+                : base(dc, clipRect)
+            {
+                _m = m;
+            }
+
+            internal Message Message
+            {
+                get
+                {
+                    return _m;
+                }
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ThreadMethodEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ThreadMethodEntry.cs
@@ -1,0 +1,118 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+
+namespace System.Windows.Forms
+{
+    public partial class Control
+    {
+        /// <summary>
+        ///  Used with BeginInvoke/EndInvoke
+        /// </summary>
+        private class ThreadMethodEntry : IAsyncResult
+        {
+            internal Control _caller;
+            internal Control _marshaler;
+            internal Delegate _method;
+            internal object[] _args;
+            internal object _retVal;
+            internal Exception _exception;
+            internal bool _synchronous;
+            private ManualResetEvent _resetEvent;
+            private readonly object _invokeSyncObject = new object();
+
+            // Store the execution context associated with the caller thread, and
+            // information about which thread actually got the stack applied to it.
+            internal ExecutionContext _executionContext;
+
+            // Optionally store the synchronization context associated with the callee thread.
+            // This overrides the sync context in the execution context of the caller thread.
+            internal SynchronizationContext _syncContext = null;
+
+            internal ThreadMethodEntry(Control caller, Control marshaler, Delegate method, object[] args, bool synchronous, ExecutionContext executionContext)
+            {
+                _caller = caller;
+                _marshaler = marshaler;
+                _method = method;
+                _args = args;
+                _exception = null;
+                _retVal = null;
+                _synchronous = synchronous;
+                IsCompleted = false;
+                _resetEvent = null;
+                _executionContext = executionContext;
+            }
+
+            ~ThreadMethodEntry()
+            {
+                if (_resetEvent != null)
+                {
+                    _resetEvent.Close();
+                }
+            }
+
+            public object AsyncState
+            {
+                get
+                {
+                    return null;
+                }
+            }
+
+            public WaitHandle AsyncWaitHandle
+            {
+                get
+                {
+                    if (_resetEvent == null)
+                    {
+                        // Locking 'this' here is ok since this is an internal class.
+                        lock (_invokeSyncObject)
+                        {
+                            // BeginInvoke hangs on Multi-proc system:
+                            // taking the lock prevents a race condition between IsCompleted
+                            // boolean flag and resetEvent mutex in multiproc scenarios.
+                            if (_resetEvent == null)
+                            {
+                                _resetEvent = new ManualResetEvent(false);
+                                if (IsCompleted)
+                                {
+                                    _resetEvent.Set();
+                                }
+                            }
+                        }
+                    }
+                    return (WaitHandle)_resetEvent;
+                }
+            }
+
+            public bool CompletedSynchronously
+            {
+                get
+                {
+                    if (IsCompleted && _synchronous)
+                    {
+                        return true;
+                    }
+
+                    return false;
+                }
+            }
+
+            public bool IsCompleted { get; private set; }
+
+            internal void Complete()
+            {
+                lock (_invokeSyncObject)
+                {
+                    IsCompleted = true;
+                    if (_resetEvent != null)
+                    {
+                        _resetEvent.Set();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -5,7 +5,7 @@
 // #define DEBUG_PREFERREDSIZE
 
 using System.Collections;
-using System.Collections.Specialized;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.ComponentModel.Design.Serialization;
@@ -13,22 +13,17 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Globalization;
-using System.IO;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
-using System.Runtime.Serialization;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
 using System.Threading;
+using System.Windows.Forms.Automation;
 using System.Windows.Forms.Internal;
 using System.Windows.Forms.Layout;
+using Accessibility;
 using Microsoft.Win32;
 using Encoding = System.Text.Encoding;
 using IComDataObject = System.Runtime.InteropServices.ComTypes.IDataObject;
-using System.Collections.Generic;
-using Accessibility;
-using System.Windows.Forms.Automation;
 
 namespace System.Windows.Forms
 {
@@ -45,26 +40,26 @@ namespace System.Windows.Forms
         ToolboxItemFilter("System.Windows.Forms")
     ]
     public partial class Control :
-    Component,
-    UnsafeNativeMethods.IOleControl,
-    UnsafeNativeMethods.IOleObject,
-    UnsafeNativeMethods.IOleInPlaceObject,
-    UnsafeNativeMethods.IOleInPlaceActiveObject,
-    UnsafeNativeMethods.IOleWindow,
-    UnsafeNativeMethods.IViewObject,
-    UnsafeNativeMethods.IViewObject2,
-    UnsafeNativeMethods.IPersist,
-    UnsafeNativeMethods.IPersistStreamInit,
-    UnsafeNativeMethods.IPersistPropertyBag,
-    UnsafeNativeMethods.IPersistStorage,
-    UnsafeNativeMethods.IQuickActivate,
-    ISupportOleDropSource,
-    IDropTarget,
-    ISynchronizeInvoke,
-    IWin32Window,
-    IArrangedElement,
-    IBindableComponent,
-    IKeyboardToolTip
+        Component,
+        UnsafeNativeMethods.IOleControl,
+        UnsafeNativeMethods.IOleObject,
+        UnsafeNativeMethods.IOleInPlaceObject,
+        UnsafeNativeMethods.IOleInPlaceActiveObject,
+        UnsafeNativeMethods.IOleWindow,
+        UnsafeNativeMethods.IViewObject,
+        UnsafeNativeMethods.IViewObject2,
+        UnsafeNativeMethods.IPersist,
+        UnsafeNativeMethods.IPersistStreamInit,
+        UnsafeNativeMethods.IPersistPropertyBag,
+        UnsafeNativeMethods.IPersistStorage,
+        UnsafeNativeMethods.IQuickActivate,
+        ISupportOleDropSource,
+        IDropTarget,
+        ISynchronizeInvoke,
+        IWin32Window,
+        IArrangedElement,
+        IBindableComponent,
+        IKeyboardToolTip
     {
 #if FINALIZATION_WATCH
         static readonly TraceSwitch ControlFinalization = new TraceSwitch("ControlFinalization", "Tracks the creation and destruction of finalization");
@@ -106,14 +101,16 @@ namespace System.Windows.Forms
                     {
                         StackFrame sf = new StackFrame(frameIndex);
                         if (frameIndex == 2 && sf.GetMethod().Name.Equals("CanProcessMnemonic"))
-                        { // log immediate call if in a virtual/recursive call.
+                        {
+                            // log immediate call if in a virtual/recursive call.
                             break;
                         }
                         str += new StackTrace(sf).ToString().TrimEnd();
                         frameIndex++;
                     }
                     if (frameIndex > 2)
-                    { // new CanProcessMnemonic virtual/recursive call stack.
+                    {
+                        // new CanProcessMnemonic virtual/recursive call stack.
                         str = "\r\n" + str;
                     }
                 }
@@ -137,15 +134,8 @@ namespace System.Windows.Forms
         internal static readonly BooleanSwitch BufferPinkRect;
 #endif
 
-        private static readonly int WM_GETCONTROLNAME;
-        private static readonly int WM_GETCONTROLTYPE;
-
-        static Control()
-        {
-            WM_GETCONTROLNAME = SafeNativeMethods.RegisterWindowMessage("WM_GETCONTROLNAME");
-            WM_GETCONTROLTYPE = SafeNativeMethods.RegisterWindowMessage("WM_GETCONTROLTYPE");
-
-        }
+        private static readonly int WM_GETCONTROLNAME = SafeNativeMethods.RegisterWindowMessage("WM_GETCONTROLNAME");
+        private static readonly int WM_GETCONTROLTYPE = SafeNativeMethods.RegisterWindowMessage("WM_GETCONTROLTYPE");
 
         internal const int STATE_CREATED = 0x00000001;
         internal const int STATE_VISIBLE = 0x00000002;
@@ -276,24 +266,21 @@ namespace System.Windows.Forms
         internal static readonly object EventPaddingChanged = new object();
         private static readonly object EventPreviewKeyDown = new object();
 
-        private static int threadCallbackMessage;
+        private static int s_threadCallbackMessage;
+        private static ContextCallback s_invokeMarshaledCallbackHelperDelegate;
 
-        // Initially check for illegal multithreading based on whether the
-        // debugger is attached.
-
-        private static bool checkForIllegalCrossThreadCalls = Debugger.IsAttached;
-        private static ContextCallback invokeMarshaledCallbackHelperDelegate;
+#pragma warning disable IDE1006 // Naming Styles
+        [ThreadStatic]
+        private static bool t_inCrossThreadSafeCall = false;
 
         [ThreadStatic]
-        private static bool inCrossThreadSafeCall = false;
+        internal static HelpInfo t_currentHelpInfo = null;
 
-        // disable csharp compiler warning #0414: field assigned unused value
-#pragma warning disable 0414
         [ThreadStatic]
-        internal static HelpInfo currentHelpInfo = null;
-#pragma warning restore 0414
+        private static byte[] t_tempKeyboardStateArray;
+#pragma warning restore IDE1006
 
-        private static FontHandleWrapper defaultFontHandleWrapper;
+        private static FontHandleWrapper s_defaultFontHandleWrapper;
 
         private const short PaintLayerBackground = 1;
         private const short PaintLayerForeground = 2;
@@ -303,12 +290,11 @@ namespace System.Windows.Forms
 
         private const byte HighOrderBitMask = 0x80;
 
-        private static Font defaultFont;
+        private static Font s_defaultFont;
 
         // Property store keys for properties.  The property store allocates most efficiently
         // in groups of four, so we try to lump properties in groups of four based on how
         // likely they are going to be used in a group.
-        //
         private static readonly int PropName = PropertyStore.CreateKey();
         private static readonly int PropBackBrush = PropertyStore.CreateKey();
         private static readonly int PropFontHeight = PropertyStore.CreateKey();
@@ -357,58 +343,49 @@ namespace System.Windows.Forms
         private static readonly int PropCacheTextField = PropertyStore.CreateKey();
         private static readonly int PropAmbientPropertiesService = PropertyStore.CreateKey();
 
-        private static bool needToLoadComCtl = true;
+        private static bool s_needToLoadComCtl = true;
 
         // This switch determines the default text rendering engine to use by some controls that support switching rendering engine.
         // CheckedListBox, PropertyGrid, GroupBox, Label and LinkLabel, and ButtonBase controls.
         // True means use GDI+, false means use GDI (TextRenderer).
         internal static bool UseCompatibleTextRenderingDefault = true;
 
-        ///////////////////////////////////////////////////////////////////////
-        // Control per instance members
+        // Control instance members
         //
         // Note: Do not add anything to this list unless absolutely neccessary.
         //       Every control on a form has the overhead of all of these
         //       variables!
-        //
-        // Begin Members {
-
-        // List of properties that are generally set, so we keep them directly on
-        // control.
-        //
 
         // Resist the temptation to make this variable 'internal' rather than
         // private. Handle access should be tightly controlled, and is in this
         // file.  Making it 'internal' makes controlling it quite difficult.
-        private readonly ControlNativeWindow window;
+        private readonly ControlNativeWindow _window;
 
-        private Control parent;
-        private Control reflectParent;
-        private CreateParams createParams;
-        private int x;                      //
-        private int y;
-        private int width;
-        private int height;
-        private int clientWidth;
-        private int clientHeight;
-        private int state;                  // See STATE_ constants above
-        private int state2;                 // See STATE2_ constants above
-        private ControlStyles controlStyle;           // User supplied control style
-        private int tabIndex;
-        private string text;                   // See ControlStyles.CacheText for usage notes
-        private byte layoutSuspendCount;
-        private byte requiredScaling;        // bits 0-4: BoundsSpecified stored in RequiredScaling property.  Bit 5: RequiredScalingEnabled property.
-        private readonly PropertyStore propertyStore;          // Contains all properties that are not always set.
-        private NativeMethods.TRACKMOUSEEVENT trackMouseEvent;
-        private short updateCount;
-        private LayoutEventArgs cachedLayoutEventArgs;
-        private Queue threadCallbackList;
-        internal int deviceDpi;
+        private Control _parent;
+        private Control _reflectParent;
+        private CreateParams _createParams;
+        private int _x;
+        private int _y;
+        private int _width;
+        private int _height;
+        private int _clientWidth;
+        private int _clientHeight;
+        private int _state;                         // See STATE_ constants above
+        private int _state2;                        // See STATE2_ constants above
+        private ControlStyles _controlStyle;        // User supplied control style
+        private int _tabIndex;
+        private string _text;                       // See ControlStyles.CacheText for usage notes
+        private byte _layoutSuspendCount;
+        private byte _requiredScaling;              // bits 0-4: BoundsSpecified stored in RequiredScaling property.  Bit 5: RequiredScalingEnabled property.
+        private NativeMethods.TRACKMOUSEEVENT _trackMouseEvent;
+        private short _updateCount;
+        private LayoutEventArgs _cachedLayoutEventArgs;
+        private Queue _threadCallbackList;
+        internal int _deviceDpi;
 
         // for keeping track of our ui state for focus and keyboard cues.  using a member variable
         // here because we hit this a lot
-        //
-        private int uiCuesState;
+        private int _uiCuesState;
 
         private const int UISTATE_FOCUS_CUES_MASK = 0x000F;
         private const int UISTATE_FOCUS_CUES_HIDDEN = 0x0001;
@@ -417,21 +394,15 @@ namespace System.Windows.Forms
         private const int UISTATE_KEYBOARD_CUES_HIDDEN = 0x0010;
         private const int UISTATE_KEYBOARD_CUES_SHOW = 0x0020;
 
-        [ThreadStatic]
-        private static byte[] tempKeyboardStateArray;
-
-        // } End Members
-        ///////////////////////////////////////////////////////////////////////
-
 #if DEBUG
         internal int LayoutSuspendCount
         {
-            get { return layoutSuspendCount; }
+            get { return _layoutSuspendCount; }
         }
 
         internal void AssertLayoutSuspendCount(int value)
         {
-            Debug.Assert(value == layoutSuspendCount, "Suspend/Resume layout mismatch!");
+            Debug.Assert(value == _layoutSuspendCount, "Suspend/Resume layout mismatch!");
         }
 
         /*
@@ -444,11 +415,10 @@ namespace System.Windows.Forms
                 AssertLayoutSuspendCount(dbgLayoutCheck);
         #endif
         */
-
 #endif
 
         /// <summary>
-        /// Initializes a new instance of the <see cref='Control'/> class.
+        ///  Initializes a new instance of the <see cref='Control'/> class.
         /// </summary>
         public Control() : this(true)
         {
@@ -463,19 +433,19 @@ namespace System.Windows.Forms
                 Debug.Assert(GetType() != typeof(Control), "Control Created!");
             }
 #endif
-            propertyStore = new PropertyStore();
+            Properties = new PropertyStore();
 
             DpiHelper.InitializeDpiHelperForWinforms();
             // Initialize DPI to the value on the primary screen, we will have the correct value when the Handle is created.
-            deviceDpi = DpiHelper.DeviceDpi;
+            _deviceDpi = DpiHelper.DeviceDpi;
 
-            window = new ControlNativeWindow(this);
+            _window = new ControlNativeWindow(this);
             RequiredScalingEnabled = true;
             RequiredScaling = BoundsSpecified.All;
-            tabIndex = -1;
+            _tabIndex = -1;
 
-            state = STATE_VISIBLE | STATE_ENABLED | STATE_TABSTOP | STATE_CAUSESVALIDATION;
-            state2 = STATE2_INTERESTEDINUSERPREFERENCECHANGED;
+            _state = STATE_VISIBLE | STATE_ENABLED | STATE_TABSTOP | STATE_CAUSESVALIDATION;
+            _state2 = STATE2_INTERESTEDINUSERPREFERENCECHANGED;
             SetStyle(ControlStyles.AllPaintingInWmPaint |
                      ControlStyles.UserPaint |
                      ControlStyles.StandardClick |
@@ -502,17 +472,16 @@ namespace System.Windows.Forms
             }
 
             // Compute our default size.
-            //
             Size defaultSize = DefaultSize;
-            width = defaultSize.Width;
-            height = defaultSize.Height;
+            _width = defaultSize.Width;
+            _height = defaultSize.Height;
 
             // DefaultSize may have hit GetPreferredSize causing a PreferredSize to be cached.  The
             // PreferredSize may change as a result of the current size.  Since a  SetBoundsCore did
             // not happen, so we need to clear the preferredSize cache manually.
             CommonProperties.xClearPreferredSizeCache(this);
 
-            if (width != 0 && height != 0)
+            if (_width != 0 && _height != 0)
             {
                 Interop.RECT rect = new Interop.RECT();
                 rect.left = rect.right = rect.top = rect.bottom = 0;
@@ -520,8 +489,8 @@ namespace System.Windows.Forms
                 CreateParams cp = CreateParams;
 
                 AdjustWindowRectEx(ref rect, cp.Style, false, cp.ExStyle);
-                clientWidth = width - (rect.right - rect.left);
-                clientHeight = height - (rect.bottom - rect.top);
+                _clientWidth = _width - (rect.right - rect.left);
+                _clientHeight = _height - (rect.bottom - rect.top);
             }
 
             // Set up for async operations on this thread.
@@ -534,7 +503,7 @@ namespace System.Windows.Forms
         /// <summary>
         /// Initializes a new instance of the <see cref='Control'/> class.
         /// </summary>
-        public Control(string text) : this((Control)null, text)
+        public Control(string text) : this(null, text)
         {
         }
 
@@ -542,7 +511,7 @@ namespace System.Windows.Forms
         /// Initializes a new instance of the <see cref='Control'/> class.
         /// </summary>
         public Control(string text, int left, int top, int width, int height) :
-                    this((Control)null, text, left, top, width, height)
+                    this(null, text, left, top, width, height)
         {
         }
 
@@ -565,15 +534,9 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        /// gets or sets control Dpi awareness context value.
+        ///  Gets control Dpi awareness context value.
         /// </summary>
-        internal DpiAwarenessContext DpiAwarenessContext
-        {
-            get
-            {
-                return window.DpiAwarenessContext;
-            }
-        }
+        internal DpiAwarenessContext DpiAwarenessContext => _window.DpiAwarenessContext;
 
         /// <summary>
         ///  The Accessibility Object for this Control
@@ -681,14 +644,8 @@ namespace System.Windows.Forms
         ]
         public string AccessibleDefaultActionDescription
         {
-            get
-            {
-                return (string)Properties.GetObject(PropAccessibleDefaultActionDescription);
-            }
-            set
-            {
-                Properties.SetObject(PropAccessibleDefaultActionDescription, value);
-            }
+            get => (string)Properties.GetObject(PropAccessibleDefaultActionDescription);
+            set => Properties.SetObject(PropAccessibleDefaultActionDescription, value);
         }
 
         /// <summary>
@@ -702,14 +659,8 @@ namespace System.Windows.Forms
         ]
         public string AccessibleDescription
         {
-            get
-            {
-                return (string)Properties.GetObject(PropAccessibleDescription);
-            }
-            set
-            {
-                Properties.SetObject(PropAccessibleDescription, value);
-            }
+            get => (string)Properties.GetObject(PropAccessibleDescription);
+            set => Properties.SetObject(PropAccessibleDescription, value);
         }
 
         /// <summary>
@@ -723,15 +674,8 @@ namespace System.Windows.Forms
         ]
         public string AccessibleName
         {
-            get
-            {
-                return (string)Properties.GetObject(PropAccessibleName);
-            }
-
-            set
-            {
-                Properties.SetObject(PropAccessibleName, value);
-            }
+            get => (string)Properties.GetObject(PropAccessibleName);
+            set => Properties.SetObject(PropAccessibleName, value);
         }
 
         /// <summary>
@@ -756,7 +700,6 @@ namespace System.Windows.Forms
                     return AccessibleRole.Default;
                 }
             }
-
             set
             {
                 //valid values are -1 to 0x40
@@ -768,65 +711,14 @@ namespace System.Windows.Forms
             }
         }
 
-        /// <summary>
-        ///  Helper method for retrieving an ActiveX property.  We abstract these
-        ///  to another method so we do not force JIT the ActiveX codebase.
-        /// </summary>
-        private Color ActiveXAmbientBackColor
-        {
-            get
-            {
-                return ActiveXInstance.AmbientBackColor;
-            }
-        }
+        // Helper methods for retrieving an ActiveX properties.
+        // We abstract these to another method so we do not force JIT the ActiveX codebase.
 
-        /// <summary>
-        ///  Helper method for retrieving an ActiveX property.  We abstract these
-        ///  to another method so we do not force JIT the ActiveX codebase.
-        /// </summary>
-        private Color ActiveXAmbientForeColor
-        {
-            get
-            {
-                return ActiveXInstance.AmbientForeColor;
-            }
-        }
-
-        /// <summary>
-        ///  Helper method for retrieving an ActiveX property.  We abstract these
-        ///  to another method so we do not force JIT the ActiveX codebase.
-        /// </summary>
-        private Font ActiveXAmbientFont
-        {
-            get
-            {
-                return ActiveXInstance.AmbientFont;
-            }
-        }
-
-        /// <summary>
-        ///  Helper method for retrieving an ActiveX property.  We abstract these
-        ///  to another method so we do not force JIT the ActiveX codebase.
-        /// </summary>
-        private bool ActiveXEventsFrozen
-        {
-            get
-            {
-                return ActiveXInstance.EventsFrozen;
-            }
-        }
-
-        /// <summary>
-        ///  Helper method for retrieving an ActiveX property.  We abstract these
-        ///  to another method so we do not force JIT the ActiveX codebase.
-        /// </summary>
-        private IntPtr ActiveXHWNDParent
-        {
-            get
-            {
-                return ActiveXInstance.HWNDParent;
-            }
-        }
+        private Color ActiveXAmbientBackColor => ActiveXInstance.AmbientBackColor;
+        private Color ActiveXAmbientForeColor => ActiveXInstance.AmbientForeColor;
+        private Font ActiveXAmbientFont => ActiveXInstance.AmbientFont;
+        private bool ActiveXEventsFrozen => ActiveXInstance.EventsFrozen;
+        private IntPtr ActiveXHWNDParent => ActiveXInstance.HWNDParent;
 
         /// <summary>
         ///  Retrieves the ActiveX control implementation for
@@ -840,10 +732,8 @@ namespace System.Windows.Forms
                 ActiveXImpl activeXImpl = (ActiveXImpl)Properties.GetObject(PropActiveXImpl);
                 if (activeXImpl == null)
                 {
-
                     // Don't allow top level objects to be hosted
                     // as activeX controls.
-                    //
                     if (GetState(STATE_TOPLEVEL))
                     {
                         throw new NotSupportedException(SR.AXTopLevelSource);
@@ -876,7 +766,6 @@ namespace System.Windows.Forms
             {
                 return GetState(STATE_ALLOWDROP);
             }
-
             set
             {
                 if (GetState(STATE_ALLOWDROP) != value)
@@ -943,14 +832,8 @@ namespace System.Windows.Forms
         ]
         public virtual AnchorStyles Anchor
         {
-            get
-            {
-                return DefaultLayout.GetAnchor(this);
-            }
-            set
-            {
-                DefaultLayout.SetAnchor(ParentInternal, this, value);
-            }
+            get => DefaultLayout.GetAnchor(this);
+            set => DefaultLayout.SetAnchor(ParentInternal, this, value);
         }
 
         [SRCategory(nameof(SR.CatLayout))]
@@ -1021,22 +904,13 @@ namespace System.Windows.Forms
             }
         }
 
-        protected void SetAutoSizeMode(AutoSizeMode mode)
-        {
-            CommonProperties.SetAutoSizeMode(this, mode);
-        }
+        protected void SetAutoSizeMode(AutoSizeMode mode) => CommonProperties.SetAutoSizeMode(this, mode);
 
-        protected AutoSizeMode GetAutoSizeMode()
-        {
-            return CommonProperties.GetAutoSizeMode(this);
-        }
+        protected AutoSizeMode GetAutoSizeMode() => CommonProperties.GetAutoSizeMode(this);
 
         // Public because this is interesting for ControlDesigners.
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Advanced)]
-        public virtual LayoutEngine LayoutEngine
-        {
-            get { return DefaultLayout.Instance; }
-        }
+        public virtual LayoutEngine LayoutEngine => DefaultLayout.Instance;
 
         /// <summary>
         ///  The GDI brush for our background color.
@@ -1050,28 +924,23 @@ namespace System.Windows.Forms
                 object customBackBrush = Properties.GetObject(PropBackBrush);
                 if (customBackBrush != null)
                 {
-
                     // We already have a valid brush.  Unbox, and return.
-                    //
                     return (IntPtr)customBackBrush;
                 }
 
                 if (!Properties.ContainsObject(PropBackColor))
                 {
-
                     // No custom back color.  See if we can get to our parent.
                     // The color check here is to account for parents and children who
                     // override the BackColor property.
-                    //
-                    if (parent != null && parent.BackColor == BackColor)
+                    if (_parent != null && _parent.BackColor == BackColor)
                     {
-                        return parent.BackColorBrush;
+                        return _parent.BackColorBrush;
                     }
                 }
 
                 // No parent, or we have a custom back color.  Either way, we need to
                 // create our own.
-                //
                 Color color = BackColor;
                 IntPtr backBrush;
 
@@ -1146,7 +1015,6 @@ namespace System.Windows.Forms
                     return DefaultBackColor;
                 }
             }
-
             set
             {
                 if (!value.Equals(Color.Empty) && !GetStyle(ControlStyles.SupportsTransparentBackColor) && value.A < 255)
@@ -1233,15 +1101,17 @@ namespace System.Windows.Forms
             {
                 if (BackgroundImageLayout != value)
                 {
-                    //valid values are 0x0 to 0x4
+                    // Valid values are 0x0 to 0x4
                     if (!ClientUtils.IsEnumValid(value, (int)value, (int)ImageLayout.None, (int)ImageLayout.Zoom))
                     {
                         throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ImageLayout));
                     }
+
                     // Check if the value is either center, strech or zoom;
                     if (value == ImageLayout.Center || value == ImageLayout.Zoom || value == ImageLayout.Stretch)
                     {
                         SetStyle(ControlStyles.ResizeRedraw, true);
+
                         // Only for images that support transparency.
                         if (ControlPaint.IsImageTransparent(BackgroundImage))
                         {
@@ -1278,11 +1148,7 @@ namespace System.Windows.Forms
             }
         }
 
-        private bool ShouldSerializeAccessibleName()
-        {
-            string accName = AccessibleName;
-            return accName != null && accName.Length > 0;
-        }
+        private bool ShouldSerializeAccessibleName() => !string.IsNullOrEmpty(AccessibleName);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void ResetBindings()
@@ -1304,7 +1170,6 @@ namespace System.Windows.Forms
             get
             {
                 // See if we have locally overridden the binding manager.
-                //
                 BindingContext context = (BindingContext)Properties.GetObject(PropBindingManager);
                 if (context != null)
                 {
@@ -1312,7 +1177,6 @@ namespace System.Windows.Forms
                 }
 
                 // Otherwise, see if the parent has one for us.
-                //
                 Control p = ParentInternal;
                 if (p != null && p.CanAccessProperties)
                 {
@@ -1320,7 +1184,6 @@ namespace System.Windows.Forms
                 }
 
                 // Otherwise, we have no binding manager available.
-                //
                 return null;
             }
             set
@@ -1346,14 +1209,8 @@ namespace System.Windows.Forms
         ]
         public virtual BindingContext BindingContext
         {
-            get
-            {
-                return BindingContextInternal;
-            }
-            set
-            {
-                BindingContextInternal = value;
-            }
+            get => BindingContextInternal;
+            set => BindingContextInternal = value;
         }
 
         [SRCategory(nameof(SR.CatPropertyChanged)), SRDescription(nameof(SR.ControlOnBindingContextChangedDescr))]
@@ -1372,13 +1229,7 @@ namespace System.Windows.Forms
             SRDescription(nameof(SR.ControlBottomDescr)),
             SRCategory(nameof(SR.CatLayout))
         ]
-        public int Bottom
-        {
-            get
-            {
-                return y + height;
-            }
-        }
+        public int Bottom => _y + _height;
 
         /// <summary>
         ///  The bounds of this control. This is the window coordinates of the
@@ -1392,24 +1243,11 @@ namespace System.Windows.Forms
         ]
         public Rectangle Bounds
         {
-            get
-            {
-                return new Rectangle(x, y, width, height);
-            }
-
-            set
-            {
-                SetBounds(value.X, value.Y, value.Width, value.Height, BoundsSpecified.All);
-            }
+            get => new Rectangle(_x, _y, _width, _height);
+            set => SetBounds(value.X, value.Y, value.Width, value.Height, BoundsSpecified.All);
         }
 
-        internal virtual bool CanAccessProperties
-        {
-            get
-            {
-                return true;
-            }
-        }
+        internal virtual bool CanAccessProperties => true;
 
         /// <summary>
         ///  Indicates whether the control can receive focus. This
@@ -1429,8 +1267,8 @@ namespace System.Windows.Forms
                 {
                     return false;
                 }
-                bool visible = SafeNativeMethods.IsWindowVisible(new HandleRef(window, Handle));
-                bool enabled = SafeNativeMethods.IsWindowEnabled(new HandleRef(window, Handle));
+                bool visible = SafeNativeMethods.IsWindowVisible(new HandleRef(_window, Handle));
+                bool enabled = SafeNativeMethods.IsWindowEnabled(new HandleRef(_window, Handle));
                 return (visible && enabled);
             }
         }
@@ -1440,18 +1278,7 @@ namespace System.Windows.Forms
         ///  hosted as an ActiveX control, this property will return false if the ActiveX
         ///  control has its events frozen.
         /// </summary>
-        protected override bool CanRaiseEvents
-        {
-            get
-            {
-                if (IsActiveX)
-                {
-                    return !ActiveXEventsFrozen;
-                }
-
-                return true;
-            }
-        }
+        protected override bool CanRaiseEvents => !IsActiveX ? true : !ActiveXEventsFrozen;
 
         /// <summary>
         ///  Indicates whether the control can be selected. This property
@@ -1463,16 +1290,7 @@ namespace System.Windows.Forms
             SRCategory(nameof(SR.CatFocus)),
             SRDescription(nameof(SR.ControlCanSelectDescr))
         ]
-        public bool CanSelect
-        {
-            // We implement this to allow only AxHost to override canSelectCore, but still
-            // expose the method publicly
-            //
-            get
-            {
-                return CanSelectCore();
-            }
-        }
+        public bool CanSelect => CanSelectCore();
 
         /// <summary>
         ///  Indicates whether the control has captured the mouse.
@@ -1485,23 +1303,13 @@ namespace System.Windows.Forms
         ]
         public bool Capture
         {
-            get
-            {
-                return CaptureInternal;
-            }
-
-            set
-            {
-                CaptureInternal = value;
-            }
+            get => CaptureInternal;
+            set => CaptureInternal = value;
         }
 
         internal bool CaptureInternal
         {
-            get
-            {
-                return IsHandleCreated && UnsafeNativeMethods.GetCapture() == Handle;
-            }
+            get => IsHandleCreated && UnsafeNativeMethods.GetCapture() == Handle;
             set
             {
                 if (CaptureInternal != value)
@@ -1528,10 +1336,7 @@ namespace System.Windows.Forms
         ]
         public bool CausesValidation
         {
-            get
-            {
-                return GetState(STATE_CAUSESVALIDATION);
-            }
+            get => GetState(STATE_CAUSESVALIDATION);
             set
             {
                 if (value != CausesValidation)
@@ -1558,36 +1363,31 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 // check if we're caching text.
-                //
-                int cacheTextCounter = Properties.GetInteger(PropCacheTextCount, out bool found);
+                int cacheTextCounter = Properties.GetInteger(PropCacheTextCount, out bool _);
 
                 return cacheTextCounter > 0 || GetStyle(ControlStyles.CacheText);
             }
             set
             {
-
-                // if this control always cachest text or the handle hasn't been created,
+                // Ff this control always cachest text or the handle hasn't been created,
                 // just bail.
-                //
                 if (GetStyle(ControlStyles.CacheText) || !IsHandleCreated)
                 {
                     return;
                 }
 
                 // otherwise, get the state and update the cache if necessary.
-                //
                 int cacheTextCounter = Properties.GetInteger(PropCacheTextCount, out bool found);
 
                 if (value)
                 {
                     if (cacheTextCounter == 0)
                     {
-                        Properties.SetObject(PropCacheTextField, text);
-                        if (text == null)
+                        Properties.SetObject(PropCacheTextField, _text);
+                        if (_text == null)
                         {
-                            text = WindowText;
+                            _text = WindowText;
                         }
                     }
                     cacheTextCounter++;
@@ -1597,7 +1397,7 @@ namespace System.Windows.Forms
                     cacheTextCounter--;
                     if (cacheTextCounter == 0)
                     {
-                        text = (string)Properties.GetObject(PropCacheTextField, out found);
+                        _text = (string)Properties.GetObject(PropCacheTextField, out found);
                     }
                 }
                 Properties.SetInteger(PropCacheTextCount, cacheTextCounter);
@@ -1609,11 +1409,7 @@ namespace System.Windows.Forms
             SRDescription(nameof(SR.ControlCheckForIllegalCrossThreadCalls)),
             DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)
         ]
-        public static bool CheckForIllegalCrossThreadCalls
-        {
-            get { return checkForIllegalCrossThreadCalls; }
-            set { checkForIllegalCrossThreadCalls = value; }
-        }
+        public static bool CheckForIllegalCrossThreadCalls { get; set; } = Debugger.IsAttached;
 
         /// <summary>
         ///  The client rect of the control.
@@ -1628,7 +1424,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                return new Rectangle(0, 0, clientWidth, clientHeight);
+                return new Rectangle(0, 0, _clientWidth, _clientHeight);
             }
         }
 
@@ -1643,15 +1439,8 @@ namespace System.Windows.Forms
         ]
         public Size ClientSize
         {
-            get
-            {
-                return new Size(clientWidth, clientHeight);
-            }
-
-            set
-            {
-                SetClientSizeCore(value.Width, value.Height);
-            }
+            get => new Size(_clientWidth, _clientHeight);
+            set => SetClientSizeCore(value.Width, value.Height);
         }
 
         /// <summary>
@@ -1672,13 +1461,7 @@ namespace System.Windows.Forms
             DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden),
             Description(nameof(SR.ControlCompanyNameDescr))
         ]
-        public string CompanyName
-        {
-            get
-            {
-                return VersionInfo.CompanyName;
-            }
-        }
+        public string CompanyName => VersionInfo.CompanyName;
 
         /// <summary>
         ///  Indicates whether the control or one of its children currently has the system
@@ -1734,10 +1517,7 @@ namespace System.Windows.Forms
         ]
         public virtual ContextMenu ContextMenu
         {
-            get
-            {
-                return (ContextMenu)Properties.GetObject(PropContextMenu);
-            }
+            get => (ContextMenu)Properties.GetObject(PropContextMenu);
             set
             {
                 ContextMenu oldValue = (ContextMenu)Properties.GetObject(PropContextMenu);
@@ -1786,10 +1566,7 @@ namespace System.Windows.Forms
         ]
         public virtual ContextMenuStrip ContextMenuStrip
         {
-            get
-            {
-                return (ContextMenuStrip)Properties.GetObject(PropContextMenuStrip);
-            }
+            get => (ContextMenuStrip)Properties.GetObject(PropContextMenuStrip);
             set
             {
                 ContextMenuStrip oldValue = Properties.GetObject(PropContextMenuStrip) as ContextMenuStrip;
@@ -1854,13 +1631,7 @@ namespace System.Windows.Forms
             DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden),
             SRDescription(nameof(SR.ControlCreatedDescr))
         ]
-        public bool Created
-        {
-            get
-            {
-                return (state & STATE_CREATED) != 0;
-            }
-        }
+        public bool Created => (_state & STATE_CREATED) != 0;
 
         /// <summary>
         ///  Returns the CreateParams used to create the handle for this control.
@@ -1872,12 +1643,12 @@ namespace System.Windows.Forms
             get
             {
                 // CLR4.0 or later, comctl32.dll needs to be loaded explicitly.
-                if (needToLoadComCtl)
+                if (s_needToLoadComCtl)
                 {
                     if ((Interop.Kernel32.GetModuleHandleW(Interop.Libraries.Comctl32) != IntPtr.Zero)
                         || (Interop.Kernel32.LoadLibraryFromSystemPathIfAvailable(Interop.Libraries.Comctl32) != IntPtr.Zero))
                     {
-                        needToLoadComCtl = false;
+                        s_needToLoadComCtl = false;
                     }
                     else
                     {
@@ -1888,22 +1659,21 @@ namespace System.Windows.Forms
 
                 // In a typical control this is accessed ten times to create and show a control.
                 // It is a net memory savings, then, to maintain a copy on control.
-                //
-                if (createParams == null)
+                if (_createParams == null)
                 {
-                    createParams = new CreateParams();
+                    _createParams = new CreateParams();
                 }
 
-                CreateParams cp = createParams;
+                CreateParams cp = _createParams;
                 cp.Style = 0;
                 cp.ExStyle = 0;
                 cp.ClassStyle = 0;
-                cp.Caption = text;
+                cp.Caption = _text;
 
-                cp.X = x;
-                cp.Y = y;
-                cp.Width = width;
-                cp.Height = height;
+                cp.X = _x;
+                cp.Y = _y;
+                cp.Width = _width;
+                cp.Height = _height;
 
                 cp.Style = NativeMethods.WS_CLIPCHILDREN;
                 if (GetStyle(ControlStyles.ContainerControl))
@@ -1912,12 +1682,12 @@ namespace System.Windows.Forms
                 }
                 cp.ClassStyle = (int)NativeMethods.ClassStyle.CS_DBLCLKS;
 
-                if ((state & STATE_TOPLEVEL) == 0)
+                if ((_state & STATE_TOPLEVEL) == 0)
                 {
                     // When the window is actually created, we will parent WS_CHILD windows to the
                     // parking form if cp.parent == 0.
                     //
-                    cp.Parent = parent == null ? IntPtr.Zero : parent.InternalHandle;
+                    cp.Parent = _parent == null ? IntPtr.Zero : _parent.InternalHandle;
                     cp.Style |= NativeMethods.WS_CHILD | NativeMethods.WS_CLIPSIBLINGS;
                 }
                 else
@@ -1925,12 +1695,12 @@ namespace System.Windows.Forms
                     cp.Parent = IntPtr.Zero;
                 }
 
-                if ((state & STATE_TABSTOP) != 0)
+                if ((_state & STATE_TABSTOP) != 0)
                 {
                     cp.Style |= NativeMethods.WS_TABSTOP;
                 }
 
-                if ((state & STATE_VISIBLE) != 0)
+                if ((_state & STATE_VISIBLE) != 0)
                 {
                     cp.Style |= NativeMethods.WS_VISIBLE;
                 }
@@ -1944,7 +1714,6 @@ namespace System.Windows.Forms
 
                 // If we are being hosted as an Ax control, try to prevent the parking window
                 // from being created by pre-filling the window handle here.
-                //
                 if (cp.Parent == IntPtr.Zero && IsActiveX)
                 {
                     cp.Parent = ActiveXHWNDParent;
@@ -2018,10 +1787,7 @@ namespace System.Windows.Forms
 
         internal bool ValidationCancelled
         {
-            set
-            {
-                SetState(STATE_VALIDATIONCANCELLED, value);
-            }
+            set => SetState(STATE_VALIDATIONCANCELLED, value);
             get
             {
                 if (GetState(STATE_VALIDATIONCANCELLED))
@@ -2048,14 +1814,8 @@ namespace System.Windows.Forms
         /// </summary>
         internal bool IsTopMdiWindowClosing
         {
-            set
-            {
-                SetState2(STATE2_TOPMDIWINDOWCLOSING, value);
-            }
-            get
-            {
-                return GetState2(STATE2_TOPMDIWINDOWCLOSING);
-            }
+            get => GetState2(STATE2_TOPMDIWINDOWCLOSING);
+            set => SetState2(STATE2_TOPMDIWINDOWCLOSING, value);
         }
 
         /// <summary>
@@ -2064,14 +1824,8 @@ namespace System.Windows.Forms
         /// </summary>
         internal bool IsCurrentlyBeingScaled
         {
-            private set
-            {
-                SetState2(STATE2_CURRENTLYBEINGSCALED, value);
-            }
-            get
-            {
-                return GetState2(STATE2_CURRENTLYBEINGSCALED);
-            }
+            get => GetState2(STATE2_CURRENTLYBEINGSCALED);
+            private set => SetState2(STATE2_CURRENTLYBEINGSCALED, value);
         }
 
         /// <summary>
@@ -2079,20 +1833,9 @@ namespace System.Windows.Forms
         ///  handle for this control.  If the control's handle hasn't been
         ///  created yet, this method will return the current thread's ID.
         /// </summary>
-        internal int CreateThreadId
-        {
-            get
-            {
-                if (IsHandleCreated)
-                {
-                    return SafeNativeMethods.GetWindowThreadProcessId(new HandleRef(this, Handle), out int pid);
-                }
-                else
-                {
-                    return SafeNativeMethods.GetCurrentThreadId();
-                }
-            }
-        }
+        internal int CreateThreadId => IsHandleCreated 
+            ? SafeNativeMethods.GetWindowThreadProcessId(new HandleRef(this, Handle), out int _)
+            : SafeNativeMethods.GetCurrentThreadId();
 
         /// <summary>
         ///  Retrieves the cursor that will be displayed when the mouse is over this
@@ -2120,7 +1863,6 @@ namespace System.Windows.Forms
 
                 // We only do ambients for things with "Cursors.Default"
                 // as their default.
-                //
                 Cursor localDefault = DefaultCursor;
                 if (localDefault != Cursors.Default)
                 {
@@ -2143,7 +1885,6 @@ namespace System.Windows.Forms
             }
             set
             {
-
                 Cursor localCursor = (Cursor)Properties.GetObject(PropCursor);
                 Cursor resolvedCursor = Cursor;
                 if (localCursor != value)
@@ -2153,7 +1894,6 @@ namespace System.Windows.Forms
 
                 // Other things can change the cursor... we
                 // really want to force the correct cursor always...
-                //
                 if (IsHandleCreated)
                 {
                     // We want to instantly change the cursor if the mouse is within our bounds.
@@ -2211,23 +1951,14 @@ namespace System.Windows.Forms
         ///  The default BackColor of a generic top-level Control.  Subclasses may have
         ///  different defaults.
         /// </summary>
-        public static Color DefaultBackColor
-        {
-            get { return SystemColors.Control; }
-        }
+        public static Color DefaultBackColor => SystemColors.Control;
 
         /// <summary>
         ///  Deriving classes can override this to configure a default cursor for their control.
         ///  This is more efficient than setting the cursor in the control's constructor,
         ///  and gives automatic support for ShouldSerialize and Reset in the designer.
         /// </summary>
-        protected virtual Cursor DefaultCursor
-        {
-            get
-            {
-                return Cursors.Default;
-            }
-        }
+        protected virtual Cursor DefaultCursor => Cursors.Default;
 
         /// <summary>
         ///  The default Font of a generic top-level Control.  Subclasses may have
@@ -2237,13 +1968,13 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (defaultFont == null)
+                if (s_defaultFont == null)
                 {
-                    defaultFont = SystemFonts.MessageBoxFont;
-                    Debug.Assert(defaultFont != null, "defaultFont wasn't set!");
+                    s_defaultFont = SystemFonts.MessageBoxFont;
+                    Debug.Assert(s_defaultFont != null, "defaultFont wasn't set!");
                 }
 
-                return defaultFont;
+                return s_defaultFont;
             }
         }
 
@@ -2251,54 +1982,27 @@ namespace System.Windows.Forms
         ///  The default ForeColor of a generic top-level Control.  Subclasses may have
         ///  different defaults.
         /// </summary>
-        public static Color DefaultForeColor
-        {
-            get { return SystemColors.ControlText; }
-        }
+        public static Color DefaultForeColor => SystemColors.ControlText;
 
-        protected virtual Padding DefaultMargin
-        {
-            get { return CommonProperties.DefaultMargin; }
-        }
+        protected virtual Padding DefaultMargin => CommonProperties.DefaultMargin;
 
-        protected virtual Size DefaultMaximumSize
-        {
-            get { return CommonProperties.DefaultMaximumSize; }
-        }
+        protected virtual Size DefaultMaximumSize => CommonProperties.DefaultMaximumSize;
 
-        protected virtual Size DefaultMinimumSize
-        {
-            get { return CommonProperties.DefaultMinimumSize; }
-        }
+        protected virtual Size DefaultMinimumSize => CommonProperties.DefaultMinimumSize;
 
-        protected virtual Padding DefaultPadding
-        {
-            get { return Padding.Empty; }
-        }
+        protected virtual Padding DefaultPadding => Padding.Empty;
 
-        private RightToLeft DefaultRightToLeft
-        {
-            get { return RightToLeft.No; }
-        }
+        private RightToLeft DefaultRightToLeft => RightToLeft.No;
 
         /// <summary>
         ///  Deriving classes can override this to configure a default size for their control.
         ///  This is more efficient than setting the size in the control's constructor.
         /// </summary>
-        protected virtual Size DefaultSize
-        {
-            get { return Size.Empty; }
-        }
+        protected virtual Size DefaultSize => Size.Empty;
 
-        private void DetachContextMenu(object sender, EventArgs e)
-        {
-            ContextMenu = null;
-        }
+        private void DetachContextMenu(object sender, EventArgs e) => ContextMenu = null;
 
-        private void DetachContextMenuStrip(object sender, EventArgs e)
-        {
-            ContextMenuStrip = null;
-        }
+        private void DetachContextMenuStrip(object sender, EventArgs e) => ContextMenuStrip = null;
 
         /// <summary>
         ///  DPI value either for the primary screen or for the monitor where the top-level parent is displayed when
@@ -2310,17 +2014,8 @@ namespace System.Windows.Forms
             DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden) // do not serialize
         ]
         public int DeviceDpi
-        {
-            get
-            {
-                if (DpiHelper.IsPerMonitorV2Awareness)
-                {
-                    // deviceDpi may change in WmDpiChangedBeforeParent in PmV2 scenarios, so we can't cache statically.
-                    return deviceDpi;
-                }
-                return DpiHelper.DeviceDpi;
-            }
-        }
+            // deviceDpi may change in WmDpiChangedBeforeParent in PmV2 scenarios, so we can't cache statically.
+            => DpiHelper.IsPerMonitorV2Awareness ? _deviceDpi : DpiHelper.DeviceDpi;
 
         // The color to use when drawing disabled text.  Normally we use BackColor,
         // but that obviously won't work if we're transparent.
@@ -2360,12 +2055,7 @@ namespace System.Windows.Forms
             SRDescription(nameof(SR.ControlDisplayRectangleDescr))
         ]
         public virtual Rectangle DisplayRectangle
-        {
-            get
-            {
-                return new Rectangle(0, 0, clientWidth, clientHeight);
-            }
-        }
+            => new Rectangle(0, 0, _clientWidth, _clientHeight);
 
         /// <summary>
         ///  Indicates whether the control has been disposed. This
@@ -2376,13 +2066,7 @@ namespace System.Windows.Forms
             DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden),
             SRDescription(nameof(SR.ControlDisposedDescr))
         ]
-        public bool IsDisposed
-        {
-            get
-            {
-                return GetState(STATE_DISPOSED);
-            }
-        }
+        public bool IsDisposed => GetState(STATE_DISPOSED);
 
         /// <summary>
         ///  Disposes of the currently selected font handle (if cached).
@@ -2408,13 +2092,7 @@ namespace System.Windows.Forms
             DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden),
             SRDescription(nameof(SR.ControlDisposingDescr))
         ]
-        public bool Disposing
-        {
-            get
-            {
-                return GetState(STATE_DISPOSING);
-            }
-        }
+        public bool Disposing => GetState(STATE_DISPOSING);
 
         /// <summary>
         ///  The dock property. The dock property controls to which edge
@@ -2431,10 +2109,7 @@ namespace System.Windows.Forms
         ]
         public virtual DockStyle Dock
         {
-            get
-            {
-                return DefaultLayout.GetDock(this);
-            }
+            get => DefaultLayout.GetDock(this);
             set
             {
                 if (value != Dock)
@@ -2475,10 +2150,7 @@ namespace System.Windows.Forms
         ]
         protected virtual bool DoubleBuffered
         {
-            get
-            {
-                return GetStyle(ControlStyles.OptimizedDoubleBuffer);
-            }
+            get => GetStyle(ControlStyles.OptimizedDoubleBuffer);
             set
             {
                 if (value != DoubleBuffered)
@@ -2495,15 +2167,7 @@ namespace System.Windows.Forms
             }
         }
 
-        private bool DoubleBufferingEnabled
-        {
-            get
-            {
-#pragma warning disable 618
-                return GetStyle(ControlStyles.DoubleBuffer | ControlStyles.UserPaint);
-#pragma warning restore 618
-            }
-        }
+        private bool DoubleBufferingEnabled => GetStyle(ControlStyles.DoubleBuffer | ControlStyles.UserPaint);
 
         /// <summary>
         ///  Indicates whether the control is currently enabled.
@@ -2532,7 +2196,6 @@ namespace System.Windows.Forms
                     return ParentInternal.Enabled;
                 }
             }
-
             set
             {
                 bool oldValue = Enabled;
@@ -2569,12 +2232,7 @@ namespace System.Windows.Forms
             SRDescription(nameof(SR.ControlFocusedDescr))
         ]
         public virtual bool Focused
-        {
-            get
-            {
-                return IsHandleCreated && UnsafeNativeMethods.GetFocus() == Handle;
-            }
-        }
+            => IsHandleCreated && UnsafeNativeMethods.GetFocus() == Handle;
 
         /// <summary>
         ///  Retrieves the current font for this control. This will be the font used
@@ -2650,17 +2308,14 @@ namespace System.Windows.Forms
                 if (localChanged)
                 {
                     // Store new local value
-                    //
                     Properties.SetObject(PropFont, value);
 
                     // We only fire the Changed event if the "resolved" value
                     // changed, however we must update the font if the local
                     // value changed...
-                    //
                     if (!resolved.Equals(value))
                     {
                         // Cleanup any font handle wrapper...
-                        //
                         DisposeFontHandle();
 
                         if (Properties.ContainsInteger(PropFontHeight))
@@ -2671,7 +2326,6 @@ namespace System.Windows.Forms
                         // Font is an ambient property.  We need to layout our parent because Font may
                         // change our size.  We need to layout ourselves because our children may change
                         // size by inheriting the new value.
-                        //
                         using (new LayoutTransaction(ParentInternal, this, PropertyNames.Font))
                         {
                             OnFontChanged(EventArgs.Empty);
@@ -2737,9 +2391,9 @@ namespace System.Windows.Forms
                     return fontHandle.Handle;
                 }
 
-                if (parent != null)
+                if (_parent != null)
                 {
-                    return parent.FontHandle;
+                    return _parent.FontHandle;
                 }
 
                 AmbientProperties ambient = AmbientPropertiesService;
@@ -2924,23 +2578,8 @@ namespace System.Windows.Forms
                     Size cachedSize = CommonProperties.xGetPreferredSizeCache(this);
 
                     // If the "default" preferred size is being requested, and we have a cached value for it, return it.
-                    //
                     if (!cachedSize.IsEmpty && (proposedSize == LayoutUtils.MaxSize))
                     {
-
-#if DEBUG
-#if DEBUG_PREFERREDSIZE
-                            Size newPreferredSize = ApplySizeConstraints(GetPreferredSizeCore(proposedSize));
-                            bool cacheHitCorrect = (cachedSize == newPreferredSize);
-                            if (!cacheHitCorrect && !GetAnyDisposingInHierarchy()) {
-                                Debug.Fail(
-                                      "Cached PreferredSize " + cachedSize.ToString()
-                                      + " did not match computed: " +newPreferredSize.ToString()
-                                      +". Did we forget to invalidate the cache?\r\n\r\nControl Information: " + WindowsFormsUtils.AssertControlInformation(cacheHitCorrect, this)
-                                      + "\r\nChanged Properties\r\n " + CommonProperties.Debug_GetChangedProperties(this));
-                            }
-#endif
-#endif
                         return cachedSize;
                     }
                 }
@@ -2960,7 +2599,6 @@ namespace System.Windows.Forms
                 prefSize = ApplySizeConstraints(prefSize);
 
                 // If the "default" preferred size was requested, cache the computed value.
-                //
                 if (GetState2(STATE2_USEPREFERREDSIZECACHE) && proposedSize == LayoutUtils.MaxSize)
                 {
                     CommonProperties.xSetPreferredSizeCache(this, prefSize);
@@ -2990,8 +2628,8 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (checkForIllegalCrossThreadCalls &&
-                    !inCrossThreadSafeCall &&
+                if (CheckForIllegalCrossThreadCalls &&
+                    !t_inCrossThreadSafeCall &&
                     InvokeRequired)
                 {
                     throw new InvalidOperationException(string.Format(SR.IllegalCrossThreadCall,
@@ -3007,13 +2645,7 @@ namespace System.Windows.Forms
             }
         }
 
-        internal IntPtr HandleInternal
-        {
-            get
-            {
-                return window.Handle;
-            }
-        }
+        internal IntPtr HandleInternal => _window.Handle;
 
         /// <summary>
         ///  True if this control has child controls in its collection.  This
@@ -3034,13 +2666,7 @@ namespace System.Windows.Forms
             }
         }
 
-        internal virtual bool HasMenu
-        {
-            get
-            {
-                return false;
-            }
-        }
+        internal virtual bool HasMenu => false;
 
         /// <summary>
         ///  The height of this control
@@ -3053,14 +2679,8 @@ namespace System.Windows.Forms
         ]
         public int Height
         {
-            get
-            {
-                return height;
-            }
-            set
-            {
-                SetBounds(x, y, width, value, BoundsSpecified.Height);
-            }
+            get => _height;
+            set => SetBounds(_x, _y, _width, value, BoundsSpecified.Height);
         }
 
         internal bool HostedInWin32DialogManager
@@ -3104,7 +2724,6 @@ namespace System.Windows.Forms
                     }
 
                     SetState(STATE_CHECKEDHOST, true);
-
                 }
 
                 return GetState(STATE_HOSTEDINDIALOG);
@@ -3119,21 +2738,12 @@ namespace System.Windows.Forms
             DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden),
             SRDescription(nameof(SR.ControlHandleCreatedDescr))
         ]
-        public bool IsHandleCreated
-        {
-            get { return window.Handle != IntPtr.Zero; }
-        }
+        public bool IsHandleCreated => _window.Handle != IntPtr.Zero;
 
         /// <summary>
         ///  Determines if layout is currently suspended.
         /// </summary>
-        internal bool IsLayoutSuspended
-        {
-            get
-            {
-                return layoutSuspendCount > 0;
-            }
-        }
+        internal bool IsLayoutSuspended => _layoutSuspendCount > 0;
 
         internal bool IsWindowObscured
         {
@@ -3211,20 +2821,7 @@ namespace System.Windows.Forms
         ///  Returns the current value of the handle. This may be zero if the handle
         ///  has not been created.
         /// </summary>
-        internal IntPtr InternalHandle
-        {
-            get
-            {
-                if (!IsHandleCreated)
-                {
-                    return IntPtr.Zero;
-                }
-                else
-                {
-                    return Handle;
-                }
-            }
-        }
+        internal IntPtr InternalHandle => !IsHandleCreated ? IntPtr.Zero : Handle;
 
         /// <summary>
         ///  Determines if the caller must call invoke when making method
@@ -3287,50 +2884,26 @@ namespace System.Windows.Forms
         ]
         public bool IsAccessible
         {
-            get
-            {
-                return GetState(STATE_ISACCESSIBLE);
-            }
-            set
-            {
-                SetState(STATE_ISACCESSIBLE, value);
-            }
+            get => GetState(STATE_ISACCESSIBLE);
+            set => SetState(STATE_ISACCESSIBLE, value);
         }
 
         /// <summary>
         ///  Used to tell if this control is being hosted as an ActiveX control.
         /// </summary>
-        internal bool IsActiveX
-        {
-            get
-            {
-                return GetState2(STATE2_ISACTIVEX);
-            }
-        }
+        internal bool IsActiveX => GetState2(STATE2_ISACTIVEX);
 
         // If the control on which GetContainerControl( ) is called is a ContainerControl, then we dont return the parent
         // but return the same control. This is Everett behavior so we cannot change this since this would be a breaking change.
         // Hence we have a new internal property IsContainerControl which returns false for all Everett control, but
         // this property is overidden in SplitContainer to return true so that we skip the SplitContainer
         // and the correct Parent ContainerControl is returned by GetContainerControl().
-        internal virtual bool IsContainerControl
-        {
-            get
-            {
-                return false;
-            }
-        }
+        internal virtual bool IsContainerControl => false;
 
         /// <summary>
         ///  Used to tell if this control is being hosted in IE.
         /// </summary>
-        internal bool IsIEParent
-        {
-            get
-            {
-                return IsActiveX ? ActiveXInstance.IsIE : false;
-            }
-        }
+        internal bool IsIEParent => IsActiveX ? ActiveXInstance.IsIE : false;
 
         /// <summary>
         ///  Used to tell if the control is mirrored
@@ -3360,13 +2933,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Specifies whether the control is willing to process mnemonics when hosted in an container ActiveX (Ax Sourcing).
         /// </summary>
-        internal virtual bool IsMnemonicsListenerAxSourced
-        {
-            get
-            {
-                return false;
-            }
-        }
+        internal virtual bool IsMnemonicsListenerAxSourced => false;
 
         /// <summary>
         ///  Used to tell if this BackColor is Supported
@@ -3378,7 +2945,6 @@ namespace System.Windows.Forms
                 return false;
             }
             return true;
-
         }
 
         /// <summary>
@@ -3397,14 +2963,8 @@ namespace System.Windows.Forms
         ]
         public int Left
         {
-            get
-            {
-                return x;
-            }
-            set
-            {
-                SetBounds(value, y, width, height, BoundsSpecified.X);
-            }
+            get => _x;
+            set => SetBounds(value, _y, _width, _height, BoundsSpecified.X);
         }
 
         /// <summary>
@@ -3417,14 +2977,8 @@ namespace System.Windows.Forms
         ]
         public Point Location
         {
-            get
-            {
-                return new Point(x, y);
-            }
-            set
-            {
-                SetBounds(value.X, value.Y, width, height, BoundsSpecified.Location);
-            }
+            get => new Point(_x, _y);
+            set => SetBounds(value.X, value.Y, _width, _height, BoundsSpecified.Location);
         }
 
         [SRCategory(nameof(SR.CatPropertyChanged)), SRDescription(nameof(SR.ControlOnLocationChangedDescr))]
@@ -3485,7 +3039,6 @@ namespace System.Windows.Forms
                     CommonProperties.SetMaximumSize(this, value);
                     Debug.Assert(MaximumSize == value, "Error detected while setting MaximumSize.");
                 }
-
             }
         }
 
@@ -3515,8 +3068,7 @@ namespace System.Windows.Forms
             get
             {
                 Keys modifiers = 0;
-                // SECURITYNOTE : only let state of Shift-Control-Alt out...
-                //
+
                 if (UnsafeNativeMethods.GetKeyState((int)Keys.ShiftKey) < 0)
                 {
                     modifiers |= Keys.Shift;
@@ -3545,8 +3097,7 @@ namespace System.Windows.Forms
             get
             {
                 MouseButtons buttons = (MouseButtons)0;
-                // SECURITYNOTE : only let state of MouseButtons out...
-                //
+
                 if (UnsafeNativeMethods.GetKeyState((int)Keys.LButton) < 0)
                 {
                     buttons |= MouseButtons.Left;
@@ -3639,25 +3190,16 @@ namespace System.Windows.Forms
         ]
         public Control Parent
         {
-            get
-            {
-                return ParentInternal;
-            }
-            set
-            {
-                ParentInternal = value;
-            }
+            get => ParentInternal;
+            set => ParentInternal = value;
         }
 
         internal virtual Control ParentInternal
         {
-            get
-            {
-                return parent;
-            }
+            get => _parent;
             set
             {
-                if (parent != value)
+                if (_parent != value)
                 {
                     if (value != null)
                     {
@@ -3665,7 +3207,7 @@ namespace System.Windows.Forms
                     }
                     else
                     {
-                        parent.Controls.Remove(this);
+                        _parent.Controls.Remove(this);
                     }
                 }
             }
@@ -3679,13 +3221,7 @@ namespace System.Windows.Forms
             DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden),
             SRDescription(nameof(SR.ControlProductNameDescr))
         ]
-        public string ProductName
-        {
-            get
-            {
-                return VersionInfo.ProductName;
-            }
-        }
+        public string ProductName => VersionInfo.ProductName;
 
         /// <summary>
         ///  Retrieves the product version of this specific component.
@@ -3695,35 +3231,17 @@ namespace System.Windows.Forms
         DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden),
         SRDescription(nameof(SR.ControlProductVersionDescr))
         ]
-        public string ProductVersion
-        {
-            get
-            {
-                return VersionInfo.ProductVersion;
-            }
-        }
+        public string ProductVersion => VersionInfo.ProductVersion;
 
         /// <summary>
         ///  Retrieves our internal property storage object. If you have a property
         ///  whose value is not always set, you should store it in here to save
         ///  space.
         /// </summary>
-        internal PropertyStore Properties
-        {
-            get
-            {
-                return propertyStore;
-            }
-        }
+        internal PropertyStore Properties { get; }
 
         // Returns the value of the backColor field -- no asking the parent with its color is, etc.
-        internal Color RawBackColor
-        {
-            get
-            {
-                return Properties.GetColor(PropBackColor);
-            }
-        }
+        internal Color RawBackColor => Properties.GetColor(PropBackColor);
 
         /// <summary>
         ///  Indicates whether the control is currently recreating its handle. This
@@ -3735,13 +3253,7 @@ namespace System.Windows.Forms
         DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden),
         SRDescription(nameof(SR.ControlRecreatingHandleDescr))
         ]
-        public bool RecreatingHandle
-        {
-            get
-            {
-                return (state & STATE_RECREATE) != 0;
-            }
-        }
+        public bool RecreatingHandle => (_state & STATE_RECREATE) != 0;
 
         internal virtual void AddReflectChild()
         {
@@ -3753,10 +3265,7 @@ namespace System.Windows.Forms
 
         private Control ReflectParent
         {
-            get
-            {
-                return reflectParent;
-            }
+            get => _reflectParent;
             set
             {
                 if (value != null)
@@ -3764,7 +3273,7 @@ namespace System.Windows.Forms
                     value.AddReflectChild();
                 }
 
-                reflectParent = value;
+                _reflectParent = value;
                 if (ReflectParent is Control c)
                 {
                     c.RemoveReflectChild();
@@ -3784,10 +3293,7 @@ namespace System.Windows.Forms
         ]
         public Region Region
         {
-            get
-            {
-                return (Region)Properties.GetObject(PropRegion);
-            }
+            get => (Region)Properties.GetObject(PropRegion);
             set
             {
                 Region oldRegion = Region;
@@ -3848,41 +3354,22 @@ namespace System.Windows.Forms
 
         // Helper function for Rtl
         [Obsolete("This property has been deprecated. Please use RightToLeft instead. http://go.microsoft.com/fwlink/?linkid=14202")]
-        protected internal bool RenderRightToLeft
-        {
-            get
-            {
-                return true;
-            }
-        }
+        protected internal bool RenderRightToLeft => true;
 
         /// <summary>
         ///  Determines if the parent's background will be rendered on the label control.
         /// </summary>
         internal bool RenderTransparent
-        {
-            get
-            {
-                return GetStyle(ControlStyles.SupportsTransparentBackColor) && BackColor.A < 255;
-            }
-        }
+            => GetStyle(ControlStyles.SupportsTransparentBackColor) && BackColor.A < 255;
 
         private bool RenderColorTransparent(Color c)
-        {
-            return GetStyle(ControlStyles.SupportsTransparentBackColor) && c.A < 255;
-        }
+            => GetStyle(ControlStyles.SupportsTransparentBackColor) && c.A < 255;
 
         /// <summary>
         /// This property is required by certain controls (TabPage) to render its transparency using theming API.
         /// We dont want all controls (that are have transparent BackColor) to use theming API to render its background because it has  HUGE PERF cost.
         /// </summary>
-        internal virtual bool RenderTransparencyWithVisualStyles
-        {
-            get
-            {
-                return false;
-            }
-        }
+        internal virtual bool RenderTransparencyWithVisualStyles => false;
 
         /// <summary>
         ///  Represents the bounds of the control that need to be scaled.  Control bounds
@@ -3893,16 +3380,16 @@ namespace System.Windows.Forms
         {
             get
             {
-                if ((requiredScaling & RequiredScalingEnabledMask) != 0)
+                if ((_requiredScaling & RequiredScalingEnabledMask) != 0)
                 {
-                    return (BoundsSpecified)(requiredScaling & RequiredScalingMask);
+                    return (BoundsSpecified)(_requiredScaling & RequiredScalingMask);
                 }
                 return BoundsSpecified.None;
             }
             set
             {
-                byte enableBit = (byte)(requiredScaling & RequiredScalingEnabledMask);
-                requiredScaling = (byte)(((int)value & RequiredScalingMask) | enableBit);
+                byte enableBit = (byte)(_requiredScaling & RequiredScalingEnabledMask);
+                _requiredScaling = (byte)(((int)value & RequiredScalingMask) | enableBit);
             }
         }
 
@@ -3912,17 +3399,14 @@ namespace System.Windows.Forms
         /// </summary>
         internal bool RequiredScalingEnabled
         {
-            get
-            {
-                return (requiredScaling & RequiredScalingEnabledMask) != 0;
-            }
+            get => (_requiredScaling & RequiredScalingEnabledMask) != 0;
             set
             {
-                byte scaling = (byte)(requiredScaling & RequiredScalingMask);
-                requiredScaling = scaling;
+                byte scaling = (byte)(_requiredScaling & RequiredScalingMask);
+                _requiredScaling = scaling;
                 if (value)
                 {
-                    requiredScaling |= RequiredScalingEnabledMask;
+                    _requiredScaling |= RequiredScalingEnabledMask;
                 }
             }
         }
@@ -3930,19 +3414,11 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Indicates whether the control should redraw itself when resized.
         /// </summary>
-        [
-        SRDescription(nameof(SR.ControlResizeRedrawDescr))
-        ]
+        [SRDescription(nameof(SR.ControlResizeRedrawDescr))]
         protected bool ResizeRedraw
         {
-            get
-            {
-                return GetStyle(ControlStyles.ResizeRedraw);
-            }
-            set
-            {
-                SetStyle(ControlStyles.ResizeRedraw, value);
-            }
+            get => GetStyle(ControlStyles.ResizeRedraw);
+            set => SetStyle(ControlStyles.ResizeRedraw, value);
         }
 
         /// <summary>
@@ -3954,13 +3430,7 @@ namespace System.Windows.Forms
         DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden),
         SRDescription(nameof(SR.ControlRightDescr))
         ]
-        public int Right
-        {
-            get
-            {
-                return x + width;
-            }
-        }
+        public int Right => _x + _width;
 
         /// <summary>
         ///  This is used for international applications where the language
@@ -3997,7 +3467,6 @@ namespace System.Windows.Forms
                 }
                 return (RightToLeft)rightToLeft;
             }
-
             set
             {
                 //valid values are 0x0 to 0x2.
@@ -4039,21 +3508,12 @@ namespace System.Windows.Forms
         ///  this property to provide a different value.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Advanced)]
-        protected virtual bool ScaleChildren
-        {
-            get
-            {
-                return true;
-            }
-        }
+        protected virtual bool ScaleChildren => true;
 
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public override ISite Site
         {
-            get
-            {
-                return base.Site;
-            }
+            get => base.Site;
             set
             {
                 AmbientProperties oldAmbients = AmbientPropertiesService;
@@ -4065,7 +3525,6 @@ namespace System.Windows.Forms
                 }
 
                 // If the ambients changed, compare each property.
-                //
                 if (oldAmbients != newAmbients)
                 {
                     bool checkFont = !Properties.ContainsObject(PropFont);
@@ -4121,7 +3580,6 @@ namespace System.Windows.Forms
                 else
                 {
                     // If the ambients haven't changed, we just set a new site.
-                    //
                     base.Site = value;
                 }
             }
@@ -4137,14 +3595,8 @@ namespace System.Windows.Forms
         ]
         public Size Size
         {
-            get
-            {
-                return new Size(width, height);
-            }
-            set
-            {
-                SetBounds(x, y, value.Width, value.Height, BoundsSpecified.Size);
-            }
+            get => new Size(_width, _height);
+            set => SetBounds(_x, _y, value.Width, value.Height, BoundsSpecified.Size);
         }
 
         [SRCategory(nameof(SR.CatPropertyChanged)), SRDescription(nameof(SR.ControlOnSizeChangedDescr))]
@@ -4155,8 +3607,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  The tab index of
-        ///  this control.
+        ///  The tab index of this control.
         /// </summary>
         [
         SRCategory(nameof(SR.CatBehavior)),
@@ -4166,10 +3617,7 @@ namespace System.Windows.Forms
         ]
         public int TabIndex
         {
-            get
-            {
-                return tabIndex == -1 ? 0 : tabIndex;
-            }
+            get => _tabIndex == -1 ? 0 : _tabIndex;
             set
             {
                 if (value < 0)
@@ -4177,9 +3625,9 @@ namespace System.Windows.Forms
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(TabIndex), value, 0));
                 }
 
-                if (tabIndex != value)
+                if (_tabIndex != value)
                 {
-                    tabIndex = value;
+                    _tabIndex = value;
                     OnTabIndexChanged(EventArgs.Empty);
                 }
             }
@@ -4204,10 +3652,7 @@ namespace System.Windows.Forms
         ]
         public bool TabStop
         {
-            get
-            {
-                return TabStopInternal;
-            }
+            get => TabStopInternal;
             set
             {
                 if (TabStop != value)
@@ -4226,10 +3671,7 @@ namespace System.Windows.Forms
         // Grab out the logical of setting TABSTOP state, so that derived class could use this.
         internal bool TabStopInternal
         {
-            get
-            {
-                return (state & STATE_TABSTOP) != 0;
-            }
+            get => (_state & STATE_TABSTOP) != 0;
             set
             {
                 if (TabStopInternal != value)
@@ -4256,14 +3698,8 @@ namespace System.Windows.Forms
         ]
         public object Tag
         {
-            get
-            {
-                return Properties.GetObject(PropUserData);
-            }
-            set
-            {
-                Properties.SetObject(PropUserData, value);
-            }
+            get => Properties.GetObject(PropUserData);
+            set => Properties.SetObject(PropUserData, value);
         }
 
         /// <summary>
@@ -4278,18 +3714,7 @@ namespace System.Windows.Forms
         ]
         public virtual string Text
         {
-            get
-            {
-                if (CacheTextInternal)
-                {
-                    return text ?? "";
-                }
-                else
-                {
-                    return WindowText;
-                }
-            }
-
+            get => CacheTextInternal ? _text ?? "" :  WindowText;
             set
             {
                 if (value == null)
@@ -4304,8 +3729,9 @@ namespace System.Windows.Forms
 
                 if (CacheTextInternal)
                 {
-                    text = value;
+                    _text = value;
                 }
+
                 WindowText = value;
                 OnTextChanged(EventArgs.Empty);
 
@@ -4321,7 +3747,6 @@ namespace System.Windows.Forms
                         }
                     }
                 }
-
             }
         }
 
@@ -4343,14 +3768,8 @@ namespace System.Windows.Forms
         ]
         public int Top
         {
-            get
-            {
-                return y;
-            }
-            set
-            {
-                SetBounds(x, value, width, height, BoundsSpecified.Y);
-            }
+            get => _y;
+            set => SetBounds(_x, value, _width, _height, BoundsSpecified.Y);
         }
 
         /// <summary>
@@ -4364,13 +3783,7 @@ namespace System.Windows.Forms
         DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden),
         SRDescription(nameof(SR.ControlTopLevelControlDescr))
         ]
-        public Control TopLevelControl
-        {
-            get
-            {
-                return TopLevelControlInternal;
-            }
-        }
+        public Control TopLevelControl => TopLevelControlInternal;
 
         internal Control TopLevelControlInternal
         {
@@ -4398,15 +3811,8 @@ namespace System.Windows.Forms
             }
         }
 
-        private BufferedGraphicsContext BufferContext
-        {
-            get
-            {
-                //This auto upgraged v1 client to per-process doublebuffering logic
-                //
-                return BufferedGraphicsManager.Current;
-            }
-        }
+        // This auto upgraged v1 client to per-process doublebuffering logic
+        private BufferedGraphicsContext BufferContext => BufferedGraphicsManager.Current;
 
         /// <summary>
         ///  Indicates whether the user interface is in a state to show or hide keyboard
@@ -4451,18 +3857,18 @@ namespace System.Windows.Forms
                 //   In WmUpdateUIState, we will update our uiCuesState cached value, which
                 //   changes the public value of what we return here for ShowKeyboardCues/ShowFocusCues.
 
-                if ((uiCuesState & UISTATE_KEYBOARD_CUES_MASK) == 0)
+                if ((_uiCuesState & UISTATE_KEYBOARD_CUES_MASK) == 0)
                 {
                     if (SystemInformation.MenuAccessKeysUnderlined)
                     {
-                        uiCuesState |= UISTATE_KEYBOARD_CUES_SHOW;
+                        _uiCuesState |= UISTATE_KEYBOARD_CUES_SHOW;
                     }
                     else
                     {
                         // if we're in the hidden state, we need to manufacture an update message so everyone knows it.
                         //
                         int actionMask = NativeMethods.UISF_HIDEACCEL << 16;
-                        uiCuesState |= UISTATE_KEYBOARD_CUES_HIDDEN;
+                        _uiCuesState |= UISTATE_KEYBOARD_CUES_HIDDEN;
 
                         // The side effect of this initial state is that adding new controls may clear the accelerator
                         // state (has been this way forever)
@@ -4472,7 +3878,7 @@ namespace System.Windows.Forms
                                 IntPtr.Zero);
                     }
                 }
-                return (uiCuesState & UISTATE_KEYBOARD_CUES_MASK) == UISTATE_KEYBOARD_CUES_SHOW;
+                return (_uiCuesState & UISTATE_KEYBOARD_CUES_MASK) == UISTATE_KEYBOARD_CUES_SHOW;
             }
         }
 
@@ -4495,18 +3901,17 @@ namespace System.Windows.Forms
 
                 // See "How this all works" in ShowKeyboardCues
 
-                if ((uiCuesState & UISTATE_FOCUS_CUES_MASK) == 0)
+                if ((_uiCuesState & UISTATE_FOCUS_CUES_MASK) == 0)
                 {
                     if (SystemInformation.MenuAccessKeysUnderlined)
                     {
-                        uiCuesState |= UISTATE_FOCUS_CUES_SHOW;
+                        _uiCuesState |= UISTATE_FOCUS_CUES_SHOW;
                     }
                     else
                     {
-                        uiCuesState |= UISTATE_FOCUS_CUES_HIDDEN;
+                        _uiCuesState |= UISTATE_FOCUS_CUES_HIDDEN;
 
                         // if we're in the hidden state, we need to manufacture an update message so everyone knows it.
-                        //
                         int actionMask = (NativeMethods.UISF_HIDEACCEL | NativeMethods.UISF_HIDEFOCUS) << 16;
 
                         // The side effect of this initial state is that adding new controls may clear the focus cue state
@@ -4518,19 +3923,12 @@ namespace System.Windows.Forms
 
                     }
                 }
-                return (uiCuesState & UISTATE_FOCUS_CUES_MASK) == UISTATE_FOCUS_CUES_SHOW;
+                return (_uiCuesState & UISTATE_FOCUS_CUES_MASK) == UISTATE_FOCUS_CUES_SHOW;
             }
         }
 
         // The parameter used in the call to ShowWindow for this control
-        //
-        internal virtual int ShowParams
-        {
-            get
-            {
-                return NativeMethods.SW_SHOW;
-            }
-        }
+        internal virtual int ShowParams => NativeMethods.SW_SHOW;
 
         /// <summary>
         ///  When this property in true the Cursor Property is set to WaitCursor as well as the Cursor Property
@@ -4545,7 +3943,7 @@ namespace System.Windows.Forms
         ]
         public bool UseWaitCursor
         {
-            get { return GetState(STATE_USEWAITCURSOR); }
+            get => GetState(STATE_USEWAITCURSOR);
             set
             {
                 if (GetState(STATE_USEWAITCURSOR) != value)
@@ -4587,7 +3985,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                return Control.UseCompatibleTextRenderingDefault;
+                return UseCompatibleTextRenderingDefault;
             }
             set
             {
@@ -4606,13 +4004,7 @@ namespace System.Windows.Forms
         ///  This is provided for container controls (PropertyGrid) to iterate through its children to set
         ///  UseCompatibleTextRendering to the same value if the child control supports it.
         /// </summary>
-        internal virtual bool SupportsUseCompatibleTextRendering
-        {
-            get
-            {
-                return false;
-            }
-        }
+        internal virtual bool SupportsUseCompatibleTextRendering => false;
 
         private ControlVersionInfo VersionInfo
         {
@@ -4638,14 +4030,8 @@ namespace System.Windows.Forms
         ]
         public bool Visible
         {
-            get
-            {
-                return GetVisibleCore();
-            }
-            set
-            {
-                SetVisibleCore(value);
-            }
+            get => GetVisibleCore();
+            set => SetVisibleCore(value);
         }
 
         /// <summary>
@@ -4695,15 +4081,15 @@ namespace System.Windows.Forms
                     throw new InvalidAsynchronousStateException(SR.ThreadNoLongerValid);
                 }
 
-                if (IsDisposed && threadCallbackList != null && threadCallbackList.Count > 0)
+                if (IsDisposed && _threadCallbackList != null && _threadCallbackList.Count > 0)
                 {
-                    lock (threadCallbackList)
+                    lock (_threadCallbackList)
                     {
                         Exception ex = new ObjectDisposedException(GetType().Name);
-                        while (threadCallbackList.Count > 0)
+                        while (_threadCallbackList.Count > 0)
                         {
-                            ThreadMethodEntry entry = (ThreadMethodEntry)threadCallbackList.Dequeue();
-                            entry.exception = ex;
+                            ThreadMethodEntry entry = (ThreadMethodEntry)_threadCallbackList.Dequeue();
+                            entry._exception = ex;
                             entry.Complete();
                         }
                     }
@@ -4724,14 +4110,8 @@ namespace System.Windows.Forms
         ]
         public int Width
         {
-            get
-            {
-                return width;
-            }
-            set
-            {
-                SetBounds(x, y, value, height, BoundsSpecified.Width);
-            }
+            get => _width;
+            set => SetBounds(_x, _y, value, _height, BoundsSpecified.Width);
         }
 
         /// <summary>
@@ -4775,14 +4155,8 @@ namespace System.Windows.Forms
         ]
         public IWindowTarget WindowTarget
         {
-            get
-            {
-                return window.WindowTarget;
-            }
-            set
-            {
-                window.WindowTarget = value;
-            }
+            get => _window.WindowTarget;
+            set => _window.WindowTarget = value;
         }
 
         /// <summary>
@@ -4796,22 +4170,21 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 if (!IsHandleCreated)
                 {
-                    if (text == null)
+                    if (_text == null)
                     {
                         return "";
                     }
                     else
                     {
-                        return text;
+                        return _text;
                     }
                 }
 
                 using (new MultithreadSafeCallScope())
                 {
-                    return Interop.User32.GetWindowText(new HandleRef(window, Handle));
+                    return Interop.User32.GetWindowText(new HandleRef(_window, Handle));
                 }
             }
             set
@@ -4825,17 +4198,17 @@ namespace System.Windows.Forms
                 {
                     if (IsHandleCreated)
                     {
-                        Interop.User32.SetWindowTextW(new HandleRef(window, Handle), value);
+                        Interop.User32.SetWindowTextW(new HandleRef(_window, Handle), value);
                     }
                     else
                     {
                         if (value.Length == 0)
                         {
-                            text = null;
+                            _text = null;
                         }
                         else
                         {
-                            text = value;
+                            _text = value;
                         }
                     }
                 }
@@ -5343,76 +4716,6 @@ namespace System.Windows.Forms
             ActiveXInstance.ViewChangedInternal();
         }
 
-#if ACTIVEX_SOURCING
-
-        //
-        // This has been cut from the product.
-        //
-
-        /// <summary>
-        ///  This is called by regasm to register a control as an ActiveX control.
-        /// </summary>
-        [ComRegisterFunction()]
-        protected static void ActiveXRegister(Type type) {
-
-            if (type == null) {
-                throw new ArgumentNullException(nameof(type));
-            }
-
-            // If the user is not registering an AX control, then
-            // bail now.
-            //
-            if (!typeof(Control).IsAssignableFrom(type)) {
-                return;
-            }
-
-            // Add the flags that define us as a control to the rest of the
-            // world.
-            //
-            RegistryKey clsidKey = Registry.ClassesRoot.OpenSubKey("CLSID", true).CreateSubKey("{" + type.GUID.ToString() + "}");
-            RegistryKey key = clsidKey.CreateSubKey("Control");
-            key.Close();
-
-            key = clsidKey.CreateSubKey("Implemented Categories");
-            RegistryKey subKey = key.CreateSubKey("{40FC6ED4-2438-11CF-A3DB-080036F12502}"); // CATID_Control
-            subKey.Close();
-            key.Close();
-
-            // Calculate MiscStatus bits.  Note that this is a static version
-            // of GetMiscStatus in ActiveXImpl below.  Keep them in sync!
-            //
-            int miscStatus = NativeMethods.OLEMISC_ACTIVATEWHENVISIBLE |
-                             NativeMethods.OLEMISC_INSIDEOUT |
-                             NativeMethods.OLEMISC_SETCLIENTSITEFIRST |
-                             NativeMethods.OLEMISC_RECOMPOSEONRESIZE;
-            if (typeof(IButtonControl).IsAssignableFrom(type)) {
-                miscStatus |= NativeMethods.OLEMISC_ACTSLIKEBUTTON;
-            }
-
-            key = clsidKey.CreateSubKey("MiscStatus");
-            key.SetValue("", miscStatus.ToString());
-            key.Close();
-
-            // Now add the typelib information.  Many containers don't
-            // host Active X controls without a typelib in the registry
-            // (visual basic won't even show it in the control dialog).
-            //
-            Guid typeLibGuid = Marshal.GetTypeLibGuidForAssembly(type.Assembly);
-            Version assemblyVer = type.Assembly.GetName().Version;
-
-            if (typeLibGuid != Guid.Empty) {
-                key = clsidKey.CreateSubKey("TypeLib");
-                key.SetValue("", "{" + typeLibGuid.ToString() + "}");
-                key.Close();
-                key = clsidKey.CreateSubKey("Version");
-                key.SetValue("", assemblyVer.Major.ToString() + "." + assemblyVer.Minor.ToString());
-                key.Close();
-            }
-
-            clsidKey.Close();
-        }
-#endif
-
         /// <summary>
         ///  Helper method for retrieving an ActiveX property.  We abstract these
         ///  to another method so we do not force JIT the ActiveX codebase.
@@ -5421,65 +4724,6 @@ namespace System.Windows.Forms
         {
             ActiveXInstance.UpdateBounds(ref x, ref y, ref width, ref height, flags);
         }
-
-#if ACTIVEX_SOURCING
-
-        //
-        // This has been cut from the product.
-        //
-
-        /// <summary>
-        ///  This is called by regasm to un-register a control as an ActiveX control.
-        /// </summary>
-        [ComUnregisterFunction()]
-        protected static void ActiveXUnregister(Type type) {
-
-            if (type == null) {
-                throw new ArgumentNullException(nameof(type));
-            }
-
-            // If the user is not unregistering an AX control, then
-            // bail now.
-            //
-            if (!typeof(Control).IsAssignableFrom(type)) {
-                return;
-            }
-
-            RegistryKey clsidKey = null;
-
-            // Unregistration should be very robust and unregister what it can.  We eat all exceptions here.
-            //
-            try {
-                clsidKey = Registry.ClassesRoot.OpenSubKey("CLSID", true).CreateSubKey("{" + type.GUID.ToString() + "}");
-
-                try {
-                    clsidKey.DeleteSubKeyTree("Control");
-                }
-                catch {
-                }
-                try {
-                    clsidKey.DeleteSubKeyTree("Implemented Categories");
-                }
-                catch {
-                }
-                try {
-                    clsidKey.DeleteSubKeyTree("MiscStatus");
-                }
-                catch {
-                }
-                try {
-                    clsidKey.DeleteSubKeyTree("TypeLib");
-                }
-                catch {
-                }
-            }
-            finally {
-                if (clsidKey != null) {
-                    clsidKey.Close();
-                }
-            }
-        }
-#endif
 
         /// <summary>
         ///  Assigns a new parent control. Sends out the appropriate property change
@@ -5496,7 +4740,6 @@ namespace System.Windows.Forms
             if (CanAccessProperties)
             {
                 // Store the old values for these properties
-                //
                 Font oldFont = Font;
                 Color oldForeColor = ForeColor;
                 Color oldBackColor = BackColor;
@@ -5505,8 +4748,7 @@ namespace System.Windows.Forms
                 bool oldVisible = Visible;
 
                 // Update the parent
-                //
-                parent = value;
+                _parent = value;
                 OnParentChanged(EventArgs.Empty);
 
                 if (GetAnyDisposingInHierarchy())
@@ -5515,7 +4757,6 @@ namespace System.Windows.Forms
                 }
 
                 // Compare property values with new parent to old values
-                //
                 if (oldEnabled != Enabled)
                 {
                     OnEnabledChanged(EventArgs.Empty);
@@ -5525,7 +4766,7 @@ namespace System.Windows.Forms
                 // yet its parent is being set to null and it's not top level, do not raise OnVisibleChanged.
                 bool newVisible = Visible;
 
-                if (oldVisible != newVisible && !(!oldVisible && newVisible && parent == null && !GetTopLevel()))
+                if (oldVisible != newVisible && !(!oldVisible && newVisible && _parent == null && !GetTopLevel()))
                 {
                     OnVisibleChanged(EventArgs.Empty);
                 }
@@ -5558,7 +4799,7 @@ namespace System.Windows.Forms
             }
             else
             {
-                parent = value;
+                _parent = value;
                 OnParentChanged(EventArgs.Empty);
             }
 
@@ -5630,12 +4871,12 @@ namespace System.Windows.Forms
             {
                 return;
             }
-            if (updateCount == 0)
+            if (_updateCount == 0)
             {
                 SendMessage(Interop.WindowMessages.WM_SETREDRAW, 0, 0);
             }
 
-            updateCount++;
+            _updateCount++;
         }
 
         /// <summary>
@@ -5643,14 +4884,14 @@ namespace System.Windows.Forms
         /// </summary>
         public void BringToFront()
         {
-            if (parent != null)
+            if (_parent != null)
             {
-                parent.Controls.SetChildIndex(this, 0);
+                _parent.Controls.SetChildIndex(this, 0);
             }
-            else if (IsHandleCreated && GetTopLevel() && SafeNativeMethods.IsWindowEnabled(new HandleRef(window, Handle)))
+            else if (IsHandleCreated && GetTopLevel() && SafeNativeMethods.IsWindowEnabled(new HandleRef(_window, Handle)))
             {
                 SafeNativeMethods.SetWindowPos(
-                    new HandleRef(window, Handle),
+                    new HandleRef(_window, Handle),
                     NativeMethods.HWND_TOP,
                     flags: NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOSIZE);
             }
@@ -5671,24 +4912,23 @@ namespace System.Windows.Forms
                 return false;
             }
 
-            if (parent != null)
+            if (_parent != null)
             {
-                return parent.CanProcessMnemonic();
+                return _parent.CanProcessMnemonic();
             }
 
             return true;
         }
 
         // Package scope to allow AxHost to override
-        //
         internal virtual bool CanSelectCore()
         {
-            if ((controlStyle & ControlStyles.Selectable) != ControlStyles.Selectable)
+            if ((_controlStyle & ControlStyles.Selectable) != ControlStyles.Selectable)
             {
                 return false;
             }
 
-            for (Control ctl = this; ctl != null; ctl = ctl.parent)
+            for (Control ctl = this; ctl != null; ctl = ctl._parent)
             {
                 if (!ctl.Enabled || !ctl.Visible)
                 {
@@ -5740,15 +4980,16 @@ namespace System.Windows.Forms
                 }
             }
         }
+
         private void ChildGotFocus(Control child)
         {
             if (IsActiveX)
             {
                 ActiveXOnFocus(true);
             }
-            if (parent != null)
+            if (_parent != null)
             {
-                parent.ChildGotFocus(child);
+                _parent.ChildGotFocus(child);
             }
         }
 
@@ -5853,10 +5094,9 @@ namespace System.Windows.Forms
                 SetState(STATE_MIRRORED, (cp.ExStyle & NativeMethods.WS_EX_LAYOUTRTL) != 0);
 
                 // Adjust for scrolling of parent...
-                //
-                if (parent != null)
+                if (_parent != null)
                 {
-                    Rectangle parentClient = parent.ClientRectangle;
+                    Rectangle parentClient = _parent.ClientRectangle;
 
                     if (!parentClient.IsEmpty)
                     {
@@ -5872,14 +5112,13 @@ namespace System.Windows.Forms
                 }
 
                 // And if we are WS_CHILD, ensure we have a parent handle.
-                //
                 if (cp.Parent == IntPtr.Zero && (cp.Style & NativeMethods.WS_CHILD) != 0)
                 {
                     Debug.Assert((cp.ExStyle & NativeMethods.WS_EX_MDICHILD) == 0, "Can't put MDI child forms on the parking form");
                     Application.ParkHandle(cp);
                 }
 
-                window.CreateHandle(cp);
+                _window.CreateHandle(cp);
 
                 UpdateReflectParent(true);
 
@@ -5929,17 +5168,16 @@ namespace System.Windows.Forms
         /// </summary>
         internal void CreateControl(bool fIgnoreVisible)
         {
-            bool ready = (state & STATE_CREATED) == 0;
+            bool ready = (_state & STATE_CREATED) == 0;
 
             // PERF: Only "create" the control if it is
             //     : visible. This has the effect of delayed handle creation of
             //     : hidden controls.
-            //
             ready = ready && Visible;
 
             if (ready || fIgnoreVisible)
             {
-                state |= STATE_CREATED;
+                _state |= STATE_CREATED;
                 bool createdOK = false;
                 try
                 {
@@ -5950,7 +5188,6 @@ namespace System.Windows.Forms
 
                     // must snapshot this array because
                     // z-order updates from Windows may rearrange it!
-                    //
                     ControlCollection controlsCollection = (ControlCollection)Properties.GetObject(PropControlsCollection);
 
                     if (controlsCollection != null)
@@ -5974,7 +5211,7 @@ namespace System.Windows.Forms
                 {
                     if (!createdOK)
                     {
-                        state &= (~STATE_CREATED);
+                        _state &= (~STATE_CREATED);
                     }
                 }
                 OnCreateControl();
@@ -5984,38 +5221,34 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Sends the message to the default window proc.
         /// </summary>
-        /* Primarily here for Form to override */
-        [
-            EditorBrowsable(EditorBrowsableState.Advanced)
-        ]
+        /// <remarks>Primarily here for Form to override.</remarks>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected virtual void DefWndProc(ref Message m)
         {
-            window.DefWndProc(ref m);
+            _window.DefWndProc(ref m);
         }
 
         /// <summary>
         ///  Destroys the handle associated with this control. Inheriting classes should
         ///  always call base.destroyHandle.
         /// </summary>
-        [
-            EditorBrowsable(EditorBrowsableState.Advanced)
-        ]
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected virtual void DestroyHandle()
         {
             if (RecreatingHandle)
             {
-                if (threadCallbackList != null)
+                if (_threadCallbackList != null)
                 {
                     // See if we have a thread marshaling request pending.  If so, we will need to
                     // re-post it after recreating the handle.
                     //
-                    lock (threadCallbackList)
+                    lock (_threadCallbackList)
                     {
-                        if (threadCallbackMessage != 0)
+                        if (s_threadCallbackMessage != 0)
                         {
                             NativeMethods.MSG msg = new NativeMethods.MSG();
-                            if (UnsafeNativeMethods.PeekMessage(ref msg, new HandleRef(this, Handle), threadCallbackMessage,
-                                                          threadCallbackMessage, NativeMethods.PM_NOREMOVE))
+                            if (UnsafeNativeMethods.PeekMessage(ref msg, new HandleRef(this, Handle), s_threadCallbackMessage,
+                                                          s_threadCallbackMessage, NativeMethods.PM_NOREMOVE))
                             {
 
                                 SetState(STATE_THREADMARSHALLPENDING, true);
@@ -6030,40 +5263,39 @@ namespace System.Windows.Forms
             // wake up.  So, we put exceptions into all these items and wake up all threads.
             // If we are recreating the handle, then we're fine because recreation will re-post
             // the thread callback message to the new handle for us.
-            //
             if (!RecreatingHandle)
             {
-                if (threadCallbackList != null)
+                if (_threadCallbackList != null)
                 {
-                    lock (threadCallbackList)
+                    lock (_threadCallbackList)
                     {
                         Exception ex = new ObjectDisposedException(GetType().Name);
 
-                        while (threadCallbackList.Count > 0)
+                        while (_threadCallbackList.Count > 0)
                         {
-                            ThreadMethodEntry entry = (ThreadMethodEntry)threadCallbackList.Dequeue();
-                            entry.exception = ex;
+                            ThreadMethodEntry entry = (ThreadMethodEntry)_threadCallbackList.Dequeue();
+                            entry._exception = ex;
                             entry.Complete();
                         }
                     }
                 }
             }
 
-            if (0 != (NativeMethods.WS_EX_MDICHILD & (int)(long)UnsafeNativeMethods.GetWindowLong(new HandleRef(window, InternalHandle), NativeMethods.GWL_EXSTYLE)))
+            if (0 != (NativeMethods.WS_EX_MDICHILD & (int)(long)UnsafeNativeMethods.GetWindowLong(new HandleRef(_window, InternalHandle), NativeMethods.GWL_EXSTYLE)))
             {
                 UnsafeNativeMethods.DefMDIChildProc(InternalHandle, Interop.WindowMessages.WM_CLOSE, IntPtr.Zero, IntPtr.Zero);
             }
             else
             {
-                window.DestroyHandle();
+                _window.DestroyHandle();
             }
 
-            trackMouseEvent = null;
+            _trackMouseEvent = null;
         }
 
         /// <summary>
         ///  Disposes of the resources (other than memory) used by the
-        ///  <see cref='Control'/>
+        ///  <see cref='Control'/>.
         /// </summary>
         protected override void Dispose(bool disposing)
         {
@@ -6117,9 +5349,9 @@ namespace System.Windows.Forms
                         DestroyHandle();
                     }
 
-                    if (parent != null)
+                    if (_parent != null)
                     {
-                        parent.Controls.Remove(this);
+                        _parent.Controls.Remove(this);
                     }
 
                     ControlCollection controlsCollection = (ControlCollection)Properties.GetObject(PropControlsCollection);
@@ -6133,7 +5365,7 @@ namespace System.Windows.Forms
                         for (int i = 0; i < controlsCollection.Count; i++)
                         {
                             Control ctl = controlsCollection[i];
-                            ctl.parent = null;
+                            ctl._parent = null;
                             ctl.Dispose();
                         }
                         Properties.SetObject(PropControlsCollection, null);
@@ -6158,17 +5390,15 @@ namespace System.Windows.Forms
 #endif
                 // This same post is done in NativeWindow's finalize method, so if you change
                 // it, change it there too.
-                //
-                if (window != null)
+                if (_window != null)
                 {
-                    window.ForceExitMessageLoop();
+                    _window.ForceExitMessageLoop();
                 }
                 base.Dispose(disposing);
             }
         }
 
         // Package scope to allow AxHost to override.
-        //
         internal virtual void DisposeAxControls()
         {
             ControlCollection controlsCollection = (ControlCollection)Properties.GetObject(PropControlsCollection);
@@ -6197,6 +5427,7 @@ namespace System.Windows.Forms
         {
             int[] finalEffect = new int[] { (int)DragDropEffects.None };
             UnsafeNativeMethods.IOleDropSource dropSource = new DropSource(this);
+
             IComDataObject dataObject = null;
 
             if (data is IComDataObject)
@@ -6205,7 +5436,6 @@ namespace System.Windows.Forms
             }
             else
             {
-
                 DataObject iwdata = null;
                 if (data is IDataObject)
                 {
@@ -6235,11 +5465,11 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        //      Trinity are currently calling IViewObject::Draw in order to render controls on Word & Excel
-        //      before they are in place active. However this method is private and they need a public way to do this.
-        //      This means that we will need to add a public method to control that supports rendering to a Bitmap:
-        //      public virtual void DrawToBitmap(Bitmap bmp, RectangleF targetBounds)
-        //      where target bounds is the bounds within which the control should render.
+        //   Trinity are currently calling IViewObject::Draw in order to render controls on Word & Excel
+        //   before they are in place active. However this method is private and they need a public way to do this.
+        //   This means that we will need to add a public method to control that supports rendering to a Bitmap:
+        //   public virtual void DrawToBitmap(Bitmap bmp, RectangleF targetBounds)
+        //   where target bounds is the bounds within which the control should render.
         /// </summary>
         public void DrawToBitmap(Bitmap bitmap, Rectangle targetBounds)
         {
@@ -6305,7 +5535,7 @@ namespace System.Windows.Forms
                 {
                     throw new ArgumentException(SR.ControlBadAsyncResult, "asyncResult");
                 }
-                Debug.Assert(this == entry.caller, "Called BeginInvoke on one control, and the corresponding EndInvoke on a different control");
+                Debug.Assert(this == entry._caller, "Called BeginInvoke on one control, and the corresponding EndInvoke on a different control");
 
                 if (!asyncResult.IsCompleted)
                 {
@@ -6317,17 +5547,17 @@ namespace System.Windows.Forms
                     }
                     else
                     {
-                        marshaler = entry.marshaler;
+                        marshaler = entry._marshaler;
                         marshaler.WaitForWaitHandle(asyncResult.AsyncWaitHandle);
                     }
                 }
 
                 Debug.Assert(asyncResult.IsCompleted, "Why isn't this asyncResult done yet?");
-                if (entry.exception != null)
+                if (entry._exception != null)
                 {
-                    throw entry.exception;
+                    throw entry._exception;
                 }
-                return entry.retVal;
+                return entry._retVal;
             }
         }
 
@@ -6338,11 +5568,11 @@ namespace System.Windows.Forms
 
         internal bool EndUpdateInternal(bool invalidate)
         {
-            if (updateCount > 0)
+            if (_updateCount > 0)
             {
                 Debug.Assert(IsHandleCreated, "Handle should be created by now");
-                updateCount--;
-                if (updateCount == 0)
+                _updateCount--;
+                if (_updateCount == 0)
                 {
                     SendMessage(Interop.WindowMessages.WM_SETREDRAW, -1, 0);
                     if (invalidate)
@@ -6382,7 +5612,6 @@ namespace System.Windows.Forms
         /// </summary>
         private Control FindMarshalingControl()
         {
-            //
             lock (this)
             {
                 Control c = this;
@@ -6399,7 +5628,6 @@ namespace System.Windows.Forms
                     // just use our own control.  MarshaledInvoke
                     // will throw an exception because there
                     // is no handle.
-                    //
                     c = this;
                 }
                 else
@@ -6407,13 +5635,13 @@ namespace System.Windows.Forms
                     Debug.Assert(c.IsHandleCreated, "FindMarshalingControl chose a bad control.");
                 }
 
-                return (Control)c;
+                return c;
             }
         }
 
         protected bool GetTopLevel()
         {
-            return (state & STATE_TOPLEVEL) != 0;
+            return (_state & STATE_TOPLEVEL) != 0;
         }
 
         /// <summary>
@@ -6450,7 +5678,7 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public bool Focus()
         {
-            Debug.WriteLineIf(Control.FocusTracing.TraceVerbose, "Control::Focus - " + Name);
+            Debug.WriteLineIf(FocusTracing.TraceVerbose, "Control::Focus - " + Name);
 
             // Call the internal method (which form overrides)
             return FocusInternal();
@@ -6463,7 +5691,7 @@ namespace System.Windows.Forms
         /// </summary>
         private protected virtual bool FocusInternal()
         {
-            Debug.WriteLineIf(Control.FocusTracing.TraceVerbose, "Control::FocusInternal - " + Name);
+            Debug.WriteLineIf(FocusTracing.TraceVerbose, "Control::FocusInternal - " + Name);
             if (CanFocus)
             {
                 UnsafeNativeMethods.SetFocus(new HandleRef(this, Handle));
@@ -6555,7 +5783,6 @@ namespace System.Windows.Forms
                 Size maximumSize = LayoutUtils.ConvertZeroToUnbounded(MaximumSize);
                 Rectangle newBounds = new Rectangle(suggestedX, suggestedY, 0, 0)
                 {
-
                     // Clip the size to maximum and inflate it to minimum as necessary.
                     Size = LayoutUtils.IntersectSizes(new Size(proposedWidth, proposedHeight), maximumSize)
                 };
@@ -6618,7 +5845,7 @@ namespace System.Windows.Forms
 
         private static bool IsFocusManagingContainerControl(Control ctl)
         {
-            return ((ctl.controlStyle & ControlStyles.ContainerControl) == ControlStyles.ContainerControl && ctl is IContainerControl);
+            return ((ctl._controlStyle & ControlStyles.ContainerControl) == ControlStyles.ContainerControl && ctl is IContainerControl);
         }
 
         /// <summary>
@@ -6628,18 +5855,18 @@ namespace System.Windows.Forms
         /// </summary>
         internal bool IsUpdating()
         {
-            return (updateCount > 0);
+            return (_updateCount > 0);
         }
 
         // Essentially an Hfont; see inner class for details.
         private static FontHandleWrapper GetDefaultFontHandleWrapper()
         {
-            if (defaultFontHandleWrapper == null)
+            if (s_defaultFontHandleWrapper == null)
             {
-                defaultFontHandleWrapper = new FontHandleWrapper(DefaultFont);
+                s_defaultFontHandleWrapper = new FontHandleWrapper(DefaultFont);
             }
 
-            return defaultFontHandleWrapper;
+            return s_defaultFontHandleWrapper;
         }
 
         internal IntPtr GetHRgn(Region region)
@@ -6706,13 +5933,13 @@ namespace System.Windows.Forms
 
             // Do this even for auto sized controls.  They'll "snap back", but it is important to size them in case
             // they are anchored.
-            if ((controlStyle & ControlStyles.FixedWidth) != ControlStyles.FixedWidth && (specified & BoundsSpecified.Width) != 0)
+            if ((_controlStyle & ControlStyles.FixedWidth) != ControlStyles.FixedWidth && (specified & BoundsSpecified.Width) != 0)
             {
                 int adornmentWidth = (adornments.right - adornments.left);
                 int localWidth = bounds.Width - adornmentWidth;
                 sw = (int)Math.Round(localWidth * dx) + adornmentWidth;
             }
-            if ((controlStyle & ControlStyles.FixedHeight) != ControlStyles.FixedHeight && (specified & BoundsSpecified.Height) != 0)
+            if ((_controlStyle & ControlStyles.FixedHeight) != ControlStyles.FixedHeight && (specified & BoundsSpecified.Height) != 0)
             {
                 int adornmentHeight = (adornments.bottom - adornments.top);
                 int localHeight = bounds.Height - adornmentHeight;
@@ -6763,7 +5990,7 @@ namespace System.Windows.Forms
                     isDisposing = true;
                     break;
                 }
-                up = up.parent;
+                up = up._parent;
             }
             return isDisposing;
         }
@@ -6848,7 +6075,7 @@ namespace System.Windows.Forms
 
             for (int i = 0; i < holders.Count; i++)
             {
-                indexes[i] = ((ControlTabOrderHolder)holders[i]).oldOrder;
+                indexes[i] = ((ControlTabOrderHolder)holders[i])._oldOrder;
             }
 
             return indexes;
@@ -6867,49 +6094,10 @@ namespace System.Windows.Forms
 
             for (int i = 0; i < holders.Count; i++)
             {
-                ctls[i] = ((ControlTabOrderHolder)holders[i]).control;
+                ctls[i] = ((ControlTabOrderHolder)holders[i])._control;
             }
 
             return ctls;
-        }
-
-        /// <summary>
-        ///  This class contains a control and associates it with a z-order.
-        ///  This is used when sorting controls based on tab index first,
-        ///  z-order second.
-        /// </summary>
-        private class ControlTabOrderHolder
-        {
-            internal readonly int oldOrder;
-            internal readonly int newOrder;
-            internal readonly Control control;
-
-            internal ControlTabOrderHolder(int oldOrder, int newOrder, Control control)
-            {
-                this.oldOrder = oldOrder;
-                this.newOrder = newOrder;
-                this.control = control;
-            }
-        }
-
-        /// <summary>
-        ///  Used to sort controls based on tab index and z-order.
-        /// </summary>
-        private class ControlTabOrderComparer : IComparer
-        {
-            int IComparer.Compare(object x, object y)
-            {
-                ControlTabOrderHolder hx = (ControlTabOrderHolder)x;
-                ControlTabOrderHolder hy = (ControlTabOrderHolder)y;
-
-                int delta = hx.newOrder - hy.newOrder;
-                if (delta == 0)
-                {
-                    delta = hx.oldOrder - hy.oldOrder;
-                }
-
-                return delta;
-            }
         }
 
         /// <summary>
@@ -6964,7 +6152,7 @@ namespace System.Windows.Forms
                 {
                     for (int c = 0; c < ctlControls.Count; c++)
                     {
-                        if (found == null || found.tabIndex > ctlControls[c].tabIndex)
+                        if (found == null || found._tabIndex > ctlControls[c]._tabIndex)
                         {
                             found = ctlControls[c];
                         }
@@ -6972,21 +6160,19 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-
                     // Cycle through the controls in reverse z-order looking for the one with the highest
                     // tab index.
-                    //
                     for (int c = ctlControls.Count - 1; c >= 0; c--)
                     {
-                        if (found == null || found.tabIndex < ctlControls[c].tabIndex)
+                        if (found == null || found._tabIndex < ctlControls[c]._tabIndex)
                         {
                             found = ctlControls[c];
                         }
                     }
                 }
             }
-            return found;
 
+            return found;
         }
 
         /// <summary>
@@ -7014,10 +6200,10 @@ namespace System.Windows.Forms
 
                 while (ctl != this)
                 {
-                    int targetIndex = ctl.tabIndex;
+                    int targetIndex = ctl._tabIndex;
                     bool hitCtl = false;
                     Control found = null;
-                    Control p = ctl.parent;
+                    Control p = ctl._parent;
 
                     // Cycle through the controls in z-order looking for the one with the next highest
                     // tab index.  Because there can be dups, we have to start with the existing tab index and
@@ -7034,32 +6220,24 @@ namespace System.Windows.Forms
 
                     for (int c = 0; c < parentControlCount; c++)
                     {
-
                         // The logic for this is a bit lengthy, so I have broken it into separate
-                        // caluses:
+                        // clauses:
 
                         // We are not interested in ourself.
-                        //
                         if (parentControls[c] != ctl)
                         {
-
                             // We are interested in controls with >= tab indexes to ctl.  We must include those
                             // controls with equal indexes to account for duplicate indexes.
-                            //
-                            if (parentControls[c].tabIndex >= targetIndex)
+                            if (parentControls[c]._tabIndex >= targetIndex)
                             {
-
                                 // Check to see if this control replaces the "best match" we've already
                                 // found.
-                                //
-                                if (found == null || found.tabIndex > parentControls[c].tabIndex)
+                                if (found == null || found._tabIndex > parentControls[c]._tabIndex)
                                 {
-
                                     // Finally, check to make sure that if this tab index is the same as ctl,
                                     // that we've already encountered ctl in the z-order.  If it isn't the same,
                                     // than we're more than happy with it.
-                                    //
-                                    if (parentControls[c].tabIndex != targetIndex || hitCtl)
+                                    if (parentControls[c]._tabIndex != targetIndex || hitCtl)
                                     {
                                         found = parentControls[c];
                                     }
@@ -7070,7 +6248,6 @@ namespace System.Windows.Forms
                         {
                             // We track when we have encountered "ctl".  We never want to select ctl again, but
                             // we want to know when we've seen it in case we find another control with the same tab index.
-                            //
                             hitCtl = true;
                         }
                     }
@@ -7080,22 +6257,20 @@ namespace System.Windows.Forms
                         return found;
                     }
 
-                    ctl = ctl.parent;
+                    ctl = ctl._parent;
                 }
             }
             else
             {
                 if (ctl != this)
                 {
-
-                    int targetIndex = ctl.tabIndex;
+                    int targetIndex = ctl._tabIndex;
                     bool hitCtl = false;
                     Control found = null;
-                    Control p = ctl.parent;
+                    Control p = ctl._parent;
 
                     // Cycle through the controls in reverse z-order looking for the next lowest tab index.  We must
                     // start with the same tab index as ctl, because there can be dups.
-                    //
                     int parentControlCount = 0;
 
                     ControlCollection parentControls = (ControlCollection)p.Properties.GetObject(PropControlsCollection);
@@ -7107,32 +6282,24 @@ namespace System.Windows.Forms
 
                     for (int c = parentControlCount - 1; c >= 0; c--)
                     {
-
                         // The logic for this is a bit lengthy, so I have broken it into separate
-                        // caluses:
+                        // clauses:
 
                         // We are not interested in ourself.
-                        //
                         if (parentControls[c] != ctl)
                         {
-
                             // We are interested in controls with <= tab indexes to ctl.  We must include those
                             // controls with equal indexes to account for duplicate indexes.
-                            //
-                            if (parentControls[c].tabIndex <= targetIndex)
+                            if (parentControls[c]._tabIndex <= targetIndex)
                             {
-
                                 // Check to see if this control replaces the "best match" we've already
                                 // found.
-                                //
-                                if (found == null || found.tabIndex < parentControls[c].tabIndex)
+                                if (found == null || found._tabIndex < parentControls[c]._tabIndex)
                                 {
-
                                     // Finally, check to make sure that if this tab index is the same as ctl,
                                     // that we've already encountered ctl in the z-order.  If it isn't the same,
                                     // than we're more than happy with it.
-                                    //
-                                    if (parentControls[c].tabIndex != targetIndex || hitCtl)
+                                    if (parentControls[c]._tabIndex != targetIndex || hitCtl)
                                     {
                                         found = parentControls[c];
                                     }
@@ -7143,14 +6310,12 @@ namespace System.Windows.Forms
                         {
                             // We track when we have encountered "ctl".  We never want to select ctl again, but
                             // we want to know when we've seen it in case we find another control with the same tab index.
-                            //
                             hitCtl = true;
                         }
                     }
 
                     // If we were unable to find a control we should return the control's parent.  However, if that parent is us, return
                     // NULL.
-                    //
                     if (found != null)
                     {
                         ctl = found;
@@ -7169,7 +6334,6 @@ namespace System.Windows.Forms
                 }
 
                 // We found a control.  Walk into this control to find the proper sub control within it to select.
-                //
                 ControlCollection ctlControls = (ControlCollection)ctl.Properties.GetObject(PropControlsCollection);
 
                 while (ctlControls != null && ctlControls.Count > 0 && (ctl == this || !IsFocusManagingContainerControl(ctl)))
@@ -7191,8 +6355,8 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        /// Return ((Control) window).Handle if window is a Control.
-        /// Otherwise, returns window.Handle
+        ///  Return ((Control) window).Handle if window is a Control.
+        ///  Otherwise, returns window.Handle
         /// </summary>
         internal static IntPtr GetSafeHandle(IWin32Window window)
         {
@@ -7220,7 +6384,7 @@ namespace System.Windows.Forms
         /// </summary>
         internal bool GetState(int flag)
         {
-            return (state & flag) != 0;
+            return (_state & flag) != 0;
         }
 
         /// <summary>
@@ -7228,7 +6392,7 @@ namespace System.Windows.Forms
         /// </summary>
         private bool GetState2(int flag)
         {
-            return (state2 & flag) != 0;
+            return (_state2 & flag) != 0;
         }
 
         /// <summary>
@@ -7237,7 +6401,7 @@ namespace System.Windows.Forms
         /// </summary>
         protected bool GetStyle(ControlStyles flag)
         {
-            return (controlStyle & flag) == flag;
+            return (_controlStyle & flag) == flag;
         }
 
         /// <summary>
@@ -7258,16 +6422,16 @@ namespace System.Windows.Forms
             {
                 SetState(STATE_TRACKINGMOUSEEVENT, true);
 
-                if (trackMouseEvent == null)
+                if (_trackMouseEvent == null)
                 {
-                    trackMouseEvent = new NativeMethods.TRACKMOUSEEVENT
+                    _trackMouseEvent = new NativeMethods.TRACKMOUSEEVENT
                     {
                         dwFlags = NativeMethods.TME_LEAVE | NativeMethods.TME_HOVER,
                         hwndTrack = Handle
                     };
                 }
 
-                SafeNativeMethods.TrackMouseEvent(trackMouseEvent);
+                SafeNativeMethods.TrackMouseEvent(_trackMouseEvent);
             }
         }
 
@@ -7286,7 +6450,7 @@ namespace System.Windows.Forms
         /// </summary>
         private void InitScaling(BoundsSpecified specified)
         {
-            requiredScaling |= (byte)((int)specified & RequiredScalingMask);
+            _requiredScaling |= (byte)((int)specified & RequiredScalingMask);
         }
 
         // Sets the text and background colors of the DC, and returns the background HBRUSH.
@@ -7396,7 +6560,7 @@ namespace System.Windows.Forms
             {
                 if (invalidateChildren)
                 {
-                    SafeNativeMethods.RedrawWindow(new HandleRef(window, Handle),
+                    SafeNativeMethods.RedrawWindow(new HandleRef(_window, Handle),
                                                    null, NativeMethods.NullHandleRef,
                                                    NativeMethods.RDW_INVALIDATE |
                                                    NativeMethods.RDW_ERASE |
@@ -7407,9 +6571,9 @@ namespace System.Windows.Forms
                     // It's safe to invoke InvalidateRect from a separate thread.
                     using (new MultithreadSafeCallScope())
                     {
-                        SafeNativeMethods.InvalidateRect(new HandleRef(window, Handle),
+                        SafeNativeMethods.InvalidateRect(new HandleRef(_window, Handle),
                                                          null,
-                                                         (controlStyle & ControlStyles.Opaque) != ControlStyles.Opaque);
+                                                         (_controlStyle & ControlStyles.Opaque) != ControlStyles.Opaque);
                     }
                 }
 
@@ -7446,7 +6610,7 @@ namespace System.Windows.Forms
                 {
                     Interop.RECT rcArea = rc;
                     SafeNativeMethods.RedrawWindow(
-                        new HandleRef(window, Handle),
+                        new HandleRef(_window, Handle),
                         ref rcArea,
                         IntPtr.Zero,
                         NativeMethods.RDW_INVALIDATE | NativeMethods.RDW_ERASE | NativeMethods.RDW_ALLCHILDREN);
@@ -7459,9 +6623,9 @@ namespace System.Windows.Forms
                     using (new MultithreadSafeCallScope())
                     {
                         SafeNativeMethods.InvalidateRect(
-                            new HandleRef(window, Handle),
+                            new HandleRef(_window, Handle),
                             ref rcArea,
-                            (controlStyle & ControlStyles.Opaque) != ControlStyles.Opaque);
+                            (_controlStyle & ControlStyles.Opaque) != ControlStyles.Opaque);
                     }
                 }
                 NotifyInvalidate(rc);
@@ -7525,11 +6689,11 @@ namespace System.Windows.Forms
         /// </summary>
         private void InvokeMarshaledCallback(ThreadMethodEntry tme)
         {
-            if (tme.executionContext != null)
+            if (tme._executionContext != null)
             {
-                if (invokeMarshaledCallbackHelperDelegate == null)
+                if (s_invokeMarshaledCallbackHelperDelegate == null)
                 {
-                    invokeMarshaledCallbackHelperDelegate = new ContextCallback(InvokeMarshaledCallbackHelper);
+                    s_invokeMarshaledCallbackHelperDelegate = new ContextCallback(InvokeMarshaledCallbackHelper);
                 }
                 // If there's no ExecutionContext, make sure we have a SynchronizationContext.  There's no
                 // direct check for ExecutionContext: this is as close as we can get.
@@ -7538,8 +6702,8 @@ namespace System.Windows.Forms
                     WindowsFormsSynchronizationContext.InstallIfNeeded();
                 }
 
-                tme.syncContext = SynchronizationContext.Current;
-                ExecutionContext.Run(tme.executionContext, invokeMarshaledCallbackHelperDelegate, tme);
+                tme._syncContext = SynchronizationContext.Current;
+                ExecutionContext.Run(tme._executionContext, s_invokeMarshaledCallbackHelperDelegate, tme);
             }
             else
             {
@@ -7554,13 +6718,13 @@ namespace System.Windows.Forms
         {
             ThreadMethodEntry tme = (ThreadMethodEntry)obj;
 
-            if (tme.syncContext != null)
+            if (tme._syncContext != null)
             {
                 SynchronizationContext oldContext = SynchronizationContext.Current;
 
                 try
                 {
-                    SynchronizationContext.SetSynchronizationContext(tme.syncContext);
+                    SynchronizationContext.SetSynchronizationContext(tme._syncContext);
 
                     InvokeMarshaledCallbackDo(tme);
                 }
@@ -7578,35 +6742,34 @@ namespace System.Windows.Forms
         private static void InvokeMarshaledCallbackDo(ThreadMethodEntry tme)
         {
             // We short-circuit a couple of common cases for speed.
-            //
-            if (tme.method is EventHandler)
+            if (tme._method is EventHandler)
             {
-                if (tme.args == null || tme.args.Length < 1)
+                if (tme._args == null || tme._args.Length < 1)
                 {
-                    ((EventHandler)tme.method)(tme.caller, EventArgs.Empty);
+                    ((EventHandler)tme._method)(tme._caller, EventArgs.Empty);
                 }
-                else if (tme.args.Length < 2)
+                else if (tme._args.Length < 2)
                 {
-                    ((EventHandler)tme.method)(tme.args[0], EventArgs.Empty);
+                    ((EventHandler)tme._method)(tme._args[0], EventArgs.Empty);
                 }
                 else
                 {
-                    ((EventHandler)tme.method)(tme.args[0], (EventArgs)tme.args[1]);
+                    ((EventHandler)tme._method)(tme._args[0], (EventArgs)tme._args[1]);
                 }
             }
-            else if (tme.method is MethodInvoker)
+            else if (tme._method is MethodInvoker)
             {
-                ((MethodInvoker)tme.method)();
+                ((MethodInvoker)tme._method)();
             }
-            else if (tme.method is WaitCallback)
+            else if (tme._method is WaitCallback)
             {
-                Debug.Assert(tme.args.Length == 1,
+                Debug.Assert(tme._args.Length == 1,
                              "Arguments are wrong for WaitCallback");
-                ((WaitCallback)tme.method)(tme.args[0]);
+                ((WaitCallback)tme._method)(tme._args[0]);
             }
             else
             {
-                tme.retVal = tme.method.DynamicInvoke(tme.args);
+                tme._retVal = tme._method.DynamicInvoke(tme._args);
             }
         }
 
@@ -7618,27 +6781,25 @@ namespace System.Windows.Forms
         private void InvokeMarshaledCallbacks()
         {
             ThreadMethodEntry current = null;
-            lock (threadCallbackList)
+            lock (_threadCallbackList)
             {
-                if (threadCallbackList.Count > 0)
+                if (_threadCallbackList.Count > 0)
                 {
-                    current = (ThreadMethodEntry)threadCallbackList.Dequeue();
+                    current = (ThreadMethodEntry)_threadCallbackList.Dequeue();
                 }
             }
 
             // Now invoke on all the queued items.
-            //
             while (current != null)
             {
-                if (current.method != null)
+                if (current._method != null)
                 {
-
                     try
                     {
                         // If we are running under the debugger, don't wrap asynchronous
                         // calls in a try catch.  It is much better to throw here than pop up
                         // a thread exception dialog below.
-                        if (NativeWindow.WndProcShouldBeDebuggable && !current.synchronous)
+                        if (NativeWindow.WndProcShouldBeDebuggable && !current._synchronous)
                         {
                             InvokeMarshaledCallback(current);
                         }
@@ -7650,7 +6811,7 @@ namespace System.Windows.Forms
                             }
                             catch (Exception t)
                             {
-                                current.exception = t.GetBaseException();
+                                current._exception = t.GetBaseException();
                             }
                         }
                     }
@@ -7662,18 +6823,18 @@ namespace System.Windows.Forms
                         // do this because the exception would have been handled above.  If we're
                         // not debugging, raise the exception here.
                         if (!NativeWindow.WndProcShouldBeDebuggable &&
-                            current.exception != null && !current.synchronous)
+                            current._exception != null && !current._synchronous)
                         {
-                            Application.OnThreadException(current.exception);
+                            Application.OnThreadException(current._exception);
                         }
                     }
                 }
 
-                lock (threadCallbackList)
+                lock (_threadCallbackList)
                 {
-                    if (threadCallbackList.Count > 0)
+                    if (_threadCallbackList.Count > 0)
                     {
-                        current = (ThreadMethodEntry)threadCallbackList.Dequeue();
+                        current = (ThreadMethodEntry)_threadCallbackList.Dequeue();
                     }
                     else
                     {
@@ -7694,7 +6855,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        /// determines whether the font is set
+        ///  Determines whether the font is set.
         /// </summary>
         internal bool IsFontSet()
         {
@@ -7727,7 +6888,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        /// This Function will return a Boolean as to whether the Key value passed in is Locked...
+        ///  This Function will return a Boolean as to whether the Key value passed in is Locked...
         /// </summary>
         public static bool IsKeyLocked(Keys keyVal)
         {
@@ -7854,7 +7015,7 @@ namespace System.Windows.Forms
             {
                 Debug.WriteLineIf(ControlKeyboardRouting.TraceVerbose, "   ...returning false");
                 return false;
-            } //if
+            }
 
             if (text != null)
             {
@@ -7914,8 +7075,8 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        /// Transforms size from logical to device units
-        /// by scaling it for the current DPI and rounding down to the nearest integer value for width and height.
+        ///  Transforms size from logical to device units by scaling it for the current
+        ///  DPI and rounding down to the nearest integer value for width and height.
         /// </summary>
         /// <param name="value"> size to be scaled</param>
         /// <returns> scaled size</returns>
@@ -7925,8 +7086,9 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        /// Create a new bitmap scaled for the device units.
-        /// When displayed on the device, the scaled image will have same size as the original image would have when displayed at 96dpi.
+        ///  Create a new bitmap scaled for the device units. When displayed on the device,
+        ///  the scaled image will have same size as the original image would have when
+        ///  displayed at 96dpi.
         /// </summary>
         /// <param name="logicalBitmap">The image to scale from logical units to device units</param>
         public void ScaleBitmapLogicalToDevice(ref Bitmap logicalBitmap)
@@ -7938,7 +7100,7 @@ namespace System.Windows.Forms
         {
             if (DpiHelper.IsPerMonitorV2Awareness)
             {
-                SafeNativeMethods.AdjustWindowRectExForDpi(ref rect, style, bMenu, exStyle, (uint)deviceDpi);
+                SafeNativeMethods.AdjustWindowRectExForDpi(ref rect, style, bMenu, exStyle, (uint)_deviceDpi);
             }
             else
             {
@@ -7962,7 +7124,6 @@ namespace System.Windows.Forms
             // 3.  If we're synchronous, wait for the message to get processed.  We don't do
             //     a SendMessage here so we're compatible with OLE, which will abort many
             //     types of calls if we're within a SendMessage.
-            //
 
             if (!IsHandleCreated)
             {
@@ -7973,8 +7134,8 @@ namespace System.Windows.Forms
 
             // We don't want to wait if we're on the same thread, or else we'll deadlock.
             // It is important that syncSameThread always be false for asynchronous calls.
-            //
             bool syncSameThread = false;
+
             // ignored
             if (SafeNativeMethods.GetWindowThreadProcessId(new HandleRef(this, Handle), out int pid) == SafeNativeMethods.GetCurrentThreadId())
             {
@@ -7987,7 +7148,6 @@ namespace System.Windows.Forms
             // Store the compressed stack information from the thread that is calling the Invoke()
             // so we can assign the same security context to the thread that will actually execute
             // the delegate being passed.
-            //
             ExecutionContext executionContext = null;
             if (!syncSameThread)
             {
@@ -7997,19 +7157,19 @@ namespace System.Windows.Forms
 
             lock (this)
             {
-                if (threadCallbackList == null)
+                if (_threadCallbackList == null)
                 {
-                    threadCallbackList = new Queue();
+                    _threadCallbackList = new Queue();
                 }
             }
 
-            lock (threadCallbackList)
+            lock (_threadCallbackList)
             {
-                if (threadCallbackMessage == 0)
+                if (s_threadCallbackMessage == 0)
                 {
-                    threadCallbackMessage = SafeNativeMethods.RegisterWindowMessage(Application.WindowMessagesVersion + "_ThreadCallbackMessage");
+                    s_threadCallbackMessage = SafeNativeMethods.RegisterWindowMessage(Application.WindowMessagesVersion + "_ThreadCallbackMessage");
                 }
-                threadCallbackList.Enqueue(tme);
+                _threadCallbackList.Enqueue(tme);
             }
 
             if (syncSameThread)
@@ -8018,9 +7178,7 @@ namespace System.Windows.Forms
             }
             else
             {
-                //
-
-                UnsafeNativeMethods.PostMessage(new HandleRef(this, Handle), threadCallbackMessage, IntPtr.Zero, IntPtr.Zero);
+                UnsafeNativeMethods.PostMessage(new HandleRef(this, Handle), s_threadCallbackMessage, IntPtr.Zero, IntPtr.Zero);
             }
 
             if (synchronous)
@@ -8029,15 +7187,15 @@ namespace System.Windows.Forms
                 {
                     WaitForWaitHandle(tme.AsyncWaitHandle);
                 }
-                if (tme.exception != null)
+                if (tme._exception != null)
                 {
-                    throw tme.exception;
+                    throw tme._exception;
                 }
-                return tme.retVal;
+                return tme._retVal;
             }
             else
             {
-                return (IAsyncResult)tme;
+                return tme;
             }
         }
 
@@ -8063,7 +7221,6 @@ namespace System.Windows.Forms
             }
 
             // Copy the name into the given IntPtr
-            //
             char[] nullChar = new char[] { (char)0 };
             byte[] nullBytes;
             byte[] bytes;
@@ -8080,14 +7237,14 @@ namespace System.Windows.Forms
         // Used by form to notify the control that it has been "entered"
         internal void NotifyEnter()
         {
-            Debug.WriteLineIf(Control.FocusTracing.TraceVerbose, "Control::NotifyEnter() - " + Name);
+            Debug.WriteLineIf(FocusTracing.TraceVerbose, "Control::NotifyEnter() - " + Name);
             OnEnter(EventArgs.Empty);
         }
 
         // Used by form to notify the control that it has been "left"
         internal void NotifyLeave()
         {
-            Debug.WriteLineIf(Control.FocusTracing.TraceVerbose, "Control::NotifyLeave() - " + Name);
+            Debug.WriteLineIf(FocusTracing.TraceVerbose, "Control::NotifyLeave() - " + Name);
             OnLeave(EventArgs.Empty);
         }
 
@@ -8318,8 +7475,9 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        /// Raises the <see cref='Enabled'/> event.
-        /// Inheriting classes should override this method to handle this event.
+        ///  Raises the <see cref='Enabled'/> event.
+        ///
+        ///  Inheriting classes should override this method to handle this event.
         ///  Call base.OnEnabled to send this event to any registered event listeners.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Advanced)]
@@ -8335,7 +7493,6 @@ namespace System.Windows.Forms
                 SafeNativeMethods.EnableWindow(new HandleRef(this, Handle), Enabled);
 
                 // User-paint controls should repaint when their enabled state changes
-                //
                 if (GetStyle(ControlStyles.UserPaint))
                 {
                     Invalidate();
@@ -8536,10 +7693,10 @@ namespace System.Windows.Forms
             }
         }
 
-        // occurs when the parent of this control has recreated
-        // its handle.
-        // presently internal as we feel this will be rare to
-        // require override
+        /// <summary>
+        ///  Occurs when the parent of this control has recreated
+        ///  its handle.
+        /// </summary>
         internal virtual void OnParentHandleRecreated()
         {
             // restore ourselves over to the original control.
@@ -8563,13 +7720,14 @@ namespace System.Windows.Forms
             }
         }
 
-        // occurs when the parent of this control is recreating
-        // its handle.
-        // presently internal as we feel this will be rare to
-        // require override
+        /// <summary>
+        ///   Occurs when the parent of this control is recreating
+        ///   its handle.
+        /// </summary>
         internal virtual void OnParentHandleRecreating()
         {
             SetState(STATE_PARENTRECREATING, true);
+
             // swoop this control over to the parking window.
 
             // if we left it parented to the parent control, the DestroyWindow
@@ -8726,9 +7884,9 @@ namespace System.Windows.Forms
             if (visible)
             {
                 UnhookMouseEvent();
-                trackMouseEvent = null;
+                _trackMouseEvent = null;
             }
-            if (parent != null && visible && !Created)
+            if (_parent != null && visible && !Created)
             {
                 bool isDisposing = GetAnyDisposingInHierarchy();
                 if (!isDisposing)
@@ -8788,7 +7946,6 @@ namespace System.Windows.Forms
                 eh(this, e);
             }
 
-            //
             // Inform the control that the topmost control is now an ActiveX control
             if (TopMostParent.IsActiveX)
             {
@@ -8860,17 +8017,16 @@ namespace System.Windows.Forms
 
                 if (DpiHelper.IsPerMonitorV2Awareness && !(typeof(Form).IsAssignableFrom(GetType())))
                 {
-                    int old = deviceDpi;
-                    deviceDpi = (int)UnsafeNativeMethods.GetDpiForWindow(new HandleRef(this, HandleInternal));
-                    if (old != deviceDpi)
+                    int old = _deviceDpi;
+                    _deviceDpi = (int)UnsafeNativeMethods.GetDpiForWindow(new HandleRef(this, HandleInternal));
+                    if (old != _deviceDpi)
                     {
-                        RescaleConstantsForDpi(old, deviceDpi);
+                        RescaleConstantsForDpi(old, _deviceDpi);
                     }
                 }
 
                 // Restore dragdrop status. Ole Initialize happens
                 // when the ThreadContext in Application is created
-                //
                 SetAcceptDrops(AllowDrop);
 
                 Region region = (Region)Properties.GetObject(PropRegion);
@@ -8913,9 +8069,9 @@ namespace System.Windows.Forms
                 }
 
                 // Set the window text from the Text property.
-                if (text != null && text.Length != 0)
+                if (_text != null && _text.Length != 0)
                 {
-                    Interop.User32.SetWindowTextW(new HandleRef(this, Handle), text);
+                    Interop.User32.SetWindowTextW(new HandleRef(this, Handle), _text);
                 }
 
                 if (!(this is ScrollableControl) && !IsMirrored && GetState2(STATE2_SETSCROLLPOS) && !GetState2(STATE2_HAVEINVOKED))
@@ -8940,7 +8096,7 @@ namespace System.Windows.Forms
                 //
                 if (GetState(STATE_THREADMARSHALLPENDING))
                 {
-                    UnsafeNativeMethods.PostMessage(new HandleRef(this, Handle), threadCallbackMessage, IntPtr.Zero, IntPtr.Zero);
+                    UnsafeNativeMethods.PostMessage(new HandleRef(this, Handle), s_threadCallbackMessage, IntPtr.Zero, IntPtr.Zero);
                     SetState(STATE_THREADMARSHALLPENDING, false);
                 }
             }
@@ -9020,10 +8176,10 @@ namespace System.Windows.Forms
             {
                 if (!GetAnyDisposingInHierarchy())
                 {
-                    text = Text;
-                    if (text != null && text.Length == 0)
+                    _text = Text;
+                    if (_text != null && _text.Length == 0)
                     {
-                        text = null;
+                        _text = null;
                     }
                 }
                 SetAcceptDrops(false);
@@ -9136,9 +8292,9 @@ namespace System.Windows.Forms
                 ActiveXOnFocus(true);
             }
 
-            if (parent != null)
+            if (_parent != null)
             {
-                parent.ChildGotFocus(this);
+                _parent.ChildGotFocus(this);
             } ((EventHandler)Events[EventGotFocus])?.Invoke(this, e);
         }
 
@@ -9153,6 +8309,7 @@ namespace System.Windows.Forms
             if (handler != null)
             {
                 handler(this, hevent);
+
                 // Mark the event as handled so that the event isn't raised for the
                 // control's parent.
                 if (hevent != null)
@@ -9463,7 +8620,7 @@ namespace System.Windows.Forms
             // We need the true client rectangle as clip rectangle causes
             // problems on "Windows Classic" theme.
             Interop.RECT rect = new Interop.RECT();
-            UnsafeNativeMethods.GetClientRect(new HandleRef(window, InternalHandle), ref rect);
+            UnsafeNativeMethods.GetClientRect(new HandleRef(_window, InternalHandle), ref rect);
 
             PaintBackground(pevent, new Rectangle(rect.left, rect.top, rect.right, rect.bottom));
         }
@@ -9522,7 +8679,7 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected virtual void OnResize(EventArgs e)
         {
-            if ((controlStyle & ControlStyles.ResizeRedraw) == ControlStyles.ResizeRedraw
+            if ((_controlStyle & ControlStyles.ResizeRedraw) == ControlStyles.ResizeRedraw
                 || GetState(STATE_EXCEPTIONWHILEPAINTING))
             {
                 Invalidate();
@@ -9703,12 +8860,10 @@ namespace System.Windows.Forms
             else
             {
                 // don't paint anything from 100% transparent background
-                //
                 if (color.A > 0)
                 {
                     // Color has some transparency or we have no HDC, so we must
                     // fall back to using GDI+.
-                    //
                     using (Brush brush = new SolidBrush(color))
                     {
                         e.Graphics.FillRectangle(brush, rectangle);
@@ -9720,71 +8875,6 @@ namespace System.Windows.Forms
         // Paints a red rectangle with a red X, painted on a white background
         private void PaintException(PaintEventArgs e)
         {
-#if false
-            StringFormat stringFormat = ControlPaint.StringFormatForAlignment(ContentAlignment.TopLeft);
-            string exceptionText = Properties.GetObject(PropPaintingException).ToString();
-            stringFormat.SetMeasurableCharacterRanges(new CharacterRange[] {new CharacterRange(0, exceptionText.Length)});
-
-            // rendering calculations...
-            //
-            int penThickness = 2;
-            Size glyphSize = SystemInformation.IconSize;
-            int marginX = penThickness * 2;
-            int marginY = penThickness * 2;
-
-            Rectangle clientRectangle = ClientRectangle;
-
-            Rectangle borderRectangle = ClientRectangle;
-            borderRectangle.X++;
-            borderRectangle.Y++;
-            borderRectangle.Width -= 2;
-            borderRectangle.Height-= 2;
-
-            Rectangle imageRect = new Rectangle(marginX, marginY, glyphSize.Width, glyphSize.Height);
-
-            Rectangle textRect = clientRectangle;
-            textRect.X = imageRect.X + imageRect.Width + 2 * marginX;
-            textRect.Y = imageRect.Y;
-            textRect.Width -= (textRect.X + marginX + penThickness);
-            textRect.Height -= (textRect.Y + marginY + penThickness);
-
-            using (Font errorFont = new Font(Font.FontFamily, Math.Max(SystemInformation.ToolWindowCaptionHeight - SystemInformation.BorderSize.Height - 2, Font.Height), GraphicsUnit.Pixel)) {
-
-                using(Region textRegion = e.Graphics.MeasureCharacterRanges(exceptionText, errorFont, textRect, stringFormat)[0]) {
-                    // paint contents... clipping optimizations for less flicker...
-                    //
-                    Region originalClip = e.Graphics.Clip;
-
-                    e.Graphics.ExcludeClip(textRegion);
-                    e.Graphics.ExcludeClip(imageRect);
-                    try {
-                        e.Graphics.FillRectangle(Brushes.White, clientRectangle);
-                    }
-                    finally {
-                        e.Graphics.Clip = originalClip;
-                    }
-
-                    using (Pen pen = new Pen(Color.Red, penThickness)) {
-                        e.Graphics.DrawRectangle(pen, borderRectangle);
-                    }
-
-                    Icon err = SystemIcons.Error;
-
-                    e.Graphics.FillRectangle(Brushes.White, imageRect);
-                    e.Graphics.DrawIcon(err, imageRect.X, imageRect.Y);
-
-                    textRect.X++;
-                    e.Graphics.IntersectClip(textRegion);
-                    try {
-                        e.Graphics.FillRectangle(Brushes.White, textRect);
-                        e.Graphics.DrawString(exceptionText, errorFont, new SolidBrush(ForeColor), textRect, stringFormat);
-                    }
-                    finally {
-                        e.Graphics.Clip = originalClip;
-                    }
-                }
-            }
-#else
             int penThickness = 2;
             using (Pen pen = new Pen(Color.Red, penThickness))
             {
@@ -9803,13 +8893,13 @@ namespace System.Windows.Forms
                 e.Graphics.DrawLine(pen, clientRectangle.Left, clientRectangle.Bottom,
                                     clientRectangle.Right, clientRectangle.Top);
             }
-#endif
         }
 
         internal void PaintTransparentBackground(PaintEventArgs e, Rectangle rectangle)
         {
             PaintTransparentBackground(e, rectangle, null);
         }
+
         // Trick our parent into painting our background for us, or paint some default
         // color if that doesn't work.
         //
@@ -9903,7 +8993,6 @@ namespace System.Windows.Forms
         // Exceptions during painting are nasty, because paint events happen so often.
         // So if user painting code has an issue, we make sure never to call it again,
         // so as not to spam the end-user with exception dialogs.
-        //
         private void PaintWithErrorHandling(PaintEventArgs e, short layer)
         {
             try
@@ -9979,10 +9068,10 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public void PerformLayout()
         {
-            if (cachedLayoutEventArgs != null)
+            if (_cachedLayoutEventArgs != null)
             {
-                PerformLayout(cachedLayoutEventArgs);
-                cachedLayoutEventArgs = null;
+                PerformLayout(_cachedLayoutEventArgs);
+                _cachedLayoutEventArgs = null;
 
                 // we need to be careful
                 // about which LayoutEventArgs are used in
@@ -10011,12 +9100,12 @@ namespace System.Windows.Forms
                 return;
             }
 
-            if (layoutSuspendCount > 0)
+            if (_layoutSuspendCount > 0)
             {
                 SetState(STATE_LAYOUTDEFERRED, true);
-                if (cachedLayoutEventArgs == null || (GetState2(STATE2_CLEARLAYOUTARGS) && args != null))
+                if (_cachedLayoutEventArgs == null || (GetState2(STATE2_CLEARLAYOUTARGS) && args != null))
                 {
-                    cachedLayoutEventArgs = args;
+                    _cachedLayoutEventArgs = args;
                     if (GetState2(STATE2_CLEARLAYOUTARGS))
                     {
                         SetState2(STATE2_CLEARLAYOUTARGS, false);
@@ -10029,29 +9118,12 @@ namespace System.Windows.Forms
             }
 
             // (Essentially the same as suspending layout while we layout, but we clear differently below.)
-            layoutSuspendCount = 1;
+            _layoutSuspendCount = 1;
 
             try
             {
                 CacheTextInternal = true;
                 OnLayout(args);
-
-#if DEBUG
-#if DEBUG_PREFERREDSIZE
-                // DO NOT REMOVE - See http://wiki/default.aspx/Microsoft.Projects.DotNetClient.PreferredSize
-                // PreferredSize has an assert that will verify that the current cached size matches
-                // the computed size.  The calls to PreferredSize below help to catch a mismatch earlier.
-                if (!this.GetState(STATE_DISPOSING | STATE_DISPOSED)) {
-                    if (GetState2(STATE2_USEPREFERREDSIZECACHE)) {
-                        this.PreferredSize.ToString();
-                    }
-
-                    if (args.AffectedControl != null && args.AffectedControl != this && args.AffectedControl.GetState2(STATE2_USEPREFERREDSIZECACHE)) {
-                        args.AffectedControl.PreferredSize.ToString();
-                    }
-                }
-#endif
-#endif
             }
             finally
             {
@@ -10060,7 +9132,7 @@ namespace System.Windows.Forms
                 // the container we just finished laying out) we set layoutSuspendCount back to zero
                 // and clear the deferred and dirty flags.
                 SetState(STATE_LAYOUTDEFERRED | STATE_LAYOUTISDIRTY, false);
-                layoutSuspendCount = 0;
+                _layoutSuspendCount = 0;
 
                 // LayoutEngine.Layout can return true to request that our parent resize us because
                 // we did not have enough room for our contents.  Now that we are unsuspended,
@@ -10182,33 +9254,33 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-            ///  This method is called by the application's message loop to pre-process
+        ///  This method is called by the application's message loop to pre-process
         ///  input messages before they are dispatched. Possible values for the
         ///  msg.message field are WM_KEYDOWN, WM_SYSKEYDOWN, WM_CHAR, and WM_SYSCHAR.
         ///  If this method processes the message it must return true, in which case
         ///  the message loop will not dispatch the message.
-                /// For WM_KEYDOWN and WM_SYSKEYDOWN messages, preProcessMessage() first
+        /// For WM_KEYDOWN and WM_SYSKEYDOWN messages, preProcessMessage() first
         ///  calls processCmdKey() to check for command keys such as accelerators and
         ///  menu shortcuts. If processCmdKey() doesn't process the message, then
         ///  isInputKey() is called to check whether the key message represents an
         ///  input key for the control. Finally, if isInputKey() indicates that the
         ///  control isn't interested in the key message, then processDialogKey() is
         ///  called to check for dialog keys such as TAB, arrow keys, and mnemonics.
-                /// For WM_CHAR messages, preProcessMessage() first calls isInputChar() to
+        /// For WM_CHAR messages, preProcessMessage() first calls isInputChar() to
         ///  check whether the character message represents an input character for
         ///  the control. If isInputChar() indicates that the control isn't interested
         ///  in the character message, then processDialogChar() is called to check for
         ///  dialog characters such as mnemonics.
-                /// For WM_SYSCHAR messages, preProcessMessage() calls processDialogChar()
+        /// For WM_SYSCHAR messages, preProcessMessage() calls processDialogChar()
         ///  to check for dialog characters such as mnemonics.
-                /// When overriding preProcessMessage(), a control should return true to
+        /// When overriding preProcessMessage(), a control should return true to
         ///  indicate that it has processed the message. For messages that aren't
         ///  processed by the control, the result of "base.preProcessMessage()"
         ///  should be returned. Controls will typically override one of the more
         ///  specialized methods (isInputChar(), isInputKey(), processCmdKey(),
         ///  processDialogChar(), or processDialogKey()) instead of overriding
         ///  preProcessMessage().
-            /// </summary>
+        /// </summary>
         public virtual bool PreProcessMessage(ref Message msg)
         {
             //   Debug.WriteLineIf(ControlKeyboardRouting.TraceVerbose, "Control.PreProcessMessage " + msg.ToString());
@@ -10282,7 +9354,7 @@ namespace System.Windows.Forms
         {
             if (target == null)
             {
-                target = Control.FromChildHandle(msg.HWnd);
+                target = FromChildHandle(msg.HWnd);
             }
 
             if (target == null)
@@ -10325,7 +9397,6 @@ namespace System.Windows.Forms
                 {
                     if (msg.Msg == Interop.WindowMessages.WM_KEYDOWN || msg.Msg == Interop.WindowMessages.WM_SYSKEYDOWN)
                     {
-
                         // check if IsInputKey has already procssed this message
                         // or if it is safe to call - we only want it to be called once.
                         if (target.GetState2(STATE2_INPUTKEY) || target.IsInputKey(keyData))
@@ -10336,7 +9407,6 @@ namespace System.Windows.Forms
                     }
                     else if (msg.Msg == Interop.WindowMessages.WM_CHAR || msg.Msg == Interop.WindowMessages.WM_SYSCHAR)
                     {
-
                         // check if IsInputChar has already procssed this message
                         // or if it is safe to call - we only want it to be called once.
                         if (target.GetState2(STATE2_INPUTCHAR) || target.IsInputChar((char)msg.WParam))
@@ -10360,22 +9430,22 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-            ///  Processes a command key. This method is called during message
+        ///  Processes a command key. This method is called during message
         ///  pre-processing to handle command keys. Command keys are keys that always
         ///  take precedence over regular input keys. Examples of command keys
         ///  include accelerators and menu shortcuts. The method must return true to
         ///  indicate that it has processed the command key, or false to indicate
         ///  that the key is not a command key.
-                /// processCmdKey() first checks if the control has a context menu, and if
+        /// processCmdKey() first checks if the control has a context menu, and if
         ///  so calls the menu's processCmdKey() to check for menu shortcuts. If the
         ///  command key isn't a menu shortcut, and if the control has a parent, the
         ///  key is passed to the parent's processCmdKey() method. The net effect is
         ///  that command keys are "bubbled" up the control hierarchy.
-                /// When overriding processCmdKey(), a control should return true to
+        /// When overriding processCmdKey(), a control should return true to
         ///  indicate that it has processed the key. For keys that aren't processed by
         ///  the control, the result of "base.processCmdKey()" should be returned.
-                /// Controls will seldom, if ever, need to override this method.
-            /// </summary>
+        /// Controls will seldom, if ever, need to override this method.
+        /// </summary>
         protected virtual bool ProcessCmdKey(ref Message msg, Keys keyData)
         {
             Debug.WriteLineIf(ControlKeyboardRouting.TraceVerbose, "Control.ProcessCmdKey " + msg.ToString());
@@ -10385,12 +9455,11 @@ namespace System.Windows.Forms
                 return true;
             }
 
-            if (parent != null)
+            if (_parent != null)
             {
-                return parent.ProcessCmdKey(ref msg, keyData);
+                return _parent.ProcessCmdKey(ref msg, keyData);
             }
             return false;
-
         }
 
         private void PrintToMetaFile(HandleRef hDC, IntPtr lParam)
@@ -10494,60 +9563,60 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-            ///  Processes a dialog character. This method is called during message
+        ///  Processes a dialog character. This method is called during message
         ///  pre-processing to handle dialog characters, such as control mnemonics.
         ///  This method is called only if the isInputChar() method indicates that
         ///  the control isn't interested in the character.
-                /// processDialogChar() simply sends the character to the parent's
+        /// processDialogChar() simply sends the character to the parent's
         ///  processDialogChar() method, or returns false if the control has no
         ///  parent. The Form class overrides this method to perform actual
         ///  processing of dialog characters.
-                /// When overriding processDialogChar(), a control should return true to
+        /// When overriding processDialogChar(), a control should return true to
         ///  indicate that it has processed the character. For characters that aren't
         ///  processed by the control, the result of "base.processDialogChar()"
         ///  should be returned.
-                /// Controls will seldom, if ever, need to override this method.
-            /// </summary>
+        /// Controls will seldom, if ever, need to override this method.
+        /// </summary>
         protected virtual bool ProcessDialogChar(char charCode)
         {
             Debug.WriteLineIf(ControlKeyboardRouting.TraceVerbose, "Control.ProcessDialogChar [" + charCode.ToString() + "]");
-            return parent == null ? false : parent.ProcessDialogChar(charCode);
+            return _parent == null ? false : _parent.ProcessDialogChar(charCode);
         }
 
         /// <summary>
-            ///  Processes a dialog key. This method is called during message
+        ///  Processes a dialog key. This method is called during message
         ///  pre-processing to handle dialog characters, such as TAB, RETURN, ESCAPE,
         ///  and arrow keys. This method is called only if the isInputKey() method
         ///  indicates that the control isn't interested in the key.
-                /// processDialogKey() simply sends the character to the parent's
+        /// processDialogKey() simply sends the character to the parent's
         ///  processDialogKey() method, or returns false if the control has no
         ///  parent. The Form class overrides this method to perform actual
         ///  processing of dialog keys.
-                /// When overriding processDialogKey(), a control should return true to
+        /// When overriding processDialogKey(), a control should return true to
         ///  indicate that it has processed the key. For keys that aren't processed
         ///  by the control, the result of "base.processDialogKey(...)" should be
         ///  returned.
-                /// Controls will seldom, if ever, need to override this method.
-            /// </summary>
+        /// Controls will seldom, if ever, need to override this method.
+        /// </summary>
         protected virtual bool ProcessDialogKey(Keys keyData)
         {
             Debug.WriteLineIf(ControlKeyboardRouting.TraceVerbose, "Control.ProcessDialogKey " + keyData.ToString());
-            return parent == null ? false : parent.ProcessDialogKey(keyData);
+            return _parent == null ? false : _parent.ProcessDialogKey(keyData);
         }
 
         /// <summary>
-            ///  Processes a key message. This method is called when a control receives a
+        ///  Processes a key message. This method is called when a control receives a
         ///  keyboard message. The method is responsible for generating the appropriate
         ///  key events for the message by calling OnKeyPress(), onKeyDown(), or
         ///  onKeyUp(). The m parameter contains the window message that must
         ///  be processed. Possible values for the m.msg field are WM_CHAR,
         ///  WM_KEYDOWN, WM_SYSKEYDOWN, WM_KEYUP, WM_SYSKEYUP, and WM_IMECHAR.
-                /// When overriding processKeyEventArgs(), a control should return true to
+        /// When overriding processKeyEventArgs(), a control should return true to
         ///  indicate that it has processed the key. For keys that aren't processed
         ///  by the control, the result of "base.processKeyEventArgs()" should be
         ///  returned.
-                /// Controls will seldom, if ever, need to override this method.
-            /// </summary>
+        /// Controls will seldom, if ever, need to override this method.
+        /// </summary>
         protected virtual bool ProcessKeyEventArgs(ref Message m)
         {
             Debug.WriteLineIf(ControlKeyboardRouting.TraceVerbose, "Control.ProcessKeyEventArgs " + m.ToString());
@@ -10646,7 +9715,7 @@ namespace System.Windows.Forms
         protected internal virtual bool ProcessKeyMessage(ref Message m)
         {
             Debug.WriteLineIf(ControlKeyboardRouting.TraceVerbose, "Control.ProcessKeyMessage " + m.ToString());
-            if (parent != null && parent.ProcessKeyPreview(ref m))
+            if (_parent != null && _parent.ProcessKeyPreview(ref m))
             {
                 return true;
             }
@@ -10655,7 +9724,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-            ///  Previews a keyboard message. This method is called by a child control
+        ///  Previews a keyboard message. This method is called by a child control
         ///  when the child control receives a keyboard message. The child control
         ///  calls this method before generating any keyboard events for the message.
         ///  If this method returns true, the child control considers the message
@@ -10663,29 +9732,29 @@ namespace System.Windows.Forms
         ///  parameter contains the window message to preview. Possible values for
         ///  the m.msg field are WM_CHAR, WM_KEYDOWN, WM_SYSKEYDOWN, WM_KEYUP,
         ///  and WM_SYSKEYUP.
-                /// processKeyPreview() simply sends the character to the parent's
+        /// processKeyPreview() simply sends the character to the parent's
         ///  processKeyPreview() method, or returns false if the control has no
         ///  parent. The Form class overrides this method to perform actual
         ///  processing of dialog keys.
-                /// When overriding processKeyPreview(), a control should return true to
+        /// When overriding processKeyPreview(), a control should return true to
         ///  indicate that it has processed the key. For keys that aren't processed
         ///  by the control, the result of "base.ProcessKeyPreview(...)" should be
         ///  returned.
-            /// </summary>
+        /// </summary>
         protected virtual bool ProcessKeyPreview(ref Message m)
         {
             Debug.WriteLineIf(ControlKeyboardRouting.TraceVerbose, "Control.ProcessKeyPreview " + m.ToString());
-            return parent == null ? false : parent.ProcessKeyPreview(ref m);
+            return _parent == null ? false : _parent.ProcessKeyPreview(ref m);
         }
 
         /// <summary>
-            ///  Processes a mnemonic character. This method is called to give a control
+        ///  Processes a mnemonic character. This method is called to give a control
         ///  the opportunity to process a mnemonic character. The method should check
         ///  if the control is in a state to process mnemonics and if the given
         ///  character represents a mnemonic. If so, the method should perform the
         ///  action associated with the mnemonic and return true. If not, the method
         ///  should return false.
-                /// Implementations of this method often use the isMnemonic() method to
+        /// Implementations of this method often use the isMnemonic() method to
         ///  check if the given character matches a mnemonic in the control's text,
         ///  for example:
         /// <code>
@@ -10693,9 +9762,9 @@ namespace System.Windows.Forms
         ///  // perform action associated with mnemonic
         ///  }
         /// </code>
-                /// This default implementation of processMnemonic() simply returns false
+        /// This default implementation of processMnemonic() simply returns false
         ///  to indicate that the control has no mnemonic.
-            /// </summary>
+        /// </summary>
         protected internal virtual bool ProcessMnemonic(char charCode)
         {
 #if DEBUG
@@ -10916,7 +9985,7 @@ namespace System.Windows.Forms
                         Debug.WriteLine("");
                     }
 #endif
-                    bool created = (state & STATE_CREATED) != 0;
+                    bool created = (_state & STATE_CREATED) != 0;
                     if (GetState(STATE_TRACKINGMOUSEEVENT))
                     {
                         SetState(STATE_MOUSEENTERPENDING, true);
@@ -10928,7 +9997,7 @@ namespace System.Windows.Forms
                     try
                     {
                         Control[] controlSnapshot = null;
-                        state |= STATE_RECREATE;
+                        _state |= STATE_RECREATE;
 
                         try
                         {
@@ -10969,7 +10038,7 @@ namespace System.Windows.Forms
                         }
                         finally
                         {
-                            state &= ~STATE_RECREATE;
+                            _state &= ~STATE_RECREATE;
 
                             // inform children that their parent's handle has recreated
                             if (controlSnapshot != null)
@@ -10993,7 +10062,7 @@ namespace System.Windows.Forms
                     finally
                     {
                         if (parentHandle.Handle != IntPtr.Zero                               // the parent was not null
-                            && (Control.FromHandle(parentHandle.Handle) == null || parent == null) // but wasnt a windows forms window
+                            && (FromHandle(parentHandle.Handle) == null || _parent == null) // but wasnt a windows forms window
                             && UnsafeNativeMethods.IsWindow(parentHandle))
                         {                 // and still is a window
                             // correctly parent back up to where we were before.
@@ -11038,7 +10107,7 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected static bool ReflectMessage(IntPtr hWnd, ref Message m)
         {
-            Control control = Control.FromHandle(hWnd);
+            Control control = FromHandle(hWnd);
             if (control == null)
             {
                 return false;
@@ -11115,30 +10184,30 @@ namespace System.Windows.Forms
 #if DEBUG
             if (CompModSwitches.LayoutSuspendResume.TraceInfo)
             {
-                Debug.WriteLine(GetType().Name + "::ResumeLayout( preformLayout = " + performLayout + ", newCount = " + Math.Max(0, layoutSuspendCount - 1) + ")");
+                Debug.WriteLine(GetType().Name + "::ResumeLayout( preformLayout = " + performLayout + ", newCount = " + Math.Max(0, _layoutSuspendCount - 1) + ")");
             }
 #endif
-            Debug.Assert(layoutSuspendCount > 0, "Unbalanance suspend/resume layout.");
+            Debug.Assert(_layoutSuspendCount > 0, "Unbalanance suspend/resume layout.");
 
             bool performedLayout = false;
 
-            if (layoutSuspendCount > 0)
+            if (_layoutSuspendCount > 0)
             {
-                if (layoutSuspendCount == 1)
+                if (_layoutSuspendCount == 1)
                 {
-                    layoutSuspendCount++;
+                    _layoutSuspendCount++;
                     try
                     {
                         OnLayoutResuming(performLayout);
                     }
                     finally
                     {
-                        layoutSuspendCount--;
+                        _layoutSuspendCount--;
                     }
                 }
 
-                layoutSuspendCount--;
-                if (layoutSuspendCount == 0
+                _layoutSuspendCount--;
+                if (_layoutSuspendCount == 0
                     && GetState(STATE_LAYOUTDEFERRED)
                     && performLayout)
                 {
@@ -11191,7 +10260,7 @@ namespace System.Windows.Forms
             {
                 try
                 {
-                    if (Application.OleRequired() != System.Threading.ApartmentState.STA)
+                    if (Application.OleRequired() != ApartmentState.STA)
                     {
                         throw new ThreadStateException(SR.ThreadMustBeSTA);
                     }
@@ -11566,18 +10635,18 @@ namespace System.Windows.Forms
             SuspendLayout();
             try
             {
-                int sx = (int)Math.Round(x * dx);
-                int sy = (int)Math.Round(y * dy);
+                int sx = (int)Math.Round(_x * dx);
+                int sy = (int)Math.Round(_y * dy);
 
-                int sw = width;
-                if ((controlStyle & ControlStyles.FixedWidth) != ControlStyles.FixedWidth)
+                int sw = _width;
+                if ((_controlStyle & ControlStyles.FixedWidth) != ControlStyles.FixedWidth)
                 {
-                    sw = (int)(Math.Round((x + width) * dx)) - sx;
+                    sw = (int)(Math.Round((_x + _width) * dx)) - sx;
                 }
-                int sh = height;
-                if ((controlStyle & ControlStyles.FixedHeight) != ControlStyles.FixedHeight)
+                int sh = _height;
+                if ((_controlStyle & ControlStyles.FixedHeight) != ControlStyles.FixedHeight)
                 {
-                    sh = (int)(Math.Round((y + height) * dy)) - sy;
+                    sh = (int)(Math.Round((_y + _height) * dy)) - sy;
                 }
 
                 SetBounds(sx, sy, sw, sh, BoundsSpecified.All);
@@ -11661,7 +10730,7 @@ namespace System.Windows.Forms
 
         private Control GetNextSelectableControl(Control ctl, bool forward, bool tabStopOnly, bool nested, bool wrap)
         {
-            if (!Contains(ctl) || !nested && ctl.parent != this)
+            if (!Contains(ctl) || !nested && ctl._parent != this)
             {
                 ctl = null;
             }
@@ -11688,10 +10757,10 @@ namespace System.Windows.Forms
                 {
                     if (ctl.CanSelect
                         && (!tabStopOnly || ctl.TabStop)
-                        && (nested || ctl.parent == this))
+                        && (nested || ctl._parent == this))
                     {
 
-                        if (ctl.parent is ToolStrip)
+                        if (ctl._parent is ToolStrip)
                         {
                             continue;
                         }
@@ -11793,14 +10862,14 @@ namespace System.Windows.Forms
         /// </summary>
         public void SendToBack()
         {
-            if (parent != null)
+            if (_parent != null)
             {
-                parent.Controls.SetChildIndex(this, -1);
+                _parent.Controls.SetChildIndex(this, -1);
             }
             else if (IsHandleCreated && GetTopLevel())
             {
                 SafeNativeMethods.SetWindowPos(
-                    new HandleRef(window, Handle),
+                    new HandleRef(_window, Handle),
                     NativeMethods.HWND_BOTTOM,
                     flags: NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOSIZE);
             }
@@ -11811,8 +10880,8 @@ namespace System.Windows.Forms
         /// </summary>
         public void SetBounds(int x, int y, int width, int height)
         {
-            if (this.x != x || this.y != y || this.width != width ||
-                this.height != height)
+            if (_x != x || _y != y || _width != width ||
+                _height != height)
             {
                 SetBoundsCore(x, y, width, height, BoundsSpecified.All);
 
@@ -11834,26 +10903,26 @@ namespace System.Windows.Forms
         {
             if ((specified & BoundsSpecified.X) == BoundsSpecified.None)
             {
-                x = this.x;
+                x = _x;
             }
 
             if ((specified & BoundsSpecified.Y) == BoundsSpecified.None)
             {
-                y = this.y;
+                y = _y;
             }
 
             if ((specified & BoundsSpecified.Width) == BoundsSpecified.None)
             {
-                width = this.width;
+                width = _width;
             }
 
             if ((specified & BoundsSpecified.Height) == BoundsSpecified.None)
             {
-                height = this.height;
+                height = _height;
             }
 
-            if (this.x != x || this.y != y || this.width != width ||
-                this.height != height)
+            if (_x != x || _y != y || _width != width ||
+                _height != height)
             {
                 SetBoundsCore(x, y, width, height, specified);
 
@@ -11900,7 +10969,7 @@ namespace System.Windows.Forms
             }
             try
             {
-                if (this.x != x || this.y != y || this.width != width || this.height != height)
+                if (_x != x || _y != y || _width != width || _height != height)
                 {
                     CommonProperties.UpdateSpecifiedBounds(this, x, y, width, height, specified);
 
@@ -11922,11 +10991,11 @@ namespace System.Windows.Forms
                         {
                             int flags = NativeMethods.SWP_NOZORDER | NativeMethods.SWP_NOACTIVATE;
 
-                            if (this.x == x && this.y == y)
+                            if (_x == x && _y == y)
                             {
                                 flags |= NativeMethods.SWP_NOMOVE;
                             }
-                            if (this.width == width && this.height == height)
+                            if (_width == width && _height == height)
                             {
                                 flags |= NativeMethods.SWP_NOSIZE;
                             }
@@ -11936,7 +11005,7 @@ namespace System.Windows.Forms
                             OnBoundsUpdate(x, y, width, height);
 
                             SafeNativeMethods.SetWindowPos(
-                                new HandleRef(window, Handle),
+                                new HandleRef(_window, Handle),
                                 NativeMethods.NullHandleRef,
                                 x,
                                 y,
@@ -11987,8 +11056,8 @@ namespace System.Windows.Forms
         protected virtual void SetClientSizeCore(int x, int y)
         {
             Size = SizeFromClientSize(x, y);
-            clientWidth = x;
-            clientHeight = y;
+            _clientWidth = x;
+            _clientHeight = y;
             OnClientSizeChanged(EventArgs.Empty);
         }
 
@@ -12021,7 +11090,7 @@ namespace System.Windows.Forms
 
             if (IsHandleCreated)
             {
-                IntPtr parentHandle = UnsafeNativeMethods.GetParent(new HandleRef(window, Handle));
+                IntPtr parentHandle = UnsafeNativeMethods.GetParent(new HandleRef(_window, Handle));
                 bool topLevel = GetTopLevel();
                 if (parentHandle != value || (parentHandle == IntPtr.Zero && !topLevel))
                 {
@@ -12054,17 +11123,17 @@ namespace System.Windows.Forms
                     {
                         if (value == IntPtr.Zero)
                         {
-                            Application.ParkHandle(new HandleRef(window, Handle));
+                            Application.ParkHandle(new HandleRef(_window, Handle));
                             UpdateRoot();
                         }
                         else
                         {
-                            UnsafeNativeMethods.SetParent(new HandleRef(window, Handle), new HandleRef(null, value));
-                            if (parent != null)
+                            UnsafeNativeMethods.SetParent(new HandleRef(_window, Handle), new HandleRef(null, value));
+                            if (_parent != null)
                             {
-                                parent.UpdateChildZOrder(this);
+                                _parent.UpdateChildZOrder(this);
                             }
-                            Application.UnparkHandle(new HandleRef(window, Handle), window.DpiAwarenessContext);
+                            Application.UnparkHandle(new HandleRef(_window, Handle), _window.DpiAwarenessContext);
                         }
                     }
                 }
@@ -12073,8 +11142,8 @@ namespace System.Windows.Forms
                     // The handle was previously parented to the parking window. Its TopLevel property was
                     // then changed to true so the above call to GetParent returns null even though the parent of the control is
                     // not null. We need to explicitly set the parent to null.
-                    UnsafeNativeMethods.SetParent(new HandleRef(window, Handle), new HandleRef(null, IntPtr.Zero));
-                    Application.UnparkHandle(new HandleRef(window, Handle), window.DpiAwarenessContext);
+                    UnsafeNativeMethods.SetParent(new HandleRef(_window, Handle), new HandleRef(null, IntPtr.Zero));
+                    Application.UnparkHandle(new HandleRef(_window, Handle), _window.DpiAwarenessContext);
                 }
             }
         }
@@ -12082,13 +11151,13 @@ namespace System.Windows.Forms
         // Form, UserControl, AxHost usage
         internal void SetState(int flag, bool value)
         {
-            state = value ? state | flag : state & ~flag;
+            _state = value ? _state | flag : _state & ~flag;
         }
 
         // Application, SKWindow usage
         internal void SetState2(int flag, bool value)
         {
-            state2 = value ? state2 | flag : state2 & ~flag;
+            _state2 = value ? _state2 | flag : _state2 & ~flag;
         }
 
         /// <summary>
@@ -12100,16 +11169,16 @@ namespace System.Windows.Forms
         {
             // WARNING: if we ever add argument checking to "flag", we will need
             // to move private styles like Layered to State.
-            controlStyle = value ? controlStyle | flag : controlStyle & ~flag;
+            _controlStyle = value ? _controlStyle | flag : _controlStyle & ~flag;
         }
 
         internal static IntPtr SetUpPalette(IntPtr dc, bool force, bool realizePalette)
         {
-            Debug.WriteLineIf(Control.PaletteTracing.TraceVerbose, "SetUpPalette(force:=" + force + ", ralizePalette:=" + realizePalette + ")");
+            Debug.WriteLineIf(PaletteTracing.TraceVerbose, "SetUpPalette(force:=" + force + ", ralizePalette:=" + realizePalette + ")");
 
             IntPtr halftonePalette = Graphics.GetHalftonePalette();
 
-            Debug.WriteLineIf(Control.PaletteTracing.TraceVerbose, "select palette " + !force);
+            Debug.WriteLineIf(PaletteTracing.TraceVerbose, "select palette " + !force);
             IntPtr result = SafeNativeMethods.SelectPalette(new HandleRef(null, dc), new HandleRef(null, halftonePalette), (force ? 0 : 1));
 
             if (result != IntPtr.Zero && realizePalette)
@@ -12136,7 +11205,7 @@ namespace System.Windows.Forms
         {
             if (GetTopLevel() != value)
             {
-                if (parent != null)
+                if (_parent != null)
                 {
                     throw new ArgumentException(SR.TopLevelParentedControl, "value");
                 }
@@ -12178,7 +11247,7 @@ namespace System.Windows.Forms
                         SafeNativeMethods.ShowWindow(new HandleRef(this, Handle), value ? ShowParams : NativeMethods.SW_HIDE);
                     }
                 }
-                else if (IsHandleCreated || value && parent != null && parent.Created)
+                else if (IsHandleCreated || value && _parent != null && _parent.Created)
                 {
                     // We want to mark the control as visible so that CreateControl
                     // knows that we are going to be displayed... however in case
@@ -12194,7 +11263,7 @@ namespace System.Windows.Forms
                         }
 
                         SafeNativeMethods.SetWindowPos(
-                            new HandleRef(window, Handle),
+                            new HandleRef(_window, Handle),
                             NativeMethods.NullHandleRef,
                             flags: NativeMethods.SWP_NOSIZE
                                 | NativeMethods.SWP_NOMOVE
@@ -12222,7 +11291,7 @@ namespace System.Windows.Forms
                     // parent window.  We do not want to indescriminiately layout
                     // due to this, but we do want to layout if the user changed
                     // our visibility.
-                    using (new LayoutTransaction(parent, this, PropertyNames.Visible))
+                    using (new LayoutTransaction(_parent, this, PropertyNames.Visible))
                     {
                         OnVisibleChanged(EventArgs.Empty);
                     }
@@ -12253,7 +11322,7 @@ namespace System.Windows.Forms
                 if (IsHandleCreated)
                 {
                     SafeNativeMethods.SetWindowPos(
-                        new HandleRef(window, Handle),
+                        new HandleRef(_window, Handle),
                         NativeMethods.NullHandleRef,
                         flags: NativeMethods.SWP_NOSIZE
                             | NativeMethods.SWP_NOMOVE
@@ -12512,7 +11581,7 @@ namespace System.Windows.Forms
             // In Whidbey the ControlDesigner class will always serialize size as it replaces the Size
             // property descriptor with its own.  This is here for compat.
             Size s = DefaultSize;
-            return width != s.Width || height != s.Height;
+            return _width != s.Width || _height != s.Height;
         }
 
         /// <summary>
@@ -12529,17 +11598,17 @@ namespace System.Windows.Forms
         /// </summary>
         public void SuspendLayout()
         {
-            layoutSuspendCount++;
-            if (layoutSuspendCount == 1)
+            _layoutSuspendCount++;
+            if (_layoutSuspendCount == 1)
             {
                 OnLayoutSuspended();
             }
 
 #if DEBUG
-            Debug.Assert(layoutSuspendCount > 0, "SuspendLayout: layoutSuspendCount overflowed.");
+            Debug.Assert(_layoutSuspendCount > 0, "SuspendLayout: layoutSuspendCount overflowed.");
             if (CompModSwitches.LayoutSuspendResume.TraceInfo)
             {
-                Debug.WriteLine(GetType().Name + "::SuspendLayout( newCount = " + layoutSuspendCount + ")");
+                Debug.WriteLine(GetType().Name + "::SuspendLayout( newCount = " + _layoutSuspendCount + ")");
             }
 #endif
         }
@@ -12557,7 +11626,7 @@ namespace System.Windows.Forms
         /// </summary>
         public void Update()
         {
-            SafeNativeMethods.UpdateWindow(new HandleRef(window, InternalHandle));
+            SafeNativeMethods.UpdateWindow(new HandleRef(_window, InternalHandle));
         }
 
         /// <summary>
@@ -12569,13 +11638,13 @@ namespace System.Windows.Forms
         protected internal void UpdateBounds()
         {
             Interop.RECT rect = new Interop.RECT();
-            UnsafeNativeMethods.GetClientRect(new HandleRef(window, InternalHandle), ref rect);
+            UnsafeNativeMethods.GetClientRect(new HandleRef(_window, InternalHandle), ref rect);
             int clientWidth = rect.right;
             int clientHeight = rect.bottom;
-            UnsafeNativeMethods.GetWindowRect(new HandleRef(window, InternalHandle), ref rect);
+            UnsafeNativeMethods.GetWindowRect(new HandleRef(_window, InternalHandle), ref rect);
             if (!GetTopLevel())
             {
-                UnsafeNativeMethods.MapWindowPoints(NativeMethods.NullHandleRef, new HandleRef(null, UnsafeNativeMethods.GetParent(new HandleRef(window, InternalHandle))), ref rect, 2);
+                UnsafeNativeMethods.MapWindowPoints(NativeMethods.NullHandleRef, new HandleRef(null, UnsafeNativeMethods.GetParent(new HandleRef(_window, InternalHandle))), ref rect, 2);
             }
 
             UpdateBounds(rect.left, rect.top, rect.right - rect.left,
@@ -12616,20 +11685,20 @@ namespace System.Windows.Forms
                 Debug.Indent();
                 Debug.WriteLine(string.Format(
                      CultureInfo.CurrentCulture, "oldBounds={{x={0} y={1} width={2} height={3} clientWidth={4} clientHeight={5}}}",
-                     this.x, this.y, this.width, this.height, this.clientWidth, this.clientHeight));
+                     _x, _y, _width, _height, _clientWidth, _clientHeight));
             }
 #endif // DEBUG
 
-            bool newLocation = this.x != x || this.y != y;
+            bool newLocation = _x != x || _y != y;
             bool newSize = Width != width || Height != height ||
-                           this.clientWidth != clientWidth || this.clientHeight != clientHeight;
+                           _clientWidth != clientWidth || _clientHeight != clientHeight;
 
-            this.x = x;
-            this.y = y;
-            this.width = width;
-            this.height = height;
-            this.clientWidth = clientWidth;
-            this.clientHeight = clientHeight;
+            _x = x;
+            _y = y;
+            _width = width;
+            _height = height;
+            _clientWidth = clientWidth;
+            _clientHeight = clientHeight;
 
             if (newLocation)
             {
@@ -12729,10 +11798,8 @@ namespace System.Windows.Forms
         // will continue to be sent to that window even after we do a SetParent call until the handle is recreated.
         // So here we keep track of that, and if that window ever gets destroyed, we'll recreate our handle.
         //
-        //
         // Scenario is when you've got a control in one parent, you move it to another, then destroy the first parent.  It'll stop
         // getting any reflected messages because Windows will send them to the original parent.
-        //
         private void UpdateReflectParent(bool findNewParent)
         {
             if (!Disposing && findNewParent && IsHandleCreated)
@@ -12740,7 +11807,7 @@ namespace System.Windows.Forms
                 IntPtr parentHandle = UnsafeNativeMethods.GetParent(new HandleRef(this, Handle));
                 if (parentHandle != IntPtr.Zero)
                 {
-                    ReflectParent = Control.FromHandle(parentHandle);
+                    ReflectParent = FromHandle(parentHandle);
                     return;
                 }
             }
@@ -12753,9 +11820,9 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected void UpdateZOrder()
         {
-            if (parent != null)
+            if (_parent != null)
             {
-                parent.UpdateChildZOrder(this);
+                _parent.UpdateChildZOrder(this);
             }
         }
 
@@ -12764,7 +11831,7 @@ namespace System.Windows.Forms
         /// </summary>
         private void UpdateChildZOrder(Control ctl)
         {
-            if (!IsHandleCreated || !ctl.IsHandleCreated || ctl.parent != this)
+            if (!IsHandleCreated || !ctl.IsHandleCreated || ctl._parent != this)
             {
                 return;
             }
@@ -12773,25 +11840,25 @@ namespace System.Windows.Forms
             for (int i = Controls.GetChildIndex(ctl); --i >= 0;)
             {
                 Control c = Controls[i];
-                if (c.IsHandleCreated && c.parent == this)
+                if (c.IsHandleCreated && c._parent == this)
                 {
                     prevHandle = c.Handle;
                     break;
                 }
             }
-            if (UnsafeNativeMethods.GetWindow(new HandleRef(ctl.window, ctl.Handle), NativeMethods.GW_HWNDPREV) != prevHandle)
+            if (UnsafeNativeMethods.GetWindow(new HandleRef(ctl._window, ctl.Handle), NativeMethods.GW_HWNDPREV) != prevHandle)
             {
-                state |= STATE_NOZORDER;
+                _state |= STATE_NOZORDER;
                 try
                 {
                     SafeNativeMethods.SetWindowPos(
-                        new HandleRef(ctl.window, ctl.Handle),
+                        new HandleRef(ctl._window, ctl.Handle),
                         new HandleRef(null, prevHandle),
                         flags: NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOSIZE);
                 }
                 finally
                 {
-                    state &= ~STATE_NOZORDER;
+                    _state &= ~STATE_NOZORDER;
                 }
             }
         }
@@ -12802,7 +11869,7 @@ namespace System.Windows.Forms
         /// </summary>
         private void UpdateRoot()
         {
-            window.LockReference(GetTopLevel() && Visible);
+            _window.LockReference(GetTopLevel() && Visible);
         }
 
         /// <summary>
@@ -12826,7 +11893,7 @@ namespace System.Windows.Forms
                 int exStyle = WindowExStyle;
 
                 // resolve the Form's lazy visibility.
-                if ((state & STATE_VISIBLE) != 0)
+                if ((_state & STATE_VISIBLE) != 0)
                 {
                     cp.Style |= NativeMethods.WS_VISIBLE;
                 }
@@ -12857,7 +11924,7 @@ namespace System.Windows.Forms
         {
             if (pref.Category == UserPreferenceCategory.Color)
             {
-                defaultFont = null;
+                s_defaultFont = null;
                 OnSystemColorsChanged(EventArgs.Empty);
             }
         }
@@ -12872,12 +11939,12 @@ namespace System.Windows.Forms
         // handle.
         internal void WindowAssignHandle(IntPtr handle, bool value)
         {
-            window.AssignHandle(handle, value);
+            _window.AssignHandle(handle, value);
         }
 
         internal void WindowReleaseHandle()
         {
-            window.ReleaseHandle();
+            _window.ReleaseHandle();
         }
 
         private void WmClose(ref Message m)
@@ -13010,7 +12077,7 @@ namespace System.Windows.Forms
         private void WmCtlColorControl(ref Message m)
         {
             // We could simply reflect the message, but it's faster to handle it here if possible.
-            Control control = Control.FromHandle(m.LParam);
+            Control control = FromHandle(m.LParam);
             if (control != null)
             {
                 m.Result = control.InitializeDCForWmCtlColor(m.WParam, m.Msg);
@@ -13181,13 +12248,10 @@ namespace System.Windows.Forms
             // See "How to Handle WM_GETOBJECT" in MSDN
             if (intAccessibleObject != null)
             {
-
                 // Get the IAccessible GUID
-                //
                 Guid IID_IAccessible = new Guid(NativeMethods.uuid_IAccessible);
 
                 // Get an Lresult for the accessibility Object for this control
-                //
                 IntPtr punkAcc;
                 try
                 {
@@ -13208,14 +12272,12 @@ namespace System.Windows.Forms
                     if (iacc == null)
                     {
                         // Accessibility is not supported on this control
-                        //
                         Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, "AccessibilityObject returned null");
                         m.Result = (IntPtr)0;
                     }
                     else
                     {
                         // Obtain the Lresult
-                        //
                         punkAcc = Marshal.GetIUnknownForObject(iacc);
 
                         try
@@ -13391,14 +12453,13 @@ namespace System.Windows.Forms
         {
             DefWndProc(ref m);
 
-            if (parent != null)
+            if (_parent != null)
             {
-                parent.UpdateChildZOrder(this);
+                _parent.UpdateChildZOrder(this);
             }
             UpdateBounds();
 
             // Let any interested sites know that we've now created a handle
-            //
             OnHandleCreated(EventArgs.Empty);
 
             // this code is important -- it is critical that we stash away
@@ -13406,10 +12467,9 @@ namespace System.Windows.Forms
             // label, etc. Without this processing, any time you change a
             // property that forces handle recreation, you lose your text!
             // See the below code in wmDestroy
-            //
             if (!GetStyle(ControlStyles.CacheText))
             {
-                text = null;
+                _text = null;
             }
         }
 
@@ -13419,9 +12479,6 @@ namespace System.Windows.Forms
         private void WmDestroy(ref Message m)
         {
             // Let any interested sites know that we're destroying our handle
-            //
-
-            //Debug.Assert(IsHandleCreated, "Need to have the handle here");
 
             if (!RecreatingHandle && !Disposing && !IsDisposed && GetState(STATE_TRACKINGMOUSEEVENT))
             {
@@ -13442,7 +12499,6 @@ namespace System.Windows.Forms
             {
                 // If we are not recreating the handle, set our created state
                 // back to false so we can be rebuilt if we need to be.
-                //
                 if (!RecreatingHandle)
                 {
                     SetState(STATE_CREATED, false);
@@ -13475,7 +12531,7 @@ namespace System.Windows.Forms
         /// </summary>
         private void WmKillFocus(ref Message m)
         {
-            Debug.WriteLineIf(Control.FocusTracing.TraceVerbose, "Control::WmKillFocus - " + Name);
+            Debug.WriteLineIf(FocusTracing.TraceVerbose, "Control::WmKillFocus - " + Name);
             WmImeKillFocus();
             DefWndProc(ref m);
             InvokeLostFocus(this, EventArgs.Empty);
@@ -13490,13 +12546,11 @@ namespace System.Windows.Forms
             // we need to see if something happens during processing of
             // user code that changed the state of the buttons (i.e. bringing up
             // a dialog) to keep the control in a consistent state...
-            //
             MouseButtons realState = MouseButtons;
             SetState(STATE_MOUSEPRESSED, true);
 
             // If the UserMouse style is set, the control does its own processing
             // of mouse messages
-            //
             if (!GetStyle(ControlStyles.UserMouse))
             {
                 DefWndProc(ref m);
@@ -13568,22 +12622,22 @@ namespace System.Windows.Forms
 
             if (IsHandleCreated)
             {
-                int deviceDpiOld = deviceDpi;
-                deviceDpi = (int)UnsafeNativeMethods.GetDpiForWindow(new HandleRef(this, HandleInternal));
+                int deviceDpiOld = _deviceDpi;
+                _deviceDpi = (int)UnsafeNativeMethods.GetDpiForWindow(new HandleRef(this, HandleInternal));
 
                 // Controls are by default font scaled.
                 // Dpi change requires font to be recalculated inorder to get controls scaled with right dpi.
-                if (deviceDpiOld != deviceDpi)
+                if (deviceDpiOld != _deviceDpi)
                 {
                     // Checking if font was inherited from parent. Font inherited from parent will receive OnParentFontChanged() events to scale those controls.
                     Font local = (Font)Properties.GetObject(PropFont);
                     if (local != null)
                     {
-                        var factor = (float)deviceDpi / deviceDpiOld;
+                        var factor = (float)_deviceDpi / deviceDpiOld;
                         Font = new Font(local.FontFamily, local.Size * factor, local.Style, local.Unit, local.GdiCharSet, local.GdiVerticalFont);
                     }
 
-                    RescaleConstantsForDpi(deviceDpiOld, deviceDpi);
+                    RescaleConstantsForDpi(deviceDpiOld, _deviceDpi);
                 }
             }
 
@@ -13617,7 +12671,6 @@ namespace System.Windows.Forms
         {
             // If the UserMouse style is set, the control does its own processing
             // of mouse messages
-            //
             if (!GetStyle(ControlStyles.UserMouse))
             {
                 DefWndProc(ref m);
@@ -13631,7 +12684,6 @@ namespace System.Windows.Forms
         private void WmMouseUp(ref Message m, MouseButtons button, int clicks)
         {
             // Get the mouse location
-            //
             try
             {
                 int x = NativeMethods.Util.SignedLOWORD(m.LParam);
@@ -13641,7 +12693,6 @@ namespace System.Windows.Forms
 
                 // If the UserMouse style is set, the control does its own processing
                 // of mouse messages
-                //
                 if (!GetStyle(ControlStyles.UserMouse))
                 {
                     DefWndProc(ref m);
@@ -13659,7 +12710,7 @@ namespace System.Windows.Forms
 
                 bool fireClick = false;
 
-                if ((controlStyle & ControlStyles.StandardClick) == ControlStyles.StandardClick)
+                if ((_controlStyle & ControlStyles.StandardClick) == ControlStyles.StandardClick)
                 {
                     if (GetState(STATE_MOUSEPRESSED) && !IsDisposed && UnsafeNativeMethods.WindowFromPoint(pt.X, pt.Y) == Handle)
                     {
@@ -13686,6 +12737,7 @@ namespace System.Windows.Forms
                     }
 
                 }
+
                 //call the MouseUp Finally...
                 OnMouseUp(new MouseEventArgs(button, clicks, NativeMethods.Util.SignedLOWORD(m.LParam), NativeMethods.Util.SignedHIWORD(m.LParam), 0));
             }
@@ -13693,7 +12745,6 @@ namespace System.Windows.Forms
             {
                 //Always Reset the STATE_DOUBLECLICKFIRED in UP.. Since we get UP - DOWN - DBLCLK - UP sequqnce
                 //The Flag is set in L_BUTTONDBLCLK in the controls WndProc() ...
-                //
                 SetState(STATE_DOUBLECLICKFIRED, false);
                 SetState(STATE_MOUSEPRESSED, false);
                 SetState(STATE_VALIDATIONCANCELLED, false);
@@ -13787,10 +12838,10 @@ namespace System.Windows.Forms
             if (!ReflectMessage(p, ref m))
             {
                 //Additional Check For Control .... TabControl truncates the Hwnd value...
-                IntPtr handle = window.GetHandleFromID((short)NativeMethods.Util.LOWORD(m.WParam));
+                IntPtr handle = _window.GetHandleFromID((short)NativeMethods.Util.LOWORD(m.WParam));
                 if (handle != IntPtr.Zero)
                 {
-                    Control control = Control.FromHandle(handle);
+                    Control control = FromHandle(handle);
                     if (control != null)
                     {
                         m.Result = control.SendMessage(Interop.WindowMessages.WM_REFLECT + m.Msg, handle, m.LParam);
@@ -14086,7 +13137,7 @@ namespace System.Windows.Forms
         /// </summary>
         private void WmSetFocus(ref Message m)
         {
-            Debug.WriteLineIf(Control.FocusTracing.TraceVerbose, "Control::WmSetFocus - " + Name);
+            Debug.WriteLineIf(FocusTracing.TraceVerbose, "Control::WmSetFocus - " + Name);
             WmImeSetFocus();
 
             if (!HostedInWin32DialogManager)
@@ -14128,7 +13179,7 @@ namespace System.Windows.Forms
 
             DefWndProc(ref m);
 
-            if ((state & STATE_RECREATE) == 0)
+            if ((_state & STATE_RECREATE) == 0)
             {
 
                 bool visible = m.WParam != IntPtr.Zero;
@@ -14156,7 +13207,8 @@ namespace System.Windows.Forms
                     }
                 }
                 else
-                { // not visible
+                {
+                    // not visible
                     // If Windows tells us it's visible, that's pretty unambiguous.
                     // But if it tells us it's not visible, there's more than one explanation --
                     // maybe the container control became invisible.  So we look at the parent
@@ -14193,8 +13245,8 @@ namespace System.Windows.Forms
             bool focus = false;
 
             // check the cached values in uiCuesState to see if we've ever set in the UI state
-            bool keyboardInitialized = (uiCuesState & UISTATE_KEYBOARD_CUES_MASK) != 0;
-            bool focusInitialized = (uiCuesState & UISTATE_FOCUS_CUES_MASK) != 0;
+            bool keyboardInitialized = (_uiCuesState & UISTATE_KEYBOARD_CUES_MASK) != 0;
+            bool focusInitialized = (_uiCuesState & UISTATE_FOCUS_CUES_MASK) != 0;
 
             if (keyboardInitialized)
             {
@@ -14240,8 +13292,8 @@ namespace System.Windows.Forms
 
                     // clear the old state.
                     //
-                    uiCuesState &= ~UISTATE_KEYBOARD_CUES_MASK;
-                    uiCuesState |= (showKeyboard ? UISTATE_KEYBOARD_CUES_SHOW : UISTATE_KEYBOARD_CUES_HIDDEN);
+                    _uiCuesState &= ~UISTATE_KEYBOARD_CUES_MASK;
+                    _uiCuesState |= (showKeyboard ? UISTATE_KEYBOARD_CUES_SHOW : UISTATE_KEYBOARD_CUES_HIDDEN);
                 }
 
                 if (showKeyboard)
@@ -14253,9 +13305,7 @@ namespace System.Windows.Forms
             // Same deal for the Focus cues as the keyboard cues.
             if ((NativeMethods.Util.HIWORD(m.WParam) & NativeMethods.UISF_HIDEFOCUS) != 0)
             {
-
                 // yes, clear means show.  nice api, guys.
-                //
                 bool showFocus = (cmd == NativeMethods.UIS_CLEAR);
 
                 if (showFocus != focus || !focusInitialized)
@@ -14263,9 +13313,8 @@ namespace System.Windows.Forms
                     UIcues |= UICues.ChangeFocus;
 
                     // clear the old state.
-                    //
-                    uiCuesState &= ~UISTATE_FOCUS_CUES_MASK;
-                    uiCuesState |= (showFocus ? UISTATE_FOCUS_CUES_SHOW : UISTATE_FOCUS_CUES_HIDDEN);
+                    _uiCuesState &= ~UISTATE_FOCUS_CUES_MASK;
+                    _uiCuesState |= (showFocus ? UISTATE_FOCUS_CUES_SHOW : UISTATE_FOCUS_CUES_HIDDEN);
                 }
 
                 if (showFocus)
@@ -14290,14 +13339,14 @@ namespace System.Windows.Forms
             DefWndProc(ref m);
             // Update new size / position
             UpdateBounds();
-            if (parent != null && UnsafeNativeMethods.GetParent(new HandleRef(window, InternalHandle)) == parent.InternalHandle &&
-                (state & STATE_NOZORDER) == 0)
+            if (_parent != null && UnsafeNativeMethods.GetParent(new HandleRef(_window, InternalHandle)) == _parent.InternalHandle &&
+                (_state & STATE_NOZORDER) == 0)
             {
 
                 NativeMethods.WINDOWPOS* wp = (NativeMethods.WINDOWPOS*)m.LParam;
                 if ((wp->flags & NativeMethods.SWP_NOZORDER) == 0)
                 {
-                    parent.UpdateChildControlIndex(this);
+                    _parent.UpdateChildControlIndex(this);
                 }
             }
         }
@@ -14312,7 +13361,7 @@ namespace System.Windows.Forms
             // inlined code from GetStyle(...) to ensure no perf hit
             // for a method call...
 
-            if ((controlStyle & ControlStyles.EnableNotifyMessage) == ControlStyles.EnableNotifyMessage)
+            if ((_controlStyle & ControlStyles.EnableNotifyMessage) == ControlStyles.EnableNotifyMessage)
             {
                 // pass message *by value* to avoid the possibility
                 // of the OnNotifyMessage modifying the message.
@@ -14642,17 +13691,17 @@ namespace System.Windows.Forms
                 default:
 
                     // If we received a thread execute message, then execute it.
-                    if (m.Msg == threadCallbackMessage && m.Msg != 0)
+                    if (m.Msg == s_threadCallbackMessage && m.Msg != 0)
                     {
                         InvokeMarshaledCallbacks();
                         return;
                     }
-                    else if (m.Msg == Control.WM_GETCONTROLNAME)
+                    else if (m.Msg == WM_GETCONTROLNAME)
                     {
                         WmGetControlName(ref m);
                         return;
                     }
-                    else if (m.Msg == Control.WM_GETCONTROLTYPE)
+                    else if (m.Msg == WM_GETCONTROLTYPE)
                     {
                         WmGetControlType(ref m);
                         return;
@@ -14744,7 +13793,7 @@ namespace System.Windows.Forms
                             }
                             sizeChanged = true;
                         }
-                        if (locationProperty != null && !locationProperty.IsReadOnly && (bounds.X != x || bounds.Y != y))
+                        if (locationProperty != null && !locationProperty.IsReadOnly && (bounds.X != _x || bounds.Y != _y))
                         {
                             if (!(site is INestedSite))
                             {
@@ -14799,128 +13848,6 @@ namespace System.Windows.Forms
             }
         }
 
-        internal sealed class ControlNativeWindow : NativeWindow, IWindowTarget
-        {
-            private readonly Control control;
-            private GCHandle rootRef;   // We will root the control when we do not want to be elligible for garbage collection.
-            internal IWindowTarget target;
-
-            internal ControlNativeWindow(Control control)
-            {
-                this.control = control;
-                target = this;
-            }
-
-            internal Control GetControl()
-            {
-                return control;
-            }
-
-            protected override void OnHandleChange()
-            {
-                target.OnHandleChange(Handle);
-            }
-
-            // IWindowTarget method
-            public void OnHandleChange(IntPtr newHandle)
-            {
-                control.SetHandle(newHandle);
-            }
-
-            internal void LockReference(bool locked)
-            {
-                if (locked)
-                {
-                    if (!rootRef.IsAllocated)
-                    {
-                        rootRef = GCHandle.Alloc(GetControl(), GCHandleType.Normal);
-                    }
-                }
-                else
-                {
-                    if (rootRef.IsAllocated)
-                    {
-                        rootRef.Free();
-                    }
-                }
-            }
-
-            protected override void OnThreadException(Exception e)
-            {
-                control.WndProcException(e);
-            }
-
-            // IWindowTarget method
-            public void OnMessage(ref Message m)
-            {
-                control.WndProc(ref m);
-            }
-
-            internal IWindowTarget WindowTarget
-            {
-                get
-                {
-                    return target;
-                }
-                set
-                {
-                    target = value;
-                }
-            }
-
-#if DEBUG
-            // We override ToString so in debug asserts that fire for
-            // non-released controls will show what control wasn't released.
-            //
-            public override string ToString()
-            {
-                if (control != null)
-                {
-                    return control.GetType().FullName;
-                }
-                return base.ToString();
-            }
-#endif
-
-            protected override void WndProc(ref Message m)
-            {
-                // There are certain messages that we want to process
-                // regardless of what window target we are using.  These
-                // messages cause other messages or state transitions
-                // to occur within control.
-                //
-                switch (m.Msg)
-                {
-                    case Interop.WindowMessages.WM_MOUSELEAVE:
-                        control.UnhookMouseEvent();
-                        break;
-
-                    case Interop.WindowMessages.WM_MOUSEMOVE:
-                        if (!control.GetState(Control.STATE_TRACKINGMOUSEEVENT))
-                        {
-                            control.HookMouseEvent();
-                            if (!control.GetState(Control.STATE_MOUSEENTERPENDING))
-                            {
-                                control.SendMessage(NativeMethods.WM_MOUSEENTER, 0, 0);
-                            }
-                            else
-                            {
-                                control.SetState(Control.STATE_MOUSEENTERPENDING, false);
-                            }
-                        }
-                        break;
-
-                    case Interop.WindowMessages.WM_MOUSEWHEEL:
-                        // TrackMouseEvent's mousehover implementation doesn't watch the wheel
-                        // correctly...
-                        //
-                        control.ResetMouseEventArgs();
-                        break;
-                }
-
-                target.OnMessage(ref m);
-            }
-        }
 
         ///
         /// Explicit support of DropTarget
@@ -14956,606 +13883,6 @@ namespace System.Windows.Forms
         void ISupportOleDropSource.OnQueryContinueDrag(QueryContinueDragEventArgs queryContinueDragEventArgs)
         {
             OnQueryContinueDrag(queryContinueDragEventArgs);
-        }
-
-        /// <summary>
-        ///  Collection of controls...
-        /// </summary>
-        [ListBindable(false), ComVisible(false)]
-        public class ControlCollection : ArrangedElementCollection, IList, ICloneable
-        {
-            private readonly Control owner;
-
-            /// A caching mechanism for key accessor
-            /// We use an index here rather than control so that we don't have lifetime
-            /// issues by holding on to extra references.
-            /// Note this is not Thread Safe - but WinForms has to be run in a STA anyways.
-            private int lastAccessedIndex = -1;
-
-            public ControlCollection(Control owner)
-            {
-                this.owner = owner;
-            }
-
-            /// <summary>
-            ///  Returns true if the collection contains an item with the specified key, false otherwise.
-            /// </summary>
-            public virtual bool ContainsKey(string key)
-            {
-                return IsValidIndex(IndexOfKey(key));
-            }
-
-            /// <summary>
-            ///  Adds a child control to this control. The control becomes the last control in
-            ///  the child control list. If the control is already a child of another control it
-            ///  is first removed from that control.
-            /// </summary>
-            public virtual void Add(Control value)
-            {
-                if (value == null)
-                {
-                    return;
-                }
-
-                if (value.GetTopLevel())
-                {
-                    throw new ArgumentException(SR.TopLevelControlAdd);
-                }
-
-                // Verify that the control being added is on the same thread as
-                // us...or our parent chain.
-                //
-                if (owner.CreateThreadId != value.CreateThreadId)
-                {
-                    throw new ArgumentException(SR.AddDifferentThreads);
-                }
-
-                CheckParentingCycle(owner, value);
-
-                if (value.parent == owner)
-                {
-                    value.SendToBack();
-                    return;
-                }
-
-                // Remove the new control from its old parent (if any)
-                //
-                if (value.parent != null)
-                {
-                    value.parent.Controls.Remove(value);
-                }
-
-                // Add the control
-                //
-                InnerList.Add(value);
-
-                if (value.tabIndex == -1)
-                {
-
-                    // Find the next highest tab index
-                    //
-                    int nextTabIndex = 0;
-                    for (int c = 0; c < (Count - 1); c++)
-                    {
-                        int t = this[c].TabIndex;
-                        if (nextTabIndex <= t)
-                        {
-                            nextTabIndex = t + 1;
-                        }
-                    }
-                    value.tabIndex = nextTabIndex;
-                }
-
-                // if we don't suspend layout, AssignParent will indirectly trigger a layout event
-                // before we're ready (AssignParent will fire a PropertyChangedEvent("Visible"), which calls PerformLayout)
-                //
-#if DEBUG
-                int dbgLayoutCheck = owner.LayoutSuspendCount;
-#endif
-                owner.SuspendLayout();
-
-                try
-                {
-                    Control oldParent = value.parent;
-                    try
-                    {
-                        // AssignParent calls into user code - this could throw, which
-                        // would make us short-circuit the rest of the reparenting logic.
-                        // you could end up with a control half reparented.
-                        value.AssignParent(owner);
-                    }
-                    finally
-                    {
-                        if (oldParent != value.parent && (owner.state & STATE_CREATED) != 0)
-                        {
-                            value.SetParentHandle(owner.InternalHandle);
-                            if (value.Visible)
-                            {
-                                value.CreateControl();
-                            }
-                        }
-                    }
-
-                    value.InitLayout();
-                }
-                finally
-                {
-                    owner.ResumeLayout(false);
-#if DEBUG
-                    owner.AssertLayoutSuspendCount(dbgLayoutCheck);
-#endif
-
-                }
-
-                // Not putting in the finally block, as it would eat the original
-                // exception thrown from AssignParent if the following throws an exception.
-                LayoutTransaction.DoLayout(owner, value, PropertyNames.Parent);
-                owner.OnControlAdded(new ControlEventArgs(value));
-            }
-
-            int IList.Add(object control)
-            {
-                if (control is Control)
-                {
-                    Add((Control)control);
-                    return IndexOf((Control)control);
-                }
-                else
-                {
-                    throw new ArgumentException(SR.ControlBadControl, "control");
-                }
-            }
-
-            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-            public virtual void AddRange(Control[] controls)
-            {
-                if (controls == null)
-                {
-                    throw new ArgumentNullException(nameof(controls));
-                }
-                if (controls.Length > 0)
-                {
-#if DEBUG
-                    int dbgLayoutCheck = owner.LayoutSuspendCount;
-#endif
-                    owner.SuspendLayout();
-                    try
-                    {
-                        for (int i = 0; i < controls.Length; ++i)
-                        {
-                            Add(controls[i]);
-                        }
-                    }
-                    finally
-                    {
-                        owner.ResumeLayout(true);
-                    }
-#if DEBUG
-                    owner.AssertLayoutSuspendCount(dbgLayoutCheck);
-#endif
-                }
-            }
-
-            object ICloneable.Clone()
-            {
-                // Use CreateControlInstance so we get the same type of ControlCollection, but whack the
-                // owner so adding controls to this new collection does not affect the control we cloned from.
-                ControlCollection ccOther = owner.CreateControlsInstance();
-
-                // We add using InnerList to prevent unnecessary parent cycle checks, etc.
-                ccOther.InnerList.AddRange(this);
-                return ccOther;
-            }
-
-            public bool Contains(Control control)
-            {
-                return InnerList.Contains(control);
-            }
-
-            /// <summary>
-            ///  Searches for Controls by their Name property, builds up an array
-            ///  of all the controls that match.
-                    /// </summary>
-            public Control[] Find(string key, bool searchAllChildren)
-            {
-                if (string.IsNullOrEmpty(key))
-                {
-                    throw new ArgumentNullException(nameof(key), SR.FindKeyMayNotBeEmptyOrNull);
-                }
-
-                ArrayList foundControls = FindInternal(key, searchAllChildren, this, new ArrayList());
-
-                // Make this a stongly typed collection.
-                Control[] stronglyTypedFoundControls = new Control[foundControls.Count];
-                foundControls.CopyTo(stronglyTypedFoundControls, 0);
-
-                return stronglyTypedFoundControls;
-            }
-
-            /// <summary>
-            ///  Searches for Controls by their Name property, builds up an array list
-            ///  of all the controls that match.
-                    /// </summary>
-            private ArrayList FindInternal(string key, bool searchAllChildren, ControlCollection controlsToLookIn, ArrayList foundControls)
-            {
-                if ((controlsToLookIn == null) || (foundControls == null))
-                {
-                    return null;
-                }
-
-                try
-                {
-                    // Perform breadth first search - as it's likely people will want controls belonging
-                    // to the same parent close to each other.
-
-                    for (int i = 0; i < controlsToLookIn.Count; i++)
-                    {
-                        if (controlsToLookIn[i] == null)
-                        {
-                            continue;
-                        }
-
-                        if (WindowsFormsUtils.SafeCompareStrings(controlsToLookIn[i].Name, key, /* ignoreCase = */ true))
-                        {
-                            foundControls.Add(controlsToLookIn[i]);
-                        }
-                    }
-
-                    // Optional recurive search for controls in child collections.
-
-                    if (searchAllChildren)
-                    {
-                        for (int i = 0; i < controlsToLookIn.Count; i++)
-                        {
-                            if (controlsToLookIn[i] == null)
-                            {
-                                continue;
-                            }
-                            if ((controlsToLookIn[i].Controls != null) && controlsToLookIn[i].Controls.Count > 0)
-                            {
-                                // if it has a valid child collecion, append those results to our collection
-                                foundControls = FindInternal(key, searchAllChildren, controlsToLookIn[i].Controls, foundControls);
-                            }
-                        }
-                    }
-                }
-                catch (Exception e)
-                {
-                    if (ClientUtils.IsSecurityOrCriticalException(e))
-                    {
-                        throw;
-                    }
-                }
-                return foundControls;
-            }
-
-            public override IEnumerator GetEnumerator()
-            {
-                return new ControlCollectionEnumerator(this);
-            }
-
-            public int IndexOf(Control control)
-            {
-                return InnerList.IndexOf(control);
-            }
-
-            /// <summary>
-            ///  The zero-based index of the first occurrence of value within the entire CollectionBase, if found; otherwise, -1.
-            /// </summary>
-            public virtual int IndexOfKey(string key)
-            {
-                // Step 0 - Arg validation
-                if (string.IsNullOrEmpty(key))
-                {
-                    return -1; // we dont support empty or null keys.
-                }
-
-                // step 1 - check the last cached item
-                if (IsValidIndex(lastAccessedIndex))
-                {
-                    if (WindowsFormsUtils.SafeCompareStrings(this[lastAccessedIndex].Name, key, /* ignoreCase = */ true))
-                    {
-                        return lastAccessedIndex;
-                    }
-                }
-
-                // step 2 - search for the item
-                for (int i = 0; i < Count; i++)
-                {
-                    if (WindowsFormsUtils.SafeCompareStrings(this[i].Name, key, /* ignoreCase = */ true))
-                    {
-                        lastAccessedIndex = i;
-                        return i;
-                    }
-                }
-
-                // step 3 - we didn't find it.  Invalidate the last accessed index and return -1.
-                lastAccessedIndex = -1;
-                return -1;
-            }
-
-            /// <summary>
-            ///  Determines if the index is valid for the collection.
-            /// </summary>
-            private bool IsValidIndex(int index)
-            {
-                return ((index >= 0) && (index < Count));
-            }
-
-            /// <summary>
-            ///  Who owns this control collection.
-            /// </summary>
-            public Control Owner
-            {
-                get
-                {
-                    return owner;
-                }
-            }
-
-            /// <summary>
-            ///  Removes control from this control. Inheriting controls should call
-            ///  base.remove to ensure that the control is removed.
-            /// </summary>
-            public virtual void Remove(Control value)
-            {
-
-                // Sanity check parameter
-                //
-                if (value == null)
-                {
-                    return;     // Don't do anything
-                }
-
-                if (value.ParentInternal == owner)
-                {
-                    Debug.Assert(owner != null);
-
-                    value.SetParentHandle(IntPtr.Zero);
-
-                    // Remove the control from the internal control array
-                    //
-                    InnerList.Remove(value);
-                    value.AssignParent(null);
-                    LayoutTransaction.DoLayout(owner, value, PropertyNames.Parent);
-                    owner.OnControlRemoved(new ControlEventArgs(value));
-
-                    // ContainerControl needs to see it needs to find a new ActiveControl.
-                    if (owner.GetContainerControl() is ContainerControl cc)
-                    {
-                        cc.AfterControlRemoved(value, owner);
-                    }
-                }
-            }
-
-            void IList.Remove(object control)
-            {
-                if (control is Control)
-                {
-                    Remove((Control)control);
-                }
-            }
-
-            public void RemoveAt(int index)
-            {
-                Remove(this[index]);
-            }
-
-            /// <summary>
-            ///  Removes the child control with the specified key.
-            /// </summary>
-            public virtual void RemoveByKey(string key)
-            {
-                int index = IndexOfKey(key);
-                if (IsValidIndex(index))
-                {
-                    RemoveAt(index);
-                }
-            }
-
-            /// <summary>
-            ///  Retrieves the child control with the specified index.
-            /// </summary>
-            public new virtual Control this[int index]
-            {
-                get
-                {
-                    //do some bounds checking here...
-                    if (index < 0 || index >= Count)
-                    {
-                        throw new ArgumentOutOfRangeException(nameof(index), string.Format(SR.IndexOutOfRange, index.ToString(CultureInfo.CurrentCulture)));
-                    }
-
-                    Control control = (Control)InnerList[index];
-                    Debug.Assert(control != null, "Why are we returning null controls from a valid index?");
-                    return control;
-                }
-            }
-
-            /// <summary>
-            ///  Retrieves the child control with the specified key.
-            /// </summary>
-            public virtual Control this[string key]
-            {
-                get
-                {
-                    // We do not support null and empty string as valid keys.
-                    if (string.IsNullOrEmpty(key))
-                    {
-                        return null;
-                    }
-
-                    // Search for the key in our collection
-                    int index = IndexOfKey(key);
-                    if (IsValidIndex(index))
-                    {
-                        return this[index];
-                    }
-                    else
-                    {
-                        return null;
-                    }
-
-                }
-            }
-
-            public virtual void Clear()
-            {
-#if DEBUG
-                int layoutSuspendCount = owner.LayoutSuspendCount;
-#endif
-                owner.SuspendLayout();
-                // clear all preferred size caches in the tree -
-                // inherited fonts could go away, etc.
-                CommonProperties.xClearAllPreferredSizeCaches(owner);
-
-                try
-                {
-                    while (Count != 0)
-                    {
-                        RemoveAt(Count - 1);
-                    }
-                }
-                finally
-                {
-                    owner.ResumeLayout();
-#if DEBUG
-                    Debug.Assert(owner.LayoutSuspendCount == layoutSuspendCount, "Suspend/Resume layout mismatch!");
-#endif
-                }
-            }
-
-            /// <summary>
-            ///  Retrieves the index of the specified
-            ///  child control in this array.  An ArgumentException
-            ///  is thrown if child is not parented to this
-            ///  Control.
-            /// </summary>
-            public int GetChildIndex(Control child)
-            {
-                return GetChildIndex(child, true);
-            }
-
-            /// <summary>
-            ///  Retrieves the index of the specified
-            ///  child control in this array.  An ArgumentException
-            ///  is thrown if child is not parented to this
-            ///  Control.
-            /// </summary>
-            public virtual int GetChildIndex(Control child, bool throwException)
-            {
-                int index = IndexOf(child);
-                if (index == -1 && throwException)
-                {
-                    throw new ArgumentException(SR.ControlNotChild);
-                }
-                return index;
-            }
-
-            /// <summary>
-            ///  This is internal virtual method so that "Readonly Collections" can override this and throw as they should not allow changing
-            ///  the child control indices.
-            /// </summary>
-            internal virtual void SetChildIndexInternal(Control child, int newIndex)
-            {
-                // Sanity check parameters
-                //
-                if (child == null)
-                {
-                    throw new ArgumentNullException(nameof(child));
-                }
-
-                int currentIndex = GetChildIndex(child);
-
-                if (currentIndex == newIndex)
-                {
-                    return;
-                }
-
-                if (newIndex >= Count || newIndex == -1)
-                {
-                    newIndex = Count - 1;
-                }
-
-                MoveElement(child, currentIndex, newIndex);
-                child.UpdateZOrder();
-
-                LayoutTransaction.DoLayout(owner, child, PropertyNames.ChildIndex);
-
-            }
-
-            /// <summary>
-            ///  Sets the index of the specified
-            ///  child control in this array.  An ArgumentException
-            ///  is thrown if child is not parented to this
-            ///  Control.
-            /// </summary>
-            public virtual void SetChildIndex(Control child, int newIndex)
-            {
-                SetChildIndexInternal(child, newIndex);
-            }
-
-            // This is the same as WinformsUtils.ArraySubsetEnumerator
-            // however since we're no longer an array, we've gotta employ a
-            // special version of this.
-            private class ControlCollectionEnumerator : IEnumerator
-            {
-                private readonly ControlCollection controls;
-                private int current;
-                private readonly int originalCount;
-
-                public ControlCollectionEnumerator(ControlCollection controls)
-                {
-                    this.controls = controls;
-                    originalCount = controls.Count;
-                    current = -1;
-                }
-
-                public bool MoveNext()
-                {
-                    // We have to use Controls.Count here because someone could have deleted
-                    // an item from the array.
-                    //
-                    // this can happen if someone does:
-                    //     foreach (Control c in Controls) { c.Dispose(); }
-                    //
-                    // We also dont want to iterate past the original size of the collection
-                    //
-                    // this can happen if someone does
-                    //     foreach (Control c in Controls) { c.Controls.Add(new Label()); }
-
-                    if (current < controls.Count - 1 && current < originalCount - 1)
-                    {
-                        current++;
-                        return true;
-                    }
-                    else
-                    {
-                        return false;
-                    }
-                }
-
-                public void Reset()
-                {
-                    current = -1;
-                }
-
-                public object Current
-                {
-                    get
-                    {
-                        if (current == -1)
-                        {
-                            return null;
-                        }
-                        else
-                        {
-                            return controls[current];
-                        }
-                    }
-                }
-            }
-
         }
 
         int UnsafeNativeMethods.IOleControl.GetControlInfo(NativeMethods.tagCONTROLINFO pCI)
@@ -15626,7 +13953,6 @@ namespace System.Windows.Forms
         {
             Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:OnFrameWindowActivate");
             OnFrameWindowActivate(fActivate);
-            // return NativeMethods.S_OK;
         }
 
         void UnsafeNativeMethods.IOleInPlaceActiveObject.OnDocWindowActivate(int fActivate)
@@ -15646,7 +13972,6 @@ namespace System.Windows.Forms
         void UnsafeNativeMethods.IOleInPlaceActiveObject.EnableModeless(int fEnable)
         {
             Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:EnableModeless");
-            // return NativeMethods.S_OK;
         }
 
         int UnsafeNativeMethods.IOleInPlaceObject.GetWindow(out IntPtr hwnd)
@@ -15662,7 +13987,7 @@ namespace System.Windows.Forms
             Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:ContextSensitiveHelp.  Mode: " + fEnterMode.ToString(CultureInfo.InvariantCulture));
             if (fEnterMode != 0)
             {
-                OnHelpRequested(new HelpEventArgs(Control.MousePosition));
+                OnHelpRequested(new HelpEventArgs(MousePosition));
             }
         }
 
@@ -15691,7 +14016,6 @@ namespace System.Windows.Forms
         void UnsafeNativeMethods.IOleInPlaceObject.ReactivateAndUndo()
         {
             Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:ReactivateAndUndo");
-            // return NativeMethods.S_OK;
         }
 
         int UnsafeNativeMethods.IOleObject.SetClientSite(UnsafeNativeMethods.IOleClientSite pClientSite)
@@ -16189,7 +14513,7 @@ namespace System.Windows.Forms
 
         bool IKeyboardToolTip.IsHoveredWithMouse()
         {
-            return ClientRectangle.Contains(PointToClient(Control.MousePosition));
+            return ClientRectangle.Contains(PointToClient(MousePosition));
         }
 
         bool IKeyboardToolTip.HasRtlModeEnabled()
@@ -16240,7 +14564,7 @@ namespace System.Windows.Forms
 
         bool IKeyboardToolTip.IsBeingTabbedTo()
         {
-            return Control.AreCommonNavigationalKeysDown();
+            return AreCommonNavigationalKeysDown();
         }
 
         bool IKeyboardToolTip.AllowsChildrenToShowToolTips()
@@ -16312,16 +14636,16 @@ namespace System.Windows.Forms
 
         private static bool IsKeyDown(Keys key)
         {
-            return (tempKeyboardStateArray[(int)key] & Control.HighOrderBitMask) != 0;
+            return (t_tempKeyboardStateArray[(int)key] & HighOrderBitMask) != 0;
         }
 
         internal static bool AreCommonNavigationalKeysDown()
         {
-            if (tempKeyboardStateArray == null)
+            if (t_tempKeyboardStateArray == null)
             {
-                tempKeyboardStateArray = new byte[256];
+                t_tempKeyboardStateArray = new byte[256];
             }
-            UnsafeNativeMethods.GetKeyboardState(tempKeyboardStateArray);
+            UnsafeNativeMethods.GetKeyboardState(t_tempKeyboardStateArray);
             return IsKeyDown(Keys.Tab)
                 || IsKeyDown(Keys.Up)
                 || IsKeyDown(Keys.Down)
@@ -16352,4306 +14676,5 @@ namespace System.Windows.Forms
         {
             return true;
         }
-
-        /// <summary>
-        ///  This class holds all of the state data for an ActiveX control and
-        ///  supplies the implementation for many of the non-trivial methods.
-        /// </summary>
-        private class ActiveXImpl : MarshalByRefObject, IWindowTarget
-        {
-            // SECUNDONE : This call is private and is only used to expose a WinForm control as
-            //           : an ActiveX control. This class needs more review.
-            //
-
-            private static readonly int hiMetricPerInch = 2540;
-            private static readonly int viewAdviseOnlyOnce = BitVector32.CreateMask();
-            private static readonly int viewAdvisePrimeFirst = BitVector32.CreateMask(viewAdviseOnlyOnce);
-            private static readonly int eventsFrozen = BitVector32.CreateMask(viewAdvisePrimeFirst);
-            private static readonly int changingExtents = BitVector32.CreateMask(eventsFrozen);
-            private static readonly int saving = BitVector32.CreateMask(changingExtents);
-            private static readonly int isDirty = BitVector32.CreateMask(saving);
-            private static readonly int inPlaceActive = BitVector32.CreateMask(isDirty);
-            private static readonly int inPlaceVisible = BitVector32.CreateMask(inPlaceActive);
-            private static readonly int uiActive = BitVector32.CreateMask(inPlaceVisible);
-            private static readonly int uiDead = BitVector32.CreateMask(uiActive);
-            private static readonly int adjustingRect = BitVector32.CreateMask(uiDead);
-
-            private static Point logPixels = Point.Empty;
-            private static NativeMethods.tagOLEVERB[] axVerbs;
-
-            private static int globalActiveXCount = 0;
-            private static bool checkedIE;
-            private static bool isIE;
-
-#if ACTIVEX_SOURCING
-
-            //
-            // This has been cut from the product.
-            //
-
-            private static ActiveXPropPage  propPage;
-
-#endif
-
-            private readonly Control control;
-            private readonly IWindowTarget controlWindowTarget;
-            private IntPtr clipRegion;
-            private UnsafeNativeMethods.IOleClientSite clientSite;
-            private UnsafeNativeMethods.IOleInPlaceUIWindow inPlaceUiWindow;
-            private UnsafeNativeMethods.IOleInPlaceFrame inPlaceFrame;
-            private readonly ArrayList adviseList;
-            private IAdviseSink viewAdviseSink;
-            private BitVector32 activeXState;
-            private readonly AmbientProperty[] ambientProperties;
-            private IntPtr hwndParent;
-            private IntPtr accelTable;
-            private short accelCount = -1;
-            private NativeMethods.COMRECT adjustRect; // temporary rect used during OnPosRectChange && SetObjectRects
-
-            /// <summary>
-            ///  Creates a new ActiveXImpl.
-            /// </summary>
-            internal ActiveXImpl(Control control)
-            {
-                this.control = control;
-
-                // We replace the control's window target with our own.  We
-                // do this so we can handle the UI Dead ambient property.
-                //
-                controlWindowTarget = control.WindowTarget;
-                control.WindowTarget = this;
-
-                adviseList = new ArrayList();
-                activeXState = new BitVector32();
-                ambientProperties = new AmbientProperty[] {
-                    new AmbientProperty("Font", NativeMethods.ActiveX.DISPID_AMBIENT_FONT),
-                    new AmbientProperty("BackColor", NativeMethods.ActiveX.DISPID_AMBIENT_BACKCOLOR),
-                    new AmbientProperty("ForeColor", NativeMethods.ActiveX.DISPID_AMBIENT_FORECOLOR)
-                };
-            }
-
-            /// <summary>
-            ///  Retrieves the ambient back color for the control.
-            /// </summary>
-            [Browsable(false), EditorBrowsable(EditorBrowsableState.Advanced), DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-            internal Color AmbientBackColor
-            {
-                get
-                {
-                    AmbientProperty prop = LookupAmbient(NativeMethods.ActiveX.DISPID_AMBIENT_BACKCOLOR);
-
-                    if (prop.Empty)
-                    {
-                        object obj = null;
-                        if (GetAmbientProperty(NativeMethods.ActiveX.DISPID_AMBIENT_BACKCOLOR, ref obj))
-                        {
-                            if (obj != null)
-                            {
-                                try
-                                {
-                                    Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Object color type=" + obj.GetType().FullName);
-                                    prop.Value = ColorTranslator.FromOle(Convert.ToInt32(obj, CultureInfo.InvariantCulture));
-                                }
-                                catch (Exception e)
-                                {
-                                    Debug.Fail("Failed to massage ambient back color to a Color", e.ToString());
-
-                                    if (ClientUtils.IsSecurityOrCriticalException(e))
-                                    {
-                                        throw;
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    if (prop.Value == null)
-                    {
-                        return Color.Empty;
-                    }
-                    else
-                    {
-                        return (Color)prop.Value;
-                    }
-                }
-            }
-
-            /// <summary>
-            ///  Retrieves the ambient font for the control.
-            /// </summary>
-            [Browsable(false), EditorBrowsable(EditorBrowsableState.Advanced), DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-            internal Font AmbientFont
-            {
-                get
-                {
-                    AmbientProperty prop = LookupAmbient(NativeMethods.ActiveX.DISPID_AMBIENT_FONT);
-
-                    if (prop.Empty)
-                    {
-                        object obj = null;
-                        if (GetAmbientProperty(NativeMethods.ActiveX.DISPID_AMBIENT_FONT, ref obj))
-                        {
-                            try
-                            {
-                                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Object font type=" + obj.GetType().FullName);
-                                Debug.Assert(obj != null, "GetAmbientProperty failed");
-                                IntPtr hfont = IntPtr.Zero;
-
-                                UnsafeNativeMethods.IFont ifont = (UnsafeNativeMethods.IFont)obj;
-                                Font font = null;
-                                hfont = ifont.GetHFont();
-                                font = Font.FromHfont(hfont);
-                                prop.Value = font;
-                            }
-                            catch (Exception e)
-                            {
-                                if (ClientUtils.IsSecurityOrCriticalException(e))
-                                {
-                                    throw;
-                                }
-
-                                // Do NULL, so we just defer to the default font
-                                prop.Value = null;
-                            }
-                        }
-                    }
-
-                    return (Font)prop.Value;
-                }
-            }
-
-            /// <summary>
-            ///  Retrieves the ambient back color for the control.
-            /// </summary>
-            [Browsable(false), EditorBrowsable(EditorBrowsableState.Advanced), DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-            internal Color AmbientForeColor
-            {
-                get
-                {
-                    AmbientProperty prop = LookupAmbient(NativeMethods.ActiveX.DISPID_AMBIENT_FORECOLOR);
-
-                    if (prop.Empty)
-                    {
-                        object obj = null;
-                        if (GetAmbientProperty(NativeMethods.ActiveX.DISPID_AMBIENT_FORECOLOR, ref obj))
-                        {
-                            if (obj != null)
-                            {
-                                try
-                                {
-                                    Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Object color type=" + obj.GetType().FullName);
-                                    prop.Value = ColorTranslator.FromOle(Convert.ToInt32(obj, CultureInfo.InvariantCulture));
-                                }
-                                catch (Exception e)
-                                {
-                                    Debug.Fail("Failed to massage ambient fore color to a Color", e.ToString());
-
-                                    if (ClientUtils.IsSecurityOrCriticalException(e))
-                                    {
-                                        throw;
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    if (prop.Value == null)
-                    {
-                        return Color.Empty;
-                    }
-                    else
-                    {
-                        return (Color)prop.Value;
-                    }
-                }
-            }
-
-            /// <summary>
-            ///  Determines if events should be frozen.
-            /// </summary>
-            [Browsable(false), EditorBrowsable(EditorBrowsableState.Advanced), DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-            internal bool EventsFrozen
-            {
-                get
-                {
-                    return activeXState[eventsFrozen];
-                }
-                set
-                {
-                    activeXState[eventsFrozen] = value;
-                }
-            }
-
-            /// <summary>
-            ///  Provides access to the parent window handle
-            ///  when we are UI active
-            /// </summary>
-            internal IntPtr HWNDParent
-            {
-                get
-                {
-                    return hwndParent;
-                }
-            }
-
-            /// <summary>
-            ///  Returns true if this app domain is running inside of IE.  The
-            ///  control must be sited for this to succeed (it will assert and
-            ///  return false if the control is not sited).
-            /// </summary>
-            internal bool IsIE
-            {
-                get
-                {
-                    if (!checkedIE)
-                    {
-                        if (clientSite == null)
-                        {
-                            Debug.Fail("Do not reference IsIE property unless control is sited.");
-                            return false;
-                        }
-
-                        // First, is this a managed EXE?  If so, it will correctly shut down
-                        // the runtime.
-                        if (Assembly.GetEntryAssembly() == null)
-                        {
-                            // Now check for IHTMLDocument2
-
-                            if (NativeMethods.Succeeded(clientSite.GetContainer(out UnsafeNativeMethods.IOleContainer container)) && container is NativeMethods.IHTMLDocument)
-                            {
-                                isIE = true;
-                                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceVerbose, "AxSource:IsIE running under IE");
-                            }
-
-                            if (container != null && Marshal.IsComObject(container))
-                            {
-                                Marshal.ReleaseComObject(container);
-                            }
-                        }
-
-                        checkedIE = true;
-                    }
-
-                    return isIE;
-                }
-            }
-
-            /// <summary>
-            ///  Retrieves the number of logical pixels per inch on the
-            ///  primary monitor.
-            /// </summary>
-            private Point LogPixels
-            {
-                get
-                {
-                    if (logPixels.IsEmpty)
-                    {
-                        logPixels = new Point();
-                        using ScreenDC dc = ScreenDC.Create();
-                        logPixels.X = Interop.Gdi32.GetDeviceCaps(dc, Interop.Gdi32.DeviceCapability.LOGPIXELSX);
-                        logPixels.Y = Interop.Gdi32.GetDeviceCaps(dc, Interop.Gdi32.DeviceCapability.LOGPIXELSY);
-                    }
-                    return logPixels;
-                }
-            }
-
-            /// <summary>
-            ///  Implements IOleObject::Advise
-            /// </summary>
-            internal int Advise(IAdviseSink pAdvSink)
-            {
-                adviseList.Add(pAdvSink);
-                return adviseList.Count;
-            }
-
-            /// <summary>
-            ///  Implements IOleObject::Close
-            /// </summary>
-            internal void Close(int dwSaveOption)
-            {
-                if (activeXState[inPlaceActive])
-                {
-                    InPlaceDeactivate();
-                }
-
-                if ((dwSaveOption == NativeMethods.OLECLOSE_SAVEIFDIRTY ||
-                     dwSaveOption == NativeMethods.OLECLOSE_PROMPTSAVE) &&
-                    activeXState[isDirty])
-                {
-
-                    if (clientSite != null)
-                    {
-                        clientSite.SaveObject();
-                    }
-                    SendOnSave();
-                }
-            }
-
-            /// <summary>
-            ///  Implements IOleObject::DoVerb
-            /// </summary>
-            internal void DoVerb(int iVerb, IntPtr lpmsg, UnsafeNativeMethods.IOleClientSite pActiveSite, int lindex, IntPtr hwndParent, NativeMethods.COMRECT lprcPosRect)
-            {
-                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceVerbose, "AxSource:ActiveXImpl:DoVerb(" + iVerb + ")");
-                switch (iVerb)
-                {
-                    case NativeMethods.OLEIVERB_SHOW:
-                    case NativeMethods.OLEIVERB_INPLACEACTIVATE:
-                    case NativeMethods.OLEIVERB_UIACTIVATE:
-                    case NativeMethods.OLEIVERB_PRIMARY:
-                        Debug.WriteLineIf(CompModSwitches.ActiveX.TraceVerbose, "DoVerb:Show, InPlaceActivate, UIActivate");
-                        InPlaceActivate(iVerb);
-
-                        // Now that we're active, send the lpmsg to the control if it
-                        // is valid.
-                        //
-                        if (lpmsg != IntPtr.Zero)
-                        {
-                            NativeMethods.MSG msg = Marshal.PtrToStructure<NativeMethods.MSG>(lpmsg);
-                            Control target = control;
-
-                            if (msg.hwnd != control.Handle && msg.message >= Interop.WindowMessages.WM_MOUSEFIRST && msg.message <= Interop.WindowMessages.WM_MOUSELAST)
-                            {
-
-                                // Must translate message coordniates over to our HWND.  We first try
-                                //
-                                IntPtr hwndMap = msg.hwnd == IntPtr.Zero ? hwndParent : msg.hwnd;
-                                NativeMethods.POINT pt = new NativeMethods.POINT
-                                {
-                                    x = NativeMethods.Util.LOWORD(msg.lParam),
-                                    y = NativeMethods.Util.HIWORD(msg.lParam)
-                                };
-                                UnsafeNativeMethods.MapWindowPoints(new HandleRef(null, hwndMap), new HandleRef(control, control.Handle), pt, 1);
-
-                                // check to see if this message should really go to a child
-                                //  control, and if so, map the point into that child's window
-                                //  coordinates
-                                //
-                                Control realTarget = target.GetChildAtPoint(new Point(pt.x, pt.y));
-                                if (realTarget != null && realTarget != target)
-                                {
-                                    UnsafeNativeMethods.MapWindowPoints(new HandleRef(target, target.Handle), new HandleRef(realTarget, realTarget.Handle), pt, 1);
-                                    target = realTarget;
-                                }
-
-                                msg.lParam = NativeMethods.Util.MAKELPARAM(pt.x, pt.y);
-                            }
-
-#if DEBUG
-                            if (CompModSwitches.ActiveX.TraceVerbose)
-                            {
-                                Message m = Message.Create(msg.hwnd, msg.message, msg.wParam, msg.lParam);
-                                Debug.WriteLine("Valid message pointer passed, sending to control: " + m.ToString());
-                            }
-#endif // DEBUG
-
-                            if (msg.message == Interop.WindowMessages.WM_KEYDOWN && msg.wParam == (IntPtr)NativeMethods.VK_TAB)
-                            {
-                                target.SelectNextControl(null, Control.ModifierKeys != Keys.Shift, true, true, true);
-                            }
-                            else
-                            {
-                                target.SendMessage(msg.message, msg.wParam, msg.lParam);
-                            }
-                        }
-                        break;
-
-                    // These affect our visibility
-                    //
-                    case NativeMethods.OLEIVERB_HIDE:
-                        Debug.WriteLineIf(CompModSwitches.ActiveX.TraceVerbose, "DoVerb:Hide");
-                        UIDeactivate();
-                        InPlaceDeactivate();
-                        if (activeXState[inPlaceVisible])
-                        {
-                            SetInPlaceVisible(false);
-                        }
-                        break;
-
-#if ACTIVEX_SOURCING
-
-                    //
-                    // This has been cut from the product.
-                    //
-
-                        // Show our property pages
-                        //
-                    case NativeMethods.OLEIVERB_PROPERTIES:
-                        Debug.WriteLineIf(CompModSwitches.ActiveX.TraceVerbose, "DoVerb:Primary, Properties");
-                        ShowProperties();
-                        break;
-
-#endif
-
-                    // All other verbs are notimpl.
-                    //
-                    default:
-                        Debug.WriteLineIf(CompModSwitches.ActiveX.TraceVerbose, "DoVerb:Other");
-                        ThrowHr(NativeMethods.E_NOTIMPL);
-                        break;
-                }
-            }
-
-            /// <summary>
-            ///  Implements IViewObject2::Draw.
-            /// </summary>
-            internal void Draw(int dwDrawAspect, int lindex, IntPtr pvAspect, NativeMethods.tagDVTARGETDEVICE ptd,
-                             IntPtr hdcTargetDev, IntPtr hdcDraw, NativeMethods.COMRECT prcBounds, NativeMethods.COMRECT lprcWBounds,
-                             IntPtr pfnContinue, int dwContinue)
-            {
-
-                // support the aspects required for multi-pass drawing
-                //
-                switch (dwDrawAspect)
-                {
-                    case NativeMethods.DVASPECT_CONTENT:
-                    case NativeMethods.DVASPECT_OPAQUE:
-                    case NativeMethods.DVASPECT_TRANSPARENT:
-                        break;
-                    default:
-                        ThrowHr(NativeMethods.DV_E_DVASPECT);
-                        break;
-                }
-
-                // We can paint to an enhanced metafile, but not all GDI / GDI+ is
-                // supported on classic metafiles.  We throw VIEW_E_DRAW in the hope that
-                // the caller figures it out and sends us a different DC.
-                //
-                int hdcType = UnsafeNativeMethods.GetObjectType(new HandleRef(null, hdcDraw));
-                if (hdcType == NativeMethods.OBJ_METADC)
-                {
-                    ThrowHr(NativeMethods.VIEW_E_DRAW);
-                }
-
-                Interop.RECT rc;
-                NativeMethods.POINT pVp = new NativeMethods.POINT();
-                NativeMethods.POINT pW = new NativeMethods.POINT();
-                NativeMethods.SIZE sWindowExt = new NativeMethods.SIZE();
-                NativeMethods.SIZE sViewportExt = new NativeMethods.SIZE();
-                int iMode = NativeMethods.MM_TEXT;
-
-                if (!control.IsHandleCreated)
-                {
-                    control.CreateHandle();
-                }
-
-                // if they didn't give us a rectangle, just copy over ours
-                //
-                if (prcBounds != null)
-                {
-                    rc = new Interop.RECT(prcBounds.left, prcBounds.top, prcBounds.right, prcBounds.bottom);
-
-                    // To draw to a given rect, we scale the DC in such a way as to
-                    // make the values it takes match our own happy MM_TEXT.  Then,
-                    // we back-convert prcBounds so that we convert it to this coordinate
-                    // system.  This puts us in the most similar coordinates as we currently
-                    // use.
-                    //
-                    SafeNativeMethods.LPtoDP(new HandleRef(null, hdcDraw), ref rc, 2);
-
-                    iMode = SafeNativeMethods.SetMapMode(new HandleRef(null, hdcDraw), NativeMethods.MM_ANISOTROPIC);
-                    SafeNativeMethods.SetWindowOrgEx(new HandleRef(null, hdcDraw), 0, 0, pW);
-                    SafeNativeMethods.SetWindowExtEx(new HandleRef(null, hdcDraw), control.Width, control.Height, sWindowExt);
-                    SafeNativeMethods.SetViewportOrgEx(new HandleRef(null, hdcDraw), rc.left, rc.top, pVp);
-                    SafeNativeMethods.SetViewportExtEx(new HandleRef(null, hdcDraw), rc.right - rc.left, rc.bottom - rc.top, sViewportExt);
-                }
-
-                // Now do the actual drawing.  We must ask all of our children to draw as well.
-                try
-                {
-                    IntPtr flags = (IntPtr)(NativeMethods.PRF_CHILDREN
-                                    | NativeMethods.PRF_CLIENT
-                                    | NativeMethods.PRF_ERASEBKGND
-                                    | NativeMethods.PRF_NONCLIENT);
-                    //| NativeMethods.PRF_CHECKVISIBLE
-                    //| NativeMethods.PRF_OWNED));
-
-                    if (hdcType != NativeMethods.OBJ_ENHMETADC)
-                    {
-                        control.SendMessage(Interop.WindowMessages.WM_PRINT, hdcDraw, flags);
-                    }
-                    else
-                    {
-                        control.PrintToMetaFile(new HandleRef(null, hdcDraw), flags);
-                    }
-                }
-                finally
-                {
-                    // And clean up the DC
-                    //
-                    if (prcBounds != null)
-                    {
-                        SafeNativeMethods.SetWindowOrgEx(new HandleRef(null, hdcDraw), pW.x, pW.y, null);
-                        SafeNativeMethods.SetWindowExtEx(new HandleRef(null, hdcDraw), sWindowExt.cx, sWindowExt.cy, null);
-                        SafeNativeMethods.SetViewportOrgEx(new HandleRef(null, hdcDraw), pVp.x, pVp.y, null);
-                        SafeNativeMethods.SetViewportExtEx(new HandleRef(null, hdcDraw), sViewportExt.cx, sViewportExt.cy, null);
-                        SafeNativeMethods.SetMapMode(new HandleRef(null, hdcDraw), iMode);
-                    }
-                }
-            }
-
-            /// <summary>
-            ///  Returns a new verb enumerator.
-            /// </summary>
-            internal static int EnumVerbs(out UnsafeNativeMethods.IEnumOLEVERB e)
-            {
-                if (axVerbs == null)
-                {
-                    NativeMethods.tagOLEVERB verbShow = new NativeMethods.tagOLEVERB();
-                    NativeMethods.tagOLEVERB verbInplaceActivate = new NativeMethods.tagOLEVERB();
-                    NativeMethods.tagOLEVERB verbUIActivate = new NativeMethods.tagOLEVERB();
-                    NativeMethods.tagOLEVERB verbHide = new NativeMethods.tagOLEVERB();
-                    NativeMethods.tagOLEVERB verbPrimary = new NativeMethods.tagOLEVERB();
-                    NativeMethods.tagOLEVERB verbProperties = new NativeMethods.tagOLEVERB();
-
-                    verbShow.lVerb = NativeMethods.OLEIVERB_SHOW;
-                    verbInplaceActivate.lVerb = NativeMethods.OLEIVERB_INPLACEACTIVATE;
-                    verbUIActivate.lVerb = NativeMethods.OLEIVERB_UIACTIVATE;
-                    verbHide.lVerb = NativeMethods.OLEIVERB_HIDE;
-                    verbPrimary.lVerb = NativeMethods.OLEIVERB_PRIMARY;
-                    verbProperties.lVerb = NativeMethods.OLEIVERB_PROPERTIES;
-                    verbProperties.lpszVerbName = SR.AXProperties;
-                    verbProperties.grfAttribs = NativeMethods.ActiveX.OLEVERBATTRIB_ONCONTAINERMENU;
-
-                    axVerbs = new NativeMethods.tagOLEVERB[] {
-                        verbShow,
-                        verbInplaceActivate,
-                        verbUIActivate,
-                        verbHide,
-                        verbPrimary
-                    #if ACTIVEX_SOURCING
-                        ,verbProperties
-                    #endif
-                    };
-                }
-
-                e = new ActiveXVerbEnum(axVerbs);
-                return NativeMethods.S_OK;
-            }
-
-            /// <summary>
-            ///  Converts the given string to a byte array.
-            /// </summary>
-            private static byte[] FromBase64WrappedString(string text)
-            {
-                if (text.IndexOfAny(new char[] { ' ', '\r', '\n' }) != -1)
-                {
-                    StringBuilder sb = new StringBuilder(text.Length);
-                    for (int i = 0; i < text.Length; i++)
-                    {
-                        switch (text[i])
-                        {
-                            case ' ':
-                            case '\r':
-                            case '\n':
-                                break;
-                            default:
-                                sb.Append(text[i]);
-                                break;
-                        }
-                    }
-                    return Convert.FromBase64String(sb.ToString());
-                }
-                else
-                {
-                    return Convert.FromBase64String(text);
-                }
-            }
-
-            /// <summary>
-            ///  Implements IViewObject2::GetAdvise.
-            /// </summary>
-            internal void GetAdvise(int[] paspects, int[] padvf, IAdviseSink[] pAdvSink)
-            {
-                // if they want it, give it to them
-                //
-                if (paspects != null)
-                {
-                    paspects[0] = NativeMethods.DVASPECT_CONTENT;
-                }
-
-                if (padvf != null)
-                {
-                    padvf[0] = 0;
-
-                    if (activeXState[viewAdviseOnlyOnce])
-                    {
-                        padvf[0] |= NativeMethods.ADVF_ONLYONCE;
-                    }
-
-                    if (activeXState[viewAdvisePrimeFirst])
-                    {
-                        padvf[0] |= NativeMethods.ADVF_PRIMEFIRST;
-                    }
-                }
-
-                if (pAdvSink != null)
-                {
-                    pAdvSink[0] = viewAdviseSink;
-                }
-            }
-
-            /// <summary>
-            ///  Helper function to retrieve an ambient property.  Returns false if the
-            ///  property wasn't found.
-            /// </summary>
-            private bool GetAmbientProperty(int dispid, ref object obj)
-            {
-                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:GetAmbientProperty");
-                Debug.Indent();
-
-                if (clientSite is UnsafeNativeMethods.IDispatch)
-                {
-                    Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "clientSite implements IDispatch");
-
-                    UnsafeNativeMethods.IDispatch disp = (UnsafeNativeMethods.IDispatch)clientSite;
-                    object[] pvt = new object[1];
-                    Guid g = Guid.Empty;
-                    int hr = disp.Invoke(dispid, ref g, NativeMethods.LOCALE_USER_DEFAULT,
-                                        NativeMethods.DISPATCH_PROPERTYGET, new NativeMethods.tagDISPPARAMS(),
-                                        pvt, null, null);
-                    if (NativeMethods.Succeeded(hr))
-                    {
-                        Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "IDispatch::Invoke succeeded. VT=" + pvt[0].GetType().FullName);
-                        obj = pvt[0];
-                        Debug.Unindent();
-                        return true;
-                    }
-                    else
-                    {
-                        Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "IDispatch::Invoke failed. HR: 0x" + string.Format(CultureInfo.CurrentCulture, "{0:X}", hr));
-                    }
-                }
-
-                Debug.Unindent();
-                return false;
-            }
-
-            /// <summary>
-            ///  Implements IOleObject::GetClientSite.
-            /// </summary>
-            internal UnsafeNativeMethods.IOleClientSite GetClientSite()
-            {
-                return clientSite;
-            }
-
-            /// <summary>
-            /// </summary>
-            internal int GetControlInfo(NativeMethods.tagCONTROLINFO pCI)
-            {
-                if (accelCount == -1)
-                {
-                    ArrayList mnemonicList = new ArrayList();
-                    GetMnemonicList(control, mnemonicList);
-
-                    accelCount = (short)mnemonicList.Count;
-
-                    if (accelCount > 0)
-                    {
-                        int accelSize = Marshal.SizeOf<NativeMethods.ACCEL>();
-
-                        // In the worst case we may have two accelerators per mnemonic:  one lower case and
-                        // one upper case, hence the * 2 below.
-                        //
-                        IntPtr accelBlob = Marshal.AllocHGlobal(accelSize * accelCount * 2);
-
-                        try
-                        {
-                            NativeMethods.ACCEL accel = new NativeMethods.ACCEL
-                            {
-                                cmd = 0
-                            };
-
-                            Debug.Indent();
-
-                            accelCount = 0;
-
-                            foreach (char ch in mnemonicList)
-                            {
-                                IntPtr structAddr = (IntPtr)((long)accelBlob + accelCount * accelSize);
-
-                                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Mnemonic: " + ch.ToString());
-
-                                if (ch >= 'A' && ch <= 'Z')
-                                {
-
-                                    // Lower case letter
-                                    //
-                                    accel.fVirt = NativeMethods.FALT | NativeMethods.FVIRTKEY;
-                                    accel.key = (short)(UnsafeNativeMethods.VkKeyScan(ch) & 0x00FF);
-                                    Marshal.StructureToPtr(accel, structAddr, false);
-
-                                    // Upper case letter
-                                    //
-                                    accelCount++;
-                                    structAddr = (IntPtr)((long)structAddr + accelSize);
-                                    accel.fVirt = NativeMethods.FALT | NativeMethods.FVIRTKEY | NativeMethods.FSHIFT;
-                                    Marshal.StructureToPtr(accel, structAddr, false);
-                                }
-                                else
-                                {
-                                    // Some non-printable character.
-                                    //
-                                    accel.fVirt = NativeMethods.FALT | NativeMethods.FVIRTKEY;
-                                    short scan = (short)(UnsafeNativeMethods.VkKeyScan(ch));
-                                    if ((scan & 0x0100) != 0)
-                                    {
-                                        accel.fVirt |= NativeMethods.FSHIFT;
-                                    }
-                                    accel.key = (short)(scan & 0x00FF);
-                                    Marshal.StructureToPtr(accel, structAddr, false);
-                                }
-
-                                accel.cmd++;
-                                accelCount++;
-                            }
-
-                            Debug.Unindent();
-
-                            // Now create an accelerator table and then free our memory.
-                            //
-
-                            if (accelTable != IntPtr.Zero)
-                            {
-                                UnsafeNativeMethods.DestroyAcceleratorTable(new HandleRef(this, accelTable));
-                                accelTable = IntPtr.Zero;
-                            }
-
-                            accelTable = UnsafeNativeMethods.CreateAcceleratorTable(new HandleRef(null, accelBlob), accelCount);
-                        }
-                        finally
-                        {
-                            if (accelBlob != IntPtr.Zero)
-                            {
-                                Marshal.FreeHGlobal(accelBlob);
-                            }
-                        }
-                    }
-                }
-
-                pCI.cAccel = accelCount;
-                pCI.hAccel = accelTable;
-                return NativeMethods.S_OK;
-            }
-
-            /// <summary>
-            ///  Implements IOleObject::GetExtent.
-            /// </summary>
-            internal void GetExtent(int dwDrawAspect, NativeMethods.tagSIZEL pSizel)
-            {
-                if ((dwDrawAspect & NativeMethods.DVASPECT_CONTENT) != 0)
-                {
-                    Size size = control.Size;
-
-                    Point pt = PixelToHiMetric(size.Width, size.Height);
-                    pSizel.cx = pt.X;
-                    pSizel.cy = pt.Y;
-                }
-                else
-                {
-                    ThrowHr(NativeMethods.DV_E_DVASPECT);
-                }
-            }
-
-            /// <summary>
-            ///  Searches the control hierarchy of the given control and adds
-            ///  the mnemonics for each control to mnemonicList.  Each mnemonic
-            ///  is added as a char to the list.
-            /// </summary>
-            private void GetMnemonicList(Control control, ArrayList mnemonicList)
-            {
-                // Get the mnemonic for our control
-                //
-                char mnemonic = WindowsFormsUtils.GetMnemonic(control.Text, true);
-                if (mnemonic != 0)
-                {
-                    mnemonicList.Add(mnemonic);
-                }
-
-                // And recurse for our children.
-                //
-                foreach (Control c in control.Controls)
-                {
-                    if (c != null)
-                    {
-                        GetMnemonicList(c, mnemonicList);
-                    }
-                }
-            }
-
-            /// <summary>
-            ///  Name to use for a stream: use the control's type name (max 31 chars, use the end chars
-            ///  if it's longer than that)
-            /// </summary>
-            private string GetStreamName()
-            {
-                string streamName = control.GetType().FullName;
-                int len = streamName.Length;
-                if (len > 31)
-                { // The max allowed length of the stream name is 31.
-                    streamName = streamName.Substring(len - 31);
-                }
-                return streamName;
-            }
-
-            /// <summary>
-            ///  Implements IOleWindow::GetWindow
-            /// </summary>
-            internal int GetWindow(out IntPtr hwnd)
-            {
-                if (!activeXState[inPlaceActive])
-                {
-                    hwnd = IntPtr.Zero;
-                    return NativeMethods.E_FAIL;
-                }
-                hwnd = control.Handle;
-                return NativeMethods.S_OK;
-            }
-
-            /// <summary>
-            ///  Converts coordinates in HiMetric to pixels.  Used for ActiveX sourcing.
-            /// </summary>
-            private Point HiMetricToPixel(int x, int y)
-            {
-                Point pt = new Point
-                {
-                    X = (LogPixels.X * x + hiMetricPerInch / 2) / hiMetricPerInch,
-                    Y = (LogPixels.Y * y + hiMetricPerInch / 2) / hiMetricPerInch
-                };
-                return pt;
-            }
-
-            /// <summary>
-            ///  In place activates this Object.
-            /// </summary>
-            internal void InPlaceActivate(int verb)
-            {
-                // If we don't have a client site, then there's not much to do.
-                // We also punt if this isn't an in-place site, since we can't
-                // go active then.
-                //
-                if (!(clientSite is UnsafeNativeMethods.IOleInPlaceSite inPlaceSite))
-                {
-                    return;
-                }
-
-                // If we're not already active, go and do it.
-                //
-                if (!activeXState[inPlaceActive])
-                {
-                    Debug.WriteLineIf(CompModSwitches.ActiveX.TraceVerbose, "\tActiveXImpl:InPlaceActivate --> inplaceactive");
-
-                    int hr = inPlaceSite.CanInPlaceActivate();
-
-                    if (hr != NativeMethods.S_OK)
-                    {
-                        if (NativeMethods.Succeeded(hr))
-                        {
-                            hr = NativeMethods.E_FAIL;
-                        }
-                        ThrowHr(hr);
-                    }
-
-                    inPlaceSite.OnInPlaceActivate();
-
-                    activeXState[inPlaceActive] = true;
-                }
-
-                // And if we're not visible, do that too.
-                //
-                if (!activeXState[inPlaceVisible])
-                {
-                    Debug.WriteLineIf(CompModSwitches.ActiveX.TraceVerbose, "\tActiveXImpl:InPlaceActivate --> inplacevisible");
-                    NativeMethods.tagOIFI inPlaceFrameInfo = new NativeMethods.tagOIFI
-                    {
-                        cb = Marshal.SizeOf<NativeMethods.tagOIFI>()
-                    };
-                    IntPtr hwndParent = IntPtr.Zero;
-
-                    // We are entering a secure context here.
-                    //
-                    hwndParent = inPlaceSite.GetWindow();
-
-                    NativeMethods.COMRECT posRect = new NativeMethods.COMRECT();
-                    NativeMethods.COMRECT clipRect = new NativeMethods.COMRECT();
-
-                    if (inPlaceUiWindow != null && Marshal.IsComObject(inPlaceUiWindow))
-                    {
-                        Marshal.ReleaseComObject(inPlaceUiWindow);
-                        inPlaceUiWindow = null;
-                    }
-
-                    if (inPlaceFrame != null && Marshal.IsComObject(inPlaceFrame))
-                    {
-                        Marshal.ReleaseComObject(inPlaceFrame);
-                        inPlaceFrame = null;
-                    }
-
-                    inPlaceSite.GetWindowContext(out UnsafeNativeMethods.IOleInPlaceFrame pFrame, out UnsafeNativeMethods.IOleInPlaceUIWindow pWindow, posRect, clipRect, inPlaceFrameInfo);
-
-                    SetObjectRects(posRect, clipRect);
-
-                    inPlaceFrame = pFrame;
-                    inPlaceUiWindow = pWindow;
-
-                    // We are parenting ourselves
-                    // directly to the host window.  The host must
-                    // implement the ambient property
-                    // DISPID_AMBIENT_MESSAGEREFLECT.
-                    // If it doesn't, that means that the host
-                    // won't reflect messages back to us.
-                    //
-                    this.hwndParent = hwndParent;
-                    UnsafeNativeMethods.SetParent(new HandleRef(control, control.Handle), new HandleRef(null, hwndParent));
-
-                    // Now create our handle if it hasn't already been done.
-                    //
-                    control.CreateControl();
-
-                    clientSite.ShowObject();
-
-                    SetInPlaceVisible(true);
-                    Debug.Assert(activeXState[inPlaceVisible], "Failed to set inplacevisible");
-                }
-
-                // if we weren't asked to UIActivate, then we're done.
-                //
-                if (verb != NativeMethods.OLEIVERB_PRIMARY && verb != NativeMethods.OLEIVERB_UIACTIVATE)
-                {
-                    Debug.WriteLineIf(CompModSwitches.ActiveX.TraceVerbose, "\tActiveXImpl:InPlaceActivate --> not becoming UIActive");
-                    return;
-                }
-
-                // if we're not already UI active, do sow now.
-                //
-                if (!activeXState[uiActive])
-                {
-                    Debug.WriteLineIf(CompModSwitches.ActiveX.TraceVerbose, "\tActiveXImpl:InPlaceActivate --> uiactive");
-                    activeXState[uiActive] = true;
-
-                    // inform the container of our intent
-                    //
-                    inPlaceSite.OnUIActivate();
-
-                    // take the focus  [which is what UI Activation is all about !]
-                    //
-                    if (!control.ContainsFocus)
-                    {
-                        control.Focus();
-                    }
-
-                    // set ourselves up in the host.
-                    //
-                    Debug.Assert(inPlaceFrame != null, "Setting us to visible should have created the in place frame");
-                    inPlaceFrame.SetActiveObject(control, null);
-                    if (inPlaceUiWindow != null)
-                    {
-                        inPlaceUiWindow.SetActiveObject(control, null);
-                    }
-
-                    // we have to explicitly say we don't wany any border space.
-                    //
-                    int hr = inPlaceFrame.SetBorderSpace(null);
-                    if (NativeMethods.Failed(hr) && hr != NativeMethods.OLE_E_INVALIDRECT &&
-                        hr != NativeMethods.INPLACE_E_NOTOOLSPACE && hr != NativeMethods.E_NOTIMPL)
-                    {
-                        Marshal.ThrowExceptionForHR(hr);
-                    }
-
-                    if (inPlaceUiWindow != null)
-                    {
-                        hr = inPlaceFrame.SetBorderSpace(null);
-                        if (NativeMethods.Failed(hr) && hr != NativeMethods.OLE_E_INVALIDRECT &&
-                            hr != NativeMethods.INPLACE_E_NOTOOLSPACE && hr != NativeMethods.E_NOTIMPL)
-                        {
-                            Marshal.ThrowExceptionForHR(hr);
-                        }
-                    }
-                }
-                else
-                {
-                    Debug.WriteLineIf(CompModSwitches.ActiveX.TraceVerbose, "\tActiveXImpl:InPlaceActivate --> already uiactive");
-                }
-            }
-
-            /// <summary>
-            ///  Implements IOleInPlaceObject::InPlaceDeactivate.
-            /// </summary>
-            internal void InPlaceDeactivate()
-            {
-                // Only do this if we're already in place active.
-                //
-                if (!activeXState[inPlaceActive])
-                {
-                    return;
-                }
-
-                // Deactivate us if we're UI active
-                //
-                if (activeXState[uiActive])
-                {
-                    UIDeactivate();
-                }
-
-                // Some containers may call into us to save, and if we're still
-                // active we will try to deactivate and recurse back into the container.
-                // So, set the state bits here first.
-                //
-                activeXState[inPlaceActive] = false;
-                activeXState[inPlaceVisible] = false;
-
-                // Notify our site of our deactivation.
-                //
-                if (clientSite is UnsafeNativeMethods.IOleInPlaceSite oleClientSite)
-                {
-                    oleClientSite.OnInPlaceDeactivate();
-                }
-
-                control.Visible = false;
-                hwndParent = IntPtr.Zero;
-
-                if (inPlaceUiWindow != null && Marshal.IsComObject(inPlaceUiWindow))
-                {
-                    Marshal.ReleaseComObject(inPlaceUiWindow);
-                    inPlaceUiWindow = null;
-                }
-
-                if (inPlaceFrame != null && Marshal.IsComObject(inPlaceFrame))
-                {
-                    Marshal.ReleaseComObject(inPlaceFrame);
-                    inPlaceFrame = null;
-                }
-            }
-
-            /// <summary>
-            ///  Implements IPersistStreamInit::IsDirty.
-            /// </summary>
-            internal int IsDirty()
-            {
-                if (activeXState[isDirty])
-                {
-                    return NativeMethods.S_OK;
-                }
-                else
-                {
-                    return NativeMethods.S_FALSE;
-                }
-            }
-
-            /// <summary>
-            ///  Looks at the property to see if it should be loaded / saved as a resource or
-            ///  through a type converter.
-            /// </summary>
-            private bool IsResourceProp(PropertyDescriptor prop)
-            {
-                TypeConverter converter = prop.Converter;
-                Type[] convertTypes = new Type[] {
-                    typeof(string),
-                    typeof(byte[])
-                    };
-
-                foreach (Type t in convertTypes)
-                {
-                    if (converter.CanConvertTo(t) && converter.CanConvertFrom(t))
-                    {
-                        return false;
-                    }
-                }
-
-                // Finally, if the property can be serialized, it is a resource property.
-                //
-                return (prop.GetValue(control) is ISerializable);
-            }
-
-            /// <summary>
-            ///  Implements IPersistStorage::Load
-            /// </summary>
-            internal void Load(UnsafeNativeMethods.IStorage stg)
-            {
-                UnsafeNativeMethods.IStream stream = null;
-
-                try
-                {
-                    stream = stg.OpenStream(GetStreamName(), IntPtr.Zero, NativeMethods.STGM_READ | NativeMethods.STGM_SHARE_EXCLUSIVE, 0);
-                }
-                catch (COMException e)
-                {
-                    if (e.ErrorCode == NativeMethods.STG_E_FILENOTFOUND)
-                    {
-                        // For backward compatibility: We were earlier using GetType().FullName
-                        // as the stream name in v1. Lets see if a stream by that name exists.
-                        stream = stg.OpenStream(GetType().FullName, IntPtr.Zero, NativeMethods.STGM_READ | NativeMethods.STGM_SHARE_EXCLUSIVE, 0);
-                    }
-                    else
-                    {
-                        throw;
-                    }
-                }
-
-                Load(stream);
-                stream = null;
-                if (Marshal.IsComObject(stg))
-                {
-                    Marshal.ReleaseComObject(stg);
-                }
-            }
-
-            /// <summary>
-            ///  Implements IPersistStreamInit::Load
-            /// </summary>
-            internal void Load(UnsafeNativeMethods.IStream stream)
-            {
-                // We do everything through property bags because we support full fidelity
-                // in them.  So, load through that method.
-                //
-                PropertyBagStream bag = new PropertyBagStream();
-                bag.Read(stream);
-                Load(bag, null);
-
-                if (Marshal.IsComObject(stream))
-                {
-                    Marshal.ReleaseComObject(stream);
-                }
-            }
-
-            /// <summary>
-            ///  Implements IPersistPropertyBag::Load
-            /// </summary>
-            internal void Load(UnsafeNativeMethods.IPropertyBag pPropBag, UnsafeNativeMethods.IErrorLog pErrorLog)
-            {
-                PropertyDescriptorCollection props = TypeDescriptor.GetProperties(control,
-                    new Attribute[] { DesignerSerializationVisibilityAttribute.Visible });
-
-                for (int i = 0; i < props.Count; i++)
-                {
-                    Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Loading property " + props[i].Name);
-
-                    try
-                    {
-                        object obj = null;
-                        int hr = pPropBag.Read(props[i].Name, ref obj, pErrorLog);
-
-                        if (NativeMethods.Succeeded(hr) && obj != null)
-                        {
-                            Debug.Indent();
-                            Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Property was in bag");
-
-                            string errorString = null;
-                            int errorCode = 0;
-
-                            try
-                            {
-                                if (obj.GetType() != typeof(string))
-                                {
-                                    Debug.Fail("Expected property " + props[i].Name + " to be stored in IPropertyBag as a string.  Attempting to coerce");
-                                    obj = Convert.ToString(obj, CultureInfo.InvariantCulture);
-                                }
-
-                                // Determine if this is a resource property or was persisted via a type converter.
-                                //
-                                if (IsResourceProp(props[i]))
-                                {
-                                    Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "It's a resource property");
-
-                                    // Resource property.  We encode these as base 64 strings.  To load them, we convert
-                                    // to a binary blob and then de-serialize.
-                                    //
-                                    byte[] bytes = Convert.FromBase64String(obj.ToString());
-                                    MemoryStream stream = new MemoryStream(bytes);
-                                    BinaryFormatter formatter = new BinaryFormatter();
-                                    props[i].SetValue(control, formatter.Deserialize(stream));
-                                }
-                                else
-                                {
-                                    Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "It's a standard property");
-
-                                    // Not a resource property.  Use TypeConverters to convert the string back to the data type.  We do
-                                    // not check for CanConvertFrom here -- we the conversion fails the type converter will throw,
-                                    // and we will log it into the COM error log.
-                                    //
-                                    TypeConverter converter = props[i].Converter;
-                                    Debug.Assert(converter != null, "No type converter for property '" + props[i].Name + "' on class " + control.GetType().FullName);
-
-                                    // Check to see if the type converter can convert from a string.  If it can,.
-                                    // use that as it is the best format for IPropertyBag.  Otherwise, check to see
-                                    // if it can convert from a byte array.  If it can, get the string, decode it
-                                    // to a byte array, and then set the value.
-                                    //
-                                    object value = null;
-
-                                    if (converter.CanConvertFrom(typeof(string)))
-                                    {
-                                        value = converter.ConvertFromInvariantString(obj.ToString());
-                                    }
-                                    else if (converter.CanConvertFrom(typeof(byte[])))
-                                    {
-                                        string objString = obj.ToString();
-                                        value = converter.ConvertFrom(null, CultureInfo.InvariantCulture, FromBase64WrappedString(objString));
-                                    }
-                                    Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Converter returned " + value);
-                                    props[i].SetValue(control, value);
-                                }
-                            }
-                            catch (Exception e)
-                            {
-                                errorString = e.ToString();
-                                if (e is ExternalException)
-                                {
-                                    errorCode = ((ExternalException)e).ErrorCode;
-                                }
-                                else
-                                {
-                                    errorCode = NativeMethods.E_FAIL;
-                                }
-                            }
-                            if (errorString != null)
-                            {
-                                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Exception converting property: " + errorString);
-                                if (pErrorLog != null)
-                                {
-                                    NativeMethods.tagEXCEPINFO err = new NativeMethods.tagEXCEPINFO
-                                    {
-                                        bstrSource = control.GetType().FullName,
-                                        bstrDescription = errorString,
-                                        scode = errorCode
-                                    };
-                                    pErrorLog.AddError(props[i].Name, err);
-                                }
-                            }
-                            Debug.Unindent();
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Debug.Fail("Unexpected failure reading property", ex.ToString());
-
-                        if (ClientUtils.IsSecurityOrCriticalException(ex))
-                        {
-                            throw;
-                        }
-                    }
-                }
-                if (Marshal.IsComObject(pPropBag))
-                {
-                    Marshal.ReleaseComObject(pPropBag);
-                }
-            }
-
-            /// <summary>
-            ///  Simple lookup to find the AmbientProperty corresponding to the given
-            ///  dispid.
-            /// </summary>
-            private AmbientProperty LookupAmbient(int dispid)
-            {
-                for (int i = 0; i < ambientProperties.Length; i++)
-                {
-                    if (ambientProperties[i].DispID == dispid)
-                    {
-                        return ambientProperties[i];
-                    }
-                }
-                Debug.Fail("No ambient property for dispid " + dispid.ToString(CultureInfo.InvariantCulture));
-                return ambientProperties[0];
-            }
-
-            /// <summary>
-            ///  Merges the input region with the current clipping region.
-            ///  The output is always a region that can be fed directly
-            ///  to SetWindowRgn.  The region does not have to be destroyed.
-            ///  The original region is destroyed if a new region is returned.
-            /// </summary>
-            internal IntPtr MergeRegion(IntPtr region)
-            {
-                if (clipRegion == IntPtr.Zero)
-                {
-                    return region;
-                }
-
-                if (region == IntPtr.Zero)
-                {
-                    return clipRegion;
-                }
-
-                IntPtr newRegion = Interop.Gdi32.CreateRectRgn(0, 0, 0, 0);
-                Interop.Gdi32.CombineRgn(newRegion, region, clipRegion, Interop.Gdi32.CombineMode.RGN_DIFF);
-                Interop.Gdi32.DeleteObject(region);
-                return newRegion;
-            }
-
-            private void CallParentPropertyChanged(Control control, string propName)
-            {
-                switch (propName)
-                {
-                    case "BackColor":
-                        control.OnParentBackColorChanged(EventArgs.Empty);
-                        break;
-
-                    case "BackgroundImage":
-                        control.OnParentBackgroundImageChanged(EventArgs.Empty);
-                        break;
-
-                    case "BindingContext":
-                        control.OnParentBindingContextChanged(EventArgs.Empty);
-                        break;
-
-                    case "Enabled":
-                        control.OnParentEnabledChanged(EventArgs.Empty);
-                        break;
-
-                    case "Font":
-                        control.OnParentFontChanged(EventArgs.Empty);
-                        break;
-
-                    case "ForeColor":
-                        control.OnParentForeColorChanged(EventArgs.Empty);
-                        break;
-
-                    case "RightToLeft":
-                        control.OnParentRightToLeftChanged(EventArgs.Empty);
-                        break;
-
-                    case "Visible":
-                        control.OnParentVisibleChanged(EventArgs.Empty);
-                        break;
-
-                    default:
-                        Debug.Fail("There is no property change notification for: " + propName + " on Control.");
-                        break;
-                }
-            }
-
-            /// <summary>
-            ///  Implements IOleControl::OnAmbientPropertyChanged
-            /// </summary>
-            internal void OnAmbientPropertyChange(int dispID)
-            {
-                if (dispID != NativeMethods.ActiveX.DISPID_UNKNOWN)
-                {
-
-                    // Look for a specific property that has changed.
-                    //
-                    for (int i = 0; i < ambientProperties.Length; i++)
-                    {
-                        if (ambientProperties[i].DispID == dispID)
-                        {
-                            ambientProperties[i].ResetValue();
-                            CallParentPropertyChanged(control, ambientProperties[i].Name);
-                            return;
-                        }
-                    }
-
-                    // Special properties that we care about
-                    object obj = new object();
-
-                    switch (dispID)
-                    {
-                        case NativeMethods.ActiveX.DISPID_AMBIENT_UIDEAD:
-                            if (GetAmbientProperty(NativeMethods.ActiveX.DISPID_AMBIENT_UIDEAD, ref obj))
-                            {
-                                activeXState[uiDead] = (bool)obj;
-                            }
-                            break;
-
-                        case NativeMethods.ActiveX.DISPID_AMBIENT_DISPLAYASDEFAULT:
-                            if (control is IButtonControl ibuttonControl && GetAmbientProperty(NativeMethods.ActiveX.DISPID_AMBIENT_DISPLAYASDEFAULT, ref obj))
-                            {
-                                ibuttonControl.NotifyDefault((bool)obj);
-                            }
-                            break;
-                    }
-                }
-                else
-                {
-                    // Invalidate all properties.  Ideally we should be checking each one, but
-                    // that's pretty expensive too.
-                    //
-                    for (int i = 0; i < ambientProperties.Length; i++)
-                    {
-                        ambientProperties[i].ResetValue();
-                        CallParentPropertyChanged(control, ambientProperties[i].Name);
-                    }
-                }
-            }
-
-            /// <summary>
-            ///  Implements IOleInPlaceActiveObject::OnDocWindowActivate.
-            /// </summary>
-            internal void OnDocWindowActivate(int fActivate)
-            {
-                if (activeXState[uiActive] && fActivate != 0 && inPlaceFrame != null)
-                {
-                    // we have to explicitly say we don't wany any border space.
-                    //
-                    int hr = inPlaceFrame.SetBorderSpace(null);
-
-                    if (NativeMethods.Failed(hr) && hr != NativeMethods.INPLACE_E_NOTOOLSPACE && hr != NativeMethods.E_NOTIMPL)
-                    {
-                        Marshal.ThrowExceptionForHR(hr);
-                    }
-                }
-            }
-
-            /// <summary>
-            ///  Called by Control when it gets the focus.
-            /// </summary>
-            internal void OnFocus(bool focus)
-            {
-                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AXSource: SetFocus:  " + focus.ToString());
-                if (activeXState[inPlaceActive] && clientSite is UnsafeNativeMethods.IOleControlSite)
-                {
-                    ((UnsafeNativeMethods.IOleControlSite)clientSite).OnFocus(focus ? 1 : 0);
-                }
-
-                if (focus && activeXState[inPlaceActive] && !activeXState[uiActive])
-                {
-                    InPlaceActivate(NativeMethods.OLEIVERB_UIACTIVATE);
-                }
-            }
-
-            /// <summary>
-            ///  Converts coordinates in pixels to HiMetric.
-            /// </summary>
-            private Point PixelToHiMetric(int x, int y)
-            {
-                Point pt = new Point
-                {
-                    X = (hiMetricPerInch * x + (LogPixels.X >> 1)) / LogPixels.X,
-                    Y = (hiMetricPerInch * y + (LogPixels.Y >> 1)) / LogPixels.Y
-                };
-                return pt;
-            }
-
-            /// <summary>
-            ///  Our implementation of IQuickActivate::QuickActivate
-            /// </summary>
-            internal void QuickActivate(UnsafeNativeMethods.tagQACONTAINER pQaContainer, UnsafeNativeMethods.tagQACONTROL pQaControl)
-            {
-                // Hookup our ambient colors
-                //
-                AmbientProperty prop = LookupAmbient(NativeMethods.ActiveX.DISPID_AMBIENT_BACKCOLOR);
-                prop.Value = ColorTranslator.FromOle(unchecked((int)pQaContainer.colorBack));
-
-                prop = LookupAmbient(NativeMethods.ActiveX.DISPID_AMBIENT_FORECOLOR);
-                prop.Value = ColorTranslator.FromOle(unchecked((int)pQaContainer.colorFore));
-
-                // And our ambient font
-                //
-                if (pQaContainer.pFont != null)
-                {
-
-                    prop = LookupAmbient(NativeMethods.ActiveX.DISPID_AMBIENT_FONT);
-
-                    try
-                    {
-                        IntPtr hfont = IntPtr.Zero;
-                        object objfont = pQaContainer.pFont;
-                        UnsafeNativeMethods.IFont ifont = (UnsafeNativeMethods.IFont)objfont;
-                        hfont = ifont.GetHFont();
-                        Font font = Font.FromHfont(hfont);
-                        prop.Value = font;
-                    }
-                    catch (Exception e)
-                    {
-                        if (ClientUtils.IsSecurityOrCriticalException(e))
-                        {
-                            throw;
-                        }
-
-                        // Do NULL, so we just defer to the default font
-                        prop.Value = null;
-                    }
-                }
-
-                // Now use the rest of the goo that we got passed in.
-                //
-
-                pQaControl.cbSize = Marshal.SizeOf<UnsafeNativeMethods.tagQACONTROL>();
-
-                SetClientSite(pQaContainer.pClientSite);
-
-                if (pQaContainer.pAdviseSink != null)
-                {
-                    SetAdvise(NativeMethods.DVASPECT_CONTENT, 0, (IAdviseSink)pQaContainer.pAdviseSink);
-                }
-
-                ((UnsafeNativeMethods.IOleObject)control).GetMiscStatus(NativeMethods.DVASPECT_CONTENT, out int status);
-                pQaControl.dwMiscStatus = status;
-
-                // Advise the event sink so VB6 can catch events raised from UserControls.
-                // VB6 expects the control to do this during IQuickActivate, otherwise it will not hook events at runtime.
-                // We will do this if all of the following are true:
-                //  1. The container (e.g., vb6) has supplied an event sink
-                //  2. The control is a UserControl (this is only to limit the scope of the changed behavior)
-                //  3. The UserControl has indicated it wants to expose events to COM via the ComSourceInterfacesAttribute
-                // Note that the AdviseHelper handles some non-standard COM interop that is required in order to access
-                // the events on the CLR-supplied CCW (COM-callable Wrapper.
-
-                if ((pQaContainer.pUnkEventSink != null) && (control is UserControl))
-                {
-                    // Check if this control exposes events to COM.
-                    Type eventInterface = GetDefaultEventsInterface(control.GetType());
-
-                    if (eventInterface != null)
-                    {
-
-                        try
-                        {
-                            // For the default source interface, call IConnectionPoint.Advise with the supplied event sink.
-                            // This is easier said than done. See notes in AdviseHelper.AdviseConnectionPoint.
-                            AdviseHelper.AdviseConnectionPoint(control, pQaContainer.pUnkEventSink, eventInterface, out pQaControl.dwEventCookie);
-                        }
-                        catch (Exception e)
-                        {
-                            if (ClientUtils.IsSecurityOrCriticalException(e))
-                            {
-                                throw;
-                            }
-                        }
-                    }
-                }
-
-                if (pQaContainer.pPropertyNotifySink != null && Marshal.IsComObject(pQaContainer.pPropertyNotifySink))
-                {
-                    Marshal.ReleaseComObject(pQaContainer.pPropertyNotifySink);
-                }
-
-                if (pQaContainer.pUnkEventSink != null && Marshal.IsComObject(pQaContainer.pUnkEventSink))
-                {
-                    Marshal.ReleaseComObject(pQaContainer.pUnkEventSink);
-                }
-            }
-
-            /// <summary>
-            ///  Helper class. Calls IConnectionPoint.Advise to hook up a native COM event sink
-            ///  to a manage .NET event interface.
-            ///  The events are exposed to COM by the CLR-supplied COM-callable Wrapper (CCW).
-            /// </summary>
-            internal static class AdviseHelper
-            {
-                /// <summary>
-                ///  Get the COM connection point container from the CLR's CCW and advise for the given event id.
-                /// </summary>
-                public static bool AdviseConnectionPoint(object connectionPoint, object sink, Type eventInterface, out int cookie)
-                {
-
-                    // Note that we cannot simply cast the connectionPoint object to
-                    // System.Runtime.InteropServices.ComTypes.IConnectionPointContainer because the .NET
-                    // object doesn't implement it directly. When the object is exposed to COM, the CLR
-                    // implements IConnectionPointContainer on the proxy object called the CCW or COM-callable wrapper.
-                    // We use the helper class ComConnectionPointContainer to get to the CCW directly
-                    // to to call the interface.
-                    // It is critical to call Dispose to ensure that the IUnknown is released.
-
-                    using (ComConnectionPointContainer cpc = new ComConnectionPointContainer(connectionPoint, true))
-                    {
-                        return AdviseConnectionPoint(cpc, sink, eventInterface, out cookie);
-                    }
-                }
-
-                /// <summary>
-                ///  Find the COM connection point and call Advise for the given event id.
-                /// </summary>
-                internal static bool AdviseConnectionPoint(ComConnectionPointContainer cpc, object sink, Type eventInterface, out int cookie)
-                {
-
-                    // Note that we cannot simply cast the returned IConnectionPoint to
-                    // System.Runtime.InteropServices.ComTypes.IConnectionPoint because the .NET
-                    // object doesn't implement it directly. When the object is exposed to COM, the CLR
-                    // implements IConnectionPoint for the proxy object via the CCW or COM-callable wrapper.
-                    // We use the helper class ComConnectionPoint to get to the CCW directly to to call the interface.
-                    // It is critical to call Dispose to ensure that the IUnknown is released.
-                    using (ComConnectionPoint cp = cpc.FindConnectionPoint(eventInterface))
-                    {
-                        using (SafeIUnknown punkEventsSink = new SafeIUnknown(sink, true))
-                        {
-                            // Finally...we can call IConnectionPoint.Advise to hook up a native COM event sink
-                            // to a managed .NET event interface.
-                            return cp.Advise(punkEventsSink.DangerousGetHandle(), out cookie);
-                        }
-                    }
-                }
-
-                /// <summary>
-                ///  Wraps a native IUnknown in a SafeHandle.
-                ///  See similar implementaton in the <see cref='Transactions.SafeIUnknown'/> class.
-                /// </summary>
-                internal class SafeIUnknown : SafeHandle
-                {
-
-                    /// <summary>
-                    ///  Wrap an incomoing unknown or get the unknown for the CCW (COM-callable wrapper).
-                    /// </summary>
-                    public SafeIUnknown(object obj, bool addRefIntPtr)
-                        : this(obj, addRefIntPtr, Guid.Empty)
-                    {
-                    }
-
-                    /// <summary>
-                    ///  Wrap an incomoing unknown or get the unknown for the CCW (COM-callable wrapper).
-                    ///  If an iid is supplied, QI for the interface and wrap that unknonwn instead.
-                    /// </summary>
-                    public SafeIUnknown(object obj, bool addRefIntPtr, Guid iid)
-                        : base(IntPtr.Zero, true)
-                    {
-
-                        System.Runtime.CompilerServices.RuntimeHelpers.PrepareConstrainedRegions();
-                        try
-                        {
-
-                            // Set this.handle in a finally block to ensure the com ptr is set in the SafeHandle
-                            // even if the runtime throws a exception (such as ThreadAbortException) during the call.
-                            // This ensures that the finalizer will clean up the COM reference.
-                        }
-                        finally
-                        {
-
-                            // Get a raw IUnknown for this object.
-                            // We are responsible for releasing the IUnknown ourselves.
-                            IntPtr unknown;
-
-                            if (obj is IntPtr)
-                            {
-                                unknown = (IntPtr)obj;
-
-                                // The incoming IntPtr may already be reference counted or not, depending on
-                                // where it came from. The caller needs to tell us whether to add-ref or not.
-                                if (addRefIntPtr)
-                                {
-                                    Marshal.AddRef(unknown);
-                                }
-
-                            }
-                            else
-                            {
-                                // GetIUnknownForObject will return a reference-counted object
-                                unknown = Marshal.GetIUnknownForObject(obj);
-                            }
-
-                            // Attempt QueryInterface if an iid is specified.
-                            if (iid != Guid.Empty)
-                            {
-                                IntPtr oldUnknown = unknown;
-                                try
-                                {
-                                    unknown = InternalQueryInterface(unknown, ref iid);
-                                }
-                                finally
-                                {
-                                    // It is critical to release the original unknown if
-                                    // InternalQueryInterface throws out so we don't leak ref counts.
-                                    Marshal.Release(oldUnknown);
-                                }
-                            }
-
-                            // Preserve the com ptr in the SafeHandle.
-                            handle = unknown;
-                        }
-                    }
-
-                    /// <summary>
-                    ///  Helper function for QueryInterface.
-                    /// </summary>
-                    private static IntPtr InternalQueryInterface(IntPtr pUnk, ref Guid iid)
-                    {
-                        int hresult = Marshal.QueryInterface(pUnk, ref iid, out IntPtr ppv);
-                        if (hresult != 0 || ppv == IntPtr.Zero)
-                        {
-                            throw new InvalidCastException(SR.AxInterfaceNotSupported);
-                        }
-                        return ppv;
-                    }
-
-                    /// <summary>
-                    ///  Return whether the handle is invalid.
-                    /// </summary>
-                    public sealed override bool IsInvalid
-                    {
-                        get
-                        {
-                            if (!base.IsClosed)
-                            {
-                                return (IntPtr.Zero == base.handle);
-                            }
-                            return true;
-                        }
-                    }
-
-                    /// <summary>
-                    ///  Release the IUnknown.
-                    /// </summary>
-                    protected sealed override bool ReleaseHandle()
-                    {
-                        IntPtr ptr1 = base.handle;
-                        base.handle = IntPtr.Zero;
-                        if (IntPtr.Zero != ptr1)
-                        {
-                            Marshal.Release(ptr1);
-                        }
-                        return true;
-                    }
-
-                    /// <summary>
-                    ///  Helper function to load a COM v-table from a com object pointer.
-                    /// </summary>
-                    protected V LoadVtable<V>()
-                    {
-                        IntPtr vtblptr = Marshal.ReadIntPtr(handle, 0);
-                        return Marshal.PtrToStructure<V>(vtblptr);
-                    }
-                }
-
-                /// <summary>
-                ///  Helper class to access IConnectionPointContainer from a .NET COM-callable wrapper.
-                ///  The IConnectionPointContainer COM pointer is wrapped in a SafeHandle.
-                /// </summary>
-                internal sealed class ComConnectionPointContainer
-                    : SafeIUnknown
-                {
-
-                    public ComConnectionPointContainer(object obj, bool addRefIntPtr)
-                        : base(obj, addRefIntPtr, typeof(IConnectionPointContainer).GUID)
-                    {
-                        vtbl = base.LoadVtable<VTABLE>();
-                    }
-
-                    private readonly VTABLE vtbl;
-
-                    [StructLayout(LayoutKind.Sequential)]
-                    private class VTABLE
-                    {
-                        public IntPtr QueryInterfacePtr;
-                        public IntPtr AddRefPtr;
-                        public IntPtr ReleasePtr;
-                        public IntPtr EnumConnectionPointsPtr;
-                        public IntPtr FindConnectionPointPtr;
-                    }
-
-                    /// <summary>
-                    ///  Call IConnectionPointContainer.FindConnectionPoint using Delegate.Invoke on the v-table slot.
-                    /// </summary>
-                    public ComConnectionPoint FindConnectionPoint(Type eventInterface)
-                    {
-                        FindConnectionPointD findConnectionPoint = (FindConnectionPointD)Marshal.GetDelegateForFunctionPointer(vtbl.FindConnectionPointPtr, typeof(FindConnectionPointD));
-                        IntPtr result = IntPtr.Zero;
-
-                        Guid iid = eventInterface.GUID;
-                        int hresult = findConnectionPoint.Invoke(handle, ref iid, out result);
-                        if (hresult != 0 || result == IntPtr.Zero)
-                        {
-                            throw new ArgumentException(string.Format(SR.AXNoConnectionPoint, eventInterface.Name));
-                        }
-
-                        return new ComConnectionPoint(result, false);   // result is already ref-counted as an out-param so pass in false
-                    }
-
-                    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-                    private delegate int FindConnectionPointD(IntPtr This, ref Guid iid, out IntPtr ppv);
-                }
-
-                /// <summary>
-                ///  Helper class to access IConnectionPoint from a .NET COM-callable wrapper.
-                ///  The IConnectionPoint COM pointer is wrapped in a SafeHandle.
-                /// </summary>
-                internal sealed class ComConnectionPoint
-                    : SafeIUnknown
-                {
-
-                    public ComConnectionPoint(object obj, bool addRefIntPtr)
-                        : base(obj, addRefIntPtr, typeof(IConnectionPoint).GUID)
-                    {
-                        vtbl = LoadVtable<VTABLE>();
-                    }
-
-                    [StructLayout(LayoutKind.Sequential)]
-                    private class VTABLE
-                    {
-                        public IntPtr QueryInterfacePtr;
-                        public IntPtr AddRefPtr;
-                        public IntPtr ReleasePtr;
-                        public IntPtr GetConnectionInterfacePtr;
-                        public IntPtr GetConnectionPointContainterPtr;
-                        public IntPtr AdvisePtr;
-                        public IntPtr UnadvisePtr;
-                        public IntPtr EnumConnectionsPtr;
-                    }
-
-                    private readonly VTABLE vtbl;
-
-                    /// <summary>
-                    ///  Call IConnectioinPoint.Advise using Delegate.Invoke on the v-table slot.
-                    /// </summary>
-                    public bool Advise(IntPtr punkEventSink, out int cookie)
-                    {
-                        AdviseD advise = (AdviseD)Marshal.GetDelegateForFunctionPointer(vtbl.AdvisePtr, typeof(AdviseD));
-                        if (advise.Invoke(handle, punkEventSink, out cookie) == 0)
-                        {
-                            return true;
-                        }
-                        return false;
-                    }
-
-                    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-                    private delegate int AdviseD(IntPtr This, IntPtr punkEventSink, out int cookie);
-                }
-
-            }
-
-            /// <summary>
-            ///  Return the default COM events interface declared on a .NET class.
-            ///  This looks for the ComSourceInterfacesAttribute and returns the .NET
-            ///  interface type of the first interface declared.
-            /// </summary>
-            private static Type GetDefaultEventsInterface(Type controlType)
-            {
-
-                Type eventInterface = null;
-                object[] custom = controlType.GetCustomAttributes(typeof(ComSourceInterfacesAttribute), false);
-
-                if (custom.Length > 0)
-                {
-                    ComSourceInterfacesAttribute coms = (ComSourceInterfacesAttribute)custom[0];
-                    string eventName = coms.Value.Split(new char[] { '\0' })[0];
-                    eventInterface = controlType.Module.Assembly.GetType(eventName, false);
-                    if (eventInterface == null)
-                    {
-                        eventInterface = Type.GetType(eventName, false);
-                    }
-                }
-
-                return eventInterface;
-            }
-
-            /// <summary>
-            ///  Implements IPersistStorage::Save
-            /// </summary>
-            internal void Save(UnsafeNativeMethods.IStorage stg, bool fSameAsLoad)
-            {
-                UnsafeNativeMethods.IStream stream = stg.CreateStream(GetStreamName(), NativeMethods.STGM_WRITE | NativeMethods.STGM_SHARE_EXCLUSIVE | NativeMethods.STGM_CREATE, 0, 0);
-                Debug.Assert(stream != null, "Stream should be non-null, or an exception should have been thrown.");
-                Save(stream, true);
-                Marshal.ReleaseComObject(stream);
-            }
-
-            /// <summary>
-            ///  Implements IPersistStreamInit::Save
-            /// </summary>
-            internal void Save(UnsafeNativeMethods.IStream stream, bool fClearDirty)
-            {
-                // We do everything through property bags because we support full fidelity
-                // in them.  So, save through that method.
-                //
-                PropertyBagStream bag = new PropertyBagStream();
-                Save(bag, fClearDirty, false);
-                bag.Write(stream);
-
-                if (Marshal.IsComObject(stream))
-                {
-                    Marshal.ReleaseComObject(stream);
-                }
-            }
-
-            /// <summary>
-            ///  Implements IPersistPropertyBag::Save
-            /// </summary>
-            internal void Save(UnsafeNativeMethods.IPropertyBag pPropBag, bool fClearDirty, bool fSaveAllProperties)
-            {
-                PropertyDescriptorCollection props = TypeDescriptor.GetProperties(control,
-                    new Attribute[] { DesignerSerializationVisibilityAttribute.Visible });
-
-                for (int i = 0; i < props.Count; i++)
-                {
-                    if (fSaveAllProperties || props[i].ShouldSerializeValue(control))
-                    {
-                        Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Saving property " + props[i].Name);
-
-                        object propValue;
-
-                        if (IsResourceProp(props[i]))
-                        {
-
-                            // Resource property.  Save this to the bag as a 64bit encoded string.
-                            //
-                            MemoryStream stream = new MemoryStream();
-                            BinaryFormatter formatter = new BinaryFormatter();
-                            formatter.Serialize(stream, props[i].GetValue(control));
-                            byte[] bytes = new byte[(int)stream.Length];
-                            stream.Position = 0;
-                            stream.Read(bytes, 0, bytes.Length);
-                            propValue = Convert.ToBase64String(bytes);
-                            pPropBag.Write(props[i].Name, ref propValue);
-                        }
-                        else
-                        {
-
-                            // Not a resource property.  Persist this using standard type converters.
-                            //
-                            TypeConverter converter = props[i].Converter;
-                            Debug.Assert(converter != null, "No type converter for property '" + props[i].Name + "' on class " + control.GetType().FullName);
-
-                            if (converter.CanConvertFrom(typeof(string)))
-                            {
-                                propValue = converter.ConvertToInvariantString(props[i].GetValue(control));
-                                pPropBag.Write(props[i].Name, ref propValue);
-                            }
-                            else if (converter.CanConvertFrom(typeof(byte[])))
-                            {
-                                byte[] data = (byte[])converter.ConvertTo(null, CultureInfo.InvariantCulture, props[i].GetValue(control), typeof(byte[]));
-                                propValue = Convert.ToBase64String(data);
-                                pPropBag.Write(props[i].Name, ref propValue);
-                            }
-                        }
-                    }
-                }
-
-                if (Marshal.IsComObject(pPropBag))
-                {
-                    Marshal.ReleaseComObject(pPropBag);
-                }
-
-                if (fClearDirty)
-                {
-                    activeXState[isDirty] = false;
-                }
-            }
-
-            /// <summary>
-            ///  Fires the OnSave event to all of our IAdviseSink
-            ///  listeners.  Used for ActiveXSourcing.
-            /// </summary>
-            private void SendOnSave()
-            {
-                int cnt = adviseList.Count;
-                for (int i = 0; i < cnt; i++)
-                {
-                    IAdviseSink s = (IAdviseSink)adviseList[i];
-                    Debug.Assert(s != null, "NULL in our advise list");
-                    s.OnSave();
-                }
-            }
-
-            /// <summary>
-            ///  Implements IViewObject2::SetAdvise.
-            /// </summary>
-            internal void SetAdvise(int aspects, int advf, IAdviseSink pAdvSink)
-            {
-                // if it's not a content aspect, we don't support it.
-                //
-                if ((aspects & NativeMethods.DVASPECT_CONTENT) == 0)
-                {
-                    ThrowHr(NativeMethods.DV_E_DVASPECT);
-                }
-
-                // set up some flags  [we gotta stash for GetAdvise ...]
-                //
-                activeXState[viewAdvisePrimeFirst] = (advf & NativeMethods.ADVF_PRIMEFIRST) != 0 ? true : false;
-                activeXState[viewAdviseOnlyOnce] = (advf & NativeMethods.ADVF_ONLYONCE) != 0 ? true : false;
-
-                if (viewAdviseSink != null && Marshal.IsComObject(viewAdviseSink))
-                {
-                    Marshal.ReleaseComObject(viewAdviseSink);
-                }
-
-                viewAdviseSink = pAdvSink;
-
-                // prime them if they want it [we need to store this so they can get flags later]
-                //
-                if (activeXState[viewAdvisePrimeFirst])
-                {
-                    ViewChanged();
-                }
-            }
-
-            /// <summary>
-            ///  Implements IOleObject::SetClientSite.
-            /// </summary>
-            internal void SetClientSite(UnsafeNativeMethods.IOleClientSite value)
-            {
-                if (clientSite != null)
-                {
-
-                    if (value == null)
-                    {
-                        globalActiveXCount--;
-
-                        if (globalActiveXCount == 0 && IsIE)
-                        {
-
-                            // This the last ActiveX control and we are
-                            // being hosted in IE.  Use private reflection
-                            // to ask SystemEvents to shutdown.  This is to
-                            // prevent a crash.
-
-                            MethodInfo method = typeof(SystemEvents).GetMethod("Shutdown",
-                                                                                BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.InvokeMethod,
-                                                                                null, Array.Empty<Type>(), Array.Empty<ParameterModifier>());
-                            Debug.Assert(method != null, "No Shutdown method on SystemEvents");
-                            if (method != null)
-                            {
-                                method.Invoke(null, null);
-                            }
-                        }
-                    }
-
-                    if (Marshal.IsComObject(clientSite))
-                    {
-                        Marshal.FinalReleaseComObject(clientSite);
-                    }
-                }
-
-                clientSite = value;
-
-                if (clientSite != null)
-                {
-                    control.Site = new AxSourcingSite(control, clientSite, "ControlAxSourcingSite");
-                }
-                else
-                {
-                    control.Site = null;
-                }
-
-                // Get the ambient properties that effect us...
-                //
-                object obj = new object();
-                if (GetAmbientProperty(NativeMethods.ActiveX.DISPID_AMBIENT_UIDEAD, ref obj))
-                {
-                    activeXState[uiDead] = (bool)obj;
-                }
-
-                if (control is IButtonControl && GetAmbientProperty(NativeMethods.ActiveX.DISPID_AMBIENT_UIDEAD, ref obj))
-                {
-                    ((IButtonControl)control).NotifyDefault((bool)obj);
-                }
-
-                if (clientSite == null)
-                {
-                    if (accelTable != IntPtr.Zero)
-                    {
-                        UnsafeNativeMethods.DestroyAcceleratorTable(new HandleRef(this, accelTable));
-                        accelTable = IntPtr.Zero;
-                        accelCount = -1;
-                    }
-
-                    if (IsIE)
-                    {
-                        control.Dispose();
-                    }
-                }
-                else
-                {
-                    globalActiveXCount++;
-
-                    if (globalActiveXCount == 1 && IsIE)
-                    {
-
-                        // This the first ActiveX control and we are
-                        // being hosted in IE.  Use private reflection
-                        // to ask SystemEvents to start.  Startup will only
-                        // restart system events if we previously shut it down.
-                        // This is to prevent a crash.
-                        //
-                        //
-
-                        MethodInfo method = typeof(SystemEvents).GetMethod("Startup",
-                                                                            BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.InvokeMethod,
-                                                                            null, Array.Empty<Type>(), Array.Empty<ParameterModifier>());
-                        Debug.Assert(method != null, "No Startup method on SystemEvents");
-                        if (method != null)
-                        {
-                            method.Invoke(null, null);
-                        }
-                    }
-                }
-                control.OnTopMostActiveXParentChanged(EventArgs.Empty);
-            }
-
-            /// <summary>
-            ///  Implements IOleObject::SetExtent
-            /// </summary>
-            internal void SetExtent(int dwDrawAspect, NativeMethods.tagSIZEL pSizel)
-            {
-                if ((dwDrawAspect & NativeMethods.DVASPECT_CONTENT) != 0)
-                {
-
-                    if (activeXState[changingExtents])
-                    {
-                        return;
-                    }
-
-                    activeXState[changingExtents] = true;
-
-                    try
-                    {
-                        Size size = new Size(HiMetricToPixel(pSizel.cx, pSizel.cy));
-                        Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "SetExtent : new size:" + size.ToString());
-
-                        // If we're in place active, let the in place site set our bounds.
-                        // Otherwise, just set it on our control directly.
-                        //
-                        if (activeXState[inPlaceActive])
-                        {
-                            if (clientSite is UnsafeNativeMethods.IOleInPlaceSite ioleClientSite)
-                            {
-                                Rectangle bounds = control.Bounds;
-                                bounds.Location = new Point(bounds.X, bounds.Y);
-                                Size adjusted = new Size(size.Width, size.Height);
-                                bounds.Width = adjusted.Width;
-                                bounds.Height = adjusted.Height;
-                                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "SetExtent : Announcing to in place site that our rect has changed.");
-                                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "            Announcing rect = " + bounds);
-                                Debug.Assert(clientSite != null, "How can we setextent before we are sited??");
-
-                                ioleClientSite.OnPosRectChange(NativeMethods.COMRECT.FromXYWH(bounds.X, bounds.Y, bounds.Width, bounds.Height));
-                            }
-                        }
-
-                        control.Size = size;
-
-                        // Check to see if the control overwrote our size with
-                        // its own values.
-                        //
-                        if (!control.Size.Equals(size))
-                        {
-                            Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "SetExtent : Control has changed size.  Setting dirty bit");
-                            activeXState[isDirty] = true;
-
-                            // If we're not inplace active, then anounce that the view changed.
-                            //
-                            if (!activeXState[inPlaceActive])
-                            {
-                                ViewChanged();
-                            }
-
-                            // We need to call RequestNewObjectLayout
-                            // here so we visually display our new extents.
-                            //
-                            if (!activeXState[inPlaceActive] && clientSite != null)
-                            {
-                                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "SetExtent : Requesting new Object layout.");
-                                clientSite.RequestNewObjectLayout();
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        activeXState[changingExtents] = false;
-                    }
-                }
-                else
-                {
-                    // We don't support any other aspects
-                    //
-                    ThrowHr(NativeMethods.DV_E_DVASPECT);
-                }
-            }
-
-            /// <summary>
-            ///  Marks our state as in place visible.
-            /// </summary>
-            private void SetInPlaceVisible(bool visible)
-            {
-                activeXState[inPlaceVisible] = visible;
-                control.Visible = visible;
-            }
-
-            /// <summary>
-            ///  Implements IOleInPlaceObject::SetObjectRects.
-            /// </summary>
-            internal void SetObjectRects(NativeMethods.COMRECT lprcPosRect, NativeMethods.COMRECT lprcClipRect)
-            {
-
-#if DEBUG
-                if (CompModSwitches.ActiveX.TraceInfo)
-                {
-                    Debug.WriteLine("SetObjectRects:");
-                    Debug.Indent();
-
-                    if (lprcPosRect != null)
-                    {
-                        Debug.WriteLine("PosLeft:    " + lprcPosRect.left.ToString(CultureInfo.InvariantCulture));
-                        Debug.WriteLine("PosTop:     " + lprcPosRect.top.ToString(CultureInfo.InvariantCulture));
-                        Debug.WriteLine("PosRight:   " + lprcPosRect.right.ToString(CultureInfo.InvariantCulture));
-                        Debug.WriteLine("PosBottom:  " + lprcPosRect.bottom.ToString(CultureInfo.InvariantCulture));
-                    }
-
-                    if (lprcClipRect != null)
-                    {
-                        Debug.WriteLine("ClipLeft:   " + lprcClipRect.left.ToString(CultureInfo.InvariantCulture));
-                        Debug.WriteLine("ClipTop:    " + lprcClipRect.top.ToString(CultureInfo.InvariantCulture));
-                        Debug.WriteLine("ClipRight:  " + lprcClipRect.right.ToString(CultureInfo.InvariantCulture));
-                        Debug.WriteLine("ClipBottom: " + lprcClipRect.bottom.ToString(CultureInfo.InvariantCulture));
-                    }
-                    Debug.Unindent();
-                }
-#endif
-
-                Rectangle posRect = Rectangle.FromLTRB(lprcPosRect.left, lprcPosRect.top, lprcPosRect.right, lprcPosRect.bottom);
-
-                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Set control bounds: " + posRect.ToString());
-
-                // ActiveX expects to be notified when a control's bounds change, and also
-                // intends to notify us through SetObjectRects when we report that the
-                // bounds are about to change.  We implement this all on a control's Bounds
-                // property, which doesn't use this callback mechanism.  The adjustRect
-                // member handles this. If it is non-null, then we are being called in
-                // response to an OnPosRectChange call.  In this case we do not
-                // set the control bounds but set the bounds on the adjustRect.  When
-                // this returns from the container and comes back to our OnPosRectChange
-                // implementation, these new bounds will be handed back to the control
-                // for the actual window change.
-                //
-                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Old Control Bounds: " + control.Bounds);
-                if (activeXState[adjustingRect])
-                {
-                    adjustRect.left = posRect.X;
-                    adjustRect.top = posRect.Y;
-                    adjustRect.right = posRect.Width + posRect.X;
-                    adjustRect.bottom = posRect.Height + posRect.Y;
-                }
-                else
-                {
-                    activeXState[adjustingRect] = true;
-                    try
-                    {
-                        control.Bounds = posRect;
-                    }
-                    finally
-                    {
-                        activeXState[adjustingRect] = false;
-                    }
-                }
-
-                bool setRegion = false;
-
-                if (clipRegion != IntPtr.Zero)
-                {
-                    // Don't delete clipRegion -- after calling SetWindowReg, Windows owns the region.
-                    clipRegion = IntPtr.Zero;
-                    setRegion = true;
-                }
-
-                if (lprcClipRect != null)
-                {
-                    // The container wants us to clip, so figure out if we really
-                    // need to.
-                    Rectangle clipRect = Rectangle.FromLTRB(lprcClipRect.left, lprcClipRect.top, lprcClipRect.right, lprcClipRect.bottom);
-
-                    Rectangle intersect;
-
-                    // Trident always sends an empty ClipRect... and so, we check for that and not do an
-                    // intersect in that case.
-                    if (!clipRect.IsEmpty)
-                    {
-                        intersect = Rectangle.Intersect(posRect, clipRect);
-                    }
-                    else
-                    {
-                        intersect = posRect;
-                    }
-
-                    if (!intersect.Equals(posRect))
-                    {
-                        // Offset the rectangle back to client coordinates
-                        Interop.RECT rcIntersect = intersect;
-                        IntPtr hWndParent = UnsafeNativeMethods.GetParent(new HandleRef(control, control.Handle));
-
-                        Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Old Intersect: " + new Rectangle(rcIntersect.left, rcIntersect.top, rcIntersect.right - rcIntersect.left, rcIntersect.bottom - rcIntersect.top));
-                        Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "New Control Bounds: " + posRect);
-
-                        UnsafeNativeMethods.MapWindowPoints(new HandleRef(null, hWndParent), new HandleRef(control, control.Handle), ref rcIntersect, 2);
-
-                        Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "New Intersect: " + new Rectangle(rcIntersect.left, rcIntersect.top, rcIntersect.right - rcIntersect.left, rcIntersect.bottom - rcIntersect.top));
-
-                        // Create a Win32 region for it
-                        clipRegion = Interop.Gdi32.CreateRectRgn(
-                            rcIntersect.left,
-                            rcIntersect.top,
-                            rcIntersect.right,
-                            rcIntersect.bottom);
-
-                        setRegion = true;
-                        Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Created clipping region");
-                    }
-                }
-
-                // If our region has changed, set the new value.  We only do this if
-                // the handle has been created, since otherwise the control will
-                // merge our region automatically.
-                if (setRegion && control.IsHandleCreated)
-                {
-                    IntPtr finalClipRegion = clipRegion;
-
-                    Region controlRegion = control.Region;
-                    if (controlRegion != null)
-                    {
-                        IntPtr rgn = control.GetHRgn(controlRegion);
-                        finalClipRegion = MergeRegion(rgn);
-                    }
-
-                    UnsafeNativeMethods.SetWindowRgn(new HandleRef(control, control.Handle), new HandleRef(this, finalClipRegion), SafeNativeMethods.IsWindowVisible(new HandleRef(control, control.Handle)));
-                }
-
-                // Yuck.  Forms^3 uses transparent overlay windows that appear to cause
-                // painting artifacts.  Flicker like a banshee.
-                //
-                control.Invalidate();
-            }
-
-#if ACTIVEX_SOURCING
-
-            //
-            // This has been cut from the product.
-            //
-
-            /// <summary>
-            ///  Shows a property page dialog.
-            /// </summary>
-            private void ShowProperties() {
-                if (propPage == null) {
-                    propPage = new ActiveXPropPage(control);
-                }
-
-                if (inPlaceFrame != null) {
-                    inPlaceFrame.EnableModeless(0);
-                }
-                try {
-                    propPage.Edit(control);
-                }
-                finally {
-                    if (inPlaceFrame != null) {
-                        inPlaceFrame.EnableModeless(1);
-                    }
-                }
-            }
-#endif
-
-            /// <summary>
-            ///  Throws the given hresult.  This is used by ActiveX sourcing.
-            /// </summary>
-            internal static void ThrowHr(int hr)
-            {
-                ExternalException e = new ExternalException(SR.ExternalException, hr);
-                throw e;
-            }
-
-            /// <summary>
-            ///  Handles IOleControl::TranslateAccelerator
-            /// </summary>
-            internal int TranslateAccelerator(ref NativeMethods.MSG lpmsg)
-            {
-#if DEBUG
-                if (CompModSwitches.ActiveX.TraceInfo)
-                {
-                    if (!control.IsHandleCreated)
-                    {
-                        Debug.WriteLine("AxSource: TranslateAccelerator before handle creation");
-                    }
-                    else
-                    {
-                        Message m = Message.Create(lpmsg.hwnd, lpmsg.message, lpmsg.wParam, lpmsg.lParam);
-                        Debug.WriteLine("AxSource: TranslateAccelerator : " + m.ToString());
-                    }
-                }
-#endif // DEBUG
-
-                bool needPreProcess = false;
-
-                switch (lpmsg.message)
-                {
-                    case Interop.WindowMessages.WM_KEYDOWN:
-                    case Interop.WindowMessages.WM_SYSKEYDOWN:
-                    case Interop.WindowMessages.WM_CHAR:
-                    case Interop.WindowMessages.WM_SYSCHAR:
-                        needPreProcess = true;
-                        break;
-                }
-
-                Message msg = Message.Create(lpmsg.hwnd, lpmsg.message, lpmsg.wParam, lpmsg.lParam);
-
-                if (needPreProcess)
-                {
-                    Control target = Control.FromChildHandle(lpmsg.hwnd);
-                    if (target != null && (control == target || control.Contains(target)))
-                    {
-                        PreProcessControlState messageState = PreProcessControlMessageInternal(target, ref msg);
-                        switch (messageState)
-                        {
-                            case PreProcessControlState.MessageProcessed:
-                                // someone returned true from PreProcessMessage
-                                // no need to dispatch the message, its already been coped with.
-                                lpmsg.message = msg.Msg;
-                                lpmsg.wParam = msg.WParam;
-                                lpmsg.lParam = msg.LParam;
-                                return NativeMethods.S_OK;
-                            case PreProcessControlState.MessageNeeded:
-                                // Here we need to dispatch the message ourselves
-                                // otherwise the host may never send the key to our wndproc.
-
-                                // Someone returned true from IsInputKey or IsInputChar
-                                UnsafeNativeMethods.TranslateMessage(ref lpmsg);
-                                if (SafeNativeMethods.IsWindowUnicode(new HandleRef(null, lpmsg.hwnd)))
-                                {
-                                    UnsafeNativeMethods.DispatchMessageW(ref lpmsg);
-                                }
-                                else
-                                {
-                                    UnsafeNativeMethods.DispatchMessageA(ref lpmsg);
-                                }
-                                return NativeMethods.S_OK;
-                            case PreProcessControlState.MessageNotNeeded:
-                                // in this case we'll check the site to see if it wants the message.
-                                break;
-                        }
-                    }
-                }
-
-                // SITE processing.  We're not interested in the message, but the site may be.
-
-                int hr = NativeMethods.S_FALSE;
-
-                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource: Control did not process accelerator, handing to site");
-
-                if (clientSite is UnsafeNativeMethods.IOleControlSite ioleClientSite)
-                {
-                    int keyState = 0;
-
-                    if (UnsafeNativeMethods.GetKeyState(NativeMethods.VK_SHIFT) < 0)
-                    {
-                        keyState |= 1;
-                    }
-
-                    if (UnsafeNativeMethods.GetKeyState(NativeMethods.VK_CONTROL) < 0)
-                    {
-                        keyState |= 2;
-                    }
-
-                    if (UnsafeNativeMethods.GetKeyState(NativeMethods.VK_MENU) < 0)
-                    {
-                        keyState |= 4;
-                    }
-
-                    hr = ioleClientSite.TranslateAccelerator(ref lpmsg, keyState);
-                }
-
-                return hr;
-            }
-
-            /// <summary>
-            ///  Implements IOleInPlaceObject::UIDeactivate.
-            /// </summary>
-            internal int UIDeactivate()
-            {
-                // Only do this if we're UI active
-                //
-                if (!activeXState[uiActive])
-                {
-                    return NativeMethods.S_OK;
-                }
-
-                activeXState[uiActive] = false;
-
-                // Notify frame windows, if appropriate, that we're no longer ui-active.
-                //
-                if (inPlaceUiWindow != null)
-                {
-                    inPlaceUiWindow.SetActiveObject(null, null);
-                }
-
-                //May need this for SetActiveObject & OnUIDeactivate, so leave until function return
-                Debug.Assert(inPlaceFrame != null, "No inplace frame -- how dod we go UI active?");
-                inPlaceFrame.SetActiveObject(null, null);
-
-                if (clientSite is UnsafeNativeMethods.IOleInPlaceSite ioleClientSite)
-                {
-                    ioleClientSite.OnUIDeactivate(0);
-                }
-
-                return NativeMethods.S_OK;
-            }
-
-            /// <summary>
-            ///  Implements IOleObject::Unadvise
-            /// </summary>
-            internal void Unadvise(int dwConnection)
-            {
-                if (dwConnection > adviseList.Count || adviseList[dwConnection - 1] == null)
-                {
-                    ThrowHr(NativeMethods.OLE_E_NOCONNECTION);
-                }
-
-                IAdviseSink sink = (IAdviseSink)adviseList[dwConnection - 1];
-                adviseList.RemoveAt(dwConnection - 1);
-                if (sink != null && Marshal.IsComObject(sink))
-                {
-                    Marshal.ReleaseComObject(sink);
-                }
-            }
-
-            /// <summary>
-            ///  Notifies our site that we have changed our size and location.
-            /// </summary>
-            internal void UpdateBounds(ref int x, ref int y, ref int width, ref int height, int flags)
-            {
-                if (!activeXState[adjustingRect] && activeXState[inPlaceVisible])
-                {
-                    if (clientSite is UnsafeNativeMethods.IOleInPlaceSite ioleClientSite)
-                    {
-                        NativeMethods.COMRECT rc = new NativeMethods.COMRECT();
-
-                        if ((flags & NativeMethods.SWP_NOMOVE) != 0)
-                        {
-                            rc.left = control.Left;
-                            rc.top = control.Top;
-                        }
-                        else
-                        {
-                            rc.left = x;
-                            rc.top = y;
-                        }
-
-                        if ((flags & NativeMethods.SWP_NOSIZE) != 0)
-                        {
-                            rc.right = rc.left + control.Width;
-                            rc.bottom = rc.top + control.Height;
-                        }
-                        else
-                        {
-                            rc.right = rc.left + width;
-                            rc.bottom = rc.top + height;
-                        }
-
-                        // This member variable may be modified by SetObjectRects by the container.
-                        adjustRect = rc;
-                        activeXState[adjustingRect] = true;
-
-                        try
-                        {
-                            ioleClientSite.OnPosRectChange(rc);
-                        }
-                        finally
-                        {
-                            adjustRect = null;
-                            activeXState[adjustingRect] = false;
-                        }
-
-                        // On output, the new bounds will be reflected in  rc
-                        if ((flags & NativeMethods.SWP_NOMOVE) == 0)
-                        {
-                            x = rc.left;
-                            y = rc.top;
-                        }
-                        if ((flags & NativeMethods.SWP_NOSIZE) == 0)
-                        {
-                            width = rc.right - rc.left;
-                            height = rc.bottom - rc.top;
-                        }
-                    }
-                }
-            }
-
-            /// <summary>
-            ///  Notifies that the accelerator table needs to be updated due to a change in a control mnemonic.
-            /// </summary>
-            internal void UpdateAccelTable()
-            {
-                // Setting the count to -1 will recreate the table on demand (when GetControlInfo is called).
-                accelCount = -1;
-
-                if (clientSite is UnsafeNativeMethods.IOleControlSite ioleClientSite)
-                {
-                    ioleClientSite.OnControlInfoChanged();
-                }
-            }
-
-            // Since this method is used by Reflection .. dont change the "signature"
-            internal void ViewChangedInternal()
-            {
-                ViewChanged();
-            }
-
-            /// <summary>
-            ///  Notifies our view advise sink (if it exists) that the view has
-            ///  changed.
-            /// </summary>
-            private void ViewChanged()
-            {
-                // send the view change notification to anybody listening.
-                //
-                // Note: Word2000 won't resize components correctly if an OnViewChange notification
-                //       is sent while the component is persisting it's state.  The !m_fSaving check
-                //       is to make sure we don't call OnViewChange in this case.
-                //
-                if (viewAdviseSink != null && !activeXState[saving])
-                {
-                    viewAdviseSink.OnViewChange(NativeMethods.DVASPECT_CONTENT, -1);
-
-                    if (activeXState[viewAdviseOnlyOnce])
-                    {
-                        if (Marshal.IsComObject(viewAdviseSink))
-                        {
-                            Marshal.ReleaseComObject(viewAdviseSink);
-                        }
-                        viewAdviseSink = null;
-                    }
-                }
-            }
-
-            /// <summary>
-            ///  Called when the window handle of the control has changed.
-            /// </summary>
-            void IWindowTarget.OnHandleChange(IntPtr newHandle)
-            {
-                controlWindowTarget.OnHandleChange(newHandle);
-            }
-
-            /// <summary>
-            ///  Called to do control-specific processing for this window.
-            /// </summary>
-            void IWindowTarget.OnMessage(ref Message m)
-            {
-                if (activeXState[uiDead])
-                {
-                    if (m.Msg >= Interop.WindowMessages.WM_MOUSEFIRST && m.Msg <= Interop.WindowMessages.WM_MOUSELAST)
-                    {
-                        return;
-                    }
-                    if (m.Msg >= Interop.WindowMessages.WM_NCLBUTTONDOWN && m.Msg <= Interop.WindowMessages.WM_NCMBUTTONDBLCLK)
-                    {
-                        return;
-                    }
-                    if (m.Msg >= Interop.WindowMessages.WM_KEYFIRST && m.Msg <= Interop.WindowMessages.WM_KEYLAST)
-                    {
-                        return;
-                    }
-                }
-
-                controlWindowTarget.OnMessage(ref m);
-            }
-
-            /// <summary>
-            ///  This is a property bag implementation that sits on a stream.  It can
-            ///  read and write the bag to the stream.
-            /// </summary>
-            private class PropertyBagStream : UnsafeNativeMethods.IPropertyBag
-            {
-                private Hashtable bag = new Hashtable();
-
-                internal void Read(UnsafeNativeMethods.IStream istream)
-                {
-                    // visual basic's memory streams don't support seeking, so we have to
-                    // work around this limitation here.  We do this by copying
-                    // the contents of the stream into a MemoryStream object.
-                    //
-                    Stream stream = new DataStreamFromComStream(istream);
-                    const int PAGE_SIZE = 0x1000; // one page (4096b)
-                    byte[] streamData = new byte[PAGE_SIZE];
-                    int offset = 0;
-
-                    int count = stream.Read(streamData, offset, PAGE_SIZE);
-                    int totalCount = count;
-
-                    while (count == PAGE_SIZE)
-                    {
-                        byte[] newChunk = new byte[streamData.Length + PAGE_SIZE];
-                        Array.Copy(streamData, newChunk, streamData.Length);
-                        streamData = newChunk;
-
-                        offset += PAGE_SIZE;
-                        count = stream.Read(streamData, offset, PAGE_SIZE);
-                        totalCount += count;
-                    }
-
-                    stream = new MemoryStream(streamData);
-
-                    BinaryFormatter formatter = new BinaryFormatter();
-                    try
-                    {
-                        bag = (Hashtable)formatter.Deserialize(stream);
-                    }
-                    catch (Exception e)
-                    {
-                        if (ClientUtils.IsSecurityOrCriticalException(e))
-                        {
-                            throw;
-                        }
-
-                        // Error reading.  Just init an empty hashtable.
-                        bag = new Hashtable();
-                    }
-                }
-
-                int UnsafeNativeMethods.IPropertyBag.Read(string pszPropName, ref object pVar, UnsafeNativeMethods.IErrorLog pErrorLog)
-                {
-                    if (!bag.Contains(pszPropName))
-                    {
-                        return NativeMethods.E_INVALIDARG;
-                    }
-
-                    pVar = bag[pszPropName];
-                    return NativeMethods.S_OK;
-                }
-
-                int UnsafeNativeMethods.IPropertyBag.Write(string pszPropName, ref object pVar)
-                {
-                    bag[pszPropName] = pVar;
-                    return NativeMethods.S_OK;
-                }
-
-                internal void Write(UnsafeNativeMethods.IStream istream)
-                {
-                    Stream stream = new DataStreamFromComStream(istream);
-                    BinaryFormatter formatter = new BinaryFormatter();
-                    formatter.Serialize(stream, bag);
-                }
-            }
-        }
-
-        private class AxSourcingSite : ISite
-        {
-            private readonly IComponent component;
-            private readonly UnsafeNativeMethods.IOleClientSite clientSite;
-            private string name;
-            private HtmlShimManager shimManager;
-
-            internal AxSourcingSite(IComponent component, UnsafeNativeMethods.IOleClientSite clientSite, string name)
-            {
-                this.component = component;
-                this.clientSite = clientSite;
-                this.name = name;
-            }
-
-            /** The component sited by this component site. */
-            public IComponent Component
-            {
-                get
-                {
-                    return component;
-                }
-            }
-
-            /** The container in which the component is sited. */
-            public IContainer Container
-            {
-                get
-                {
-                    return null;
-                }
-            }
-
-            public object GetService(Type service)
-            {
-                object retVal = null;
-
-                if (service == typeof(HtmlDocument))
-                {
-
-                    int hr = clientSite.GetContainer(out UnsafeNativeMethods.IOleContainer iOlecontainer);
-
-                    if (NativeMethods.Succeeded(hr)
-                            && (iOlecontainer is UnsafeNativeMethods.IHTMLDocument))
-                    {
-                        if (shimManager == null)
-                        {
-                            shimManager = new HtmlShimManager();
-                        }
-
-                        retVal = new HtmlDocument(shimManager, iOlecontainer as UnsafeNativeMethods.IHTMLDocument);
-                    }
-
-                }
-                else if (clientSite.GetType().IsAssignableFrom(service))
-                {
-                    retVal = clientSite;
-                }
-
-                return retVal;
-            }
-
-            /** Indicates whether the component is in design mode. */
-            public bool DesignMode
-            {
-                get
-                {
-                    return false;
-                }
-            }
-
-            /**
-             * The name of the component.
-             */
-            public string Name
-            {
-                get { return name; }
-                set
-                {
-                    if (value == null || name == null)
-                    {
-                        name = value;
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        ///  This is a marshaler object that knows how to marshal IFont to Font
-        ///  and back.
-        /// </summary>
-        private class ActiveXFontMarshaler : ICustomMarshaler
-        {
-            private static ActiveXFontMarshaler instance;
-
-            public void CleanUpManagedData(object obj)
-            {
-            }
-
-            public void CleanUpNativeData(IntPtr pObj)
-            {
-                Marshal.Release(pObj);
-            }
-
-            internal static ICustomMarshaler GetInstance(string cookie)
-            {
-                if (instance == null)
-                {
-                    instance = new ActiveXFontMarshaler();
-                }
-                return instance;
-            }
-            public int GetNativeDataSize()
-            {
-                return -1; // not a value type, so use -1
-            }
-
-            public IntPtr MarshalManagedToNative(object obj)
-            {
-                Font font = (Font)obj;
-                NativeMethods.tagFONTDESC fontDesc = new NativeMethods.tagFONTDESC();
-                NativeMethods.LOGFONTW logFont = NativeMethods.LOGFONTW.FromFont(font);
-
-                fontDesc.lpstrName = font.Name;
-                fontDesc.cySize = (long)(font.SizeInPoints * 10000);
-                fontDesc.sWeight = (short)logFont.lfWeight;
-                fontDesc.sCharset = logFont.lfCharSet;
-                fontDesc.fItalic = font.Italic;
-                fontDesc.fUnderline = font.Underline;
-                fontDesc.fStrikethrough = font.Strikeout;
-
-                Guid iid = typeof(UnsafeNativeMethods.IFont).GUID;
-
-                UnsafeNativeMethods.IFont oleFont = UnsafeNativeMethods.OleCreateFontIndirect(fontDesc, ref iid);
-                IntPtr pFont = Marshal.GetIUnknownForObject(oleFont);
-
-                int hr = Marshal.QueryInterface(pFont, ref iid, out IntPtr pIFont);
-
-                Marshal.Release(pFont);
-
-                if (NativeMethods.Failed(hr))
-                {
-                    Marshal.ThrowExceptionForHR(hr);
-                }
-
-                return pIFont;
-            }
-
-            public object MarshalNativeToManaged(IntPtr pObj)
-            {
-                UnsafeNativeMethods.IFont nativeFont = (UnsafeNativeMethods.IFont)Marshal.GetObjectForIUnknown(pObj);
-                IntPtr hfont = nativeFont.GetHFont();
-
-                Font font = null;
-
-                try
-                {
-                    font = Font.FromHfont(hfont);
-                }
-                catch (Exception e)
-                {
-                    if (ClientUtils.IsSecurityOrCriticalException(e))
-                    {
-                        throw;
-                    }
-
-                    font = Control.DefaultFont;
-                }
-
-                return font;
-            }
-        }
-
-        /// <summary>
-        ///  Simple verb enumerator.
-        /// </summary>
-        private class ActiveXVerbEnum : UnsafeNativeMethods.IEnumOLEVERB
-        {
-            private readonly NativeMethods.tagOLEVERB[] verbs;
-            private int current;
-
-            internal ActiveXVerbEnum(NativeMethods.tagOLEVERB[] verbs)
-            {
-                this.verbs = verbs;
-                current = 0;
-            }
-
-            public int Next(int celt, NativeMethods.tagOLEVERB rgelt, int[] pceltFetched)
-            {
-                int fetched = 0;
-
-                if (celt != 1)
-                {
-                    Debug.Fail("Caller of IEnumOLEVERB requested celt > 1, but clr marshalling does not support this.");
-                    celt = 1;
-                }
-
-                while (celt > 0 && current < verbs.Length)
-                {
-                    rgelt.lVerb = verbs[current].lVerb;
-                    rgelt.lpszVerbName = verbs[current].lpszVerbName;
-                    rgelt.fuFlags = verbs[current].fuFlags;
-                    rgelt.grfAttribs = verbs[current].grfAttribs;
-                    celt--;
-                    current++;
-                    fetched++;
-                }
-
-                if (pceltFetched != null)
-                {
-                    pceltFetched[0] = fetched;
-                }
-
-#if DEBUG
-                if (CompModSwitches.ActiveX.TraceInfo)
-                {
-                    Debug.WriteLine("AxSource:IEnumOLEVERB::Next returning " + fetched.ToString(CultureInfo.InvariantCulture) + " verbs:");
-                    Debug.Indent();
-                    for (int i = current - fetched; i < current; i++)
-                    {
-                        Debug.WriteLine(i.ToString(CultureInfo.InvariantCulture) + ": " + verbs[i].lVerb + " " + (verbs[i].lpszVerbName ?? string.Empty));
-                    }
-                    Debug.Unindent();
-                }
-#endif
-                return (celt == 0 ? NativeMethods.S_OK : NativeMethods.S_FALSE);
-            }
-
-            public int Skip(int celt)
-            {
-                if (current + celt < verbs.Length)
-                {
-                    current += celt;
-                    return NativeMethods.S_OK;
-                }
-                else
-                {
-                    current = verbs.Length;
-                    return NativeMethods.S_FALSE;
-                }
-            }
-
-            public void Reset()
-            {
-                current = 0;
-            }
-
-            public void Clone(out UnsafeNativeMethods.IEnumOLEVERB ppenum)
-            {
-                ppenum = new ActiveXVerbEnum(verbs);
-            }
-        }
-
-#if ACTIVEX_SOURCING
-
-        //
-        // This has been cut from the product.
-        //
-
-        /// <summary>
-        ///  The properties window we display.
-        /// </summary>
-        private class ActiveXPropPage {
-            private Form form;
-            private PropertyGrid grid;
-            private ComponentEditor compEditor;
-
-            internal ActiveXPropPage(object component) {
-                compEditor = (ComponentEditor)TypeDescriptor.GetEditor(component, typeof(ComponentEditor));
-
-                if (compEditor == null) {
-                    form = new Form();
-                    grid = new PropertyGrid();
-
-                    form.Text = SR.AXProperties;
-                    form.StartPosition = FormStartPosition.CenterParent;
-                    form.Size = new Size(300, 350);
-                    form.FormBorderStyle = FormBorderStyle.Sizable;
-                    form.MinimizeBox = false;
-                    form.MaximizeBox = false;
-                    form.ControlBox = true;
-                    form.SizeGripStyle = SizeGripStyle.Show;
-                    form.DockPadding.Bottom = 16; // size grip size
-                    form.Icon = new Icon(grid.GetType(), "PropertyGrid");
-
-                    grid.Dock = DockStyle.Fill;
-
-                    form.Controls.Add(grid);
-                }
-            }
-
-            internal void Edit(object editingObject) {
-                if (compEditor != null) {
-                    compEditor.EditComponent(null, editingObject);
-                }
-                else {
-                    grid.SelectedObject = editingObject;
-                    form.ShowDialog();
-                }
-            }
-        }
-
-#endif
-
-        /// <summary>
-        ///  Contains a single ambient property, including DISPID, name and value.
-        /// </summary>
-        private class AmbientProperty
-        {
-            private readonly string name;
-            private readonly int dispID;
-            private object value;
-            private bool empty;
-
-            /// <summary>
-            ///  Creates a new, empty ambient property.
-            ///</summary>
-            internal AmbientProperty(string name, int dispID)
-            {
-                this.name = name;
-                this.dispID = dispID;
-                value = null;
-                empty = true;
-            }
-
-            /// <summary>
-            ///  The windows forms property name.
-            /// </summary>
-            internal string Name
-            {
-                get
-                {
-                    return name;
-                }
-            }
-
-            /// <summary>
-            ///  The DispID for the property.
-            /// </summary>
-            internal int DispID
-            {
-                get
-                {
-                    return dispID;
-                }
-            }
-
-            /// <summary>
-            ///  Returns true if this property has not been set.
-            /// </summary>
-            internal bool Empty
-            {
-                get
-                {
-                    return empty;
-                }
-            }
-
-            /// <summary>
-            ///  The current value of the property.
-            /// </summary>
-            internal object Value
-            {
-                get
-                {
-                    return value;
-                }
-                set
-                {
-                    this.value = value;
-                    empty = false;
-                }
-            }
-
-            /// <summary>
-            ///  Resets the property.
-            /// </summary>
-            internal void ResetValue()
-            {
-                empty = true;
-                value = null;
-            }
-        }
-
-        /// <summary>
-        ///  MetafileDCWrapper is used to wrap a metafile DC so that subsequent
-        ///  paint operations are rendered to a temporary bitmap.  When the
-        ///  wrapper is disposed, it copies the bitmap back to the metafile DC.
-        ///
-        ///  Example:
-        ///
-        ///  using(MetafileDCWrapper dcWrapper = new MetafileDCWrapper(hDC, size) {
-        ///  // ...use dcWrapper.HDC to do painting
-        ///  }
-        /// </summary>
-        private class MetafileDCWrapper : IDisposable
-        {
-            private IntPtr _hBitmap = IntPtr.Zero;
-            private IntPtr _hOriginalBmp = IntPtr.Zero;
-            private readonly HandleRef _hMetafileDC;
-            private Interop.RECT _destRect;
-
-            internal MetafileDCWrapper(HandleRef hOriginalDC, Size size)
-            {
-                Debug.Assert(UnsafeNativeMethods.GetObjectType(hOriginalDC) == NativeMethods.OBJ_ENHMETADC,
-                    "Why wrap a non-Enhanced MetaFile DC?");
-
-                // Security fix: make sure the size has non-negative width and height.
-                if (size.Width < 0 || size.Height < 0)
-                {
-                    throw new ArgumentException(nameof(size), SR.ControlMetaFileDCWrapperSizeInvalid);
-                }
-
-                _hMetafileDC = hOriginalDC;
-                _destRect = new Interop.RECT(0, 0, size.Width, size.Height);
-                HDC = Interop.Gdi32.CreateCompatibleDC(IntPtr.Zero);
-
-                int planes = Interop.Gdi32.GetDeviceCaps(HDC, Interop.Gdi32.DeviceCapability.PLANES);
-                int bitsPixel = Interop.Gdi32.GetDeviceCaps(HDC, Interop.Gdi32.DeviceCapability.BITSPIXEL);
-                _hBitmap = SafeNativeMethods.CreateBitmap(size.Width, size.Height, planes, bitsPixel, IntPtr.Zero);
-                _hOriginalBmp = Interop.Gdi32.SelectObject(HDC, _hBitmap);
-            }
-
-            ~MetafileDCWrapper()
-            {
-                ((IDisposable)this).Dispose();
-            }
-
-            void IDisposable.Dispose()
-            {
-                if (HDC == IntPtr.Zero || _hMetafileDC.Handle == IntPtr.Zero || _hBitmap == IntPtr.Zero)
-                {
-                    return;
-                }
-
-                bool success;
-
-                try
-                {
-                    success = DICopy(_hMetafileDC, HDC, _destRect, true);
-                    Debug.Assert(success, "DICopy() failed.");
-                    Interop.Gdi32.SelectObject(HDC, _hOriginalBmp);
-                    success = Interop.Gdi32.DeleteObject(_hBitmap) != Interop.BOOL.FALSE;
-                    Debug.Assert(success, "DeleteObject() failed.");
-                    success = Interop.Gdi32.DeleteDC(HDC);
-                    Debug.Assert(success, "DeleteObject() failed.");
-                }
-                finally
-                {
-                    // Dispose is done. Set all the handles to IntPtr.Zero so this way the Dispose method executes only once.
-                    HDC = IntPtr.Zero;
-                    _hBitmap = IntPtr.Zero;
-                    _hOriginalBmp = IntPtr.Zero;
-
-                    GC.SuppressFinalize(this);
-                }
-            }
-
-            internal IntPtr HDC { get; private set; } = IntPtr.Zero;
-
-            // ported form VB6 (Ctls\PortUtil\StdCtl.cpp:6176)
-            private unsafe bool DICopy(HandleRef hdcDest, IntPtr hdcSrc, Interop.RECT rect, bool bStretch)
-            {
-                long i;
-
-                // Get the bitmap from the DC by selecting in a 1x1 pixel temp bitmap
-                IntPtr hNullBitmap = SafeNativeMethods.CreateBitmap(1, 1, 1, 1, IntPtr.Zero);
-                if (hNullBitmap == IntPtr.Zero)
-                {
-                    return false;
-                }
-
-                try
-                {
-                    IntPtr hBitmap = Interop.Gdi32.SelectObject(hdcSrc, hNullBitmap);
-                    if (hBitmap == IntPtr.Zero)
-                    {
-                        return false;
-                    }
-
-                    // Restore original bitmap
-                    Interop.Gdi32.SelectObject(hdcSrc, hBitmap);
-
-                    NativeMethods.BITMAP bmp = new NativeMethods.BITMAP();
-                    if (UnsafeNativeMethods.GetObject(new HandleRef(null, hBitmap), Marshal.SizeOf(bmp), bmp) == 0)
-                    {
-                        return false;
-                    }
-
-                    NativeMethods.BITMAPINFO_FLAT lpbmi = new NativeMethods.BITMAPINFO_FLAT
-                    {
-                        bmiHeader_biSize = Marshal.SizeOf<NativeMethods.BITMAPINFOHEADER>(),
-                        bmiHeader_biWidth = bmp.bmWidth,
-                        bmiHeader_biHeight = bmp.bmHeight,
-                        bmiHeader_biPlanes = 1,
-                        bmiHeader_biBitCount = bmp.bmBitsPixel,
-                        bmiHeader_biCompression = NativeMethods.BI_RGB,
-                        bmiHeader_biSizeImage = 0,               //Not needed since using BI_RGB
-                        bmiHeader_biXPelsPerMeter = 0,
-                        bmiHeader_biYPelsPerMeter = 0,
-                        bmiHeader_biClrUsed = 0,
-                        bmiHeader_biClrImportant = 0,
-                        bmiColors = new byte[NativeMethods.BITMAPINFO_MAX_COLORSIZE * 4]
-                    };
-
-                    // Include the palette for 256 color bitmaps
-                    long iColors = 1 << (bmp.bmBitsPixel * bmp.bmPlanes);
-                    if (iColors <= 256)
-                    {
-                        byte[] aj = new byte[Marshal.SizeOf<NativeMethods.PALETTEENTRY>() * 256];
-                        SafeNativeMethods.GetSystemPaletteEntries(hdcSrc, 0, (int)iColors, aj);
-
-                        fixed (byte* pcolors = lpbmi.bmiColors)
-                        {
-                            fixed (byte* ppal = aj)
-                            {
-                                NativeMethods.RGBQUAD* prgb = (NativeMethods.RGBQUAD*)pcolors;
-                                NativeMethods.PALETTEENTRY* lppe = (NativeMethods.PALETTEENTRY*)ppal;
-
-                                // Convert the palette entries to RGB quad entries
-                                for (i = 0; i < (int)iColors; i++)
-                                {
-                                    prgb[i].rgbRed = lppe[i].peRed;
-                                    prgb[i].rgbBlue = lppe[i].peBlue;
-                                    prgb[i].rgbGreen = lppe[i].peGreen;
-                                }
-                            }
-                        }
-                    }
-
-                    // Allocate memory to hold the bitmap bits
-                    long bitsPerScanLine = bmp.bmBitsPixel * (long)bmp.bmWidth;
-                    long bytesPerScanLine = (bitsPerScanLine + 7) / 8;
-                    long totalBytesReqd = bytesPerScanLine * bmp.bmHeight;
-                    byte[] lpBits = new byte[totalBytesReqd];
-
-                    // Get the bitmap bits
-                    int diRet = SafeNativeMethods.GetDIBits(hdcSrc, hBitmap, 0, bmp.bmHeight, lpBits,
-                            ref lpbmi, NativeMethods.DIB_RGB_COLORS);
-                    if (diRet == 0)
-                    {
-                        return false;
-                    }
-
-                    // Set the destination coordiates depending on whether stretch-to-fit was chosen
-                    int xDest, yDest, cxDest, cyDest;
-                    if (bStretch)
-                    {
-                        xDest = rect.left;
-                        yDest = rect.top;
-                        cxDest = rect.right - rect.left;
-                        cyDest = rect.bottom - rect.top;
-                    }
-                    else
-                    {
-                        xDest = rect.left;
-                        yDest = rect.top;
-                        cxDest = bmp.bmWidth;
-                        cyDest = bmp.bmHeight;
-                    }
-
-                    // Paint the bitmap
-                    int iRet = SafeNativeMethods.StretchDIBits(hdcDest,
-                            xDest, yDest, cxDest, cyDest, 0, 0, bmp.bmWidth, bmp.bmHeight,
-                            lpBits, ref lpbmi, NativeMethods.DIB_RGB_COLORS, NativeMethods.SRCCOPY);
-
-                    if (iRet == NativeMethods.GDI_ERROR)
-                    {
-                        return false;
-                    }
-                }
-                finally
-                {
-                    Interop.Gdi32.DeleteObject(hNullBitmap);
-                }
-
-                return true;
-            }
-        }
-
-        /// <summary>
-        ///  An implementation of AccessibleChild for use with Controls
-        /// </summary>
-        [ComVisible(true)]
-        public class ControlAccessibleObject : AccessibleObject
-        {
-            private static IntPtr oleAccAvailable = NativeMethods.InvalidIntPtr;
-
-            // Member variables
-
-            private IntPtr handle = IntPtr.Zero; // Associated window handle (if any)
-            private readonly Control ownerControl = null; // The associated Control for this AccessibleChild (if any)
-            private int[] runtimeId = null; // Used by UIAutomation
-
-            // constructors
-
-            public ControlAccessibleObject(Control ownerControl)
-            {
-
-                Debug.Assert(ownerControl != null, "Cannot construct a ControlAccessibleObject with a null ownerControl");
-
-                this.ownerControl = ownerControl ?? throw new ArgumentNullException(nameof(ownerControl));
-
-                IntPtr handle = ownerControl.Handle;
-
-                Handle = handle;
-            }
-
-            internal ControlAccessibleObject(Control ownerControl, int accObjId)
-            {
-
-                Debug.Assert(ownerControl != null, "Cannot construct a ControlAccessibleObject with a null ownerControl");
-
-                AccessibleObjectId = accObjId; // ...must set this *before* setting the Handle property
-
-                this.ownerControl = ownerControl ?? throw new ArgumentNullException(nameof(ownerControl));
-                IntPtr handle = ownerControl.Handle;
-
-                Handle = handle;
-            }
-
-            /// <summary>
-            ///  For container controls only, return array of child controls sorted into
-            ///  tab index order. This gets applies to the list of child accessible objects
-            ///  as returned by the system, so that we can present a meaningful order to
-            ///  the user. The system defaults to z-order, which is bad for us because
-            ///  that is usually the reverse of tab order!
-            /// </summary>
-            internal override int[] GetSysChildOrder()
-            {
-                if (ownerControl.GetStyle(ControlStyles.ContainerControl))
-                {
-                    return ownerControl.GetChildWindowsInTabOrder();
-                }
-
-                return base.GetSysChildOrder();
-            }
-
-            /// <summary>
-            ///  Perform custom navigation between parent/child/sibling accessible objects,
-            ///  using tab index order as the guide, rather than letting the system default
-            ///  behavior do navigation based on z-order.
-            ///
-            ///  For a container control and its child controls, the accessible object tree
-            ///  looks like this...
-            ///
-            ///  [client area of container]
-            ///   [non-client area of child #1]
-            ///       [random non-client elements]
-            ///       [client area of child #1]
-            ///       [random non-client elements]
-            ///   [non-client area of child #2]
-            ///       [random non-client elements]
-            ///       [client area of child #2]
-            ///       [random non-client elements]
-            ///   [non-client area of child #3]
-            ///       [random non-client elements]
-            ///       [client area of child #3]
-            ///       [random non-client elements]
-            ///
-            ///  We need to intercept first-child / last-child navigation from the container's
-            ///  client object, and next-sibling / previous-sibling navigation from each child's
-            ///  non-client object. All other navigation operations must be allowed to fall back
-            ///  on the system's deafult behavior (provided by OLEACC.DLL).
-            ///
-            ///  When combined with the re-ordering behavior of GetSysChildOrder() above, this
-            ///  allows us to present the end user with the illusion of accessible objects in
-            ///  tab index order, even though the system behavior only supports z-order.
-            /// </summary>
-            internal override bool GetSysChild(AccessibleNavigation navdir, out AccessibleObject accessibleObject)
-            {
-
-                // Clear the out parameter
-                accessibleObject = null;
-
-                // Get the owning control's parent, if it has one
-                Control parentControl = ownerControl.ParentInternal;
-
-                // ctrls[index] will indicate the control at the destination of this navigation operation
-                int index = -1;
-                Control[] ctrls = null;
-
-                // Now handle any 'appropriate' navigation requests...
-                switch (navdir)
-                {
-
-                    case AccessibleNavigation.FirstChild:
-                        if (IsClientObject)
-                        {
-                            ctrls = ownerControl.GetChildControlsInTabOrder(true);
-                            index = 0;
-                        }
-                        break;
-
-                    case AccessibleNavigation.LastChild:
-                        if (IsClientObject)
-                        {
-                            ctrls = ownerControl.GetChildControlsInTabOrder(true);
-                            index = ctrls.Length - 1;
-                        }
-                        break;
-
-                    case AccessibleNavigation.Previous:
-                        if (IsNonClientObject && parentControl != null)
-                        {
-                            ctrls = parentControl.GetChildControlsInTabOrder(true);
-                            index = Array.IndexOf(ctrls, ownerControl);
-                            if (index != -1)
-                            {
-                                --index;
-                            }
-                        }
-                        break;
-
-                    case AccessibleNavigation.Next:
-                        if (IsNonClientObject && parentControl != null)
-                        {
-                            ctrls = parentControl.GetChildControlsInTabOrder(true);
-                            index = Array.IndexOf(ctrls, ownerControl);
-                            if (index != -1)
-                            {
-                                ++index;
-                            }
-                        }
-                        break;
-                }
-
-                // Unsupported navigation operation for this object, or unexpected error.
-                // Return false to force fall back on default system navigation behavior.
-                if (ctrls == null || ctrls.Length == 0)
-                {
-                    return false;
-                }
-
-                // If ctrls[index] is a valid control, return its non-client accessible object.
-                // If index is invalid, return null pointer meaning "end of list reached".
-                if (index >= 0 && index < ctrls.Length)
-                {
-                    accessibleObject = ctrls[index].NcAccessibilityObject;
-                }
-
-                // Return true to use the found accessible object and block default system behavior
-                return true;
-            }
-
-            public override string DefaultAction
-            {
-                get
-                {
-                    string defaultAction = ownerControl.AccessibleDefaultActionDescription;
-                    if (defaultAction != null)
-                    {
-                        return defaultAction;
-                    }
-                    else
-                    {
-                        return base.DefaultAction;
-                    }
-                }
-            }
-
-            // This is used only if control supports IAccessibleEx
-            internal override int[] RuntimeId
-            {
-                get
-                {
-                    if (runtimeId == null)
-                    {
-                        runtimeId = new int[2];
-                        runtimeId[0] = 0x2a;
-                        runtimeId[1] = (int)(long)Handle;
-                    }
-
-                    return runtimeId;
-                }
-            }
-
-            public override string Description
-            {
-                get
-                {
-                    string description = ownerControl.AccessibleDescription;
-                    if (description != null)
-                    {
-                        return description;
-                    }
-                    else
-                    {
-                        return base.Description;
-                    }
-                }
-            }
-
-            public IntPtr Handle
-            {
-
-                get
-                {
-                    return handle;
-                }
-
-                set
-                {
-                    if (handle != value)
-                    {
-                        handle = value;
-
-                        if (oleAccAvailable == IntPtr.Zero)
-                        {
-                            return;
-                        }
-
-                        bool freeLib = false;
-
-                        if (oleAccAvailable == NativeMethods.InvalidIntPtr)
-                        {
-                            oleAccAvailable = Interop.Kernel32.LoadLibraryFromSystemPathIfAvailable("oleacc.dll");
-                            freeLib = (oleAccAvailable != IntPtr.Zero);
-                        }
-
-                        // Update systemIAccessible
-                        // We need to store internally the system provided
-                        // IAccessible, because some windows forms controls use it
-                        // as the default IAccessible implementation.
-                        if (handle != IntPtr.Zero && oleAccAvailable != IntPtr.Zero)
-                        {
-                            UseStdAccessibleObjects(handle);
-                        }
-
-                        if (freeLib)
-                        {
-                            Interop.Kernel32.FreeLibrary(oleAccAvailable);
-                        }
-
-                    }
-                } // end Handle.Set
-
-            } // end Handle
-
-            public override string Help
-            {
-                get
-                {
-                    QueryAccessibilityHelpEventHandler handler = (QueryAccessibilityHelpEventHandler)Owner.Events[EventQueryAccessibilityHelp];
-
-                    if (handler != null)
-                    {
-                        QueryAccessibilityHelpEventArgs args = new QueryAccessibilityHelpEventArgs();
-                        handler(Owner, args);
-                        return args.HelpString;
-                    }
-                    else
-                    {
-                        return base.Help;
-                    }
-                }
-            }
-
-            public override string KeyboardShortcut
-            {
-                get
-                {
-                    // For controls, the default keyboard shortcut comes directly from the accessible
-                    // name property. This matches the default behavior of OLEACC.DLL exactly.
-                    char mnemonic = WindowsFormsUtils.GetMnemonic(TextLabel, false);
-                    return (mnemonic == (char)0) ? null : ("Alt+" + mnemonic);
-                }
-            }
-
-            public override string Name
-            {
-                get
-                {
-                    // Special case: If an explicit name has been set in the AccessibleName property, use that.
-                    // Note: Any non-null value in AccessibleName overrides the default accessible name logic,
-                    // even an empty string (this is the only way to *force* the accessible name to be blank).
-                    string name = ownerControl.AccessibleName;
-                    if (name != null)
-                    {
-                        return name;
-                    }
-
-                    // Otherwise just return the default label string, minus any mnemonics
-                    return WindowsFormsUtils.TextWithoutMnemonics(TextLabel);
-                }
-
-                set
-                {
-                    // If anyone tries to set the accessible name, just cache the value in the control's
-                    // AccessibleName property. This value will then end up overriding the normal accessible
-                    // name logic, until such time as AccessibleName is set back to null.
-                    ownerControl.AccessibleName = value;
-                }
-            }
-
-            public override AccessibleObject Parent
-            {
-                get
-                {
-                    return base.Parent;
-                }
-            }
-
-            // Determine the text that should be used to 'label' this control for accessibility purposes.
-            //
-            // Prior to Whidbey, we just called 'base.Name' to determine the accessible name. This would end up calling
-            // OLEACC.DLL to determine the name. The rules used by OLEACC.DLL are the same as what we now have below,
-            // except that OLEACC searches for preceding labels using z-order, and we want to search for labels using
-            // TabIndex order.
-            //
-            internal string TextLabel
-            {
-                get
-                {
-                    // If owning control allows, use its Text property - but only if that Text is not empty
-                    if (ownerControl.GetStyle(ControlStyles.UseTextForAccessibility))
-                    {
-                        string text = ownerControl.Text;
-                        if (!string.IsNullOrEmpty(text))
-                        {
-                            return text;
-                        }
-                    }
-
-                    // Otherwise use the text of the preceding Label control, if there is one
-                    Label previousLabel = PreviousLabel;
-                    if (previousLabel != null)
-                    {
-                        string text = previousLabel.Text;
-                        if (!string.IsNullOrEmpty(text))
-                        {
-                            return text;
-                        }
-                    }
-
-                    // This control has no discernable MSAA name - return an empty string to indiciate 'nameless'.
-                    return null;
-                }
-            }
-
-            public Control Owner
-            {
-                get
-                {
-                    return ownerControl;
-                }
-            }
-
-            // Look for a label immediately preceeding this control in
-            // the tab order, and use its name for the accessible name.
-            //
-            // This method aims to emulate the equivalent behavior in OLEACC.DLL,
-            // but walking controls in TabIndex order rather than native z-order.
-            //
-            internal Label PreviousLabel
-            {
-                get
-                {
-                    // Try to get to the parent of this control.
-                    Control parent = Owner.ParentInternal;
-
-                    if (parent == null)
-                    {
-                        return null;
-                    }
-
-                    // Find this control's containing control
-                    if (!(parent.GetContainerControl() is ContainerControl container))
-                    {
-                        return null;
-                    }
-
-                    // Walk backwards through peer controls...
-                    for (Control previous = container.GetNextControl(Owner, false);
-                         previous != null;
-                         previous = container.GetNextControl(previous, false))
-                    {
-
-                        // Stop when we hit a Label (whether visible or invisible)
-                        if (previous is Label)
-                        {
-                            return previous as Label;
-                        }
-
-                        // Stop at any *visible* tab stop
-                        if (previous.Visible && previous.TabStop)
-                        {
-                            break;
-                        }
-                    }
-
-                    return null;
-                }
-            }
-
-            public override AccessibleRole Role
-            {
-                get
-                {
-                    AccessibleRole role = ownerControl.AccessibleRole;
-                    if (role != AccessibleRole.Default)
-                    {
-                        return role;
-                    }
-                    else
-                    {
-                        return base.Role;
-                    }
-
-                }
-            }
-
-            public override int GetHelpTopic(out string fileName)
-            {
-                int topic = 0;
-
-                QueryAccessibilityHelpEventHandler handler = (QueryAccessibilityHelpEventHandler)Owner.Events[EventQueryAccessibilityHelp];
-
-                if (handler != null)
-                {
-                    QueryAccessibilityHelpEventArgs args = new QueryAccessibilityHelpEventArgs();
-                    handler(Owner, args);
-
-                    fileName = args.HelpNamespace;
-
-                    try
-                    {
-                        topic = int.Parse(args.HelpKeyword, CultureInfo.InvariantCulture);
-                    }
-                    catch (Exception e)
-                    {
-                        if (ClientUtils.IsSecurityOrCriticalException(e))
-                        {
-                            throw;
-                        }
-                    }
-
-                    return topic;
-                }
-                else
-                {
-                    return base.GetHelpTopic(out fileName);
-                }
-            }
-
-            public void NotifyClients(AccessibleEvents accEvent)
-            {
-                Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, "Control.NotifyClients: this = " +
-                                  ToString() + ", accEvent = " + accEvent.ToString() + ", childID = self");
-
-                UnsafeNativeMethods.NotifyWinEvent((int)accEvent, new HandleRef(this, Handle), NativeMethods.OBJID_CLIENT, 0);
-            }
-
-            public void NotifyClients(AccessibleEvents accEvent, int childID)
-            {
-
-                Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, "Control.NotifyClients: this = " +
-                                  ToString() +
-                                  ", accEvent = " + accEvent.ToString() +
-                                  ", childID = " + childID.ToString(CultureInfo.InvariantCulture));
-
-                UnsafeNativeMethods.NotifyWinEvent((int)accEvent, new HandleRef(this, Handle), NativeMethods.OBJID_CLIENT, childID + 1);
-            }
-
-            public void NotifyClients(AccessibleEvents accEvent, int objectID, int childID)
-            {
-
-                Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, "Control.NotifyClients: this = " +
-                                  ToString() +
-                                  ", accEvent = " + accEvent.ToString() +
-                                  ", childID = " + childID.ToString(CultureInfo.InvariantCulture));
-
-                UnsafeNativeMethods.NotifyWinEvent((int)accEvent, new HandleRef(this, Handle), objectID, childID + 1);
-            }
-
-            /// <summary>
-            /// Raises the LiveRegionChanged UIA event.
-            /// To make this method effective, the control must implement System.Windows.Forms.Automation.IAutomationLiveRegion interface
-            /// and its LiveSetting property must return either AutomationLiveSetting.Polite or AutomationLiveSetting.Assertive value.
-            /// </summary>
-            /// <returns>True if operation succeeds, False otherwise.</returns>
-            public override bool RaiseLiveRegionChanged()
-            {
-                if (!(Owner is IAutomationLiveRegion))
-                {
-                    throw new InvalidOperationException(SR.OwnerControlIsNotALiveRegion);
-                }
-
-                return RaiseAutomationEvent(NativeMethods.UIA_LiveRegionChangedEventId);
-            }
-
-            internal override bool IsIAccessibleExSupported()
-            {
-                if (Owner is IAutomationLiveRegion)
-                {
-                    return true;
-                }
-
-                return base.IsIAccessibleExSupported();
-            }
-
-            internal override object GetPropertyValue(int propertyID)
-            {
-                if (propertyID == NativeMethods.UIA_LiveSettingPropertyId && Owner is IAutomationLiveRegion)
-                {
-                    return ((IAutomationLiveRegion)Owner).LiveSetting;
-                }
-
-                if (Owner.SupportsUiaProviders)
-                {
-                    switch (propertyID)
-                    {
-                        case NativeMethods.UIA_IsKeyboardFocusablePropertyId:
-                            return Owner.CanSelect;
-                        case NativeMethods.UIA_IsOffscreenPropertyId:
-                        case NativeMethods.UIA_IsPasswordPropertyId:
-                            return false;
-                        case NativeMethods.UIA_AccessKeyPropertyId:
-                            return string.Empty;
-                        case NativeMethods.UIA_HelpTextPropertyId:
-                            return Help ?? string.Empty;
-                    }
-                }
-
-                return base.GetPropertyValue(propertyID);
-            }
-
-            internal override UnsafeNativeMethods.IRawElementProviderSimple HostRawElementProvider
-            {
-                get
-                {
-                    UnsafeNativeMethods.UiaHostProviderFromHwnd(new HandleRef(this, Handle), out UnsafeNativeMethods.IRawElementProviderSimple provider);
-                    return provider;
-                }
-            }
-
-            public override string ToString()
-            {
-                if (Owner != null)
-                {
-                    return "ControlAccessibleObject: Owner = " + Owner.ToString();
-                }
-                else
-                {
-                    return "ControlAccessibleObject: Owner = null";
-                }
-            }
-        }
-
-        // Fonts can be a pain to track, so we wrap Hfonts in this class to get a Finalize method.
-        //
-        internal sealed class FontHandleWrapper : MarshalByRefObject, IDisposable
-        {
-#if DEBUG
-            private readonly string stackOnCreate = null;
-            private string stackOnDispose = null;
-            private bool finalizing = false;
-#endif
-            private IntPtr handle;
-
-            internal FontHandleWrapper(Font font)
-            {
-#if DEBUG
-                if (CompModSwitches.LifetimeTracing.Enabled)
-                {
-                    stackOnCreate = new StackTrace().ToString();
-                }
-#endif
-                handle = font.ToHfont();
-            }
-
-            internal IntPtr Handle
-            {
-                get
-                {
-                    Debug.Assert(handle != IntPtr.Zero, "FontHandleWrapper disposed, but still being accessed");
-                    return handle;
-                }
-            }
-
-            public void Dispose()
-            {
-                Dispose(true);
-                GC.SuppressFinalize(this);
-            }
-
-            private void Dispose(bool disposing)
-            {
-
-#if DEBUG
-                Debug.Assert(finalizing || this != defaultFontHandleWrapper, "Don't dispose the defaultFontHandleWrapper");
-#endif
-
-                if (handle != IntPtr.Zero)
-                {
-#if DEBUG
-                    if (CompModSwitches.LifetimeTracing.Enabled)
-                    {
-                        stackOnDispose = new StackTrace().ToString();
-                    }
-#endif
-                    Interop.Gdi32.DeleteObject(handle);
-                    handle = IntPtr.Zero;
-                }
-
-            }
-
-            ~FontHandleWrapper()
-            {
-#if DEBUG
-                finalizing = true;
-#endif
-                Dispose(false);
-            }
-        }
-
-        /// <summary>
-        ///  Used with BeginInvoke/EndInvoke
-        /// </summary>
-        private class ThreadMethodEntry : IAsyncResult
-        {
-            internal Control caller;
-            internal Control marshaler;
-            internal Delegate method;
-            internal object[] args;
-            internal object retVal;
-            internal Exception exception;
-            internal bool synchronous;
-            private bool isCompleted;
-            private ManualResetEvent resetEvent;
-            private readonly object invokeSyncObject = new object();
-
-            // Store the execution context associated with the caller thread, and
-            // information about which thread actually got the stack applied to it.
-            //
-            internal ExecutionContext executionContext;
-
-            // Optionally store the synchronization context associated with the callee thread.
-            // This overrides the sync context in the execution context of the caller thread.
-            //
-            internal SynchronizationContext syncContext = null;
-
-            internal ThreadMethodEntry(Control caller, Control marshaler, Delegate method, object[] args, bool synchronous, ExecutionContext executionContext)
-            {
-                this.caller = caller;
-                this.marshaler = marshaler;
-                this.method = method;
-                this.args = args;
-                exception = null;
-                retVal = null;
-                this.synchronous = synchronous;
-                isCompleted = false;
-                resetEvent = null;
-                this.executionContext = executionContext;
-            }
-
-            ~ThreadMethodEntry()
-            {
-                if (resetEvent != null)
-                {
-                    resetEvent.Close();
-                }
-            }
-
-            public object AsyncState
-            {
-                get
-                {
-                    return null;
-                }
-            }
-
-            public WaitHandle AsyncWaitHandle
-            {
-                get
-                {
-                    if (resetEvent == null)
-                    {
-                        // Locking 'this' here is ok since this is an internal class.
-                        lock (invokeSyncObject)
-                        {
-                            // BeginInvoke hangs on Multi-proc system:
-                            // taking the lock prevents a race condition between IsCompleted
-                            // boolean flag and resetEvent mutex in multiproc scenarios.
-                            if (resetEvent == null)
-                            {
-                                resetEvent = new ManualResetEvent(false);
-                                if (isCompleted)
-                                {
-                                    resetEvent.Set();
-                                }
-                            }
-                        }
-                    }
-                    return (WaitHandle)resetEvent;
-                }
-            }
-
-            public bool CompletedSynchronously
-            {
-                get
-                {
-                    if (isCompleted && synchronous)
-                    {
-                        return true;
-                    }
-
-                    return false;
-                }
-            }
-
-            public bool IsCompleted
-            {
-                get
-                {
-                    return isCompleted;
-                }
-            }
-
-            internal void Complete()
-            {
-                lock (invokeSyncObject)
-                {
-                    isCompleted = true;
-                    if (resetEvent != null)
-                    {
-                        resetEvent.Set();
-                    }
-                }
-            }
-        }
-
-        private class ControlVersionInfo
-        {
-            private string companyName = null;
-            private string productName = null;
-            private string productVersion = null;
-            private FileVersionInfo versionInfo = null;
-            private readonly Control owner;
-
-            internal ControlVersionInfo(Control owner)
-            {
-                this.owner = owner;
-            }
-
-            /// <summary>
-            ///  The company name associated with the component.
-            /// </summary>
-            internal string CompanyName
-            {
-                get
-                {
-                    if (companyName == null)
-                    {
-                        object[] attrs = owner.GetType().Module.Assembly.GetCustomAttributes(typeof(AssemblyCompanyAttribute), false);
-                        if (attrs != null && attrs.Length > 0)
-                        {
-                            companyName = ((AssemblyCompanyAttribute)attrs[0]).Company;
-                        }
-
-                        if (companyName == null || companyName.Length == 0)
-                        {
-                            companyName = GetFileVersionInfo().CompanyName;
-                            if (companyName != null)
-                            {
-                                companyName = companyName.Trim();
-                            }
-                        }
-
-                        if (companyName == null || companyName.Length == 0)
-                        {
-                            string ns = owner.GetType().Namespace;
-
-                            if (ns == null)
-                            {
-                                ns = string.Empty;
-                            }
-
-                            int firstDot = ns.IndexOf('/');
-                            if (firstDot != -1)
-                            {
-                                companyName = ns.Substring(0, firstDot);
-                            }
-                            else
-                            {
-                                companyName = ns;
-                            }
-                        }
-                    }
-                    return companyName;
-                }
-            }
-
-            /// <summary>
-            ///  The product name associated with this component.
-            /// </summary>
-            internal string ProductName
-            {
-                get
-                {
-                    if (productName == null)
-                    {
-                        object[] attrs = owner.GetType().Module.Assembly.GetCustomAttributes(typeof(AssemblyProductAttribute), false);
-                        if (attrs != null && attrs.Length > 0)
-                        {
-                            productName = ((AssemblyProductAttribute)attrs[0]).Product;
-                        }
-
-                        if (productName == null || productName.Length == 0)
-                        {
-                            productName = GetFileVersionInfo().ProductName;
-                            if (productName != null)
-                            {
-                                productName = productName.Trim();
-                            }
-                        }
-
-                        if (productName == null || productName.Length == 0)
-                        {
-                            string ns = owner.GetType().Namespace;
-
-                            if (ns == null)
-                            {
-                                ns = string.Empty;
-                            }
-                            int firstDot = ns.IndexOf('.');
-                            if (firstDot != -1)
-                            {
-                                productName = ns.Substring(firstDot + 1);
-                            }
-                            else
-                            {
-                                productName = ns;
-                            }
-                        }
-                    }
-
-                    return productName;
-                }
-            }
-
-            /// <summary>
-            ///  The product version associated with this component.
-            /// </summary>
-            internal string ProductVersion
-            {
-                get
-                {
-                    if (productVersion == null)
-                    {
-                        // custom attribute
-                        //
-                        object[] attrs = owner.GetType().Module.Assembly.GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false);
-                        if (attrs != null && attrs.Length > 0)
-                        {
-                            productVersion = ((AssemblyInformationalVersionAttribute)attrs[0]).InformationalVersion;
-                        }
-
-                        // win32 version info
-                        //
-                        if (productVersion == null || productVersion.Length == 0)
-                        {
-                            productVersion = GetFileVersionInfo().ProductVersion;
-                            if (productVersion != null)
-                            {
-                                productVersion = productVersion.Trim();
-                            }
-                        }
-
-                        // fake it
-                        //
-                        if (productVersion == null || productVersion.Length == 0)
-                        {
-                            productVersion = "1.0.0.0";
-                        }
-                    }
-                    return productVersion;
-                }
-            }
-
-            /// <summary>
-            ///  Retrieves the FileVersionInfo associated with the main module for
-            ///  the component.
-            /// </summary>
-            private FileVersionInfo GetFileVersionInfo()
-            {
-                if (versionInfo == null)
-                {
-                    string path = owner.GetType().Module.FullyQualifiedName;
-
-                    versionInfo = FileVersionInfo.GetVersionInfo(path);
-                }
-                return versionInfo;
-            }
-        }
-
-        private sealed class MultithreadSafeCallScope : IDisposable
-        {
-            // Use local stack variable rather than a refcount since we're
-            // guaranteed that these 'scopes' are properly nested.
-            private readonly bool resultedInSet;
-
-            internal MultithreadSafeCallScope()
-            {
-                // Only access the thread-local stuff if we're going to be
-                // checking for illegal thread calling (no need to incur the
-                // expense otherwise).
-                if (checkForIllegalCrossThreadCalls && !inCrossThreadSafeCall)
-                {
-                    inCrossThreadSafeCall = true;
-                    resultedInSet = true;
-                }
-                else
-                {
-                    resultedInSet = false;
-                }
-            }
-
-            void IDisposable.Dispose()
-            {
-                if (resultedInSet)
-                {
-                    inCrossThreadSafeCall = false;
-                }
-            }
-        }
-
-        private sealed class PrintPaintEventArgs : PaintEventArgs
-        {
-            Message m;
-
-            internal PrintPaintEventArgs(Message m, IntPtr dc, Rectangle clipRect)
-                : base(dc, clipRect)
-            {
-                this.m = m;
-            }
-
-            internal Message Message
-            {
-                get
-                {
-                    return m;
-                }
-            }
-        }
-
-    } // end class Control
-
-} // end namespace System.Windows.Forms
-
-
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -4746,8 +4746,8 @@ namespace System.Windows.Forms
         {
             DefWndProc(ref m);
 
-            DpiChangedEventArgs e = new DpiChangedEventArgs(deviceDpi, m);
-            deviceDpi = e.DeviceDpiNew;
+            DpiChangedEventArgs e = new DpiChangedEventArgs(_deviceDpi, m);
+            _deviceDpi = e.DeviceDpiNew;
 
             OnDpiChanged(e);
         }
@@ -4777,7 +4777,7 @@ namespace System.Windows.Forms
             DefWndProc(ref m);
 
             Size desiredSize = new Size();
-            if (OnGetDpiScaledSize(deviceDpi, NativeMethods.Util.SignedLOWORD(m.WParam), ref desiredSize))
+            if (OnGetDpiScaledSize(_deviceDpi, NativeMethods.Util.SignedLOWORD(m.WParam), ref desiredSize))
             {
                 m.Result = (IntPtr)(unchecked((Size.Height & 0xFFFF) << 16) | (Size.Width & 0xFFFF));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -286,7 +286,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     btnDropDown.LostFocus += new EventHandler(OnChildLostFocus);
                     btnDropDown.TabIndex = 2;
                     CommonEditorSetup(btnDropDown);
-                    btnDropDown.Size = DpiHelper.IsScalingRequirementMet ? new Size(SystemInformation.VerticalScrollBarArrowHeightForDpi(deviceDpi), RowHeight) : new Size(SystemInformation.VerticalScrollBarArrowHeight, RowHeight);
+                    btnDropDown.Size = DpiHelper.IsScalingRequirementMet ? new Size(SystemInformation.VerticalScrollBarArrowHeightForDpi(_deviceDpi), RowHeight) : new Size(SystemInformation.VerticalScrollBarArrowHeight, RowHeight);
                 }
                 return btnDropDown;
             }
@@ -316,7 +316,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     btnDialog.KeyDown += new KeyEventHandler(OnBtnKeyDown);
                     btnDialog.GotFocus += new EventHandler(OnDropDownButtonGotFocus);
                     btnDialog.LostFocus += new EventHandler(OnChildLostFocus);
-                    btnDialog.Size = DpiHelper.IsScalingRequirementMet ? new Size(SystemInformation.VerticalScrollBarArrowHeightForDpi(deviceDpi), RowHeight) : new Size(SystemInformation.VerticalScrollBarArrowHeight, RowHeight);
+                    btnDialog.Size = DpiHelper.IsScalingRequirementMet ? new Size(SystemInformation.VerticalScrollBarArrowHeightForDpi(_deviceDpi), RowHeight) : new Size(SystemInformation.VerticalScrollBarArrowHeight, RowHeight);
                     CommonEditorSetup(btnDialog);
                 }
                 return btnDialog;
@@ -5109,7 +5109,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             if ((fBtnDialog || fBtnDropDown) && !gridEntry.ShouldRenderReadOnly && FocusInside)
             {
                 Control btn = fBtnDropDown ? (Control)DropDownButton : (Control)DialogButton;
-                Size sizeBtn = DpiHelper.IsScalingRequirementMet ? new Size(SystemInformation.VerticalScrollBarArrowHeightForDpi(deviceDpi), RowHeight) :
+                Size sizeBtn = DpiHelper.IsScalingRequirementMet ? new Size(SystemInformation.VerticalScrollBarArrowHeightForDpi(_deviceDpi), RowHeight) :
                                                                                new Size(SystemInformation.VerticalScrollBarArrowHeight, RowHeight);
                 Rectangle rectTarget = new Rectangle(rect.X + rect.Width - sizeBtn.Width,
                                                       rect.Y,
@@ -5988,7 +5988,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         var isScalingRequirementMet = DpiHelper.IsScalingRequirementMet;
                         if (isScalingRequirementMet)
                         {
-                            btnDropDown.Size = new Size(SystemInformation.VerticalScrollBarArrowHeightForDpi(deviceDpi), RowHeight);
+                            btnDropDown.Size = new Size(SystemInformation.VerticalScrollBarArrowHeightForDpi(_deviceDpi), RowHeight);
                         }
                         else
                         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
@@ -432,11 +432,11 @@ namespace System.Windows.Forms
 
             if (Multiline && !WordWrap && (ScrollBars & ScrollBars.Horizontal) != 0)
             {
-                scrollBarPadding.Height += SystemInformation.GetHorizontalScrollBarHeightForDpi(deviceDpi);
+                scrollBarPadding.Height += SystemInformation.GetHorizontalScrollBarHeightForDpi(_deviceDpi);
             }
             if (Multiline && (ScrollBars & ScrollBars.Vertical) != 0)
             {
-                scrollBarPadding.Width += SystemInformation.GetVerticalScrollBarWidthForDpi(deviceDpi);
+                scrollBarPadding.Width += SystemInformation.GetVerticalScrollBarWidthForDpi(_deviceDpi);
             }
 
             // Subtract the scroll bar padding before measuring

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -922,7 +922,7 @@ namespace System.Windows.Forms
                 int height = FontHeight;
                 if (borderStyle != BorderStyle.None)
                 {
-                    height += SystemInformation.GetBorderSizeForDpi(deviceDpi).Height * 4 + 3;
+                    height += SystemInformation.GetBorderSizeForDpi(_deviceDpi).Height * 4 + 3;
                 }
                 return height;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
@@ -730,7 +730,7 @@ namespace System.Windows.Forms
                 {
                     // The following does not get set, since dropDown has no parent/is not part of the
                     // controls collection, so this gets never called through the normal inheritance chain.
-                    item.dropDown.deviceDpi = newDpi;
+                    item.dropDown._deviceDpi = newDpi;
                     item.dropDown.ResetScaling(newDpi);
 
                     foreach (ToolStripItem childItem in item.DropDown.Items)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VScrollBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VScrollBar.cs
@@ -34,7 +34,7 @@ namespace System.Windows.Forms
             {
                 if (DpiHelper.IsScalingRequirementMet)
                 {
-                    return new Size(SystemInformation.GetVerticalScrollBarWidthForDpi(deviceDpi), LogicalToDeviceUnits(DefaultHeight));
+                    return new Size(SystemInformation.GetVerticalScrollBarWidthForDpi(_deviceDpi), LogicalToDeviceUnits(DefaultHeight));
                 }
                 else
                 {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.cs
@@ -42,7 +42,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(Padding.Empty, control.DefaultPadding);
             Assert.Equal(Size.Empty, control.DefaultSize);
             Assert.False(control.DesignMode);
-            Assert.Equal(DpiHelper.DeviceDpi, control.deviceDpi);
+            Assert.Equal(DpiHelper.DeviceDpi, control._deviceDpi);
             Assert.Equal(Rectangle.Empty, control.DisplayRectangle);
             Assert.Equal(DockStyle.None, control.Dock);
             Assert.True(control.Enabled);
@@ -103,7 +103,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(Padding.Empty, control.DefaultPadding);
             Assert.Equal(Size.Empty, control.DefaultSize);
             Assert.False(control.DesignMode);
-            Assert.Equal(DpiHelper.DeviceDpi, control.deviceDpi);
+            Assert.Equal(DpiHelper.DeviceDpi, control._deviceDpi);
             Assert.Equal(Rectangle.Empty, control.DisplayRectangle);
             Assert.Equal(DockStyle.None, control.Dock);
             Assert.True(control.Enabled);
@@ -172,7 +172,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(Padding.Empty, control.DefaultPadding);
             Assert.Equal(Size.Empty, control.DefaultSize);
             Assert.False(control.DesignMode);
-            Assert.Equal(DpiHelper.DeviceDpi, control.deviceDpi);
+            Assert.Equal(DpiHelper.DeviceDpi, control._deviceDpi);
             Assert.Equal(new Rectangle(0, 0, width, height), control.DisplayRectangle);
             Assert.Equal(DockStyle.None, control.Dock);
             Assert.True(control.Enabled);
@@ -241,7 +241,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(Padding.Empty, control.DefaultPadding);
             Assert.Equal(Size.Empty, control.DefaultSize);
             Assert.False(control.DesignMode);
-            Assert.Equal(DpiHelper.DeviceDpi, control.deviceDpi);
+            Assert.Equal(DpiHelper.DeviceDpi, control._deviceDpi);
             Assert.Equal(Rectangle.Empty, control.DisplayRectangle);
             Assert.Equal(DockStyle.None, control.Dock);
             Assert.True(control.Enabled);
@@ -312,7 +312,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(Padding.Empty, control.DefaultPadding);
             Assert.Equal(Size.Empty, control.DefaultSize);
             Assert.False(control.DesignMode);
-            Assert.Equal(DpiHelper.DeviceDpi, control.deviceDpi);
+            Assert.Equal(DpiHelper.DeviceDpi, control._deviceDpi);
             Assert.Equal(new Rectangle(0, 0, width, height), control.DisplayRectangle);
             Assert.Equal(DockStyle.None, control.Dock);
             Assert.True(control.Enabled);


### PR DESCRIPTION
Break out all of the nested classes in Control into separate files.
Pull most of the field names into line with coding styles.
Clean up some comments and collapse some code.
Remove dead code.

VS was choking with all of the style violations in Control. This should hopefully make working on Control a lot less painful and set us up for further cleanup.

No functional changes were made.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1475)