### PR TITLE
Porting DataMemberFieldConverter into core

### DIFF
--- a/src/System.Windows.Forms.Design/src/Resources/SR.resx
+++ b/src/System.Windows.Forms.Design/src/Resources/SR.resx
@@ -171,6 +171,12 @@
   <data name="DesignerOptions_SnapToGridDesc" xml:space="preserve">
     <value>Controls whether designers should snap to grid dots when LayoutMode = SnapToGrid.</value>
   </data>
+  <data name="None" xml:space="preserve">
+    <value>(None)</value>
+  </data>
+  <data name="None_lc" xml:space="preserve">
+    <value>(none)</value>
+  </data>
   <data name="NotImplementedByDesign" xml:space="preserve">
     <value>This method/object is not implemented by design.</value>
   </data>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.cs.xlf
@@ -513,6 +513,16 @@
         <target state="translated">Hodnota {1} není platnou hodnotou pro argument {0}. Hodnota {0} musí být v rozsahu od {2} do {3}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="None_lc">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotImplementedByDesign">
         <source>This method/object is not implemented by design.</source>
         <target state="translated">Tuto metodu nebo objekt návrh neimplementuje.</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.de.xlf
@@ -513,6 +513,16 @@
         <target state="translated">{1} ist kein gültiger Wert für {0}. {0} sollte zwischen {2} und {3} liegen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="None_lc">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotImplementedByDesign">
         <source>This method/object is not implemented by design.</source>
         <target state="translated">Diese Methode/dieses Objekt wird entwurfsbedingt nicht implementiert.</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.es.xlf
@@ -513,6 +513,16 @@
         <target state="translated">'{1}' no es un valor válido para '{0}'. '{0}' debería estar entre {2} y {3}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="None_lc">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotImplementedByDesign">
         <source>This method/object is not implemented by design.</source>
         <target state="translated">Este objeto o método no se implementa por diseño.</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.fr.xlf
@@ -513,6 +513,16 @@
         <target state="translated">'{1}' n'est pas une valeur valide pour '{0}'. '{0}' doit être compris entre {2} et {3}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="None_lc">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotImplementedByDesign">
         <source>This method/object is not implemented by design.</source>
         <target state="translated">Cette méthode ou cet objet n'est pas implémenté(e) dans la conception.</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.it.xlf
@@ -513,6 +513,16 @@
         <target state="translated">'{1}' non è un valore valido per '{0}'. '{0}' deve essere compreso tra {2} e {3}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="None_lc">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotImplementedByDesign">
         <source>This method/object is not implemented by design.</source>
         <target state="translated">Questo metodo/oggetto non è implementato per impostazione predefinita.</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ja.xlf
@@ -513,6 +513,16 @@
         <target state="translated">'{1}' は '{0}' に有効な値ではありません。'{0}' は {2} と {3} の間でなければなりません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="None_lc">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotImplementedByDesign">
         <source>This method/object is not implemented by design.</source>
         <target state="translated">このメソッド/オブジェクトはデザインによって実装されていません。</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ko.xlf
@@ -513,6 +513,16 @@
         <target state="translated">'{1}'은(는) '{0}'에 사용할 수 없는 값입니다. '{0}'은(는) {2}에서 {3} 사이에 있어야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="None_lc">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotImplementedByDesign">
         <source>This method/object is not implemented by design.</source>
         <target state="translated">이 메서드/개체는 의도적으로 구현되지 않습니다.</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pl.xlf
@@ -513,6 +513,16 @@
         <target state="translated">'{1}' nie jest prawidłową wartością dla '{0}'. Wartość '{0}' powinna należeć do zakresu od {2} do {3}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="None_lc">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotImplementedByDesign">
         <source>This method/object is not implemented by design.</source>
         <target state="translated">Ta metoda/obiekt nie jest domyślnie implementowana.</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pt-BR.xlf
@@ -513,6 +513,16 @@
         <target state="translated">'{1}' não é um valor válido para '{0}'. '{0}' deve estar entre {2} e {3}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="None_lc">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotImplementedByDesign">
         <source>This method/object is not implemented by design.</source>
         <target state="translated">Este método/objeto não é implementado por design.</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ru.xlf
@@ -513,6 +513,16 @@
         <target state="translated">'{1}' не является допустимым значением для '{0}'. Значение '{0}' должно лежать в диапазоне от {2} до {3}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="None_lc">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotImplementedByDesign">
         <source>This method/object is not implemented by design.</source>
         <target state="translated">Этот метод или объект не реализован намеренно.</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.tr.xlf
@@ -513,6 +513,16 @@
         <target state="translated">'{1}' değeri '{0}' öğesi için geçerli değil. '{0}' değeri {2} ile {3} arasında olmalıdır.</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="None_lc">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotImplementedByDesign">
         <source>This method/object is not implemented by design.</source>
         <target state="translated">Tasarım gereği, bu metot/nesne uygulanmadı.</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hans.xlf
@@ -513,6 +513,16 @@
         <target state="translated">“{1}”不是“{0}”的有效值。“{0}”应介于 {2} 和 {3} 之间。</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="None_lc">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotImplementedByDesign">
         <source>This method/object is not implemented by design.</source>
         <target state="translated">未按设计实现此方法/对象。</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hant.xlf
@@ -513,6 +513,16 @@
         <target state="translated">'{1}' 不是 '{0}' 的有效值。'{0}' 應該介於 {2} 與 {3} 之間。</target>
         <note />
       </trans-unit>
+      <trans-unit id="None">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="None_lc">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotImplementedByDesign">
         <source>This method/object is not implemented by design.</source>
         <target state="translated">此方法/物件並非由設計實作。</target>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataMemberFieldConverter.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataMemberFieldConverter.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.ComponentModel;
+
+namespace System.Windows.Forms.Design
+{
+    internal class DataMemberFieldConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string) ? true : base.CanConvertFrom(context, sourceType);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            return value != null && value.Equals(SR.None) ? string.Empty : value;
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == typeof(string) && (value == null || value.Equals(string.Empty)))
+                return SR.None_lc;
+
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataMemberFieldConverterTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataMemberFieldConverterTests.cs
@@ -34,7 +34,6 @@ namespace System.Windows.Forms.Design.Tests
         [InlineData("", typeof(string), "(none)")]
         [InlineData(null, typeof(string), "(none)")]
         [InlineData("FirstName", typeof(string), "FirstName")]
-        [InlineData(1, typeof(int), 1)]
         public static void ConvertTo(object actual, Type expectedType, object expected)
         {
             Assert.Equal(expected, s_converter.ConvertTo(s_context, CultureInfo.CurrentCulture, actual, expectedType));
@@ -43,7 +42,6 @@ namespace System.Windows.Forms.Design.Tests
         [Theory]
         [InlineData("", typeof(int))]
         [InlineData("FirstName", typeof(int))]
-        [InlineData(null, typeof(string))]
         public static void ConvertTo_ThrowsNotSupportedException(object actual, Type expectedType)
         {
             Assert.Throws<NotSupportedException>(

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataMemberFieldConverterTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataMemberFieldConverterTests.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.ComponentModel.Design.Serialization;
+using System.Globalization;
+using Xunit;
+
+namespace System.Windows.Forms.Design.Tests
+{
+    public class DataMemberFieldConverterTests
+    {
+        private static DataMemberFieldConverter s_converter = new DataMemberFieldConverter();
+        private static ITypeDescriptorContext s_context = new MyTypeDescriptorContext();
+
+        [Fact]    
+        public static void CanConvertFrom()
+        {
+            Assert.True(s_converter.CanConvertFrom(s_context, typeof(string)));
+            Assert.True(s_converter.CanConvertFrom(s_context, typeof(InstanceDescriptor)));
+        }
+       
+        [Theory]
+        [InlineData("", "")]
+        [InlineData(null, null)]
+        [InlineData("(None)", "")]
+        public static void ConvertFrom( object actual, object expected)
+        {
+            Assert.Equal(expected, s_converter.ConvertFrom(s_context, CultureInfo.CurrentCulture, actual));
+        }
+
+        [Theory]
+        [InlineData("", typeof(string), "(none)")]
+        [InlineData(null, typeof(string), "(none)")]
+        [InlineData("FirstName", typeof(string), "FirstName")]
+        [InlineData(1, typeof(int), 1)]
+        public static void ConvertTo(object actual, Type expectedType, object expected)
+        {
+            Assert.Equal(expected, s_converter.ConvertTo(s_context, CultureInfo.CurrentCulture, actual, expectedType));
+        }
+
+        [Theory]
+        [InlineData("", typeof(int))]
+        [InlineData("FirstName", typeof(int))]
+        [InlineData(null, typeof(string))]
+        public static void ConvertTo_ThrowsNotSupportedException(object actual, Type expectedType)
+        {
+            Assert.Throws<NotSupportedException>(
+                () => s_converter.ConvertTo(s_context, CultureInfo.CurrentCulture, actual, expectedType));
+        }
+    }
+
+    [Serializable]
+    public class MyTypeDescriptorContext : ITypeDescriptorContext
+    {
+        public IContainer Container => null;
+        public object Instance { get { return null; } }
+        public PropertyDescriptor PropertyDescriptor { get { return null; } }
+        public bool OnComponentChanging() { return true; }
+        public void OnComponentChanged() { }
+        public object GetService(Type serviceType) { return null; }
+    }
+}

--- a/src/System.Windows.Forms/src/AssemblyRef.cs
+++ b/src/System.Windows.Forms/src/AssemblyRef.cs
@@ -13,4 +13,5 @@ internal static class AssemblyRef
     internal const string SystemDesign = "System.Design, Version=" + FXAssembly.Version + ", Culture=neutral, PublicKeyToken=" + MicrosoftPublicKey;
     internal const string SystemDrawingDesign = "System.Drawing.Design, Version=" + FXAssembly.Version + ", Culture=neutral, PublicKeyToken=" + MicrosoftPublicKey;
     internal const string SystemDrawing = "System.Drawing, Version=" + FXAssembly.Version + ", Culture=neutral, PublicKeyToken=" + MicrosoftPublicKey;
+    internal const string SystemWinformsDesign = "System.Windows.Forms.Design, Version=" + FXAssembly.Version + ", Culture=neutral, PublicKeyToken=" + MicrosoftPublicKey;
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumn.cs
@@ -186,7 +186,7 @@ namespace System.Windows.Forms
         [
             Browsable(true),
             DefaultValue(""),
-            TypeConverter("System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemDesign),
+            TypeConverter("System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemWinformsDesign),
             Editor("System.Windows.Forms.Design.DataGridViewColumnDataPropertyNameEditor, " + AssemblyRef.SystemDesign, typeof(Drawing.Design.UITypeEditor)),
             SRDescription(nameof(SR.DataGridView_ColumnDataPropertyNameDescr)),
             SRCategory(nameof(SR.CatData))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxColumn.cs
@@ -139,7 +139,7 @@ namespace System.Windows.Forms
             DefaultValue(""),
             SRCategory(nameof(SR.CatData)),
             SRDescription(nameof(SR.DataGridView_ComboBoxColumnDisplayMemberDescr)),
-            TypeConverter("System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemDesign),
+            TypeConverter("System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemWinformsDesign),
             Editor("System.Windows.Forms.Design.DataMemberFieldEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))
         ]
         public string DisplayMember
@@ -353,7 +353,7 @@ namespace System.Windows.Forms
             DefaultValue(""),
             SRCategory(nameof(SR.CatData)),
             SRDescription(nameof(SR.DataGridView_ComboBoxColumnValueMemberDescr)),
-            TypeConverter("System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemDesign),
+            TypeConverter("System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemWinformsDesign),
             Editor("System.Windows.Forms.Design.DataMemberFieldEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))
         ]
         public string ValueMember

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListControl.cs
@@ -103,7 +103,7 @@ namespace System.Windows.Forms
         /// </summary>
         [SRCategory(nameof(SR.CatData))]
         [DefaultValue("")]
-        [TypeConverter("System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemDesign)]
+        [TypeConverter("System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemWinformsDesign)]
         [Editor("System.Windows.Forms.Design.DataMemberFieldEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
         [SRDescription(nameof(SR.ListControlDisplayMemberDescr))]
         public string DisplayMember


### PR DESCRIPTION
Porting DataMemberFieldConverter to System.Windows.Forms.Design.dll and changing the references from System.Design to this assembly wherever required. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1545)

Fixes #1542
**Proposed changes**
- Porting DataMemberFieldConverter into core. 

**Customer Impact**
 - Some of the winforms properties have added this converter as member attribute and thus use of those properties, by third party applications, resulting in 'MissingMethodExceptions'.

**Regression?**
Yes

**Risk**
None

**Screenshots 
Before**

![image](https://user-images.githubusercontent.com/36968667/62199975-5447a500-b339-11e9-9e48-0bc80a7bc280.png)

**After**

No Exception.


