### PR TITLE
Remove pointstruct and friends

### DIFF
--- a/src/Common/src/Interop/Gdi32/Interop.GetTextExtentPoint32.cs
+++ b/src/Common/src/Interop/Gdi32/Interop.GetTextExtentPoint32.cs
@@ -10,12 +10,12 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [DllImport(Libraries.Gdi32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
-        public static extern int GetTextExtentPoint32W(IntPtr hdc, string lpString, int c, ref Size psizl);
+        [DllImport(Libraries.Gdi32, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        public static extern BOOL GetTextExtentPoint32W(IntPtr hdc, string lpString, int c, ref Size psizl);
 
-        public static int GetTextExtentPoint32W(HandleRef hdc, string lpString, int c, ref Size psizl)
+        public static BOOL GetTextExtentPoint32W(HandleRef hdc, string lpString, int c, ref Size psizl)
         {
-            int result = GetTextExtentPoint32W(hdc.Handle, lpString, c, ref psizl);
+            BOOL result = GetTextExtentPoint32W(hdc.Handle, lpString, c, ref psizl);
             GC.KeepAlive(hdc.Wrapper);
             return result;
         }

--- a/src/Common/src/Interop/Interop.HRESULT.cs
+++ b/src/Common/src/Interop/Interop.HRESULT.cs
@@ -12,6 +12,8 @@ internal static partial class Interop
         E_NOINTERFACE = unchecked((int)0x80004002),
         E_POINTER = unchecked((int)0x80004003),
         E_FAIL = unchecked((int)0x80004005),
+        DRAGDROP_E_NOTREGISTERED = unchecked((int)0x80040100),
+        DRAGDROP_E_ALREADYREGISTERED = unchecked((int)0x80040101),
         STG_E_INVALIDFUNCTION = unchecked((int)0x80030001L),
         STG_E_FILENOTFOUND = unchecked((int)0x80030002),
         STG_E_ACCESSDENIED = unchecked((int)0x80030005),

--- a/src/Common/src/Interop/Ole32/Interop.IDropTarget.cs
+++ b/src/Common/src/Interop/Ole32/Interop.IDropTarget.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Drawing;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal static partial class Ole32
+    {
+        [ComImport]
+        [Guid("00000122-0000-0000-C000-000000000046")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        public interface IDropTarget
+        {
+            [PreserveSig]
+            HRESULT DragEnter(
+                [MarshalAs(UnmanagedType.Interface)]
+                object pDataObj,
+                uint grfKeyState,
+                Point pt,
+                ref uint pdwEffect);
+
+            [PreserveSig]
+            HRESULT DragOver(
+                uint grfKeyState,
+                Point pt,
+                ref uint pdwEffect);
+
+            [PreserveSig]
+            HRESULT DragLeave();
+
+            [PreserveSig]
+            HRESULT Drop(
+                [MarshalAs(UnmanagedType.Interface)]
+                object pDataObj,
+                uint grfKeyState,
+                Point pt,
+                ref uint pdwEffect);
+        }
+    }
+}

--- a/src/Common/src/Interop/Ole32/Interop.RegisterDragDrop.cs
+++ b/src/Common/src/Interop/Ole32/Interop.RegisterDragDrop.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal static partial class Ole32
+    {
+        [DllImport(Libraries.Ole32, ExactSpelling = true)]
+        public static extern HRESULT RegisterDragDrop(IntPtr hwnd, IDropTarget pDropTarget);
+
+        public static HRESULT RegisterDragDrop(HandleRef hwnd, IDropTarget pDropTarget)
+        {
+            HRESULT result = RegisterDragDrop(hwnd.Handle, pDropTarget);
+            GC.KeepAlive(hwnd.Wrapper);
+            return result;
+        }
+    }
+}

--- a/src/Common/src/Interop/Ole32/Interop.RevokeDragDrop.cs
+++ b/src/Common/src/Interop/Ole32/Interop.RevokeDragDrop.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal static partial class Ole32
+    {
+        [DllImport(Libraries.Ole32, ExactSpelling = true)]
+        public static extern HRESULT RevokeDragDrop(IntPtr hwnd);
+
+        public static HRESULT RevokeDragDrop(HandleRef hwnd)
+        {
+            HRESULT result = RevokeDragDrop(hwnd.Handle);
+            GC.KeepAlive(hwnd.Wrapper);
+            return result;
+        }
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -262,8 +262,6 @@ namespace System.Windows.Forms
         DISP_E_PARAMNOTFOUND = unchecked((int)0x80020004),
         DISP_E_EXCEPTION = unchecked((int)0x80020009),
         DIB_RGB_COLORS = 0,
-        DRAGDROP_E_NOTREGISTERED = unchecked((int)0x80040100),
-        DRAGDROP_E_ALREADYREGISTERED = unchecked((int)0x80040101),
         DUPLICATE_SAME_ACCESS = 0x00000002,
         DFC_CAPTION = 1,
         DFC_MENU = 2,
@@ -2052,20 +2050,6 @@ namespace System.Windows.Forms
             public int dwHoverTime = 100; // Never set this to field ZERO, or to HOVER_DEFAULT, ever!
         }
 
-        // use this in cases where the Native API takes a POINT not a POINT*
-        // classes marshal by ref.
-        [StructLayout(LayoutKind.Sequential)]
-        public struct POINTSTRUCT
-        {
-            public int x;
-            public int y;
-            public POINTSTRUCT(int x, int y)
-            {
-                this.x = x;
-                this.y = y;
-            }
-        }
-
         public delegate IntPtr WndProc(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
 
         [StructLayout(LayoutKind.Sequential)]
@@ -2162,23 +2146,6 @@ namespace System.Windows.Forms
             public int rcExclude_top;
             public int rcExclude_right;
             public int rcExclude_bottom;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public class SIZE
-        {
-            public int cx;
-            public int cy;
-
-            public SIZE()
-            {
-            }
-
-            public SIZE(int cx, int cy)
-            {
-                this.cx = cx;
-                this.cy = cy;
-            }
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -2798,22 +2765,6 @@ namespace System.Windows.Forms
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        public sealed class _POINTL
-        {
-            public int x;
-            public int y;
-
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public sealed class tagSIZE
-        {
-            public int cx = 0;
-            public int cy = 0;
-
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
         public class COMRECT
         {
             public int left;
@@ -2881,17 +2832,6 @@ namespace System.Windows.Forms
             public int uOldState;
             public int uChanged;
             public IntPtr lParam;
-        }
-
-        [StructLayout(LayoutKind.Sequential)/*leftover(noAutoOffset)*/]
-        public sealed class tagPOINTF
-        {
-            [MarshalAs(UnmanagedType.R4)/*leftover(offset=0, x)*/]
-            public float x;
-
-            [MarshalAs(UnmanagedType.R4)/*leftover(offset=4, y)*/]
-            public float y;
-
         }
 
         [StructLayout(LayoutKind.Sequential)/*leftover(noAutoOffset)*/]
@@ -2975,13 +2915,6 @@ namespace System.Windows.Forms
                 [In, MarshalAs(UnmanagedType.U4)]
                 int lcid,
                 out string categoryName);
-        }
-
-        [StructLayout(LayoutKind.Sequential)/*leftover(noAutoOffset)*/]
-        public sealed class tagSIZEL
-        {
-            public int cx;
-            public int cy;
         }
 
         [StructLayout(LayoutKind.Sequential)/*leftover(noAutoOffset)*/]
@@ -3533,13 +3466,6 @@ namespace System.Windows.Forms
         {
             public NMHDR hdr;
             public TV_ITEM item;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public sealed class POINTL
-        {
-            public int x;
-            public int y;
         }
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
@@ -4114,7 +4040,7 @@ namespace System.Windows.Forms
             public uint cbSize = (uint)Marshal.SizeOf<LVTILEVIEWINFO>();
             public int dwMask;
             public int dwFlags;
-            public SIZE sizeTile;
+            public Size sizeTile;
             public int cLines;
             public Interop.RECT rcLabelMargin;
         }

--- a/src/Common/src/SafeNativeMethods.cs
+++ b/src/Common/src/SafeNativeMethods.cs
@@ -117,7 +117,7 @@ namespace System.Windows.Forms
         public static extern IntPtr CreateSolidBrush(int crColor);
 
         [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern bool SetWindowExtEx(HandleRef hDC, int x, int y, [In, Out] NativeMethods.SIZE size);
+        public static unsafe extern bool SetWindowExtEx(IntPtr hDC, int x, int y, Size *size);
 
         [DllImport(ExternDll.Kernel32, CharSet = CharSet.Auto)]
         public static extern int FormatMessage(int dwFlags, HandleRef lpSource, int dwMessageId,
@@ -252,7 +252,7 @@ namespace System.Windows.Forms
         public static extern bool GetMonitorInfo(HandleRef hmonitor, [In, Out]NativeMethods.MONITORINFOEX info);
 
         [DllImport(ExternDll.User32, ExactSpelling = true)]
-        public static extern IntPtr MonitorFromPoint(NativeMethods.POINTSTRUCT pt, int flags);
+        public static extern IntPtr MonitorFromPoint(Point pt, int flags);
 
         [DllImport(ExternDll.User32, ExactSpelling = true)]
         public static extern IntPtr MonitorFromRect(ref Interop.RECT rect, int flags);
@@ -296,8 +296,8 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true)]
         public static extern IntPtr ExtCreatePen(int fnStyle, int dwWidth, ref NativeMethods.LOGBRUSH lplb, int dwStyleCount, int[] lpStyle);
 
-        [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern bool SetViewportExtEx(HandleRef hDC, int x, int y, NativeMethods.SIZE size);
+        [DllImport(ExternDll.Gdi32, ExactSpelling = true)]
+        public static unsafe extern bool SetViewportExtEx(IntPtr hDC, int x, int y, Size *size);
 
         [DllImport(ExternDll.User32, ExactSpelling = true)]
         public extern static bool GetClipCursor(ref Interop.RECT lpRect);
@@ -595,7 +595,7 @@ namespace System.Windows.Forms
         public static extern int GetThemeInt(HandleRef hTheme, int iPartId, int iStateId, int iPropId, ref int piVal);
 
         [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
-        public static extern int GetThemePartSize(HandleRef hTheme, HandleRef hdc, int iPartId, int iStateId, [In] NativeMethods.COMRECT prc, VisualStyles.ThemeSizeType eSize, [Out] NativeMethods.SIZE psz);
+        public static extern int GetThemePartSize(HandleRef hTheme, HandleRef hdc, int iPartId, int iStateId, [In] NativeMethods.COMRECT prc, VisualStyles.ThemeSizeType eSize, out Size psz);
 
         [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
         public static extern int GetThemePosition(HandleRef hTheme, int iPartId, int iStateId, int iPropId, out Point pPoint);
@@ -613,7 +613,7 @@ namespace System.Windows.Forms
         public static extern int GetThemeTextMetrics(HandleRef hTheme, HandleRef hdc, int iPartId, int iStateId, ref VisualStyles.TextMetrics ptm);
 
         [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
-        public static extern int HitTestThemeBackground(HandleRef hTheme, HandleRef hdc, int iPartId, int iStateId, int dwOptions, [In] NativeMethods.COMRECT pRect, HandleRef hrgn, [In] NativeMethods.POINTSTRUCT ptTest, ref int pwHitTestCode);
+        public static extern int HitTestThemeBackground(HandleRef hTheme, HandleRef hdc, int iPartId, int iStateId, int dwOptions, [In] NativeMethods.COMRECT pRect, HandleRef hrgn, Point ptTest, ref ushort pwHitTestCode);
 
         [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
         public static extern bool IsThemeBackgroundPartiallyTransparent(HandleRef hTheme, int iPartId, int iStateId);

--- a/src/System.Windows.Forms.Design.Editors/src/Misc/NativeMethods.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/Misc/NativeMethods.cs
@@ -181,14 +181,6 @@ namespace System.Windows.Forms.Design
             public readonly IntPtr hwndFrame;
         }
 
-        [StructLayout(LayoutKind.Sequential)]
-        public sealed class tagSIZE
-        {
-            [MarshalAs(UnmanagedType.I4)] public readonly int cx = 0;
-
-            [MarshalAs(UnmanagedType.I4)] public readonly int cy = 0;
-        }
-
         [ComVisible(true)]
         [ComImport]
         [Guid("00000116-0000-0000-C000-000000000046")]
@@ -376,10 +368,8 @@ namespace System.Windows.Forms.Design
                 [Out] COMRECT lprcClipRect,
                 [In] [Out] tagOIFI lpFrameInfo);
 
-            [return: MarshalAs(UnmanagedType.I4)]
             [PreserveSig]
-            int Scroll(
-                [In] [MarshalAs(UnmanagedType.U4)] tagSIZE scrollExtant);
+            Interop.HRESULT Scroll(Size scrollExtant);
 
             void OnUIDeactivate(
                 [In] [MarshalAs(UnmanagedType.I4)] int fUndoable);

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -51,15 +51,18 @@
     <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.CreateRectRgn.cs" Link="Interop\Gdi32\Interop.CreateRectRgn.cs" />
     <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.DeleteObject.cs" Link="Interop\Gdi32\Interop.DeleteObject.cs" />
     <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.GetDeviceCaps.cs" Link="Interop\Gdi32\Interop.GetDeviceCaps.cs" />
+    <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.GetTextExtentPoint32.cs" Link="Interop\Gdi32\Interop.GetTextExtentPoint32.cs" />
     <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.SelectObject.cs" Link="Interop\Gdi32\Interop.SelectObject.cs" />
     <Compile Include="..\..\Common\src\Interop\Kernel32\Interop.MAX_PATH.cs" Link="Interop\Kernel32\Interop.MAX_PATH.cs" />
     <Compile Include="..\..\Common\src\Interop\Kernel32\Interop.MAX_UNICODESTRING_LEN.cs" Link="Interop\Kernel32\Interop.MAX_UNICODESTRING_LEN.cs" />
     <Compile Include="..\..\Common\src\Interop\Kernel32\Interop.GetModuleHandle.cs" Link="Interop\Kernel32\Interop.GetModuleHandle.cs" />
     <Compile Include="..\..\Common\src\Interop\NtDll\Interop.RTL_OSVERSIONINFOEX.cs" Link="Interop\NtDll\Interop.RTL_OSVERSIONINFOEX.cs" />
     <Compile Include="..\..\Common\src\Interop\NtDll\Interop.RtlGetVersion.cs" Link="Interop\NtDll\Interop.RtlGetVersion.cs" />
+    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IDropTarget.cs" Link="Interop\Ole32\Interop.IDropTarget.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.ILockBytes.cs" Link="Interop\Ole32\Interop.ILockBytes.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IStorage.cs" Link="Interop\Ole32\Interop.IStorage.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IStream.cs" Link="Interop\Ole32\Interop.IStream.cs" />
+    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.RevokeDragDrop.cs" Link="Interop\Ole32\Interop.RevokeDragDrop.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.STATFLAG.cs" Link="Interop\Ole32\Interop.STATFLAG.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.STATSTG.cs" Link="Interop\Ole32\Interop.STATSTG.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.STGC.cs" Link="Interop\Ole32\Interop.STGC.cs" />

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.cs
@@ -1965,11 +1965,11 @@ namespace System.ComponentModel.Design
                         hFont = Gdi32.SelectObject(hdc, hFont);
                         if (listBox.Items.Count > 0)
                         {
-                            NativeMethods.SIZE textSize = new NativeMethods.SIZE();
                             foreach (string s in listBox.Items)
                             {
-                                SafeNativeMethods.GetTextExtentPoint32(new HandleRef(listBox, hdc), s, s.Length, textSize);
-                                maxWidth = Math.Max((int)textSize.cx, maxWidth);
+                                var textSize = new Size();
+                                Gdi32.GetTextExtentPoint32W(new HandleRef(listBox, hdc), s, s.Length, ref textSize);
+                                maxWidth = Math.Max((int)textSize.Width, maxWidth);
                             }
                         }
                         SafeNativeMethods.GetTextMetrics(new HandleRef(listBox, hdc), ref tm);
@@ -2532,16 +2532,6 @@ namespace System.ComponentModel.Design
                     public static int LOWORD(int n) => n & 0xffff;
                 }
 
-                [StructLayout(LayoutKind.Sequential)]
-                public class SIZE
-                {
-                    public int cx = 0;
-                    public int cy = 0;
-                    public SIZE()
-                    {
-                    }
-                }
-
                 [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
                 public struct TEXTMETRIC
                 {
@@ -2600,9 +2590,6 @@ namespace System.ComponentModel.Design
 
                 [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
                 public static extern IntPtr SelectObject(HandleRef hDC, HandleRef hObject);
-
-                [DllImport(ExternDll.Gdi32, SetLastError = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-                public static extern int GetTextExtentPoint32(HandleRef hDC, string str, int len, [In, Out] NativeMethods.SIZE size);
 
                 [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
                 public static extern int GetTextMetricsW(HandleRef hDC, [In, Out] ref NativeMethods.TEXTMETRIC lptm);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -501,7 +501,7 @@ namespace System.Windows.Forms.Design
                     if (e.Control.IsHandleCreated)
                     {
                         Application.OleRequired();
-                        UnsafeNativeMethods.RevokeDragDrop(e.Control.Handle);
+                        Ole32.RevokeDragDrop(e.Control.Handle);
                         // We only hook the control's children if there was no designer. We leave it up to the designer to hook its own children.
                         HookChildControls(e.Control);
                     }
@@ -884,7 +884,7 @@ namespace System.Windows.Forms.Design
                         if (child.IsHandleCreated)
                         {
                             Application.OleRequired();
-                            UnsafeNativeMethods.RevokeDragDrop(child.Handle);
+                            Ole32.RevokeDragDrop(child.Handle);
                             HookChildHandles(child.Handle);
                         }
                         else
@@ -1218,7 +1218,7 @@ namespace System.Windows.Forms.Design
             OnHandleChange();
             if (_revokeDragDrop)
             {
-                UnsafeNativeMethods.RevokeDragDrop(Control.Handle);
+                Ole32.RevokeDragDrop(Control.Handle);
             }
         }
 
@@ -2644,7 +2644,7 @@ namespace System.Windows.Forms.Design
                         // have a Windows Forms control associated with them, we have to RevokeDragDrop()
                         // for them so that the ParentControlDesigner()'s drag-drop support can work
                         // correctly.
-                        UnsafeNativeMethods.RevokeDragDrop(hwndChild);
+                        Ole32.RevokeDragDrop(hwndChild);
                         new ChildSubClass(this, hwndChild);
                         SubclassedChildWindows[hwndChild] = true;
                     }
@@ -2892,7 +2892,7 @@ namespace System.Windows.Forms.Design
                     if (m.Msg == WindowMessages.WM_CREATE)
                     {
                         Debug.Assert(_handle != IntPtr.Zero, "Handle for control not created");
-                        UnsafeNativeMethods.RevokeDragDrop(_handle);
+                        Ole32.RevokeDragDrop(_handle);
                     }
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Button.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Button.cs
@@ -279,7 +279,7 @@ namespace System.Windows.Forms
                 if (isMouseDown)
                 {
                     Point pt = PointToScreen(new Point(mevent.X, mevent.Y));
-                    if (UnsafeNativeMethods.WindowFromPoint(pt.X, pt.Y) == Handle && !ValidationCancelled)
+                    if (UnsafeNativeMethods.WindowFromPoint(pt) == Handle && !ValidationCancelled)
                     {
                         if (GetStyle(ControlStyles.UserPaint))
                         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckBox.cs
@@ -619,7 +619,7 @@ namespace System.Windows.Forms
                 if (base.MouseIsDown)
                 {
                     Point pt = PointToScreen(new Point(mevent.X, mevent.Y));
-                    if (UnsafeNativeMethods.WindowFromPoint(pt.X, pt.Y) == Handle)
+                    if (UnsafeNativeMethods.WindowFromPoint(pt) == Handle)
                     {
                         //Paint in raised state...
                         ResetFlagsandPaint();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -2565,7 +2565,7 @@ namespace System.Windows.Forms
                     Point pt = new Point(x, y);
                     pt = PointToScreen(pt);
                     bool captured = Capture;
-                    if (captured && UnsafeNativeMethods.WindowFromPoint(pt.X, pt.Y) == Handle)
+                    if (captured && UnsafeNativeMethods.WindowFromPoint(pt) == Handle)
                     {
                         if (!doubleClickFired && !ValidationCancelled)
                         {
@@ -2612,7 +2612,7 @@ namespace System.Windows.Forms
                     Point rpt = new Point(rx, ry);
                     rpt = PointToScreen(rpt);
                     bool rCaptured = Capture;
-                    if (rCaptured && UnsafeNativeMethods.WindowFromPoint(rpt.X, rpt.Y) == Handle)
+                    if (rCaptured && UnsafeNativeMethods.WindowFromPoint(rpt) == Handle)
                     {
                         if (selectedItems != null)
                         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -1789,7 +1789,7 @@ namespace System.Windows.Forms
                             dwMask = NativeMethods.LVTVIM_TILESIZE
                         };
                         UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.LVM_GETTILEVIEWINFO, 0, tileViewInfo);
-                        return new Size(tileViewInfo.sizeTile.cx, tileViewInfo.sizeTile.cy);
+                        return tileViewInfo.sizeTile;
                     }
                     else
                     {
@@ -1817,7 +1817,7 @@ namespace System.Windows.Forms
                         {
                             dwMask = NativeMethods.LVTVIM_TILESIZE,
                             dwFlags = NativeMethods.LVTVIF_FIXEDSIZE,
-                            sizeTile = new NativeMethods.SIZE(tileSize.Width, tileSize.Height)
+                            sizeTile = tileSize
                         };
                         bool retval = UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.LVM_SETTILEVIEWINFO, 0, tileViewInfo);
                         Debug.Assert(retval, "LVM_SETTILEVIEWINFO failed");
@@ -5701,7 +5701,7 @@ namespace System.Windows.Forms
             // the tile view info size
             tileViewInfo.dwMask |= NativeMethods.LVTVIM_TILESIZE;
             tileViewInfo.dwFlags = NativeMethods.LVTVIF_FIXEDSIZE;
-            tileViewInfo.sizeTile = new NativeMethods.SIZE(TileSize.Width, TileSize.Height);
+            tileViewInfo.sizeTile = TileSize;
 
             bool retval = UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.LVM_SETTILEVIEWINFO, 0, tileViewInfo);
             Debug.Assert(retval, "LVM_SETTILEVIEWINFO failed");

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RadioButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RadioButton.cs
@@ -563,7 +563,7 @@ namespace System.Windows.Forms
                 if (base.MouseIsDown)
                 {
                     Point pt = PointToScreen(new Point(mevent.X, mevent.Y));
-                    if (UnsafeNativeMethods.WindowFromPoint(pt.X, pt.Y) == Handle)
+                    if (UnsafeNativeMethods.WindowFromPoint(pt) == Handle)
                     {
                         //Paint in raised state...
                         //

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Screen.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Screen.cs
@@ -301,8 +301,7 @@ namespace System.Windows.Forms
         {
             if (multiMonitorSupport)
             {
-                NativeMethods.POINTSTRUCT pt = new NativeMethods.POINTSTRUCT(point.X, point.Y);
-                return new Screen(SafeNativeMethods.MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST));
+                return new Screen(SafeNativeMethods.MonitorFromPoint(point, MONITOR_DEFAULTTONEAREST));
             }
             else
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -1644,7 +1644,7 @@ namespace System.Windows.Forms
 
             if (mevent.Button == MouseButtons.Left)
             {
-                if (!ValidationCancelled && UnsafeNativeMethods.WindowFromPoint(pt.X, pt.Y) == Handle)
+                if (!ValidationCancelled && UnsafeNativeMethods.WindowFromPoint(pt) == Handle)
                 {
                     if (!doubleClickFired)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -5141,7 +5141,7 @@ namespace System.Windows.Forms
                 // if someone clicks on a child control (combobox, textbox, etc) focus will
                 // be taken - but we'll handle that in WM_NCACTIVATE handler.
                 Point pt = PointToClient(WindowsFormsUtils.LastCursorPoint);
-                IntPtr hwndClicked = UnsafeNativeMethods.ChildWindowFromPointEx(new HandleRef(null, Handle), pt.X, pt.Y, (int)(GetChildAtPointSkip.Invisible | GetChildAtPointSkip.Disabled | GetChildAtPointSkip.Transparent));
+                IntPtr hwndClicked = UnsafeNativeMethods.ChildWindowFromPointEx(Handle, pt, (int)(GetChildAtPointSkip.Invisible | GetChildAtPointSkip.Disabled | GetChildAtPointSkip.Transparent));
                 // if we click on the toolstrip itself, eat the activation.
                 // if we click on a child control, allow the toolstrip to activate.
                 if (hwndClicked == Handle)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropTargetManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropTargetManager.cs
@@ -8,6 +8,7 @@ using System.Drawing;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Threading;
+using static Interop;
 
 namespace System.Windows.Forms
 {
@@ -267,29 +268,15 @@ namespace System.Windows.Forms
                     {
                         throw new ThreadStateException(SR.ThreadMustBeSTA);
                     }
-                    if (accept)
-                    {
-                        Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, "Registering as drop target: " + owner.Handle.ToString());
-                        // Register
-                        int n = UnsafeNativeMethods.RegisterDragDrop(new HandleRef(owner, owner.Handle), (UnsafeNativeMethods.IOleDropTarget)(new DropTarget(this)));
 
-                        Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, "   ret:" + n.ToString(CultureInfo.InvariantCulture));
-                        if (n != 0 && n != NativeMethods.DRAGDROP_E_ALREADYREGISTERED)
-                        {
-                            throw new Win32Exception(n);
-                        }
-                    }
-                    else
-                    {
-                        Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, "Revoking drop target: " + owner.Handle.ToString());
+                    Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, "Registering as drop target: " + owner.Handle.ToString());
 
-                        // Revoke
-                        int n = UnsafeNativeMethods.RevokeDragDrop(new HandleRef(owner, owner.Handle));
-                        Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, "   ret:" + n.ToString(CultureInfo.InvariantCulture));
-                        if (n != 0 && n != NativeMethods.DRAGDROP_E_NOTREGISTERED)
-                        {
-                            throw new Win32Exception(n);
-                        }
+                    // Register
+                    HRESULT n = Ole32.RegisterDragDrop(new HandleRef(owner, owner.Handle), (Ole32.IDropTarget)new DropTarget(this));
+                    Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, "   ret:" + n.ToString(CultureInfo.InvariantCulture));
+                    if (n != HRESULT.S_OK && n != HRESULT.DRAGDROP_E_ALREADYREGISTERED)
+                    {
+                        throw Marshal.GetExceptionForHR((int)n);
                     }
                 }
                 catch (Exception e)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -1114,7 +1114,7 @@ namespace System.Windows.Forms
             if (baseVar != null && baseVar.IsActiveX)
             {
                 // Find the matching HWnd matching the ScreenCoord and find if the Control has a Tooltip.
-                IntPtr hwndControl = UnsafeNativeMethods.WindowFromPoint(screenCoords.X, screenCoords.Y);
+                IntPtr hwndControl = UnsafeNativeMethods.WindowFromPoint(screenCoords);
                 if (hwndControl != IntPtr.Zero)
                 {
                     Control currentControl = Control.FromHandle(hwndControl);
@@ -1137,7 +1137,7 @@ namespace System.Windows.Forms
                     pt = baseVar.PointToClient(screenCoords);
                 }
 
-                IntPtr found = UnsafeNativeMethods.ChildWindowFromPointEx(new HandleRef(null, baseHwnd), pt.X, pt.Y, NativeMethods.CWP_SKIPINVISIBLE);
+                IntPtr found = UnsafeNativeMethods.ChildWindowFromPointEx(baseHwnd, pt, NativeMethods.CWP_SKIPINVISIBLE);
                 if (found == baseHwnd)
                 {
                     hwnd = found;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
@@ -916,7 +916,7 @@ namespace System.Windows.Forms
             if (mevent.Button == MouseButtons.Left)
             {
                 Point pt = PointToScreen(new Point(mevent.X, mevent.Y));
-                if (UnsafeNativeMethods.WindowFromPoint(pt.X, pt.Y) == Handle && !ValidationCancelled)
+                if (UnsafeNativeMethods.WindowFromPoint(pt) == Handle && !ValidationCancelled)
                 {
                     if (!doubleClickFired)
                     {
@@ -1275,7 +1275,7 @@ namespace System.Windows.Forms
                 MouseEventArgs me = parent.TranslateMouseEvent(this, e);
                 if (e.Button == MouseButtons.Left)
                 {
-                    if (!parent.ValidationCancelled && UnsafeNativeMethods.WindowFromPoint(pt.X, pt.Y) == Handle)
+                    if (!parent.ValidationCancelled && UnsafeNativeMethods.WindowFromPoint(pt) == Handle)
                     {
                         if (!doubleClickFired)
                         {
@@ -1645,7 +1645,7 @@ namespace System.Windows.Forms
                 MouseEventArgs me = parent.TranslateMouseEvent(this, e);
                 if (e.Button == MouseButtons.Left)
                 {
-                    if (!parent.ValidationCancelled && UnsafeNativeMethods.WindowFromPoint(pt.X, pt.Y) == Handle)
+                    if (!parent.ValidationCancelled && UnsafeNativeMethods.WindowFromPoint(pt) == Handle)
                     {
                         if (!doubleClickFired)
                         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
@@ -755,8 +755,6 @@ namespace System.Windows.Forms.VisualStyles
                 throw new InvalidEnumArgumentException(nameof(type), (int)type, typeof(ThemeSizeType));
             }
 
-            NativeMethods.SIZE size = new NativeMethods.SIZE();
-
             using (WindowsGraphicsWrapper wgr = new WindowsGraphicsWrapper(dc, AllGraphicsProperties))
             {
                 HandleRef hdc = new HandleRef(wgr, wgr.WindowsGraphics.DeviceContext.Hdc);
@@ -764,16 +762,16 @@ namespace System.Windows.Forms.VisualStyles
                 {
                     using (ThemeHandle hTheme = ThemeHandle.Create(_class, true, new HandleRef(null, hWnd)))
                     {
-                        lastHResult = SafeNativeMethods.GetThemePartSize(new HandleRef(this, hTheme.NativeHandle), hdc, part, state, null, type, size);
+                        lastHResult = SafeNativeMethods.GetThemePartSize(new HandleRef(this, hTheme.NativeHandle), hdc, part, state, null, type, out Size size);
+                        return size;
                     }
                 }
                 else
                 {
-                    lastHResult = SafeNativeMethods.GetThemePartSize(new HandleRef(this, Handle), hdc, part, state, null, type, size);
+                    lastHResult = SafeNativeMethods.GetThemePartSize(new HandleRef(this, Handle), hdc, part, state, null, type, out Size size);
+                    return size;
                 }
             }
-
-            return new Size(size.cx, size.cy);
         }
 
         /// <summary>
@@ -792,15 +790,12 @@ namespace System.Windows.Forms.VisualStyles
                 throw new InvalidEnumArgumentException(nameof(type), (int)type, typeof(ThemeSizeType));
             }
 
-            NativeMethods.SIZE size = new NativeMethods.SIZE();
-
             using (WindowsGraphicsWrapper wgr = new WindowsGraphicsWrapper(dc, AllGraphicsProperties))
             {
                 HandleRef hdc = new HandleRef(wgr, wgr.WindowsGraphics.DeviceContext.Hdc);
-                lastHResult = SafeNativeMethods.GetThemePartSize(new HandleRef(this, Handle), hdc, part, state, new NativeMethods.COMRECT(bounds), type, size);
+                lastHResult = SafeNativeMethods.GetThemePartSize(new HandleRef(this, Handle), hdc, part, state, new NativeMethods.COMRECT(bounds), type, out Size size);
+                return size;
             }
-
-            return new Size(size.cx, size.cy);
         }
 
         /// <summary>
@@ -944,13 +939,11 @@ namespace System.Windows.Forms.VisualStyles
                 throw new ArgumentNullException(nameof(dc));
             }
 
-            int htCode = 0;
-            NativeMethods.POINTSTRUCT point = new NativeMethods.POINTSTRUCT(pt.X, pt.Y);
-
+            ushort htCode = 0;
             using (WindowsGraphicsWrapper wgr = new WindowsGraphicsWrapper(dc, AllGraphicsProperties))
             {
                 HandleRef hdc = new HandleRef(wgr, wgr.WindowsGraphics.DeviceContext.Hdc);
-                lastHResult = SafeNativeMethods.HitTestThemeBackground(new HandleRef(this, Handle), hdc, part, state, (int)options, new NativeMethods.COMRECT(backgroundRectangle), NativeMethods.NullHandleRef, point, ref htCode);
+                lastHResult = SafeNativeMethods.HitTestThemeBackground(new HandleRef(this, Handle), hdc, part, state, (int)options, new NativeMethods.COMRECT(backgroundRectangle), NativeMethods.NullHandleRef, pt, ref htCode);
             }
 
             return (HitTestCode)htCode;
@@ -981,13 +974,11 @@ namespace System.Windows.Forms.VisualStyles
                 throw new ArgumentNullException(nameof(dc));
             }
 
-            int htCode = 0;
-            NativeMethods.POINTSTRUCT point = new NativeMethods.POINTSTRUCT(pt.X, pt.Y);
-
+            ushort htCode = 0;
             using (WindowsGraphicsWrapper wgr = new WindowsGraphicsWrapper(dc, AllGraphicsProperties))
             {
                 HandleRef hdc = new HandleRef(wgr, wgr.WindowsGraphics.DeviceContext.Hdc);
-                lastHResult = SafeNativeMethods.HitTestThemeBackground(new HandleRef(this, Handle), hdc, part, state, (int)options, new NativeMethods.COMRECT(backgroundRectangle), new HandleRef(this, hRgn), point, ref htCode);
+                lastHResult = SafeNativeMethods.HitTestThemeBackground(new HandleRef(this, Handle), hdc, part, state, (int)options, new NativeMethods.COMRECT(backgroundRectangle), new HandleRef(this, hRgn), pt, ref htCode);
             }
 
             return (HitTestCode)htCode;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.cs
@@ -1624,13 +1624,12 @@ namespace System.Windows.Forms
                 return NativeMethods.E_NOTIMPL;
             }
 
-            int UnsafeNativeMethods.IDocHostUIHandler.GetDropTarget(UnsafeNativeMethods.IOleDropTarget pDropTarget, out UnsafeNativeMethods.IOleDropTarget ppDropTarget)
+            HRESULT UnsafeNativeMethods.IDocHostUIHandler.GetDropTarget(Ole32.IDropTarget pDropTarget, out Ole32.IDropTarget ppDropTarget)
             {
-                //
                 // Set to null no matter what we return, to prevent the marshaller
                 // from having issues if the pointer points to random stuff.
                 ppDropTarget = null;
-                return NativeMethods.E_NOTIMPL;
+                return HRESULT.E_NOTIMPL;
             }
 
             int UnsafeNativeMethods.IDocHostUIHandler.GetExternal(out object ppDispatch)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserSiteBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserSiteBase.cs
@@ -5,7 +5,9 @@
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;
+using System.Drawing;
 using System.Runtime.InteropServices;
+using static Interop;
 
 namespace System.Windows.Forms
 {
@@ -90,48 +92,53 @@ namespace System.Windows.Forms
             return NativeMethods.E_NOTIMPL;
         }
 
-        int UnsafeNativeMethods.IOleControlSite.TransformCoords(NativeMethods._POINTL pPtlHimetric, NativeMethods.tagPOINTF pPtfContainer, int dwFlags)
+        unsafe HRESULT UnsafeNativeMethods.IOleControlSite.TransformCoords(Point *pPtlHimetric, PointF *pPtfContainer, uint dwFlags)
         {
+            if (pPtlHimetric == null || pPtfContainer == null)
+            {
+                return HRESULT.E_INVALIDARG;
+            }
+
             if ((dwFlags & NativeMethods.ActiveX.XFORMCOORDS_HIMETRICTOCONTAINER) != 0)
             {
                 if ((dwFlags & NativeMethods.ActiveX.XFORMCOORDS_SIZE) != 0)
                 {
-                    pPtfContainer.x = (float)WebBrowserHelper.HM2Pix(pPtlHimetric.x, WebBrowserHelper.LogPixelsX);
-                    pPtfContainer.y = (float)WebBrowserHelper.HM2Pix(pPtlHimetric.y, WebBrowserHelper.LogPixelsY);
+                    pPtfContainer->X = (float)WebBrowserHelper.HM2Pix(pPtlHimetric->X, WebBrowserHelper.LogPixelsX);
+                    pPtfContainer->Y = (float)WebBrowserHelper.HM2Pix(pPtlHimetric->Y, WebBrowserHelper.LogPixelsY);
                 }
                 else if ((dwFlags & NativeMethods.ActiveX.XFORMCOORDS_POSITION) != 0)
                 {
-                    pPtfContainer.x = (float)WebBrowserHelper.HM2Pix(pPtlHimetric.x, WebBrowserHelper.LogPixelsX);
-                    pPtfContainer.y = (float)WebBrowserHelper.HM2Pix(pPtlHimetric.y, WebBrowserHelper.LogPixelsY);
+                    pPtfContainer->X = (float)WebBrowserHelper.HM2Pix(pPtlHimetric->X, WebBrowserHelper.LogPixelsX);
+                    pPtfContainer->Y = (float)WebBrowserHelper.HM2Pix(pPtlHimetric->Y, WebBrowserHelper.LogPixelsY);
                 }
                 else
                 {
-                    return NativeMethods.E_INVALIDARG;
+                    return HRESULT.E_INVALIDARG;
                 }
             }
             else if ((dwFlags & NativeMethods.ActiveX.XFORMCOORDS_CONTAINERTOHIMETRIC) != 0)
             {
                 if ((dwFlags & NativeMethods.ActiveX.XFORMCOORDS_SIZE) != 0)
                 {
-                    pPtlHimetric.x = WebBrowserHelper.Pix2HM((int)pPtfContainer.x, WebBrowserHelper.LogPixelsX);
-                    pPtlHimetric.y = WebBrowserHelper.Pix2HM((int)pPtfContainer.y, WebBrowserHelper.LogPixelsY);
+                    pPtlHimetric->X = WebBrowserHelper.Pix2HM((int)pPtfContainer->X, WebBrowserHelper.LogPixelsX);
+                    pPtlHimetric->Y = WebBrowserHelper.Pix2HM((int)pPtfContainer->Y, WebBrowserHelper.LogPixelsY);
                 }
                 else if ((dwFlags & NativeMethods.ActiveX.XFORMCOORDS_POSITION) != 0)
                 {
-                    pPtlHimetric.x = WebBrowserHelper.Pix2HM((int)pPtfContainer.x, WebBrowserHelper.LogPixelsX);
-                    pPtlHimetric.y = WebBrowserHelper.Pix2HM((int)pPtfContainer.y, WebBrowserHelper.LogPixelsY);
+                    pPtlHimetric->X = WebBrowserHelper.Pix2HM((int)pPtfContainer->X, WebBrowserHelper.LogPixelsX);
+                    pPtlHimetric->Y = WebBrowserHelper.Pix2HM((int)pPtfContainer->Y, WebBrowserHelper.LogPixelsY);
                 }
                 else
                 {
-                    return NativeMethods.E_INVALIDARG;
+                    return HRESULT.E_INVALIDARG;
                 }
             }
             else
             {
-                return NativeMethods.E_INVALIDARG;
+                return HRESULT.E_INVALIDARG;
             }
 
-            return NativeMethods.S_OK;
+            return HRESULT.S_OK;
         }
 
         int UnsafeNativeMethods.IOleControlSite.TranslateAccelerator(ref NativeMethods.MSG pMsg, int grfModifiers)
@@ -284,9 +291,9 @@ namespace System.Windows.Forms
             return NativeMethods.S_OK;
         }
 
-        int UnsafeNativeMethods.IOleInPlaceSite.Scroll(NativeMethods.tagSIZE scrollExtant)
+        Interop.HRESULT UnsafeNativeMethods.IOleInPlaceSite.Scroll(Size scrollExtant)
         {
-            return NativeMethods.S_FALSE;
+            return Interop.HRESULT.S_FALSE;
         }
 
         int UnsafeNativeMethods.IOleInPlaceSite.OnUIDeactivate(int fUndoable)

--- a/src/System.Windows.Forms/src/misc/GDI/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms/src/misc/GDI/UnsafeNativeMethods.cs
@@ -132,7 +132,7 @@ namespace System.Windows.Forms.Internal
         [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true)]
         public static extern bool GetViewportOrgEx(HandleRef hdc, out Point lpPoint);
 
-        [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true)]
+        [DllImport(ExternDll.Gdi32, ExactSpelling = true)]
         public static extern bool SetViewportExtEx(HandleRef hDC, int x, int y, ref Size size);
 
         [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true)]


### PR DESCRIPTION
## Proposed changes

- Remove `POINTSTRUCT` preferring `Point` which marshals the same
- Remove `_POINTL` preferring `Point` which marshals the same
- Remove `tagPOINTF`, preferring `PointF` which marshals the same
- Remove `tagSIZEL`, preferring `Size` which marshals the same
- Remove `tagSIZE`, preferring `Size` which marshals the same
- Remove `SIZE`, preferring `Size` which marshals the same

## Customer Impact

- Reduced allocations as we now use classes instead of structs

## Regression? 

- No

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->

- Existing tests and #1530 

Extracted from #1508

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1583)