### PR TITLE
Add system.resource.extensions as a dependency from corefx

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -39,6 +39,10 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>b82d2bc44424c8a99a1f0fc13202bdfd43e6f9f5</Sha>
     </Dependency>
+    <Dependency Name="System.Resources.Extensions" Version="4.6.0-preview9.19409.17" CoherentParentDependency="Microsoft.NETCore.App">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>b82d2bc44424c8a99a1f0fc13202bdfd43e6f9f5</Sha>
+    </Dependency>
     <Dependency Name="System.Security.Cryptography.Cng" Version="4.6.0-preview9.19409.17" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>b82d2bc44424c8a99a1f0fc13202bdfd43e6f9f5</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,6 +20,7 @@
     <SystemCodeDomPackageVersion>4.6.0-preview9.19409.17</SystemCodeDomPackageVersion>
     <SystemConfigurationConfigurationManagerPackageVersion>4.6.0-preview9.19409.17</SystemConfigurationConfigurationManagerPackageVersion>
     <SystemDrawingCommonPackageVersion>4.6.0-preview9.19409.17</SystemDrawingCommonPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>4.6.0-preview9.19409.17</SystemResourcesExtensionsPackageVersion>
     <SystemSecurityCryptographyCngPackageVersion>4.6.0-preview9.19409.17</SystemSecurityCryptographyCngPackageVersion>
     <SystemSecurityPermissionsPackageVersion>4.6.0-preview9.19409.17</SystemSecurityPermissionsPackageVersion>
     <SystemWindowsExtensionsPackageVersion>4.6.0-preview9.19409.17</SystemWindowsExtensionsPackageVersion>

--- a/src/System.Windows.Forms/src/System.Windows.Forms.csproj
+++ b/src/System.Windows.Forms/src/System.Windows.Forms.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.Win32.SystemEvents" Version="$(MicrosoftWin32SystemEventsPackageVersion)" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" />
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonPackageVersion)" />
+    <PackageReference Include="System.Resources.Extensions" Version="$(SystemResourcesExtensionsPackageVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes error when building locally, but only with VS int-preview installed. Error looks like this:

```
C:\Program Files (x86)\Microsoft Visual Studio\2019\IntPreview\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(3056,5): error : MSB3822: Non-string resources require the System.Resources.Extensions assembly at runtime, but it
was not found in this project's references. [E:\src\repos\github\winforms\src\System.Windows.Forms\src\System.Windows.F
orms.csproj]
```

## Proposed changes

- Add the package reference specified by the error

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- None, the CI build is passing without this. This is only needed if you build locally with VS int-preview installed.

## Regression? 

- Might be a regression on the VS side, we submitted a feedback ticket to find out

## Risk

- Very low


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1637)