### PR TITLE
fix: `AccessibleObject` throws 'Value does not fall within the expected range.' creating `CollectionEditor`

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -1316,8 +1316,13 @@ namespace System.Windows.Forms
                 }
             }
 
+            if (systemIAccessible == null || systemIAccessible.accChildCount == 0)
+            {
+                return null;
+            }
+
             // Otherwise, return the default system child for this control (if any)
-            return systemIAccessible?.get_accChild(childID);
+            return systemIAccessible.get_accChild(childID);
         }
 
         /// <summary>
@@ -1691,7 +1696,12 @@ namespace System.Windows.Forms
                 }
             }
 
-            return systemIAccessible?.get_accRole(childID);
+            if (systemIAccessible == null || systemIAccessible.accChildCount == 0)
+            {
+                return null;
+            }
+
+            return systemIAccessible.get_accRole(childID);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1556

## Proposed changes

- Verify that the underlying control contains children before attempting to query those.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- None

## Regression? 

- No

## Risk

- None

<!-- end TELL-MODE -->




## Test methodology <!-- How did you ensure quality? -->

- manual runs with IDE attached breaking on `System.ArgumentException` to ensure no exceptions are thrown
- run Narrator to verify elements are still read correctly




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1557)