### PR TITLE
Fix issue 1746 - Screen reader is not announcing change in expanded/collapsed state of PropertyGrid Category item

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/CategoryGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/CategoryGridEntry.cs
@@ -311,6 +311,19 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return base.FragmentNavigate(direction);
             }
 
+            internal override object GetPropertyValue(int propertyID)
+            {
+                switch (propertyID)
+                {
+                    case NativeMethods.UIA_ControlTypePropertyId:
+                        // To announce expanded collapsed state control type should be appropriate:
+                        // https://docs.microsoft.com/en-us/windows/win32/winauto/uiauto-controlpatternmapping
+                        return NativeMethods.UIA_TreeItemControlTypeId;
+                }
+
+                return base.GetPropertyValue(propertyID);
+            }
+
             public override AccessibleRole Role
             {
                 get

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
@@ -3227,17 +3227,14 @@ namespace System.Windows.Forms.PropertyGridInternal
                     case NativeMethods.UIA_NamePropertyId:
                         return Name;
                     case NativeMethods.UIA_ControlTypePropertyId:
+
                         // The accessible hierarchy is changed so we cannot use Button type
                         // for the grid items to not break automation logic that searches for the first
                         // button in the PropertyGridView to show dialog/drop-down. In Level < 3 action
                         // button is one of the first children of PropertyGridView.
-                        return NativeMethods.UIA_DataItemControlTypeId;
+                        return NativeMethods.UIA_TreeItemControlTypeId;
                     case NativeMethods.UIA_IsExpandCollapsePatternAvailablePropertyId:
                         return (Object)IsPatternSupported(NativeMethods.UIA_ExpandCollapsePatternId);
-                }
-
-                switch (propertyID)
-                {
                     case NativeMethods.UIA_AccessKeyPropertyId:
                         return string.Empty;
                     case NativeMethods.UIA_HasKeyboardFocusPropertyId:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -5333,6 +5333,14 @@ namespace System.Windows.Forms.PropertyGridInternal
                 int items = totalProps;
 
                 gridEntry.InternalExpanded = value;
+
+                var oldExpandedState = value ? UnsafeNativeMethods.ExpandCollapseState.Collapsed : UnsafeNativeMethods.ExpandCollapseState.Expanded;
+                var newExpandedState = value ? UnsafeNativeMethods.ExpandCollapseState.Expanded : UnsafeNativeMethods.ExpandCollapseState.Collapsed;
+                selectedGridEntry?.AccessibilityObject?.RaiseAutomationPropertyChangedEvent(
+                    NativeMethods.UIA_ExpandCollapseExpandCollapseStatePropertyId,
+                    oldExpandedState,
+                    newExpandedState);
+
                 RecalculateProps();
                 GridEntry ipeSelect = selectedGridEntry;
                 if (!value)


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1746


## Proposed changes

- Adding triggering ScreenReader announcement by raising UIA property changed event for ExpandedCollapsed automation property.
- Changed accessibility control type of Category items to TreeItem to allow announcement (as DataItem control type does not support ExpandCollapse property announcement: https://docs.microsoft.com/en-us/windows/win32/winauto/uiauto-controlpatternmapping 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Screen reader users will get to know that if PropertyGrid Category item is expanded or collapsed.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![PropertyGrid_Category_Expand_collapse](https://user-images.githubusercontent.com/23213980/64197949-f3f3d800-ce8f-11e9-9ca5-f56d4be5dd6d.gif)


### After

![image](https://user-images.githubusercontent.com/23213980/64194607-416c4700-ce88-11e9-8a6c-25153e0b5202.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual testing. Verified using Screen Reader apps.
- Unit tests implemented.
- QA verified.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

.NET Core SDK (reflecting any global.json):
 Version:   3.0.100-preview8-012929
 Commit:    795f8aeaa8

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.18362
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\3.0.100-preview8-012929\

Host (useful for support):
  Version: 3.0.0-preview8-27907-09
  Commit:  fc924dc319

.NET Core SDKs installed:
  2.1.801 [C:\Program Files\dotnet\sdk]
  3.0.100-preview8-012929 [C:\Program Files\dotnet\sdk]

.NET Core runtimes installed:
  Microsoft.AspNetCore.All 2.1.12 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.All]
  Microsoft.AspNetCore.App 2.1.12 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.AspNetCore.App 3.0.0-preview8.19351.9 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 2.1.12 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 3.0.0-preview8-27907-09 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.WindowsDesktop.App 3.0.0-preview8-27907-09 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1747)