### PR TITLE
Fixing ToolStripMenu  checked box rendering issue when Visual Styles are ON

### DIFF
--- a/src/Common/src/Interop/UxTheme/Interop.GetThemeDocumentationProperty.cs
+++ b/src/Common/src/Interop/UxTheme/Interop.GetThemeDocumentationProperty.cs
@@ -20,7 +20,7 @@ internal static partial class Interop
                 GetThemeDocumentationPropertyInternal(pszThemeName, pszPropertyName, pBuffer, buffer.Length);
             }
 
-            return buffer.ToString();
+            return buffer.SliceAtFirstNull().ToString();
         }
 
         public static class VisualStyleDocProperty

--- a/src/Common/src/Interop/UxTheme/Interop.GetThemeDocumentationProperty.cs
+++ b/src/Common/src/Interop/UxTheme/Interop.GetThemeDocumentationProperty.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Windows.Forms;
 
 internal static partial class Interop
 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleInformation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleInformation.cs
@@ -48,7 +48,7 @@ namespace System.Windows.Forms.VisualStyles
                         UxTheme.GetCurrentThemeName(pFilename, filename.Length, null, 0, null, 0);
                     }
 
-                    return filename.ToString();
+                    return filename.SliceAtFirstNull().ToString();
                 }
 
                 return string.Empty;
@@ -70,7 +70,7 @@ namespace System.Windows.Forms.VisualStyles
                         UxTheme.GetCurrentThemeName(null, 0, pColorScheme, colorScheme.Length, null, 0);
                     }
 
-                    return colorScheme.ToString();
+                    return colorScheme.SliceAtFirstNull().ToString();
                 }
 
                 return string.Empty;
@@ -92,7 +92,7 @@ namespace System.Windows.Forms.VisualStyles
                         UxTheme.GetCurrentThemeName(null, 0, null, 0, pSize, size.Length);
                     }
 
-                    return size.ToString();
+                    return size.SliceAtFirstNull().ToString();
                 }
 
                 return string.Empty;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/VisualStyles/VisualStyleInformationTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/VisualStyles/VisualStyleInformationTests.cs
@@ -1,4 +1,4 @@
- // Licensed to the .NET Foundation under one or more agreements.
+﻿ // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -9,156 +9,171 @@ namespace System.Windows.Forms.VisualStyles.Tests
 {
     public class VisualStyleInformationTests
     {
-        // Commenting out due to local tests failing. Tracked by https://github.com/dotnet/winforms/issues/1093
-        // [Fact]
-        // public void VisualStyleInformation_Author_Get_ReturnsExpected()
-        // {
-        //     string author = VisualStyleInformation.Author;
-        //     Assert.NotNull(author);
-        //     Assert.Equal(author, VisualStyleInformation.Author);
-        // }
+        [Fact]
+        public void VisualStyleInformation_Author_Get_ReturnsExpected()
+        {
+            string author = VisualStyleInformation.Author;
+            Assert.NotNull(author);
+            Assert.Equal(author, VisualStyleInformation.Author);
+            Assert.DoesNotContain('\0', author);
+        }
 
-        // [Fact]
-        // public void VisualStyleInformation_ColorScheme_Get_ReturnsExpected()
-        // {
-        //     string scheme = VisualStyleInformation.ColorScheme;
-        //     Assert.NotNull(scheme);
-        //     Assert.Equal(scheme, VisualStyleInformation.ColorScheme);
-        // }
+        [Fact]
+        public void VisualStyleInformation_ColorScheme_Get_ReturnsExpected()
+        {
+            string scheme = VisualStyleInformation.ColorScheme;
+            Assert.NotNull(scheme);
+            Assert.Equal(scheme, VisualStyleInformation.ColorScheme);
+            Assert.DoesNotContain('\0', scheme);
+        }
 
-        // [Fact]
-        // public void VisualStyleInformation_ColorScheme_Get_ReturnsDifferent()
-        // {
-        //     string scheme = VisualStyleInformation.ColorScheme;
-        //     if (scheme != string.Empty)
-        //     {
-        //         Assert.NotEqual(scheme, VisualStyleInformation.Size);
-        //         Assert.NotEqual(scheme, VisualStyleInformation.Version);
-        //     }
-        // }
+        [Fact]
+        public void VisualStyleInformation_ColorScheme_Get_ReturnsDifferent()
+        {
+            string scheme = VisualStyleInformation.ColorScheme;
+            if (scheme != string.Empty)
+            {
+                Assert.NotEqual(scheme, VisualStyleInformation.Size);
+                Assert.NotEqual(scheme, VisualStyleInformation.Version);
+            }
 
-        // [Fact]
-        // public void VisualStyleInformation_Company_Get_ReturnsExpected()
-        // {
-        //     string company = VisualStyleInformation.Company;
-        //     Assert.NotNull(company);
-        //     Assert.Equal(company, VisualStyleInformation.Company);
-        // }
+            Assert.DoesNotContain('\0', scheme);
+        }
 
-        // [Fact]
-        // public void VisualStyleInformation_ControlHighlightHot_Get_ReturnsExpected()
-        // {
-        //     Color color = VisualStyleInformation.ControlHighlightHot;
-        //     Assert.NotEqual(Color.Empty, color);
-        //     Assert.Equal(color, VisualStyleInformation.ControlHighlightHot);
-        // }
+        [Fact]
+        public void VisualStyleInformation_Company_Get_ReturnsExpected()
+        {
+            string company = VisualStyleInformation.Company;
+            Assert.NotNull(company);
+            Assert.Equal(company, VisualStyleInformation.Company);
+            Assert.DoesNotContain('\0', company);
+        }
 
-        // [Fact]
-        // public void VisualStyleInformation_Copyright_Get_ReturnsExpected()
-        // {
-        //     string copyright = VisualStyleInformation.Copyright;
-        //     Assert.NotNull(copyright);
-        //     Assert.Equal(copyright, VisualStyleInformation.Copyright);
-        // }
+        [Fact]
+        public void VisualStyleInformation_ControlHighlightHot_Get_ReturnsExpected()
+        {
+            Color color = VisualStyleInformation.ControlHighlightHot;
+            Assert.NotEqual(Color.Empty, color);
+            Assert.Equal(color, VisualStyleInformation.ControlHighlightHot);
+        }
 
-        // [Fact]
-        // public void VisualStyleInformation_Description_Get_ReturnsExpected()
-        // {
-        //     string description = VisualStyleInformation.Description;
-        //     Assert.NotNull(description);
-        //     Assert.Equal(description, VisualStyleInformation.Description);
-        // }
+        [Fact]
+        public void VisualStyleInformation_Copyright_Get_ReturnsExpected()
+        {
+            string copyright = VisualStyleInformation.Copyright;
+            Assert.NotNull(copyright);
+            Assert.Equal(copyright, VisualStyleInformation.Copyright);
+            Assert.DoesNotContain('\0', copyright);
+        }
 
-        // [Fact]
-        // public void VisualStyleInformation_DisplayName_Get_ReturnsExpected()
-        // {
-        //     string displayName = VisualStyleInformation.DisplayName;
-        //     Assert.NotNull(displayName);
-        //     Assert.Equal(displayName, VisualStyleInformation.DisplayName);
-        // }
+        [Fact]
+        public void VisualStyleInformation_Description_Get_ReturnsExpected()
+        {
+            string description = VisualStyleInformation.Description;
+            Assert.NotNull(description);
+            Assert.Equal(description, VisualStyleInformation.Description);
+            Assert.DoesNotContain('\0', description);
+        }
 
-        // [Fact]
-        // public void VisualStyleInformation_IsEnabledByUser_Get_ReturnsExpected()
-        // {
-        //     bool enabled = VisualStyleInformation.IsEnabledByUser;
-        //     Assert.Equal(enabled, VisualStyleInformation.IsEnabledByUser);
-        // }
+        [Fact]
+        public void VisualStyleInformation_DisplayName_Get_ReturnsExpected()
+        {
+            string displayName = VisualStyleInformation.DisplayName;
+            Assert.NotNull(displayName);
+            Assert.Equal(displayName, VisualStyleInformation.DisplayName);
+            Assert.DoesNotContain('\0', displayName);
+        }
 
-        // [Fact]
-        // public void VisualStyleInformation_IsSupportedByOS_Get_ReturnsExpected()
-        // {
-        //     bool supported = VisualStyleInformation.IsSupportedByOS;
-        //     Assert.True(supported);
-        //     Assert.Equal(supported, VisualStyleInformation.IsSupportedByOS);
-        // }
+        [Fact]
+        public void VisualStyleInformation_IsEnabledByUser_Get_ReturnsExpected()
+        {
+            bool enabled = VisualStyleInformation.IsEnabledByUser;
+            Assert.Equal(enabled, VisualStyleInformation.IsEnabledByUser);
+        }
 
-        // [Fact]
-        // public void VisualStyleInformation_MinimumColorDepth_Get_ReturnsExpected()
-        // {
-        //     int depth = VisualStyleInformation.MinimumColorDepth;
-        //     Assert.True(depth >= 0);
-        //     Assert.Equal(depth, VisualStyleInformation.MinimumColorDepth);
-        // }
+        [Fact]
+        public void VisualStyleInformation_IsSupportedByOS_Get_ReturnsExpected()
+        {
+            bool supported = VisualStyleInformation.IsSupportedByOS;
+            Assert.True(supported);
+            Assert.Equal(supported, VisualStyleInformation.IsSupportedByOS);
+        }
 
-        // [Fact]
-        // public void VisualStyleInformation_Size_Get_ReturnsExpected()
-        // {
-        //     string size = VisualStyleInformation.Size;
-        //     Assert.NotNull(size);
-        //     Assert.Equal(size, VisualStyleInformation.Size);
-        // }
+        [Fact]
+        public void VisualStyleInformation_MinimumColorDepth_Get_ReturnsExpected()
+        {
+            int depth = VisualStyleInformation.MinimumColorDepth;
+            Assert.True(depth >= 0);
+            Assert.Equal(depth, VisualStyleInformation.MinimumColorDepth);
+        }
 
-        // [Fact]
-        // public void VisualStyleInformation_Size_Get_ReturnsDifferent()
-        // {
-        //     string size = VisualStyleInformation.Size;
-        //     if (size != string.Empty)
-        //     {
-        //         Assert.NotEqual(size, VisualStyleInformation.ColorScheme);
-        //         Assert.NotEqual(size, VisualStyleInformation.Version);
-        //     }
-        // }
+        [Fact]
+        public void VisualStyleInformation_Size_Get_ReturnsExpected()
+        {
+            string size = VisualStyleInformation.Size;
+            Assert.NotNull(size);
+            Assert.Equal(size, VisualStyleInformation.Size);
+            Assert.DoesNotContain('\0', size);
+        }
 
-        // [Fact]
-        // public void VisualStyleInformation_SupportsFlatMenus_Get_ReturnsExpected()
-        // {
-        //     bool supported = VisualStyleInformation.SupportsFlatMenus;
-        //     Assert.Equal(supported, VisualStyleInformation.SupportsFlatMenus);
-        // }
+        [Fact]
+        public void VisualStyleInformation_Size_Get_ReturnsDifferent()
+        {
+            string size = VisualStyleInformation.Size;
+            if (size != string.Empty)
+            {
+                Assert.NotEqual(size, VisualStyleInformation.ColorScheme);
+                Assert.NotEqual(size, VisualStyleInformation.Version);
+            }
 
-        // [Fact]
-        // public void VisualStyleInformation_TextControlBorder_Get_ReturnsExpected()
-        // {
-        //     Color color = VisualStyleInformation.TextControlBorder;
-        //     Assert.NotEqual(Color.Empty, color);
-        //     Assert.Equal(color, VisualStyleInformation.TextControlBorder);
-        // }
+            Assert.DoesNotContain('\0', size);
+        }
 
-        // [Fact]
-        // public void VisualStyleInformation_Url_Get_ReturnsExpected()
-        // {
-        //     string url = VisualStyleInformation.Url;
-        //     Assert.NotNull(url);
-        //     Assert.Equal(url, VisualStyleInformation.Url);
-        // }
+        [Fact]
+        public void VisualStyleInformation_SupportsFlatMenus_Get_ReturnsExpected()
+        {
+            bool supported = VisualStyleInformation.SupportsFlatMenus;
+            Assert.Equal(supported, VisualStyleInformation.SupportsFlatMenus);
+        }
 
-        // [Fact]
-        // public void VisualStyleInformation_Version_Get_ReturnsExpected()
-        // {
-        //     string version = VisualStyleInformation.Version;
-        //     Assert.NotNull(version);
-        //     Assert.Equal(version, VisualStyleInformation.Version);
-        // }
+        [Fact]
+        public void VisualStyleInformation_TextControlBorder_Get_ReturnsExpected()
+        {
+            Color color = VisualStyleInformation.TextControlBorder;
+            Assert.NotEqual(Color.Empty, color);
+            Assert.Equal(color, VisualStyleInformation.TextControlBorder);
+        }
 
-        // [Fact]
-        // public void VisualStyleInformation_Version_Get_ReturnsDifferent()
-        // {
-        //     string version = VisualStyleInformation.Version;
-        //     if (version != string.Empty)
-        //     {
-        //         Assert.NotEqual(version, VisualStyleInformation.ColorScheme);
-        //         Assert.NotEqual(version, VisualStyleInformation.Size);
-        //     }
-        // }
+        [Fact]
+        public void VisualStyleInformation_Url_Get_ReturnsExpected()
+        {
+            string url = VisualStyleInformation.Url;
+            Assert.NotNull(url);
+            Assert.Equal(url, VisualStyleInformation.Url);
+            Assert.DoesNotContain('\0', url);
+
+        }
+
+        [Fact]
+        public void VisualStyleInformation_Version_Get_ReturnsExpected()
+        {
+            string version = VisualStyleInformation.Version;
+            Assert.NotNull(version);
+            Assert.Equal(version, VisualStyleInformation.Version);
+            Assert.DoesNotContain('\0', version);
+        }
+
+        [Fact]
+        public void VisualStyleInformation_Version_Get_ReturnsDifferent()
+        {
+            string version = VisualStyleInformation.Version;
+            if (version != string.Empty)
+            {
+                Assert.NotEqual(version, VisualStyleInformation.ColorScheme);
+                Assert.NotEqual(version, VisualStyleInformation.Size);
+            }
+
+            Assert.DoesNotContain('\0', version);
+        }
     }
 }


### PR DESCRIPTION
This was a regression when we changed local variable from `StringBuilder` to `Span<char>` for optimization.

We allocate fixed size char that was a 'null terminated' and span.ToString() method was not trimming those null terminated chars.
This is causing all string comparisons that were converted from span<char> to fail.

for the end user, this means that accessibility strings will be wrong. And all users who use the public class `VisualStyleInformation`

Fixes #1597 


## Proposed changes

Trimming the string for 'null terminated' chars before returning.

## Customer Impact

Checked boxes rendering on menu strip, in customer application, behave differently  when Visual Styles or ON/OFF.
## Regression? 
- Yes 

## Risk

- Low

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/36968667/64217966-7b335280-ce74-11e9-8855-acc4788dbc82.png)


### After
![image](https://user-images.githubusercontent.com/36968667/64217960-6eaefa00-ce74-11e9-8c8d-6a09d610f586.png)


## Test methodology <!-- How did you ensure quality? -->

- manual validation of the scenario


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1751)