### PR TITLE
Disable WinFormsControlsClassicTests.csproj on non-windows platforms

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/WinFormsControlsClassicTests/WinFormsControlsClassicTests.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinFormsControlsClassicTests/WinFormsControlsClassicTests.csproj
@@ -336,4 +336,6 @@
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="Build" Condition="'$(OS)' != 'Windows_NT'">
+  </Target>
 </Project>


### PR DESCRIPTION
I opted to do it this way because it is an old-style project that only supports .NET Framework. Therefore by overriding `Build` to be a nop on Unix we can avoid failures in the build

Old error:

> /Users/hugh/Documents/GitHub/winforms/.dotnet/sdk/3.0.100-preview6-012264/Microsoft.Common.CurrentVersion.targets(1175,5): error MSB3644: The reference assemblies for .NETFramework,Version=v4.7.2 were not found. To resolve this, install the Developer Pack (SDK/Targeting Pack) for this framework version or retarget your application. You can download .NET Framework Developer Packs at https://aka.ms/msbuild/developerpacks [/Users/hugh/Documents/GitHub/winforms/src/System.Windows.Forms/tests/IntegrationTests/WinFormsControlsClassicTests/WinFormsControlsClassicTests.csproj]

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1540)