### PR TITLE
Fix issue 1705 - Accessibility: PropertyGridView should support Table and Grid accessibility patterns

### DIFF
--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -1596,6 +1596,8 @@ namespace System.Windows.Forms
         public const string uuid_IAccessible = "{618736E0-3C3D-11CF-810C-00AA00389B71}";
         public const string uuid_IEnumVariant = "{00020404-0000-0000-C000-000000000046}";
 
+        public const string WinFormFrameworkId = "WinForm";
+
         /*
         * MISCELLANEOUS
         */

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/CategoryGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/CategoryGridEntry.cs
@@ -311,6 +311,17 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return base.FragmentNavigate(direction);
             }
 
+            internal override bool IsPatternSupported(int patternId)
+            {
+                if (patternId == NativeMethods.UIA_GridItemPatternId ||
+                    patternId == NativeMethods.UIA_TableItemPatternId)
+                {
+                    return true;
+                }
+
+                return base.IsPatternSupported(patternId);
+            }
+
             internal override object GetPropertyValue(int propertyID)
             {
                 switch (propertyID)
@@ -331,6 +342,48 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return AccessibleRole.ButtonDropDownGrid;
                 }
             }
+
+            internal override int Row
+            {
+                get
+                {
+                    var parent = Parent as PropertyGridView.PropertyGridViewAccessibleObject;
+                    if (parent == null)
+                    {
+                        return -1;
+                    }
+
+                    var gridView = parent.Owner as PropertyGridView;
+                    if (gridView == null || gridView.OwnerGrid == null || !gridView.OwnerGrid.SortedByCategories)
+                    {
+                        return -1;
+                    }
+
+                    var topLevelGridEntries = gridView.TopLevelGridEntries;
+                    if (topLevelGridEntries == null)
+                    {
+                        return -1;
+                    }
+
+                    int categoryIndex = 0;
+                    foreach (var topLevelGridEntry in topLevelGridEntries)
+                    {
+                        if (_owningCategoryGridEntry == topLevelGridEntry)
+                        {
+                            return categoryIndex;
+                        }
+
+                        if (topLevelGridEntry is CategoryGridEntry)
+                        {
+                            categoryIndex++;
+                        }
+                    }
+
+                    return -1;
+                }
+            }
+
+            internal override int Column => 0; // Category is in the first column.
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
@@ -3251,10 +3251,14 @@ namespace System.Windows.Forms.PropertyGridInternal
                         return false;
                     case NativeMethods.UIA_IsOffscreenPropertyId:
                         return (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen;
+                    case NativeMethods.UIA_IsGridItemPatternAvailablePropertyId:
+                    case NativeMethods.UIA_IsTableItemPatternAvailablePropertyId:
+                        return true;
                     case NativeMethods.UIA_LegacyIAccessibleRolePropertyId:
                         return Role;
                     case NativeMethods.UIA_LegacyIAccessibleDefaultActionPropertyId:
                         return DefaultAction;
+
                     default:
                         return base.GetPropertyValue(propertyID);
                 }
@@ -3262,19 +3266,39 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             internal override bool IsPatternSupported(int patternId)
             {
-                if (owner.Expandable &&
-                    patternId == NativeMethods.UIA_ExpandCollapsePatternId)
+                switch (patternId)
                 {
-                    return true;
+                    case NativeMethods.UIA_InvokePatternId:
+                    case NativeMethods.UIA_LegacyIAccessiblePatternId:
+                        return true;
+
+                    case NativeMethods.UIA_ExpandCollapsePatternId:
+                        if (owner != null && owner.Expandable)
+                        {
+                            return true;
+                        }
+
+                        break;
+
+                    case NativeMethods.UIA_GridItemPatternId:
+                    case NativeMethods.UIA_TableItemPatternId:
+                        if (owner == null || owner.OwnerGrid == null || owner.OwnerGrid.SortedByCategories)
+                        {
+                            break;
+                        }
+
+                        // Only top level rows are grid items.
+                        // Sub-items (for instance height in size is not a grid item)
+                        GridEntry parentGridEntry = owner.ParentGridEntry;
+                        if (parentGridEntry != null && parentGridEntry is SingleSelectRootGridEntry)
+                        {
+                            return true;
+                        }
+
+                        break;
                 }
 
-                if (patternId == NativeMethods.UIA_InvokePatternId ||
-                    patternId == NativeMethods.UIA_LegacyIAccessiblePatternId)
-                {
-                    return true;
-                }
-
-                return false;
+                return base.IsPatternSupported(patternId);
             }
 
             internal override void Expand()
@@ -3319,7 +3343,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 get
                 {
-                    return owner.PropertyLabel;
+                    return owner?.PropertyLabel;
                 }
             }
 
@@ -3327,7 +3351,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 get
                 {
-                    return ((Control)owner.GridEntryHost).AccessibilityObject;
+                    return owner?.GridEntryHost?.AccessibilityObject;
                 }
             }
 
@@ -3335,7 +3359,13 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 get
                 {
-                    return (PropertyGridView)((PropertyGridView.PropertyGridViewAccessibleObject)Parent).Owner;
+                    var propertyGridViewAccessibleObject = Parent as PropertyGridView.PropertyGridViewAccessibleObject;
+                    if (propertyGridViewAccessibleObject != null)
+                    {
+                        return propertyGridViewAccessibleObject.Owner as PropertyGridView;
+                    }
+
+                    return null;
                 }
             }
 
@@ -3502,6 +3532,48 @@ namespace System.Windows.Forms.PropertyGridInternal
                 base.SetFocus();
 
                 RaiseAutomationEvent(NativeMethods.UIA_AutomationFocusChangedEventId);
+            }
+
+            internal override int Row
+            {
+                get
+                {
+                    var parent = Parent as PropertyGridView.PropertyGridViewAccessibleObject;
+                    if (parent == null)
+                    {
+                        return -1;
+                    }
+
+                    var gridView = parent.Owner as PropertyGridView;
+                    if (gridView == null)
+                    {
+                        return -1;
+                    }
+
+                    var topLevelGridEntries = gridView.TopLevelGridEntries;
+                    if (topLevelGridEntries == null)
+                    {
+                        return -1;
+                    }
+
+                    for (int i = 0; i < topLevelGridEntries.Count; i++)
+                    {
+                        var topLevelGridEntry = topLevelGridEntries[i];
+                        if (owner == topLevelGridEntry)
+                        {
+                            return i;
+                        }
+                    }
+
+                    return -1;
+                }
+            }
+
+            internal override int Column => 0;
+
+            internal override UnsafeNativeMethods.IRawElementProviderSimple ContainingGrid
+            {
+                get => this.PropertyGridView.AccessibilityObject;
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -11,6 +11,7 @@ using System.Drawing.Design;
 using System.Drawing.Drawing2D;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Windows.Forms.Design;
 using System.Windows.Forms.VisualStyles;
 using Microsoft.Win32;
@@ -2439,7 +2440,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             return rect;
         }
 
-        private /*protected virtual*/ int GetRowFromGridEntry(GridEntry gridEntry)
+        internal /*protected virtual*/ int GetRowFromGridEntry(GridEntry gridEntry)
         {
             GridEntryCollection rgipesAll = GetAllGridEntries();
             if (gridEntry == null || rgipesAll == null)
@@ -7646,6 +7647,13 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return base.IsInputChar(keyChar);
             }
 
+            protected override void OnGotFocus(EventArgs e)
+            {
+                base.OnGotFocus(e);
+
+                this.AccessibilityObject.RaiseAutomationEvent(NativeMethods.UIA_AutomationFocusChangedEventId);
+            }
+
             protected override void OnKeyDown(KeyEventArgs ke)
             {
 
@@ -7996,21 +8004,24 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 internal override object GetPropertyValue(int propertyID)
                 {
-                    if (propertyID == NativeMethods.UIA_IsEnabledPropertyId)
+                    switch (propertyID)
                     {
-                        return !IsReadOnly;
-                    }
-                    else if (propertyID == NativeMethods.UIA_IsValuePatternAvailablePropertyId)
-                    {
-                        return IsPatternSupported(NativeMethods.UIA_ValuePatternId);
-                    }
-                    else if (propertyID == NativeMethods.UIA_ControlTypePropertyId)
-                    {
-                        return NativeMethods.UIA_EditControlTypeId;
-                    }
-                    else if (propertyID == NativeMethods.UIA_NamePropertyId)
-                    {
-                        return Name;
+                        case NativeMethods.UIA_RuntimeIdPropertyId:
+                            return RuntimeId;
+                        case NativeMethods.UIA_ControlTypePropertyId:
+                            return NativeMethods.UIA_EditControlTypeId;
+                        case NativeMethods.UIA_NamePropertyId:
+                            return Name;
+                        case NativeMethods.UIA_HasKeyboardFocusPropertyId:
+                            return Owner.Focused;
+                        case NativeMethods.UIA_IsEnabledPropertyId:
+                            return !IsReadOnly;
+                        case NativeMethods.UIA_ClassNamePropertyId:
+                            return Owner.GetType().ToString();
+                        case NativeMethods.UIA_FrameworkIdPropertyId:
+                            return NativeMethods.WinFormFrameworkId;
+                        case NativeMethods.UIA_IsValuePatternAvailablePropertyId:
+                            return IsPatternSupported(NativeMethods.UIA_ValuePatternId);
                     }
 
                     return base.GetPropertyValue(propertyID);
@@ -8024,6 +8035,18 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
 
                     return base.IsPatternSupported(patternId);
+                }
+
+                internal override UnsafeNativeMethods.IRawElementProviderSimple HostRawElementProvider
+                {
+                    get
+                    {
+                        // Prevent sending same runtime ID for all edit boxes. Individual edit in 
+                        // each row should have unique runtime ID to prevent incorrect announcement.
+                        // For instance screen reader may announce row 2 for the third row edit 
+                        // as the sme TextBox control is used both in row 2 and row 3.
+                        return null;
+                    }
                 }
 
                 public override string Name
@@ -8050,6 +8073,30 @@ namespace System.Windows.Forms.PropertyGridInternal
                     set
                     {
                         base.Name = value;
+                    }
+                }
+
+                internal override int[] RuntimeId
+                {
+                    get
+                    {
+                        var selectedGridEntryAccessibleRuntimeId =
+                            propertyGridView?.SelectedGridEntry?.AccessibilityObject?.RuntimeId;
+
+                        if (selectedGridEntryAccessibleRuntimeId == null)
+                        {
+                            return null;
+                        }
+
+                        int[] runtimeId = new int[selectedGridEntryAccessibleRuntimeId.Length + 1];
+                        for (int i = 0; i < selectedGridEntryAccessibleRuntimeId.Length; i++)
+                        {
+                            runtimeId[i] = selectedGridEntryAccessibleRuntimeId[i];
+                        }
+
+                        runtimeId[runtimeId.Length - 1] = 1;
+
+                        return runtimeId;
                     }
                 }
 
@@ -8448,16 +8495,30 @@ namespace System.Windows.Forms.PropertyGridInternal
             /// <returns>Returns a ValInfo indicating whether the element supports this property, or has no value for it.</returns>
             internal override object GetPropertyValue(int propertyID)
             {
-                if (propertyID == NativeMethods.UIA_ControlTypePropertyId)
+                switch (propertyID)
                 {
-                    return NativeMethods.UIA_TableControlTypeId;
-                }
-                else if (propertyID == NativeMethods.UIA_NamePropertyId)
-                {
-                    return Name;
+                    case NativeMethods.UIA_ControlTypePropertyId:
+                        return NativeMethods.UIA_TableControlTypeId;
+                    case NativeMethods.UIA_NamePropertyId:
+                        return Name;
+                    case NativeMethods.UIA_IsTablePatternAvailablePropertyId:
+                    case NativeMethods.UIA_IsGridPatternAvailablePropertyId:
+                        return true;
                 }
 
                 return base.GetPropertyValue(propertyID);
+            }
+
+            internal override bool IsPatternSupported(int patternId)
+            {
+                switch (patternId)
+                {
+                    case NativeMethods.UIA_TablePatternId:
+                    case NativeMethods.UIA_GridPatternId:
+                        return true;
+                }
+
+                return base.IsPatternSupported(patternId);
             }
 
             public override string Name
@@ -8858,6 +8919,41 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
                 return null;    // Perform default behavior
             }
+
+            internal override UnsafeNativeMethods.IRawElementProviderSimple GetItem(int row, int column)
+            {
+                return GetChild(row);
+            }
+
+            internal override int RowCount
+            {
+                get
+                {
+                    var topLevelGridEntries = _owningPropertyGridView.TopLevelGridEntries;
+                    if (topLevelGridEntries == null)
+                    {
+                        return 0;
+                    }
+
+                    if (!_owningPropertyGridView.OwnerGrid.SortedByCategories)
+                    {
+                        return topLevelGridEntries.Count;
+                    }
+
+                    int categoriesCount = 0;
+                    foreach (var topLevelGridEntry in topLevelGridEntries)
+                    {
+                        if (topLevelGridEntry is CategoryGridEntry)
+                        {
+                            categoriesCount++;
+                        }
+                    }
+
+                    return categoriesCount;
+                }
+            }
+
+            internal override int ColumnCount => 1; // There is one column: grid item represents both label and input.
         }
 
         internal class GridPositionData

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridViewAccessibleObjectTests.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Windows.Forms.Tests.AccessibleObjects
+{
+    public class PropertyGridViewAccessibleObjectTests
+    {
+        [Theory]
+        [InlineData(NativeMethods.UIA_GridPatternId)]
+        [InlineData(NativeMethods.UIA_TablePatternId)]
+        public void PropertyGridAccessibleObject_Supports_TablePattern(int pattern)
+        {
+            PropertyGrid propertyGrid = new PropertyGrid();
+            ComboBox comboBox = new ComboBox();
+            propertyGrid.SelectedObject = comboBox;
+
+            var propertyGridAccessibleObject = new PropertyGridAccessibleObject(propertyGrid);
+
+            // First child should be PropertyGrid toolbox.
+            var firstChild = propertyGridAccessibleObject.FragmentNavigate(
+                UnsafeNativeMethods.NavigateDirection.FirstChild) as AccessibleObject;
+
+            // Second child entry should be PropertyGridView.
+            var gridViewChild = firstChild.FragmentNavigate(
+                UnsafeNativeMethods.NavigateDirection.NextSibling) as AccessibleObject;
+
+            Assert.True(gridViewChild.IsPatternSupported(pattern));
+        }
+
+        [Theory]
+        [InlineData(NativeMethods.UIA_GridItemPatternId)]
+        [InlineData(NativeMethods.UIA_TableItemPatternId)]
+        public void PropertyGridViewAccessibleObject_Supports_TablePattern(int pattern)
+        {
+            PropertyGrid propertyGrid = new PropertyGrid();
+            ComboBox comboBox = new ComboBox();
+            propertyGrid.SelectedObject = comboBox;
+
+            var defaultGridEntry = propertyGrid.GetDefaultGridEntry();
+            var parentGridEntry = defaultGridEntry.ParentGridEntry; // Category which has item pattern.
+            var accessibleObject = parentGridEntry.AccessibilityObject;
+            Assert.True(accessibleObject.IsPatternSupported(pattern));
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1705


## Proposed changes

- Adding Grid and Table accessibility patterns to PropertyGridView child of PropertyGrid control.
- Adding GridItem and TableItem accessibility patterns to PropertyGrid entries.
- Implemented related accessibility properties to provide information about rows and columns.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Users will be able to get more informative description about PropertyGrid control when navigating and entering data.
- PropertyGrid control becomes more accessible.

## Regression? 

- No

## Risk

- Low

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/23213980/63792805-00fc4e80-c907-11e9-879b-7f5e5a05dbe4.png)

### After

![image](https://user-images.githubusercontent.com/23213980/63793046-7cf69680-c907-11e9-9b35-3fd0e30f4e40.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual testing: validation in accessibility tools.
- Need to add automation tests.
- Need to get approval from QA.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->

- No UI changes, only accessibility improvements.
 

## Test environment(s) <!-- Remove any that don't apply -->

<!-- use `dotnet --info` -->
.NET Core SDK (reflecting any global.json):
Version: 3.0.100-preview8-012929
Commit: 795f8aeaa8
Runtime Environment:
OS Name: Windows
OS Version: 10.0.18362
OS Platform: Windows
RID: win10-x64
Base Path: C:\Program Files\dotnet\sdk\3.0.100-preview8-012929\
Host (useful for support):
Version: 3.0.0-preview8-27907-09
Commit: fc924dc319
.NET Core SDKs installed:
2.1.700-preview-009601 [C:\Program Files\dotnet\sdk]
2.1.800-preview-009696 [C:\Program Files\dotnet\sdk]
3.0.100-preview8-012929 [C:\Program Files\dotnet\sdk]
.NET Core runtimes installed:
Microsoft.AspNetCore.All 2.1.9 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.All]
Microsoft.AspNetCore.All 2.1.11 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.All]
Microsoft.AspNetCore.App 2.1.9 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
Microsoft.AspNetCore.App 2.1.11 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
Microsoft.AspNetCore.App 3.0.0-preview8.19351.9 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
Microsoft.NETCore.App 2.1.9 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
Microsoft.NETCore.App 2.1.11 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
Microsoft.NETCore.App 3.0.0-preview8-27907-09 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
Microsoft.WindowsDesktop.App 3.0.0-preview8-27907-09 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1706)