### PR TITLE
Fix tooltip crash and harden

### DIFF
--- a/src/Common/src/Interop/ComCtl32/Interop.TTDT.cs
+++ b/src/Common/src/Interop/ComCtl32/Interop.TTDT.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        public enum TTDT : uint
+        {
+            AUTOMATIC = 0,
+            RESHOW = 1,
+            AUTOPOP = 2,
+            INITIAL = 3,
+        }
+    }
+}

--- a/src/Common/src/Interop/ComCtl32/Interop.TTTOOLINFOW.cs
+++ b/src/Common/src/Interop/ComCtl32/Interop.TTTOOLINFOW.cs
@@ -1,0 +1,99 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        public unsafe struct TTOOLINFOW
+        {
+            public uint cbSize;
+            public TTF uFlags;
+            public IntPtr hwnd;
+            public IntPtr uId;
+            public RECT rect;
+            public IntPtr hinst;
+            public char* lpszText;
+            public IntPtr lParam;
+            // void *lpReserved;
+        }
+
+        [Flags]
+        public enum TTF
+        {
+            IDISHWND = 0x0001,
+            CENTERTIP = 0x0002,
+            RTLREADING = 0x0004,
+            SUBCLASS = 0x0010,
+            TRACK = 0x0020,
+            ABSOLUTE = 0x0080,
+            TRANSPARENT = 0x0100,
+            PARSELINKS = 0x1000,
+            DI_SETITEM = 0x8000
+        }
+
+        public struct ToolInfoWrapper
+        {
+            public TTOOLINFOW Info;
+            public string Text { get; set; }
+            private readonly object _handle;
+
+            public unsafe ToolInfoWrapper(object handle, TTF flags = default, string text = null)
+            {
+                IntPtr hwnd = GetHWND(handle);
+                Info = new TTOOLINFOW
+                {
+                    hwnd = hwnd,
+                    uId = hwnd,
+                    uFlags = flags | TTF.IDISHWND
+                };
+                Text = text;
+                _handle = handle;
+            }
+
+            public unsafe ToolInfoWrapper(object handle, IntPtr id, TTF flags = default, string text = null, RECT rect = default)
+            {
+                Info = new TTOOLINFOW
+                {
+                    hwnd = GetHWND(handle),
+                    uId = id,
+                    uFlags = flags,
+                    rect = rect
+                };
+                Text = text;
+                _handle = handle;
+            }
+
+            private static IntPtr GetHWND(object handle)
+                => handle switch
+                {
+                    IHandle iHandle => iHandle.Handle,
+                    IWin32Window window => Control.GetSafeHandle(window),
+                    _ => throw new InvalidOperationException("Unexpected handle type.")
+                };
+
+
+            public unsafe IntPtr SendMessage(IHandle sender, uint message, BOOL state = BOOL.FALSE)
+            {
+                Info.cbSize = (uint)sizeof(TTOOLINFOW);
+                fixed (char* c = Text)
+                fixed (void* i = &Info)
+                {
+                    if (Text != null)
+                    {
+                        Info.lpszText = c;
+                    }
+                    IntPtr result = User32.SendMessageW(sender, message, (IntPtr)state, (IntPtr)i);
+                    GC.KeepAlive(_handle);
+                    return result;
+                }
+            }
+        }
+    }
+}

--- a/src/Common/src/Interop/Interop.PARAM.cs
+++ b/src/Common/src/Interop/Interop.PARAM.cs
@@ -10,7 +10,7 @@ internal partial class Interop
     /// <summary>
     ///  Helpers for creating W/LPARAM arguments for messages.
     /// </summary>
-    public static class PARAM
+    internal static class PARAM
     {
         public static IntPtr FromLowHigh(int low, int high)
             => (IntPtr)((high << 16) | (low & 0xffff));

--- a/src/Common/src/Interop/Interop.PARAM.cs
+++ b/src/Common/src/Interop/Interop.PARAM.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Drawing;
+
+internal partial class Interop
+{
+    /// <summary>
+    ///  Helpers for creating W/LPARAM arguments for messages.
+    /// </summary>
+    public static class PARAM
+    {
+        public static IntPtr FromLowHigh(int low, int high)
+            => (IntPtr)((high << 16) | (low & 0xffff));
+
+        public static IntPtr FromBool(bool value)
+            => (IntPtr)(value ? BOOL.TRUE : BOOL.FALSE);
+
+        public static IntPtr FromColor(Color color)
+            => (IntPtr)ColorTranslator.ToWin32(color);
+    }
+}

--- a/src/Common/src/Interop/Interop.WindowMessages.cs
+++ b/src/Common/src/Interop/Interop.WindowMessages.cs
@@ -221,5 +221,33 @@ internal static partial class Interop
         public const int WM_USER = 0x0400;
         public const int WM_REFLECT = WM_USER + 0x1C00;
         public const int WM_CHOOSEFONT_GETLOGFONT = (0x0400 + 1);
+
+        public const uint TTM_ACTIVATE          = WM_USER + 1;
+        public const uint TTM_SETDELAYTIME      = WM_USER + 3;
+        public const uint TTM_RELAYEVENT        = WM_USER + 7;
+        public const uint TTM_WINDOWFROMPOINT   = WM_USER + 16;
+        public const uint TTM_TRACKACTIVATE     = WM_USER + 17;
+        public const uint TTM_TRACKPOSITION     = WM_USER + 18;
+        public const uint TTM_SETTIPBKCOLOR     = WM_USER + 19;
+        public const uint TTM_SETTIPTEXTCOLOR   = WM_USER + 20;
+        public const uint TTM_GETDELAYTIME      = WM_USER + 21;
+        public const uint TTM_GETTIPBKCOLOR     = WM_USER + 22;
+        public const uint TTM_GETTIPTEXTCOLOR   = WM_USER + 23;
+        public const uint TTM_SETMAXTIPWIDTH    = WM_USER + 24;
+        public const uint TTM_POP               = WM_USER + 28;
+        public const uint TTM_UPDATE            = WM_USER + 29;
+        public const uint TTM_GETBUBBLESIZE     = WM_USER + 30;
+        public const uint TTM_ADJUSTRECT        = WM_USER + 31;
+        public const uint TTM_SETTITLEW         = WM_USER + 33;
+        public const uint TTM_ADDTOOLW          = WM_USER + 50;
+        public const uint TTM_DELTOOLW          = WM_USER + 51;
+        public const uint TTM_NEWTOOLRECTW      = WM_USER + 52;
+        public const uint TTM_GETTOOLINFOW      = WM_USER + 53;
+        public const uint TTM_SETTOOLINFOW      = WM_USER + 54;
+        public const uint TTM_HITTESTW          = WM_USER + 55;
+        public const uint TTM_GETTEXTW          = WM_USER + 56;
+        public const uint TTM_UPDATETIPTEXTW    = WM_USER + 57;
+        public const uint TTM_ENUMTOOLSW        = WM_USER + 58;
+        public const uint TTM_GETCURRENTTOOLW   = WM_USER + 59;
     }
 }

--- a/src/Common/src/Interop/User32/Interop.SendMessageW.cs
+++ b/src/Common/src/Interop/User32/Interop.SendMessageW.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern IntPtr SendMessageW(
+            IntPtr hWnd,
+            uint Msg,
+            IntPtr wParam,
+            IntPtr lParam);
+
+        public static IntPtr SendMessageW(
+            IHandle hWnd,
+            uint Msg,
+            IntPtr wParam = default,
+            IntPtr lParam = default)
+        {
+            IntPtr result = SendMessageW(hWnd.Handle, Msg, wParam, lParam);
+            GC.KeepAlive(hWnd);
+            return result;
+        }
+
+        public unsafe static IntPtr SendMessageW(
+            IHandle hWnd,
+            uint Msg,
+            IntPtr wParam,
+            string lParam)
+        {
+            fixed (char* c = lParam)
+            {
+                return SendMessageW(hWnd, Msg, wParam, (IntPtr)(void*)c);
+            }
+        }
+
+        public unsafe static IntPtr SendMessageW(
+            IntPtr hWnd,
+            uint Msg,
+            IntPtr wParam,
+            RECT lParam)
+        {
+            return SendMessageW(hWnd, Msg, wParam, (IntPtr)(void*)&lParam);
+        }
+
+        public unsafe static IntPtr SendMessageW(
+            IHandle hWnd,
+            uint Msg,
+            IntPtr wParam,
+            RECT lParam)
+        {
+             return SendMessageW(hWnd, Msg, wParam, (IntPtr)(void*)&lParam);
+        }
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -1287,44 +1287,6 @@ namespace System.Windows.Forms
         //TTI_INFO                =1,
         TTI_WARNING = 2,
         //TTI_ERROR               =3,
-        TTF_IDISHWND = 0x0001,
-        TTF_RTLREADING = 0x0004,
-        TTF_TRACK = 0x0020,
-        TTF_CENTERTIP = 0x0002,
-        TTF_SUBCLASS = 0x0010,
-        TTF_TRANSPARENT = 0x0100,
-        TTF_ABSOLUTE = 0x0080,
-        TTDT_AUTOMATIC = 0,
-        TTDT_RESHOW = 1,
-        TTDT_AUTOPOP = 2,
-        TTDT_INITIAL = 3,
-        TTM_TRACKACTIVATE = (0x0400 + 17),
-        TTM_TRACKPOSITION = (0x0400 + 18),
-        TTM_ACTIVATE = (0x0400 + 1),
-        TTM_POP = (0x0400 + 28),
-        TTM_ADJUSTRECT = (0x400 + 31),
-        TTM_SETDELAYTIME = (0x0400 + 3),
-        TTM_SETTITLE = (Interop.WindowMessages.WM_USER + 33), // wParam = TTI_*, lParam = wchar* szTitle
-        TTM_ADDTOOL = (0x0400 + 50),
-        TTM_DELTOOL = (0x0400 + 51),
-        TTM_NEWTOOLRECT = (0x0400 + 52),
-        TTM_RELAYEVENT = (0x0400 + 7),
-        TTM_GETTIPBKCOLOR = (0x0400 + 22),
-        TTM_SETTIPBKCOLOR = (0x0400 + 19),
-        TTM_SETTIPTEXTCOLOR = (0x0400 + 20),
-        TTM_GETTIPTEXTCOLOR = (0x0400 + 23),
-        TTM_GETTOOLINFO = (0x0400 + 53),
-        TTM_SETTOOLINFO = (0x0400 + 54),
-        TTM_HITTEST = (0x0400 + 55),
-        TTM_GETTEXT = (0x0400 + 56),
-        TTM_UPDATE = (0x0400 + 29),
-        TTM_UPDATETIPTEXT = (0x0400 + 57),
-        TTM_ENUMTOOLS = (0x0400 + 58),
-        TTM_GETCURRENTTOOL = (0x0400 + 59),
-        TTM_WINDOWFROMPOINT = (0x0400 + 16),
-        TTM_GETDELAYTIME = (0x0400 + 21),
-        TTM_SETMAXTIPWIDTH = (0x0400 + 24),
-        TTM_GETBUBBLESIZE = (0x0400 + 30),
         TTN_GETDISPINFO = ((0 - 520) - 10),
         TTN_SHOW = ((0 - 520) - 1),
         TTN_POP = ((0 - 520) - 2),
@@ -3442,32 +3404,6 @@ namespace System.Windows.Forms
             public const int msocWindowFrameOwner = 1;
             public const int msocWindowComponent = 2;
             public const int msocWindowDlgOwner = 3;
-        }
-
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
-        public class TOOLINFO_T
-        {
-            public int cbSize = Marshal.SizeOf<TOOLINFO_T>();
-            public int uFlags;
-            public IntPtr hwnd;
-            public IntPtr uId;
-            public Interop.RECT rect;
-            public IntPtr hinst = IntPtr.Zero;
-            public string lpszText;
-            public IntPtr lParam = IntPtr.Zero;
-        }
-
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
-        public class TOOLINFO_TOOLTIP
-        {
-            public int cbSize = Marshal.SizeOf<TOOLINFO_TOOLTIP>();
-            public int uFlags;
-            public IntPtr hwnd;
-            public IntPtr uId;
-            public Interop.RECT rect;
-            public IntPtr hinst = IntPtr.Zero;
-            public IntPtr lpszText;
-            public IntPtr lParam = IntPtr.Zero;
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -472,12 +472,6 @@ namespace System.Windows.Forms
         public static extern IntPtr SendMessage(HandleRef hWnd, int msg, int wParam, StringBuilder lParam);
 
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-        public static extern IntPtr SendMessage(HandleRef hWnd, int msg, int wParam, NativeMethods.TOOLINFO_T lParam);
-
-        [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-        public static extern IntPtr SendMessage(HandleRef hWnd, int msg, int wParam, NativeMethods.TOOLINFO_TOOLTIP lParam);
-
-        [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
         public static extern IntPtr SendMessage(HandleRef hWnd, int msg, int wParam, ref NativeMethods.TBBUTTON lParam);
 
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -60,7 +60,8 @@ namespace System.Windows.Forms
         IWin32Window,
         IArrangedElement,
         IBindableComponent,
-        IKeyboardToolTip
+        IKeyboardToolTip,
+        IHandle
     {
 #if FINALIZATION_WATCH
         static readonly TraceSwitch ControlFinalization = new TraceSwitch("ControlFinalization", "Tracks the creation and destruction of finalization");

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridToolTip.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.Drawing;
 using System.Runtime.InteropServices;
+using static Interop;
 
 namespace System.Windows.Forms
 {
@@ -45,39 +46,29 @@ namespace System.Windows.Forms
                 tipWindow = new NativeWindow();
                 tipWindow.CreateHandle(cparams);
 
-                UnsafeNativeMethods.SendMessage(new HandleRef(tipWindow, tipWindow.Handle), NativeMethods.TTM_SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
+                User32.SendMessageW(tipWindow, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
                 SafeNativeMethods.SetWindowPos(new HandleRef(tipWindow, tipWindow.Handle), NativeMethods.HWND_NOTOPMOST, 0, 0, 0, 0, NativeMethods.SWP_NOSIZE | NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOACTIVATE);
-                UnsafeNativeMethods.SendMessage(new HandleRef(tipWindow, tipWindow.Handle), NativeMethods.TTM_SETDELAYTIME, NativeMethods.TTDT_INITIAL, 0);
+                User32.SendMessageW(tipWindow, WindowMessages.TTM_SETDELAYTIME, (IntPtr)ComCtl32.TTDT.INITIAL, (IntPtr)0);
             }
         }
 
-        // this function will add a toolTip to the
-        // windows system
         public void AddToolTip(string toolTipString, IntPtr toolTipId, Rectangle iconBounds)
         {
             Debug.Assert(tipWindow != null && tipWindow.Handle != IntPtr.Zero, "the tipWindow was not initialized, bailing out");
             if (iconBounds.IsEmpty)
-            {
                 throw new ArgumentNullException(nameof(iconBounds), SR.DataGridToolTipEmptyIcon);
-            }
 
-            NativeMethods.TOOLINFO_T toolInfo = new NativeMethods.TOOLINFO_T();
-            toolInfo.cbSize = Marshal.SizeOf(toolInfo);
-            toolInfo.hwnd = dataGrid.Handle;
-            toolInfo.uId = toolTipId;
-            toolInfo.lpszText = toolTipString ?? throw new ArgumentNullException(nameof(toolTipString));
-            toolInfo.rect = iconBounds;
-            toolInfo.uFlags = NativeMethods.TTF_SUBCLASS;
-            UnsafeNativeMethods.SendMessage(new HandleRef(tipWindow, tipWindow.Handle), NativeMethods.TTM_ADDTOOL, 0, toolInfo);
+            if (toolTipString == null)
+                throw new ArgumentNullException(nameof(toolTipString));
+
+            var info = new ComCtl32.ToolInfoWrapper(dataGrid, toolTipId, ComCtl32.TTF.SUBCLASS, toolTipString, iconBounds);
+            info.SendMessage(tipWindow, WindowMessages.TTM_ADDTOOLW);
         }
 
         public void RemoveToolTip(IntPtr toolTipId)
         {
-            NativeMethods.TOOLINFO_T toolInfo = new NativeMethods.TOOLINFO_T();
-            toolInfo.cbSize = Marshal.SizeOf(toolInfo);
-            toolInfo.hwnd = dataGrid.Handle;
-            toolInfo.uId = toolTipId;
-            UnsafeNativeMethods.SendMessage(new HandleRef(tipWindow, tipWindow.Handle), NativeMethods.TTM_DELTOOL, 0, toolInfo);
+            var info = new ComCtl32.ToolInfoWrapper(dataGrid, toolTipId);
+            info.SendMessage(tipWindow, WindowMessages.TTM_DELTOOLW);
         }
 
         // will destroy the tipWindow

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -29273,15 +29273,15 @@ namespace System.Windows.Forms
 
                 if (!string.IsNullOrEmpty(toolTip))
                 {
-                    // MSDN: Setting the max width has the added benefit of enabling multiline tool tips!
-                    UnsafeNativeMethods.SendMessage(new HandleRef(this, nmhdr->hwndFrom), NativeMethods.TTM_SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
+                    // Setting the max width has the added benefit of enabling multiline tool tips!
+                    User32.SendMessageW(nmhdr->hwndFrom, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
                     NativeMethods.TOOLTIPTEXT ttt = (NativeMethods.TOOLTIPTEXT)m.GetLParam(typeof(NativeMethods.TOOLTIPTEXT));
 
                     ttt.lpszText = toolTip;
 
                     if (RightToLeft == RightToLeft.Yes)
                     {
-                        ttt.uFlags |= NativeMethods.TTF_RTLREADING;
+                        ttt.uFlags |= (int)ComCtl32.TTF.RTLREADING;
                     }
                     Marshal.StructureToPtr(ttt, m.LParam, false);
                     return true;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -29273,7 +29273,7 @@ namespace System.Windows.Forms
 
                 if (!string.IsNullOrEmpty(toolTip))
                 {
-                    // Setting the max width has the added benefit of enabling multiline tool tips!
+                    // Setting the max width has the added benefit of enabling multiline tool tips
                     User32.SendMessageW(nmhdr->hwndFrom, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
                     NativeMethods.TOOLTIPTEXT ttt = (NativeMethods.TOOLTIPTEXT)m.GetLParam(typeof(NativeMethods.TOOLTIPTEXT));
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
@@ -848,13 +848,8 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                NativeMethods.TOOLINFO_T toolInfo = new NativeMethods.TOOLINFO_T();
-                toolInfo.cbSize = Marshal.SizeOf(toolInfo);
-                toolInfo.hwnd = Handle;
-                toolInfo.uId = item.Id;
-                toolInfo.lpszText = item.Error;
-                toolInfo.uFlags = NativeMethods.TTF_SUBCLASS;
-                UnsafeNativeMethods.SendMessage(new HandleRef(_tipWindow, _tipWindow.Handle), NativeMethods.TTM_ADDTOOL, 0, toolInfo);
+                var toolInfo = new ComCtl32.ToolInfoWrapper(this, item.Id, ComCtl32.TTF.SUBCLASS, item.Error);
+                toolInfo.SendMessage(_tipWindow, WindowMessages.TTM_ADDTOOLW);
 
                 Update(timerCaused: false);
             }
@@ -904,9 +899,9 @@ namespace System.Windows.Forms
                     _tipWindow = new NativeWindow();
                     _tipWindow.CreateHandle(cparams);
 
-                    UnsafeNativeMethods.SendMessage(new HandleRef(_tipWindow, _tipWindow.Handle), NativeMethods.TTM_SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
+                    User32.SendMessageW(_tipWindow, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
                     SafeNativeMethods.SetWindowPos(new HandleRef(_tipWindow, _tipWindow.Handle), NativeMethods.HWND_TOP, 0, 0, 0, 0, NativeMethods.SWP_NOSIZE | NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOACTIVATE);
-                    UnsafeNativeMethods.SendMessage(new HandleRef(_tipWindow, _tipWindow.Handle), NativeMethods.TTM_SETDELAYTIME, NativeMethods.TTDT_INITIAL, 0);
+                    User32.SendMessageW(_tipWindow, WindowMessages.TTM_SETDELAYTIME, (IntPtr)ComCtl32.TTDT.INITIAL, (IntPtr)0);
                 }
 
                 return true;
@@ -1076,11 +1071,7 @@ namespace System.Windows.Forms
 
                 if (_tipWindow != null)
                 {
-                    NativeMethods.TOOLINFO_T toolInfo = new NativeMethods.TOOLINFO_T();
-                    toolInfo.cbSize = Marshal.SizeOf(toolInfo);
-                    toolInfo.hwnd = Handle;
-                    toolInfo.uId = item.Id;
-                    UnsafeNativeMethods.SendMessage(new HandleRef(_tipWindow, _tipWindow.Handle), NativeMethods.TTM_DELTOOL, 0, toolInfo);
+                    new ComCtl32.ToolInfoWrapper(this, item.Id).SendMessage(_tipWindow, WindowMessages.TTM_DELTOOLW);
                 }
 
                 if (items.Count == 0)
@@ -1179,18 +1170,14 @@ namespace System.Windows.Forms
 
                         if (_tipWindow != null)
                         {
-                            NativeMethods.TOOLINFO_T toolInfo = new NativeMethods.TOOLINFO_T();
-                            toolInfo.cbSize = Marshal.SizeOf(toolInfo);
-                            toolInfo.hwnd = Handle;
-                            toolInfo.uId = item.Id;
-                            toolInfo.lpszText = item.Error;
-                            toolInfo.rect = iconBounds;
-                            toolInfo.uFlags = NativeMethods.TTF_SUBCLASS;
+                            ComCtl32.TTF flags = ComCtl32.TTF.SUBCLASS;
                             if (_provider.RightToLeft)
                             {
-                                toolInfo.uFlags |= NativeMethods.TTF_RTLREADING;
+                                flags |= ComCtl32.TTF.RTLREADING;
                             }
-                            UnsafeNativeMethods.SendMessage(new HandleRef(_tipWindow, _tipWindow.Handle), NativeMethods.TTM_SETTOOLINFO, 0, toolInfo);
+
+                            var toolInfo = new ComCtl32.ToolInfoWrapper(this, item.Id, flags, item.Error, iconBounds);
+                            toolInfo.SendMessage(_tipWindow, WindowMessages.TTM_SETTOOLINFOW);
                         }
 
                         if (timerCaused && item.BlinkPhase > 0)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
@@ -1071,7 +1071,8 @@ namespace System.Windows.Forms
 
                 if (_tipWindow != null)
                 {
-                    new ComCtl32.ToolInfoWrapper(this, item.Id).SendMessage(_tipWindow, WindowMessages.TTM_DELTOOLW);
+                    var info = new ComCtl32.ToolInfoWrapper(this, item.Id);
+                    info .SendMessage(_tipWindow, WindowMessages.TTM_DELTOOLW);
                 }
 
                 if (items.Count == 0)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/IHandle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/IHandle.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms
+{
+    /// <summary>
+    ///  Used to abstract access to classes that contain a handle.
+    /// </summary>
+    internal interface IHandle
+    {
+        public IntPtr Handle { get; }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/KeyboardToolTipStateMachine.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/KeyboardToolTipStateMachine.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using static Interop;
 
 namespace System.Windows.Forms
 {
@@ -182,7 +183,7 @@ namespace System.Windows.Forms
         {
             _currentTool = tool;
             ResetTimer();
-            StartTimer(toolTip.GetDelayTime(NativeMethods.TTDT_RESHOW),
+            StartTimer(toolTip.GetDelayTime(ComCtl32.TTDT.RESHOW),
                 GetOneRunTickHandler((Timer sender) => Transit(SmEvent.ReshowDelayTimerExpired, tool)));
             return SmState.ReadyForReshow;
         }
@@ -190,7 +191,7 @@ namespace System.Windows.Forms
         private SmState ShowToolTip(IKeyboardToolTip tool, ToolTip toolTip)
         {
             string toolTipText = tool.GetCaptionForTool(toolTip);
-            int autoPopDelay = toolTip.GetDelayTime(NativeMethods.TTDT_AUTOPOP);
+            int autoPopDelay = toolTip.GetDelayTime(ComCtl32.TTDT.AUTOPOP);
             if (!_currentTool.IsHoveredWithMouse())
             {
                 toolTip.ShowKeyboardToolTip(toolTipText, _currentTool, autoPopDelay);
@@ -204,7 +205,7 @@ namespace System.Windows.Forms
         {
             _currentTool = tool;
             ResetTimer();
-            StartTimer(toolTip.GetDelayTime(NativeMethods.TTDT_INITIAL),
+            StartTimer(toolTip.GetDelayTime(ComCtl32.TTDT.INITIAL),
                 GetOneRunTickHandler((Timer sender) => Transit(SmEvent.InitialDelayTimerExpired, _currentTool)));
 
             return SmState.ReadyForInitShow;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -6539,7 +6539,7 @@ namespace System.Windows.Forms
                             ListViewItem lvi = Items[infoTip.item];
                             if (lvi != null && !string.IsNullOrEmpty(lvi.ToolTipText))
                             {
-                                // Setting the max width has the added benefit of enabling multiline tool tips!
+                                // Setting the max width has the added benefit of enabling multiline tool tips
                                 User32.SendMessageW(nmhdr->hwndFrom, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
 
                                 // UNICODE. Use char.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -6539,13 +6539,8 @@ namespace System.Windows.Forms
                             ListViewItem lvi = Items[infoTip.item];
                             if (lvi != null && !string.IsNullOrEmpty(lvi.ToolTipText))
                             {
-
-                                // MSDN:
-                                // Setting the max width has the added benefit of enabling multiline
-                                // tool tips!
-                                //
-
-                                UnsafeNativeMethods.SendMessage(new HandleRef(this, nmhdr->hwndFrom), NativeMethods.TTM_SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
+                                // Setting the max width has the added benefit of enabling multiline tool tips!
+                                User32.SendMessageW(nmhdr->hwndFrom, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
 
                                 // UNICODE. Use char.
                                 // we need to copy the null terminator character ourselves

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
@@ -18,7 +18,7 @@ namespace System.Windows.Forms
     ///  Provides a low-level encapsulation of a window handle
     ///  and a window procedure. The class automatically manages window class creation and registration.
     /// </summary>
-    public class NativeWindow : MarshalByRefObject, IWin32Window
+    public class NativeWindow : MarshalByRefObject, IWin32Window, IHandle
     {
 #if DEBUG
         private static readonly BooleanSwitch AlwaysUseNormalWndProc = new BooleanSwitch("AlwaysUseNormalWndProc", "Skips checking for the debugger when choosing the debuggable WndProc handler");

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridToolTip.cs
@@ -149,7 +149,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     Debug.Fail($"TTM_ADDTOOL failed for {control.GetType().Name}");
                 }
 
-                // Setting the max width has the added benefit of enabling multiline tool tips!)
+                // Setting the max width has the added benefit of enabling multiline tool tips
                 User32.SendMessageW(this, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -4527,7 +4527,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             RECT rect = itemRect;
 
-            ToolTip.SendMessage(NativeMethods.TTM_ADJUSTRECT, 1, ref rect);
+            ToolTip.SendMessage((int)WindowMessages.TTM_ADJUSTRECT, 1, ref rect);
 
             // now offset it back to screen coords
             Point locPoint = parent.PointToScreen(new Point(rect.left, rect.top));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
@@ -1819,7 +1819,7 @@ namespace System.Windows.Forms
                                      NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOSIZE |
                                      NativeMethods.SWP_NOACTIVATE);
 
-                // Setting the max width has the added benefit of enabling multiline tool tips!
+                // Setting the max width has the added benefit of enabling multiline tool tips
                 User32.SendMessageW(this, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
@@ -1628,7 +1628,7 @@ namespace System.Windows.Forms
         ///  this control binds to rectangular regions, instead of
         ///  full controls.
         /// </summary>
-        private class ControlToolTip
+        private class ControlToolTip : IHandle
         {
             public class Tool
             {
@@ -1775,35 +1775,28 @@ namespace System.Windows.Forms
             {
                 if (tool != null && tool.text != null && tool.text.Length > 0)
                 {
-                    int ret;
                     StatusBar p = (StatusBar)parent;
 
-                    if (p.ToolTipSet)
-                    {
-                        ret = (int)UnsafeNativeMethods.SendMessage(new HandleRef(p.MainToolTip, p.MainToolTip.Handle), NativeMethods.TTM_ADDTOOL, 0, GetTOOLINFO(tool));
-                    }
-                    else
-                    {
-                        ret = (int)UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_ADDTOOL, 0, GetTOOLINFO(tool));
-                    }
-                    if (ret == 0)
+                    if (GetTOOLINFO(tool).SendMessage(p.ToolTipSet ? (IHandle)p.mainToolTip : this, WindowMessages.TTM_ADDTOOLW) == IntPtr.Zero)
                     {
                         throw new InvalidOperationException(SR.StatusBarAddFailed);
                     }
                 }
             }
+
             private void RemoveTool(Tool tool)
             {
                 if (tool != null && tool.text != null && tool.text.Length > 0 && (int)tool.id >= 0)
                 {
-                    UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_DELTOOL, 0, GetMinTOOLINFO(tool));
+                    GetMinTOOLINFO(tool).SendMessage(this, WindowMessages.TTM_DELTOOLW);
                 }
             }
+
             private void UpdateTool(Tool tool)
             {
                 if (tool != null && tool.text != null && tool.text.Length > 0 && (int)tool.id >= 0)
                 {
-                    UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_SETTOOLINFO, 0, GetTOOLINFO(tool));
+                    GetTOOLINFO(tool).SendMessage(this, WindowMessages.TTM_SETTOOLINFOW);
                 }
             }
 
@@ -1823,10 +1816,9 @@ namespace System.Windows.Forms
                                      NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOSIZE |
                                      NativeMethods.SWP_NOACTIVATE);
 
-                // Setting the max width has the added benefit of enabling multiline
-                // tool tips!
-                //
-                UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
+                // Setting the max width has the added benefit of enabling multiline tool tips!
+
+                User32.SendMessageW(this, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
             }
 
             /// <summary>
@@ -1856,48 +1848,36 @@ namespace System.Windows.Forms
             ///  required data to uniquely identify a region. This is used primarily
             ///  for delete operations. NOTE: This cannot force the creation of a handle.
             /// </summary>
-            private NativeMethods.TOOLINFO_T GetMinTOOLINFO(Tool tool)
+            private ComCtl32.ToolInfoWrapper GetMinTOOLINFO(Tool tool)
             {
-                NativeMethods.TOOLINFO_T ti = new NativeMethods.TOOLINFO_T
-                {
-                    cbSize = Marshal.SizeOf<NativeMethods.TOOLINFO_T>(),
-                    hwnd = parent.Handle
-                };
                 if ((int)tool.id < 0)
                 {
                     AssignId(tool);
                 }
-                StatusBar p = (StatusBar)parent;
-                if (p != null && p.ToolTipSet)
-                {
-                    ti.uId = parent.Handle;
-                }
-                else
-                {
-                    ti.uId = tool.id;
-                }
-                return ti;
+
+                return new ComCtl32.ToolInfoWrapper(
+                    parent,
+                    id: parent is StatusBar sb ? sb.Handle : tool.id);
             }
 
             /// <summary>
             ///  Returns a detailed TOOLINFO_T structure that represents the specified
             ///  region. NOTE: This may force the creation of a handle.
             /// </summary>
-            private NativeMethods.TOOLINFO_T GetTOOLINFO(Tool tool)
+            private ComCtl32.ToolInfoWrapper GetTOOLINFO(Tool tool)
             {
-                NativeMethods.TOOLINFO_T ti = GetMinTOOLINFO(tool);
-                ti.cbSize = Marshal.SizeOf<NativeMethods.TOOLINFO_T>();
-                ti.uFlags |= NativeMethods.TTF_TRANSPARENT | NativeMethods.TTF_SUBCLASS;
+                ComCtl32.ToolInfoWrapper ti = GetMinTOOLINFO(tool);
+                ti.Info.uFlags |= ComCtl32.TTF.TRANSPARENT | ComCtl32.TTF.SUBCLASS;
 
                 // RightToLeft reading order
                 Control richParent = parent;
                 if (richParent != null && richParent.RightToLeft == RightToLeft.Yes)
                 {
-                    ti.uFlags |= NativeMethods.TTF_RTLREADING;
+                    ti.Info.uFlags |= ComCtl32.TTF.RTLREADING;
                 }
 
-                ti.lpszText = tool.text;
-                ti.rect = tool.rect;
+                ti.Text = tool.text;
+                ti.Info.rect = tool.rect;
                 return ti;
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
@@ -1777,7 +1777,8 @@ namespace System.Windows.Forms
                 {
                     StatusBar p = (StatusBar)parent;
 
-                    if (GetTOOLINFO(tool).SendMessage(p.ToolTipSet ? (IHandle)p.mainToolTip : this, WindowMessages.TTM_ADDTOOLW) == IntPtr.Zero)
+                    ComCtl32.ToolInfoWrapper info = GetTOOLINFO(tool);
+                    if (info.SendMessage(p.ToolTipSet ? (IHandle)p.mainToolTip : this, WindowMessages.TTM_ADDTOOLW) == IntPtr.Zero)
                     {
                         throw new InvalidOperationException(SR.StatusBarAddFailed);
                     }
@@ -1788,7 +1789,8 @@ namespace System.Windows.Forms
             {
                 if (tool != null && tool.text != null && tool.text.Length > 0 && (int)tool.id >= 0)
                 {
-                    GetMinTOOLINFO(tool).SendMessage(this, WindowMessages.TTM_DELTOOLW);
+                    ComCtl32.ToolInfoWrapper info = GetMinTOOLINFO(tool);
+                    info.SendMessage(this, WindowMessages.TTM_DELTOOLW);
                 }
             }
 
@@ -1796,7 +1798,8 @@ namespace System.Windows.Forms
             {
                 if (tool != null && tool.text != null && tool.text.Length > 0 && (int)tool.id >= 0)
                 {
-                    GetTOOLINFO(tool).SendMessage(this, WindowMessages.TTM_SETTOOLINFOW);
+                    ComCtl32.ToolInfoWrapper info = GetTOOLINFO(tool);
+                    info.SendMessage(this, WindowMessages.TTM_SETTOOLINFOW);
                 }
             }
 
@@ -1817,7 +1820,6 @@ namespace System.Windows.Forms
                                      NativeMethods.SWP_NOACTIVATE);
 
                 // Setting the max width has the added benefit of enabling multiline tool tips!
-
                 User32.SendMessageW(this, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -2052,10 +2052,9 @@ namespace System.Windows.Forms
             ttt.hinst = IntPtr.Zero;
 
             // RightToLeft reading order
-            //
             if (RightToLeft == RightToLeft.Yes)
             {
-                ttt.uFlags |= NativeMethods.TTF_RTLREADING;
+                ttt.uFlags |= (int)ComCtl32.TTF.RTLREADING;
             }
 
             Marshal.StructureToPtr(ttt, m.LParam, false);
@@ -2204,11 +2203,8 @@ namespace System.Windows.Forms
                             }
                             break;
                         case NativeMethods.TTN_GETDISPINFO:
-                            // MSDN:
-                            // Setting the max width has the added benefit of enabling Multiline
-                            // tool tips!
-                            //
-                            UnsafeNativeMethods.SendMessage(new HandleRef(nmhdr, nmhdr.hwndFrom), NativeMethods.TTM_SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
+                            // Setting the max width has the added benefit of enabling Multiline tool tips!
+                            User32.SendMessageW(nmhdr.hwndFrom, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
                             WmNeedText(ref m);
                             m.Result = (IntPtr)1;
                             return;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -2203,7 +2203,7 @@ namespace System.Windows.Forms
                             }
                             break;
                         case NativeMethods.TTN_GETDISPINFO:
-                            // Setting the max width has the added benefit of enabling Multiline tool tips!
+                            // Setting the max width has the added benefit of enabling Multiline tool tips
                             User32.SendMessageW(nmhdr.hwndFrom, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
                             WmNeedText(ref m);
                             m.Result = (IntPtr)1;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolBar.cs
@@ -1733,10 +1733,6 @@ namespace System.Windows.Forms
                     switch (note.code)
                     {
                         case NativeMethods.TTN_NEEDTEXT:
-                            // MSDN:
-                            // Setting the max width has the added benefit of enabling multiline
-                            // tool tips!
-
                             WmNotifyNeedText(ref m);
                             m.Result = (IntPtr)1;
                             return;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolBar.cs
@@ -1635,7 +1635,7 @@ namespace System.Windows.Forms
         {
             NativeMethods.TOOLTIPTEXT ttt = (NativeMethods.TOOLTIPTEXT)m.GetLParam(typeof(NativeMethods.TOOLTIPTEXT));
             int commandID = (int)ttt.hdr.idFrom;
-            ToolBarButton tbb = (ToolBarButton)buttons[commandID];
+            ToolBarButton tbb = buttons[commandID];
 
             if (tbb != null && tbb.ToolTipText != null)
             {
@@ -1652,7 +1652,7 @@ namespace System.Windows.Forms
             //
             if (RightToLeft == RightToLeft.Yes)
             {
-                ttt.uFlags |= NativeMethods.TTF_RTLREADING;
+                ttt.uFlags |= (int)ComCtl32.TTF.RTLREADING;
             }
 
             Marshal.StructureToPtr(ttt, m.LParam, false);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -21,7 +21,7 @@ namespace System.Windows.Forms
     [DefaultEvent(nameof(Popup))]
     [ToolboxItemFilter("System.Windows.Forms")]
     [SRDescription(nameof(SR.DescriptionToolTip))]
-    public class ToolTip : Component, IExtenderProvider
+    public class ToolTip : Component, IExtenderProvider, IHandle
     {
         private const int DefaultDelay = 500;
         private const int ReshowRatio = 5;
@@ -92,7 +92,7 @@ namespace System.Windows.Forms
         {
             _window = new ToolTipNativeWindow(this);
             _auto = true;
-            _delayTimes[NativeMethods.TTDT_AUTOMATIC] = DefaultDelay;
+            _delayTimes[(int)ComCtl32.TTDT.AUTOMATIC] = DefaultDelay;
             AdjustBaseFromAuto();
         }
 
@@ -113,7 +113,7 @@ namespace System.Windows.Forms
                     // Don't activate the tooltip if we're in the designer.
                     if (!DesignMode && GetHandleCreated())
                     {
-                        UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_ACTIVATE, (value == true) ? 1 : 0, 0);
+                        User32.SendMessageW(this, WindowMessages.TTM_ACTIVATE, PARAM.FromBool(value));
                     }
                 }
             }
@@ -132,7 +132,7 @@ namespace System.Windows.Forms
         [DefaultValue(DefaultDelay)]
         public int AutomaticDelay
         {
-            get => _delayTimes[NativeMethods.TTDT_AUTOMATIC];
+            get => _delayTimes[(int)ComCtl32.TTDT.AUTOMATIC];
             set
             {
                 if (value < 0)
@@ -140,7 +140,7 @@ namespace System.Windows.Forms
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(AutomaticDelay), value, 0));
                 }
 
-                SetDelayTime(NativeMethods.TTDT_AUTOMATIC, value);
+                SetDelayTime((int)ComCtl32.TTDT.AUTOMATIC, value);
             }
         }
 
@@ -157,7 +157,7 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.ToolTipAutoPopDelayDescr))]
         public int AutoPopDelay
         {
-            get => _delayTimes[NativeMethods.TTDT_AUTOPOP];
+            get => _delayTimes[(int)ComCtl32.TTDT.AUTOPOP];
             set
             {
                 if (value < 0)
@@ -165,7 +165,7 @@ namespace System.Windows.Forms
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(AutoPopDelay), value, 0));
                 }
 
-                SetDelayTime(NativeMethods.TTDT_AUTOPOP, value);
+                SetDelayTime(ComCtl32.TTDT.AUTOPOP, value);
             }
         }
 
@@ -182,7 +182,7 @@ namespace System.Windows.Forms
                 _backColor = value;
                 if (GetHandleCreated())
                 {
-                    UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_SETTIPBKCOLOR, ColorTranslator.ToWin32(_backColor), 0);
+                    User32.SendMessageW(this, WindowMessages.TTM_SETTIPBKCOLOR, PARAM.FromColor(_backColor));
                 }
             }
         }
@@ -245,10 +245,12 @@ namespace System.Windows.Forms
                 _foreColor = value;
                 if (GetHandleCreated())
                 {
-                    UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_SETTIPTEXTCOLOR, ColorTranslator.ToWin32(_foreColor), 0);
+                    User32.SendMessageW(this, WindowMessages.TTM_SETTIPTEXTCOLOR, PARAM.FromColor(_foreColor));
                 }
             }
         }
+
+        IntPtr IHandle.Handle => Handle;
 
         internal IntPtr Handle
         {
@@ -317,7 +319,7 @@ namespace System.Windows.Forms
         [Description(nameof(SR.ToolTipInitialDelayDescr))]
         public int InitialDelay
         {
-            get => _delayTimes[NativeMethods.TTDT_INITIAL];
+            get => _delayTimes[(int)ComCtl32.TTDT.INITIAL];
             set
             {
                 if (value < 0)
@@ -325,7 +327,7 @@ namespace System.Windows.Forms
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(InitialDelay), value, 0));
                 }
 
-                SetDelayTime(NativeMethods.TTDT_INITIAL, value);
+                SetDelayTime(ComCtl32.TTDT.INITIAL, value);
             }
         }
 
@@ -345,7 +347,7 @@ namespace System.Windows.Forms
         [Description(nameof(SR.ToolTipReshowDelayDescr))]
         public int ReshowDelay
         {
-            get => _delayTimes[NativeMethods.TTDT_RESHOW];
+            get => _delayTimes[(int)ComCtl32.TTDT.RESHOW];
             set
             {
                 if (value < 0)
@@ -353,7 +355,7 @@ namespace System.Windows.Forms
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(ReshowDelay), value, 0));
                 }
 
-                SetDelayTime(NativeMethods.TTDT_RESHOW, value);
+                SetDelayTime(ComCtl32.TTDT.RESHOW, value);
             }
         }
 
@@ -431,11 +433,11 @@ namespace System.Windows.Forms
                     {
                         // If the title is null/empty, the icon won't display.
                         string title = !string.IsNullOrEmpty(_toolTipTitle) ? _toolTipTitle : " ";
-                        UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_SETTITLE, (int)_toolTipIcon, title);
+                        User32.SendMessageW(this, WindowMessages.TTM_SETTITLEW, (IntPtr)_toolTipIcon, title);
 
                         // Tooltip need to be updated to reflect the changes in the icon because
                         // this operation directly affects the size of the tooltip
-                        UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_UPDATE, 0, 0);
+                        User32.SendMessageW(this, WindowMessages.TTM_UPDATE);
                     }
                 }
             }
@@ -461,11 +463,11 @@ namespace System.Windows.Forms
                     _toolTipTitle = value;
                     if (GetHandleCreated())
                     {
-                        UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_SETTITLE, (int)_toolTipIcon, _toolTipTitle);
+                        User32.SendMessageW(this, WindowMessages.TTM_SETTITLEW, (IntPtr)_toolTipIcon, _toolTipTitle);
 
                         // Tooltip need to be updated to reflect the changes in the titletext because
                         // this operation directly affects the size of the tooltip
-                        UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_UPDATE, 0, 0);
+                        User32.SendMessageW(this, WindowMessages.TTM_UPDATE);
                     }
                 }
             }
@@ -605,9 +607,9 @@ namespace System.Windows.Forms
         /// </summary>
         private void AdjustBaseFromAuto()
         {
-            _delayTimes[NativeMethods.TTDT_RESHOW] = _delayTimes[NativeMethods.TTDT_AUTOMATIC] / ReshowRatio;
-            _delayTimes[NativeMethods.TTDT_AUTOPOP] = _delayTimes[NativeMethods.TTDT_AUTOMATIC] * AutoPopRatio;
-            _delayTimes[NativeMethods.TTDT_INITIAL] = _delayTimes[NativeMethods.TTDT_AUTOMATIC];
+            _delayTimes[(int)ComCtl32.TTDT.RESHOW] = _delayTimes[(int)ComCtl32.TTDT.AUTOMATIC] / ReshowRatio;
+            _delayTimes[(int)ComCtl32.TTDT.AUTOPOP] = _delayTimes[(int)ComCtl32.TTDT.AUTOMATIC] * AutoPopRatio;
+            _delayTimes[(int)ComCtl32.TTDT.INITIAL] = _delayTimes[(int)ComCtl32.TTDT.AUTOMATIC];
         }
 
         private void HandleCreated(object sender, EventArgs eventargs)
@@ -762,16 +764,14 @@ namespace System.Windows.Forms
             }
 
             // Setting the max width has the added benefit of enabling multiline tool tips.
-            UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
-
-            Debug.Assert(NativeMethods.TTDT_AUTOMATIC == 0, "TTDT_AUTOMATIC != 0");
+            User32.SendMessageW(this, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
 
             if (_auto)
             {
-                SetDelayTime(NativeMethods.TTDT_AUTOMATIC, _delayTimes[NativeMethods.TTDT_AUTOMATIC]);
-                _delayTimes[NativeMethods.TTDT_AUTOPOP] = GetDelayTime(NativeMethods.TTDT_AUTOPOP);
-                _delayTimes[NativeMethods.TTDT_INITIAL] = GetDelayTime(NativeMethods.TTDT_INITIAL);
-                _delayTimes[NativeMethods.TTDT_RESHOW] = GetDelayTime(NativeMethods.TTDT_RESHOW);
+                SetDelayTime(ComCtl32.TTDT.AUTOMATIC, _delayTimes[(int)ComCtl32.TTDT.AUTOMATIC]);
+                _delayTimes[(int)ComCtl32.TTDT.AUTOPOP] = GetDelayTime(ComCtl32.TTDT.AUTOPOP);
+                _delayTimes[(int)ComCtl32.TTDT.INITIAL] = GetDelayTime(ComCtl32.TTDT.INITIAL);
+                _delayTimes[(int)ComCtl32.TTDT.RESHOW] = GetDelayTime(ComCtl32.TTDT.RESHOW);
             }
             else
             {
@@ -779,27 +779,27 @@ namespace System.Windows.Forms
                 {
                     if (_delayTimes[i] >= 1)
                     {
-                        SetDelayTime(i, _delayTimes[i]);
+                        SetDelayTime((ComCtl32.TTDT)i, _delayTimes[i]);
                     }
                 }
             }
 
             // Set active status
-            UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_ACTIVATE, (active == true) ? 1 : 0, 0);
+            User32.SendMessageW(this, WindowMessages.TTM_ACTIVATE, PARAM.FromBool(active));
 
             if (BackColor != SystemColors.Info)
             {
-                UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_SETTIPBKCOLOR, ColorTranslator.ToWin32(BackColor), 0);
+                User32.SendMessageW(this, WindowMessages.TTM_SETTIPBKCOLOR, PARAM.FromColor(BackColor));
             }
             if (ForeColor != SystemColors.InfoText)
             {
-                UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_SETTIPTEXTCOLOR, ColorTranslator.ToWin32(ForeColor), 0);
+                User32.SendMessageW(this, WindowMessages.TTM_SETTIPTEXTCOLOR, PARAM.FromColor(ForeColor));
             }
             if (_toolTipIcon > 0 || !string.IsNullOrEmpty(_toolTipTitle))
             {
                 // If the title is null/empty, the icon won't display.
                 string title = !string.IsNullOrEmpty(_toolTipTitle) ? _toolTipTitle : " ";
-                UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_SETTITLE, (int)_toolTipIcon, title);
+                User32.SendMessageW(this, WindowMessages.TTM_SETTITLEW, (IntPtr)_toolTipIcon, title);
             }
         }
 
@@ -837,30 +837,17 @@ namespace System.Windows.Forms
 
         private void SetToolInfo(Control ctl, string caption)
         {
-            NativeMethods.TOOLINFO_TOOLTIP tool = GetTOOLINFO(ctl, caption, out bool allocatedString);
-            try
-            {
-                int ret = (int)UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_ADDTOOL, 0, tool);
-                if (ctl is TreeView tv && tv.ShowNodeToolTips)
-                {
-                    return;
-                }
-                else if (ctl is ListView lv && lv.ShowItemToolTips)
-                {
-                    return;
-                }
+            IntPtr result = GetTOOLINFO(ctl, caption).SendMessage(this, WindowMessages.TTM_ADDTOOLW);
 
-                if (ret == 0)
-                {
-                    throw new InvalidOperationException(SR.ToolTipAddFailed);
-                }
-            }
-            finally
+            if ((ctl is TreeView tv && tv.ShowNodeToolTips)
+                || (ctl is ListView lv && lv.ShowItemToolTips))
             {
-                if (allocatedString && IntPtr.Zero != tool.lpszText)
-                {
-                    Marshal.FreeHGlobal(tool.lpszText);
-                }
+                return;
+            }
+
+            if (result == IntPtr.Zero)
+            {
+                throw new InvalidOperationException(SR.ToolTipAddFailed);
             }
         }
 
@@ -928,8 +915,7 @@ namespace System.Windows.Forms
 
             if (_created.ContainsKey(ctl) && handlesCreated && !DesignMode)
             {
-
-                UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_DELTOOL, 0, GetMinTOOLINFO(ctl));
+                new ComCtl32.ToolInfoWrapper(ctl).SendMessage(this, WindowMessages.TTM_DELTOOLW);
                 _created.Remove(ctl);
             }
         }
@@ -972,116 +958,62 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Returns the delayTime based on the NativeMethods.TTDT_* values.
         /// </summary>
-        internal int GetDelayTime(int type)
+        internal int GetDelayTime(ComCtl32.TTDT type)
         {
             if (!GetHandleCreated())
             {
-                return _delayTimes[type];
+                return _delayTimes[(int)type];
             }
 
-            return (int)UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_GETDELAYTIME, type, 0);
+            return (int)(long)User32.SendMessageW(this, WindowMessages.TTM_GETDELAYTIME, (IntPtr)type);
         }
 
         internal bool GetHandleCreated() => _window != null && _window.Handle != IntPtr.Zero;
 
         /// <summary>
-        ///  Returns a new instance of the TOOLINFO_T structure with the minimum required data to
-        ///  uniquely identify a region. This is used primarily for delete operations.
-        ///  NOTE: This cannot force the creation of a handle.
-        /// </summary>
-        private NativeMethods.TOOLINFO_TOOLTIP GetMinTOOLINFO(Control ctl)
-        {
-            return GetMinToolInfoForHandle(ctl.Handle);
-        }
-
-        private NativeMethods.TOOLINFO_TOOLTIP GetMinToolInfoForTool(IWin32Window tool)
-        {
-            return GetMinToolInfoForHandle(tool.Handle);
-        }
-
-        private NativeMethods.TOOLINFO_TOOLTIP GetMinToolInfoForHandle(IntPtr handle)
-        {
-            var ti = new NativeMethods.TOOLINFO_TOOLTIP
-            {
-                cbSize = Marshal.SizeOf<NativeMethods.TOOLINFO_TOOLTIP>(),
-                hwnd = handle
-            };
-            ti.uFlags |= NativeMethods.TTF_IDISHWND;
-            ti.uId = handle;
-            return ti;
-        }
-
-        /// <summary>
         ///  Returns a detailed TOOLINFO_TOOLTIP structure that represents the specified region.
-        ///  NOTE: This may force the creation of a handle.
-        ///  If the out parameter allocatedString has been set to true, It is the responsibility of
-        ///  the caller to free the string buffer referenced by lpszText (using Marshal.FreeHGlobal).
         /// </summary>
-        private NativeMethods.TOOLINFO_TOOLTIP GetTOOLINFO(Control ctl, string caption, out bool allocatedString)
+        private unsafe ComCtl32.ToolInfoWrapper GetTOOLINFO(Control control, string caption)
         {
-            allocatedString = false;
-            NativeMethods.TOOLINFO_TOOLTIP ti = GetMinTOOLINFO(ctl);
-            ti.cbSize = Marshal.SizeOf<NativeMethods.TOOLINFO_TOOLTIP>();
-            ti.uFlags |= NativeMethods.TTF_TRANSPARENT | NativeMethods.TTF_SUBCLASS;
+            ComCtl32.TTF flags = ComCtl32.TTF.TRANSPARENT | ComCtl32.TTF.SUBCLASS;
 
             // RightToLeft reading order
-            Control richParent = TopLevelControl;
-            if (richParent != null && richParent.RightToLeft == RightToLeft.Yes && !ctl.IsMirrored)
+            if (TopLevelControl?.RightToLeft == RightToLeft.Yes && !control.IsMirrored)
             {
                 // Indicates that the ToolTip text will be displayed in the opposite direction
                 // to the text in the parent window.
-                ti.uFlags |= NativeMethods.TTF_RTLREADING;
+                flags |= ComCtl32.TTF.RTLREADING;
             }
 
-            if (ctl is TreeView || ctl is ListView)
-            {
-                if (ctl is TreeView tv && tv.ShowNodeToolTips)
-                {
-                    ti.lpszText = NativeMethods.InvalidIntPtr;
-                }
-                else if (ctl is ListView lv && lv.ShowItemToolTips)
-                {
-                    ti.lpszText = NativeMethods.InvalidIntPtr;
-                }
-                else
-                {
-                    ti.lpszText = Marshal.StringToHGlobalAuto(caption);
-                    allocatedString = true;
-                }
-            }
-            else
-            {
-                ti.lpszText = Marshal.StringToHGlobalAuto(caption);
-                allocatedString = true;
-            }
+            bool noText = (control is TreeView tv && tv.ShowNodeToolTips)
+                || (control is ListView lv && lv.ShowItemToolTips);
 
-            return ti;
+            var info = new ComCtl32.ToolInfoWrapper(control, flags, noText ? null : caption);
+            if (noText)
+                info.Info.lpszText = (char*)(-1);
+
+            return info;
         }
 
-        private NativeMethods.TOOLINFO_TOOLTIP GetWinTOOLINFO(IntPtr hWnd)
+        private ComCtl32.ToolInfoWrapper GetWinTOOLINFO(IWin32Window hWnd)
         {
-            var ti = new NativeMethods.TOOLINFO_TOOLTIP
-            {
-                cbSize = Marshal.SizeOf<NativeMethods.TOOLINFO_TOOLTIP>(),
-                hwnd = hWnd
-            };
-            ti.uFlags |= NativeMethods.TTF_IDISHWND | NativeMethods.TTF_TRANSPARENT | NativeMethods.TTF_SUBCLASS;
+            ComCtl32.TTF flags = ComCtl32.TTF.TRANSPARENT | ComCtl32.TTF.SUBCLASS;
 
             // RightToLeft reading order
-            Control richParent = TopLevelControl;
-            if (richParent != null && richParent.RightToLeft == RightToLeft.Yes)
+            if (TopLevelControl?.RightToLeft == RightToLeft.Yes)
             {
-                bool isWindowMirrored = ((unchecked((int)(long)UnsafeNativeMethods.GetWindowLong(new HandleRef(this, hWnd), NativeMethods.GWL_STYLE)) & NativeMethods.WS_EX_LAYOUTRTL) == NativeMethods.WS_EX_LAYOUTRTL);
+                bool isWindowMirrored = ((unchecked((int)(long)UnsafeNativeMethods.GetWindowLong(
+                    new HandleRef(this, Control.GetSafeHandle(hWnd)), NativeMethods.GWL_STYLE)) & NativeMethods.WS_EX_LAYOUTRTL) == NativeMethods.WS_EX_LAYOUTRTL);
+
                 // Indicates that the ToolTip text will be displayed in the opposite direction
                 // to the text in the parent window.
                 if (!isWindowMirrored)
                 {
-                    ti.uFlags |= NativeMethods.TTF_RTLREADING;
+                    flags |= ComCtl32.TTF.RTLREADING;
                 }
             }
 
-            ti.uId = ti.hwnd;
-            return ti;
+            return new ComCtl32.ToolInfoWrapper(hWnd, flags);
         }
 
         /// <summary>
@@ -1247,22 +1179,22 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Sets the delayTime based on the NativeMethods.TTDT_* values.
         /// </summary>
-        private void SetDelayTime(int type, int time)
+        private void SetDelayTime(ComCtl32.TTDT type, int time)
         {
-            _auto = type == NativeMethods.TTDT_AUTOMATIC;
-            _delayTimes[type] = time;
+            _auto = type == ComCtl32.TTDT.AUTOMATIC;
+            _delayTimes[(int)type] = time;
 
             if (GetHandleCreated() && time >= 0)
             {
-                UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_SETDELAYTIME, type, time);
+                User32.SendMessageW(this, WindowMessages.TTM_SETDELAYTIME, (IntPtr)type, (IntPtr)time);
 
                 // Update everyone else if automatic is set. we need to do this
                 // to preserve value in case of handle recreation.
                 if (_auto)
                 {
-                    _delayTimes[NativeMethods.TTDT_AUTOPOP] = GetDelayTime(NativeMethods.TTDT_AUTOPOP);
-                    _delayTimes[NativeMethods.TTDT_INITIAL] = GetDelayTime(NativeMethods.TTDT_INITIAL);
-                    _delayTimes[NativeMethods.TTDT_RESHOW] = GetDelayTime(NativeMethods.TTDT_RESHOW);
+                    _delayTimes[(int)ComCtl32.TTDT.AUTOPOP] = GetDelayTime(ComCtl32.TTDT.AUTOPOP);
+                    _delayTimes[(int)ComCtl32.TTDT.INITIAL] = GetDelayTime(ComCtl32.TTDT.INITIAL);
+                    _delayTimes[(int)ComCtl32.TTDT.RESHOW] = GetDelayTime(ComCtl32.TTDT.RESHOW);
                 }
             }
             else if (_auto)
@@ -1318,20 +1250,7 @@ namespace System.Windows.Forms
                                       && TopLevelControl.IsHandleCreated;
                 if (exists && !empty && handlesCreated && !DesignMode)
                 {
-                    NativeMethods.TOOLINFO_TOOLTIP toolInfo = GetTOOLINFO(control, info.Caption, out bool allocatedString);
-                    try
-                    {
-                        UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_SETTOOLINFO,
-                                                        0, toolInfo);
-                    }
-                    finally
-                    {
-                        if (allocatedString && IntPtr.Zero != toolInfo.lpszText)
-                        {
-                            Marshal.FreeHGlobal(toolInfo.lpszText);
-                        }
-                    }
-
+                    GetTOOLINFO(control, info.Caption).SendMessage(this, WindowMessages.TTM_SETTOOLINFOW);
                     CheckNativeToolTip(control);
                     CheckCompositeControls(control);
                 }
@@ -1615,16 +1534,20 @@ namespace System.Windows.Forms
 
         private bool TryGetBubbleSize(IKeyboardToolTip tool, Rectangle toolRectangle, out Size bubbleSize)
         {
-            // Get bubble size to use it for optimal position calculation
-            IntPtr bubbleSizeInt = UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_GETBUBBLESIZE, 0, GetMinToolInfoForTool(tool.GetOwnerWindow()));
-            if (bubbleSizeInt.ToInt32() == NativeMethods.S_FALSE)
+            // Get bubble size to use it for optimal position calculation. Requesting the bubble
+            // size will AV if there isn't a current tool window.
+
+            IntPtr result = GetCurrentToolHwnd() == IntPtr.Zero ? IntPtr.Zero
+                 : new ComCtl32.ToolInfoWrapper(tool.GetOwnerWindow()).SendMessage(this, WindowMessages.TTM_GETBUBBLESIZE);
+
+            if (result == IntPtr.Zero)
             {
                 bubbleSize = Size.Empty;
                 return false;
             }
 
-            int width = NativeMethods.Util.LOWORD(bubbleSizeInt);
-            int height = NativeMethods.Util.HIWORD(bubbleSizeInt);
+            int width = NativeMethods.Util.LOWORD(result);
+            int height = NativeMethods.Util.HIWORD(result);
             bubbleSize = new Size(width, height);
             return true;
         }
@@ -1784,7 +1707,7 @@ namespace System.Windows.Forms
             try
             {
                 _trackPosition = true;
-                UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_TRACKPOSITION, 0, NativeMethods.Util.MAKELONG(pointX, pointY));
+                User32.SendMessageW(this, WindowMessages.TTM_TRACKPOSITION, IntPtr.Zero, PARAM.FromLowHigh(pointX, pointY));
             }
             finally
             {
@@ -1809,9 +1732,9 @@ namespace System.Windows.Forms
 
             if (GetHandleCreated())
             {
-                IntPtr hWnd = Control.GetSafeHandle(win);
-                UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_TRACKACTIVATE, 0, GetWinTOOLINFO(hWnd));
-                UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_DELTOOL, 0, GetWinTOOLINFO(hWnd));
+                var info = new ComCtl32.ToolInfoWrapper(win);
+                info.SendMessage(this, WindowMessages.TTM_TRACKACTIVATE);
+                info.SendMessage(this, WindowMessages.TTM_DELTOOLW);
             }
             StopTimer();
 
@@ -1866,49 +1789,33 @@ namespace System.Windows.Forms
             Control tool = win as Control;
             if (tool != null && _tools.ContainsKey(tool))
             {
-                bool allocatedString = false;
-                var ti = new NativeMethods.TOOLINFO_TOOLTIP();
-                try
+                var toolInfo = new ComCtl32.ToolInfoWrapper(tool);
+                if (toolInfo.SendMessage(this, WindowMessages.TTM_GETTOOLINFOW) != IntPtr.Zero)
                 {
-                    ti.cbSize = Marshal.SizeOf<NativeMethods.TOOLINFO_TOOLTIP>();
-                    ti.hwnd = tool.Handle;
-                    ti.uId = tool.Handle;
-                    int ret = (int)UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_GETTOOLINFO, 0, ti);
-                    if (ret != 0)
+                    ComCtl32.TTF flags = ComCtl32.TTF.TRACK;
+                    if (type == TipInfo.Type.Absolute || type == TipInfo.Type.SemiAbsolute)
                     {
-                        ti.uFlags |= NativeMethods.TTF_TRACK;
-
-                        if (type == TipInfo.Type.Absolute || type == TipInfo.Type.SemiAbsolute)
-                        {
-                            ti.uFlags |= NativeMethods.TTF_ABSOLUTE;
-                        }
-                        ti.lpszText = Marshal.StringToHGlobalAuto(text);
-                        allocatedString = true;
+                        flags |= ComCtl32.TTF.ABSOLUTE;
                     }
-
-                    TipInfo tt = (TipInfo)_tools[tool];
-                    if (tt == null)
-                    {
-                        tt = new TipInfo(text, type);
-                    }
-                    else
-                    {
-                        tt.TipType |= type;
-                        tt.Caption = text;
-                    }
-                    tt.Position = position;
-                    _tools[tool] = tt;
-
-                    UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_SETTOOLINFO, 0, ti);
-                    UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_TRACKACTIVATE, 1, ti);
+                    toolInfo.Info.uFlags |= flags;
+                    toolInfo.Text = text;
                 }
-                finally
+
+                TipInfo tt = (TipInfo)_tools[tool];
+                if (tt == null)
                 {
-                    if (allocatedString && IntPtr.Zero != ti.lpszText)
-                    {
-                        Marshal.FreeHGlobal(ti.lpszText);
-                    }
+                    tt = new TipInfo(text, type);
                 }
+                else
+                {
+                    tt.TipType |= type;
+                    tt.Caption = text;
+                }
+                tt.Position = position;
+                _tools[tool] = tt;
+
+                IntPtr result = toolInfo.SendMessage(this, WindowMessages.TTM_SETTOOLINFOW);
+                result = toolInfo.SendMessage(this, WindowMessages.TTM_TRACKACTIVATE, BOOL.TRUE);
             }
             else
             {
@@ -1932,27 +1839,18 @@ namespace System.Windows.Forms
 
                 IntPtr hWnd = Control.GetSafeHandle(win);
                 _owners[hWnd] = win;
-                NativeMethods.TOOLINFO_TOOLTIP toolInfo = GetWinTOOLINFO(hWnd);
-                toolInfo.uFlags |= NativeMethods.TTF_TRACK;
+
+                var toolInfo = GetWinTOOLINFO(win);
+                toolInfo.Info.uFlags |= ComCtl32.TTF.TRACK;
 
                 if (type == TipInfo.Type.Absolute || type == TipInfo.Type.SemiAbsolute)
                 {
-                    toolInfo.uFlags |= NativeMethods.TTF_ABSOLUTE;
+                    toolInfo.Info.uFlags |= ComCtl32.TTF.ABSOLUTE;
                 }
 
-                try
-                {
-                    toolInfo.lpszText = Marshal.StringToHGlobalAuto(text);
-                    UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_ADDTOOL, 0, toolInfo);
-                    UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_TRACKACTIVATE, 1, toolInfo);
-                }
-                finally
-                {
-                    if (IntPtr.Zero != toolInfo.lpszText)
-                    {
-                        Marshal.FreeHGlobal(toolInfo.lpszText);
-                    }
-                }
+                toolInfo.Text = text;
+                IntPtr result = toolInfo.SendMessage(this, WindowMessages.TTM_ADDTOOLW);
+                result = toolInfo.SendMessage(this, WindowMessages.TTM_TRACKACTIVATE, BOOL.TRUE);
             }
 
             if (tool != null)
@@ -2046,52 +1944,55 @@ namespace System.Windows.Forms
             NativeMethods.SWP_NOACTIVATE | NativeMethods.SWP_NOSIZE | NativeMethods.SWP_NOOWNERZORDER);
         }
 
+        private IntPtr GetCurrentToolHwnd()
+        {
+            var toolInfo = new ComCtl32.ToolInfoWrapper();
+            if (toolInfo.SendMessage(this, WindowMessages.TTM_GETCURRENTTOOLW) != IntPtr.Zero)
+            {
+                return toolInfo.Info.hwnd;
+            }
+            return IntPtr.Zero;
+        }
+
+        private IWin32Window GetCurrentToolWindow()
+        {
+            IntPtr hwnd = GetCurrentToolHwnd();
+            return (IWin32Window)_owners[hwnd] ?? Control.FromHandle(hwnd);
+        }
+
         /// <summary>
         ///  Handles the WM_MOVE message.
         /// </summary>
         private void WmMove()
         {
+            IWin32Window window = GetCurrentToolWindow();
+            if (window == null)
+                return;
+
+            TipInfo tt = (TipInfo)_tools[window];
+            if (window == null || tt == null)
+            {
+                return;
+            }
+
+            // Treeview handles its own ToolTips.
+            if (window is TreeView treeView)
+            {
+                if (treeView.ShowNodeToolTips)
+                {
+                    return;
+                }
+            }
+
+            // Reposition the tooltip when its about to be shown since the tooltip can go out of screen
+            // working area bounds Reposition would check the bounds for us.
+
             var r = new RECT();
             UnsafeNativeMethods.GetWindowRect(new HandleRef(this, Handle), ref r);
-            var ti = new NativeMethods.TOOLINFO_TOOLTIP
+
+            if (tt.Position != Point.Empty)
             {
-                cbSize = Marshal.SizeOf<NativeMethods.TOOLINFO_TOOLTIP>()
-            };
-            int ret = (int)UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_GETCURRENTTOOL, 0, ti);
-            if (ret != 0)
-            {
-                IWin32Window win = (IWin32Window)_owners[ti.hwnd];
-                if (win == null)
-                {
-                    win = (IWin32Window)Control.FromHandle(ti.hwnd);
-                }
-
-                if (win == null)
-                {
-                    return;
-                }
-
-                TipInfo tt = (TipInfo)_tools[win];
-                if (win == null || tt == null)
-                {
-                    return;
-                }
-
-                // Treeview handles its own ToolTips.
-                if (win is TreeView treeView)
-                {
-                    if (treeView.ShowNodeToolTips)
-                    {
-                        return;
-                    }
-                }
-
-                // Reposition the tooltip when its about to be shown. since the tooltip can go out of screen workingarea bounds
-                // Reposition would check the bounds for us.
-                if (tt.Position != Point.Empty)
-                {
-                    Reposition(tt.Position, r.Size);
-                }
+                Reposition(tt.Position, r.Size);
             }
         }
 
@@ -2100,37 +2001,20 @@ namespace System.Windows.Forms
         /// </summary>
         private void WmMouseActivate(ref Message msg)
         {
-            var ti = new NativeMethods.TOOLINFO_TOOLTIP
+            IWin32Window window = GetCurrentToolWindow();
+            if (window == null)
+                return;
+
+            var r = new RECT();
+            UnsafeNativeMethods.GetWindowRect(new HandleRef(window, Control.GetSafeHandle(window)), ref r);
+            Point cursorLocation = Cursor.Position;
+
+            // Do not activate the mouse if its within the bounds of the
+            // the associated tool
+            if (cursorLocation.X >= r.left && cursorLocation.X <= r.right &&
+                cursorLocation.Y >= r.top && cursorLocation.Y <= r.bottom)
             {
-                cbSize = Marshal.SizeOf<NativeMethods.TOOLINFO_TOOLTIP>()
-            };
-            int ret = (int)UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_GETCURRENTTOOL, 0, ti);
-
-            if (ret != 0)
-            {
-
-                IWin32Window win = (IWin32Window)_owners[ti.hwnd];
-                if (win == null)
-                {
-                    win = (IWin32Window)Control.FromHandle(ti.hwnd);
-                }
-
-                if (win == null)
-                {
-                    return;
-                }
-
-                var r = new RECT();
-                UnsafeNativeMethods.GetWindowRect(new HandleRef(win, Control.GetSafeHandle(win)), ref r);
-                Point cursorLocation = Cursor.Position;
-
-                // Do not activate the mouse if its within the bounds of the
-                // the associated tool
-                if (cursorLocation.X >= r.left && cursorLocation.X <= r.right &&
-                    cursorLocation.Y >= r.top && cursorLocation.Y <= r.bottom)
-                {
-                    msg.Result = (IntPtr)NativeMethods.MA_NOACTIVATE;
-                }
+                msg.Result = (IntPtr)NativeMethods.MA_NOACTIVATE;
             }
         }
 
@@ -2149,89 +2033,73 @@ namespace System.Windows.Forms
         /// </summary>
         private void WmShow()
         {
+            IWin32Window window = GetCurrentToolWindow();
+            if (window == null)
+                return;
+
             // Get the bounds.
             var r = new RECT();
             UnsafeNativeMethods.GetWindowRect(new HandleRef(this, Handle), ref r);
 
-            var ti = new NativeMethods.TOOLINFO_TOOLTIP
+            Control toolControl = window as Control;
+
+            Size currentTooltipSize = r.Size;
+            PopupEventArgs e = new PopupEventArgs(window, toolControl, IsBalloon, currentTooltipSize);
+            OnPopup(e);
+
+            if (toolControl is DataGridView dataGridView && dataGridView.CancelToolTipPopup(this))
             {
-                cbSize = Marshal.SizeOf<NativeMethods.TOOLINFO_TOOLTIP>()
-            };
-            int ret = (int)UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_GETCURRENTTOOL, 0, ti);
+                // The dataGridView cancelled the tooltip.
+                e.Cancel = true;
+            }
 
-            if (ret != 0)
+            // We need to re-get the rectangle of the tooltip here because
+            // any of the tooltip attributes/properties could have been updated
+            // during the popup event; in which case the size of the tooltip is
+            // affected. e.ToolTipSize is respected over r.Size
+            UnsafeNativeMethods.GetWindowRect(new HandleRef(this, Handle), ref r);
+            currentTooltipSize = (e.ToolTipSize == currentTooltipSize) ? r.Size : e.ToolTipSize;
+
+            if (IsBalloon)
             {
-                IWin32Window win = (IWin32Window)_owners[ti.hwnd];
-                if (win == null)
+                // Get the text display rectangle
+                User32.SendMessageW(this, WindowMessages.TTM_ADJUSTRECT, PARAM.FromBool(true), r);
+                if (r.Size.Height > currentTooltipSize.Height)
                 {
-                    win = (IWin32Window)Control.FromHandle(ti.hwnd);
+                    currentTooltipSize.Height = r.Size.Height;
                 }
+            }
 
-                if (win == null)
-                {
-                    return;
-                }
+            // Set the max possible size of the tooltip to the size we received.
+            // This prevents the operating system from drawing incorrect rectangles
+            // when determing the correct display rectangle
+            // Set the MaxWidth only if user has changed the width.
+            if (currentTooltipSize != r.Size)
+            {
+                Screen screen = Screen.FromPoint(Cursor.Position);
+                int maxwidth = (IsBalloon) ?
+                Math.Min(currentTooltipSize.Width - 2 * BalloonOffsetX, screen.WorkingArea.Width) :
+                Math.Min(currentTooltipSize.Width, screen.WorkingArea.Width);
+                User32.SendMessageW(this, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)maxwidth);
+            }
 
-                Control toolControl = win as Control;
+            if (e.Cancel)
+            {
+                _cancelled = true;
+                SafeNativeMethods.SetWindowPos(new HandleRef(this, Handle),
+                NativeMethods.HWND_TOPMOST,
+                0, 0, 0, 0,
+                NativeMethods.SWP_NOACTIVATE | NativeMethods.SWP_NOOWNERZORDER);
 
-                Size currentTooltipSize = r.Size;
-                PopupEventArgs e = new PopupEventArgs(win, toolControl, IsBalloon, currentTooltipSize);
-                OnPopup(e);
-
-                if (toolControl is DataGridView dataGridView && dataGridView.CancelToolTipPopup(this))
-                {
-                    // The dataGridView cancelled the tooltip.
-                    e.Cancel = true;
-                }
-
-                // We need to re-get the rectangle of the tooltip here because
-                // any of the tooltip attributes/properties could have been updated
-                // during the popup event; in which case the size of the tooltip is
-                // affected. e.ToolTipSize is respected over r.Size
-                UnsafeNativeMethods.GetWindowRect(new HandleRef(this, Handle), ref r);
-                currentTooltipSize = (e.ToolTipSize == currentTooltipSize) ? r.Size : e.ToolTipSize;
-
-                if (IsBalloon)
-                {
-                    // Get the text display rectangle
-                    UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_ADJUSTRECT, 1, ref r);
-                    if (r.Size.Height > currentTooltipSize.Height)
-                    {
-                        currentTooltipSize.Height = r.Size.Height;
-                    }
-                }
-
-                // Set the max possible size of the tooltip to the size we received.
-                // This prevents the operating system from drawing incorrect rectangles
-                // when determing the correct display rectangle
-                // Set the MaxWidth only if user has changed the width.
-                if (currentTooltipSize != r.Size)
-                {
-                    Screen screen = Screen.FromPoint(Cursor.Position);
-                    int maxwidth = (IsBalloon) ?
-                    Math.Min(currentTooltipSize.Width - 2 * BalloonOffsetX, screen.WorkingArea.Width) :
-                    Math.Min(currentTooltipSize.Width, screen.WorkingArea.Width);
-                    UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_SETMAXTIPWIDTH, 0, maxwidth);
-                }
-
-                if (e.Cancel)
-                {
-                    _cancelled = true;
-                    SafeNativeMethods.SetWindowPos(new HandleRef(this, Handle),
-                    NativeMethods.HWND_TOPMOST,
-                    0, 0, 0, 0,
-                    NativeMethods.SWP_NOACTIVATE | NativeMethods.SWP_NOOWNERZORDER);
-
-                }
-                else
-                {
-                    _cancelled = false;
-                    // Only width/height changes are respected, so set top,left to what we got earlier
-                    SafeNativeMethods.SetWindowPos(new HandleRef(this, Handle),
-                    NativeMethods.HWND_TOPMOST,
-                    r.left, r.top, currentTooltipSize.Width, currentTooltipSize.Height,
-                    NativeMethods.SWP_NOACTIVATE | NativeMethods.SWP_NOOWNERZORDER);
-                }
+            }
+            else
+            {
+                _cancelled = false;
+                // Only width/height changes are respected, so set top,left to what we got earlier
+                SafeNativeMethods.SetWindowPos(new HandleRef(this, Handle),
+                NativeMethods.HWND_TOPMOST,
+                r.left, r.top, currentTooltipSize.Width, currentTooltipSize.Height,
+                NativeMethods.SWP_NOACTIVATE | NativeMethods.SWP_NOOWNERZORDER);
             }
         }
 
@@ -2266,35 +2134,20 @@ namespace System.Windows.Forms
             Cursor currentCursor = Cursor.Current;
             Point cursorPos = Cursor.Position;
 
-            var ti = new NativeMethods.TOOLINFO_TOOLTIP
+            IWin32Window window = GetCurrentToolWindow();
+            if (window != null)
             {
-                cbSize = Marshal.SizeOf<NativeMethods.TOOLINFO_TOOLTIP>()
-            };
-            int ret = (int)UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_GETCURRENTTOOL, 0, ti);
-            if (ret != 0)
-            {
-                IWin32Window win = (IWin32Window)_owners[ti.hwnd];
-                if (win == null)
-                {
-                    win = (IWin32Window)Control.FromHandle(ti.hwnd);
-                }
-
-                if (win == null || !IsWindowActive(win))
-                {
-                    return;
-                }
-
                 TipInfo tt = null;
-                if (win != null)
+                if (window != null)
                 {
-                    tt = (TipInfo)_tools[win];
+                    tt = (TipInfo)_tools[window];
                     if (tt == null)
                     {
                         return;
                     }
 
                     // Treeview handles its own ToolTips.
-                    if (win is TreeView treeView)
+                    if (window is TreeView treeView)
                     {
                         if (treeView.ShowNodeToolTips)
                         {
@@ -2364,63 +2217,47 @@ namespace System.Windows.Forms
         /// </summary>
         private void WmPop()
         {
-            var ti = new NativeMethods.TOOLINFO_TOOLTIP
+            IWin32Window window = GetCurrentToolWindow();
+            if (window == null)
+                return;
+
+            Control control = window as Control;
+            TipInfo tt = (TipInfo)_tools[window];
+            if (tt == null)
             {
-                cbSize = Marshal.SizeOf<NativeMethods.TOOLINFO_TOOLTIP>()
-            };
-            int ret = (int)UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_GETCURRENTTOOL, 0, ti);
-            if (ret != 0)
+                return;
+            }
+
+            // Must reset the maxwidth to the screen size.
+            if ((tt.TipType & TipInfo.Type.Auto) != 0 || (tt.TipType & TipInfo.Type.SemiAbsolute) != 0)
             {
+                Screen screen = Screen.FromPoint(Cursor.Position);
+                User32.SendMessageW(this, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)screen.WorkingArea.Width);
+            }
 
-                IWin32Window win = (IWin32Window)_owners[ti.hwnd];
-                if (win == null)
+            // For non-auto tips (those showned through the show(.) methods, we need to
+            // dissassociate them from the tip control.
+            if ((tt.TipType & TipInfo.Type.Auto) == 0)
+            {
+                _tools.Remove(control);
+                _owners.Remove(window.Handle);
+
+                control.HandleCreated -= new EventHandler(HandleCreated);
+                control.HandleDestroyed -= new EventHandler(HandleDestroyed);
+                _created.Remove(control);
+
+                if (_originalPopupDelay != 0)
                 {
-                    win = (IWin32Window)Control.FromHandle(ti.hwnd);
+                    AutoPopDelay = _originalPopupDelay;
+                    _originalPopupDelay = 0;
                 }
-
-                if (win == null)
-                {
-                    return;
-                }
-
-                Control control = win as Control;
-                TipInfo tt = (TipInfo)_tools[win];
-                if (tt == null)
-                {
-                    return;
-                }
-
-                // Must reset the maxwidth to the screen size.
-                if ((tt.TipType & TipInfo.Type.Auto) != 0 || (tt.TipType & TipInfo.Type.SemiAbsolute) != 0)
-                {
-                    Screen screen = Screen.FromPoint(Cursor.Position);
-                    UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_SETMAXTIPWIDTH, 0, screen.WorkingArea.Width);
-                }
-
-                // For non-auto tips (those showned through the show(.) methods, we need to
-                // dissassociate them from the tip control.
-                if ((tt.TipType & TipInfo.Type.Auto) == 0)
-                {
-                    _tools.Remove(control);
-                    _owners.Remove(win.Handle);
-
-                    control.HandleCreated -= new EventHandler(HandleCreated);
-                    control.HandleDestroyed -= new EventHandler(HandleDestroyed);
-                    _created.Remove(control);
-
-                    if (_originalPopupDelay != 0)
-                    {
-                        AutoPopDelay = _originalPopupDelay;
-                        _originalPopupDelay = 0;
-                    }
-                }
-                else
-                {
-                    // Clear all other flags except for the Auto flag to ensure automatic tips can still show
-                    tt.TipType = TipInfo.Type.Auto;
-                    tt.Position = Point.Empty;
-                    _tools[control] = tt;
-                }
+            }
+            else
+            {
+                // Clear all other flags except for the Auto flag to ensure automatic tips can still show
+                tt.TipType = TipInfo.Type.Auto;
+                tt.Position = Point.Empty;
+                _tools[control] = tt;
             }
         }
 
@@ -2463,7 +2300,7 @@ namespace System.Windows.Forms
                     WmMove();
                     break;
 
-                case NativeMethods.TTM_WINDOWFROMPOINT:
+                case (int)WindowMessages.TTM_WINDOWFROMPOINT:
                     WmWindowFromPoint(ref msg);
                     break;
 
@@ -2485,19 +2322,10 @@ namespace System.Windows.Forms
                             {
                                 return;
                             }
-                            var ti = new NativeMethods.TOOLINFO_TOOLTIP
+
+                            IWin32Window window = GetCurrentToolWindow();
+                            if (window != null)
                             {
-                                cbSize = Marshal.SizeOf<NativeMethods.TOOLINFO_TOOLTIP>()
-                            };
-                            int ret = unchecked((int)(long)UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TTM_GETCURRENTTOOL, 0, ti));
-                            if (ret != 0)
-                            {
-                                IWin32Window win = (IWin32Window)_owners[ti.hwnd];
-                                Control ac = Control.FromHandle(ti.hwnd);
-                                if (win == null)
-                                {
-                                    win = (IWin32Window)ac;
-                                }
                                 Font font;
                                 try
                                 {
@@ -2510,8 +2338,9 @@ namespace System.Windows.Forms
                                     font = Control.DefaultFont;
                                 }
 
-                                OnDraw(new DrawToolTipEventArgs(g, win, ac, bounds, GetToolTip(ac),
-                                                                BackColor, ForeColor, font));
+                                Control control = window as Control ?? Control.FromHandle(window.Handle);
+                                OnDraw(new DrawToolTipEventArgs(
+                                    g, window, control, bounds, GetToolTip(control), BackColor, ForeColor, font));
 
                                 break;
                             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -1248,9 +1248,11 @@ namespace System.Windows.Forms
                 bool handlesCreated = control.IsHandleCreated
                                       && TopLevelControl != null
                                       && TopLevelControl.IsHandleCreated;
+
                 if (exists && !empty && handlesCreated && !DesignMode)
                 {
-                    GetTOOLINFO(control, info.Caption).SendMessage(this, WindowMessages.TTM_SETTOOLINFOW);
+                    ComCtl32.ToolInfoWrapper toolInfo = GetTOOLINFO(control, info.Caption);
+                    toolInfo.SendMessage(this, WindowMessages.TTM_SETTOOLINFOW);
                     CheckNativeToolTip(control);
                     CheckCompositeControls(control);
                 }
@@ -2077,29 +2079,32 @@ namespace System.Windows.Forms
             if (currentTooltipSize != r.Size)
             {
                 Screen screen = Screen.FromPoint(Cursor.Position);
-                int maxwidth = (IsBalloon) ?
-                Math.Min(currentTooltipSize.Width - 2 * BalloonOffsetX, screen.WorkingArea.Width) :
-                Math.Min(currentTooltipSize.Width, screen.WorkingArea.Width);
+                int maxwidth = (IsBalloon)
+                    ? Math.Min(currentTooltipSize.Width - 2 * BalloonOffsetX, screen.WorkingArea.Width)
+                    : Math.Min(currentTooltipSize.Width, screen.WorkingArea.Width);
                 User32.SendMessageW(this, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)maxwidth);
             }
 
             if (e.Cancel)
             {
                 _cancelled = true;
-                SafeNativeMethods.SetWindowPos(new HandleRef(this, Handle),
-                NativeMethods.HWND_TOPMOST,
-                0, 0, 0, 0,
-                NativeMethods.SWP_NOACTIVATE | NativeMethods.SWP_NOOWNERZORDER);
+                SafeNativeMethods.SetWindowPos(
+                    new HandleRef(this, Handle),
+                    NativeMethods.HWND_TOPMOST,
+                    0, 0, 0, 0,
+                    NativeMethods.SWP_NOACTIVATE | NativeMethods.SWP_NOOWNERZORDER);
 
             }
             else
             {
                 _cancelled = false;
+
                 // Only width/height changes are respected, so set top,left to what we got earlier
-                SafeNativeMethods.SetWindowPos(new HandleRef(this, Handle),
-                NativeMethods.HWND_TOPMOST,
-                r.left, r.top, currentTooltipSize.Width, currentTooltipSize.Height,
-                NativeMethods.SWP_NOACTIVATE | NativeMethods.SWP_NOOWNERZORDER);
+                SafeNativeMethods.SetWindowPos(
+                    new HandleRef(this, Handle),
+                    NativeMethods.HWND_TOPMOST,
+                    r.left, r.top, currentTooltipSize.Width, currentTooltipSize.Height,
+                    NativeMethods.SWP_NOACTIVATE | NativeMethods.SWP_NOOWNERZORDER);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -3270,7 +3270,7 @@ namespace System.Windows.Forms
                     switch (nmhdr.code)
                     {
                         case NativeMethods.TTN_GETDISPINFO:
-                            // Setting the max width has the added benefit of enabling multiline tool tips!
+                            // Setting the max width has the added benefit of enabling multiline tool tips
                             User32.SendMessageW(nmhdr.hwndFrom, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
                             WmNeedText(ref m);
                             m.Result = (IntPtr)1;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -1784,7 +1784,7 @@ namespace System.Windows.Forms
         {
             if (toolTip != null)
             {
-                User32.SendMessageW(toolTip, WindowMessages.TTM_SETMAXTIPWIDTH, (IntPtr)0, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
+                User32.SendMessageW(toolTip, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
                 UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TVM_SETTOOLTIPS, new HandleRef(toolTip, toolTip.Handle), 0);
                 controlToolTipText = toolTipText;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -1784,7 +1784,7 @@ namespace System.Windows.Forms
         {
             if (toolTip != null)
             {
-                UnsafeNativeMethods.SendMessage(new HandleRef(toolTip, toolTip.Handle), NativeMethods.TTM_SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
+                User32.SendMessageW(toolTip, WindowMessages.TTM_SETMAXTIPWIDTH, (IntPtr)0, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
                 UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TVM_SETTOOLTIPS, new HandleRef(toolTip, toolTip.Handle), 0);
                 controlToolTipText = toolTipText;
             }
@@ -2992,7 +2992,7 @@ namespace System.Windows.Forms
                         Rectangle bounds = tn.Bounds;
                         bounds.Location = PointToScreen(bounds.Location);
 
-                        UnsafeNativeMethods.SendMessage(new HandleRef(this, tooltipHandle), NativeMethods.TTM_ADJUSTRECT, 1, ref bounds);
+                        User32.SendMessageW(tooltipHandle, WindowMessages.TTM_ADJUSTRECT, PARAM.FromBool(true), bounds);
                         SafeNativeMethods.SetWindowPos(new HandleRef(this, tooltipHandle),
                                 NativeMethods.HWND_TOPMOST, bounds.Left, bounds.Top, 0, 0, NativeMethods.SWP_NOACTIVATE | NativeMethods.SWP_NOSIZE | NativeMethods.SWP_NOZORDER);
                         return true;
@@ -3033,10 +3033,9 @@ namespace System.Windows.Forms
             ttt.hinst = IntPtr.Zero;
 
             // RightToLeft reading order
-            //
             if (RightToLeft == RightToLeft.Yes)
             {
-                ttt.uFlags |= NativeMethods.TTF_RTLREADING;
+                ttt.uFlags |= (int)ComCtl32.TTF.RTLREADING;
             }
             Marshal.StructureToPtr(ttt, m.LParam, false);
         }
@@ -3271,11 +3270,8 @@ namespace System.Windows.Forms
                     switch (nmhdr.code)
                     {
                         case NativeMethods.TTN_GETDISPINFO:
-                            // MSDN:
-                            // Setting the max width has the added benefit of enabling multiline
-                            // tool tips!
-                            //
-                            UnsafeNativeMethods.SendMessage(new HandleRef(nmhdr, nmhdr.hwndFrom), NativeMethods.TTM_SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
+                            // Setting the max width has the added benefit of enabling multiline tool tips!
+                            User32.SendMessageW(nmhdr.hwndFrom, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
                             WmNeedText(ref m);
                             m.Result = (IntPtr)1;
                             return;


### PR DESCRIPTION
The tooltip class will cause Windows to AV when attempting to get the tooltip bubble size when there isn't an actively showing tooltip. (Really Windows should be checking before derefing their internal pointer, but this has been there forever.) Fixing this by making sure to check that one is active when sending the query message.

The existing TooInfo usage was not safe and could crash with bad timing with a GC. I've hardened usage of the TTTOOLINFO struct and made it blittable, which should make things both safe and more performant as we're not instantiating a class anymore.

Fixes #1602.

## Proposed changes

- Refactor TTOOLINFO to guard against AVs
- Fix the explicit AV in #1602

## Customer Impact

- Won't easily AV
- Better performance

## Regression? 

- Yes - Introduced in 4.8

## Risk

- Reasonably low- it is much easier to reason about the code with this change

## Test methodology

- Manual testing with Tooltip
- Debugging into Windows to validate behavior


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1612)