### PR TITLE
Use Dictionary in NativeWindow

### DIFF
--- a/src/Common/src/Interop/User32/Interop.SetClassLong.cs
+++ b/src/Common/src/Interop/User32/Interop.SetClassLong.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        // We only ever call this on 32 bit so IntPtr is correct
+        [DllImport(ExternDll.User32, ExactSpelling = true)]
+        private static extern IntPtr SetClassLongW(IntPtr hwnd, GCL nIndex, IntPtr dwNewLong);
+
+        [DllImport(ExternDll.User32, ExactSpelling = true)]
+        private static extern IntPtr SetClassLongPtrW(IntPtr hwnd, GCL nIndex, IntPtr dwNewLong);
+
+        public static IntPtr SetClassLong(IntPtr hWnd, GCL nIndex, IntPtr dwNewLong)
+        {
+            if (IntPtr.Size == 4)
+            {
+                return SetClassLongW(hWnd, nIndex, dwNewLong);
+            }
+            return SetClassLongPtrW(hWnd, nIndex, dwNewLong);
+        }
+
+        public enum GCL : int
+        {
+            WNDPROC = -24
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.SetWindowLong.cs
+++ b/src/Common/src/Interop/User32/Interop.SetWindowLong.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        // We only ever call this on 32 bit so IntPtr is correct
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        private static extern IntPtr SetWindowLongW(IntPtr hWnd, GWL nIndex, IntPtr dwNewLong);
+
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern IntPtr SetWindowLongPtrW(IntPtr hWnd, GWL nIndex, IntPtr dwNewLong);
+
+        public static IntPtr SetWindowLong(IntPtr hWnd, GWL nIndex, IntPtr dwNewLong)
+        {
+            if (IntPtr.Size == 4)
+            {
+                return SetWindowLongW(hWnd, nIndex, dwNewLong);
+            }
+            return SetWindowLongPtrW(hWnd, nIndex, dwNewLong);
+        }
+
+        public static IntPtr SetWindowLong(IHandle hWnd, GWL nIndex, IntPtr dwNewLong)
+        {
+            IntPtr result = SetWindowLong(hWnd.Handle, nIndex, dwNewLong);
+            GC.KeepAlive(hWnd);
+            return result;
+        }
+
+        public enum GWL : int
+        {
+            WNDPROC = (-4),
+            HWNDPARENT = (-8),
+            STYLE = (-16),
+            EXSTYLE = (-20),
+            ID = (-12),
+        }
+    }
+}

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -751,8 +751,10 @@ namespace System.Windows.Forms
         public static extern bool PeekMessage([In, Out] ref NativeMethods.MSG msg, HandleRef hwnd, int msgMin, int msgMax, int remove);
 
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-
         public static extern bool PostMessage(HandleRef hwnd, int msg, IntPtr wparam, IntPtr lparam);
+
+        [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
+        public static extern bool PostMessage(IntPtr hwnd, int msg, IntPtr wparam, IntPtr lparam);
 
         [DllImport(ExternDll.Oleacc, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern IntPtr LresultFromObject(ref Guid refiid, IntPtr wParam, HandleRef pAcc);

--- a/src/Common/tests/NoAssertContext.cs
+++ b/src/Common/tests/NoAssertContext.cs
@@ -1,0 +1,111 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+
+namespace System
+{
+    /// <summary>
+    ///  Use (within a using) to eat asserts.
+    /// </summary>
+    public sealed class NoAssertContext : IDisposable
+    {
+        private static readonly object s_lock = new object();
+        private static readonly HashSet<int> s_suppressedThreads = new HashSet<int>();
+        private static TraceListener s_defaultListener;
+        private static readonly NoAssertListener s_noAssertListener = new NoAssertListener();
+
+        public NoAssertContext()
+        {
+            lock (s_lock)
+            {
+                s_suppressedThreads.Add(Thread.CurrentThread.ManagedThreadId);
+                if (s_suppressedThreads.Count == 1)
+                {
+                    // Hook our custom listener first so we don't lose assertions from other threads when
+                    // we disconnect the default listener.
+                    Trace.Listeners.Add(s_noAssertListener);
+
+                    // "Default" is the listener that terminates the process when debug assertions fail.
+                    s_defaultListener = Trace.Listeners["Default"];
+                    Trace.Listeners.Remove(s_defaultListener);
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            lock (s_lock)
+            {
+                s_suppressedThreads.Remove(Thread.CurrentThread.ManagedThreadId);
+                if (s_suppressedThreads.Count == 0 && s_defaultListener != null)
+                {
+                    // Add the default listener back first to make sure we don't lose any
+                    // asserts from other threads.
+                    Trace.Listeners.Add(s_defaultListener);
+                    Trace.Listeners.Remove(s_noAssertListener);
+                    s_defaultListener = null;
+                }
+            }
+        }
+
+        ~NoAssertContext()
+        {
+            // We need this class to be used in a using to effectively rationalize about a test.
+            throw new InvalidOperationException($"Did not dispose {nameof(NoAssertContext)}");
+        }
+
+        private class NoAssertListener : TraceListener
+        {
+            public NoAssertListener()
+                : base(typeof(NoAssertListener).FullName)
+            {
+            }
+
+            public override void Fail(string message)
+            {
+                lock (s_lock)
+                {
+                    if (!s_suppressedThreads.Contains(Thread.CurrentThread.ManagedThreadId))
+                    {
+                        s_defaultListener?.Fail(message);
+                    }
+                }
+            }
+
+            public override void Fail(string message, string detailMessage)
+            {
+                lock (s_lock)
+                {
+                    if (!s_suppressedThreads.Contains(Thread.CurrentThread.ManagedThreadId))
+                    {
+                        s_defaultListener?.Fail(message, detailMessage);
+                    }
+                }
+            }
+
+            // Write and WriteLine are virtual
+
+            public override void Write(string message)
+            {
+                lock (s_lock)
+                {
+                    s_defaultListener?.Write(message);
+                }
+            }
+
+            public override void WriteLine(string message)
+            {
+                lock (s_lock)
+                {
+                    s_defaultListener?.WriteLine(message);
+                }
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -12826,8 +12826,8 @@ namespace System.Windows.Forms
             }
             if (!ReflectMessage(p, ref m))
             {
-                //Additional Check For Control .... TabControl truncates the Hwnd value...
-                IntPtr handle = _window.GetHandleFromID((short)NativeMethods.Util.LOWORD(m.WParam));
+                // Additional Check For Control .... TabControl truncates the Hwnd value...
+                IntPtr handle = _window.GetHandleFromWindowId((short)NativeMethods.Util.LOWORD(m.WParam));
                 if (handle != IntPtr.Zero)
                 {
                     Control control = FromHandle(handle);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.WindowClass.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.WindowClass.cs
@@ -22,11 +22,14 @@ namespace System.Windows.Forms
 
             internal WindowClass _next;
             internal string _className;
-            private NativeMethods.ClassStyle _classStyle;
             internal string _windowClassName;
-            private IntPtr _defaultWindProc;
-            private NativeMethods.WndProc _windProc;
             internal NativeWindow _targetWindow;
+
+            private readonly NativeMethods.ClassStyle _classStyle;
+            private IntPtr _defaultWindProc;
+
+            // This needs to be a field so the GC doesn't collect the managed callback
+            private NativeMethods.WndProc _windProc;
 
             // There is only ever one AppDomain
             private static readonly string s_currentAppDomainHash = Convert.ToString(AppDomain.CurrentDomain.GetHashCode(), 16);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.WindowClass.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.WindowClass.cs
@@ -14,7 +14,7 @@ namespace System.Windows.Forms
     public partial class NativeWindow
     {
         /// <summary>
-        ///  WindowClass encapsulates a window class.
+        ///  WindowClass encapsulates a Windows window class.
         /// </summary>
         private class WindowClass
         {
@@ -22,11 +22,10 @@ namespace System.Windows.Forms
 
             internal WindowClass _next;
             internal string _className;
-            internal NativeMethods.ClassStyle _classStyle;
+            private NativeMethods.ClassStyle _classStyle;
             internal string _windowClassName;
-            internal int _hashCode;
-            internal IntPtr _defaultWindowProc;
-            internal NativeMethods.WndProc _windowProc;
+            private IntPtr _defaultWindProc;
+            private NativeMethods.WndProc _windProc;
             internal NativeWindow _targetWindow;
 
             // There is only ever one AppDomain
@@ -46,7 +45,7 @@ namespace System.Windows.Forms
                 Debug.Assert(hWnd != IntPtr.Zero, "Windows called us with an HWND of 0");
 
                 // Set the window procedure to the default window procedure
-                UnsafeNativeMethods.SetWindowLong(new HandleRef(null, hWnd), NativeMethods.GWL_WNDPROC, new HandleRef(this, _defaultWindowProc));
+                UnsafeNativeMethods.SetWindowLong(new HandleRef(null, hWnd), NativeMethods.GWL_WNDPROC, new HandleRef(this, _defaultWindProc));
                 _targetWindow.AssignHandle(hWnd);
                 return _targetWindow.Callback(hWnd, msg, wparam, lparam);
             }
@@ -141,9 +140,8 @@ namespace System.Windows.Forms
                     windowClass.hbrBackground = Gdi32.GetStockObject(Gdi32.StockObject.HOLLOW_BRUSH);
                     windowClass.style = _classStyle;
 
-                    _defaultWindowProc = DefaultWindowProc;
+                    _defaultWindProc = DefaultWindowProc;
                     localClassName = "Window." + Convert.ToString((int)_classStyle, 16);
-                    _hashCode = 0;
                 }
                 else
                 {
@@ -155,13 +153,12 @@ namespace System.Windows.Forms
                     }
 
                     localClassName = _className;
-                    _defaultWindowProc = windowClass.lpfnWndProc;
-                    _hashCode = _className.GetHashCode();
+                    _defaultWindProc = windowClass.lpfnWndProc;
                 }
 
                 _windowClassName = GetFullClassName(localClassName);
-                _windowProc = new NativeMethods.WndProc(Callback);
-                windowClass.lpfnWndProc = Marshal.GetFunctionPointerForDelegate(_windowProc);
+                _windProc = new NativeMethods.WndProc(Callback);
+                windowClass.lpfnWndProc = Marshal.GetFunctionPointerForDelegate(_windProc);
                 windowClass.hInstance = Kernel32.GetModuleHandleW(null);
 
                 fixed (char* c = _windowClassName)
@@ -170,7 +167,7 @@ namespace System.Windows.Forms
 
                     if (UnsafeNativeMethods.RegisterClassW(ref windowClass) == 0)
                     {
-                        _windowProc = null;
+                        _windProc = null;
                         throw new Win32Exception();
                     }
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.WindowClass.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.WindowClass.cs
@@ -30,7 +30,7 @@ namespace System.Windows.Forms
             internal NativeWindow _targetWindow;
 
             // There is only ever one AppDomain
-            private static string s_currentAppDomainHash = Convert.ToString(AppDomain.CurrentDomain.GetHashCode(), 16);
+            private static readonly string s_currentAppDomainHash = Convert.ToString(AppDomain.CurrentDomain.GetHashCode(), 16);
 
             private static readonly object s_wcInternalSyncObject = new object();
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.WindowClass.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.WindowClass.cs
@@ -1,0 +1,180 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Text;
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    public partial class NativeWindow
+    {
+        /// <summary>
+        ///  WindowClass encapsulates a window class.
+        /// </summary>
+        private class WindowClass
+        {
+            internal static WindowClass s_cache;
+
+            internal WindowClass _next;
+            internal string _className;
+            internal NativeMethods.ClassStyle _classStyle;
+            internal string _windowClassName;
+            internal int _hashCode;
+            internal IntPtr _defaultWindowProc;
+            internal NativeMethods.WndProc _windowProc;
+            internal NativeWindow _targetWindow;
+
+            // There is only ever one AppDomain
+            private static string s_currentAppDomainHash = Convert.ToString(AppDomain.CurrentDomain.GetHashCode(), 16);
+
+            private static readonly object s_wcInternalSyncObject = new object();
+
+            internal WindowClass(string className, NativeMethods.ClassStyle classStyle)
+            {
+                _className = className;
+                _classStyle = classStyle;
+                RegisterClass();
+            }
+
+            public IntPtr Callback(IntPtr hWnd, int msg, IntPtr wparam, IntPtr lparam)
+            {
+                Debug.Assert(hWnd != IntPtr.Zero, "Windows called us with an HWND of 0");
+
+                // Set the window procedure to the default window procedure
+                UnsafeNativeMethods.SetWindowLong(new HandleRef(null, hWnd), NativeMethods.GWL_WNDPROC, new HandleRef(this, _defaultWindowProc));
+                _targetWindow.AssignHandle(hWnd);
+                return _targetWindow.Callback(hWnd, msg, wparam, lparam);
+            }
+
+            /// <summary>
+            ///  Retrieves a WindowClass object for use.  This will create a new
+            ///  object if there is no such class/style available, or retrun a
+            ///  cached object if one exists.
+            /// </summary>
+            internal static WindowClass Create(string className, NativeMethods.ClassStyle classStyle)
+            {
+                lock (s_wcInternalSyncObject)
+                {
+                    WindowClass wc = s_cache;
+                    if (className == null)
+                    {
+                        // If we weren't given a class name, look for a window
+                        // that has the exact class style.
+                        while (wc != null
+                            && (wc._className != null || wc._classStyle != classStyle))
+                        {
+                            wc = wc._next;
+                        }
+                    }
+                    else
+                    {
+                        while (wc != null && !className.Equals(wc._className))
+                        {
+                            wc = wc._next;
+                        }
+                    }
+
+                    if (wc == null)
+                    {
+                        // Didn't find an existing class, create one and attatch it to
+                        // the end of the linked list.
+                        wc = new WindowClass(className, classStyle)
+                        {
+                            _next = s_cache
+                        };
+                        s_cache = wc;
+                    }
+
+                    return wc;
+                }
+            }
+
+            /// <summary>
+            ///  Fabricates a full class name from a partial.
+            /// </summary>
+            private string GetFullClassName(string className)
+            {
+                StringBuilder b = new StringBuilder(50);
+                b.Append(Application.WindowsFormsVersion);
+                b.Append('.');
+                b.Append(className);
+
+                // While we don't have multiple AppDomains any more, we'll still include the information
+                // to keep the names in the same historical format for now.
+
+                b.Append(".app.0.");
+
+                // VersioningHelper does a lot of string allocations, and on .NET Core for our purposes
+                // it always returns the exact same string (process is hardcoded to r3 and the AppDomain
+                // id is always 1 as there is only one AppDomain).
+
+                const string versionSuffix = "_r3_ad1";
+                Debug.Assert(string.Equals(
+                    VersioningHelper.MakeVersionSafeName(s_currentAppDomainHash, ResourceScope.Process, ResourceScope.AppDomain),
+                    s_currentAppDomainHash + versionSuffix));
+                b.Append(s_currentAppDomainHash);
+                b.Append(versionSuffix);
+
+                return b.ToString();
+            }
+
+            /// <summary>
+            ///  Once the classname and style bits have been set, this can be called to register the class.
+            /// </summary>
+            private unsafe void RegisterClass()
+            {
+                NativeMethods.WNDCLASS windowClass = new NativeMethods.WNDCLASS();
+
+                string localClassName = _className;
+
+                if (localClassName == null)
+                {
+                    // If we don't use a hollow brush here, Windows will "pre paint" us with COLOR_WINDOW which
+                    // creates a little bit if flicker.  This happens even though we are overriding wm_erasebackgnd.
+                    // Make this hollow to avoid all flicker.
+
+                    windowClass.hbrBackground = Gdi32.GetStockObject(Gdi32.StockObject.HOLLOW_BRUSH);
+                    windowClass.style = _classStyle;
+
+                    _defaultWindowProc = DefaultWindowProc;
+                    localClassName = "Window." + Convert.ToString((int)_classStyle, 16);
+                    _hashCode = 0;
+                }
+                else
+                {
+                    // A system defined Window class was specified, get its info
+
+                    if (!UnsafeNativeMethods.GetClassInfoW(NativeMethods.NullHandleRef, _className, ref windowClass))
+                    {
+                        throw new Win32Exception(Marshal.GetLastWin32Error(), SR.InvalidWndClsName);
+                    }
+
+                    localClassName = _className;
+                    _defaultWindowProc = windowClass.lpfnWndProc;
+                    _hashCode = _className.GetHashCode();
+                }
+
+                _windowClassName = GetFullClassName(localClassName);
+                _windowProc = new NativeMethods.WndProc(Callback);
+                windowClass.lpfnWndProc = Marshal.GetFunctionPointerForDelegate(_windowProc);
+                windowClass.hInstance = Kernel32.GetModuleHandleW(null);
+
+                fixed (char* c = _windowClassName)
+                {
+                    windowClass.lpszClassName = c;
+
+                    if (UnsafeNativeMethods.RegisterClassW(ref windowClass) == 0)
+                    {
+                        _windowProc = null;
+                        throw new Win32Exception();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
@@ -265,9 +265,9 @@ namespace System.Windows.Forms
 
                     if (oldRoot.IsAllocated)
                     {
-                        if (oldRoot.Target != null)
+                        if (oldRoot.Target is NativeWindow target)
                         {
-                            window.PreviousWindow = (NativeWindow)oldRoot.Target;
+                            window.PreviousWindow = target;
                             Debug.Assert(window.PreviousWindow._nextWindow == null, "Last window in chain should have null next ptr");
                             window.PreviousWindow._nextWindow = window;
                         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -84,6 +84,7 @@ namespace System.Windows.Forms
         private TabPage[] tabPages;
         private int tabPageCount;
         private int lastSelection;
+        private short _windowId;
 
         private bool rightToLeftLayout = false;
         private bool skipUpdateSize;
@@ -1358,7 +1359,7 @@ namespace System.Windows.Forms
         protected override void OnHandleCreated(EventArgs e)
         {
             //Add the handle to hashtable for Ids ..
-            NativeWindow.AddWindowToIDTable(this, Handle);
+            _windowId = NativeWindow.CreateWindowId(this);
             handleInTable = true;
 
             // Set the padding BEFORE setting the control's font (as done
@@ -1430,7 +1431,7 @@ namespace System.Windows.Forms
             if (handleInTable)
             {
                 handleInTable = false;
-                NativeWindow.RemoveWindowFromIDTable(Handle);
+                NativeWindow.RemoveWindowFromIDTable(_windowId);
             }
 
             base.OnHandleDestroyed(e);

--- a/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
+++ b/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
@@ -19,7 +19,6 @@
   <ItemGroup>
     <Compile Include="..\..\..\Common\tests\CommonTestHelper.cs" Link="Common\CommonTestHelper.cs" />
     <Compile Include="..\..\..\Common\tests\CommonMemberDataAttribute.cs" Link="Common\CommonMemberDataAttribute.cs" />
-    <Compile Include="..\..\..\Common\tests\NoAssertContext.cs" Link="Common\NoAssertContext.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
+++ b/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <Compile Include="..\..\..\Common\tests\CommonTestHelper.cs" Link="Common\CommonTestHelper.cs" />
     <Compile Include="..\..\..\Common\tests\CommonMemberDataAttribute.cs" Link="Common\CommonMemberDataAttribute.cs" />
+    <Compile Include="..\..\..\Common\tests\NoAssertContext.cs" Link="Common\NoAssertContext.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NativeWindowTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NativeWindowTests.cs
@@ -1,0 +1,126 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    public class NativeWindowTests
+    {
+        [Fact]
+        public void AssignHandle_TwiceThrowsArgumentException()
+        {
+            using Form form = new Form();
+            NativeWindow nativeWindow = new NativeWindow();
+            nativeWindow.AssignHandle(form.Handle);
+            Assert.Throws<InvalidOperationException>(() => nativeWindow.AssignHandle(form.Handle));
+        }
+
+        [Fact]
+        public void AssignHandle_AfterRelease()
+        {
+            using Form form = new Form();
+            NativeWindow nativeWindow = new NativeWindow();
+            nativeWindow.AssignHandle(form.Handle);
+            nativeWindow.ReleaseHandle();
+            nativeWindow.AssignHandle(form.Handle);
+        }
+
+        [Fact]
+        public void AssignHandle_TwoNativeWindows()
+        {
+            using Form form = new Form();
+            NativeWindow nativeWindow1 = new NativeWindow();
+
+            // ControlNativeWindow (via Form) will be registered with the Handle (by calling .Handle) already.
+            // Invoking AssignHandle on it will set ControlNativeWindow to Previous and assign nativeWindow1
+            // in the dictionary of window handles (s_windowHandles).
+            nativeWindow1.AssignHandle(form.Handle);
+
+            // This will further chain nativeWindow2, putting nativeWindow1, then ControlNativeWindow as previous
+            // (Previous) entries in the chain.
+            NativeWindow nativeWindow2 = new NativeWindow();
+            nativeWindow2.AssignHandle(form.Handle);
+        }
+
+        [Fact]
+        public void DefWindProc_NoHandle()
+        {
+            MyNativeWindow nativeWindow = new MyNativeWindow();
+            Message message = default;
+
+            // This isn't supported per the docs, but we always have called DefWindowProc and shouldn't fail.
+            // We assert as it isn't behavior we want to allow internally.
+            using (new NoAssertContext())
+            {
+                nativeWindow.DefWndProc(ref message);
+            }
+
+            Assert.Empty(nativeWindow.Messages);
+        }
+
+        [Fact]
+        public void DefWindProc_AfterAssignHandle()
+        {
+            MyNativeWindow nativeWindow = new MyNativeWindow
+            {
+                MessageTypePredicate = (int msg) => msg == 123456
+            };
+
+            nativeWindow.CreateHandle(new CreateParams());
+
+            Message message = Message.Create(IntPtr.Zero, 123456, IntPtr.Zero, IntPtr.Zero);
+
+            // As we don't have a "Previous" the default window procedure gets called
+            nativeWindow.DefWndProc(ref message);
+            Assert.Empty(nativeWindow.Messages);
+
+            MyNativeWindow nativeWindow2 = new MyNativeWindow
+            {
+                MessageTypePredicate = (int msg) => msg == 123456
+            };
+
+            // This will set the existing nativeWindow as Previous. When Previous NativeWindows
+            // are registered for the same handle, a chain of calls will happen until the original
+            // registered NativeWindow for a given handle is reached (i.e. no Previous). The
+            // call chain is like this:
+            //
+            //   DefWndProc() -> PreviousWindow.CallBack() -> WndProc() -> DefWndProc()
+
+            nativeWindow2.AssignHandle(nativeWindow.Handle);
+            nativeWindow2.DefWndProc(ref message);
+            Assert.Single(nativeWindow.Messages);
+            Assert.Empty(nativeWindow2.Messages);
+
+            // Check that the message continues to work back.
+
+            MyNativeWindow nativeWindow3 = new MyNativeWindow
+            {
+                MessageTypePredicate = (int msg) => msg == 123456
+            };
+
+            nativeWindow3.AssignHandle(nativeWindow.Handle);
+            nativeWindow3.DefWndProc(ref message);
+            Assert.Equal(2, nativeWindow.Messages.Count);
+            Assert.Single(nativeWindow2.Messages);
+            Assert.Empty(nativeWindow3.Messages);
+        }
+
+        public class MyNativeWindow : NativeWindow
+        {
+            public Predicate<int> MessageTypePredicate { get; set; }
+
+            public List<Message> Messages { get; } = new List<Message>();
+
+            protected override void WndProc(ref Message m)
+            {
+                if (MessageTypePredicate == null || MessageTypePredicate(m.Msg))
+                    Messages.Add(m);
+
+                base.WndProc(ref m);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

- Break NativeWindow subclass into separate file
- Fix naming
- Remove custom hashset

Following what is going on in NativeWindow is more confusing than it needs to be with the custom hashset implementation. Switching to Dictionary, which didn't exist when this code was originally written.

I have three commits to make this easier to follow. Note that I've other changes that build on this, moving more into Interop and using a WindowMessage enum as we do in the designer. (These will be follow up PR's in the future.)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1748)