### PR TITLE
Fixing menu control type and menu items navigation

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -5255,6 +5255,11 @@ namespace System.Windows.Forms
                 this.owner = owner;
             }
 
+            internal override UnsafeNativeMethods.IRawElementProviderFragment ElementProviderFromPoint(double x, double y)
+            {
+                return HitTest((int)x, (int)y);
+            }
+
             /// <summary>
             /// Return the child object at the given screen coordinates.
             /// </summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
@@ -2363,6 +2363,21 @@ namespace System.Windows.Forms
                 this.owner = owner;
             }
 
+            internal override object GetPropertyValue(int propertyID)
+            {
+                switch (propertyID)
+                {
+                    case NativeMethods.UIA_ControlTypePropertyId:
+                        return NativeMethods.UIA_MenuControlTypeId;
+                    case NativeMethods.UIA_IsKeyboardFocusablePropertyId:
+                        return (State & AccessibleStates.Focusable) == AccessibleStates.Focusable;
+                    case NativeMethods.UIA_NamePropertyId:
+                        return Name;
+                }
+
+                return base.GetPropertyValue(propertyID);
+            }
+
             public override string Name
             {
                 get
@@ -2376,12 +2391,9 @@ namespace System.Windows.Forms
                         return name;
                     }
 
-                    // NOT localized for testing purposes.  Localizers can use AccessibleName.
-                    name = "DropDown";
-
                     if (owner.OwnerItem != null && owner.OwnerItem.AccessibilityObject.Name != null)
                     {
-                        name = owner.OwnerItem.AccessibilityObject.Name + name;
+                        name = owner.OwnerItem.AccessibilityObject.Name;
                     }
 
                     return name;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
@@ -943,22 +943,6 @@ namespace System.Windows.Forms
 
             switch (direction)
             {
-                case UnsafeNativeMethods.NavigateDirection.FirstChild:
-                    int childCount = GetChildCount();
-                    if (childCount > 0)
-                    {
-                        return GetChildFragment(0);
-                    }
-
-                    return null;
-                case UnsafeNativeMethods.NavigateDirection.LastChild:
-                    childCount = GetChildCount();
-                    if (childCount > 0)
-                    {
-                        return GetChildFragment(childCount - 1);
-                    }
-
-                    return null;
                 case UnsafeNativeMethods.NavigateDirection.NextSibling:
                 case UnsafeNativeMethods.NavigateDirection.PreviousSibling:
                     if (!(owner.Owner is ToolStripDropDown dropDown))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -4597,10 +4597,6 @@ namespace System.Windows.Forms
                     {
                         // Return the owner item as the accessible parent.
                         ToolStripDropDown dropDown = Owner.GetCurrentParentDropDown();
-                        if (dropDown.OwnerItem != null)
-                        {
-                            return dropDown.OwnerItem.AccessibilityObject;
-                        }
                         return dropDown.AccessibilityObject;
                     }
                     return (Owner.Parent != null) ? Owner.Parent.AccessibilityObject : base.Parent;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1582 
**Original bug:**
- [Bug 937670:](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/937670) [Screen Reader - SSMA - Create new project] Incorrect control type is defined for all menus like 'File and Edit and View and Tools...' on SSMA.


## Proposed changes
Fix the accessibility navigation tree for MenuStrip, ContextMenuStrip, ToolStrip, StatusStrip, BindingNavigator controls.
Implement ToolStrip behavior like as the Notepad:
- Implement ElementProviderFromPoint method for ToolStrip to the Inspect tool can get access to item's AccessibleObject when the mouse is over it
- Implement Accessible properties for ToolStripDropDown as menu
- Remove not localized DropDown name
- Change the fragment navigate to change accessibility tree

Items will not have children. Instead, the dropdown pane is in the navigation tree as a separate item. This will get rid of this error: "An element's BoundingRectangle must be contained within its parent element."​

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The fix will allow the client to receive an accessible object when hovering over it with the mouse.

## Regression? 

- No

## Risk

- None, it repeats the implementation of the Notepad ToolStrip

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/49272759/62637790-e0168e00-b944-11e9-8b3c-c99d44a40472.png)


### After

<!-- TODO -->
![image](https://user-images.githubusercontent.com/49272759/62637798-e442ab80-b944-11e9-97da-cb50dfe38b48.png)


## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Manual testing with using the Inspect tool
<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->
- .NET Core SDK (3.0.100-preview8-013392)
- Microsoft Windows [Version 10.0.18362.239]


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1594)