### PR TITLE
Fixing DataGridViewCell AccessibleObject Value.IsReadOnly property

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -5294,6 +5294,8 @@ namespace System.Windows.Forms
                     return owner.DataGridView.AccessibilityObject;
                 }
             }
+
+            internal override bool IsReadOnly => owner.ReadOnly;
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewCellAccessibleObjectTests.cs
@@ -38,5 +38,29 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
 
             Assert.True(accCellWidthSum == accRowWidth - dataGridView.RowHeadersWidth);
         }
+
+        [StaFact]
+        public void DataGridViewCellsAccessibleObject_IsReadOnly_property()
+        {
+            DataGridView dataGridView = new DataGridView();
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add(new DataGridViewRow()); 
+            dataGridView.Rows.Add(new DataGridViewRow()); 
+
+            dataGridView.Rows[0].Cells[0].ReadOnly = true;
+            dataGridView.Rows[1].ReadOnly = true;
+            dataGridView.Rows[2].ReadOnly = false;
+
+            foreach (DataGridViewRow row in dataGridView.Rows)
+            {
+                foreach (DataGridViewCell cell in row.Cells)
+                {
+                    bool value = cell.AccessibilityObject.IsReadOnly;
+
+                    Assert.Equal(cell.ReadOnly, value);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1578 


## Proposed changes

- Override the IsReadOnly property for DataGridViewCell AccessibleObject

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The Narrator will say "readonly" for readonly cells

## Regression? 

- No

## Risk

- None, this is a minimal extension.

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://user-images.githubusercontent.com/49272759/62694277-b01ac980-b9dc-11e9-9e83-681da817ba64.png)

![image](https://user-images.githubusercontent.com/49272759/62704190-75705b80-b9f3-11e9-838d-5f314a98bdb4.png)

<!-- TODO -->

### After
![image](https://user-images.githubusercontent.com/49272759/62694079-52867d00-b9dc-11e9-8f4a-b1a1cebc5acd.png)

![image](https://user-images.githubusercontent.com/49272759/62703993-14488800-b9f3-11e9-9847-e52d613176d3.png)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Unit test (DataGridViewCellAccessibleObjectTests.cs) 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Manual testing with using the Inspect tool
- Manual testing with using the Narrator
<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->
- .NET Core SDK: 3.0.0-preview9-19407-06
- Microsoft Windows [Version 10.0.18362.239]

<!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1592)