### PR TITLE
Fix screen related tests

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CursorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CursorTests.cs
@@ -169,19 +169,15 @@ namespace System.Windows.Forms.Tests
                 Assert.True(Cursor.Clip.Width >= 0);
                 Assert.True(Cursor.Clip.Height >= 0);
 
+                Rectangle virtualScreen = SystemInformation.VirtualScreen;
+
                 // Set empty.
                 Cursor.Clip = new Rectangle(0, 0, 0, 0);
-                Assert.True(Cursor.Clip.X >= 0);
-                Assert.True(Cursor.Clip.Y >= 0);
-                Assert.True(Cursor.Clip.Width >= 0);
-                Assert.True(Cursor.Clip.Height >= 0);
+                Assert.Equal(virtualScreen, Cursor.Clip);
 
-                // Set negative.
-                Cursor.Clip = new Rectangle(-1, -2, -3, -4);
-                Assert.True(Cursor.Clip.X >= 0);
-                Assert.True(Cursor.Clip.Y >= 0);
-                Assert.True(Cursor.Clip.Width >= 0);
-                Assert.True(Cursor.Clip.Height >= 0);
+                // Set outside normal bounds.
+                Cursor.Clip = Rectangle.Inflate(virtualScreen, 10, 10);
+                Assert.Equal(virtualScreen, Cursor.Clip);
             }
             finally
             {
@@ -227,8 +223,12 @@ namespace System.Windows.Forms.Tests
         public void Cursor_Position_Get_ReturnsExpected()
         {
             Point position = Cursor.Position;
-            Assert.True(position.X >= 0);
-            Assert.True(position.Y >= 0);
+            Rectangle virtualScreen = SystemInformation.VirtualScreen;
+
+            Assert.True(position.X >= virtualScreen.X);
+            Assert.True(position.Y >= virtualScreen.Y);
+            Assert.True(position.X <= virtualScreen.Right);
+            Assert.True(position.Y <= virtualScreen.Bottom);
         }
 
         [Fact]
@@ -238,12 +238,15 @@ namespace System.Windows.Forms.Tests
             try
             {
                 Cursor.Position = new Point(1, 2);
+                position = Cursor.Position;
                 Assert.True(position.X >= 0);
                 Assert.True(position.Y >= 0);
 
-                Cursor.Position = new Point(-2, -3);
-                Assert.True(position.X >= 0);
-                Assert.True(position.Y >= 0);
+                Rectangle virtualScreen = SystemInformation.VirtualScreen;
+                Cursor.Position = new Point(virtualScreen.X - 1, virtualScreen.Y - 1);
+                position = Cursor.Position;
+                Assert.True(position.X >= virtualScreen.X);
+                Assert.True(position.Y >= virtualScreen.Y);
             }
             finally
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScreenTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScreenTests.cs
@@ -206,16 +206,12 @@ namespace System.Windows.Forms.Tests
         private static void VerifyScreen(Screen screen)
         {
             Assert.Contains(screen.BitsPerPixel, new int[] { 1, 2, 4, 8, 16, 24, 32, 48, 64 });
-            Assert.True(screen.Bounds.X >= 0);
-            Assert.True(screen.Bounds.Y >= 0);
-            Assert.True(screen.Bounds.Width > 0);
-            Assert.True(screen.Bounds.Height > 0);
+            Assert.True(screen.Bounds.Width != 0);
+            Assert.True(screen.Bounds.Height != 0);
             Assert.InRange(screen.DeviceName.Length, 1, 32);
             Assert.Equal(screen.DeviceName, screen.DeviceName.Trim('\0'));
-            Assert.True(screen.WorkingArea.X >= 0);
-            Assert.True(screen.WorkingArea.Y >= 0);
-            Assert.InRange(screen.WorkingArea.Width, 1, screen.Bounds.Width);
-            Assert.InRange(screen.WorkingArea.Height, 1, screen.Bounds.Height);
+            Assert.InRange(screen.WorkingArea.Width, screen.Bounds.X, screen.Bounds.Width);
+            Assert.InRange(screen.WorkingArea.Height, screen.Bounds.Y, screen.Bounds.Height);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/SystemInformationTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/SystemInformationTests.cs
@@ -791,10 +791,8 @@ namespace System.Windows.Forms.Tests
         public void SystemInformation_VirtualScreen_Get_ReturnsExpected()
         {
             Rectangle screen = SystemInformation.VirtualScreen;
-            Assert.True(screen.X >= 0);
-            Assert.True(screen.Y >= 0);
-            Assert.True(screen.Width > 0);
-            Assert.True(screen.Height > 0);
+            Assert.True(screen.Width != 0);
+            Assert.True(screen.Height != 0);
             Assert.Equal(screen, SystemInformation.VirtualScreen);
         }
 


### PR DESCRIPTION
Recently added tests are not multimonitor friendly. Screens frequently have negative coordinates. The common case is with the primary screen to the right of the secondary screen. The primary screen origin is 0,0. Anything to the left or above will have negative coordinates (including the virtual screen).

## Customer Impact

None- this is a test break.

## Regression? 

No

## Risk

None, test only change.

## Test methodology

- Ran tests on multimonitor system


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1603)