### PR TITLE
Disabling SystemRendering mode for ToolStrip in HC mode to make buttons contrasted

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewDialog.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1248,7 +1248,14 @@ namespace System.Windows.Forms
             separatorToolStripSeparator1,
             closeToolStripButton});
             toolStrip1.Name = "toolStrip1";
-            toolStrip1.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
+
+            // in High Contrast mode the color scheme provided by ToolStripSystemRenderer 
+            // is not sufficiently contrast; so disable it in High Contrast mode.
+            if (!SystemInformation.HighContrast)
+            {
+                toolStrip1.RenderMode = ToolStripRenderMode.System;
+            }
+
             toolStrip1.GripStyle = ToolStripGripStyle.Hidden;
 
             //


### PR DESCRIPTION
…ns contrasted.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1421

## Proposed changes

- Disabling System RenderMode for the PrintPreview ToolStrip to prevent ToolStripSystemRenderer to draw buttons with not contrasted color in HC themes.
- The change works and is effective only in HC mode. To enable change the ToolStrip control should be recreated or app should be restarted in HC mode enabled environment.
- In non-HC mode environment RenderMode.System is enabled by default (as it was before)

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- In HC mode PrintPreview ToolStrip buttons are enough contrasted.
- in non-HC mode PrintPreview ToolStrip buttons are rendered as before the change.
- App should be restarted to make the change effective if system HC mode is turned on/off.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Please see the #1421 

### After

<!-- TODO -->
![image](https://user-images.githubusercontent.com/23213980/63109623-4d07d480-bf92-11e9-96f0-e11d262c5a0a.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual testing.
- Awaiting QA approval.
- HC analyzer - contrast level is sufficient.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

Version: 3.0.100-preview8-012929
Commit: 795f8aeaa8
Runtime Environment:
OS Name: Windows
OS Version: 10.0.18362
OS Platform: Windows
RID: win10-x64
Base Path: C:\Program Files\dotnet\sdk\3.0.100-preview8-012929\
Host (useful for support):
Version: 3.0.0-preview8-27907-09
Commit: fc924dc319
.NET Core SDKs installed:
2.1.700-preview-009601 [C:\Program Files\dotnet\sdk]
2.1.800-preview-009696 [C:\Program Files\dotnet\sdk]
3.0.100-preview8-012929 [C:\Program Files\dotnet\sdk]
.NET Core runtimes installed:
Microsoft.AspNetCore.All 2.1.9 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.All]
Microsoft.AspNetCore.All 2.1.11 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.All]
Microsoft.AspNetCore.App 2.1.9 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
Microsoft.AspNetCore.App 2.1.11 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
Microsoft.AspNetCore.App 3.0.0-preview8.19351.9 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
Microsoft.NETCore.App 2.1.9 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
Microsoft.NETCore.App 2.1.11 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
Microsoft.NETCore.App 3.0.0-preview8-27907-09 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
Microsoft.WindowsDesktop.App 3.0.0-preview8-27907-09 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1642)