### PR TITLE
Wilcard include interop files for System.Windows.Forms

### DIFF
--- a/src/System.Windows.Forms/src/System.Windows.Forms.csproj
+++ b/src/System.Windows.Forms/src/System.Windows.Forms.csproj
@@ -40,79 +40,9 @@
     <Compile Include="..\..\Common\src\ScreenDC.cs" Link="Common\ScreenDC.cs" />
     <Compile Include="..\..\Common\src\SpanHelpers.cs" Link="Common\SpanHelpers.cs" />
     <Compile Include="..\..\Common\src\UnsafeNativeMethods.cs" Link="System\Windows\Forms\UnsafeNativeMethods.cs" />
-    <Compile Include="..\..\Common\src\Interop\Interop.BOOL.cs" Link="Interop\Interop.BOOL.cs" />
-    <Compile Include="..\..\Common\src\Interop\Interop.Errors.cs" Link="Interop\Interop.Errors.cs" />
-    <Compile Include="..\..\Common\src\Interop\Interop.EditMessages.cs" Link="Interop\Interop.EditMessages.cs" />
-    <Compile Include="..\..\Common\src\Interop\Interop.HRESULT.cs" Link="Interop\Interop.HRESULT.cs" />
-    <Compile Include="..\..\Common\src\Interop\Interop.Libraries.cs" Link="Interop\Interop.Libraries.cs" />
-    <Compile Include="..\..\Common\src\Interop\Interop.RegionType.cs" Link="Interop\Interop.RegionType.cs" />
-    <Compile Include="..\..\Common\src\Interop\Interop.RichEditMessages.cs" Link="Interop\Interop.RichEditMessages.cs" />
-    <Compile Include="..\..\Common\src\Interop\Interop.RECT.cs" Link="Interop\Interop.RECT.cs" />
-    <Compile Include="..\..\Common\src\Interop\Interop.WindowMessages.cs" Link="Interop\Interop.WindowMessages.cs" />
-    <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.CombineRgn.cs" Link="Interop\Gdi32\Interop.CombineRgn.cs" />
-    <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.CreateCompatibleDC.cs" Link="Interop\Gdi32\Interop.CreateCompatibleDC.cs" />
-    <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.CreateDC.cs" Link="Interop\Gdi32\Interop.CreateDC.cs" />
-    <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.CreateRectRgn.cs" Link="Interop\Gdi32\Interop.CreateRectRgn.cs" />
-    <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.DeleteDC.cs" Link="Interop\Gdi32\Interop.DeleteDC.cs" />
-    <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.DeleteObject.cs" Link="Interop\Gdi32\Interop.DeleteObject.cs" />
-    <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.GetClipRgn.cs" Link="Interop\Gdi32\Interop.GetClipRgn.cs" />
-    <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.GetCurrentObject.cs" Link="Interop\Gdi32\Interop.GetCurrentObject.cs" />
-    <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.GetDeviceCaps.cs" Link="Interop\Gdi32\Interop.GetDeviceCaps.cs" />
-    <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.GetObjectType.cs" Link="Interop\Gdi32\Interop.GetObjectType.cs" />
-    <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.GetRgnBox.cs" Link="Interop\Gdi32\Interop.GetRgnBox.cs" />
-    <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.GetStockObject.cs" Link="Interop\Gdi32\Interop.GetStockObject.cs" />
-    <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.GetTextExtentPoint32.cs" Link="Interop\Gdi32\Interop.GetTextExtentPoint32.cs" />
-    <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.ObjectType.cs" Link="Interop\Gdi32\Interop.ObjectType.cs" />
-    <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.OffsetViewportOrgEx.cs" Link="Interop\Gdi32\Interop.OffsetViewportOrgEx.cs" />
-    <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.RestoreDC.cs" Link="Interop\Gdi32\Interop.RestoreDC.cs" />
-    <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.SaveDC.cs" Link="Interop\Gdi32\Interop.SaveDC.cs" />
-    <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.SelectClipRgn.cs" Link="Interop\Gdi32\Interop.SelectClipRgn.cs" />
-    <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.SelectObject.cs" Link="Interop\Gdi32\Interop.SelectObject.cs" />
-    <Compile Include="..\..\Common\src\Interop\Kernel32\Interop.MAX_PATH.cs" Link="Interop\Kernel32\Interop.MAX_PATH.cs" />
-    <Compile Include="..\..\Common\src\Interop\Kernel32\Interop.MAX_UNICODESTRING_LEN.cs" Link="Interop\Kernel32\Interop.MAX_UNICODESTRING_LEN.cs" />
-    <Compile Include="..\..\Common\src\Interop\Kernel32\Interop.GetModuleHandle.cs" Link="Interop\Kernel32\Interop.GetModuleHandle.cs" />
-    <Compile Include="..\..\Common\src\Interop\Kernel32\Interop.GetProcAddress.cs" Link="Interop\Kernel32\Interop.GetProcAddress.cs" />
-    <Compile Include="..\..\Common\src\Interop\Kernel32\Interop.FreeLibrary.cs" Link="Interop\Kernel32\Interop.FreeLibrary.cs" />
-    <Compile Include="..\..\Common\src\Interop\Kernel32\Interop.LoadLibrary.cs" Link="Interop\Kernel32\Interop.LoadLibrary.cs" />
-    <Compile Include="..\..\Common\src\Interop\Mshtml\**.cs" Link="Interop\Mshtml\**.cs" />
-    <Compile Include="..\..\Common\src\Interop\NtDll\Interop.RTL_OSVERSIONINFOEX.cs" Link="Interop\NtDll\Interop.RTL_OSVERSIONINFOEX.cs" />
-    <Compile Include="..\..\Common\src\Interop\NtDll\Interop.RtlGetVersion.cs" Link="Interop\NtDll\Interop.RtlGetVersion.cs" />
-    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.CreateILockBytesOnHGlobal.cs" Link="Interop\Ole32\Interop.CreateILockBytesOnHGlobal.cs" />
-    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.GetHGlobalFromILockBytes.cs" Link="Interop\Ole32\Interop.GetHGlobalFromILockBytes.cs" />
-    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.GpStream.cs" Link="Interop\Ole32\Interop.GpStream.cs" />
-    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.ILockBytes.cs" Link="Interop\Ole32\Interop.ILockBytes.cs" />
-    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IPersistStorage.cs" Link="Interop\Ole32\Interop.IPersistStorage.cs" />
-    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IPersistStream.cs" Link="Interop\Ole32\Interop.IPersistStream.cs" />
-    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IPersistStreamInit.cs" Link="Interop\Ole32\Interop.IPersistStreamInit.cs" />
-    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IStorage.cs" Link="Interop\Ole32\Interop.IStorage.cs" />
-    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IStream.cs" Link="Interop\Ole32\Interop.IStream.cs" />
-    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.STATFLAG.cs" Link="Interop\Ole32\Interop.STATFLAG.cs" />
-    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.STATSTG.cs" Link="Interop\Ole32\Interop.STATSTG.cs" />
-    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.STGC.cs" Link="Interop\Ole32\Interop.STGC.cs" />
-    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.StgCreateDocfileOnILockBytes.cs" Link="Interop\Ole32\Interop.StgCreateDocfileOnILockBytes.cs" />
-    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.STGM.cs" Link="Interop\Ole32\Interop.STGM.cs" />
-    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.StgOpenStorageOnILockBytes.cs" Link="Interop\Ole32\Interop.StgOpenStorageOnILockBytes.cs" />
-    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.STGTY.cs" Link="Interop\Ole32\Interop.STGTY.cs" />
-    <Compile Include="..\..\Common\src\Interop\Richedit\Interop.CHARRANGE.cs" Link="Interop\Richedit\Interop.CHARRANGE.cs" />
-    <Compile Include="..\..\Common\src\Interop\Richedit\Interop.IRichEditOleCallback.cs" Link="Interop\Richedit\Interop.IRichEditOleCallback.cs" />
-    <Compile Include="..\..\Common\src\Interop\Shell32\Interop.SHBrowseForFolder.cs" Link="Interop\Shell32\Interop.SHBrowseForFolder.cs" />
-    <Compile Include="..\..\Common\src\Interop\Shell32\Interop.SHGetKnownFolderPath.cs" Link="Interop\Shell32\Interop.SHGetKnownFolderPath.cs" />
-    <Compile Include="..\..\Common\src\Interop\Shell32\Interop.SHGetPathFromIDListLongPath.cs" Link="Interop\Shell32\Interop.SHGetPathFromIDListLongPath.cs" />
-    <Compile Include="..\..\Common\src\Interop\Shell32\Interop.SHGetSpecialFolderLocation.cs" Link="Interop\Shell32\Interop.SHGetSpecialFolderLocation.cs" />
-    <Compile Include="..\..\Common\src\Interop\User32\Interop.DrawText.cs" Link="Interop\User32\Interop.DrawText.cs" />
-    <Compile Include="..\..\Common\src\Interop\User32\Interop.DrawTextEx.cs" Link="Interop\User32\Interop.DrawTextEx.cs" />
-    <Compile Include="..\..\Common\src\Interop\User32\Interop.DRAWTEXTPARAMS.cs" Link="Interop\User32\Interop.DRAWTEXTPARAMS.cs" />
-    <Compile Include="..\..\Common\src\Interop\User32\Interop.GetDC.cs" Link="Interop\User32\Interop.GetDC.cs" />
-    <Compile Include="..\..\Common\src\Interop\User32\Interop.GetSystemMetrics.cs" Link="Interop\User32\Interop.GetSystemMetrics.cs" />
-    <Compile Include="..\..\Common\src\Interop\User32\Interop.GetUpdateRgn.cs" Link="Interop\User32\Interop.GetUpdateRgn.cs" />
-    <Compile Include="..\..\Common\src\Interop\User32\Interop.GetWindowText.cs" Link="Interop\User32\Interop.GetWindowText.cs" />
-    <Compile Include="..\..\Common\src\Interop\User32\Interop.LoadCursorW.cs" Link="Interop\User32\Interop.LoadCursorW.cs" />
-    <Compile Include="..\..\Common\src\Interop\User32\Interop.ReleaseDC.cs" Link="Interop\User32\Interop.ReleaseDC.cs" />
-    <Compile Include="..\..\Common\src\Interop\User32\Interop.SetWindowText.cs" Link="Interop\User32\Interop.SetWindowText.cs" />
-    <Compile Include="..\..\Common\src\Interop\User32\Interop.TextFormatFlags.cs" Link="Interop\User32\Interop.TextFormatFlags.cs" />
-    <Compile Include="..\..\Common\src\Interop\User32\Interop.WindowFromDC.cs" Link="Interop\User32\Interop.WindowFromDC.cs" />
-    <Compile Include="..\..\Common\src\Interop\UxTheme\Interop.GetCurrentThemeName.cs" Link="Interop\UxTheme\Interop.GetCurrentThemeName.cs" />
-    <Compile Include="..\..\Common\src\Interop\UxTheme\Interop.GetThemeDocumentationProperty.cs" Link="Interop\UxTheme\Interop.GetCurrentThemeName.cs" />
+    <Compile Include="..\..\Common\src\Interop\**\*.cs">
+      <Link>Interop\%(RecursiveDir)\%(Filename)%(Extension)</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\Microsoft\Win32\SafeHandles\CoTaskMemSafeHandle.cs" Link="Microsoft\Win32\SafeHandles\CoTaskMemSafeHandle.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
So far System.Windows.Forms is the superset of Interop usage. There was one existing wildcard that wasn't properly defined, including all of interop as one wildcard to make continued work here easier (less conflicts, easier to add files).

If we need to exclude individual files we can add those explicitly. If needed we can break this out into individual subdirectories as well.

The other projects include only a subset of the interop definitions, so keeping those explicit.

## Customer Impact

None

## Regression? 

No

## Risk

Very low

## Test methodology

- Built, ran tests.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1601)