### PR TITLE
fix: RichTextBox `LinkClicked` event for "friendly named" hyperlinks

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -3481,21 +3481,22 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Converts a CHARRANGE to a string. Note: The behavior of this is dependent on the current window
-        ///  class name being used. We have to create a CharBuffer of the type of RichTextBox DLL we're using,
-        ///  not based on the SystemCharWidth.
+        ///  Converts a CHARRANGE to a string.
         /// </summary>
+        /// <remarks>
+        ///  The behavior of this is dependent on the current window class name being used. 
+        ///  We have to create a CharBuffer of the type of RichTextBox DLL we're using,
+        ///  not based on the SystemCharWidth.
+        /// </remarks>
         private string CharRangeToString(Richedit.CHARRANGE c)
         {
             NativeMethods.TEXTRANGE txrg = new NativeMethods.TEXTRANGE
             {
                 chrg = c
             };
+
             Debug.Assert((c.cpMax - c.cpMin) > 0, "CHARRANGE was null or negative - can't do it!");
-
-            //Windows
-
-            if (c.cpMax > Text.Length || c.cpMax - c.cpMin <= 0)
+            if (c.cpMax - c.cpMin <= 0)
             {
                 return string.Empty;
             }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinFormsControlsClassicTests/WinFormsControlsClassicTests.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinFormsControlsClassicTests/WinFormsControlsClassicTests.csproj
@@ -308,6 +308,10 @@
       <Link>PropertyGrid.resx</Link>
       <DependentUpon>PropertyGrid.cs</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="..\WinformsControlsTest\RichTextBoxes.resx">
+      <Link>RichTextBoxes.resx</Link>
+      <DependentUpon>RichTextBoxes.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="..\WinformsControlsTest\ScalingBeforeChanges.resx">
       <Link>ScalingBeforeChanges.resx</Link>
       <DependentUpon>ScalingBeforeChanges.cs</DependentUpon>

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/RichTextBoxes.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/RichTextBoxes.Designer.cs
@@ -33,25 +33,37 @@ namespace WinformsControlsTest
         private void InitializeComponent()
         {
             this.richTextBox1 = new System.Windows.Forms.RichTextBox();
+            this.richTextBox2 = new System.Windows.Forms.RichTextBox();
             this.SuspendLayout();
             // 
             // richTextBox1
             // 
-            this.richTextBox1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.richTextBox1.Location = new System.Drawing.Point(12, 12);
+            this.richTextBox1.Dock = System.Windows.Forms.DockStyle.Top;
+            this.richTextBox1.Location = new System.Drawing.Point(0, 0);
             this.richTextBox1.Name = "richTextBox1";
-            this.richTextBox1.Size = new System.Drawing.Size(396, 144);
+            this.richTextBox1.Size = new System.Drawing.Size(455, 104);
             this.richTextBox1.TabIndex = 0;
             this.richTextBox1.Text = "";
-            this.richTextBox1.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.RichTextBox1_LinkClicked);
+            this.richTextBox1.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.richTextBox1_LinkClicked);
             // 
-            // Form2
+            // richTextBox2
+            // 
+            this.richTextBox2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.richTextBox2.Location = new System.Drawing.Point(0, 104);
+            this.richTextBox2.Name = "richTextBox2";
+            this.richTextBox2.Size = new System.Drawing.Size(455, 99);
+            this.richTextBox2.TabIndex = 1;
+            this.richTextBox2.Text = "";
+            this.richTextBox2.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.richTextBox2_LinkClicked);
+            // 
+            // RichTextBoxes
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(455, 203);
+            this.Controls.Add(this.richTextBox2);
             this.Controls.Add(this.richTextBox1);
-            this.Name = "Form2";
+            this.Name = "RichTextBoxes";
             this.Text = "Form2";
             this.ResumeLayout(false);
 
@@ -60,5 +72,6 @@ namespace WinformsControlsTest
         #endregion
 
         private System.Windows.Forms.RichTextBox richTextBox1;
+        private System.Windows.Forms.RichTextBox richTextBox2;
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/RichTextBoxes.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/RichTextBoxes.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.IO;
 using System.Windows.Forms;
 
@@ -14,10 +15,24 @@ namespace WinformsControlsTest
             InitializeComponent();
 
             richTextBox1.LoadFile(File.OpenRead(@"Data\example.rtf"), RichTextBoxStreamType.RichText);
-
+            Load += Form1_Load;
         }
 
-        private void RichTextBox1_LinkClicked(object sender, LinkClickedEventArgs e)
+        private void Form1_Load(object sender, EventArgs e)
+        {
+            richTextBox2.Rtf = @"{\rtf1\ansi\ansicpg1252\deff0\nouicompat\deflang4105{\fonttbl{\f0\fnil\fcharset0 Calibri;}}
+{\*\generator Riched20 10.0.17134}\viewkind4\uc1 
+{\field{\*\fldinst { HYPERLINK ""http://www.google.com"" }}{\fldrslt {Click here}}}
+\pard\sa200\sl276\slmult1\f0\fs22\lang9  for more information.\par
+}";
+        }
+      
+        private void richTextBox1_LinkClicked(object sender, LinkClickedEventArgs e)
+        {
+            MessageBox.Show(this, e.LinkText, "link clicked");
+        }
+
+        private void richTextBox2_LinkClicked(object sender, LinkClickedEventArgs e)
         {
             MessageBox.Show(this, e.LinkText, "link clicked");
         }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/RichTextBoxes.resx
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/RichTextBoxes.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.cs.xlf
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.cs.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../RichTextBoxes.resx">
+    <body />
+  </file>
+</xliff>

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.de.xlf
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.de.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../RichTextBoxes.resx">
+    <body />
+  </file>
+</xliff>

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.es.xlf
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.es.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../RichTextBoxes.resx">
+    <body />
+  </file>
+</xliff>

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.fr.xlf
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.fr.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../RichTextBoxes.resx">
+    <body />
+  </file>
+</xliff>

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.it.xlf
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.it.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../RichTextBoxes.resx">
+    <body />
+  </file>
+</xliff>

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.ja.xlf
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.ja.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../RichTextBoxes.resx">
+    <body />
+  </file>
+</xliff>

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.ko.xlf
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.ko.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../RichTextBoxes.resx">
+    <body />
+  </file>
+</xliff>

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.pl.xlf
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.pl.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../RichTextBoxes.resx">
+    <body />
+  </file>
+</xliff>

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.pt-BR.xlf
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.pt-BR.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../RichTextBoxes.resx">
+    <body />
+  </file>
+</xliff>

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.ru.xlf
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.ru.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../RichTextBoxes.resx">
+    <body />
+  </file>
+</xliff>

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.tr.xlf
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.tr.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../RichTextBoxes.resx">
+    <body />
+  </file>
+</xliff>

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.zh-Hans.xlf
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.zh-Hans.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../RichTextBoxes.resx">
+    <body />
+  </file>
+</xliff>

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.zh-Hant.xlf
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/xlf/RichTextBoxes.zh-Hant.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../RichTextBoxes.resx">
+    <body />
+  </file>
+</xliff>


### PR DESCRIPTION




<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1631
Relates to #1139


## Proposed changes

The newer RichEdit controls (v4.1+) in specific cases had troubles detecting "friendly named" hyperlinks as the `Text` property was reportig less characters than the rage of the actual hyperlink.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- "friendly named" hyperlinks raise `LinkClicked` events in RichEdit v4.1+.

## Regression? 

- Yes

## Risk

- Low

<!-- end TELL-MODE -->




## Test methodology <!-- How did you ensure quality? -->

- manual


 

## Test environment(s) <!-- Remove any that don't apply -->

- <!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1745)