### PR TITLE
update SDK used to build winforms to latest release channel SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview6-012264",
+    "dotnet": "3.0.100-preview9-013796",
     "vs": {
       "version": "16.0"
     },
@@ -12,7 +12,7 @@
     }
   },
   "sdk": {
-    "version": "3.0.100-preview6-012264"
+    "version": "3.0.100-preview9-013796"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19411.1",


### PR DESCRIPTION
We like to do this now and again so that we are:
1. building on latest bits aside from the RuntimeFrameworkVersion
1. demonstrating an up-to-date .NET sdk version global.json (are good examples to others looking to build on our stack)
1. find problems as a result of this earlier

This should be the last rev until we update to 3.1 RTM

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1610)