### PR TITLE
fix SnapLine is not implemented

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/SnapLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/SnapLine.cs
@@ -18,8 +18,8 @@ namespace System.Windows.Forms.Design.Behavior
     /// </summary>
     public sealed class SnapLine
     {
-        // These are used in the SnapLine filter to define custom margin/padding SnapLines.	
-        // Margins will have special rules of equality, basically opposites will attract one another	
+        // These are used in the SnapLine filter to define custom margin/padding SnapLines.
+        // Margins will have special rules of equality, basically opposites will attract one another
         // (ex: margin right == margin left) and paddings will be attracted to like-margins.
         internal const string Margin = "Margin";
         internal const string MarginRight = Margin + ".Right";
@@ -35,21 +35,24 @@ namespace System.Windows.Forms.Design.Behavior
         /// <summary>
         ///  SnapLine constructor that takes the type and offset of SnapLine.
         /// </summary>
-        public SnapLine(SnapLineType type, int offset) : this(type, offset, null, SnapLinePriority.Low)
+        public SnapLine(SnapLineType type, int offset)
+            : this(type, offset, null, SnapLinePriority.Low)
         {
         }
 
         /// <summary>
         ///  SnapLine constructor that takes the type, offset and filter of SnapLine.
         /// </summary>
-        public SnapLine(SnapLineType type, int offset, string filter) : this(type, offset, filter, SnapLinePriority.Low)
+        public SnapLine(SnapLineType type, int offset, string filter)
+            : this(type, offset, filter, SnapLinePriority.Low)
         {
         }
 
         /// <summary>
         ///  SnapLine constructor that takes the type, offset, and priority of SnapLine.
         /// </summary>
-        public SnapLine(SnapLineType type, int offset, SnapLinePriority priority) : this(type, offset, null, priority)
+        public SnapLine(SnapLineType type, int offset, SnapLinePriority priority)
+            : this(type, offset, null, priority)
         {
         }
 
@@ -58,7 +61,10 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         public SnapLine(SnapLineType type, int offset, string filter, SnapLinePriority priority)
         {
-            throw new NotImplementedException(SR.NotImplementedByDesign);
+            SnapLineType = type;
+            Offset = offset;
+            Filter = filter;
+            Priority = priority;
         }
 
         /// <summary>
@@ -66,39 +72,46 @@ namespace System.Windows.Forms.Design.Behavior
         ///  Setting this filter will allow only those SnapLines with similar filters to align
         ///  to one another.
         /// </summary>
-        public string Filter => throw new NotImplementedException(SR.NotImplementedByDesign);
+        public string Filter { get; }
 
         /// <summary>
         ///  Returns true if the SnapLine is of a horizontal type.
         /// </summary>
-        public bool IsHorizontal => throw new NotImplementedException(SR.NotImplementedByDesign);
+        public bool IsHorizontal =>
+            SnapLineType == SnapLineType.Top ||
+            SnapLineType == SnapLineType.Bottom ||
+            SnapLineType == SnapLineType.Horizontal ||
+            SnapLineType == SnapLineType.Baseline;
 
         /// <summary>
         ///  Returns true if the SnapLine is of a vertical type.
         /// </summary>
-        public bool IsVertical => throw new NotImplementedException(SR.NotImplementedByDesign);
+        public bool IsVertical =>
+            SnapLineType == SnapLineType.Left ||
+            SnapLineType == SnapLineType.Right ||
+            SnapLineType == SnapLineType.Vertical;
 
         /// <summary>
         ///  Read-only property that returns the distance from the origin to where this SnapLine is defined.
         /// </summary>
-        public int Offset => throw new NotImplementedException(SR.NotImplementedByDesign);
+        public int Offset { get; private set; }
 
         /// <summary>
         ///  Read-only property that returns the priority of the SnapLine.
         /// </summary>
-        public SnapLinePriority Priority => throw new NotImplementedException(SR.NotImplementedByDesign);
+        public SnapLinePriority Priority { get; }
 
         /// <summary>
         ///  Read-only property that represents the 'type' of SnapLine.
         /// </summary>
-        public SnapLineType SnapLineType => throw new NotImplementedException(SR.NotImplementedByDesign);
+        public SnapLineType SnapLineType { get; }
 
         /// <summary>
         ///  Adjusts the offset property of the SnapLine.
         /// </summary>
         public void AdjustOffset(int adjustment)
         {
-            throw new NotImplementedException(SR.NotImplementedByDesign);
+            Offset += adjustment;
         }
 
         /// <summary>
@@ -106,7 +119,61 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         public static bool ShouldSnap(SnapLine line1, SnapLine line2)
         {
-            throw new NotImplementedException(SR.NotImplementedByDesign);
+            // types must first be equal
+            if (line1.SnapLineType != line2.SnapLineType)
+            {
+                return false;
+            }
+
+            // if the filters are both null - then return true
+            if (line1.Filter == null && line2.Filter == null)
+            {
+                return true;
+            }
+
+            // at least one filter is non-null so if the other is null
+            // then we don't have a match
+            if (line1.Filter == null || line2.Filter == null)
+            {
+                return false;
+            }
+
+            // check for our special-cased margin filter
+            if (line1.Filter.Contains(Margin))
+            {
+                if (line1.Filter.Equals(MarginRight) && (line2.Filter.Equals(MarginLeft) || line2.Filter.Equals(PaddingRight)) ||
+                  line1.Filter.Equals(MarginLeft) && (line2.Filter.Equals(MarginRight) || line2.Filter.Equals(PaddingLeft)) ||
+                  line1.Filter.Equals(MarginTop) && (line2.Filter.Equals(MarginBottom) || line2.Filter.Equals(PaddingTop)) ||
+                  line1.Filter.Equals(MarginBottom) && (line2.Filter.Equals(MarginTop) || line2.Filter.Equals(PaddingBottom)))
+                {
+                    return true;
+                }
+
+                return false;
+            }
+
+            // check for padding & margins
+            if (line1.Filter.Contains(Padding))
+            {
+                if ((line1.Filter.Equals(PaddingLeft) && line2.Filter.Equals(MarginLeft)) ||
+                  (line1.Filter.Equals(PaddingRight) && line2.Filter.Equals(MarginRight)) ||
+                  (line1.Filter.Equals(PaddingTop) && line2.Filter.Equals(MarginTop)) ||
+                  (line1.Filter.Equals(PaddingBottom) && line2.Filter.Equals(MarginBottom)))
+                {
+                    return true;
+                }
+
+                return false;
+            }
+
+            // basic filter equality
+            if (line1.Filter.Equals(line2.Filter))
+            {
+                return true;
+            }
+
+            // not equal!
+            return false;
         }
 
         /// <summary>
@@ -114,7 +181,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         public override string ToString()
         {
-            throw new NotImplementedException(SR.NotImplementedByDesign);
+            return "SnapLine: {type = " + SnapLineType + ", offset = " + Offset + ", priority = " + Priority + ", filter = " + (Filter == null ? "<null>" : Filter) + "}";
         }
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/Behavior/SnapLineTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/Behavior/SnapLineTests.cs
@@ -1,0 +1,244 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace System.Windows.Forms.Design.Behavior.Tests
+{
+    public class SnapLineTests
+    {
+        private static string[] s_Margins = new[] { SnapLine.MarginLeft, SnapLine.MarginTop, SnapLine.MarginRight, SnapLine.MarginBottom };
+        private static string[] s_Paddings = new[] { SnapLine.PaddingLeft, SnapLine.PaddingTop, SnapLine.PaddingRight, SnapLine.PaddingBottom };
+
+        private const int DefaultOffset = 123;
+        private const string DefaultFilter = "filter";
+        private const SnapLinePriority DefaultPriority = SnapLinePriority.Medium;
+
+        [Fact]
+        public void SnapLine_Ctor_type_offset()
+        {
+            var snapLine = new SnapLine(SnapLineType.Baseline, DefaultOffset);
+
+            Assert.Equal(SnapLineType.Baseline, snapLine.SnapLineType);
+            Assert.Equal(DefaultOffset, snapLine.Offset);
+            Assert.Null(snapLine.Filter);
+            Assert.Equal(SnapLinePriority.Low, snapLine.Priority);
+        }
+
+        [Fact]
+        public void SnapLine_Ctor_type_offset_filter()
+        {
+            var snapLine = new SnapLine(SnapLineType.Baseline, DefaultOffset, DefaultFilter);
+
+            Assert.Equal(SnapLineType.Baseline, snapLine.SnapLineType);
+            Assert.Equal(DefaultOffset, snapLine.Offset);
+            Assert.Equal(DefaultFilter, snapLine.Filter);
+            Assert.Equal(SnapLinePriority.Low, snapLine.Priority);
+        }
+
+        [Fact]
+        public void SnapLine_Ctor_type_offset_priority()
+        {
+            var snapLine = new SnapLine(SnapLineType.Baseline, DefaultOffset, DefaultPriority);
+
+            Assert.Equal(SnapLineType.Baseline, snapLine.SnapLineType);
+            Assert.Equal(DefaultOffset, snapLine.Offset);
+            Assert.Null(snapLine.Filter);
+            Assert.Equal(DefaultPriority, snapLine.Priority);
+        }
+
+        [Fact]
+        public void SnapLine_Ctor_type_offset_filter_priority()
+        {
+            var snapLine = new SnapLine(SnapLineType.Baseline, DefaultOffset, DefaultFilter, DefaultPriority);
+
+            Assert.Equal(SnapLineType.Baseline, snapLine.SnapLineType);
+            Assert.Equal(DefaultOffset, snapLine.Offset);
+            Assert.Equal(DefaultFilter, snapLine.Filter);
+            Assert.Equal(DefaultPriority, snapLine.Priority);
+        }
+
+        [Theory]
+        [InlineData(SnapLineType.Top, true)]
+        [InlineData(SnapLineType.Bottom, true)]
+        [InlineData(SnapLineType.Horizontal, true)]
+        [InlineData(SnapLineType.Baseline, true)]
+        [InlineData(SnapLineType.Left, false)]
+        [InlineData(SnapLineType.Right, false)]
+        [InlineData(SnapLineType.Vertical, false)]
+        public void SnapLine_IsHorizontal(SnapLineType type, bool expected)
+        {
+            var snapLine = new SnapLine(type, DefaultOffset, DefaultFilter, DefaultPriority);
+
+            Assert.Equal(expected, snapLine.IsHorizontal);
+        }
+
+        [Theory]
+        [InlineData(SnapLineType.Top, false)]
+        [InlineData(SnapLineType.Bottom, false)]
+        [InlineData(SnapLineType.Horizontal, false)]
+        [InlineData(SnapLineType.Baseline, false)]
+        [InlineData(SnapLineType.Left, true)]
+        [InlineData(SnapLineType.Right, true)]
+        [InlineData(SnapLineType.Vertical, true)]
+        public void SnapLine_IsVertical(SnapLineType type, bool expected)
+        {
+            var snapLine = new SnapLine(type, DefaultOffset, DefaultFilter, DefaultPriority);
+
+            Assert.Equal(expected, snapLine.IsVertical);
+        }
+
+        public static IEnumerable<object[]> SnapLineType_Set_TestData()
+        {
+            foreach (var type in Enum.GetValues(typeof(SnapLineType)))
+            {
+                yield return new[] { type };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(SnapLineType_Set_TestData))]
+        public void SnapLine_ensure_IsHorizontal_IsVertical_do_not_overlap(SnapLineType type)
+        {
+            var snapLine = new SnapLine(type, DefaultOffset, DefaultFilter, DefaultPriority);
+
+            Assert.NotEqual(snapLine.IsHorizontal, snapLine.IsVertical);
+        }
+
+        [Theory]
+        [InlineData(DefaultOffset, 10, DefaultOffset + 10)]
+        [InlineData(DefaultOffset, -10, DefaultOffset - 10)]
+        [InlineData(DefaultOffset, int.MaxValue, /* overflown */-2147483526)]
+        [InlineData(-DefaultOffset, int.MinValue, /* overflown */2147483525)]
+        public void SnapLine_AdjustOffset(int offset, int adjustment, int expected)
+        {
+            var snapLine = new SnapLine(SnapLineType.Baseline, offset, DefaultFilter, DefaultPriority);
+
+            snapLine.AdjustOffset(adjustment);
+            Assert.Equal(expected, snapLine.Offset);
+        }
+
+        [Fact]
+        public void SnapLine_ShouldSnap_should_return_false_if_types_differ()
+        {
+            var snapLine1 = new SnapLine(SnapLineType.Top, DefaultOffset, DefaultFilter, DefaultPriority);
+            var snapLine2 = new SnapLine(SnapLineType.Baseline, DefaultOffset, DefaultFilter, DefaultPriority);
+
+            Assert.False(SnapLine.ShouldSnap(snapLine1, snapLine2));
+        }
+
+        [Fact]
+        public void SnapLine_ShouldSnap_should_return_true_if_types_equal_and_both_filters_null()
+        {
+            var snapLine1 = new SnapLine(SnapLineType.Top, DefaultOffset, null, DefaultPriority);
+            var snapLine2 = new SnapLine(SnapLineType.Top, DefaultOffset, null, SnapLinePriority.Low);
+
+            Assert.True(SnapLine.ShouldSnap(snapLine1, snapLine2));
+        }
+
+        [Fact]
+        public void SnapLine_ShouldSnap_should_return_false_if_types_equal_and_one_of_filters_not_null()
+        {
+            var snapLine1 = new SnapLine(SnapLineType.Top, DefaultOffset, null, DefaultPriority);
+            var snapLine2 = new SnapLine(SnapLineType.Top, DefaultOffset, DefaultFilter, SnapLinePriority.Low);
+
+            Assert.False(SnapLine.ShouldSnap(snapLine1, snapLine2));
+        }
+
+        public static IEnumerable<object[]> SnapLineFilter_Margin_TestData()
+        {
+            return EnumerateFilterMarginPaths(SnapLine.MarginRight, SnapLine.MarginLeft, SnapLine.PaddingRight)
+                .Union(EnumerateFilterMarginPaths(SnapLine.MarginLeft, SnapLine.MarginRight, SnapLine.PaddingLeft))
+                .Union(EnumerateFilterMarginPaths(SnapLine.MarginTop, SnapLine.MarginBottom, SnapLine.PaddingTop))
+                .Union(EnumerateFilterMarginPaths(SnapLine.MarginBottom, SnapLine.MarginTop, SnapLine.PaddingBottom));
+
+            IEnumerable<object[]> EnumerateFilterMarginPaths(string snapLine1Filter, string snapLine2MarginFilter, string snapLine2PaddingFilter)
+            {
+                // happy paths
+                yield return new object[] { snapLine1Filter, snapLine2MarginFilter, true };
+                yield return new object[] { snapLine1Filter, snapLine2PaddingFilter, true };
+
+                // unhappy paths
+                foreach (var margin in s_Margins.Except(new[] { snapLine2MarginFilter }))
+                {
+                    yield return new object[] { snapLine1Filter, margin, false };
+                }
+                foreach (var margin in s_Paddings.Except(new[] { snapLine2PaddingFilter }))
+                {
+                    yield return new object[] { snapLine1Filter, margin, false };
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(SnapLineFilter_Margin_TestData))]
+        public void SnapLine_ShouldSnap_should_return_expected_if_types_equal_and_filter_contains_margin(string snapLine1Filter, string snapLine2Filter, bool expected)
+        {
+            var snapLine1 = new SnapLine(SnapLineType.Top, DefaultOffset, snapLine1Filter, DefaultPriority);
+            var snapLine2 = new SnapLine(SnapLineType.Top, DefaultOffset, snapLine2Filter, SnapLinePriority.Low);
+
+            Assert.Equal(expected, SnapLine.ShouldSnap(snapLine1, snapLine2));
+        }
+
+        public static IEnumerable<object[]> SnapLineFilter_Padding_TestData()
+        {
+            return EnumerateFilterPaddingPaths(SnapLine.PaddingLeft, SnapLine.MarginLeft)
+                .Union(EnumerateFilterPaddingPaths(SnapLine.PaddingRight, SnapLine.MarginRight))
+                .Union(EnumerateFilterPaddingPaths(SnapLine.PaddingTop, SnapLine.MarginTop))
+                .Union(EnumerateFilterPaddingPaths(SnapLine.PaddingBottom, SnapLine.MarginBottom));
+
+            IEnumerable<object[]> EnumerateFilterPaddingPaths(string snapLine1Filter, string snapLine2Filter)
+            {
+                // happy paths
+                yield return new object[] { snapLine1Filter, snapLine2Filter, true };
+
+                // unhappy paths
+                foreach (var margin in s_Margins.Except(new[] { snapLine2Filter }))
+                {
+                    yield return new object[] { snapLine1Filter, margin, false };
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(SnapLineFilter_Padding_TestData))]
+        public void SnapLine_ShouldSnap_should_return_expected_if_types_equal_and_filter_contains_padding(string snapLine1Filter, string snapLine2Filter, bool expected)
+        {
+            var snapLine1 = new SnapLine(SnapLineType.Top, DefaultOffset, snapLine1Filter, DefaultPriority);
+            var snapLine2 = new SnapLine(SnapLineType.Top, DefaultOffset, snapLine2Filter, SnapLinePriority.Low);
+
+            Assert.Equal(expected, SnapLine.ShouldSnap(snapLine1, snapLine2));
+        }
+
+        [Fact]
+        public void SnapLine_ShouldSnap_should_return_true_if_types_equal_and_filters_match()
+        {
+            var snapLine1 = new SnapLine(SnapLineType.Top, DefaultOffset, "custom filter", DefaultPriority);
+            var snapLine2 = new SnapLine(SnapLineType.Top, DefaultOffset, "custom filter", SnapLinePriority.Low);
+
+            Assert.True(SnapLine.ShouldSnap(snapLine1, snapLine2));
+        }
+
+        [Fact]
+        public void SnapLine_ShouldSnap_should_return_false_if_types_equal_and_filters_not_match()
+        {
+            var snapLine1 = new SnapLine(SnapLineType.Top, DefaultOffset, "custom filter", DefaultPriority);
+            var snapLine2 = new SnapLine(SnapLineType.Top, DefaultOffset, "another filter", SnapLinePriority.Low);
+
+            Assert.False(SnapLine.ShouldSnap(snapLine1, snapLine2));
+        }
+
+        [Theory]
+        [InlineData(null, "SnapLine: {type = Baseline, offset = 123, priority = Medium, filter = <null>}")]
+        [InlineData(DefaultFilter, "SnapLine: {type = Baseline, offset = 123, priority = Medium, filter = filter}")]
+        public void SnapLine_ToString(string filter, string expected)
+        {
+            var snapLine = new SnapLine(SnapLineType.Baseline, DefaultOffset, filter, DefaultPriority);
+
+            Assert.Equal(expected, snapLine.ToString());
+        }
+    }
+}


### PR DESCRIPTION
Closes #1412


## Proposed changes

* Port the functionality from NET Fx

* Discover and fix an old bug that incorrectly compared `MarginBottom` filter against `MarginTop OR PaddingBottom`
![image](https://user-images.githubusercontent.com/4403806/62322753-6e56c400-b4ae-11e9-8c26-6e88fab7ec31.png)


* Fix incorrect spacing in `ToString` implementation
![image](https://user-images.githubusercontent.com/4403806/62323028-0a80cb00-b4af-11e9-9277-3c7829a996eb.png)


* Add unit tests as well.



<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- More things working, less throwing `NotImplementedException`

## Regression? 

- No

## Risk

- None, unless the ported code is buggy

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

- Added unit tests
- Designer to provide real testing


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1551)