### PR TITLE
[Keyboard][Accessibility]: Fixing activation DataGridView cell tooltips with using a keyboard

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -2842,6 +2842,21 @@ To replace this default dialog please handle the DataError event.</value>
   <data name="DefManifestNotFound" xml:space="preserve">
     <value>Default manifest file required to enable visual styles cannot be found.</value>
   </data>
+  <data name="DefaultDataGridViewButtonCellTollTipText" xml:space="preserve">
+    <value>Button</value>
+  </data>
+  <data name="DefaultDataGridViewComboBoxCellTollTipText" xml:space="preserve">
+    <value>ComboBox</value>
+  </data>
+  <data name="DefaultDataGridViewImageCellToolTipText" xml:space="preserve">
+    <value>Image</value>
+  </data>
+  <data name="DefaultDataGridViewLinkCellTollTipText" xml:space="preserve">
+    <value>Link</value>
+  </data>
+  <data name="DefaultDataGridViewTextBoxCellTollTipText" xml:space="preserve">
+    <value>Edit</value>
+  </data>
   <data name="DescriptionBindingNavigator" xml:space="preserve">
     <value>Provides a user interface for navigation and manipulation of data bound to controls on a form.</value>
   </data>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -4679,6 +4679,31 @@ Chcete-li nahradit toto výchozí dialogové okno, nastavte popisovač události
         <target state="translated">Výchozí soubor manifestu požadovaný k povolení vizuálních stylů nebyl nalezen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+        <source>Button</source>
+        <target state="needs-review-translation">Button</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewImageCellToolTipText">
+        <source>Image</source>
+        <target state="needs-review-translation">Image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+        <source>Link</source>
+        <target state="new">Link</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+        <source>Edit</source>
+        <target state="new">Edit</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionBindingNavigator">
         <source>Provides a user interface for navigation and manipulation of data bound to controls on a form.</source>
         <target state="translated">Zajišťuje uživatelské rozhraní pro navigaci a manipulaci s daty vázanými na ovládací prvky ve formuláři.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -4679,6 +4679,31 @@ Behandeln Sie das DataError-Ereignis, um dieses Standarddialogfeld zu ersetzen.<
         <target state="translated">Die für die Aktivierung des visuellen Stils erforderliche Standardmanifestdatei kann nicht gefunden werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+        <source>Button</source>
+        <target state="needs-review-translation">Button</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewImageCellToolTipText">
+        <source>Image</source>
+        <target state="needs-review-translation">Image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+        <source>Link</source>
+        <target state="new">Link</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+        <source>Edit</source>
+        <target state="new">Edit</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionBindingNavigator">
         <source>Provides a user interface for navigation and manipulation of data bound to controls on a form.</source>
         <target state="translated">Stellt eine Benutzeroberfläche für die Navigation und Bearbeitung von Daten bereit, die an Steuerelemente für ein Formular gebunden sind.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -4679,6 +4679,31 @@ Para reemplazar este cuadro de diálogo predeterminado controle el evento DataEr
         <target state="translated">No se encuentra el archivo de manifiesto predeterminado necesario para habilitar los estilos visuales.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+        <source>Button</source>
+        <target state="needs-review-translation">Button</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewImageCellToolTipText">
+        <source>Image</source>
+        <target state="needs-review-translation">Image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+        <source>Link</source>
+        <target state="new">Link</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+        <source>Edit</source>
+        <target state="new">Edit</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionBindingNavigator">
         <source>Provides a user interface for navigation and manipulation of data bound to controls on a form.</source>
         <target state="translated">Proporciona una interfaz de usuario para navegar y manipular los datos enlazados a controles en un formulario.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -4679,6 +4679,31 @@ Pour remplacer cette boîte de dialogue par défaut, traitez l'événement DataE
         <target state="translated">Le fichier manifeste par défaut requis pour activer les styles visuels est introuvable.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+        <source>Button</source>
+        <target state="needs-review-translation">Button</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewImageCellToolTipText">
+        <source>Image</source>
+        <target state="needs-review-translation">Image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+        <source>Link</source>
+        <target state="new">Link</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+        <source>Edit</source>
+        <target state="new">Edit</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionBindingNavigator">
         <source>Provides a user interface for navigation and manipulation of data bound to controls on a form.</source>
         <target state="translated">Fournit une interface utilisateur pour la navigation et la manipulation de contrôles liés aux données sur un formulaire.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -4679,6 +4679,31 @@ Per sostituire questa finestra di dialogo predefinita, gestire l'evento DataErro
         <target state="translated">Il file manifesto predefinito necessario per abilitare gli stili di visualizzazione non è stato trovato.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+        <source>Button</source>
+        <target state="needs-review-translation">Button</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewImageCellToolTipText">
+        <source>Image</source>
+        <target state="needs-review-translation">Image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+        <source>Link</source>
+        <target state="new">Link</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+        <source>Edit</source>
+        <target state="new">Edit</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionBindingNavigator">
         <source>Provides a user interface for navigation and manipulation of data bound to controls on a form.</source>
         <target state="translated">Fornisce un'interfaccia utente per la navigazione e l'elaborazione dei dati associati ai controlli presenti in un form.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -4679,6 +4679,31 @@ To replace this default dialog please handle the DataError event.</source>
         <target state="translated">visual スタイルを有効にする必要のある既定のマニフェスト ファイルが見つかりません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+        <source>Button</source>
+        <target state="needs-review-translation">Button</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewImageCellToolTipText">
+        <source>Image</source>
+        <target state="needs-review-translation">Image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+        <source>Link</source>
+        <target state="new">Link</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+        <source>Edit</source>
+        <target state="new">Edit</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionBindingNavigator">
         <source>Provides a user interface for navigation and manipulation of data bound to controls on a form.</source>
         <target state="translated">フォーム上のコントロールにバインドされたデータのナビゲートおよび操作に使用するユーザー インターフェイスを提供します。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -4679,6 +4679,31 @@ To replace this default dialog please handle the DataError event.</source>
         <target state="translated">비주얼 스타일을 사용하는 데 필요한 기본 매니페스트 파일을 찾을 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+        <source>Button</source>
+        <target state="needs-review-translation">Button</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewImageCellToolTipText">
+        <source>Image</source>
+        <target state="needs-review-translation">Image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+        <source>Link</source>
+        <target state="new">Link</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+        <source>Edit</source>
+        <target state="new">Edit</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionBindingNavigator">
         <source>Provides a user interface for navigation and manipulation of data bound to controls on a form.</source>
         <target state="translated">폼의 컨트롤에 바인딩된 데이터의 탐색과 조작에 필요한 사용자 인터페이스를 제공합니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -4679,6 +4679,31 @@ Aby zamienić to domyślne okno dialogowe, obsłuż zdarzenie DataError.</target
         <target state="translated">Nie można odnaleźć domyślnego pliku manifestu, który ma włączyć style wizualne.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+        <source>Button</source>
+        <target state="needs-review-translation">Button</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewImageCellToolTipText">
+        <source>Image</source>
+        <target state="needs-review-translation">Image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+        <source>Link</source>
+        <target state="new">Link</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+        <source>Edit</source>
+        <target state="new">Edit</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionBindingNavigator">
         <source>Provides a user interface for navigation and manipulation of data bound to controls on a form.</source>
         <target state="translated">Udostępnia interfejs użytkownika służący do nawigacji i manipulacji danymi powiązanymi z formantami formularza.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -4679,6 +4679,31 @@ Para substituir a caixa de diálogo padrão, manipule o evento DataError.</targe
         <target state="translated">Não foi possível encontrar o arquivo de manifesto padrão, necessário para habilitar estilos visuais.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+        <source>Button</source>
+        <target state="needs-review-translation">Button</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewImageCellToolTipText">
+        <source>Image</source>
+        <target state="needs-review-translation">Image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+        <source>Link</source>
+        <target state="new">Link</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+        <source>Edit</source>
+        <target state="new">Edit</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionBindingNavigator">
         <source>Provides a user interface for navigation and manipulation of data bound to controls on a form.</source>
         <target state="translated">Fornece uma interface de usuário para navegação e manipulação de dados associados aos controles em um formulário.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -4679,6 +4679,31 @@ To replace this default dialog please handle the DataError event.</source>
         <target state="translated">Не найден файл манифеста по умолчанию, необходимый для подключения визуальных стилей.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+        <source>Button</source>
+        <target state="needs-review-translation">Button</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewImageCellToolTipText">
+        <source>Image</source>
+        <target state="needs-review-translation">Image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+        <source>Link</source>
+        <target state="new">Link</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+        <source>Edit</source>
+        <target state="new">Edit</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionBindingNavigator">
         <source>Provides a user interface for navigation and manipulation of data bound to controls on a form.</source>
         <target state="translated">Указывает интерфейс пользователя для навигации и управления данными, привязанными к элементам управления формы.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -4679,6 +4679,31 @@ Bu varsayılan iletişim kutusunu değiştirmek için, lütfen DataError olayın
         <target state="translated">Görsel stilleri etkinleştirmek için gerekli olan varsayılan bildirim dosyası bulunamıyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+        <source>Button</source>
+        <target state="needs-review-translation">Button</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewImageCellToolTipText">
+        <source>Image</source>
+        <target state="needs-review-translation">Image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+        <source>Link</source>
+        <target state="new">Link</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+        <source>Edit</source>
+        <target state="new">Edit</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionBindingNavigator">
         <source>Provides a user interface for navigation and manipulation of data bound to controls on a form.</source>
         <target state="translated">Bir formdaki denetimlere bağlı verilere gitmek veya değiştirmek için bir kullanıcı arabirimi sağlar.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -4679,6 +4679,31 @@ To replace this default dialog please handle the DataError event.</source>
         <target state="translated">未找到启用视觉样式所需的默认清单文件。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+        <source>Button</source>
+        <target state="needs-review-translation">Button</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewImageCellToolTipText">
+        <source>Image</source>
+        <target state="needs-review-translation">Image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+        <source>Link</source>
+        <target state="new">Link</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+        <source>Edit</source>
+        <target state="new">Edit</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionBindingNavigator">
         <source>Provides a user interface for navigation and manipulation of data bound to controls on a form.</source>
         <target state="translated">提供用于导航和处理绑定到窗体控件的数据的用户界面。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -4679,6 +4679,31 @@ To replace this default dialog please handle the DataError event.</source>
         <target state="translated">找不到啟用視覺化樣式所需的預設資訊清單檔。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+        <source>Button</source>
+        <target state="needs-review-translation">Button</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewImageCellToolTipText">
+        <source>Image</source>
+        <target state="needs-review-translation">Image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+        <source>Link</source>
+        <target state="new">Link</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+        <source>Edit</source>
+        <target state="new">Edit</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionBindingNavigator">
         <source>Provides a user interface for navigation and manipulation of data bound to controls on a form.</source>
         <target state="translated">提供使用者介面，以巡覽及操作繫結至表單上控制項的資料。</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -384,6 +384,7 @@ namespace System.Windows.Forms
 
         // ToolTip
         private readonly DataGridViewToolTip toolTipControl;
+        private static readonly int PropToolTip = PropertyStore.CreateKey();
         // the tool tip string we get from cells
         private string toolTipCaption = string.Empty;
 
@@ -3475,6 +3476,26 @@ namespace System.Windows.Forms
             DataGridViewElementStates rowState = Rows.GetRowState(rowIndex);
             return (rowState & DataGridViewElementStates.Visible) != 0 &&
                    (dataGridViewCell.OwningColumn != null && dataGridViewCell.OwningColumn.Visible);
+        }
+
+        internal ToolTip KeyboardToolTip
+        {
+            get
+            {
+                ToolTip toolTip;
+                if (!Properties.ContainsObject(PropToolTip))
+                {
+                    toolTip = new ToolTip();
+                    toolTip.ReshowDelay = 500;
+                    toolTip.InitialDelay = 500;
+                    Properties.SetObject(PropToolTip, toolTip);
+                }
+                else
+                {
+                    toolTip = (ToolTip)Properties.GetObject(PropToolTip);
+                }
+                return toolTip;
+            }
         }
 
         internal LayoutData LayoutInfo

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.cs
@@ -239,6 +239,16 @@ namespace System.Windows.Forms
             return contentBounds;
         }
 
+        private protected override string GetDefaultToolTipText()
+        {
+            if (string.IsNullOrEmpty(Value?.ToString()?.Trim(' ')) || Value is DBNull)
+            {
+                return SR.DefaultDataGridViewButtonCellTollTipText;
+            }
+
+            return null;
+        }
+
         protected override Rectangle GetErrorIconBounds(Graphics graphics, DataGridViewCellStyle cellStyle, int rowIndex)
         {
             if (cellStyle == null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.cs
@@ -551,6 +551,16 @@ namespace System.Windows.Forms
             return checkBoxBounds;
         }
 
+        private protected override string GetDefaultToolTipText()
+        {
+            if (string.IsNullOrEmpty(Value?.ToString()?.Trim(' ')) || Value is DBNull)
+            {
+                return SR.DataGridViewCheckBoxCell_ClipboardFalse;
+            }
+
+            return null;
+        }
+
         protected override Rectangle GetErrorIconBounds(Graphics graphics, DataGridViewCellStyle cellStyle, int rowIndex)
         {
             if (cellStyle == null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
@@ -980,6 +980,16 @@ namespace System.Windows.Forms
             return cm;
         }
 
+        private protected override string GetDefaultToolTipText()
+        {
+            if (string.IsNullOrEmpty(Value?.ToString()?.Trim(' ')) || Value is DBNull)
+            {
+                return SR.DefaultDataGridViewComboBoxCellTollTipText;
+            }
+
+            return null;
+        }
+
         private int GetDropDownButtonHeight(Graphics graphics, DataGridViewCellStyle cellStyle)
         {
             int adjustment = 4;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewImageCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewImageCell.cs
@@ -334,6 +334,11 @@ namespace System.Windows.Forms
             return imgBounds;
         }
 
+        private protected override string GetDefaultToolTipText()
+        {
+            return SR.DefaultDataGridViewImageCellToolTipText;
+        }
+
         protected override Rectangle GetErrorIconBounds(Graphics graphics, DataGridViewCellStyle cellStyle, int rowIndex)
         {
             if (cellStyle == null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.cs
@@ -563,6 +563,16 @@ namespace System.Windows.Forms
             return linkBounds;
         }
 
+        private protected override string GetDefaultToolTipText()
+        {
+            if (string.IsNullOrEmpty(Value?.ToString()?.Trim(' ')) || Value is DBNull)
+            {
+                return SR.DefaultDataGridViewLinkCellTollTipText;
+            }
+
+            return null;
+        }
+
         protected override Rectangle GetErrorIconBounds(Graphics graphics, DataGridViewCellStyle cellStyle, int rowIndex)
         {
             if (cellStyle == null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxCell.cs
@@ -329,6 +329,16 @@ namespace System.Windows.Forms
             return textBounds;
         }
 
+        private protected override string GetDefaultToolTipText()
+        {
+            if (string.IsNullOrEmpty(Value?.ToString()?.Trim(' ')) || Value is DBNull)
+            {
+                return SR.DefaultDataGridViewTextBoxCellTollTipText;
+            }
+
+            return null;
+        }
+
         protected override Rectangle GetErrorIconBounds(Graphics graphics, DataGridViewCellStyle cellStyle, int rowIndex)
         {
             if (cellStyle == null)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellTests.cs
@@ -1448,6 +1448,55 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<InvalidOperationException>(() => cell.GetInheritedStyle(new DataGridViewCellStyle(), -1, true));
         }
 
+        [StaFact]
+        public void DataGridViewCell_GetNeighboringToolsRectangles_ReturnsCorrectRectangles()
+        {
+            DataGridView dataGridView = new DataGridView();
+            dataGridView.Size = new Size(600, 200);
+            dataGridView.CreateControl();
+
+            DataGridViewTextBoxColumn column1 = new DataGridViewTextBoxColumn();
+            DataGridViewTextBoxColumn column2 = new DataGridViewTextBoxColumn();
+            DataGridViewTextBoxColumn column3 = new DataGridViewTextBoxColumn();
+            DataGridViewTextBoxColumn column4 = new DataGridViewTextBoxColumn();
+
+            dataGridView.Columns.Add(column1);
+            dataGridView.Columns.Add(column2);
+            dataGridView.Columns.Add(column3);
+            dataGridView.Columns.Add(column4);
+
+            dataGridView.Rows.Add();
+            dataGridView.Rows.Add();
+            dataGridView.Rows.Add();
+            dataGridView.Rows.Add();
+
+            dataGridView.Rows[0].Cells[1].Value = "Text";
+            dataGridView.Rows[1].Cells[2].Value = "Text";
+            dataGridView.Rows[1].Cells[3].Value = "Text";
+            dataGridView.Rows[2].Cells[0].Value = "Text";
+            dataGridView.Rows[2].Cells[1].Value = "Text";
+            dataGridView.Rows[2].Cells[3].Value = "Text";
+            dataGridView.Rows[3].Cells[1].Value = "Text";
+            dataGridView.Rows[3].Cells[2].Value = "Text";
+
+            IList<Rectangle> neighbors00 = ((IKeyboardToolTip)dataGridView.Rows[0].Cells[0]).GetNeighboringToolsRectangles();
+            Assert.True(neighbors00.Contains(dataGridView.Rows[0].Cells[1].AccessibilityObject.Bounds));
+            Assert.False(neighbors00.Contains(dataGridView.Rows[1].Cells[1].AccessibilityObject.Bounds));
+            Assert.False(neighbors00.Contains(dataGridView.Rows[1].Cells[0].AccessibilityObject.Bounds));
+
+            IList<Rectangle> neighbors21 = ((IKeyboardToolTip)dataGridView.Rows[2].Cells[1]).GetNeighboringToolsRectangles();
+            Assert.True(neighbors21.Contains(dataGridView.Rows[1].Cells[2].AccessibilityObject.Bounds));
+            Assert.True(neighbors21.Contains(dataGridView.Rows[2].Cells[0].AccessibilityObject.Bounds));
+            Assert.True(neighbors21.Contains(dataGridView.Rows[2].Cells[1].AccessibilityObject.Bounds));
+            Assert.True(neighbors21.Contains(dataGridView.Rows[3].Cells[1].AccessibilityObject.Bounds));
+            Assert.False(neighbors21.Contains(dataGridView.Rows[1].Cells[1].AccessibilityObject.Bounds));
+
+            IList<Rectangle> neighbors33 = ((IKeyboardToolTip)dataGridView.Rows[3].Cells[3]).GetNeighboringToolsRectangles();
+            Assert.True(neighbors33.Contains(dataGridView.Rows[2].Cells[3].AccessibilityObject.Bounds));
+            Assert.True(neighbors33.Contains(dataGridView.Rows[3].Cells[2].AccessibilityObject.Bounds));
+            Assert.False(neighbors33.Contains(dataGridView.Rows[2].Cells[2].AccessibilityObject.Bounds));
+        }
+
         [Fact]
         public void DataGridViewCell_GetPreferredSize_Invoke_ReturnsExpected()
         {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1680

**Original bug:**
- [Bug 528682:](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/528682) Accessibility: WinForm DataGridView's CellErrorTextNeeded tooltip data isn't accessible to customers only using the keyboard

## Proposed changes
- Implement `IKeyboardToolTip` interface for `DataGridViewCell` class to use the `KeyboardToolTipStateMachine`
- Add `ProcessControlShiftF10Keys` method to have the ability to activate/deactivate a cell tooltip using hotkeys (Control+Shift+F10 like as WPF)
- Add `IsActivatedByKeyboard` property which stores keyboard tooltip state
- Add `KeyboardToolTip` property which stores keyboard tooltip info and settings

> - Propose to set for the keyboard tooltip `InitialDelay` and `ReshowDelay` equal to 0.5 seconds (see gif below).

- <del>Add [**_public ShowCellKeyboardToolTips_**]() property to enable users to turn on/off keyboard tooltips display
            

> - <del>`ShowCellToolTips` property turn on/off keyboard and mouse tooltips activation together
>  - <del>`ShowCellKeyboardToolTips` property turn on/off keyboard tooltips activation only (`ShowCellToolTips` property must be _true_)</del>
- Use `ShowCellToolTips` to enable users to turn on/off **mouse** and **keyboard** tooltips display

- Add default tooltip text to resources for all cells (needs review translation)

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
- Now a user has a possibility to get DataGridView cell tooltip text or error text with using only a keyboard (Tab/arrow navigation, hotkeys)
- Minor bugs of mouse and keyboard tooltip conflicts have little impact on users

## Regression? 

- No

## Risk
- <del>Adding **public** `ShowCellKeyboardToolTips` property is risky. In the future, it will be problematic to change the implementation of keyboard tooltip activation without affecting users who already use this property.
Instead, we can use `ShowCellToolTips` property, but it turns on/off both keyboard and mouse tooltips activation</del>
None. It was decided to use `ShowCellToolTips` property only.

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
- There is no way to activate a tooltip using a keyboard
<!-- TODO -->

### After

- Cell tooltips are displayed when tab/keyboard arrow navigation
- Cell tooltip is activated/deactivated when clicking Control+Shift+F10 hotkey (end of the gif)
![NH5SSK7eId](https://user-images.githubusercontent.com/49272759/63585587-2821eb80-c5a8-11e9-9f09-7ea2c0a216e0.gif)


<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual testing

<!--## Accessibility testing   Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.18362.239]
- .NET Core Version: 3.0.100-preview9-013722


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1681)