### PR TITLE
Standardise some User32 struct interop

### DIFF
--- a/src/Common/src/Interop/ComCtl32/Interop.TTTOOLINFOW.cs
+++ b/src/Common/src/Interop/ComCtl32/Interop.TTTOOLINFOW.cs
@@ -79,7 +79,7 @@ internal static partial class Interop
                 };
 
 
-            public unsafe IntPtr SendMessage(IHandle sender, uint message, BOOL state = BOOL.FALSE)
+            public unsafe IntPtr SendMessage(IHandle sender, User32.WindowMessage message, BOOL state = BOOL.FALSE)
             {
                 Info.cbSize = (uint)sizeof(TTOOLINFOW);
                 fixed (char* c = Text)

--- a/src/Common/src/Interop/Gdi32/Interop.RealizePalette.cs
+++ b/src/Common/src/Interop/Gdi32/Interop.RealizePalette.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Gdi32
+    {
+        [DllImport(ExternDll.Gdi32, ExactSpelling = true)]
+        public static extern uint RealizePalette(IntPtr hdc);
+    }
+}

--- a/src/Common/src/Interop/Gdi32/Interop.SelectPalette.cs
+++ b/src/Common/src/Interop/Gdi32/Interop.SelectPalette.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Gdi32
+    {
+        [DllImport(Libraries.Gdi32, ExactSpelling = true, SetLastError = true)]
+        public static extern IntPtr SelectPalette(IntPtr hdc, IntPtr hPal, BOOL bForceBkgd);
+
+        public static IntPtr SelectPalette(HandleRef hdc, IntPtr hPal, BOOL bForceBkgd)
+        {
+            IntPtr result = SelectPalette(hdc.Handle, hPal, bForceBkgd);
+            GC.KeepAlive(hdc.Wrapper);
+            return result;
+        }
+
+        public static IntPtr SelectPalette(HandleRef hdc, HandleRef hPal, BOOL bForceBkgd)
+        {
+            IntPtr result = SelectPalette(hdc.Handle, hPal.Handle, bForceBkgd);
+            GC.KeepAlive(hdc.Wrapper);
+            GC.KeepAlive(hPal.Wrapper);
+            return result;
+        }
+    }
+}

--- a/src/Common/src/Interop/Gdi32/Interop.SelectPalette.cs
+++ b/src/Common/src/Interop/Gdi32/Interop.SelectPalette.cs
@@ -12,13 +12,6 @@ internal static partial class Interop
         [DllImport(Libraries.Gdi32, ExactSpelling = true, SetLastError = true)]
         public static extern IntPtr SelectPalette(IntPtr hdc, IntPtr hPal, BOOL bForceBkgd);
 
-        public static IntPtr SelectPalette(HandleRef hdc, IntPtr hPal, BOOL bForceBkgd)
-        {
-            IntPtr result = SelectPalette(hdc.Handle, hPal, bForceBkgd);
-            GC.KeepAlive(hdc.Wrapper);
-            return result;
-        }
-
         public static IntPtr SelectPalette(HandleRef hdc, HandleRef hPal, BOOL bForceBkgd)
         {
             IntPtr result = SelectPalette(hdc.Handle, hPal.Handle, bForceBkgd);

--- a/src/Common/src/Interop/Interop.WindowMessages.cs
+++ b/src/Common/src/Interop/Interop.WindowMessages.cs
@@ -221,35 +221,5 @@ internal static partial class Interop
         public const int WM_USER = 0x0400;
         public const int WM_REFLECT = WM_USER + 0x1C00;
         public const int WM_CHOOSEFONT_GETLOGFONT = (0x0400 + 1);
-
-        public const uint TTM_ACTIVATE          = WM_USER + 1;
-        public const uint TTM_SETDELAYTIME      = WM_USER + 3;
-        public const uint TTM_RELAYEVENT        = WM_USER + 7;
-        public const uint TTM_WINDOWFROMPOINT   = WM_USER + 16;
-        public const uint TTM_TRACKACTIVATE     = WM_USER + 17;
-        public const uint TTM_TRACKPOSITION     = WM_USER + 18;
-        public const uint TTM_SETTIPBKCOLOR     = WM_USER + 19;
-        public const uint TTM_SETTIPTEXTCOLOR   = WM_USER + 20;
-        public const uint TTM_GETDELAYTIME      = WM_USER + 21;
-        public const uint TTM_GETTIPBKCOLOR     = WM_USER + 22;
-        public const uint TTM_GETTIPTEXTCOLOR   = WM_USER + 23;
-        public const uint TTM_SETMAXTIPWIDTH    = WM_USER + 24;
-        public const uint TTM_POP               = WM_USER + 28;
-        public const uint TTM_UPDATE            = WM_USER + 29;
-        public const uint TTM_GETBUBBLESIZE     = WM_USER + 30;
-        public const uint TTM_ADJUSTRECT        = WM_USER + 31;
-        public const uint TTM_SETTITLEW         = WM_USER + 33;
-        public const uint TTM_ADDTOOLW          = WM_USER + 50;
-        public const uint TTM_DELTOOLW          = WM_USER + 51;
-        public const uint TTM_NEWTOOLRECTW      = WM_USER + 52;
-        public const uint TTM_GETTOOLINFOW      = WM_USER + 53;
-        public const uint TTM_SETTOOLINFOW      = WM_USER + 54;
-        public const uint TTM_HITTESTW          = WM_USER + 55;
-        public const uint TTM_GETTEXTW          = WM_USER + 56;
-        public const uint TTM_UPDATETIPTEXTW    = WM_USER + 57;
-        public const uint TTM_ENUMTOOLSW        = WM_USER + 58;
-        public const uint TTM_GETCURRENTTOOLW   = WM_USER + 59;
-
-        public const uint HDM_LAYOUT = (0x1200 + 5);
     }
 }

--- a/src/Common/src/Interop/Interop.WindowMessages.cs
+++ b/src/Common/src/Interop/Interop.WindowMessages.cs
@@ -249,5 +249,7 @@ internal static partial class Interop
         public const uint TTM_UPDATETIPTEXTW    = WM_USER + 57;
         public const uint TTM_ENUMTOOLSW        = WM_USER + 58;
         public const uint TTM_GETCURRENTTOOLW   = WM_USER + 59;
+
+        public const uint HDM_LAYOUT = (0x1200 + 5);
     }
 }

--- a/src/Common/src/Interop/User32/Interop.ACCEL.cs
+++ b/src/Common/src/Interop/User32/Interop.ACCEL.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public struct ACCEL
+        {
+            public AcceleratorFlags fVirt;
+            public ushort key;
+            public ushort cmd;
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.AcceleratorFlags.cs
+++ b/src/Common/src/Interop/User32/Interop.AcceleratorFlags.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [Flags]
+        public enum AcceleratorFlags : byte
+        {
+            FVIRTKEY = 0x01,
+            FSHIFT = 0x04,
+            FCONTROL = 0x08,
+            FALT = 0x10,
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.AcceleratorFlags.cs
+++ b/src/Common/src/Interop/User32/Interop.AcceleratorFlags.cs
@@ -13,6 +13,7 @@ internal static partial class Interop
         public enum AcceleratorFlags : byte
         {
             FVIRTKEY = 0x01,
+            FNOINVERT = 0x02,
             FSHIFT = 0x04,
             FCONTROL = 0x08,
             FALT = 0x10,

--- a/src/Common/src/Interop/User32/Interop.DRAWITEMSTRUCT.cs
+++ b/src/Common/src/Interop/User32/Interop.DRAWITEMSTRUCT.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public struct DRAWITEMSTRUCT
+        {
+            public ItemControlType CtlType;
+            public uint CtlID;
+            public int itemID;
+            public DrawItemAction itemAction;
+            public DrawItemState itemState;
+            public IntPtr hwndItem;
+            public IntPtr hDC;
+            public RECT rcItem;
+            public IntPtr itemData;
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.DRAWITEMSTRUCT.cs
+++ b/src/Common/src/Interop/User32/Interop.DRAWITEMSTRUCT.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
         {
             public ItemControlType CtlType;
             public uint CtlID;
-            public int itemID;
+            public uint itemID;
             public DrawItemAction itemAction;
             public DrawItemState itemState;
             public IntPtr hwndItem;

--- a/src/Common/src/Interop/User32/Interop.DrawItemAction.cs
+++ b/src/Common/src/Interop/User32/Interop.DrawItemAction.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [Flags]
+        public enum DrawItemAction : uint
+        {
+            ODA_DRAWENTIRE = 0x1,
+            ODA_SELECT = 0x2,
+            ODA_FOCUS = 0x4,
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.DrawItemAction.cs
+++ b/src/Common/src/Interop/User32/Interop.DrawItemAction.cs
@@ -12,9 +12,9 @@ internal static partial class Interop
         [Flags]
         public enum DrawItemAction : uint
         {
-            ODA_DRAWENTIRE = 0x1,
-            ODA_SELECT = 0x2,
-            ODA_FOCUS = 0x4,
+            DRAWENTIRE = 0x1,
+            SELECT = 0x2,
+            FOCUS = 0x4,
         }
     }
 }

--- a/src/Common/src/Interop/User32/Interop.DrawItemState.cs
+++ b/src/Common/src/Interop/User32/Interop.DrawItemState.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [Flags]
+        public enum DrawItemState : uint
+        {
+            ODS_CHECKED = 0x0008,
+            ODS_COMBOBOXEDIT = 0x1000,
+            ODS_DEFAULT = 0x0020,
+            ODS_DISABLED = 0x0004,
+            ODS_FOCUS = 0x0010,
+            ODS_GRAYED = 0x0002,
+            ODS_HOTLIGHT = 0x0040,
+            ODS_INACTIVE = 0x0080,
+            ODS_NOACCEL = 0x0100,
+            ODS_NOFOCUSRECT = 0x0200,
+            ODS_SELECTED = 0x0001,
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.DrawItemState.cs
+++ b/src/Common/src/Interop/User32/Interop.DrawItemState.cs
@@ -12,17 +12,17 @@ internal static partial class Interop
         [Flags]
         public enum DrawItemState : uint
         {
-            ODS_CHECKED = 0x0008,
-            ODS_COMBOBOXEDIT = 0x1000,
-            ODS_DEFAULT = 0x0020,
-            ODS_DISABLED = 0x0004,
-            ODS_FOCUS = 0x0010,
-            ODS_GRAYED = 0x0002,
-            ODS_HOTLIGHT = 0x0040,
-            ODS_INACTIVE = 0x0080,
-            ODS_NOACCEL = 0x0100,
-            ODS_NOFOCUSRECT = 0x0200,
-            ODS_SELECTED = 0x0001,
+            SELECTED = 0x0001,
+            GRAYED = 0x0002,
+            DISABLED = 0x0004,
+            CHECKED = 0x0008,
+            FOCUS = 0x0010,
+            DEFAULT = 0x0020,
+            HOTLIGHT = 0x0040,
+            INACTIVE = 0x0080,
+            NOACCEL = 0x0100,
+            NOFOCUSRECT = 0x0200,
+            COMBOBOXEDIT = 0x1000,
         }
     }
 }

--- a/src/Common/src/Interop/User32/Interop.HDLAYOUT.cs
+++ b/src/Common/src/Interop/User32/Interop.HDLAYOUT.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public unsafe struct HDLAYOUT
+        {
+            public RECT* prc;
+            public WINDOWPOS* pwpos;
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.HDLAYOUT.cs
+++ b/src/Common/src/Interop/User32/Interop.HDLAYOUT.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Drawing;
-
 internal static partial class Interop
 {
     internal static partial class User32

--- a/src/Common/src/Interop/User32/Interop.HELPINFO.cs
+++ b/src/Common/src/Interop/User32/Interop.HELPINFO.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Drawing;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public struct HELPINFO
+        {
+            public uint cbSize;
+            public HelpInfoContextType iContextType;
+            public int iCtrlId;
+            public IntPtr hItemHandle;
+            public IntPtr dwContextId;
+            public Point MousePos;
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.HelpInfoContextType.cs
+++ b/src/Common/src/Interop/User32/Interop.HelpInfoContextType.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public enum HelpInfoContextType : int
+        {
+            HELPINFO_WINDOW = 0x1,
+            HELPINFO_MENUITEM = 0x2,
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.HelpInfoContextType.cs
+++ b/src/Common/src/Interop/User32/Interop.HelpInfoContextType.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
     {
         public enum HelpInfoContextType : int
         {
-            HELPINFO_WINDOW = 0x1,
-            HELPINFO_MENUITEM = 0x2,
+            WINDOW = 0x0001,
+            MENUITEM = 0x0002,
         }
     }
 }

--- a/src/Common/src/Interop/User32/Interop.ItemControlType.cs
+++ b/src/Common/src/Interop/User32/Interop.ItemControlType.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public enum ItemControlType : uint
+        {
+            ODT_MENU = 1,
+            ODT_LISTBOX = 2,
+            ODT_COMBOBOX = 3,
+            ODT_BUTTON = 4,
+            ODT_STATIC = 5,
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.ItemControlType.cs
+++ b/src/Common/src/Interop/User32/Interop.ItemControlType.cs
@@ -11,11 +11,14 @@ internal static partial class Interop
     {
         public enum ItemControlType : uint
         {
-            ODT_MENU = 1,
-            ODT_LISTBOX = 2,
-            ODT_COMBOBOX = 3,
-            ODT_BUTTON = 4,
-            ODT_STATIC = 5,
+            MENU = 1,
+            LISTBOX = 2,
+            COMBOBOX = 3,
+            BUTTON = 4,
+            STATIC = 5,
+            HEADER = 100,
+            TAB = 101,
+            LISTVIEW = 102
         }
     }
 }

--- a/src/Common/src/Interop/User32/Interop.MEASUREITEMSTRUCT.cs
+++ b/src/Common/src/Interop/User32/Interop.MEASUREITEMSTRUCT.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public struct MEASUREITEMSTRUCT
+        {
+            public ItemControlType CtlType;
+            public uint CtlID;
+            public int itemID;
+            public int itemWidth;
+            public int itemHeight;
+            public IntPtr itemData;
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.MEASUREITEMSTRUCT.cs
+++ b/src/Common/src/Interop/User32/Interop.MEASUREITEMSTRUCT.cs
@@ -13,9 +13,9 @@ internal static partial class Interop
         {
             public ItemControlType CtlType;
             public uint CtlID;
-            public int itemID;
-            public int itemWidth;
-            public int itemHeight;
+            public uint itemID;
+            public uint itemWidth;
+            public uint itemHeight;
             public IntPtr itemData;
         }
     }

--- a/src/Common/src/Interop/User32/Interop.MINMAXINFO.cs
+++ b/src/Common/src/Interop/User32/Interop.MINMAXINFO.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public struct MINMAXINFO
+        {
+            public Point ptReserved;
+            public Point ptMaxSize;
+            public Point ptMaxPosition;
+            public Point ptMinTrackSize;
+            public Point ptMaxTrackSize;
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.SendMessageW.cs
+++ b/src/Common/src/Interop/User32/Interop.SendMessageW.cs
@@ -13,13 +13,13 @@ internal static partial class Interop
         [DllImport(Libraries.User32, ExactSpelling = true)]
         public static extern IntPtr SendMessageW(
             IntPtr hWnd,
-            uint Msg,
+            WindowMessage Msg,
             IntPtr wParam,
             IntPtr lParam);
 
         public static IntPtr SendMessageW(
             HandleRef hWnd,
-            uint Msg,
+            WindowMessage Msg,
             IntPtr wParam,
             IntPtr lParam)
         {
@@ -30,7 +30,7 @@ internal static partial class Interop
 
         public static IntPtr SendMessageW(
             IHandle hWnd,
-            uint Msg,
+            WindowMessage Msg,
             IntPtr wParam = default,
             IntPtr lParam = default)
         {
@@ -41,7 +41,7 @@ internal static partial class Interop
 
         public unsafe static IntPtr SendMessageW(
             IHandle hWnd,
-            uint Msg,
+            WindowMessage Msg,
             IntPtr wParam,
             string lParam)
         {
@@ -51,31 +51,28 @@ internal static partial class Interop
             }
         }
 
-        public unsafe static IntPtr SendMessageW(
+        public unsafe static IntPtr SendMessageW<T>(
             IntPtr hWnd,
-            uint Msg,
+            WindowMessage Msg,
             IntPtr wParam,
-            RECT lParam)
+            ref T lParam) where T : unmanaged
         {
-            return SendMessageW(hWnd, Msg, wParam, (IntPtr)(void*)&lParam);
+            fixed (void* l = &lParam)
+            {
+                return SendMessageW(hWnd, Msg, wParam, (IntPtr)l);
+            }
         }
 
-        public unsafe static IntPtr SendMessageW(
+        public unsafe static IntPtr SendMessageW<T>(
             IHandle hWnd,
-            uint Msg,
+            WindowMessage Msg,
             IntPtr wParam,
-            RECT lParam)
+            ref T lParam) where T : unmanaged
         {
-            return SendMessageW(hWnd, Msg, wParam, (IntPtr)(void*)&lParam);
-        }
-
-        public unsafe static IntPtr SendMessageW(
-            HandleRef hWnd,
-            uint Msg,
-            IntPtr wParam,
-            HDLAYOUT* lParam)
-        {
-            return SendMessageW(hWnd, Msg, wParam, (IntPtr)lParam);
+            fixed (void* l = &lParam)
+            {
+                return SendMessageW(hWnd, Msg, wParam, (IntPtr)l);
+            }
         }
     }
 }

--- a/src/Common/src/Interop/User32/Interop.SendMessageW.cs
+++ b/src/Common/src/Interop/User32/Interop.SendMessageW.cs
@@ -18,6 +18,17 @@ internal static partial class Interop
             IntPtr lParam);
 
         public static IntPtr SendMessageW(
+            HandleRef hWnd,
+            uint Msg,
+            IntPtr wParam,
+            IntPtr lParam)
+        {
+            IntPtr result = SendMessageW(hWnd.Handle, Msg, wParam, lParam);
+            GC.KeepAlive(hWnd.Wrapper);
+            return result;
+        }
+
+        public static IntPtr SendMessageW(
             IHandle hWnd,
             uint Msg,
             IntPtr wParam = default,
@@ -55,7 +66,16 @@ internal static partial class Interop
             IntPtr wParam,
             RECT lParam)
         {
-             return SendMessageW(hWnd, Msg, wParam, (IntPtr)(void*)&lParam);
+            return SendMessageW(hWnd, Msg, wParam, (IntPtr)(void*)&lParam);
+        }
+
+        public unsafe static IntPtr SendMessageW(
+            HandleRef hWnd,
+            uint Msg,
+            IntPtr wParam,
+            HDLAYOUT* lParam)
+        {
+            return SendMessageW(hWnd, Msg, wParam, (IntPtr)lParam);
         }
     }
 }

--- a/src/Common/src/Interop/User32/Interop.SetWindowPos.cs
+++ b/src/Common/src/Interop/User32/Interop.SetWindowPos.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public static IntPtr HWND_TOP = (IntPtr)0;
+        public static IntPtr HWND_BOTTOM = (IntPtr)1;
+        public static IntPtr HWND_TOPMOST = (IntPtr)(-1);
+        public static IntPtr HWND_NOTOPMOST = (IntPtr)(-2);
+        public static IntPtr HWND_MESSAGE = (IntPtr)(-3);
+
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern BOOL SetWindowPos(
+            IntPtr hWnd,
+            IntPtr hWndInsertAfter,
+            int x = 0,
+            int y = 0,
+            int cx = 0,
+            int cy = 0,
+            WindowPosition flags = (WindowPosition)0);
+
+        public static BOOL SetWindowPos(
+            HandleRef hWnd,
+            IntPtr hWndInsertAfter,
+            int x = 0,
+            int y = 0,
+            int cx = 0,
+            int cy = 0,
+            WindowPosition flags = (WindowPosition)0)
+        {
+            BOOL result = SetWindowPos(hWnd.Handle, hWndInsertAfter, x, y, cx, cy, flags);
+            GC.KeepAlive(hWnd.Wrapper);
+            return result;
+        }
+
+        public static BOOL SetWindowPos(
+            HandleRef hWnd,
+            HandleRef hWndInsertAfter,
+            int x = 0,
+            int y = 0,
+            int cx = 0,
+            int cy = 0,
+            WindowPosition flags = (WindowPosition)0)
+        {
+            BOOL result = SetWindowPos(hWnd.Handle, hWndInsertAfter.Handle, x, y, cx, cy, flags);
+            GC.KeepAlive(hWnd.Wrapper);
+            GC.KeepAlive(hWndInsertAfter.Wrapper);
+            return result;
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.VkKeyScanW.cs
+++ b/src/Common/src/Interop/User32/Interop.VkKeyScanW.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        public static extern short VkKeyScanW(char key);
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.WINDOWPOS.cs
+++ b/src/Common/src/Interop/User32/Interop.WINDOWPOS.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Drawing;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public struct WINDOWPOS
+        {
+            public IntPtr hwnd;
+            public IntPtr hwndInsertAfter;
+            public int x;
+            public int y;
+            public int cx;
+            public int cy;
+            public WindowPosition flags;
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.WindowPosition.cs
+++ b/src/Common/src/Interop/User32/Interop.WindowPosition.cs
@@ -12,21 +12,21 @@ internal static partial class Interop
         [Flags]
         public enum WindowPosition : uint
         {
-            SWP_NOSIZE = 0x0001,
-            SWP_NOMOVE = 0x0002,
-            SWP_NOZORDER = 0x0004,
-            SWP_NOREDRAW = 0x0008,
-            SWP_NOACTIVATE = 0x0010,
-            SWP_FRAMECHANGED = 0x0020,
-            SWP_SHOWWINDOW = 0x0040,
-            SWP_HIDEWINDOW = 0x0080,
-            SWP_NOCOPYBITS = 0x0100,
-            SWP_NOOWNERZORDER = 0x0200,
-            SWP_NOSENDCHANGING = 0x0400,
-            SWP_DEFERERASE = 0x2000,
-            SWP_ASYNCWINDOWPOS = 0x4000,
-            SWP_DRAWFRAME = SWP_FRAMECHANGED,
-            SWP_NOREPOSITION = SWP_NOOWNERZORDER
+            NOSIZE = 0x0001,
+            NOMOVE = 0x0002,
+            NOZORDER = 0x0004,
+            NOREDRAW = 0x0008,
+            NOACTIVATE = 0x0010,
+            FRAMECHANGED = 0x0020,
+            SHOWWINDOW = 0x0040,
+            HIDEWINDOW = 0x0080,
+            NOCOPYBITS = 0x0100,
+            NOOWNERZORDER = 0x0200,
+            NOSENDCHANGING = 0x0400,
+            DEFERERASE = 0x2000,
+            ASYNCWINDOWPOS = 0x4000,
+            DRAWFRAME = FRAMECHANGED,
+            NOREPOSITION = NOOWNERZORDER
         }
     }
 }

--- a/src/Common/src/Interop/User32/Interop.WindowPosition.cs
+++ b/src/Common/src/Interop/User32/Interop.WindowPosition.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [Flags]
+        public enum WindowPosition : uint
+        {
+            SWP_NOSIZE = 0x0001,
+            SWP_NOMOVE = 0x0002,
+            SWP_NOZORDER = 0x0004,
+            SWP_NOREDRAW = 0x0008,
+            SWP_NOACTIVATE = 0x0010,
+            SWP_FRAMECHANGED = 0x0020,
+            SWP_SHOWWINDOW = 0x0040,
+            SWP_HIDEWINDOW = 0x0080,
+            SWP_NOCOPYBITS = 0x0100,
+            SWP_NOOWNERZORDER = 0x0200,
+            SWP_NOSENDCHANGING = 0x0400,
+            SWP_DEFERERASE = 0x2000,
+            SWP_ASYNCWINDOWPOS = 0x4000,
+            SWP_DRAWFRAME = SWP_FRAMECHANGED,
+            SWP_NOREPOSITION = SWP_NOOWNERZORDER
+        }
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -3268,16 +3268,6 @@ namespace System.Windows.Forms
             public IntPtr pwpos;      // pointer to a WINDOWPOS
         }
 
-        [StructLayout(LayoutKind.Sequential)]
-        public class MINMAXINFO
-        {
-            public Point ptReserved;
-            public Point ptMaxSize;
-            public Point ptMaxPosition;
-            public Point ptMinTrackSize;
-            public Point ptMaxTrackSize;
-        }
-
         [ComImport]
         [Guid("B196B28B-BAB4-101A-B69C-00AA00341D07")]
         [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -357,19 +357,16 @@ namespace System.Windows.Forms
         public const int ERROR_INVALID_HANDLE = 6;
         public const int ERROR_CLASS_ALREADY_EXISTS = 1410;
 
-        public const int FNERR_SUBCLASSFAILURE = 0x3001,
-        FNERR_INVALIDFILENAME = 0x3002,
-        FNERR_BUFFERTOOSMALL = 0x3003,
-        FRERR_BUFFERLENGTHZERO = 0x4001,
-        FADF_BSTR = (0x100),
-        FADF_UNKNOWN = (0x200),
-        FADF_DISPATCH = (0x400),
-        FADF_VARIANT = (unchecked((int)0x800)),
-        FORMAT_MESSAGE_FROM_SYSTEM = 0x00001000,
-        FORMAT_MESSAGE_IGNORE_INSERTS = 0x00000200,
-        FVIRTKEY = 0x01,
-        FSHIFT = 0x04,
-        FALT = 0x10;
+        public const int FNERR_SUBCLASSFAILURE = 0x3001;
+        public const int FNERR_INVALIDFILENAME = 0x3002;
+        public const int FNERR_BUFFERTOOSMALL = 0x3003;
+        public const int FRERR_BUFFERLENGTHZERO = 0x4001;
+        public const int FADF_BSTR = (0x100);
+        public const int FADF_UNKNOWN = (0x200);
+        public const int FADF_DISPATCH = (0x400);
+        public const int FADF_VARIANT = (unchecked((int)0x800));
+        public const int FORMAT_MESSAGE_FROM_SYSTEM = 0x00001000;
+        public const int FORMAT_MESSAGE_IGNORE_INSERTS = 0x00000200;
 
         public const int GMEM_FIXED = 0x0000,
         GMEM_MOVEABLE = 0x0002,
@@ -3269,14 +3266,6 @@ namespace System.Windows.Forms
         {
             public IntPtr prc;        // pointer to a RECT
             public IntPtr pwpos;      // pointer to a WINDOWPOS
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public class ACCEL
-        {
-            public byte fVirt;
-            public short key;
-            public short cmd;
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -441,7 +441,6 @@ namespace System.Windows.Forms
         HTBOTTOMLEFT = 16,
         HTBOTTOMRIGHT = 17,
         HTBORDER = 18,
-        HELPINFO_WINDOW = 0x0001,
         HCF_HIGHCONTRASTON = 0x00000001,
         HDI_ORDER = 0x0080,
         HDI_WIDTH = 0x0001,
@@ -3270,17 +3269,6 @@ namespace System.Windows.Forms
         {
             public IntPtr prc;        // pointer to a RECT
             public IntPtr pwpos;      // pointer to a WINDOWPOS
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public class HELPINFO
-        {
-            public int cbSize = Marshal.SizeOf<HELPINFO>();
-            public int iContextType = 0;
-            public int iCtrlId = 0;
-            public IntPtr hItemHandle = IntPtr.Zero;
-            public IntPtr dwContextId = IntPtr.Zero;
-            public Point MousePos;
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -474,12 +474,6 @@ namespace System.Windows.Forms
         HBMMENU_POPUP_MAXIMIZE = 10,
         HBMMENU_POPUP_MINIMIZE = 11;
 
-        public static HandleRef HWND_TOP = new HandleRef(null, (IntPtr)0);
-        public static HandleRef HWND_BOTTOM = new HandleRef(null, (IntPtr)1);
-        public static HandleRef HWND_TOPMOST = new HandleRef(null, new IntPtr(-1));
-        public static HandleRef HWND_NOTOPMOST = new HandleRef(null, new IntPtr(-2));
-        public static HandleRef HWND_MESSAGE = new HandleRef(null, new IntPtr(-3));
-
         public const int IME_CMODE_NATIVE = 0x0001,
         IME_CMODE_KATAKANA = 0x0002,
         IME_CMODE_FULLSHAPE = 0x0008,
@@ -1083,14 +1077,7 @@ namespace System.Windows.Forms
         SW_SHOWNA = 8,
         SW_RESTORE = 9,
         SW_MAX = 10,
-        SWP_NOSIZE = 0x0001,
-        SWP_NOMOVE = 0x0002,
-        SWP_NOZORDER = 0x0004,
-        SWP_NOACTIVATE = 0x0010,
-        SWP_SHOWWINDOW = 0x0040,
-        SWP_HIDEWINDOW = 0x0080,
-        SWP_DRAWFRAME = 0x0020,
-        SWP_NOOWNERZORDER = 0x0200;
+        SWP_NOSIZE = 0x0001;
 
         public const int HLP_FILE = 1,
         HLP_KEYWORD = 2,
@@ -3247,18 +3234,6 @@ namespace System.Windows.Forms
             [MarshalAs(UnmanagedType.U2)]
             public short wVarFlags;
             public    /*NativeMethods.tagVARKIND*/ int varkind;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public struct WINDOWPOS
-        {
-            public IntPtr hwnd;
-            public IntPtr hwndInsertAfter;
-            public int x;
-            public int y;
-            public int cx;
-            public int cy;
-            public int flags;
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -444,7 +444,6 @@ namespace System.Windows.Forms
         HDM_GETITEMCOUNT = (0x1200 + 0),
         HDM_INSERTITEMW = (0x1200 + 10),
         HDM_GETITEMW = (0x1200 + 11),
-        HDM_LAYOUT = (0x1200 + 5),
         HDM_SETITEMW = (0x1200 + 12),
         HDN_ITEMCHANGING = ((0 - 300) - 20),
         HDN_ITEMCHANGED = ((0 - 300) - 21),
@@ -3234,13 +3233,6 @@ namespace System.Windows.Forms
             [MarshalAs(UnmanagedType.U2)]
             public short wVarFlags;
             public    /*NativeMethods.tagVARKIND*/ int varkind;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public unsafe struct HDLAYOUT
-        {
-            public IntPtr prc;        // pointer to a RECT
-            public IntPtr pwpos;      // pointer to a WINDOWPOS
         }
 
         [ComImport]

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -3273,17 +3273,6 @@ namespace System.Windows.Forms
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        public class MEASUREITEMSTRUCT
-        {
-            public int CtlType = 0;
-            public int CtlID = 0;
-            public int itemID = 0;
-            public int itemWidth = 0;
-            public int itemHeight = 0;
-            public IntPtr itemData = IntPtr.Zero;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
         public class HELPINFO
         {
             public int cbSize = Marshal.SizeOf<HELPINFO>();

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -944,17 +944,6 @@ namespace System.Windows.Forms
         OLEMISC_ACTIVATEWHENVISIBLE = 0x0000100,
         OLEMISC_ACTSLIKEBUTTON = 0x00001000,
         OLEMISC_SETCLIENTSITEFIRST = 0x00020000,
-        ODS_CHECKED = 0x0008,
-        ODS_COMBOBOXEDIT = 0x1000,
-        ODS_DEFAULT = 0x0020,
-        ODS_DISABLED = 0x0004,
-        ODS_FOCUS = 0x0010,
-        ODS_GRAYED = 0x0002,
-        ODS_HOTLIGHT = 0x0040,
-        ODS_INACTIVE = 0x0080,
-        ODS_NOACCEL = 0x0100,
-        ODS_NOFOCUSRECT = 0x0200,
-        ODS_SELECTED = 0x0001,
         OLECLOSE_SAVEIFDIRTY = 0,
         OLECLOSE_PROMPTSAVE = 2;
 
@@ -3281,20 +3270,6 @@ namespace System.Windows.Forms
         {
             public IntPtr prc;        // pointer to a RECT
             public IntPtr pwpos;      // pointer to a WINDOWPOS
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public class DRAWITEMSTRUCT
-        {
-            public int CtlType = 0;
-            public int CtlID = 0;
-            public int itemID = 0;
-            public int itemAction = 0;
-            public int itemState = 0;
-            public IntPtr hwndItem = IntPtr.Zero;
-            public IntPtr hDC = IntPtr.Zero;
-            public RECT rcItem;
-            public IntPtr itemData = IntPtr.Zero;
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/Common/src/SafeNativeMethods.cs
+++ b/src/Common/src/SafeNativeMethods.cs
@@ -325,9 +325,6 @@ namespace System.Windows.Forms
         public static extern int SetBkColor(HandleRef hDC, int clr);
 
         [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern IntPtr /* HPALETTE */SelectPalette(HandleRef hdc, HandleRef hpal, int bForceBackground);
-
-        [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static unsafe extern bool SetViewportOrgEx(IntPtr hdc, int x, int y, Point *lppt);
 
         public static unsafe bool SetViewportOrgEx(HandleRef hdc, int x, int y, Point *lppt)
@@ -336,9 +333,6 @@ namespace System.Windows.Forms
             GC.KeepAlive(hdc.Wrapper);
             return result;
         }
-
-        [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true)]
-        public static extern int RealizePalette(HandleRef hDC);
 
         [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true)]
         public static extern bool LPtoDP(HandleRef hDC, ref Interop.RECT lpRect, int nCount);

--- a/src/Common/src/SafeNativeMethods.cs
+++ b/src/Common/src/SafeNativeMethods.cs
@@ -369,20 +369,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern bool ShowWindow(HandleRef hWnd, int nCmdShow);
 
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern bool SetWindowPos(
-            HandleRef hWnd,
-            HandleRef hWndInsertAfter,
-            int x = 0,
-            int y = 0,
-            int cx = 0,
-            int cy = 0,
-            int flags = 0);
-
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter,
-                                       int x, int y, int cx, int cy, int flags);
-
         // this is a wrapper that comctl exposes for the NT function since it doesn't exist natively on 95.
         [DllImport(ExternDll.Comctl32, ExactSpelling = true)]
 

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -310,9 +310,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.User32, ExactSpelling = true)]
         public static extern bool DestroyAcceleratorTable(HandleRef hAccel);
 
-        [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-        public static extern short VkKeyScan(char key);
-
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern IntPtr GetCapture();
 

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -448,9 +448,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
         public static extern IntPtr SendMessage(HandleRef hWnd, int msg, int wParam, NativeMethods.TCITEM_T lParam);
 
-        [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-        public static extern IntPtr SendMessage(HandleRef hWnd, int msg, int wParam, ref NativeMethods.HDLAYOUT hdlayout);
-
         //for Tooltips
         //
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]

--- a/src/System.Windows.Forms.Design.Editors/src/Misc/NativeMethods.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/Misc/NativeMethods.cs
@@ -44,9 +44,6 @@ namespace System.Windows.Forms.Design
         public static extern bool EnableWindow(IntPtr hWnd, bool enable);
 
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int x, int y, int cx, int cy, int flags);
-
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern int GetDlgItemInt(IntPtr hWnd, int nIDDlgItem, bool[] err, bool signed);
 
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
@@ -467,10 +464,6 @@ namespace System.Windows.Forms.Design
         public const int HHT_BELOW = 0x0200;
         public const int HHT_TORIGHT = 0x0400;
         public const int HHT_TOLEFT = 0x0800;
-        public const int HWND_TOP = 0;
-        public const int HWND_BOTTOM = 1;
-        public const int HWND_TOPMOST = -1;
-        public const int HWND_NOTOPMOST = -2;
         public const int CWP_SKIPINVISIBLE = 0x0001;
         public const int TVM_GETITEMRECT = 0x1100 + 4;
         public const int TVM_GETCOUNT = 0x1100 + 5;
@@ -588,21 +581,6 @@ namespace System.Windows.Forms.Design
         public const int PRF_CLIENT = 0x00000004;
         public const int PRF_ERASEBKGND = 0x00000008;
         public const int PRF_CHILDREN = 0x00000010;
-        public const int SWP_NOSIZE = 0x0001;
-        public const int SWP_NOMOVE = 0x0002;
-        public const int SWP_NOZORDER = 0x0004;
-        public const int SWP_NOREDRAW = 0x0008;
-        public const int SWP_NOACTIVATE = 0x0010;
-        public const int SWP_FRAMECHANGED = 0x0020;
-        public const int SWP_SHOWWINDOW = 0x0040;
-        public const int SWP_HIDEWINDOW = 0x0080;
-        public const int SWP_NOCOPYBITS = 0x0100;
-        public const int SWP_NOOWNERZORDER = 0x0200;
-        public const int SWP_NOSENDCHANGING = 0x0400;
-        public const int SWP_DRAWFRAME = 0x0020;
-        public const int SWP_NOREPOSITION = 0x0200;
-        public const int SWP_DEFERERASE = 0x2000;
-        public const int SWP_ASYNCWINDOWPOS = 0x4000;
 
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
         public static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);

--- a/src/System.Windows.Forms.Design.Editors/src/System.Windows.Forms.Design.Editors.csproj
+++ b/src/System.Windows.Forms.Design.Editors/src/System.Windows.Forms.Design.Editors.csproj
@@ -83,7 +83,10 @@
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetDC.cs" Link="Interop\User32\Interop.GetDC.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.ReleaseDC.cs" Link="Interop\User32\Interop.ReleaseDC.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SetWindowText.cs" Link="Interop\User32\Interop.SetWindowText.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.SetWindowPos.cs" Link="Interop\User32\Interop.SetWindowPos.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.TextFormatFlags.cs" Link="Interop\User32\Interop.TextFormatFlags.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.WINDOWPOS.cs" Link="Interop\User32\Interop.WINDOWPOS.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.WindowPosition.cs" Link="Interop\User32\Interop.WindowPosition.cs" />
     <Compile Include="..\..\Common\src\Microsoft\Win32\SafeHandles\CoTaskMemSafeHandle.cs" Link="Microsoft\Win32\SafeHandles\CoTaskMemSafeHandle.cs" />
   </ItemGroup>
 

--- a/src/System.Windows.Forms.Design.Editors/src/System/Drawing/Design/ColorEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/Drawing/Design/ColorEditor.cs
@@ -1122,10 +1122,16 @@ namespace System.Drawing.Design
                         NativeMethods.SendDlgItemMessage(hwnd, COLOR_BLUE, EditMessages.EM_SETMARGINS, (IntPtr)(NativeMethods.EC_LEFTMARGIN | NativeMethods.EC_RIGHTMARGIN), IntPtr.Zero);
                         IntPtr hwndCtl = NativeMethods.GetDlgItem(hwnd, COLOR_MIX);
                         NativeMethods.EnableWindow(hwndCtl, false);
-                        NativeMethods.SetWindowPos(hwndCtl, IntPtr.Zero, 0, 0, 0, 0, NativeMethods.SWP_HIDEWINDOW);
+                        User32.SetWindowPos(
+                            hwndCtl,
+                            User32.HWND_TOP,
+                            flags: User32.WindowPosition.SWP_HIDEWINDOW);
                         hwndCtl = NativeMethods.GetDlgItem(hwnd, NativeMethods.IDOK);
                         NativeMethods.EnableWindow(hwndCtl, false);
-                        NativeMethods.SetWindowPos(hwndCtl, IntPtr.Zero, 0, 0, 0, 0, NativeMethods.SWP_HIDEWINDOW);
+                        User32.SetWindowPos(
+                            hwndCtl,
+                            User32.HWND_TOP,
+                            flags: User32.WindowPosition.SWP_HIDEWINDOW);
                         this.Color = Color.Empty;
                         break;
                     case WindowMessages.WM_COMMAND:

--- a/src/System.Windows.Forms.Design.Editors/src/System/Drawing/Design/ColorEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/Drawing/Design/ColorEditor.cs
@@ -1125,13 +1125,13 @@ namespace System.Drawing.Design
                         User32.SetWindowPos(
                             hwndCtl,
                             User32.HWND_TOP,
-                            flags: User32.WindowPosition.SWP_HIDEWINDOW);
+                            flags: User32.WindowPosition.HIDEWINDOW);
                         hwndCtl = NativeMethods.GetDlgItem(hwnd, NativeMethods.IDOK);
                         NativeMethods.EnableWindow(hwndCtl, false);
                         User32.SetWindowPos(
                             hwndCtl,
                             User32.HWND_TOP,
-                            flags: User32.WindowPosition.SWP_HIDEWINDOW);
+                            flags: User32.WindowPosition.HIDEWINDOW);
                         this.Color = Color.Empty;
                         break;
                     case WindowMessages.WM_COMMAND:

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -80,6 +80,9 @@
     <Compile Include="..\..\Common\src\Interop\User32\Interop.PAINTSTRUCT.cs" Link="Interop\User32\Interop.PAINTSTRUCT.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.RedrawWindow.cs" Link="Interop\User32\Interop.RedrawWindow.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.ReleaseDC.cs" Link="Interop\User32\Interop.ReleaseDC.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.SetWindowPos.cs" Link="Interop\User32\Interop.SetWindowPos.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.WINDOWPOS.cs" Link="Interop\User32\Interop.WINDOWPOS.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.WindowPosition.cs" Link="Interop\User32\Interop.WindowPosition.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\System\ComponentModel\Design\Arrow.ico">

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerFrame.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerFrame.cs
@@ -452,7 +452,10 @@ namespace System.Windows.Forms.Design
             private void ParentOverlay(Control control)
             {
                 NativeMethods.SetParent(control.Handle, Handle);
-                SafeNativeMethods.SetWindowPos(control.Handle, (IntPtr)NativeMethods.HWND_TOP, 0, 0, 0, 0, NativeMethods.SWP_NOSIZE | NativeMethods.SWP_NOMOVE);
+                User32.SetWindowPos(
+                    control.Handle,
+                    User32.HWND_TOP,
+                    flags: User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOMOVE);
             }
 
             /// <summary>
@@ -561,7 +564,10 @@ namespace System.Windows.Forms.Design
                         {
                             foreach (Control c in _overlayList)
                             {
-                                SafeNativeMethods.SetWindowPos(c.Handle, (IntPtr)NativeMethods.HWND_TOP, 0, 0, 0, 0, NativeMethods.SWP_NOSIZE | NativeMethods.SWP_NOMOVE);
+                                User32.SetWindowPos(
+                                    c.Handle,
+                                    User32.HWND_TOP,
+                                    flags: User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOMOVE);
                             }
                         }
                     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerFrame.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerFrame.cs
@@ -455,7 +455,7 @@ namespace System.Windows.Forms.Design
                 User32.SetWindowPos(
                     control.Handle,
                     User32.HWND_TOP,
-                    flags: User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOMOVE);
+                    flags: User32.WindowPosition.NOSIZE | User32.WindowPosition.NOMOVE);
             }
 
             /// <summary>
@@ -567,7 +567,7 @@ namespace System.Windows.Forms.Design
                                 User32.SetWindowPos(
                                     c.Handle,
                                     User32.HWND_TOP,
-                                    flags: User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOMOVE);
+                                    flags: User32.WindowPosition.NOSIZE | User32.WindowPosition.NOMOVE);
                             }
                         }
                     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormDocumentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormDocumentDesigner.cs
@@ -686,7 +686,7 @@ namespace System.Windows.Forms.Design
             // we want to update the size if we have a menu and...
             // 1) we're doing an autoscale
             // 2) we're loading a form without an inherited menu (inherited forms will already have the right size)
-            if (updateSize && Menu != null && (wp->flags & User32.WindowPosition.SWP_NOSIZE) == 0 && (IsMenuInherited || _inAutoscale))
+            if (updateSize && Menu != null && (wp->flags & User32.WindowPosition.NOSIZE) == 0 && (IsMenuInherited || _inAutoscale))
             {
                 _heightDelta = GetMenuHeight();
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormDocumentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormDocumentDesigner.cs
@@ -673,7 +673,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private unsafe void WmWindowPosChanging(ref Message m)
         {
-            NativeMethods.WINDOWPOS* wp = (NativeMethods.WINDOWPOS*)m.LParam;
+            User32.WINDOWPOS* wp = (User32.WINDOWPOS*)m.LParam;
             bool updateSize = _inAutoscale;
             if (!updateSize)
             {
@@ -686,7 +686,7 @@ namespace System.Windows.Forms.Design
             // we want to update the size if we have a menu and...
             // 1) we're doing an autoscale
             // 2) we're loading a form without an inherited menu (inherited forms will already have the right size)
-            if (updateSize && Menu != null && (wp->flags & NativeMethods.SWP_NOSIZE) == 0 && (IsMenuInherited || _inAutoscale))
+            if (updateSize && Menu != null && (wp->flags & User32.WindowPosition.SWP_NOSIZE) == 0 && (IsMenuInherited || _inAutoscale))
             {
                 _heightDelta = GetMenuHeight();
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.MarshallingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.MarshallingControl.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using static Interop;
+
 namespace System.Windows.Forms
 {
     public sealed partial class Application
@@ -30,7 +32,7 @@ namespace System.Windows.Forms
 
                     // Message only windows are cheaper and have fewer issues than
                     // full blown invisible windows.
-                    cp.Parent = (IntPtr)NativeMethods.HWND_MESSAGE;
+                    cp.Parent = User32.HWND_MESSAGE;
                     return cp;
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ParkingWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ParkingWindow.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Windows.Forms.Layout;
+using static Interop;
 
 namespace System.Windows.Forms
 {
@@ -40,7 +41,7 @@ namespace System.Windows.Forms
 
                     // Message only windows are cheaper and have fewer issues than
                     // full blown invisible windows.
-                    cp.Parent = (IntPtr)NativeMethods.HWND_MESSAGE;
+                    cp.Parent = User32.HWND_MESSAGE;
                     return cp;
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
@@ -212,7 +212,7 @@ namespace System.Windows.Forms
                             Debug.Fail($"Failed to query service: {e.Message}");
                             return null;
                         }
-#pragma warning enable CA1031
+#pragma warning restore CA1031
 
                         // We have the component manager service, now get the component manager interface
                         HRESULT hr = (HRESULT)Marshal.QueryInterface(serviceHandle, ref iid, out IntPtr componentManagerHandle);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -3545,7 +3545,7 @@ namespace System.Windows.Forms
                     0,
                     DropDownWidth,
                     height,
-                    User32.WindowPosition.SWP_NOMOVE | User32.WindowPosition.SWP_NOZORDER);
+                    User32.WindowPosition.NOMOVE | User32.WindowPosition.NOZORDER);
             }
         }
 
@@ -3784,7 +3784,7 @@ namespace System.Windows.Forms
             try
             {
                 using Graphics g = Graphics.FromHdcInternal(dis->hDC);
-                OnDrawItem(new DrawItemEventArgs(g, Font, dis->rcItem, dis->itemID, (DrawItemState)dis->itemState, ForeColor, BackColor));
+                OnDrawItem(new DrawItemEventArgs(g, Font, dis->rcItem, (int)dis->itemID, (DrawItemState)dis->itemState, ForeColor, BackColor));
             }
             finally
             {
@@ -3805,14 +3805,14 @@ namespace System.Windows.Forms
             if (DrawMode == DrawMode.OwnerDrawVariable && mis->itemID >= 0)
             {
                 using Graphics graphics = CreateGraphicsInternal();
-                MeasureItemEventArgs mie = new MeasureItemEventArgs(graphics, mis->itemID, ItemHeight);
+                var mie = new MeasureItemEventArgs(graphics, (int)mis->itemID, ItemHeight);
                 OnMeasureItem(mie);
-                mis->itemHeight = mie.ItemHeight;
+                mis->itemHeight = unchecked((uint)mie.ItemHeight);
             }
             else
             {
                 // Message was sent by the combo edit field
-                mis->itemHeight = ItemHeight;
+                mis->itemHeight = (uint)ItemHeight;
             }
 
             m.Result = (IntPtr)1;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -3538,8 +3538,14 @@ namespace System.Windows.Forms
                     int count = Math.Min(Math.Max(itemCount, 1), maxDropDownItems);
                     height = (ItemHeight * count + 2);
                 }
-                SafeNativeMethods.SetWindowPos(new HandleRef(this, dropDownHandle), NativeMethods.NullHandleRef, 0, 0, DropDownWidth, height,
-                                     NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOZORDER);
+                User32.SetWindowPos(
+                    new HandleRef(this, dropDownHandle),
+                    User32.HWND_TOP,
+                    0,
+                    0,
+                    DropDownWidth,
+                    height,
+                    User32.WindowPosition.SWP_NOMOVE | User32.WindowPosition.SWP_NOZORDER);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -3791,25 +3791,24 @@ namespace System.Windows.Forms
             m.Result = (IntPtr)1;
         }
 
-        private void WmReflectMeasureItem(ref Message m)
+        private unsafe void WmReflectMeasureItem(ref Message m)
         {
-            NativeMethods.MEASUREITEMSTRUCT mis = (NativeMethods.MEASUREITEMSTRUCT)m.GetLParam(typeof(NativeMethods.MEASUREITEMSTRUCT));
+            User32.MEASUREITEMSTRUCT* mis = (User32.MEASUREITEMSTRUCT*)m.LParam;
 
             // Determine if message was sent by a combo item or the combo edit field
-            if (DrawMode == DrawMode.OwnerDrawVariable && mis.itemID >= 0)
+            if (DrawMode == DrawMode.OwnerDrawVariable && mis->itemID >= 0)
             {
-                Graphics graphics = CreateGraphicsInternal();
-                MeasureItemEventArgs mie = new MeasureItemEventArgs(graphics, mis.itemID, ItemHeight);
+                using Graphics graphics = CreateGraphicsInternal();
+                MeasureItemEventArgs mie = new MeasureItemEventArgs(graphics, mis->itemID, ItemHeight);
                 OnMeasureItem(mie);
-                mis.itemHeight = mie.ItemHeight;
-                graphics.Dispose();
+                mis->itemHeight = mie.ItemHeight;
             }
             else
             {
                 // Message was sent by the combo edit field
-                mis.itemHeight = ItemHeight;
+                mis->itemHeight = ItemHeight;
             }
-            Marshal.StructureToPtr(mis, m.LParam, false);
+
             m.Result = (IntPtr)1;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CommonDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CommonDialog.cs
@@ -101,7 +101,7 @@ namespace System.Windows.Forms
                 y,
                 0,
                 0,
-                User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOZORDER | User32.WindowPosition.SWP_NOACTIVATE);
+                User32.WindowPosition.NOSIZE | User32.WindowPosition.NOZORDER | User32.WindowPosition.NOACTIVATE);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CommonDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CommonDialog.cs
@@ -94,8 +94,14 @@ namespace System.Windows.Forms
             Rectangle screen = Screen.GetWorkingArea(Control.MousePosition);
             int x = screen.X + (screen.Width - r.right + r.left) / 2;
             int y = screen.Y + (screen.Height - r.bottom + r.top) / 3;
-            SafeNativeMethods.SetWindowPos(new HandleRef(null, hWnd), NativeMethods.NullHandleRef, x, y, 0, 0, NativeMethods.SWP_NOSIZE |
-                                 NativeMethods.SWP_NOZORDER | NativeMethods.SWP_NOACTIVATE);
+            User32.SetWindowPos(
+                hWnd,
+                User32.HWND_TOP,
+                x,
+                y,
+                0,
+                0,
+                User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOZORDER | User32.WindowPosition.SWP_NOACTIVATE);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -2406,7 +2406,7 @@ namespace System.Windows.Forms
                     {
                         NativeMethods.COMRECT rc = new NativeMethods.COMRECT();
 
-                        if ((flags & User32.WindowPosition.SWP_NOMOVE) != 0)
+                        if ((flags & User32.WindowPosition.NOMOVE) != 0)
                         {
                             rc.left = _control.Left;
                             rc.top = _control.Top;
@@ -2417,7 +2417,7 @@ namespace System.Windows.Forms
                             rc.top = y;
                         }
 
-                        if ((flags & User32.WindowPosition.SWP_NOSIZE) != 0)
+                        if ((flags & User32.WindowPosition.NOSIZE) != 0)
                         {
                             rc.right = rc.left + _control.Width;
                             rc.bottom = rc.top + _control.Height;
@@ -2443,12 +2443,12 @@ namespace System.Windows.Forms
                         }
 
                         // On output, the new bounds will be reflected in  rc
-                        if ((flags & User32.WindowPosition.SWP_NOMOVE) == 0)
+                        if ((flags & User32.WindowPosition.NOMOVE) == 0)
                         {
                             x = rc.left;
                             y = rc.top;
                         }
-                        if ((flags & User32.WindowPosition.SWP_NOSIZE) == 0)
+                        if ((flags & User32.WindowPosition.NOSIZE) == 0)
                         {
                             width = rc.right - rc.left;
                             height = rc.bottom - rc.top;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -669,16 +669,14 @@ namespace System.Windows.Forms
 
                     if (_accelCount > 0)
                     {
-                        int accelSize = Marshal.SizeOf<NativeMethods.ACCEL>();
+                        int accelSize = Marshal.SizeOf<User32.ACCEL>();
 
                         // In the worst case we may have two accelerators per mnemonic:  one lower case and
                         // one upper case, hence the * 2 below.
-                        //
                         IntPtr accelBlob = Marshal.AllocHGlobal(accelSize * _accelCount * 2);
-
                         try
                         {
-                            NativeMethods.ACCEL accel = new NativeMethods.ACCEL
+                            var accel = new User32.ACCEL
                             {
                                 cmd = 0
                             };
@@ -696,26 +694,26 @@ namespace System.Windows.Forms
                                 if (ch >= 'A' && ch <= 'Z')
                                 {
                                     // Lower case letter
-                                    accel.fVirt = NativeMethods.FALT | NativeMethods.FVIRTKEY;
-                                    accel.key = (short)(UnsafeNativeMethods.VkKeyScan(ch) & 0x00FF);
+                                    accel.fVirt = User32.AcceleratorFlags.FALT | User32.AcceleratorFlags.FVIRTKEY;
+                                    accel.key = (ushort)(User32.VkKeyScanW(ch) & 0x00FF);
                                     Marshal.StructureToPtr(accel, structAddr, false);
 
                                     // Upper case letter
                                     _accelCount++;
                                     structAddr = (IntPtr)((long)structAddr + accelSize);
-                                    accel.fVirt = NativeMethods.FALT | NativeMethods.FVIRTKEY | NativeMethods.FSHIFT;
+                                    accel.fVirt = User32.AcceleratorFlags.FALT | User32.AcceleratorFlags.FVIRTKEY | User32.AcceleratorFlags.FSHIFT;
                                     Marshal.StructureToPtr(accel, structAddr, false);
                                 }
                                 else
                                 {
                                     // Some non-printable character.
-                                    accel.fVirt = NativeMethods.FALT | NativeMethods.FVIRTKEY;
-                                    short scan = (short)(UnsafeNativeMethods.VkKeyScan(ch));
+                                    accel.fVirt = User32.AcceleratorFlags.FALT | User32.AcceleratorFlags.FVIRTKEY;
+                                    short scan = User32.VkKeyScanW(ch);
                                     if ((scan & 0x0100) != 0)
                                     {
-                                        accel.fVirt |= NativeMethods.FSHIFT;
+                                        accel.fVirt |= User32.AcceleratorFlags.FSHIFT;
                                     }
-                                    accel.key = (short)(scan & 0x00FF);
+                                    accel.key = (ushort)(scan & 0x00FF);
                                     Marshal.StructureToPtr(accel, structAddr, false);
                                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -2398,7 +2398,7 @@ namespace System.Windows.Forms
             /// <summary>
             ///  Notifies our site that we have changed our size and location.
             /// </summary>
-            internal void UpdateBounds(ref int x, ref int y, ref int width, ref int height, int flags)
+            internal void UpdateBounds(ref int x, ref int y, ref int width, ref int height, User32.WindowPosition flags)
             {
                 if (!_activeXState[s_adjustingRect] && _activeXState[s_inPlaceVisible])
                 {
@@ -2406,7 +2406,7 @@ namespace System.Windows.Forms
                     {
                         NativeMethods.COMRECT rc = new NativeMethods.COMRECT();
 
-                        if ((flags & NativeMethods.SWP_NOMOVE) != 0)
+                        if ((flags & User32.WindowPosition.SWP_NOMOVE) != 0)
                         {
                             rc.left = _control.Left;
                             rc.top = _control.Top;
@@ -2417,7 +2417,7 @@ namespace System.Windows.Forms
                             rc.top = y;
                         }
 
-                        if ((flags & NativeMethods.SWP_NOSIZE) != 0)
+                        if ((flags & User32.WindowPosition.SWP_NOSIZE) != 0)
                         {
                             rc.right = rc.left + _control.Width;
                             rc.bottom = rc.top + _control.Height;
@@ -2443,12 +2443,12 @@ namespace System.Windows.Forms
                         }
 
                         // On output, the new bounds will be reflected in  rc
-                        if ((flags & NativeMethods.SWP_NOMOVE) == 0)
+                        if ((flags & User32.WindowPosition.SWP_NOMOVE) == 0)
                         {
                             x = rc.left;
                             y = rc.top;
                         }
-                        if ((flags & NativeMethods.SWP_NOSIZE) == 0)
+                        if ((flags & User32.WindowPosition.SWP_NOSIZE) == 0)
                         {
                             width = rc.right - rc.left;
                             height = rc.bottom - rc.top;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -4819,7 +4819,7 @@ namespace System.Windows.Forms
                 User32.SetWindowPos(
                     new HandleRef(_window, Handle),
                     User32.HWND_TOP,
-                    flags: User32.WindowPosition.SWP_NOMOVE | User32.WindowPosition.SWP_NOSIZE);
+                    flags: User32.WindowPosition.NOMOVE | User32.WindowPosition.NOSIZE);
             }
         }
 
@@ -10782,7 +10782,7 @@ namespace System.Windows.Forms
                 User32.SetWindowPos(
                     new HandleRef(_window, Handle),
                     User32.HWND_BOTTOM,
-                    flags: User32.WindowPosition.SWP_NOMOVE | User32.WindowPosition.SWP_NOSIZE);
+                    flags: User32.WindowPosition.NOMOVE | User32.WindowPosition.NOSIZE);
             }
         }
 
@@ -10900,15 +10900,15 @@ namespace System.Windows.Forms
                     {
                         if (!GetState(States.SizeLockedByOS))
                         {
-                            User32.WindowPosition flags = User32.WindowPosition.SWP_NOZORDER | User32.WindowPosition.SWP_NOACTIVATE;
+                            User32.WindowPosition flags = User32.WindowPosition.NOZORDER | User32.WindowPosition.NOACTIVATE;
 
                             if (_x == x && _y == y)
                             {
-                                flags |= User32.WindowPosition.SWP_NOMOVE;
+                                flags |= User32.WindowPosition.NOMOVE;
                             }
                             if (_width == width && _height == height)
                             {
-                                flags |= User32.WindowPosition.SWP_NOSIZE;
+                                flags |= User32.WindowPosition.NOSIZE;
                             }
 
                             //
@@ -11173,11 +11173,11 @@ namespace System.Windows.Forms
                         User32.SetWindowPos(
                             new HandleRef(_window, Handle),
                             IntPtr.Zero,
-                            flags: User32.WindowPosition.SWP_NOSIZE
-                                | User32.WindowPosition.SWP_NOMOVE
-                                | User32.WindowPosition.SWP_NOZORDER
-                                | User32.WindowPosition.SWP_NOACTIVATE
-                                | (value ? User32.WindowPosition.SWP_SHOWWINDOW : User32.WindowPosition.SWP_HIDEWINDOW));
+                            flags: User32.WindowPosition.NOSIZE
+                                | User32.WindowPosition.NOMOVE
+                                | User32.WindowPosition.NOZORDER
+                                | User32.WindowPosition.NOACTIVATE
+                                | (value ? User32.WindowPosition.SHOWWINDOW : User32.WindowPosition.HIDEWINDOW));
                     }
                     catch
                     {
@@ -11232,11 +11232,11 @@ namespace System.Windows.Forms
                     User32.SetWindowPos(
                         new HandleRef(_window, Handle),
                         User32.HWND_TOP,
-                        flags: User32.WindowPosition.SWP_NOSIZE
-                            | User32.WindowPosition.SWP_NOMOVE
-                            | User32.WindowPosition.SWP_NOZORDER
-                            | User32.WindowPosition.SWP_NOACTIVATE
-                            | (value ? User32.WindowPosition.SWP_SHOWWINDOW : User32.WindowPosition.SWP_HIDEWINDOW));
+                        flags: User32.WindowPosition.NOSIZE
+                            | User32.WindowPosition.NOMOVE
+                            | User32.WindowPosition.NOZORDER
+                            | User32.WindowPosition.NOACTIVATE
+                            | (value ? User32.WindowPosition.SHOWWINDOW : User32.WindowPosition.HIDEWINDOW));
                 }
             }
         }
@@ -11756,7 +11756,7 @@ namespace System.Windows.Forms
                     User32.SetWindowPos(
                         new HandleRef(ctl._window, ctl.Handle),
                         prevHandle,
-                        flags: User32.WindowPosition.SWP_NOMOVE | User32.WindowPosition.SWP_NOSIZE);
+                        flags: User32.WindowPosition.NOMOVE | User32.WindowPosition.NOSIZE);
                 }
                 finally
                 {
@@ -11812,11 +11812,11 @@ namespace System.Windows.Forms
                 User32.SetWindowPos(
                     new HandleRef(this, Handle),
                     User32.HWND_TOP,
-                    flags: User32.WindowPosition.SWP_DRAWFRAME
-                        | User32.WindowPosition.SWP_NOACTIVATE
-                        | User32.WindowPosition.SWP_NOMOVE
-                        | User32.WindowPosition.SWP_NOSIZE
-                        | User32.WindowPosition.SWP_NOZORDER);
+                    flags: User32.WindowPosition.DRAWFRAME
+                        | User32.WindowPosition.NOACTIVATE
+                        | User32.WindowPosition.NOMOVE
+                        | User32.WindowPosition.NOSIZE
+                        | User32.WindowPosition.NOZORDER);
 
                 Invalidate(true);
             }
@@ -12977,11 +12977,11 @@ namespace System.Windows.Forms
                 //
                 bool different = false;
 
-                if ((wp->flags & User32.WindowPosition.SWP_NOMOVE) == 0 && (wp->x != Left || wp->y != Top))
+                if ((wp->flags & User32.WindowPosition.NOMOVE) == 0 && (wp->x != Left || wp->y != Top))
                 {
                     different = true;
                 }
-                if ((wp->flags & User32.WindowPosition.SWP_NOSIZE) == 0 && (wp->cx != Width || wp->cy != Height))
+                if ((wp->flags & User32.WindowPosition.NOSIZE) == 0 && (wp->cx != Width || wp->cy != Height))
                 {
                     different = true;
                 }
@@ -13231,7 +13231,7 @@ namespace System.Windows.Forms
             {
 
                 User32.WINDOWPOS* wp = (User32.WINDOWPOS*)m.LParam;
-                if ((wp->flags & User32.WindowPosition.SWP_NOZORDER) == 0)
+                if ((wp->flags & User32.WindowPosition.NOZORDER) == 0)
                 {
                     _parent.UpdateChildControlIndex(this);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -12204,7 +12204,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Handles the WM_HELP message
         /// </summary>
-        private void WmHelp(ref Message m)
+        private unsafe void WmHelp(ref Message m)
         {
             // if there's currently a message box open - grab the help info from it.
             HelpInfo hpi = MessageBox.HelpInfo;
@@ -12228,15 +12228,13 @@ namespace System.Windows.Forms
             }
 
             // Note: info.hItemHandle is the handle of the window that sent the help message.
-            NativeMethods.HELPINFO info = (NativeMethods.HELPINFO)m.GetLParam(typeof(NativeMethods.HELPINFO));
-
-            HelpEventArgs hevent = new HelpEventArgs(info.MousePos);
+            User32.HELPINFO* info = (User32.HELPINFO*)m.LParam;
+            var hevent = new HelpEventArgs(info->MousePos);
             OnHelpRequested(hevent);
             if (!hevent.Handled)
             {
                 DefWndProc(ref m);
             }
-
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -12259,29 +12259,24 @@ namespace System.Windows.Forms
         /// <summary>
         ///  WM_MEASUREITEM handler
         /// </summary>
-        private void WmMeasureItem(ref Message m)
+        private unsafe void WmMeasureItem(ref Message m)
         {
             // If the wparam is zero, then the message was sent by a menu.
             // See WM_MEASUREITEM in MSDN.
             if (m.WParam == IntPtr.Zero)
             {
-
                 // Obtain the menu item object
-                NativeMethods.MEASUREITEMSTRUCT mis = (NativeMethods.MEASUREITEMSTRUCT)m.GetLParam(typeof(NativeMethods.MEASUREITEMSTRUCT));
-
                 Debug.Assert(m.LParam != IntPtr.Zero, "m.lparam is null");
+                User32.MEASUREITEMSTRUCT* mis = (User32.MEASUREITEMSTRUCT*)m.LParam;
 
                 // A pointer to the correct MenuItem is stored in the measure item
                 // information sent with the message.
                 // (See MenuItem.CreateMenuItemInfo)
-                MenuItem menuItem = MenuItem.GetMenuItemFromItemData(mis.itemData);
+                MenuItem menuItem = MenuItem.GetMenuItemFromItemData(mis->itemData);
                 Debug.Assert(menuItem != null, "UniqueID is not associated with a menu item");
 
                 // Delegate this message to the menu item
-                if (menuItem != null)
-                {
-                    menuItem.WmMeasureItem(ref m);
-                }
+                menuItem?.WmMeasureItem(ref m);
             }
             else
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -11088,11 +11088,10 @@ namespace System.Windows.Forms
             IntPtr halftonePalette = Graphics.GetHalftonePalette();
 
             Debug.WriteLineIf(s_paletteTracing.TraceVerbose, "select palette " + !force);
-            IntPtr result = SafeNativeMethods.SelectPalette(new HandleRef(null, dc), new HandleRef(null, halftonePalette), (force ? 0 : 1));
-
+            IntPtr result = Gdi32.SelectPalette(dc, halftonePalette, force ? BOOL.FALSE : BOOL.TRUE);
             if (result != IntPtr.Zero && realizePalette)
             {
-                SafeNativeMethods.RealizePalette(new HandleRef(null, dc));
+                Gdi32.RealizePalette(dc);
             }
 
             return result;
@@ -12016,21 +12015,18 @@ namespace System.Windows.Forms
             }
         }
 
-        private void WmDrawItemMenuItem(ref Message m)
+        private unsafe void WmDrawItemMenuItem(ref Message m)
         {
             // Obtain the menu item object
-            NativeMethods.DRAWITEMSTRUCT dis = (NativeMethods.DRAWITEMSTRUCT)m.GetLParam(typeof(NativeMethods.DRAWITEMSTRUCT));
+            User32.DRAWITEMSTRUCT* dis = (User32.DRAWITEMSTRUCT*)m.LParam;
 
             // A pointer to the correct MenuItem is stored in the draw item
             // information sent with the message.
             // (See MenuItem.CreateMenuItemInfo)
-            MenuItem menuItem = MenuItem.GetMenuItemFromItemData(dis.itemData);
+            MenuItem menuItem = MenuItem.GetMenuItemFromItemData(dis->itemData);
 
             // Delegate this message to the menu item
-            if (menuItem != null)
-            {
-                menuItem.WmDrawItem(ref m);
-            }
+            menuItem?.WmDrawItem(ref m);
         }
 
         /// <summary>
@@ -12908,13 +12904,10 @@ namespace System.Windows.Forms
                     {
                         if (oldPal != IntPtr.Zero)
                         {
-                            SafeNativeMethods.SelectPalette(new HandleRef(null, dc), new HandleRef(null, oldPal), 0);
+                            Gdi32.SelectPalette(dc, oldPal, BOOL.FALSE);
                         }
-                        if (bufferedGraphics != null)
-                        {
-                            bufferedGraphics.Dispose();
-                        }
-
+                        
+                        bufferedGraphics?.Dispose();
                     }
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -4646,7 +4646,7 @@ namespace System.Windows.Forms
         ///  Helper method for retrieving an ActiveX property.  We abstract these
         ///  to another method so we do not force JIT the ActiveX codebase.
         /// </summary>
-        private void ActiveXUpdateBounds(ref int x, ref int y, ref int width, ref int height, int flags)
+        private void ActiveXUpdateBounds(ref int x, ref int y, ref int width, ref int height, User32.WindowPosition flags)
         {
             ActiveXInstance.UpdateBounds(ref x, ref y, ref width, ref height, flags);
         }
@@ -4816,10 +4816,10 @@ namespace System.Windows.Forms
             }
             else if (IsHandleCreated && GetTopLevel() && SafeNativeMethods.IsWindowEnabled(new HandleRef(_window, Handle)))
             {
-                SafeNativeMethods.SetWindowPos(
+                User32.SetWindowPos(
                     new HandleRef(_window, Handle),
-                    NativeMethods.HWND_TOP,
-                    flags: NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOSIZE);
+                    User32.HWND_TOP,
+                    flags: User32.WindowPosition.SWP_NOMOVE | User32.WindowPosition.SWP_NOSIZE);
             }
         }
 
@@ -10779,10 +10779,10 @@ namespace System.Windows.Forms
             }
             else if (IsHandleCreated && GetTopLevel())
             {
-                SafeNativeMethods.SetWindowPos(
+                User32.SetWindowPos(
                     new HandleRef(_window, Handle),
-                    NativeMethods.HWND_BOTTOM,
-                    flags: NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOSIZE);
+                    User32.HWND_BOTTOM,
+                    flags: User32.WindowPosition.SWP_NOMOVE | User32.WindowPosition.SWP_NOSIZE);
             }
         }
 
@@ -10900,24 +10900,24 @@ namespace System.Windows.Forms
                     {
                         if (!GetState(States.SizeLockedByOS))
                         {
-                            int flags = NativeMethods.SWP_NOZORDER | NativeMethods.SWP_NOACTIVATE;
+                            User32.WindowPosition flags = User32.WindowPosition.SWP_NOZORDER | User32.WindowPosition.SWP_NOACTIVATE;
 
                             if (_x == x && _y == y)
                             {
-                                flags |= NativeMethods.SWP_NOMOVE;
+                                flags |= User32.WindowPosition.SWP_NOMOVE;
                             }
                             if (_width == width && _height == height)
                             {
-                                flags |= NativeMethods.SWP_NOSIZE;
+                                flags |= User32.WindowPosition.SWP_NOSIZE;
                             }
 
                             //
                             // Give a chance for derived controls to do what they want, just before we resize.
                             OnBoundsUpdate(x, y, width, height);
 
-                            SafeNativeMethods.SetWindowPos(
+                            User32.SetWindowPos(
                                 new HandleRef(_window, Handle),
-                                NativeMethods.NullHandleRef,
+                                IntPtr.Zero,
                                 x,
                                 y,
                                 width,
@@ -11170,14 +11170,14 @@ namespace System.Windows.Forms
                             CreateControl();
                         }
 
-                        SafeNativeMethods.SetWindowPos(
+                        User32.SetWindowPos(
                             new HandleRef(_window, Handle),
-                            NativeMethods.NullHandleRef,
-                            flags: NativeMethods.SWP_NOSIZE
-                                | NativeMethods.SWP_NOMOVE
-                                | NativeMethods.SWP_NOZORDER
-                                | NativeMethods.SWP_NOACTIVATE
-                                | (value ? NativeMethods.SWP_SHOWWINDOW : NativeMethods.SWP_HIDEWINDOW));
+                            IntPtr.Zero,
+                            flags: User32.WindowPosition.SWP_NOSIZE
+                                | User32.WindowPosition.SWP_NOMOVE
+                                | User32.WindowPosition.SWP_NOZORDER
+                                | User32.WindowPosition.SWP_NOACTIVATE
+                                | (value ? User32.WindowPosition.SWP_SHOWWINDOW : User32.WindowPosition.SWP_HIDEWINDOW));
                     }
                     catch
                     {
@@ -11229,14 +11229,14 @@ namespace System.Windows.Forms
                 // but the child control has already been created.
                 if (IsHandleCreated)
                 {
-                    SafeNativeMethods.SetWindowPos(
+                    User32.SetWindowPos(
                         new HandleRef(_window, Handle),
-                        NativeMethods.NullHandleRef,
-                        flags: NativeMethods.SWP_NOSIZE
-                            | NativeMethods.SWP_NOMOVE
-                            | NativeMethods.SWP_NOZORDER
-                            | NativeMethods.SWP_NOACTIVATE
-                            | (value ? NativeMethods.SWP_SHOWWINDOW : NativeMethods.SWP_HIDEWINDOW));
+                        User32.HWND_TOP,
+                        flags: User32.WindowPosition.SWP_NOSIZE
+                            | User32.WindowPosition.SWP_NOMOVE
+                            | User32.WindowPosition.SWP_NOZORDER
+                            | User32.WindowPosition.SWP_NOACTIVATE
+                            | (value ? User32.WindowPosition.SWP_SHOWWINDOW : User32.WindowPosition.SWP_HIDEWINDOW));
                 }
             }
         }
@@ -11738,7 +11738,7 @@ namespace System.Windows.Forms
                 return;
             }
 
-            IntPtr prevHandle = (IntPtr)NativeMethods.HWND_TOP;
+            IntPtr prevHandle = User32.HWND_TOP;
             for (int i = Controls.GetChildIndex(ctl); --i >= 0;)
             {
                 Control c = Controls[i];
@@ -11753,10 +11753,10 @@ namespace System.Windows.Forms
                 _state |= States.NoZOrder;
                 try
                 {
-                    SafeNativeMethods.SetWindowPos(
+                    User32.SetWindowPos(
                         new HandleRef(ctl._window, ctl.Handle),
-                        new HandleRef(null, prevHandle),
-                        flags: NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOSIZE);
+                        prevHandle,
+                        flags: User32.WindowPosition.SWP_NOMOVE | User32.WindowPosition.SWP_NOSIZE);
                 }
                 finally
                 {
@@ -11809,14 +11809,14 @@ namespace System.Windows.Forms
                     SetState(States.Mirrored, (cp.ExStyle & NativeMethods.WS_EX_LAYOUTRTL) != 0);
                 }
 
-                SafeNativeMethods.SetWindowPos(
+                User32.SetWindowPos(
                     new HandleRef(this, Handle),
-                    NativeMethods.NullHandleRef,
-                    flags: NativeMethods.SWP_DRAWFRAME
-                        | NativeMethods.SWP_NOACTIVATE
-                        | NativeMethods.SWP_NOMOVE
-                        | NativeMethods.SWP_NOSIZE
-                        | NativeMethods.SWP_NOZORDER);
+                    User32.HWND_TOP,
+                    flags: User32.WindowPosition.SWP_DRAWFRAME
+                        | User32.WindowPosition.SWP_NOACTIVATE
+                        | User32.WindowPosition.SWP_NOMOVE
+                        | User32.WindowPosition.SWP_NOSIZE
+                        | User32.WindowPosition.SWP_NOZORDER);
 
                 Invalidate(true);
             }
@@ -12972,16 +12972,16 @@ namespace System.Windows.Forms
             //
             if (IsActiveX)
             {
-                NativeMethods.WINDOWPOS* wp = (NativeMethods.WINDOWPOS*)m.LParam;
+                User32.WINDOWPOS* wp = (User32.WINDOWPOS*)m.LParam;
                 // Only call UpdateBounds if the new bounds are different.
                 //
                 bool different = false;
 
-                if ((wp->flags & NativeMethods.SWP_NOMOVE) == 0 && (wp->x != Left || wp->y != Top))
+                if ((wp->flags & User32.WindowPosition.SWP_NOMOVE) == 0 && (wp->x != Left || wp->y != Top))
                 {
                     different = true;
                 }
-                if ((wp->flags & NativeMethods.SWP_NOSIZE) == 0 && (wp->cx != Width || wp->cy != Height))
+                if ((wp->flags & User32.WindowPosition.SWP_NOSIZE) == 0 && (wp->cx != Width || wp->cy != Height))
                 {
                     different = true;
                 }
@@ -13230,8 +13230,8 @@ namespace System.Windows.Forms
                 (_state & States.NoZOrder) == 0)
             {
 
-                NativeMethods.WINDOWPOS* wp = (NativeMethods.WINDOWPOS*)m.LParam;
-                if ((wp->flags & NativeMethods.SWP_NOZORDER) == 0)
+                User32.WINDOWPOS* wp = (User32.WINDOWPOS*)m.LParam;
+                if ((wp->flags & User32.WindowPosition.SWP_NOZORDER) == 0)
                 {
                     _parent.UpdateChildControlIndex(this);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridToolTip.cs
@@ -46,12 +46,12 @@ namespace System.Windows.Forms
                 tipWindow = new NativeWindow();
                 tipWindow.CreateHandle(cparams);
 
-                User32.SendMessageW(tipWindow, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
+                User32.SendMessageW(tipWindow, User32.WindowMessage.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
                 User32.SetWindowPos(
                     new HandleRef(tipWindow, tipWindow.Handle),
                     User32.HWND_NOTOPMOST,
-                    flags: User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOMOVE | User32.WindowPosition.SWP_NOACTIVATE);
-                User32.SendMessageW(tipWindow, WindowMessages.TTM_SETDELAYTIME, (IntPtr)ComCtl32.TTDT.INITIAL, (IntPtr)0);
+                    flags: User32.WindowPosition.NOSIZE | User32.WindowPosition.NOMOVE | User32.WindowPosition.NOACTIVATE);
+                User32.SendMessageW(tipWindow, User32.WindowMessage.TTM_SETDELAYTIME, (IntPtr)ComCtl32.TTDT.INITIAL, (IntPtr)0);
             }
         }
 
@@ -65,13 +65,13 @@ namespace System.Windows.Forms
                 throw new ArgumentNullException(nameof(toolTipString));
 
             var info = new ComCtl32.ToolInfoWrapper(dataGrid, toolTipId, ComCtl32.TTF.SUBCLASS, toolTipString, iconBounds);
-            info.SendMessage(tipWindow, WindowMessages.TTM_ADDTOOLW);
+            info.SendMessage(tipWindow, User32.WindowMessage.TTM_ADDTOOLW);
         }
 
         public void RemoveToolTip(IntPtr toolTipId)
         {
             var info = new ComCtl32.ToolInfoWrapper(dataGrid, toolTipId);
-            info.SendMessage(tipWindow, WindowMessages.TTM_DELTOOLW);
+            info.SendMessage(tipWindow, User32.WindowMessage.TTM_DELTOOLW);
         }
 
         // will destroy the tipWindow

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridToolTip.cs
@@ -47,7 +47,10 @@ namespace System.Windows.Forms
                 tipWindow.CreateHandle(cparams);
 
                 User32.SendMessageW(tipWindow, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
-                SafeNativeMethods.SetWindowPos(new HandleRef(tipWindow, tipWindow.Handle), NativeMethods.HWND_NOTOPMOST, 0, 0, 0, 0, NativeMethods.SWP_NOSIZE | NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOACTIVATE);
+                User32.SetWindowPos(
+                    new HandleRef(tipWindow, tipWindow.Handle),
+                    User32.HWND_NOTOPMOST,
+                    flags: User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOMOVE | User32.WindowPosition.SWP_NOACTIVATE);
                 User32.SendMessageW(tipWindow, WindowMessages.TTM_SETDELAYTIME, (IntPtr)ComCtl32.TTDT.INITIAL, (IntPtr)0);
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -29274,7 +29274,7 @@ namespace System.Windows.Forms
                 if (!string.IsNullOrEmpty(toolTip))
                 {
                     // Setting the max width has the added benefit of enabling multiline tool tips
-                    User32.SendMessageW(nmhdr->hwndFrom, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
+                    User32.SendMessageW(nmhdr->hwndFrom, User32.WindowMessage.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
                     NativeMethods.TOOLTIPTEXT ttt = (NativeMethods.TOOLTIPTEXT)m.GetLParam(typeof(NativeMethods.TOOLTIPTEXT));
 
                     ttt.lpszText = toolTip;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DrawItemState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DrawItemState.cs
@@ -15,57 +15,57 @@ namespace System.Windows.Forms
         /// <summary>
         ///  The item is checked. Only menu controls use this value.
         /// </summary>
-        Checked = (int)User32.DrawItemState.ODS_CHECKED,
+        Checked = (int)User32.DrawItemState.CHECKED,
 
         /// <summary>
         ///  The item is the editing portion of a <see cref='ComboBox'/> .
         /// </summary>
-        ComboBoxEdit = (int)User32.DrawItemState.ODS_COMBOBOXEDIT,
+        ComboBoxEdit = (int)User32.DrawItemState.COMBOBOXEDIT,
 
         /// <summary>
         ///  The item is the default item of the control.
         /// </summary>
-        Default = (int)User32.DrawItemState.ODS_DEFAULT,
+        Default = (int)User32.DrawItemState.DEFAULT,
 
         /// <summary>
         ///  The item is disabled.
         /// </summary>
-        Disabled = (int)User32.DrawItemState.ODS_DISABLED,
+        Disabled = (int)User32.DrawItemState.DISABLED,
 
         /// <summary>
         ///  The item has focus.
         /// </summary>
-        Focus = (int)User32.DrawItemState.ODS_FOCUS,
+        Focus = (int)User32.DrawItemState.FOCUS,
 
         /// <summary>
         ///  The item is grayed. Only menu controls use this value.
         /// </summary>
-        Grayed = (int)User32.DrawItemState.ODS_GRAYED,
+        Grayed = (int)User32.DrawItemState.GRAYED,
 
         /// <summary>
         ///  The item is being hot-tracked.
         /// </summary>
-        HotLight = (int)User32.DrawItemState.ODS_HOTLIGHT,
+        HotLight = (int)User32.DrawItemState.HOTLIGHT,
 
         /// <summary>
         ///  The item is inactive.
         /// </summary>
-        Inactive = (int)User32.DrawItemState.ODS_INACTIVE,
+        Inactive = (int)User32.DrawItemState.INACTIVE,
 
         /// <summary>
         ///  The item displays without a keyboard accelarator.
         /// </summary>
-        NoAccelerator = (int)User32.DrawItemState.ODS_NOACCEL,
+        NoAccelerator = (int)User32.DrawItemState.NOACCEL,
 
         /// <summary>
         ///  The item displays without the visual cue that indicates it has the focus.
         /// </summary>
-        NoFocusRect = (int)User32.DrawItemState.ODS_NOFOCUSRECT,
+        NoFocusRect = (int)User32.DrawItemState.NOFOCUSRECT,
 
         /// <summary>
         ///  The item is selected.
         /// </summary>
-        Selected = (int)User32.DrawItemState.ODS_SELECTED,
+        Selected = (int)User32.DrawItemState.SELECTED,
 
         /// <summary>
         ///  The item is in its default visual state.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DrawItemState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DrawItemState.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using static Interop;
+
 namespace System.Windows.Forms
 {
     /// <summary>
@@ -13,57 +15,57 @@ namespace System.Windows.Forms
         /// <summary>
         ///  The item is checked. Only menu controls use this value.
         /// </summary>
-        Checked = NativeMethods.ODS_CHECKED,
+        Checked = (int)User32.DrawItemState.ODS_CHECKED,
 
         /// <summary>
         ///  The item is the editing portion of a <see cref='ComboBox'/> .
         /// </summary>
-        ComboBoxEdit = NativeMethods.ODS_COMBOBOXEDIT,
+        ComboBoxEdit = (int)User32.DrawItemState.ODS_COMBOBOXEDIT,
 
         /// <summary>
         ///  The item is the default item of the control.
         /// </summary>
-        Default = NativeMethods.ODS_DEFAULT,
+        Default = (int)User32.DrawItemState.ODS_DEFAULT,
 
         /// <summary>
         ///  The item is disabled.
         /// </summary>
-        Disabled = NativeMethods.ODS_DISABLED,
+        Disabled = (int)User32.DrawItemState.ODS_DISABLED,
 
         /// <summary>
         ///  The item has focus.
         /// </summary>
-        Focus = NativeMethods.ODS_FOCUS,
+        Focus = (int)User32.DrawItemState.ODS_FOCUS,
 
         /// <summary>
         ///  The item is grayed. Only menu controls use this value.
         /// </summary>
-        Grayed = NativeMethods.ODS_GRAYED,
+        Grayed = (int)User32.DrawItemState.ODS_GRAYED,
 
         /// <summary>
         ///  The item is being hot-tracked.
         /// </summary>
-        HotLight = NativeMethods.ODS_HOTLIGHT,
+        HotLight = (int)User32.DrawItemState.ODS_HOTLIGHT,
 
         /// <summary>
         ///  The item is inactive.
         /// </summary>
-        Inactive = NativeMethods.ODS_INACTIVE,
+        Inactive = (int)User32.DrawItemState.ODS_INACTIVE,
 
         /// <summary>
         ///  The item displays without a keyboard accelarator.
         /// </summary>
-        NoAccelerator = NativeMethods.ODS_NOACCEL,
+        NoAccelerator = (int)User32.DrawItemState.ODS_NOACCEL,
 
         /// <summary>
         ///  The item displays without the visual cue that indicates it has the focus.
         /// </summary>
-        NoFocusRect = NativeMethods.ODS_NOFOCUSRECT,
+        NoFocusRect = (int)User32.DrawItemState.ODS_NOFOCUSRECT,
 
         /// <summary>
         ///  The item is selected.
         /// </summary>
-        Selected = NativeMethods.ODS_SELECTED,
+        Selected = (int)User32.DrawItemState.ODS_SELECTED,
 
         /// <summary>
         ///  The item is in its default visual state.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
@@ -900,7 +900,10 @@ namespace System.Windows.Forms
                     _tipWindow.CreateHandle(cparams);
 
                     User32.SendMessageW(_tipWindow, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
-                    SafeNativeMethods.SetWindowPos(new HandleRef(_tipWindow, _tipWindow.Handle), NativeMethods.HWND_TOP, 0, 0, 0, 0, NativeMethods.SWP_NOSIZE | NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOACTIVATE);
+                    User32.SetWindowPos(
+                        new HandleRef(_tipWindow, _tipWindow.Handle),
+                        User32.HWND_TOP,
+                        flags: User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOMOVE | User32.WindowPosition.SWP_NOACTIVATE);
                     User32.SendMessageW(_tipWindow, WindowMessages.TTM_SETDELAYTIME, (IntPtr)ComCtl32.TTDT.INITIAL, (IntPtr)0);
                 }
 
@@ -926,16 +929,14 @@ namespace System.Windows.Forms
                 // Hide the window and invalidate the parent to ensure
                 // that we leave no visual artifacts. given that we
                 // have a bizare region window, this is needed.
-                //
-                SafeNativeMethods.SetWindowPos(new HandleRef(this, Handle),
-                                               NativeMethods.HWND_TOP,
-                                               _windowBounds.X,
-                                               _windowBounds.Y,
-                                               _windowBounds.Width,
-                                               _windowBounds.Height,
-                                               NativeMethods.SWP_HIDEWINDOW
-                                               | NativeMethods.SWP_NOSIZE
-                                               | NativeMethods.SWP_NOMOVE);
+                User32.SetWindowPos(
+                    new HandleRef(this, Handle),
+                    User32.HWND_TOP,
+                    _windowBounds.X,
+                    _windowBounds.Y,
+                    _windowBounds.Width,
+                    _windowBounds.Height,
+                    User32.WindowPosition.SWP_HIDEWINDOW | User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOMOVE);
                 _parent?.Invalidate(true);
                 DestroyHandle();
 
@@ -1238,8 +1239,14 @@ namespace System.Windows.Forms
                     }
                 }
 
-                SafeNativeMethods.SetWindowPos(new HandleRef(this, Handle), NativeMethods.HWND_TOP, _windowBounds.X, _windowBounds.Y,
-                                     _windowBounds.Width, _windowBounds.Height, NativeMethods.SWP_NOACTIVATE);
+                User32.SetWindowPos(
+                    new HandleRef(this, Handle),
+                    User32.HWND_TOP,
+                    _windowBounds.X,
+                    _windowBounds.Y,
+                    _windowBounds.Width,
+                    _windowBounds.Height,
+                    User32.WindowPosition.SWP_NOACTIVATE);
                 User32.InvalidateRect(new HandleRef(this, Handle), null, BOOL.FALSE);
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
@@ -849,7 +849,7 @@ namespace System.Windows.Forms
                 }
 
                 var toolInfo = new ComCtl32.ToolInfoWrapper(this, item.Id, ComCtl32.TTF.SUBCLASS, item.Error);
-                toolInfo.SendMessage(_tipWindow, WindowMessages.TTM_ADDTOOLW);
+                toolInfo.SendMessage(_tipWindow, User32.WindowMessage.TTM_ADDTOOLW);
 
                 Update(timerCaused: false);
             }
@@ -899,12 +899,12 @@ namespace System.Windows.Forms
                     _tipWindow = new NativeWindow();
                     _tipWindow.CreateHandle(cparams);
 
-                    User32.SendMessageW(_tipWindow, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
+                    User32.SendMessageW(_tipWindow, User32.WindowMessage.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
                     User32.SetWindowPos(
                         new HandleRef(_tipWindow, _tipWindow.Handle),
                         User32.HWND_TOP,
-                        flags: User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOMOVE | User32.WindowPosition.SWP_NOACTIVATE);
-                    User32.SendMessageW(_tipWindow, WindowMessages.TTM_SETDELAYTIME, (IntPtr)ComCtl32.TTDT.INITIAL, (IntPtr)0);
+                        flags: User32.WindowPosition.NOSIZE | User32.WindowPosition.NOMOVE | User32.WindowPosition.NOACTIVATE);
+                    User32.SendMessageW(_tipWindow, User32.WindowMessage.TTM_SETDELAYTIME, (IntPtr)ComCtl32.TTDT.INITIAL, (IntPtr)0);
                 }
 
                 return true;
@@ -936,7 +936,7 @@ namespace System.Windows.Forms
                     _windowBounds.Y,
                     _windowBounds.Width,
                     _windowBounds.Height,
-                    User32.WindowPosition.SWP_HIDEWINDOW | User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOMOVE);
+                    User32.WindowPosition.HIDEWINDOW | User32.WindowPosition.NOSIZE | User32.WindowPosition.NOMOVE);
                 _parent?.Invalidate(true);
                 DestroyHandle();
 
@@ -1078,7 +1078,7 @@ namespace System.Windows.Forms
                 if (_tipWindow != null)
                 {
                     var info = new ComCtl32.ToolInfoWrapper(this, item.Id);
-                    info .SendMessage(_tipWindow, WindowMessages.TTM_DELTOOLW);
+                    info .SendMessage(_tipWindow, User32.WindowMessage.TTM_DELTOOLW);
                 }
 
                 if (items.Count == 0)
@@ -1184,7 +1184,7 @@ namespace System.Windows.Forms
                             }
 
                             var toolInfo = new ComCtl32.ToolInfoWrapper(this, item.Id, flags, item.Error, iconBounds);
-                            toolInfo.SendMessage(_tipWindow, WindowMessages.TTM_SETTOOLINFOW);
+                            toolInfo.SendMessage(_tipWindow, User32.WindowMessage.TTM_SETTOOLINFOW);
                         }
 
                         if (timerCaused && item.BlinkPhase > 0)
@@ -1246,7 +1246,7 @@ namespace System.Windows.Forms
                     _windowBounds.Y,
                     _windowBounds.Width,
                     _windowBounds.Height,
-                    User32.WindowPosition.SWP_NOACTIVATE);
+                    User32.WindowPosition.NOACTIVATE);
                 User32.InvalidateRect(new HandleRef(this, Handle), null, BOOL.FALSE);
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -1637,7 +1637,7 @@ namespace System.Windows.Forms
                             Location.Y,
                             Size.Width,
                             Size.Height,
-                            User32.WindowPosition.SWP_NOZORDER);
+                            User32.WindowPosition.NOZORDER);
                     }
 
                     OnMinimumSizeChanged(EventArgs.Empty);
@@ -2448,7 +2448,7 @@ namespace System.Windows.Forms
                     User32.SetWindowPos(
                         new HandleRef(this, Handle),
                         value ? User32.HWND_TOPMOST : User32.HWND_NOTOPMOST,
-                        flags: User32.WindowPosition.SWP_NOMOVE | User32.WindowPosition.SWP_NOSIZE);
+                        flags: User32.WindowPosition.NOMOVE | User32.WindowPosition.NOSIZE);
                 }
 
                 formState[FormStateTopMost] = value ? 1 : 0;
@@ -4706,7 +4706,7 @@ namespace System.Windows.Forms
                             e.SuggestedRectangle.Y,
                             e.SuggestedRectangle.Width,
                             e.SuggestedRectangle.Height,
-                            User32.WindowPosition.SWP_NOZORDER | User32.WindowPosition.SWP_NOACTIVATE);
+                            User32.WindowPosition.NOZORDER | User32.WindowPosition.NOACTIVATE);
                         if (AutoScaleMode != AutoScaleMode.Font)
                         {
                             Font = new Font(Font.FontFamily, Font.Size * factor, Font.Style);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -6831,14 +6831,13 @@ namespace System.Windows.Forms
             }
         }
 
-        private void WmGetMinMaxInfoHelper(ref Message m, Size minTrack, Size maxTrack, Rectangle maximizedBounds)
+        private unsafe void WmGetMinMaxInfoHelper(ref Message m, Size minTrack, Size maxTrack, Rectangle maximizedBounds)
         {
-            NativeMethods.MINMAXINFO mmi = (NativeMethods.MINMAXINFO)m.GetLParam(typeof(NativeMethods.MINMAXINFO));
-
+            User32.MINMAXINFO* mmi = (User32.MINMAXINFO*)m.LParam;
             if (!minTrack.IsEmpty)
             {
-                mmi.ptMinTrackSize.X = minTrack.Width;
-                mmi.ptMinTrackSize.Y = minTrack.Height;
+                mmi->ptMinTrackSize.X = minTrack.Width;
+                mmi->ptMinTrackSize.Y = minTrack.Height;
 
                 // When the MinTrackSize is set to a value larger than the screen
                 // size but the MaxTrackSize is not set to a value equal to or greater than the
@@ -6855,11 +6854,11 @@ namespace System.Windows.Forms
                     Size virtualScreen = SystemInformation.VirtualScreen.Size;
                     if (minTrack.Height > virtualScreen.Height)
                     {
-                        mmi.ptMaxTrackSize.Y = int.MaxValue;
+                        mmi->ptMaxTrackSize.Y = int.MaxValue;
                     }
                     if (minTrack.Width > virtualScreen.Width)
                     {
-                        mmi.ptMaxTrackSize.X = int.MaxValue;
+                        mmi->ptMaxTrackSize.X = int.MaxValue;
                     }
                 }
             }
@@ -6868,19 +6867,18 @@ namespace System.Windows.Forms
             {
                 // Is the specified MaxTrackSize smaller than the smallest allowable Window size?
                 Size minTrackWindowSize = SystemInformation.MinWindowTrackSize;
-                mmi.ptMaxTrackSize.X = Math.Max(maxTrack.Width, minTrackWindowSize.Width);
-                mmi.ptMaxTrackSize.Y = Math.Max(maxTrack.Height, minTrackWindowSize.Height);
+                mmi->ptMaxTrackSize.X = Math.Max(maxTrack.Width, minTrackWindowSize.Width);
+                mmi->ptMaxTrackSize.Y = Math.Max(maxTrack.Height, minTrackWindowSize.Height);
             }
 
             if (!maximizedBounds.IsEmpty)
             {
-                mmi.ptMaxPosition.X = maximizedBounds.X;
-                mmi.ptMaxPosition.Y = maximizedBounds.Y;
-                mmi.ptMaxSize.X = maximizedBounds.Width;
-                mmi.ptMaxSize.Y = maximizedBounds.Height;
+                mmi->ptMaxPosition.X = maximizedBounds.X;
+                mmi->ptMaxPosition.Y = maximizedBounds.Y;
+                mmi->ptMaxSize.X = maximizedBounds.Width;
+                mmi->ptMaxSize.Y = maximizedBounds.Height;
             }
 
-            Marshal.StructureToPtr(mmi, m.LParam, false);
             m.Result = IntPtr.Zero;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -1630,12 +1630,14 @@ namespace System.Windows.Forms
                     {
                         // "Move" the form to the same size and position to prevent windows from moving it
                         // when the user tries to grab a resizing border.
-                        SafeNativeMethods.SetWindowPos(new HandleRef(this, Handle), NativeMethods.NullHandleRef,
-                                                       Location.X,
-                                                       Location.Y,
-                                                       Size.Width,
-                                                       Size.Height,
-                                                       NativeMethods.SWP_NOZORDER);
+                        User32.SetWindowPos(
+                            new HandleRef(this, Handle),
+                            User32.HWND_TOP,
+                            Location.X,
+                            Location.Y,
+                            Size.Width,
+                            Size.Height,
+                            User32.WindowPosition.SWP_NOZORDER);
                     }
 
                     OnMinimumSizeChanged(EventArgs.Empty);
@@ -2443,9 +2445,10 @@ namespace System.Windows.Forms
             {
                 if (IsHandleCreated && TopLevel)
                 {
-                    HandleRef key = value ? NativeMethods.HWND_TOPMOST : NativeMethods.HWND_NOTOPMOST;
-                    SafeNativeMethods.SetWindowPos(new HandleRef(this, Handle), key, 0, 0, 0, 0,
-                                         NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOSIZE);
+                    User32.SetWindowPos(
+                        new HandleRef(this, Handle),
+                        value ? User32.HWND_TOPMOST : User32.HWND_NOTOPMOST,
+                        flags: User32.WindowPosition.SWP_NOMOVE | User32.WindowPosition.SWP_NOSIZE);
                 }
 
                 formState[FormStateTopMost] = value ? 1 : 0;
@@ -4696,7 +4699,14 @@ namespace System.Windows.Forms
                     SuspendAllLayout(this);
                     try
                     {
-                        SafeNativeMethods.SetWindowPos(new HandleRef(this, HandleInternal), NativeMethods.NullHandleRef, e.SuggestedRectangle.X, e.SuggestedRectangle.Y, e.SuggestedRectangle.Width, e.SuggestedRectangle.Height, NativeMethods.SWP_NOZORDER | NativeMethods.SWP_NOACTIVATE);
+                        User32.SetWindowPos(
+                            new HandleRef(this, HandleInternal),
+                            User32.HWND_TOP,
+                            e.SuggestedRectangle.X,
+                            e.SuggestedRectangle.Y,
+                            e.SuggestedRectangle.Width,
+                            e.SuggestedRectangle.Height,
+                            User32.WindowPosition.SWP_NOZORDER | User32.WindowPosition.SWP_NOACTIVATE);
                         if (AutoScaleMode != AutoScaleMode.Font)
                         {
                             Font = new Font(Font.FontFamily, Font.Size * factor, Font.Style);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -2473,7 +2473,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                OnDrawItem(new DrawItemEventArgs(g, Font, bounds, dis->itemID, (DrawItemState)dis->itemState, ForeColor, BackColor));
+                OnDrawItem(new DrawItemEventArgs(g, Font, bounds, (int)dis->itemID, (DrawItemState)dis->itemState, ForeColor, BackColor));
             }
             finally
             {
@@ -2494,13 +2494,13 @@ namespace System.Windows.Forms
             if (drawMode == DrawMode.OwnerDrawVariable && mis->itemID >= 0)
             {
                 using Graphics graphics = CreateGraphicsInternal();
-                var mie = new MeasureItemEventArgs(graphics, mis->itemID, ItemHeight);
+                var mie = new MeasureItemEventArgs(graphics, (int)mis->itemID, ItemHeight);
                 OnMeasureItem(mie);
-                mis->itemHeight = mie.ItemHeight;
+                mis->itemHeight = unchecked((uint)mie.ItemHeight);
             }
             else
             {
-                mis->itemHeight = ItemHeight;
+                mis->itemHeight = unchecked((uint)ItemHeight);
             }
 
             m.Result = (IntPtr)1;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -2453,45 +2453,36 @@ namespace System.Windows.Forms
             }
         }
 
-        private void WmReflectDrawItem(ref Message m)
+        private unsafe void WmReflectDrawItem(ref Message m)
         {
-            NativeMethods.DRAWITEMSTRUCT dis = (NativeMethods.DRAWITEMSTRUCT)m.GetLParam(typeof(NativeMethods.DRAWITEMSTRUCT));
-            IntPtr dc = dis.hDC;
-            IntPtr oldPal = SetUpPalette(dc, false /*force*/, false /*realize*/);
+            User32.DRAWITEMSTRUCT* dis = (User32.DRAWITEMSTRUCT*)m.LParam;
+            IntPtr oldPal = SetUpPalette(dis->hDC, force: false, realizePalette: false);
             try
             {
-                Graphics g = Graphics.FromHdcInternal(dc);
-
-                try
+                using Graphics g = Graphics.FromHdcInternal(dis->hDC);
+                Rectangle bounds = dis->rcItem;
+                if (HorizontalScrollbar)
                 {
-                    Rectangle bounds = Rectangle.FromLTRB(dis.rcItem.left, dis.rcItem.top, dis.rcItem.right, dis.rcItem.bottom);
-
-                    if (HorizontalScrollbar)
+                    if (MultiColumn)
                     {
-                        if (MultiColumn)
-                        {
-                            bounds.Width = Math.Max(ColumnWidth, bounds.Width);
-                        }
-                        else
-                        {
-                            bounds.Width = Math.Max(MaxItemWidth, bounds.Width);
-                        }
+                        bounds.Width = Math.Max(ColumnWidth, bounds.Width);
                     }
+                    else
+                    {
+                        bounds.Width = Math.Max(MaxItemWidth, bounds.Width);
+                    }
+                }
 
-                    OnDrawItem(new DrawItemEventArgs(g, Font, bounds, dis.itemID, (DrawItemState)dis.itemState, ForeColor, BackColor));
-                }
-                finally
-                {
-                    g.Dispose();
-                }
+                OnDrawItem(new DrawItemEventArgs(g, Font, bounds, dis->itemID, (DrawItemState)dis->itemState, ForeColor, BackColor));
             }
             finally
             {
                 if (oldPal != IntPtr.Zero)
                 {
-                    SafeNativeMethods.SelectPalette(new HandleRef(null, dc), new HandleRef(null, oldPal), 0);
+                    Gdi32.SelectPalette(dis->hDC, oldPal, BOOL.FALSE);
                 }
             }
+
             m.Result = (IntPtr)1;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -2487,29 +2487,22 @@ namespace System.Windows.Forms
         }
 
         // This method is only called if in owner draw mode
-        private void WmReflectMeasureItem(ref Message m)
+        private unsafe void WmReflectMeasureItem(ref Message m)
         {
-            NativeMethods.MEASUREITEMSTRUCT mis = (NativeMethods.MEASUREITEMSTRUCT)m.GetLParam(typeof(NativeMethods.MEASUREITEMSTRUCT));
+            User32.MEASUREITEMSTRUCT* mis = (User32.MEASUREITEMSTRUCT*)m.LParam;
 
-            if (drawMode == DrawMode.OwnerDrawVariable && mis.itemID >= 0)
+            if (drawMode == DrawMode.OwnerDrawVariable && mis->itemID >= 0)
             {
-                Graphics graphics = CreateGraphicsInternal();
-                MeasureItemEventArgs mie = new MeasureItemEventArgs(graphics, mis.itemID, ItemHeight);
-                try
-                {
-                    OnMeasureItem(mie);
-                    mis.itemHeight = mie.ItemHeight;
-                }
-                finally
-                {
-                    graphics.Dispose();
-                }
+                using Graphics graphics = CreateGraphicsInternal();
+                var mie = new MeasureItemEventArgs(graphics, mis->itemID, ItemHeight);
+                OnMeasureItem(mie);
+                mis->itemHeight = mie.ItemHeight;
             }
             else
             {
-                mis.itemHeight = ItemHeight;
+                mis->itemHeight = ItemHeight;
             }
-            Marshal.StructureToPtr(mis, m.LParam, false);
+
             m.Result = (IntPtr)1;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -4832,7 +4832,7 @@ namespace System.Windows.Forms
                 };
 
                 // get the layout information
-                User32.SendMessageW(new HandleRef(this, hdrHWND), WindowMessages.HDM_LAYOUT, IntPtr.Zero, &hd);
+                User32.SendMessageW(hdrHWND, User32.WindowMessage.HDM_LAYOUT, IntPtr.Zero, ref hd);
 
                 // position the header control
                 User32.SetWindowPos(
@@ -4842,7 +4842,7 @@ namespace System.Windows.Forms
                     wpos.y,
                     wpos.cx,
                     wpos.cy,
-                    wpos.flags | User32.WindowPosition.SWP_SHOWWINDOW);
+                    wpos.flags | User32.WindowPosition.SHOWWINDOW);
             }
         }
 
@@ -6496,7 +6496,7 @@ namespace System.Windows.Forms
                             if (lvi != null && !string.IsNullOrEmpty(lvi.ToolTipText))
                             {
                                 // Setting the max width has the added benefit of enabling multiline tool tips
-                                User32.SendMessageW(nmhdr->hwndFrom, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
+                                User32.SendMessageW(nmhdr->hwndFrom, User32.WindowMessage.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
 
                                 // UNICODE. Use char.
                                 // we need to copy the null terminator character ourselves

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -4821,64 +4821,28 @@ namespace System.Windows.Forms
             IntPtr hdrHWND = UnsafeNativeMethods.GetWindow(new HandleRef(this, Handle), NativeMethods.GW_CHILD);
             if (hdrHWND != IntPtr.Zero)
             {
+                var rc = new RECT();
+                var wpos = new User32.WINDOWPOS();
+                UnsafeNativeMethods.GetClientRect(new HandleRef(this, Handle), ref rc);
 
-                IntPtr prc = IntPtr.Zero;
-                IntPtr pwpos = IntPtr.Zero;
-
-                prc = Marshal.AllocHGlobal(Marshal.SizeOf<RECT>());
-                if (prc == IntPtr.Zero)
+                var hd = new User32.HDLAYOUT
                 {
-                    return;
-                }
+                    prc = &rc,
+                    pwpos = &wpos
+                };
 
-                try
-                {
-                    pwpos = Marshal.AllocHGlobal(Marshal.SizeOf<User32.WINDOWPOS>());
+                // get the layout information
+                User32.SendMessageW(new HandleRef(this, hdrHWND), WindowMessages.HDM_LAYOUT, IntPtr.Zero, &hd);
 
-                    if (prc == IntPtr.Zero)
-                    {
-                        // we could not allocate memory.
-                        // return
-                        return;
-                    }
-
-                    UnsafeNativeMethods.GetClientRect(new HandleRef(this, Handle), prc);
-
-                    NativeMethods.HDLAYOUT hd = new NativeMethods.HDLAYOUT
-                    {
-                        prc = prc,
-                        pwpos = pwpos
-                    };
-
-                    // get the layout information
-                    UnsafeNativeMethods.SendMessage(new HandleRef(this, hdrHWND), NativeMethods.HDM_LAYOUT, 0, ref hd);
-
-                    // now take the information from the native wpos struct and put it into a managed WINDOWPOS
-                    User32.WINDOWPOS wpos = Marshal.PtrToStructure<User32.WINDOWPOS>(pwpos);
-
-                    // position the header control
-                    User32.SetWindowPos(
-                        new HandleRef(this, hdrHWND),
-                        new HandleRef(this, wpos.hwndInsertAfter),
-                        wpos.x,
-                        wpos.y,
-                        wpos.cx,
-                        wpos.cy,
-                        wpos.flags | User32.WindowPosition.SWP_SHOWWINDOW);
-                }
-                finally
-                {
-
-                    // clean up our memory
-                    if (prc != IntPtr.Zero)
-                    {
-                        Marshal.FreeHGlobal(prc);
-                    }
-                    if (pwpos != IntPtr.Zero)
-                    {
-                        Marshal.FreeHGlobal(pwpos);
-                    }
-                }
+                // position the header control
+                User32.SetWindowPos(
+                    new HandleRef(this, hdrHWND),
+                    new HandleRef(this, wpos.hwndInsertAfter),
+                    wpos.x,
+                    wpos.y,
+                    wpos.cx,
+                    wpos.cy,
+                    wpos.flags | User32.WindowPosition.SWP_SHOWWINDOW);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -4833,7 +4833,7 @@ namespace System.Windows.Forms
 
                 try
                 {
-                    pwpos = Marshal.AllocHGlobal(Marshal.SizeOf<NativeMethods.WINDOWPOS>());
+                    pwpos = Marshal.AllocHGlobal(Marshal.SizeOf<User32.WINDOWPOS>());
 
                     if (prc == IntPtr.Zero)
                     {
@@ -4854,16 +4854,17 @@ namespace System.Windows.Forms
                     UnsafeNativeMethods.SendMessage(new HandleRef(this, hdrHWND), NativeMethods.HDM_LAYOUT, 0, ref hd);
 
                     // now take the information from the native wpos struct and put it into a managed WINDOWPOS
-                    NativeMethods.WINDOWPOS wpos = Marshal.PtrToStructure<NativeMethods.WINDOWPOS>(pwpos);
+                    User32.WINDOWPOS wpos = Marshal.PtrToStructure<User32.WINDOWPOS>(pwpos);
 
                     // position the header control
-                    SafeNativeMethods.SetWindowPos(new HandleRef(this, hdrHWND),
-                                                   new HandleRef(this, wpos.hwndInsertAfter),
-                                                   wpos.x,
-                                                   wpos.y,
-                                                   wpos.cx,
-                                                   wpos.cy,
-                                                   wpos.flags | NativeMethods.SWP_SHOWWINDOW);
+                    User32.SetWindowPos(
+                        new HandleRef(this, hdrHWND),
+                        new HandleRef(this, wpos.hwndInsertAfter),
+                        wpos.x,
+                        wpos.y,
+                        wpos.cx,
+                        wpos.cy,
+                        wpos.flags | User32.WindowPosition.SWP_SHOWWINDOW);
                 }
                 finally
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MenuItem.cs
@@ -1454,12 +1454,12 @@ namespace System.Windows.Forms
             using ScreenDC screendc = ScreenDC.Create();
             using Graphics graphics = Graphics.FromHdcInternal(screendc);
 
-            MeasureItemEventArgs mie = new MeasureItemEventArgs(graphics, Index);
+            var mie = new MeasureItemEventArgs(graphics, Index);
             OnMeasureItem(mie);
 
             // Update the measure item struct with the new width and height
-            mis->itemHeight = mie.ItemHeight;
-            mis->itemWidth = mie.ItemWidth;
+            mis->itemHeight = unchecked((uint)mie.ItemHeight);
+            mis->itemWidth = unchecked((uint)mie.ItemWidth);
 
             m.Result = (IntPtr)1;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MenuItem.cs
@@ -1442,26 +1442,24 @@ namespace System.Windows.Forms
             m.Result = (IntPtr)1;
         }
 
-        internal void WmMeasureItem(ref Message m)
+        /// <summary>
+        ///  Handles the OnMeasureItem message sent from ContainerControl
+        /// </summary>
+        internal unsafe void WmMeasureItem(ref Message m)
         {
-            // Handles the OnMeasureItem message sent from ContainerControl
-
             // Obtain the measure item struct
-            NativeMethods.MEASUREITEMSTRUCT mis = (NativeMethods.MEASUREITEMSTRUCT)m.GetLParam(typeof(NativeMethods.MEASUREITEMSTRUCT));
+            User32.MEASUREITEMSTRUCT* mis = (User32.MEASUREITEMSTRUCT*)m.LParam;
 
             // The OnMeasureItem handler now determines the height and width of the item
             using ScreenDC screendc = ScreenDC.Create();
-            Graphics graphics = Graphics.FromHdcInternal(screendc);
+            using Graphics graphics = Graphics.FromHdcInternal(screendc);
+
             MeasureItemEventArgs mie = new MeasureItemEventArgs(graphics, Index);
-            using (graphics)
-            {
-                OnMeasureItem(mie);
-            }
+            OnMeasureItem(mie);
 
             // Update the measure item struct with the new width and height
-            mis.itemHeight = mie.ItemHeight;
-            mis.itemWidth = mie.ItemWidth;
-            Marshal.StructureToPtr(mis, m.LParam, false);
+            mis->itemHeight = mie.ItemHeight;
+            mis->itemWidth = mie.ItemWidth;
 
             m.Result = (IntPtr)1;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
@@ -895,24 +895,20 @@ namespace System.Windows.Forms
             window.DefWndProc(ref m);
         }
 
-        private void WmMeasureMenuItem(ref Message m)
+        private unsafe void WmMeasureMenuItem(ref Message m)
         {
             // Obtain the menu item object
-            NativeMethods.MEASUREITEMSTRUCT mis = (NativeMethods.MEASUREITEMSTRUCT)m.GetLParam(typeof(NativeMethods.MEASUREITEMSTRUCT));
-
             Debug.Assert(m.LParam != IntPtr.Zero, "m.lparam is null");
+            User32.MEASUREITEMSTRUCT* mis = (User32.MEASUREITEMSTRUCT*)m.LParam;
 
             // A pointer to the correct MenuItem is stored in the measure item
             // information sent with the message.
             // (See MenuItem.CreateMenuItemInfo)
-            MenuItem menuItem = MenuItem.GetMenuItemFromItemData(mis.itemData);
+            MenuItem menuItem = MenuItem.GetMenuItemFromItemData(mis->itemData);
             Debug.Assert(menuItem != null, "UniqueID is not associated with a menu item");
 
             // Delegate this message to the menu item
-            if (menuItem != null)
-            {
-                menuItem.WmMeasureItem(ref m);
-            }
+            menuItem?.WmMeasureItem(ref m);
         }
 
         private unsafe void WmDrawItemMenuItem(ref Message m)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
@@ -915,21 +915,18 @@ namespace System.Windows.Forms
             }
         }
 
-        private void WmDrawItemMenuItem(ref Message m)
+        private unsafe void WmDrawItemMenuItem(ref Message m)
         {
             // Obtain the menu item object
-            NativeMethods.DRAWITEMSTRUCT dis = (NativeMethods.DRAWITEMSTRUCT)m.GetLParam(typeof(NativeMethods.DRAWITEMSTRUCT));
+            User32.DRAWITEMSTRUCT* dis = (User32.DRAWITEMSTRUCT*)m.LParam;
 
             // A pointer to the correct MenuItem is stored in the draw item
             // information sent with the message.
             // (See MenuItem.CreateMenuItemInfo)
-            MenuItem menuItem = MenuItem.GetMenuItemFromItemData(dis.itemData);
+            MenuItem menuItem = MenuItem.GetMenuItemFromItemData(dis->itemData);
 
             // Delegate this message to the menu item
-            if (menuItem != null)
-            {
-                menuItem.WmDrawItem(ref m);
-            }
+            menuItem?.WmDrawItem(ref m);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PaintEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PaintEventArgs.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Runtime.InteropServices;
+using static Interop;
 
 namespace System.Windows.Forms
 {
@@ -129,7 +130,7 @@ namespace System.Windows.Forms
 
             if (oldPal != IntPtr.Zero && _dc != IntPtr.Zero)
             {
-                SafeNativeMethods.SelectPalette(new HandleRef(this, _dc), new HandleRef(this, oldPal), 0);
+                Gdi32.SelectPalette(new HandleRef(this, _dc), new HandleRef(this, oldPal), BOOL.FALSE);
                 oldPal = IntPtr.Zero;
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridToolTip.cs
@@ -138,10 +138,10 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             if (IsHandleCreated)
             {
-                SafeNativeMethods.SetWindowPos(new HandleRef(this, Handle), NativeMethods.HWND_TOPMOST,
-                                  0, 0, 0, 0,
-                                  NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOSIZE |
-                                  NativeMethods.SWP_NOACTIVATE);
+                User32.SetWindowPos(
+                    new HandleRef(this, Handle),
+                    User32.HWND_TOPMOST,
+                    flags: User32.WindowPosition.SWP_NOMOVE | User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOACTIVATE);
 
                 ComCtl32.ToolInfoWrapper info = GetTOOLINFO(control);
                 if (info.SendMessage(this, WindowMessages.TTM_ADDTOOLW) == IntPtr.Zero)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridToolTip.cs
@@ -71,7 +71,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     for (int i = 0; i < controls.Length; i++)
                     {
                         ComCtl32.ToolInfoWrapper info = GetTOOLINFO(controls[i]);
-                        info.SendMessage(this, WindowMessages.TTM_UPDATETIPTEXTW);
+                        info.SendMessage(this, User32.WindowMessage.TTM_UPDATETIPTEXTW);
                     }
 
                     if (visible && !dontShow)
@@ -118,7 +118,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             if (IsHandleCreated)
             {
-                GetTOOLINFO((Control)sender).SendMessage(this, WindowMessages.TTM_DELTOOLW);
+                GetTOOLINFO((Control)sender).SendMessage(this, User32.WindowMessage.TTM_DELTOOLW);
             }
         }
 
@@ -141,16 +141,16 @@ namespace System.Windows.Forms.PropertyGridInternal
                 User32.SetWindowPos(
                     new HandleRef(this, Handle),
                     User32.HWND_TOPMOST,
-                    flags: User32.WindowPosition.SWP_NOMOVE | User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOACTIVATE);
+                    flags: User32.WindowPosition.NOMOVE | User32.WindowPosition.NOSIZE | User32.WindowPosition.NOACTIVATE);
 
                 ComCtl32.ToolInfoWrapper info = GetTOOLINFO(control);
-                if (info.SendMessage(this, WindowMessages.TTM_ADDTOOLW) == IntPtr.Zero)
+                if (info.SendMessage(this, User32.WindowMessage.TTM_ADDTOOLW) == IntPtr.Zero)
                 {
                     Debug.Fail($"TTM_ADDTOOL failed for {control.GetType().Name}");
                 }
 
                 // Setting the max width has the added benefit of enabling multiline tool tips
-                User32.SendMessageW(this, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
+                User32.SendMessageW(this, User32.WindowMessage.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
             }
         }
 
@@ -166,14 +166,14 @@ namespace System.Windows.Forms.PropertyGridInternal
             for (int i = 0; i < controls.Length; i++)
             {
                 ComCtl32.ToolInfoWrapper info = GetTOOLINFO(controls[i]);
-                if (info.SendMessage(this, WindowMessages.TTM_UPDATETIPTEXTW) == IntPtr.Zero)
+                if (info.SendMessage(this, User32.WindowMessage.TTM_UPDATETIPTEXTW) == IntPtr.Zero)
                 {
                     // Debug.Fail("TTM_UPDATETIPTEXT failed for " + controls[i].GetType().Name);
                 }
             }
 
             toolTipText = oldText;
-            User32.SendMessageW(this, WindowMessages.TTM_UPDATE);
+            User32.SendMessageW(this, User32.WindowMessage.TTM_UPDATE);
         }
 
         protected override void WndProc(ref Message msg)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -4527,7 +4527,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             RECT rect = itemRect;
 
-            ToolTip.SendMessage((int)WindowMessages.TTM_ADJUSTRECT, 1, ref rect);
+            ToolTip.SendMessage((int)User32.WindowMessage.TTM_ADJUSTRECT, 1, ref rect);
 
             // now offset it back to screen coords
             Point locPoint = parent.PointToScreen(new Point(rect.left, rect.top));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.cs
@@ -151,7 +151,7 @@ namespace System.Windows.Forms
         // Helper function for ParseKeys for doing simple, self-describing characters.
         private static bool AddSimpleKey(char character, int repeat, IntPtr hwnd, int[] haveKeys, bool fStartNewChar, int cGrp)
         {
-            int vk = UnsafeNativeMethods.VkKeyScan(character);
+            int vk = User32.VkKeyScanW(character);
 
             if (vk != -1)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
@@ -997,9 +997,9 @@ namespace System.Windows.Forms
             }
 
             // The itemState is not defined for a statusbar control
-            StatusBarPanel panel = (StatusBarPanel)panels[dis->itemID];
+            StatusBarPanel panel = (StatusBarPanel)panels[(int)dis->itemID];
             Graphics g = Graphics.FromHdcInternal(dis->hDC);
-            OnDrawItem(new StatusBarDrawItemEventArgs(g, Font, dis->rcItem, dis->itemID, DrawItemState.None, panel, ForeColor, BackColor));
+            OnDrawItem(new StatusBarDrawItemEventArgs(g, Font, dis->rcItem, (int)dis->itemID, DrawItemState.None, panel, ForeColor, BackColor));
         }
 
         private void WmNotifyNMClick(NativeMethods.NMHDR note)
@@ -1773,7 +1773,7 @@ namespace System.Windows.Forms
                     StatusBar p = (StatusBar)parent;
 
                     ComCtl32.ToolInfoWrapper info = GetTOOLINFO(tool);
-                    if (info.SendMessage(p.ToolTipSet ? (IHandle)p.mainToolTip : this, WindowMessages.TTM_ADDTOOLW) == IntPtr.Zero)
+                    if (info.SendMessage(p.ToolTipSet ? (IHandle)p.mainToolTip : this, User32.WindowMessage.TTM_ADDTOOLW) == IntPtr.Zero)
                     {
                         throw new InvalidOperationException(SR.StatusBarAddFailed);
                     }
@@ -1785,7 +1785,7 @@ namespace System.Windows.Forms
                 if (tool != null && tool.text != null && tool.text.Length > 0 && (int)tool.id >= 0)
                 {
                     ComCtl32.ToolInfoWrapper info = GetMinTOOLINFO(tool);
-                    info.SendMessage(this, WindowMessages.TTM_DELTOOLW);
+                    info.SendMessage(this, User32.WindowMessage.TTM_DELTOOLW);
                 }
             }
 
@@ -1794,7 +1794,7 @@ namespace System.Windows.Forms
                 if (tool != null && tool.text != null && tool.text.Length > 0 && (int)tool.id >= 0)
                 {
                     ComCtl32.ToolInfoWrapper info = GetTOOLINFO(tool);
-                    info.SendMessage(this, WindowMessages.TTM_SETTOOLINFOW);
+                    info.SendMessage(this, User32.WindowMessage.TTM_SETTOOLINFOW);
                 }
             }
 
@@ -1812,10 +1812,10 @@ namespace System.Windows.Forms
                 User32.SetWindowPos(
                     new HandleRef(this, Handle),
                     User32.HWND_TOPMOST,
-                    flags: User32.WindowPosition.SWP_NOMOVE | User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOACTIVATE);
+                    flags: User32.WindowPosition.NOMOVE | User32.WindowPosition.NOSIZE | User32.WindowPosition.NOACTIVATE);
 
                 // Setting the max width has the added benefit of enabling multiline tool tips
-                User32.SendMessageW(this, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
+                User32.SendMessageW(this, User32.WindowMessage.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
             }
 
             /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
@@ -1809,10 +1809,10 @@ namespace System.Windows.Forms
                 }
 
                 window.CreateHandle(CreateParams);
-                SafeNativeMethods.SetWindowPos(new HandleRef(this, Handle), NativeMethods.HWND_TOPMOST,
-                                     0, 0, 0, 0,
-                                     NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOSIZE |
-                                     NativeMethods.SWP_NOACTIVATE);
+                User32.SetWindowPos(
+                    new HandleRef(this, Handle),
+                    User32.HWND_TOPMOST,
+                    flags: User32.WindowPosition.SWP_NOMOVE | User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOACTIVATE);
 
                 // Setting the max width has the added benefit of enabling multiline tool tips
                 User32.SendMessageW(this, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
@@ -986,25 +986,20 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Processes messages for ownerdraw panels.
         /// </summary>
-        private void WmDrawItem(ref Message m)
+        private unsafe void WmDrawItem(ref Message m)
         {
-            NativeMethods.DRAWITEMSTRUCT dis = (NativeMethods.DRAWITEMSTRUCT)m.GetLParam(typeof(NativeMethods.DRAWITEMSTRUCT));
+            User32.DRAWITEMSTRUCT* dis = (User32.DRAWITEMSTRUCT*)m.LParam;
 
             int length = panels.Count;
-            if (dis.itemID < 0 || dis.itemID >= length)
+            if (dis->itemID < 0 || dis->itemID >= length)
             {
                 Debug.Fail("OwnerDraw item out of range");
             }
 
-            StatusBarPanel panel = (StatusBarPanel)
-                                   panels[dis.itemID];
-
-            Graphics g = Graphics.FromHdcInternal(dis.hDC);
-            Rectangle r = Rectangle.FromLTRB(dis.rcItem.left, dis.rcItem.top, dis.rcItem.right, dis.rcItem.bottom);
-
-            //The itemstate is not defined for a statusbar control
-            OnDrawItem(new StatusBarDrawItemEventArgs(g, Font, r, dis.itemID, DrawItemState.None, panel, ForeColor, BackColor));
-            g.Dispose();
+            // The itemState is not defined for a statusbar control
+            StatusBarPanel panel = (StatusBarPanel)panels[dis->itemID];
+            Graphics g = Graphics.FromHdcInternal(dis->hDC);
+            OnDrawItem(new StatusBarDrawItemEventArgs(g, Font, dis->rcItem, dis->itemID, DrawItemState.None, panel, ForeColor, BackColor));
         }
 
         private void WmNotifyNMClick(NativeMethods.NMHDR note)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -2062,18 +2062,23 @@ namespace System.Windows.Forms
 
         }
 
-        private void WmReflectDrawItem(ref Message m)
+        private unsafe void WmReflectDrawItem(ref Message m)
         {
-            NativeMethods.DRAWITEMSTRUCT dis = (NativeMethods.DRAWITEMSTRUCT)m.GetLParam(typeof(NativeMethods.DRAWITEMSTRUCT));
-            IntPtr oldPal = SetUpPalette(dis.hDC, false /*force*/, false /*realize*/);
-            using (Graphics g = Graphics.FromHdcInternal(dis.hDC))
+            User32.DRAWITEMSTRUCT* dis = (User32.DRAWITEMSTRUCT*)m.LParam;
+            IntPtr oldPal = SetUpPalette(dis->hDC, force: false, realizePalette: false);
+            try
             {
-                OnDrawItem(new DrawItemEventArgs(g, Font, Rectangle.FromLTRB(dis.rcItem.left, dis.rcItem.top, dis.rcItem.right, dis.rcItem.bottom), dis.itemID, (DrawItemState)dis.itemState));
+                using Graphics g = Graphics.FromHdcInternal(dis->hDC);
+                OnDrawItem(new DrawItemEventArgs(g, Font, dis->rcItem, dis->itemID, (DrawItemState)dis->itemState));
             }
-            if (oldPal != IntPtr.Zero)
+            finally
             {
-                SafeNativeMethods.SelectPalette(new HandleRef(null, dis.hDC), new HandleRef(null, oldPal), 0);
+                if (oldPal != IntPtr.Zero)
+                {
+                    Gdi32.SelectPalette(dis->hDC, oldPal, BOOL.FALSE);
+                }
             }
+
             m.Result = (IntPtr)1;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -1384,11 +1384,10 @@ namespace System.Windows.Forms
                 tooltipHwnd = SendMessage(NativeMethods.TCM_GETTOOLTIPS, 0, 0);
                 if (tooltipHwnd != IntPtr.Zero)
                 {
-                    SafeNativeMethods.SetWindowPos(new HandleRef(this, tooltipHwnd),
-                                         NativeMethods.HWND_TOPMOST,
-                                         0, 0, 0, 0,
-                                         NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOSIZE |
-                                         NativeMethods.SWP_NOACTIVATE);
+                    User32.SetWindowPos(
+                        new HandleRef(this, tooltipHwnd),
+                        User32.HWND_TOPMOST,
+                        flags: User32.WindowPosition.SWP_NOMOVE | User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOACTIVATE);
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -1387,7 +1387,7 @@ namespace System.Windows.Forms
                     User32.SetWindowPos(
                         new HandleRef(this, tooltipHwnd),
                         User32.HWND_TOPMOST,
-                        flags: User32.WindowPosition.SWP_NOMOVE | User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOACTIVATE);
+                        flags: User32.WindowPosition.NOMOVE | User32.WindowPosition.NOSIZE | User32.WindowPosition.NOACTIVATE);
                 }
             }
 
@@ -2068,7 +2068,7 @@ namespace System.Windows.Forms
             try
             {
                 using Graphics g = Graphics.FromHdcInternal(dis->hDC);
-                OnDrawItem(new DrawItemEventArgs(g, Font, dis->rcItem, dis->itemID, (DrawItemState)dis->itemState));
+                OnDrawItem(new DrawItemEventArgs(g, Font, dis->rcItem, (int)dis->itemID, (DrawItemState)dis->itemState));
             }
             finally
             {
@@ -2209,7 +2209,7 @@ namespace System.Windows.Forms
                             break;
                         case NativeMethods.TTN_GETDISPINFO:
                             // Setting the max width has the added benefit of enabling Multiline tool tips
-                            User32.SendMessageW(nmhdr.hwndFrom, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
+                            User32.SendMessageW(nmhdr.hwndFrom, User32.WindowMessage.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
                             WmNeedText(ref m);
                             m.Result = (IntPtr)1;
                             return;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Timer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Timer.cs
@@ -225,7 +225,7 @@ namespace System.Windows.Forms
 
                         // Message only windows are cheaper and have fewer issues than
                         // full blown invisible windows.
-                        Parent = (IntPtr)NativeMethods.HWND_MESSAGE
+                        Parent = User32.HWND_MESSAGE
                     };
 
                     CreateHandle(cp);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolBar.cs
@@ -1788,7 +1788,7 @@ namespace System.Windows.Forms
                                     leftTop.Y,
                                     0,
                                     0,
-                                    User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOZORDER | User32.WindowPosition.SWP_NOACTIVATE);
+                                    User32.WindowPosition.NOSIZE | User32.WindowPosition.NOZORDER | User32.WindowPosition.NOACTIVATE);
                                 m.Result = (IntPtr)1;
                                 return;
                             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolBar.cs
@@ -1781,7 +1781,14 @@ namespace System.Windows.Forms
                                     leftTop.X -= (ButtonSize.Width + tooltipWidth + 2);
                                 }
 
-                                SafeNativeMethods.SetWindowPos(new HandleRef(null, note.hwndFrom), NativeMethods.NullHandleRef, leftTop.X, leftTop.Y, 0, 0, NativeMethods.SWP_NOSIZE | NativeMethods.SWP_NOZORDER | NativeMethods.SWP_NOACTIVATE);
+                                User32.SetWindowPos(
+                                    note.hwndFrom,
+                                    User32.HWND_TOP,
+                                    leftTop.X,
+                                    leftTop.Y,
+                                    0,
+                                    0,
+                                    User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOZORDER | User32.WindowPosition.SWP_NOACTIVATE);
                                 m.Result = (IntPtr)1;
                                 return;
                             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
@@ -1104,9 +1104,10 @@ namespace System.Windows.Forms
         {
             if (TopMost)
             {
-                HandleRef topMostFlag = (topMost) ? NativeMethods.HWND_TOPMOST : NativeMethods.HWND_NOTOPMOST;
-                SafeNativeMethods.SetWindowPos(new HandleRef(this, Handle), topMostFlag, 0, 0, 0, 0,
-                                             NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOSIZE | NativeMethods.SWP_NOACTIVATE);
+                User32.SetWindowPos(
+                    new HandleRef(this, Handle),
+                    topMost ? User32.HWND_TOPMOST : User32.HWND_NOTOPMOST,
+                    flags: User32.WindowPosition.SWP_NOMOVE | User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOACTIVATE);
             }
         }
 
@@ -1910,8 +1911,10 @@ namespace System.Windows.Forms
                             }
                             else if (IsHandleCreated && SafeNativeMethods.IsWindowEnabled(new HandleRef(this, Handle)))
                             {
-                                SafeNativeMethods.SetWindowPos(new HandleRef(this, Handle), NativeMethods.HWND_TOP, 0, 0, 0, 0,
-                                                             NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOSIZE | NativeMethods.SWP_NOACTIVATE);
+                                User32.SetWindowPos(
+                                    new HandleRef(this, Handle),
+                                    User32.HWND_TOP,
+                                    flags: User32.WindowPosition.SWP_NOMOVE | User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOACTIVATE);
                             }
                         }
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
@@ -1107,7 +1107,7 @@ namespace System.Windows.Forms
                 User32.SetWindowPos(
                     new HandleRef(this, Handle),
                     topMost ? User32.HWND_TOPMOST : User32.HWND_NOTOPMOST,
-                    flags: User32.WindowPosition.SWP_NOMOVE | User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOACTIVATE);
+                    flags: User32.WindowPosition.NOMOVE | User32.WindowPosition.NOSIZE | User32.WindowPosition.NOACTIVATE);
             }
         }
 
@@ -1914,7 +1914,7 @@ namespace System.Windows.Forms
                                 User32.SetWindowPos(
                                     new HandleRef(this, Handle),
                                     User32.HWND_TOP,
-                                    flags: User32.WindowPosition.SWP_NOMOVE | User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOACTIVATE);
+                                    flags: User32.WindowPosition.NOMOVE | User32.WindowPosition.NOSIZE | User32.WindowPosition.NOACTIVATE);
                             }
                         }
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -113,7 +113,7 @@ namespace System.Windows.Forms
                     // Don't activate the tooltip if we're in the designer.
                     if (!DesignMode && GetHandleCreated())
                     {
-                        User32.SendMessageW(this, WindowMessages.TTM_ACTIVATE, PARAM.FromBool(value));
+                        User32.SendMessageW(this, User32.WindowMessage.TTM_ACTIVATE, PARAM.FromBool(value));
                     }
                 }
             }
@@ -182,7 +182,7 @@ namespace System.Windows.Forms
                 _backColor = value;
                 if (GetHandleCreated())
                 {
-                    User32.SendMessageW(this, WindowMessages.TTM_SETTIPBKCOLOR, PARAM.FromColor(_backColor));
+                    User32.SendMessageW(this, User32.WindowMessage.TTM_SETTIPBKCOLOR, PARAM.FromColor(_backColor));
                 }
             }
         }
@@ -245,7 +245,7 @@ namespace System.Windows.Forms
                 _foreColor = value;
                 if (GetHandleCreated())
                 {
-                    User32.SendMessageW(this, WindowMessages.TTM_SETTIPTEXTCOLOR, PARAM.FromColor(_foreColor));
+                    User32.SendMessageW(this, User32.WindowMessage.TTM_SETTIPTEXTCOLOR, PARAM.FromColor(_foreColor));
                 }
             }
         }
@@ -433,11 +433,11 @@ namespace System.Windows.Forms
                     {
                         // If the title is null/empty, the icon won't display.
                         string title = !string.IsNullOrEmpty(_toolTipTitle) ? _toolTipTitle : " ";
-                        User32.SendMessageW(this, WindowMessages.TTM_SETTITLEW, (IntPtr)_toolTipIcon, title);
+                        User32.SendMessageW(this, User32.WindowMessage.TTM_SETTITLEW, (IntPtr)_toolTipIcon, title);
 
                         // Tooltip need to be updated to reflect the changes in the icon because
                         // this operation directly affects the size of the tooltip
-                        User32.SendMessageW(this, WindowMessages.TTM_UPDATE);
+                        User32.SendMessageW(this, User32.WindowMessage.TTM_UPDATE);
                     }
                 }
             }
@@ -463,11 +463,11 @@ namespace System.Windows.Forms
                     _toolTipTitle = value;
                     if (GetHandleCreated())
                     {
-                        User32.SendMessageW(this, WindowMessages.TTM_SETTITLEW, (IntPtr)_toolTipIcon, _toolTipTitle);
+                        User32.SendMessageW(this, User32.WindowMessage.TTM_SETTITLEW, (IntPtr)_toolTipIcon, _toolTipTitle);
 
                         // Tooltip need to be updated to reflect the changes in the titletext because
                         // this operation directly affects the size of the tooltip
-                        User32.SendMessageW(this, WindowMessages.TTM_UPDATE);
+                        User32.SendMessageW(this, User32.WindowMessage.TTM_UPDATE);
                     }
                 }
             }
@@ -769,7 +769,7 @@ namespace System.Windows.Forms
             }
 
             // Setting the max width has the added benefit of enabling multiline tool tips.
-            User32.SendMessageW(this, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
+            User32.SendMessageW(this, User32.WindowMessage.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
 
             if (_auto)
             {
@@ -790,21 +790,21 @@ namespace System.Windows.Forms
             }
 
             // Set active status
-            User32.SendMessageW(this, WindowMessages.TTM_ACTIVATE, PARAM.FromBool(active));
+            User32.SendMessageW(this, User32.WindowMessage.TTM_ACTIVATE, PARAM.FromBool(active));
 
             if (BackColor != SystemColors.Info)
             {
-                User32.SendMessageW(this, WindowMessages.TTM_SETTIPBKCOLOR, PARAM.FromColor(BackColor));
+                User32.SendMessageW(this, User32.WindowMessage.TTM_SETTIPBKCOLOR, PARAM.FromColor(BackColor));
             }
             if (ForeColor != SystemColors.InfoText)
             {
-                User32.SendMessageW(this, WindowMessages.TTM_SETTIPTEXTCOLOR, PARAM.FromColor(ForeColor));
+                User32.SendMessageW(this, User32.WindowMessage.TTM_SETTIPTEXTCOLOR, PARAM.FromColor(ForeColor));
             }
             if (_toolTipIcon > 0 || !string.IsNullOrEmpty(_toolTipTitle))
             {
                 // If the title is null/empty, the icon won't display.
                 string title = !string.IsNullOrEmpty(_toolTipTitle) ? _toolTipTitle : " ";
-                User32.SendMessageW(this, WindowMessages.TTM_SETTITLEW, (IntPtr)_toolTipIcon, title);
+                User32.SendMessageW(this, User32.WindowMessage.TTM_SETTITLEW, (IntPtr)_toolTipIcon, title);
             }
         }
 
@@ -842,7 +842,7 @@ namespace System.Windows.Forms
 
         private void SetToolInfo(Control ctl, string caption)
         {
-            IntPtr result = GetTOOLINFO(ctl, caption).SendMessage(this, WindowMessages.TTM_ADDTOOLW);
+            IntPtr result = GetTOOLINFO(ctl, caption).SendMessage(this, User32.WindowMessage.TTM_ADDTOOLW);
 
             if ((ctl is TreeView tv && tv.ShowNodeToolTips)
                 || (ctl is ListView lv && lv.ShowItemToolTips))
@@ -920,7 +920,7 @@ namespace System.Windows.Forms
 
             if (_created.ContainsKey(ctl) && handlesCreated && !DesignMode)
             {
-                new ComCtl32.ToolInfoWrapper(ctl).SendMessage(this, WindowMessages.TTM_DELTOOLW);
+                new ComCtl32.ToolInfoWrapper(ctl).SendMessage(this, User32.WindowMessage.TTM_DELTOOLW);
                 _created.Remove(ctl);
             }
         }
@@ -970,7 +970,7 @@ namespace System.Windows.Forms
                 return _delayTimes[(int)type];
             }
 
-            return (int)(long)User32.SendMessageW(this, WindowMessages.TTM_GETDELAYTIME, (IntPtr)type);
+            return (int)(long)User32.SendMessageW(this, User32.WindowMessage.TTM_GETDELAYTIME, (IntPtr)type);
         }
 
         internal bool GetHandleCreated() => _window != null && _window.Handle != IntPtr.Zero;
@@ -1191,7 +1191,7 @@ namespace System.Windows.Forms
 
             if (GetHandleCreated() && time >= 0)
             {
-                User32.SendMessageW(this, WindowMessages.TTM_SETDELAYTIME, (IntPtr)type, (IntPtr)time);
+                User32.SendMessageW(this, User32.WindowMessage.TTM_SETDELAYTIME, (IntPtr)type, (IntPtr)time);
 
                 // Update everyone else if automatic is set. we need to do this
                 // to preserve value in case of handle recreation.
@@ -1257,7 +1257,7 @@ namespace System.Windows.Forms
                 if (exists && !empty && handlesCreated && !DesignMode)
                 {
                     ComCtl32.ToolInfoWrapper toolInfo = GetTOOLINFO(control, info.Caption);
-                    toolInfo.SendMessage(this, WindowMessages.TTM_SETTOOLINFOW);
+                    toolInfo.SendMessage(this, User32.WindowMessage.TTM_SETTOOLINFOW);
                     CheckNativeToolTip(control);
                     CheckCompositeControls(control);
                 }
@@ -1545,7 +1545,7 @@ namespace System.Windows.Forms
             // size will AV if there isn't a current tool window.
 
             IntPtr result = GetCurrentToolHwnd() == IntPtr.Zero ? IntPtr.Zero
-                 : new ComCtl32.ToolInfoWrapper(tool.GetOwnerWindow()).SendMessage(this, WindowMessages.TTM_GETBUBBLESIZE);
+                 : new ComCtl32.ToolInfoWrapper(tool.GetOwnerWindow()).SendMessage(this, User32.WindowMessage.TTM_GETBUBBLESIZE);
 
             if (result == IntPtr.Zero)
             {
@@ -1714,7 +1714,7 @@ namespace System.Windows.Forms
             try
             {
                 _trackPosition = true;
-                User32.SendMessageW(this, WindowMessages.TTM_TRACKPOSITION, IntPtr.Zero, PARAM.FromLowHigh(pointX, pointY));
+                User32.SendMessageW(this, User32.WindowMessage.TTM_TRACKPOSITION, IntPtr.Zero, PARAM.FromLowHigh(pointX, pointY));
             }
             finally
             {
@@ -1740,8 +1740,8 @@ namespace System.Windows.Forms
             if (GetHandleCreated())
             {
                 var info = new ComCtl32.ToolInfoWrapper(win);
-                info.SendMessage(this, WindowMessages.TTM_TRACKACTIVATE);
-                info.SendMessage(this, WindowMessages.TTM_DELTOOLW);
+                info.SendMessage(this, User32.WindowMessage.TTM_TRACKACTIVATE);
+                info.SendMessage(this, User32.WindowMessage.TTM_DELTOOLW);
             }
             StopTimer();
 
@@ -1797,7 +1797,7 @@ namespace System.Windows.Forms
             if (tool != null && _tools.ContainsKey(tool))
             {
                 var toolInfo = new ComCtl32.ToolInfoWrapper(tool);
-                if (toolInfo.SendMessage(this, WindowMessages.TTM_GETTOOLINFOW) != IntPtr.Zero)
+                if (toolInfo.SendMessage(this, User32.WindowMessage.TTM_GETTOOLINFOW) != IntPtr.Zero)
                 {
                     ComCtl32.TTF flags = ComCtl32.TTF.TRACK;
                     if (type == TipInfo.Type.Absolute || type == TipInfo.Type.SemiAbsolute)
@@ -1821,8 +1821,8 @@ namespace System.Windows.Forms
                 tt.Position = position;
                 _tools[tool] = tt;
 
-                IntPtr result = toolInfo.SendMessage(this, WindowMessages.TTM_SETTOOLINFOW);
-                result = toolInfo.SendMessage(this, WindowMessages.TTM_TRACKACTIVATE, BOOL.TRUE);
+                IntPtr result = toolInfo.SendMessage(this, User32.WindowMessage.TTM_SETTOOLINFOW);
+                result = toolInfo.SendMessage(this, User32.WindowMessage.TTM_TRACKACTIVATE, BOOL.TRUE);
             }
             else
             {
@@ -1856,8 +1856,8 @@ namespace System.Windows.Forms
                 }
 
                 toolInfo.Text = text;
-                IntPtr result = toolInfo.SendMessage(this, WindowMessages.TTM_ADDTOOLW);
-                result = toolInfo.SendMessage(this, WindowMessages.TTM_TRACKACTIVATE, BOOL.TRUE);
+                IntPtr result = toolInfo.SendMessage(this, User32.WindowMessage.TTM_ADDTOOLW);
+                result = toolInfo.SendMessage(this, User32.WindowMessage.TTM_TRACKACTIVATE, BOOL.TRUE);
             }
 
             if (tool != null)
@@ -1952,13 +1952,13 @@ namespace System.Windows.Forms
                 moveToLocation.Y,
                 tipSize.Width,
                 tipSize.Height,
-                User32.WindowPosition.SWP_NOACTIVATE | User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOOWNERZORDER);
+                User32.WindowPosition.NOACTIVATE | User32.WindowPosition.NOSIZE | User32.WindowPosition.NOOWNERZORDER);
         }
 
         private IntPtr GetCurrentToolHwnd()
         {
             var toolInfo = new ComCtl32.ToolInfoWrapper();
-            if (toolInfo.SendMessage(this, WindowMessages.TTM_GETCURRENTTOOLW) != IntPtr.Zero)
+            if (toolInfo.SendMessage(this, User32.WindowMessage.TTM_GETCURRENTTOOLW) != IntPtr.Zero)
             {
                 return toolInfo.Info.hwnd;
             }
@@ -2074,7 +2074,7 @@ namespace System.Windows.Forms
             if (IsBalloon)
             {
                 // Get the text display rectangle
-                User32.SendMessageW(this, WindowMessages.TTM_ADJUSTRECT, PARAM.FromBool(true), r);
+                User32.SendMessageW(this, User32.WindowMessage.TTM_ADJUSTRECT, PARAM.FromBool(true), ref r);
                 if (r.Size.Height > currentTooltipSize.Height)
                 {
                     currentTooltipSize.Height = r.Size.Height;
@@ -2091,7 +2091,7 @@ namespace System.Windows.Forms
                 int maxwidth = (IsBalloon)
                     ? Math.Min(currentTooltipSize.Width - 2 * BalloonOffsetX, screen.WorkingArea.Width)
                     : Math.Min(currentTooltipSize.Width, screen.WorkingArea.Width);
-                User32.SendMessageW(this, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)maxwidth);
+                User32.SendMessageW(this, User32.WindowMessage.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)maxwidth);
             }
 
             if (e.Cancel)
@@ -2100,7 +2100,7 @@ namespace System.Windows.Forms
                 User32.SetWindowPos(
                     new HandleRef(this, Handle),
                     User32.HWND_TOPMOST,
-                    flags: User32.WindowPosition.SWP_NOACTIVATE | User32.WindowPosition.SWP_NOOWNERZORDER);
+                    flags: User32.WindowPosition.NOACTIVATE | User32.WindowPosition.NOOWNERZORDER);
             }
             else
             {
@@ -2114,7 +2114,7 @@ namespace System.Windows.Forms
                     r.top,
                     currentTooltipSize.Width,
                     currentTooltipSize.Height,
-                    User32.WindowPosition.SWP_NOACTIVATE | User32.WindowPosition.SWP_NOOWNERZORDER);
+                    User32.WindowPosition.NOACTIVATE | User32.WindowPosition.NOOWNERZORDER);
             }
         }
 
@@ -2247,7 +2247,7 @@ namespace System.Windows.Forms
             if ((tt.TipType & TipInfo.Type.Auto) != 0 || (tt.TipType & TipInfo.Type.SemiAbsolute) != 0)
             {
                 Screen screen = Screen.FromPoint(Cursor.Position);
-                User32.SendMessageW(this, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)screen.WorkingArea.Width);
+                User32.SendMessageW(this, User32.WindowMessage.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)screen.WorkingArea.Width);
             }
 
             // For non-auto tips (those showned through the show(.) methods, we need to
@@ -2315,7 +2315,7 @@ namespace System.Windows.Forms
                     WmMove();
                     break;
 
-                case (int)WindowMessages.TTM_WINDOWFROMPOINT:
+                case (int)User32.WindowMessage.TTM_WINDOWFROMPOINT:
                     WmWindowFromPoint(ref msg);
                     break;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -1945,10 +1945,14 @@ namespace System.Windows.Forms
                 moveToLocation.Y = screen.WorkingArea.Bottom - tipSize.Height;
             }
 
-            SafeNativeMethods.SetWindowPos(new HandleRef(this, Handle),
-            NativeMethods.HWND_TOPMOST,
-            moveToLocation.X, moveToLocation.Y, tipSize.Width, tipSize.Height,
-            NativeMethods.SWP_NOACTIVATE | NativeMethods.SWP_NOSIZE | NativeMethods.SWP_NOOWNERZORDER);
+            User32.SetWindowPos(
+                new HandleRef(this, Handle),
+                User32.HWND_TOPMOST,
+                moveToLocation.X,
+                moveToLocation.Y,
+                tipSize.Width,
+                tipSize.Height,
+                User32.WindowPosition.SWP_NOACTIVATE | User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOOWNERZORDER);
         }
 
         private IntPtr GetCurrentToolHwnd()
@@ -2093,23 +2097,24 @@ namespace System.Windows.Forms
             if (e.Cancel)
             {
                 _cancelled = true;
-                SafeNativeMethods.SetWindowPos(
+                User32.SetWindowPos(
                     new HandleRef(this, Handle),
-                    NativeMethods.HWND_TOPMOST,
-                    0, 0, 0, 0,
-                    NativeMethods.SWP_NOACTIVATE | NativeMethods.SWP_NOOWNERZORDER);
-
+                    User32.HWND_TOPMOST,
+                    flags: User32.WindowPosition.SWP_NOACTIVATE | User32.WindowPosition.SWP_NOOWNERZORDER);
             }
             else
             {
                 _cancelled = false;
 
                 // Only width/height changes are respected, so set top,left to what we got earlier
-                SafeNativeMethods.SetWindowPos(
+                User32.SetWindowPos(
                     new HandleRef(this, Handle),
-                    NativeMethods.HWND_TOPMOST,
-                    r.left, r.top, currentTooltipSize.Width, currentTooltipSize.Height,
-                    NativeMethods.SWP_NOACTIVATE | NativeMethods.SWP_NOOWNERZORDER);
+                    User32.HWND_TOPMOST,
+                    r.left,
+                    r.top,
+                    currentTooltipSize.Width,
+                    currentTooltipSize.Height,
+                    User32.WindowPosition.SWP_NOACTIVATE | User32.WindowPosition.SWP_NOOWNERZORDER);
             }
         }
 
@@ -2139,7 +2144,7 @@ namespace System.Windows.Forms
                 return;
             }
 
-            NativeMethods.WINDOWPOS* wp = (NativeMethods.WINDOWPOS*)m.LParam;
+            User32.WINDOWPOS* wp = (User32.WINDOWPOS*)m.LParam;
 
             Cursor currentCursor = Cursor.Current;
             Point cursorPos = Cursor.Position;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -2070,14 +2070,28 @@ namespace System.Windows.Forms
 
                 treeViewState[TREEVIEWSTATE_stopResizeWindowMsgs] = true;
                 oldSize = Width;
-                int flags = NativeMethods.SWP_NOZORDER | NativeMethods.SWP_NOACTIVATE | NativeMethods.SWP_NOMOVE;
-                SafeNativeMethods.SetWindowPos(new HandleRef(this, Handle), NativeMethods.NullHandleRef, Left, Top, int.MaxValue, Height, flags);
+                User32.WindowPosition flags = User32.WindowPosition.SWP_NOZORDER | User32.WindowPosition.SWP_NOACTIVATE | User32.WindowPosition.SWP_NOMOVE;
+                User32.SetWindowPos(
+                    new HandleRef(this, Handle),
+                    User32.HWND_TOP,
+                    Left,
+                    Top,
+                    int.MaxValue,
+                    Height,
+                    flags);
 
                 root.Realize(false);
 
                 if (oldSize != 0)
                 {
-                    SafeNativeMethods.SetWindowPos(new HandleRef(this, Handle), NativeMethods.NullHandleRef, Left, Top, oldSize, Height, flags);
+                    User32.SetWindowPos(
+                        new HandleRef(this, Handle),
+                        User32.HWND_TOP,
+                        Left,
+                        Top,
+                        oldSize,
+                        Height,
+                        flags);
                 }
             }
             finally
@@ -2983,8 +2997,14 @@ namespace System.Windows.Forms
                         bounds.Location = PointToScreen(bounds.Location);
 
                         User32.SendMessageW(tooltipHandle, WindowMessages.TTM_ADJUSTRECT, PARAM.FromBool(true), bounds);
-                        SafeNativeMethods.SetWindowPos(new HandleRef(this, tooltipHandle),
-                                NativeMethods.HWND_TOPMOST, bounds.Left, bounds.Top, 0, 0, NativeMethods.SWP_NOACTIVATE | NativeMethods.SWP_NOSIZE | NativeMethods.SWP_NOZORDER);
+                        User32.SetWindowPos(
+                            new HandleRef(this, tooltipHandle),
+                            User32.HWND_TOPMOST,
+                            bounds.Left,
+                            bounds.Top,
+                            0,
+                            0,
+                            User32.WindowPosition.SWP_NOACTIVATE | User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOZORDER);
                         return true;
                     }
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -1775,7 +1775,7 @@ namespace System.Windows.Forms
         {
             if (toolTip != null)
             {
-                User32.SendMessageW(toolTip, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
+                User32.SendMessageW(toolTip, User32.WindowMessage.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
                 UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TVM_SETTOOLTIPS, new HandleRef(toolTip, toolTip.Handle), 0);
                 controlToolTipText = toolTipText;
             }
@@ -2070,7 +2070,7 @@ namespace System.Windows.Forms
 
                 treeViewState[TREEVIEWSTATE_stopResizeWindowMsgs] = true;
                 oldSize = Width;
-                User32.WindowPosition flags = User32.WindowPosition.SWP_NOZORDER | User32.WindowPosition.SWP_NOACTIVATE | User32.WindowPosition.SWP_NOMOVE;
+                User32.WindowPosition flags = User32.WindowPosition.NOZORDER | User32.WindowPosition.NOACTIVATE | User32.WindowPosition.NOMOVE;
                 User32.SetWindowPos(
                     new HandleRef(this, Handle),
                     User32.HWND_TOP,
@@ -2996,7 +2996,7 @@ namespace System.Windows.Forms
                         Rectangle bounds = tn.Bounds;
                         bounds.Location = PointToScreen(bounds.Location);
 
-                        User32.SendMessageW(tooltipHandle, WindowMessages.TTM_ADJUSTRECT, PARAM.FromBool(true), bounds);
+                        User32.SendMessageW(tooltipHandle, User32.WindowMessage.TTM_ADJUSTRECT, PARAM.FromBool(true), ref bounds);
                         User32.SetWindowPos(
                             new HandleRef(this, tooltipHandle),
                             User32.HWND_TOPMOST,
@@ -3004,7 +3004,7 @@ namespace System.Windows.Forms
                             bounds.Top,
                             0,
                             0,
-                            User32.WindowPosition.SWP_NOACTIVATE | User32.WindowPosition.SWP_NOSIZE | User32.WindowPosition.SWP_NOZORDER);
+                            User32.WindowPosition.NOACTIVATE | User32.WindowPosition.NOSIZE | User32.WindowPosition.NOZORDER);
                         return true;
                     }
                 }
@@ -3281,7 +3281,7 @@ namespace System.Windows.Forms
                     {
                         case NativeMethods.TTN_GETDISPINFO:
                             // Setting the max width has the added benefit of enabling multiline tool tips
-                            User32.SendMessageW(nmhdr.hwndFrom, WindowMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
+                            User32.SendMessageW(nmhdr.hwndFrom, User32.WindowMessage.TTM_SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
                             WmNeedText(ref m);
                             m.Result = (IntPtr)1;
                             return;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
@@ -1864,7 +1864,7 @@ namespace System.Windows.Forms
 
             private unsafe void WmWindowPosChanging(ref Message m)
             {
-                NativeMethods.WINDOWPOS* wp = (NativeMethods.WINDOWPOS*)m.LParam;
+                User32.WINDOWPOS* wp = (User32.WINDOWPOS*)m.LParam;
                 wp->x = 0;
                 wp->y = 0;
                 Size s = WebBrowserBase.webBrowserBaseChangingSize;


### PR DESCRIPTION
## Proposed changes

- Use structs instead of classes
- Avoid allocating HGlobals and prefer pointers
- Consolidate common code

## Customer Impact

- Fewer allocations
- Code size reductions

## Regression? 

- No

## Risk

- Medium

## Test methodology <!-- How did you ensure quality? -->

- Existing tests

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1741)