### PR TITLE
Add missing StructLayout

### DIFF
--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -4397,6 +4397,7 @@ namespace System.Windows.Forms
             public IntPtr pItem = IntPtr.Zero;    // HDITEM*
         }
 
+        [StructLayout(LayoutKind.Sequential)]
         public class MOUSEHOOKSTRUCT
         {
             // pt was a by-value POINT structure


### PR DESCRIPTION
[StructLayout] inadvertently got removed from an interop class that is being used like a struct.

Audited the other interop classes- they all have the attribute.

fixes #1558

## Customer Impact

Moving the mouse after changing some properties without committing can throw.

## Regression? 

Yes

## Risk

Very low


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1563)