### PR TITLE
Set system aware mode in project templates c#

### DIFF
--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/Program.cs
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/Program.cs
@@ -14,6 +14,7 @@ namespace Company.WinFormsApplication1
         [STAThread]
         static void Main()
         {
+            Application.SetHighDpiMode(HighDpiMode.SystemAware);
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new Form1());


### PR DESCRIPTION
Fixes #1634

## Proposed changes

- Set DPI mode to System Aware in the project templates

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Winforms applications will be system aware by default
- Customers can always change this behavior by modifying the program.cs

## Regression? 

- No

## Risk

- Very low

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

See https://github.com/dotnet/winforms-designer/pull/637


## Test methodology <!-- How did you ensure quality? -->

- Manual testing (instructions are at https://github.com/dotnet/winforms/blob/63a29cea7f717aea6b614dc3d5d317c4b7a996d4/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/readme.md)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1635)