### PR TITLE
Fix issue 1703 - Adding ExpandCollapse pattern to DataGridViewComboBoxCell

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
@@ -3115,12 +3115,39 @@ namespace System.Windows.Forms
 
             internal override object GetPropertyValue(int propertyID)
             {
-                if (propertyID == NativeMethods.UIA_ControlTypePropertyId)
+                switch (propertyID)
                 {
-                    return NativeMethods.UIA_ComboBoxControlTypeId;
+                    case NativeMethods.UIA_ControlTypePropertyId:
+                        return NativeMethods.UIA_ComboBoxControlTypeId;
+                    case NativeMethods.UIA_IsExpandCollapsePatternAvailablePropertyId:
+                        return IsPatternSupported(NativeMethods.UIA_ExpandCollapsePatternId);
                 }
 
                 return base.GetPropertyValue(propertyID);
+            }
+
+            internal override bool IsPatternSupported(int patternId)
+            {
+                if (patternId == NativeMethods.UIA_ExpandCollapsePatternId)
+                {
+                    return true;
+                }
+
+                return base.IsPatternSupported(patternId);
+            }
+
+            internal override UnsafeNativeMethods.ExpandCollapseState ExpandCollapseState
+            {
+                get
+                {
+                    DataGridViewComboBoxEditingControl comboBox = Owner.Properties.GetObject(PropComboBoxCellEditingComboBox) as DataGridViewComboBoxEditingControl;
+                    if (comboBox != null)
+                    {
+                        return comboBox.DroppedDown ? UnsafeNativeMethods.ExpandCollapseState.Expanded : UnsafeNativeMethods.ExpandCollapseState.Collapsed;
+                    }
+
+                    return UnsafeNativeMethods.ExpandCollapseState.Collapsed;
+                }
             }
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewComboBoxCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewComboBoxCellAccessibleObjectTests.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Windows.Forms.Tests.AccessibleObjects
+{
+    public class DataGridViewComboBoxCellAccessibleObjectTests
+    {
+        [Theory]
+        [InlineData(NativeMethods.UIA_IsExpandCollapsePatternAvailablePropertyId, true)]
+        public void GetPropertyValue_Returns_Correct_Value(int propertyID, object expectedPropertyValue)
+        {
+            DataGridView dataGridView = new DataGridView();
+            DataGridViewComboBoxColumn column = new DataGridViewComboBoxColumn();
+            dataGridView.Columns.Add(column);
+            dataGridView.Rows.Add();
+
+            object actualPropertyValue = dataGridView.Rows[0].Cells[0].AccessibilityObject.GetPropertyValue(propertyID);
+
+            Assert.Equal(expectedPropertyValue, actualPropertyValue);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1703


## Proposed changes

- Adding ExpandCollapsePatternProvider to DataGridViewComboBox cell as corresponding cell has ComboBox control type. So adding pattern is obligatory.
- ExpandCollapsePattern is also presented in child ComboBox control: made the value of ExpandCollapseState synced between ComboBox and DataGridViewComboBoxCell.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- DataGridView UI will be more accessible for users with visual impairment. 
- Users will be notified about the control state during DataGridView cell navigation without necessity to expand/collapse the ComboBox.

## Regression? 

- No, but conditionally is dependent on the changes with DataGridView (.NET Framework 4.7.2)

## Risk

- Lowest.

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/23213980/63774623-52e0ac80-c8e6-11e9-8c12-8539d76d7083.png)


### After

<!-- TODO -->
![image](https://user-images.githubusercontent.com/23213980/63774860-d3071200-c8e6-11e9-989a-9e45fda0481e.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual testing, accessibility validation tools.
- Waiting for test results from QA.
- Automated tests and apps.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->

The change does not modify current UI itself, but only fixes the accessibility issue.
 

## Test environment(s) <!-- Remove any that don't apply -->

- <!-- use `dotnet --info` -->
.NET Core SDK (reflecting any global.json):
 Version:   3.0.100-preview8-012929
 Commit:    795f8aeaa8

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.18362
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\3.0.100-preview8-012929\

Host (useful for support):
  Version: 3.0.0-preview8-27907-09
  Commit:  fc924dc319

.NET Core SDKs installed:
  2.1.700-preview-009601 [C:\Program Files\dotnet\sdk]
  2.1.800-preview-009696 [C:\Program Files\dotnet\sdk]
  3.0.100-preview8-012929 [C:\Program Files\dotnet\sdk]

.NET Core runtimes installed:
  Microsoft.AspNetCore.All 2.1.9 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.All]
  Microsoft.AspNetCore.All 2.1.11 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.All]
  Microsoft.AspNetCore.App 2.1.9 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.AspNetCore.App 2.1.11 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.AspNetCore.App 3.0.0-preview8.19351.9 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 2.1.9 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 2.1.11 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 3.0.0-preview8-27907-09 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.WindowsDesktop.App 3.0.0-preview8-27907-09 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1704)