### PR TITLE
fix `PowerStatus_BatteryChargeStatus_Get_ReturnsExpected` test

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PowerStatusTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PowerStatusTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using Xunit;
 
 namespace System.Windows.Forms.Tests
@@ -12,7 +13,32 @@ namespace System.Windows.Forms.Tests
         public void PowerStatus_BatteryChargeStatus_Get_ReturnsExpected()
         {
             PowerStatus status = SystemInformation.PowerStatus;
-            Assert.True(Enum.IsDefined(typeof(BatteryChargeStatus), status.BatteryChargeStatus));
+
+            // try a valid combination
+            // an edge-case can surface on laptops that are not permanently connected to power
+            // e.g. a charing laptop in a high performance mode would be HIGH | CHARGING
+            Assert.True(EnumIsDefined(status.BatteryChargeStatus));
+
+            // try an invalid (as of time of writing) combination
+            Assert.False(EnumIsDefined((BatteryChargeStatus)67));
+
+            bool EnumIsDefined(BatteryChargeStatus value)
+            {
+                // BatteryChargeStatus.Unknown == 1111_1111, OR'ing anything with it won't change the result
+                // and thus won't catch invalid combinations, so we need to exclude if from further consideration
+
+                if (value == BatteryChargeStatus.Unknown)
+                {
+                    return true;
+                }
+
+                var values = Enum.GetValues(typeof(BatteryChargeStatus))
+                    .OfType<BatteryChargeStatus>()
+                    .Where(v => v != BatteryChargeStatus.Unknown)
+                    .Aggregate((e1, e2) => (e1 | e2));
+
+                return (values & value) == value;
+            }
         }
 
         [Fact]


### PR DESCRIPTION


<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

PowerStatus_BatteryChargeStatus_Get_ReturnsExpected was not correctly validating combination of flags.
The test was likely written on a workstation permanently connected to a power point. As a result the test did not account for combination of flags that can occur on laptops that are not permanently connected, e.g. if a laptop was being charged querying power would result in a combination of flags, such as `HIGH | CHARGING`.

Enhance the test to assert on combinations of valid flags.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- None, test change only

## Regression? 

- No

## Risk

- None, test change only

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/4403806/63942763-04164c80-ca77-11e9-8a51-072432edb7a7.png)



## Test methodology <!-- How did you ensure quality? -->

- manually running on a laptop partially discarged plugged and unplugged.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1722)