### PR TITLE
The CellParsing event of the datagridview can't be invoked when changing the value of the cell firstly #1098

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -26804,6 +26804,19 @@ namespace System.Windows.Forms
             }
         }
 
+        internal void SetAccessibleObjectParent(AccessibleObject editingControlAccessibleObject)
+        {
+            if (CurrentCell == null)
+            {
+                return;
+            }
+
+            editingControlAccessibleObject.SetParent(CurrentCell.AccessibilityObject);
+
+            CurrentCell.AccessibilityObject.SetDetachableChild(editingControlAccessibleObject);
+            CurrentCell.AccessibilityObject.RaiseStructureChangedEvent(UnsafeNativeMethods.StructureChangeType.ChildAdded, editingControlAccessibleObject.RuntimeId);
+        }
+
         private bool SetAndSelectCurrentCellAddress(int columnIndex,
             int rowIndex,
             bool setAnchorCellAddress,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -2580,10 +2580,6 @@ namespace System.Windows.Forms
                 dgv.ComboBoxControlWasDetached = false;
                 dgv.TextBoxControlWasDetached = false;
             }
-
-            dgv.EditingControlAccessibleObject.SetParent(AccessibilityObject);
-            AccessibilityObject.SetDetachableChild(dgv.EditingControl.AccessibilityObject);
-            AccessibilityObject.RaiseStructureChangedEvent(UnsafeNativeMethods.StructureChangeType.ChildAdded, dgv.EditingControlAccessibleObject.RuntimeId);
         }
 
         protected virtual bool KeyDownUnsharesRow(KeyEventArgs e, int rowIndex)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs
@@ -156,6 +156,13 @@ namespace System.Windows.Forms
                 NotifyDataGridViewOfValueChange();
             }
         }
+
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+
+            dataGridView.SetAccessibleObjectParent(this.AccessibilityObject);
+        }
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
@@ -295,6 +295,13 @@ namespace System.Windows.Forms
                 return HorizontalAlignment.Left;
             }
         }
+
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+
+            dataGridView.SetAccessibleObjectParent(this.AccessibilityObject);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1098 


## Proposed changes

- Reworking `DataGridViewCell.InitializeEditingControl()` method to delay EditingControlAccessibleObject initialization until DataGridView EditingControl is initialized and its handle is created.
- Delaying EditingControlAccessibleObject initialization is done by moving dgv.EditingControlAccessibleObject.get() call to dgv.EditingControl.HandleCreated event handler, so we have EditingControlAccessibleObject accessed only after the control's handle creation.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![Bug_1098_Before](https://user-images.githubusercontent.com/23213980/62045062-13527200-b20d-11e9-9068-bb915d17ae0e.gif)

* For the first time control's handle is created when accessing EditingControlAccessibleObject.

### After

![Bug_1098_After](https://user-images.githubusercontent.com/23213980/62045071-1c434380-b20d-11e9-87ec-682bb17dbb31.gif)

* For the first time control's handle is created and the EditingControlAccessibleObject is accessed.

## Test methodology <!-- How did you ensure quality? -->

- Manual testing, debugging, Narrator announcement - passed.
- Need QA approval.
- Need to test near cases and search for regressions.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

.NET Core SDK (reflecting any global.json):
 Version:   3.0.100-preview8-012929
 Commit:    795f8aeaa8

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.18362
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\3.0.100-preview8-012929\

Host (useful for support):
  Version: 3.0.0-preview8-27907-09
  Commit:  fc924dc319

.NET Core SDKs installed:
  2.1.700-preview-009601 [C:\Program Files\dotnet\sdk]
  2.1.800-preview-009696 [C:\Program Files\dotnet\sdk]
  3.0.100-preview8-012929 [C:\Program Files\dotnet\sdk]

.NET Core runtimes installed:
  Microsoft.AspNetCore.All 2.1.9 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.All]
  Microsoft.AspNetCore.All 2.1.11 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.All]
  Microsoft.AspNetCore.App 2.1.9 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.AspNetCore.App 2.1.11 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.AspNetCore.App 3.0.0-preview8.19351.9 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 2.1.9 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 2.1.11 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 3.0.0-preview8-27907-09 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.WindowsDesktop.App 3.0.0-preview8-27907-09 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]

To install additional .NET Core runtimes or SDKs:
  https://aka.ms/dotnet-download

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1524)