### PR TITLE
[Accessibility]: Fixing ToolStripComboBox/ComboBox edit element AccessibleName property value

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -670,6 +670,9 @@
   <data name="ComboBoxDroppedDownDescr" xml:space="preserve">
     <value>Indicates if the combo box is currently dropped down.</value>
   </data>
+  <data name="ComboBoxEditDefaultAccessibleName" xml:space="preserve">
+    <value>ComboBox</value>
+  </data>
   <data name="ComboBoxFlatStyleDescr" xml:space="preserve">
     <value>Determines the display of the control.</value>
   </data>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -1017,6 +1017,11 @@
         <target state="translated">Určuje, zda je pole se seznamem nyní otevřeno.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComboBoxEditDefaultAccessibleName">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ComboBoxFlatStyleDescr">
         <source>Determines the display of the control.</source>
         <target state="translated">Určuje zobrazení ovládacího prvku.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -1017,6 +1017,11 @@
         <target state="translated">Zeigt an, ob das Kombinationsfeld momentan ausgeklappt ist.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComboBoxEditDefaultAccessibleName">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ComboBoxFlatStyleDescr">
         <source>Determines the display of the control.</source>
         <target state="translated">Bestimmt die Anzeige des Steuerelements.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -1017,6 +1017,11 @@
         <target state="translated">Indica si el cuadro combinado está desplegado actualmente.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComboBoxEditDefaultAccessibleName">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ComboBoxFlatStyleDescr">
         <source>Determines the display of the control.</source>
         <target state="translated">Determina la visualización del control.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -1017,6 +1017,11 @@
         <target state="translated">Indique si la zone de liste déroulante est déroulée.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComboBoxEditDefaultAccessibleName">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ComboBoxFlatStyleDescr">
         <source>Determines the display of the control.</source>
         <target state="translated">Détermine l'affichage du contrôle.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -1017,6 +1017,11 @@
         <target state="translated">Indica se l'elenco a discesa della casella combinata è correntemente visualizzato.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComboBoxEditDefaultAccessibleName">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ComboBoxFlatStyleDescr">
         <source>Determines the display of the control.</source>
         <target state="translated">Determina la visualizzazione del controllo.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -1017,6 +1017,11 @@
         <target state="translated">コンボ ボックスが現在ドロップダウンしていることを示します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComboBoxEditDefaultAccessibleName">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ComboBoxFlatStyleDescr">
         <source>Determines the display of the control.</source>
         <target state="translated">コントロールの表示を決定します。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -1017,6 +1017,11 @@
         <target state="translated">콤보 상자가 현재 드롭다운되었는지 여부를 나타냅니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComboBoxEditDefaultAccessibleName">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ComboBoxFlatStyleDescr">
         <source>Determines the display of the control.</source>
         <target state="translated">컨트롤 표시 방법을 결정합니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -1017,6 +1017,11 @@
         <target state="translated">Określa, czy pole kombi ma rozwiniętą listę.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComboBoxEditDefaultAccessibleName">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ComboBoxFlatStyleDescr">
         <source>Determines the display of the control.</source>
         <target state="translated">Określa wyświetlanie formantu.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -1017,6 +1017,11 @@
         <target state="translated">Indica se a caixa de combinação está suspensa no momento.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComboBoxEditDefaultAccessibleName">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ComboBoxFlatStyleDescr">
         <source>Determines the display of the control.</source>
         <target state="translated">Determina a exibição do controle.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -1017,6 +1017,11 @@
         <target state="translated">Показывает, развернут ли список в комбинированном окне в данный момент.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComboBoxEditDefaultAccessibleName">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ComboBoxFlatStyleDescr">
         <source>Determines the display of the control.</source>
         <target state="translated">Определяет внешний вид элемента управления.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -1017,6 +1017,11 @@
         <target state="translated">Birleşik giriş kutusunun şu anda açılmış olup olmadığını gösterir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComboBoxEditDefaultAccessibleName">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ComboBoxFlatStyleDescr">
         <source>Determines the display of the control.</source>
         <target state="translated">Denetimin görünümünü belirler.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -1017,6 +1017,11 @@
         <target state="translated">指示组合框当前是否下拉。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComboBoxEditDefaultAccessibleName">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ComboBoxFlatStyleDescr">
         <source>Determines the display of the control.</source>
         <target state="translated">确定控件的显示。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -1017,6 +1017,11 @@
         <target state="translated">表示下拉式方塊目前是否為下拉狀態。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComboBoxEditDefaultAccessibleName">
+        <source>ComboBox</source>
+        <target state="new">ComboBox</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ComboBoxFlatStyleDescr">
         <source>Determines the display of the control.</source>
         <target state="translated">決定控制項的顯示方式。</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -5410,7 +5410,7 @@ namespace System.Windows.Forms
                     case NativeMethods.UIA_ControlTypePropertyId:
                         return NativeMethods.UIA_EditControlTypeId;
                     case NativeMethods.UIA_NamePropertyId:
-                        return Name;
+                        return Name ?? SR.ComboBoxEditDefaultAccessibleName;
                     case NativeMethods.UIA_AccessKeyPropertyId:
                         return string.Empty;
                     case NativeMethods.UIA_HasKeyboardFocusPropertyId:

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ComboBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ComboBoxAccessibleObjectTests.cs
@@ -58,5 +58,17 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             UnsafeNativeMethods.IRawElementProviderFragment firstChild = accessibleObject.FragmentNavigate(UnsafeNativeMethods.NavigateDirection.FirstChild);
             Assert.NotNull(firstChild);
         }
+
+        [Theory]
+        [InlineData("Test text")]
+        [InlineData(null)]
+        public void ComboBoxEditAccessibleObject_NameNotNull(string name)
+        {
+            ComboBox comboBox = new ComboBox();
+            comboBox.AccessibleName = name;
+            comboBox.CreateControl(false);
+            object editAccessibleName = comboBox.ChildEditAccessibleObject.GetPropertyValue(NativeMethods.UIA_NamePropertyId);
+            Assert.NotNull(editAccessibleName);
+        }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

_**Needs review translation!**_

Fixes #1691
**Original bug:**
- [Bug 956710:](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/956710) ToolbarStripContainer: (CoreTesting/edit '') The Name property of a focusable element must not be null.

## Proposed changes

- Add default accessible name ("_ComboBox_") for `ComboBox` edit element to resources
- Use a default accessible name if AccessibleName property value is null

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Narrator adds default accessible name when reading


## Regression? 

- No

## Risk

- None

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
- If no accessible name is given then it is null

![image](https://user-images.githubusercontent.com/49272759/63686501-b39ab700-c80a-11e9-9ced-6a0a6ddd836b.png)

![image](https://user-images.githubusercontent.com/49272759/63686761-63702480-c80b-11e9-86e7-b4aa2097461e.png)

<!-- TODO -->

### After
- If no accessible name is given then it is the default

![image](https://user-images.githubusercontent.com/49272759/63686508-b85f6b00-c80a-11e9-8034-9a064ef0fb7e.png)

![image](https://user-images.githubusercontent.com/49272759/63686176-e42e2100-c809-11e9-9c95-7cbf0b827585.png)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- The unit test: ComboBoxAccessibleObjectTests.cs 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Using Narrator and Inspect tools
<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- .NET Core Version: 3.0.100-preview9-013722
- Microsoft Windows [Version 10.0.18362.295]


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1692)