### PR TITLE
Retarget to .NET 5.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,9 @@
   <Import Project="eng\FacadeAssemblies.props" />
 
   <PropertyGroup>
+    <TargetFrameworkName>netcoreapp</TargetFrameworkName>
+    <TargetFrameworkVersion>5.0</TargetFrameworkVersion>
+    <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>
     <Product>Microsoft&#xAE; .NET</Product>
     <Copyright>$(CopyrightNetFoundation)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -25,17 +25,17 @@
   <ItemGroup>
     <!-- Set TargetingPackVersion -->
     <FrameworkReference Update="Microsoft.NETCore.App" 
-      Condition=" '$(MicrosoftNETCoreAppPackageVersion)'!='' And $(TargetFramework.StartsWith('netcoreapp3.')) ">
+      Condition=" '$(MicrosoftNETCoreAppPackageVersion)'!='' And $(TargetFramework.StartsWith('netcoreapp5.')) ">
     <TargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</TargetingPackVersion>
     </FrameworkReference>
   </ItemGroup>
 
   <PropertyGroup>
     <!-- Set RuntimeFrameworkVersion to MicrosoftNETCoreAppPackageVersion from Core Setup to prevent large SDK cycle -->
-    <RuntimeFrameworkVersion Condition="'$(MicrosoftNETCoreAppPackageVersion)'!='' And $(TargetFramework.StartsWith('netcoreapp3.')) ">$(MicrosoftNETCoreAppPackageVersion)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition="'$(MicrosoftNETCoreAppPackageVersion)'!='' And $(TargetFramework.StartsWith('netcoreapp5.')) ">$(MicrosoftNETCoreAppPackageVersion)</RuntimeFrameworkVersion>
 
-    <!-- If TargetFramework is not netcoreapp3.x, then reset RuntimeFrameworkVersion -->
-    <RuntimeFrameworkVersion Condition="!$(TargetFramework.StartsWith('netcoreapp3.'))" />
+    <!-- If TargetFramework is not netcoreapp5.x, then reset RuntimeFrameworkVersion -->
+    <RuntimeFrameworkVersion Condition="!$(TargetFramework.StartsWith('netcoreapp5.'))" />
   </PropertyGroup>
 
 </Project>

--- a/Documentation/building.md
+++ b/Documentation/building.md
@@ -30,7 +30,7 @@ Note that this does **not** build using your machine-wide installed version of t
 
 * All build outputs are generated under the `artifacts` folder.
 * Binaries are under `artifacts\bin`
-  * For example, `System.Windows.Forms.dll` can be found under `artifacts\bin\System.Windows.Forms\Debug\netcoreapp3.0`
+  * For example, `System.Windows.Forms.dll` can be found under `artifacts\bin\System.Windows.Forms\Debug\netcoreapp5.0`
 * Logs are found under `artifacts\log`
 * Packages are found under `artifacts\packages`
 

--- a/Documentation/debugging.md
+++ b/Documentation/debugging.md
@@ -12,7 +12,7 @@ If you do not want to modify your local SDK, you may with to perform technique 2
 
 copy the resulting assembly(-ies) from the base of the repository  
 
-`[path-to-repo]\winforms\artifacts\bin\System.Windows.Forms\Debug\netcoreapp3.0_`
+`[path-to-repo]\winforms\artifacts\bin\System.Windows.Forms\Debug\netcoreapp5.0_`
 
 to your dotnet folder at:  
 
@@ -28,11 +28,11 @@ Add references to the binary(-ies) to your project ported to Core. For example, 
 
 ```xml
 <ItemGroup>
-    <Reference Include="[Drive]:[path-to-repo]\winforms\artifacts\bin\System.Windows.Forms\Debug\netcoreapp3.0\System.Windows.Forms.dll" />
+    <Reference Include="[Drive]:[path-to-repo]\winforms\artifacts\bin\System.Windows.Forms\Debug\netcoreapp5.0\System.Windows.Forms.dll" />
 </ItemGroup>
 ```
 
-where **[Drive]** is the drive you have our repository in and **[path-to-repo]** is the additional path to our repository from the base drive (this may be nothing). Note netcoreapp3.0 may change.
+where **[Drive]** is the drive you have our repository in and **[path-to-repo]** is the additional path to our repository from the base drive (this may be nothing). Note netcoreapp5.0 may change.
 
 [comment]: <> (URI Links)
 

--- a/Documentation/testing.md
+++ b/Documentation/testing.md
@@ -17,8 +17,8 @@ To execute unit tests, run `.\build -test`
 If all the tests are successful, you should see something like this:
 
 ```console
-  Running tests: E:\src\repos\github\winforms\artifacts\bin\System.Windows.Forms.Tests\Debug\netcoreapp3.0\System.Windows.Forms.Tests.dll [netcoreapp3.0|x64]
-  Tests succeeded: E:\src\repos\github\winforms\artifacts\bin\System.Windows.Forms.Tests\Debug\netcoreapp3.0\System.Windows.Forms.Tests.dll [netcoreapp3.0|x64]
+  Running tests: E:\src\repos\github\winforms\artifacts\bin\System.Windows.Forms.Tests\Debug\netcoreapp5.0\System.Windows.Forms.Tests.dll [netcoreapp5.0|x64]
+  Tests succeeded: E:\src\repos\github\winforms\artifacts\bin\System.Windows.Forms.Tests\Debug\netcoreapp5.0\System.Windows.Forms.Tests.dll [netcoreapp5.0|x64]
 
 Build succeeded.
     0 Warning(s)
@@ -30,9 +30,9 @@ Build succeeded.
 When testing from the command line, a failed test should look something like this:
 
 ```console
-Running tests: E:\src\repos\github\winforms\artifacts\bin\System.Windows.Forms.Tests\Debug\netcoreapp3.0\System.Windows.Forms.Tests.dll [netcoreapp3.0|x64]
-XUnit : error : Tests failed: E:\src\repos\github\winforms\artifacts\TestResults\Debug\System.Windows.Forms.Tests_netcoreapp3.0_x64.html [netcoreapp3.0|x64] [E:\src\repos\github\winforms\src\System.Windows.Forms\tests\UnitTests\System.Windows.Forms.Tests.csproj]
-XUnit : error : Tests failed: E:\src\repos\github\winforms\artifacts\TestResults\Debug\System.Windows.Forms.Tests_netcoreapp3.0_x64.html [netcoreapp3.0|x64] [E:\src\repos\github\winforms\src\System.Windows.Forms\tests\UnitTests\System.Windows.Forms.Tests.csproj]
+Running tests: E:\src\repos\github\winforms\artifacts\bin\System.Windows.Forms.Tests\Debug\netcoreapp5.0\System.Windows.Forms.Tests.dll [netcoreapp5.0|x64]
+XUnit : error : Tests failed: E:\src\repos\github\winforms\artifacts\TestResults\Debug\System.Windows.Forms.Tests_netcoreapp5.0_x64.html [netcoreapp5.0|x64] [E:\src\repos\github\winforms\src\System.Windows.Forms\tests\UnitTests\System.Windows.Forms.Tests.csproj]
+XUnit : error : Tests failed: E:\src\repos\github\winforms\artifacts\TestResults\Debug\System.Windows.Forms.Tests_netcoreapp5.0_x64.html [netcoreapp5.0|x64] [E:\src\repos\github\winforms\src\System.Windows.Forms\tests\UnitTests\System.Windows.Forms.Tests.csproj]
 
 Build FAILED.
 ```
@@ -118,8 +118,8 @@ To execute functional tests, run `.\build -integrationTest`
 You will see various windows open and close very quickly. If all the tests are successful, you should see something like this:
 
 ```console
-  Running tests: E:\src\repos\github\winforms\artifacts\bin\System.Windows.Forms.IntegrationTests\Debug\netcoreapp3.0\System.Windows.Forms.IntegrationTests.dll [netcoreapp3.0|x64]
-  Tests succeeded: E:\src\repos\github\winforms\artifacts\bin\System.Windows.Forms.IntegrationTests\Debug\netcoreapp3.0\System.Windows.Forms.IntegrationTests.dll [netcoreapp3.0|x64]
+  Running tests: E:\src\repos\github\winforms\artifacts\bin\System.Windows.Forms.IntegrationTests\Debug\netcoreapp5.0\System.Windows.Forms.IntegrationTests.dll [netcoreapp5.0|x64]
+  Tests succeeded: E:\src\repos\github\winforms\artifacts\bin\System.Windows.Forms.IntegrationTests\Debug\netcoreapp5.0\System.Windows.Forms.IntegrationTests.dll [netcoreapp5.0|x64]
 
 Build succeeded.
     0 Warning(s)

--- a/Documentation/winforms-designer.md
+++ b/Documentation/winforms-designer.md
@@ -54,8 +54,8 @@ There are few options available to help you to design UI for your .NET Core proj
 2. Open the `SimpleWinForms` project file by double clicking on it in Solution Explorer. Change the ``TargetFramework`` property from:
 
     ```diff
-    -    <TargetFramework>netcoreapp3.0</TargetFramework>
-    +    <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
+    -    <TargetFramework>netcoreapp5.0</TargetFramework>
+    +    <TargetFrameworks>net472;netcoreapp5.0</TargetFrameworks>
     ```
 
 3. Add for any and every form file you have in this ``ItemGroup``:

--- a/eng/CodeCoverage.proj
+++ b/eng/CodeCoverage.proj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- We need to specify a framework in order for the Restore target to work -->
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -10,60 +10,60 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
   </ProductDependencies>
   <ToolsetDependencies>
     <!-- Core Setup for coherency -->
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview9-19419-06">
+    <Dependency Name="Microsoft.NETCore.App" Version="5.0.0-alpha1.19454.1">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>5b508e86c9ce66af8b41bbc1f3b756e7724bcaa0</Sha>
+      <Sha>4b0f3a699e79a91ceedf52c00262c69714008f8d</Sha>
     </Dependency>
     <!-- CoreFX via Core Setup -->
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="3.0.0-preview9.19409.17" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha1.19453.11" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>b82d2bc44424c8a99a1f0fc13202bdfd43e6f9f5</Sha>
+      <Sha>70b4d01e18236c925c2d44d49fff7cbb4919dc43</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.Registry" Version="4.6.0-preview9.19409.17" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha1.19453.11" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>b82d2bc44424c8a99a1f0fc13202bdfd43e6f9f5</Sha>
+      <Sha>70b4d01e18236c925c2d44d49fff7cbb4919dc43</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.SystemEvents" Version="4.6.0-preview9.19409.17" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha1.19453.11" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>b82d2bc44424c8a99a1f0fc13202bdfd43e6f9f5</Sha>
+      <Sha>70b4d01e18236c925c2d44d49fff7cbb4919dc43</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="4.6.0-preview9.19409.17" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.CodeDom" Version="5.0.0-alpha1.19453.11" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>b82d2bc44424c8a99a1f0fc13202bdfd43e6f9f5</Sha>
+      <Sha>70b4d01e18236c925c2d44d49fff7cbb4919dc43</Sha>
     </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="4.6.0-preview9.19409.17" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-alpha1.19453.11" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>b82d2bc44424c8a99a1f0fc13202bdfd43e6f9f5</Sha>
+      <Sha>70b4d01e18236c925c2d44d49fff7cbb4919dc43</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="4.6.0-preview9.19409.17" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha1.19453.11" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>b82d2bc44424c8a99a1f0fc13202bdfd43e6f9f5</Sha>
+      <Sha>70b4d01e18236c925c2d44d49fff7cbb4919dc43</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="4.6.0-preview9.19409.17" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha1.19453.11" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>b82d2bc44424c8a99a1f0fc13202bdfd43e6f9f5</Sha>
+      <Sha>70b4d01e18236c925c2d44d49fff7cbb4919dc43</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Cng" Version="4.6.0-preview9.19409.17" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha1.19453.11" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>b82d2bc44424c8a99a1f0fc13202bdfd43e6f9f5</Sha>
+      <Sha>70b4d01e18236c925c2d44d49fff7cbb4919dc43</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="4.6.0-preview9.19409.17" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha1.19453.11" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>b82d2bc44424c8a99a1f0fc13202bdfd43e6f9f5</Sha>
+      <Sha>70b4d01e18236c925c2d44d49fff7cbb4919dc43</Sha>
     </Dependency>
-    <Dependency Name="System.Windows.Extensions" Version="4.6.0-preview9.19409.17" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha1.19453.11" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>b82d2bc44424c8a99a1f0fc13202bdfd43e6f9f5</Sha>
+      <Sha>70b4d01e18236c925c2d44d49fff7cbb4919dc43</Sha>
     </Dependency>
     <!-- CoreCLR via Core Setup -->
-    <Dependency Name="Microsoft.NET.Sdk.IL" Version="3.0.0-preview9.19409.2" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="Microsoft.NET.Sdk.IL" Version="5.0.0-alpha1.19453.2" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>eeec95164a0b39ad3f98dfe04012675f30807cb1</Sha>
+      <Sha>6e1b160523db1c6e7d96aa3c9244a0baf8edb06a</Sha>
       <SourceBuildId>5596</SourceBuildId>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.ILAsm" Version="3.0.0-preview9.19409.2" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="Microsoft.NETCore.ILAsm" Version="5.0.0-alpha1.19453.2" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>eeec95164a0b39ad3f98dfe04012675f30807cb1</Sha>
+      <Sha>6e1b160523db1c6e7d96aa3c9244a0baf8edb06a</Sha>
       <SourceBuildId>5596</SourceBuildId>
     </Dependency>
     <!-- Arcade -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,31 +4,31 @@
     <VersionPrefix>5.0.0</VersionPrefix>
     <!-- version in our package name #.#.#-below.#####.## -->
     <PreReleaseVersionLabel>alpha1</PreReleaseVersionLabel>
-    <!-- Use the compiler in the CLI instead of in the sdk, since the sdk one doesn't work with netcoreapp3.0 yet -->
+    <!-- Use the compiler in the CLI instead of in the sdk, since the sdk one doesn't work with netcoreapp5.0 yet -->
     <UsingToolMicrosoftNetCompilers>false</UsingToolMicrosoftNetCompilers>
   </PropertyGroup>
   <!-- Below have corresponding entries in Versions.Details.XML because they are updated via Maestro -->
   <!-- Core Setup for coherency -->
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview9-19419-06</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>5.0.0-alpha1.19454.1</MicrosoftNETCoreAppPackageVersion>
   </PropertyGroup>
   <!-- CoreFX via Core Setup -->
   <PropertyGroup>
-    <MicrosoftNETCorePlatformsPackageVersion>3.0.0-preview9.19409.17</MicrosoftNETCorePlatformsPackageVersion>
-    <MicrosoftWin32RegistryPackageVersion>4.6.0-preview9.19409.17</MicrosoftWin32RegistryPackageVersion>
-    <MicrosoftWin32SystemEventsPackageVersion>4.6.0-preview9.19409.17</MicrosoftWin32SystemEventsPackageVersion>
-    <SystemCodeDomPackageVersion>4.6.0-preview9.19409.17</SystemCodeDomPackageVersion>
-    <SystemConfigurationConfigurationManagerPackageVersion>4.6.0-preview9.19409.17</SystemConfigurationConfigurationManagerPackageVersion>
-    <SystemDrawingCommonPackageVersion>4.6.0-preview9.19409.17</SystemDrawingCommonPackageVersion>
-    <SystemResourcesExtensionsPackageVersion>4.6.0-preview9.19409.17</SystemResourcesExtensionsPackageVersion>
-    <SystemSecurityCryptographyCngPackageVersion>4.6.0-preview9.19409.17</SystemSecurityCryptographyCngPackageVersion>
-    <SystemSecurityPermissionsPackageVersion>4.6.0-preview9.19409.17</SystemSecurityPermissionsPackageVersion>
-    <SystemWindowsExtensionsPackageVersion>4.6.0-preview9.19409.17</SystemWindowsExtensionsPackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>5.0.0-alpha1.19453.11</MicrosoftNETCorePlatformsPackageVersion>
+    <MicrosoftWin32RegistryPackageVersion>5.0.0-alpha1.19453.11</MicrosoftWin32RegistryPackageVersion>
+    <MicrosoftWin32SystemEventsPackageVersion>5.0.0-alpha1.19453.11</MicrosoftWin32SystemEventsPackageVersion>
+    <SystemCodeDomPackageVersion>5.0.0-alpha1.19453.11</SystemCodeDomPackageVersion>
+    <SystemConfigurationConfigurationManagerPackageVersion>5.0.0-alpha1.19453.11</SystemConfigurationConfigurationManagerPackageVersion>
+    <SystemDrawingCommonPackageVersion>5.0.0-alpha1.19453.11</SystemDrawingCommonPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>5.0.0-alpha1.19453.11</SystemResourcesExtensionsPackageVersion>
+    <SystemSecurityCryptographyCngPackageVersion>5.0.0-alpha1.19453.11</SystemSecurityCryptographyCngPackageVersion>
+    <SystemSecurityPermissionsPackageVersion>5.0.0-alpha1.19453.11</SystemSecurityPermissionsPackageVersion>
+    <SystemWindowsExtensionsPackageVersion>5.0.0-alpha1.19453.11</SystemWindowsExtensionsPackageVersion>
   </PropertyGroup>
   <!-- CoreCLR via Core Setup -->
   <PropertyGroup>
     <MicrosoftNETCoreILPackageVersion>3.0.0-preview5-27616-73</MicrosoftNETCoreILPackageVersion>
-    <MicrosoftNETCoreILAsmPackageVersion>3.0.0-preview9.19409.2</MicrosoftNETCoreILAsmPackageVersion>
+    <MicrosoftNETCoreILAsmPackageVersion>5.0.0-alpha1.19453.2</MicrosoftNETCoreILAsmPackageVersion>
   </PropertyGroup>
   <!-- Arcade -->
   <PropertyGroup>

--- a/eng/common/templates/job/performance.yml
+++ b/eng/common/templates/job/performance.yml
@@ -6,7 +6,7 @@ parameters:
   pool: ''                        # required -- name of the Build pool
   container: ''                   # required -- name of the container
   extraSetupParameters: ''        # optional -- extra arguments to pass to the setup script
-  frameworks: ['netcoreapp3.0']   # optional -- list of frameworks to run against
+  frameworks: ['netcoreapp5.0']   # optional -- list of frameworks to run against
   continueOnError: 'false'        # optional -- determines whether to continue the build if the step errors
   dependsOn: ''                   # optional -- dependencies of the job
   timeoutInMinutes: 320           # optional -- timeout for the job

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview9-013796",
+    "dotnet": "5.0.100-alpha1-013788",
     "vs": {
       "version": "16.0"
     },
@@ -12,12 +12,12 @@
     }
   },
   "sdk": {
-    "version": "3.0.100-preview9-013796"
+    "version": "5.0.100-alpha1-013788"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19453.5",
     "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19453.5",
-    "Microsoft.NET.Sdk.IL": "3.0.0-preview9.19409.2"
+    "Microsoft.NET.Sdk.IL": "5.0.0-alpha1.19453.2"
   },
   "native-tools": {
     "dotnet-api-docs_netcoreapp3.0": "0.0.0.1"

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/Microsoft.Dotnet.Winforms.ProjectTemplates.csproj
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/Microsoft.Dotnet.Winforms.ProjectTemplates.csproj
@@ -2,7 +2,7 @@
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
   <PropertyGroup>
     <TargetFrameworkName>netcoreapp</TargetFrameworkName>
-    <TargetFrameworkVersion>3.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>5.0</TargetFrameworkVersion>
     <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/template.json
@@ -29,12 +29,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp3.0",
-          "description": "Target netcoreapp3.0"
+          "choice": "netcoreapp5.0",
+          "description": "Target netcoreapp5.0"
         }
       ],
-      "replaces": "netcoreapp3.0",
-      "defaultValue": "netcoreapp3.0"
+      "replaces": "netcoreapp5.0",
+      "defaultValue": "netcoreapp5.0"
     },
     "langVersion": {
       "type": "parameter",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/Company.WinFormsApplication1.csproj
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/Company.WinFormsApplication1.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp3.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp5.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.WinFormsApplication1</RootNamespace>
     <LangVersion Condition="'$(langVersion)' != ''">$(ProjectLanguageVersion)</LangVersion>

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/template.json
@@ -29,12 +29,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp3.0",
-          "description": "Target netcoreapp3.0"
+          "choice": "netcoreapp5.0",
+          "description": "Target netcoreapp5.0"
         }
       ],
-      "replaces": "netcoreapp3.0",
-      "defaultValue": "netcoreapp3.0"
+      "replaces": "netcoreapp5.0",
+      "defaultValue": "netcoreapp5.0"
     },
     "langVersion": {
       "type": "parameter",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/Company.WinFormsApplication1.vbproj
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/Company.WinFormsApplication1.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp3.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp5.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace>Company.WinFormsApplication1</RootNamespace>
     <StartupObject>Company.WinFormsApplication1.Form1</StartupObject>

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/template.json
@@ -29,12 +29,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp3.0",
-          "description": "Target netcoreapp3.0"
+          "choice": "netcoreapp5.0",
+          "description": "Target netcoreapp5.0"
         }
       ],
-      "replaces": "netcoreapp3.0",
-      "defaultValue": "netcoreapp3.0"
+      "replaces": "netcoreapp5.0",
+      "defaultValue": "netcoreapp5.0"
     },
     "langVersion": {
       "type": "parameter",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/Company.ClassLibrary1.csproj
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/Company.ClassLibrary1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp3.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp5.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.ClassLibrary1</RootNamespace>
     <LangVersion Condition="'$(langVersion)' != ''">$(ProjectLanguageVersion)</LangVersion>

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/template.json
@@ -29,12 +29,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp3.0",
-          "description": "Target netcoreapp3.0"
+          "choice": "netcoreapp5.0",
+          "description": "Target netcoreapp5.0"
         }
       ],
-      "replaces": "netcoreapp3.0",
-      "defaultValue": "netcoreapp3.0"
+      "replaces": "netcoreapp5.0",
+      "defaultValue": "netcoreapp5.0"
     },
     "langVersion": {
       "type": "parameter",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/Company.ClassLibrary1.vbproj
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/Company.ClassLibrary1.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>Company.ClassLibrary1</RootNamespace>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp3.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp5.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <LangVersion Condition="'$(langVersion)' != ''">$(ProjectLanguageVersion)</LangVersion>
     <UseWindowsForms>true</UseWindowsForms>

--- a/pkg/Microsoft.Private.Winforms/Microsoft.Private.Winforms.csproj
+++ b/pkg/Microsoft.Private.Winforms/Microsoft.Private.Winforms.csproj
@@ -14,8 +14,6 @@
   -->
 
   <PropertyGroup>
-    <TargetFrameworkName>netcoreapp</TargetFrameworkName>
-    <TargetFrameworkVersion>3.0</TargetFrameworkVersion>
     <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>
   </PropertyGroup>
 

--- a/src/Accessibility/src/Accessibility.ilproj
+++ b/src/Accessibility/src/Accessibility.ilproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>
     <!-- Package this as both a reference and implementation -->
     <PackageAsRefAndLib>true</PackageAsRefAndLib>
     <!-- ILAsm doesn't produce a PDB - https://github.com/dotnet/coreclr/issues/15299 -->

--- a/src/Accessibility/ver/Accessibility-version.csproj
+++ b/src/Accessibility/ver/Accessibility-version.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-    
     <!-- this project is intentionally empty, it's only built so that we can 
          use its resources when assembling the Accessibility dll -->
   </PropertyGroup>

--- a/src/Common/tests/Directory.Build.props
+++ b/src/Common/tests/Directory.Build.props
@@ -2,7 +2,6 @@
 <Project>
   <Import Project="..\..\..\Directory.Build.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/Common/tests/InternalUtilitiesForTests/InternalUtilitiesForTests.csproj
+++ b/src/Common/tests/InternalUtilitiesForTests/InternalUtilitiesForTests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyName>InternalUtilitiesForTests</AssemblyName> 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/System.Design/Directory.Build.props
+++ b/src/System.Design/Directory.Build.props
@@ -2,7 +2,6 @@
 <Project>
   <Import Project="..\..\Directory.Build.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
 	<StrongNameKeyId>Microsoft</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/System.Design/src/System.Design.Facade.csproj
+++ b/src/System.Design/src/System.Design.Facade.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyName>System.Design</AssemblyName>
   </PropertyGroup>
 

--- a/src/System.Drawing.Design/Directory.Build.props
+++ b/src/System.Drawing.Design/Directory.Build.props
@@ -2,7 +2,6 @@
 <Project>
   <Import Project="..\..\Directory.Build.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
 	<StrongNameKeyId>Microsoft</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/System.Drawing.Design/src/System.Drawing.Design.Facade.csproj
+++ b/src/System.Drawing.Design/src/System.Drawing.Design.Facade.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyName>System.Drawing.Design</AssemblyName>
   </PropertyGroup>
 

--- a/src/System.Drawing/Directory.Build.props
+++ b/src/System.Drawing/Directory.Build.props
@@ -2,7 +2,6 @@
 <Project>
   <Import Project="..\..\Directory.Build.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
 	<StrongNameKeyId>Microsoft</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/System.Drawing/src/System.Drawing.Facade.csproj
+++ b/src/System.Drawing/src/System.Drawing.Facade.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyName>System.Drawing</AssemblyName>
   </PropertyGroup>
 

--- a/src/System.Windows.Forms.Design.Editors/Directory.Build.props
+++ b/src/System.Windows.Forms.Design.Editors/Directory.Build.props
@@ -2,7 +2,6 @@
 <Project>
   <Import Project="..\..\Directory.Build.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/System.Windows.Forms.Design.Editors/src/System.Windows.Forms.Design.Editors.csproj
+++ b/src/System.Windows.Forms.Design.Editors/src/System.Windows.Forms.Design.Editors.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <AssemblyName>System.Windows.Forms.Design.Editors</AssemblyName>
-    <TargetFramework>netcoreapp3.0</TargetFramework>    
     <CLSCompliant>true</CLSCompliant>
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/src/System.Windows.Forms.Design.Editors/tests/UnitTests/System.Windows.Forms.Design.Editors.Tests.csproj
+++ b/src/System.Windows.Forms.Design.Editors/tests/UnitTests/System.Windows.Forms.Design.Editors.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>    
     <AssemblyName>System.Windows.Forms.Design.Editors.Tests</AssemblyName>
   </PropertyGroup>
 

--- a/src/System.Windows.Forms.Design/Directory.Build.props
+++ b/src/System.Windows.Forms.Design/Directory.Build.props
@@ -2,7 +2,6 @@
 <Project>
   <Import Project="..\..\Directory.Build.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyName>System.Windows.Forms.Design</AssemblyName>    
     <CLSCompliant>true</CLSCompliant>
     <Deterministic>true</Deterministic>

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System.Windows.Forms.Design.Tests.csproj
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System.Windows.Forms.Design.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AssemblyName>System.Windows.Forms.Design.Tests</AssemblyName>    
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <AssemblyName>System.Windows.Forms.Design.Tests</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/Directory.Build.props
+++ b/src/System.Windows.Forms/Directory.Build.props
@@ -2,8 +2,6 @@
 <Project>
   <Import Project="..\..\Directory.Build.props" />
   <PropertyGroup>
-    <!-- Identity needs to match what was in desktop so we remain compatible with desktop assemblies built against winforms -->
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/System.Windows.Forms/src/System.Windows.Forms.csproj
+++ b/src/System.Windows.Forms/src/System.Windows.Forms.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyName>System.Windows.Forms</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLSCompliant>true</CLSCompliant>

--- a/src/System.Windows.Forms/tests/AccessibilityTests/AccessibilityTests.csproj
+++ b/src/System.Windows.Forms/tests/AccessibilityTests/AccessibilityTests.csproj
@@ -5,8 +5,7 @@
     <RootNamespace>AccessibilityTests</RootNamespace>
     <AssemblyName>AccessibilityTests</AssemblyName>
     <RootNamespace>AccessibilityTests</RootNamespace>
-    <!--<TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>-->
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <!--<TargetFrameworks>net472;netcoreapp5.0</TargetFrameworks>-->
     <ApplicationManifest>app1.manifest</ApplicationManifest>
     <UsingToolXliff>false</UsingToolXliff>
   </PropertyGroup>

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiButtonTests/MauiButtonTests.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiButtonTests/MauiButtonTests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiComboBoxTests/MauiComboBoxTests.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiComboBoxTests/MauiComboBoxTests.csproj
@@ -2,7 +2,6 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/System.Windows.Forms.IntegrationTests.Common.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/System.Windows.Forms.IntegrationTests.Common.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
  
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/TestHelpers.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/TestHelpers.cs
@@ -40,7 +40,7 @@ namespace System.Windows.Forms.IntegrationTests.Common
                 throw new ArgumentNullException(nameof(projectName));
 
             var repoRoot = GetRepoRoot();
-            var exePath = Path.Combine(repoRoot, $"artifacts\\bin\\{projectName}\\{Config}\\netcoreapp3.0\\{projectName}.exe");
+            var exePath = Path.Combine(repoRoot, $"artifacts\\bin\\{projectName}\\{Config}\\netcoreapp5.0\\{projectName}.exe");
 
             if (!File.Exists(exePath))
                 throw new FileNotFoundException("File does not exist", exePath);

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests/System.Windows.Forms.IntegrationTests.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests/System.Windows.Forms.IntegrationTests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.Maui.IntegrationTests/System.Windows.Forms.Maui.IntegrationTests.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.Maui.IntegrationTests/System.Windows.Forms.Maui.IntegrationTests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.Maui.IntegrationTests/readme.md
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.Maui.IntegrationTests/readme.md
@@ -81,7 +81,7 @@ See the pull request at https://github.com/dotnet/winforms/pull/1240 for an exam
 
         .\build-local.ps1
 	
-1. Browse to `.\artifacts\bin\<your-test-name>\Debug\netcoreapp3.0`
+1. Browse to `.\artifacts\bin\<your-test-name>\Debug\netcoreapp5.0`
 1. Double click on `<your-test-name>.exe`
 1. Check the results.log in the same directory to make sure everything passed
 1. If anything shows as a failure in the log, **STOP**. 
@@ -105,9 +105,9 @@ See the pull request at https://github.com/dotnet/winforms/pull/1240 for an exam
         .\build -integrationTest /m:1
 	
 1. Verify all the integration tests pass. If there is a failure, the following files may help:
-    - xUnit test results summary can be found at `.\artifacts\TestResults\Debug\System.Windows.Forms.Maui.IntegrationTests_netcoreapp3.0_x64.html`
-    - xUnit test outputs can be found at `.\artifacts\log\Debug\System.Windows.Forms.Maui.IntegrationTests_netcoreapp3.0_x64.log`
-    - The results.log for your individual Maui test can be found at `.\artifacts\bin\<your-test-name>\Debug\netcoreapp3.0\results.log`
+    - xUnit test results summary can be found at `.\artifacts\TestResults\Debug\System.Windows.Forms.Maui.IntegrationTests_netcoreapp5.0_x64.html`
+    - xUnit test outputs can be found at `.\artifacts\log\Debug\System.Windows.Forms.Maui.IntegrationTests_netcoreapp5.0_x64.log`
+    - The results.log for your individual Maui test can be found at `.\artifacts\bin\<your-test-name>\Debug\netcoreapp5.0\results.log`
 
 ## Run the maui test through the CI build
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/WinformsControlsTest.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/WinformsControlsTest.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyName>WinformsControlsTest</AssemblyName>
     <RootNamespace>WinformsControlsTest</RootNamespace>
     <ApplicationIcon />

--- a/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
+++ b/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <AssemblyName>System.Windows.Forms.Tests</AssemblyName>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

1. Update dependencies with darc tool:     `darc update-dependencies --channel ".NET Core 5 Dev"`

2. Manually update references to `netcoreapp5`

3.  Delete all the hard-coded assembly versions and just rely on the product version since the version is higher than the NET Fx

4. Update serialization tests due to assembly version change.
Test serialisation only one way .NET Fx -> .NET, as well as .NET -> .NET. 
Serialisation .NET -> .NET Fx will need to be added later, if it is deemed necessary.



## Test methodology <!-- How did you ensure quality? -->

- manually build
  ![image](https://user-images.githubusercontent.com/4403806/63612250-7f46b100-c5e6-11e9-9991-b680e88255ea.png)





###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1684)