### PR TITLE
Cleanup misc Ole32 interop

### DIFF
--- a/src/Common/src/Interop/Interop.HRESULT.cs
+++ b/src/Common/src/Interop/Interop.HRESULT.cs
@@ -27,6 +27,7 @@ internal static partial class Interop
         E_ACCESSDENIED = unchecked((int)0x80070005L),
         E_INVALIDARG = unchecked((int)0x80070057),
         ERROR_CANCELLED = unchecked((int)0x800704C7),
+        RPC_E_CHANGED_MODE = unchecked((int)0x80010106),
     }
 }
 

--- a/src/Common/src/Interop/Ole32/Interop.CLSCTX.cs
+++ b/src/Common/src/Interop/Ole32/Interop.CLSCTX.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal partial class Interop
+{
+    internal static partial class Ole32
+    {
+        [Flags]
+        public enum CLSCTX : uint
+        {
+            INPROC_SERVER = 0x1,
+            INPROC_HANDLER = 0x2,
+            LOCAL_SERVER = 0x4,
+            INPROC_SERVER16 = 0x8,
+            REMOTE_SERVER = 0x10,
+            INPROC_HANDLER16 = 0x20,
+            INPROC_SERVERX86 = 0x40,
+            INPROC_HANDLERX86 = 0x80,
+            ESERVER_HANDLER = 0x100,
+            NO_CODE_DOWNLOAD = 0x400,
+            NO_CUSTOM_MARSHAL = 0x1000,
+            ENABLE_CODE_DOWNLOAD = 0x2000,
+            NO_FAILURE_LOG = 0x4000,
+            DISABLE_AAA = 0x8000,
+            ENABLE_AAA = 0x10000,
+            FROM_DEFAULT_CONTEXT = 0x20000,
+        }
+    }
+}

--- a/src/Common/src/Interop/Ole32/Interop.CoCreateInstance.cs
+++ b/src/Common/src/Interop/Ole32/Interop.CoCreateInstance.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal static partial class Ole32
+    {
+        [DllImport(Libraries.Ole32, ExactSpelling = true)]
+        public static extern HRESULT CoCreateInstance(
+            ref Guid rclsid,
+            IntPtr punkOuter,
+            CLSCTX dwClsContext,
+            ref Guid riid,
+            [MarshalAs(UnmanagedType.Interface)] out object ppv);
+    }
+}

--- a/src/Common/src/Interop/Ole32/Interop.CoGetClassObject.cs
+++ b/src/Common/src/Interop/Ole32/Interop.CoGetClassObject.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Ole32
+    {
+        [DllImport(Libraries.Ole32, ExactSpelling = true)]
+        public static extern HRESULT CoGetClassObject(
+            ref Guid rclsid,
+            CLSCTX dwContext,
+            IntPtr pvReserved,
+            ref Guid riid,
+            [MarshalAs(UnmanagedType.Interface)] out IClassFactory2 ppv);
+    }
+}

--- a/src/Common/src/Interop/Ole32/Interop.IClassFactory2.cs
+++ b/src/Common/src/Interop/Ole32/Interop.IClassFactory2.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal static partial class Ole32
+    {
+        [ComImport]
+        [Guid("B196B28F-BAB4-101A-B69C-00AA00341D07")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        public unsafe interface IClassFactory2
+        {
+            [PreserveSig]
+            HRESULT CreateInstance(
+                IntPtr pUnkOuter,
+                Guid* riid,
+                [Out, MarshalAs(UnmanagedType.LPArray)] object[] ppunk);
+
+            [PreserveSig]
+            HRESULT LockServer(
+                BOOL fLock);
+
+            [PreserveSig]
+            HRESULT GetLicInfo(
+                LICINFO* licInfo);
+
+            [PreserveSig]
+            HRESULT RequestLicKey(
+                uint dwReserved,
+                [MarshalAs(UnmanagedType.LPArray)] string[] pBstrKey);
+
+            [PreserveSig]
+            HRESULT CreateInstanceLic(
+                IntPtr pUnkOuter,
+                IntPtr pUnkReserved,
+                ref Guid riid,
+                string bstrKey,
+                [MarshalAs(UnmanagedType.Interface)] out object ppVal);
+        }
+    }
+}

--- a/src/Common/src/Interop/Ole32/Interop.LICINFO.cs
+++ b/src/Common/src/Interop/Ole32/Interop.LICINFO.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class Ole32
+    {
+        public struct LICINFO
+        {
+            public int cbLicInfo;
+            public BOOL fRuntimeAvailable;
+            public BOOL fLicVerified;
+        }
+    }
+}

--- a/src/Common/src/Interop/Ole32/Interop.OleInitialize.cs
+++ b/src/Common/src/Interop/Ole32/Interop.OleInitialize.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal static partial class Ole32
+    {
+        [DllImport(Libraries.Ole32, ExactSpelling = true)]
+        public static extern HRESULT OleInitialize(IntPtr pvReserved);
+    }
+}

--- a/src/Common/src/Interop/Ole32/Interop.OleUninitialize.cs
+++ b/src/Common/src/Interop/Ole32/Interop.OleUninitialize.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal static partial class Ole32
+    {
+        [DllImport(Libraries.Ole32, ExactSpelling = true)]
+        public static extern void OleUninitialize();
+    }
+}

--- a/src/Common/src/Interop/Ole32/Interop.ReadClassStg.cs
+++ b/src/Common/src/Interop/Ole32/Interop.ReadClassStg.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal static partial class Ole32
+    {
+        [DllImport(Libraries.Ole32, ExactSpelling = true)]
+        public static extern HRESULT ReadClassStg(IntPtr pStg, out Guid pclsid);
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -173,8 +173,6 @@ namespace System.Windows.Forms
         CF_ENHMETAFILE = 14,
         CF_HDROP = 15,
         CF_LOCALE = 16,
-        CLSCTX_INPROC_SERVER = 0x1,
-        CLSCTX_LOCAL_SERVER = 0x4,
         CW_USEDEFAULT = (unchecked((int)0x80000000)),
         CWP_SKIPINVISIBLE = 0x0001,
         COLOR_WINDOW = 5,
@@ -1053,9 +1051,6 @@ namespace System.Windows.Forms
                                                     //public const int RECO_COPY  = 0x00000002;    // copy to the clipboard
                                                     //public const int RECO_CUT   = 0x00000003; // cut to the clipboard
                                                     //public const int RECO_DRAG  = 0x00000004;    // drag
-
-        public const int RPC_E_CHANGED_MODE = unchecked((int)0x80010106),
-            RPC_E_CANTCALLOUT_ININPUTSYNCCALL = unchecked((int)0x8001010D);
 
         public const int stc4 = 0x0443,
         STARTF_USESHOWWINDOW = 0x00000001,
@@ -2941,16 +2936,6 @@ namespace System.Windows.Forms
             {
                 return Marshal.ReadIntPtr(value);
             }
-        }
-
-        [StructLayout(LayoutKind.Sequential)/*leftover(noAutoOffset)*/]
-        public sealed class tagLICINFO
-        {
-            [MarshalAs(UnmanagedType.U4)/*leftover(offset=0, cb)*/]
-            public int cbLicInfo = Marshal.SizeOf<tagLICINFO>();
-
-            public int fRuntimeAvailable = 0;
-            public int fLicVerified = 0;
         }
 
         public enum tagVT

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -45,26 +45,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.User32, CharSet = System.Runtime.InteropServices.CharSet.Auto, EntryPoint = "SetClassLongPtr")]
         public static extern IntPtr SetClassLongPtr64(HandleRef hwnd, int nIndex, IntPtr dwNewLong);
 
-        [DllImport(ExternDll.Ole32, ExactSpelling = true, PreserveSig = false)]
-        public static extern IClassFactory2 CoGetClassObject(
-            [In]
-            ref Guid clsid,
-            int dwContext,
-            int serverInfo,
-            [In]
-            ref Guid refiid);
-
-        [return: MarshalAs(UnmanagedType.Interface)]
-        [DllImport(ExternDll.Ole32, ExactSpelling = true, PreserveSig = false)]
-        public static extern object CoCreateInstance(
-            [In]
-            ref Guid clsid,
-            [MarshalAs(UnmanagedType.Interface)]
-            object punkOuter,
-            int context,
-            [In]
-            ref Guid iid);
-
         [DllImport(ExternDll.Kernel32, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
         public static extern int GetLocaleInfo(uint Locale, int LCType, StringBuilder lpLCData, int cchData);
 
@@ -261,14 +241,8 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Unicode)]
         public static extern IntPtr DispatchMessageW([In] ref NativeMethods.MSG msg);
 
-        [DllImport(ExternDll.Ole32, ExactSpelling = true, SetLastError = true)]
-        public static extern int OleInitialize(int val = 0);
-
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
         public extern static IntPtr SendDlgItemMessage(HandleRef hDlg, int nIDDlgItem, int Msg, IntPtr wParam, IntPtr lParam);
-
-        [DllImport(ExternDll.Ole32, ExactSpelling = true, CharSet = CharSet.Auto, SetLastError = true)]
-        public static extern int OleUninitialize();
 
         [DllImport(ExternDll.Comdlg32, SetLastError = true, CharSet = CharSet.Auto)]
         public static extern bool GetSaveFileName([In, Out] NativeMethods.OPENFILENAME_I ofn);
@@ -2426,43 +2400,6 @@ namespace System.Windows.Forms
                     buffer[offset++] = (char)0;
                 }
             }
-        }
-
-        [ComImport(), Guid("B196B28F-BAB4-101A-B69C-00AA00341D07"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        public interface IClassFactory2
-        {
-            void CreateInstance(
-                   [In, MarshalAs(UnmanagedType.Interface)]
-                  object unused,
-                           [In]
-                  ref Guid refiid,
-                   [Out, MarshalAs(UnmanagedType.LPArray)]
-                  object[] ppunk);
-
-            void LockServer(
-                    int fLock);
-
-            void GetLicInfo(
-                   [Out]
-                  NativeMethods.tagLICINFO licInfo);
-
-            void RequestLicKey(
-                   [In, MarshalAs(UnmanagedType.U4)]
-                 int dwReserved,
-                   [Out, MarshalAs(UnmanagedType.LPArray)]
-                   string[] pBstrKey);
-
-            void CreateInstanceLic(
-                   [In, MarshalAs(UnmanagedType.Interface)]
-                  object pUnkOuter,
-                   [In, MarshalAs(UnmanagedType.Interface)]
-                  object pUnkReserved,
-                           [In]
-                  ref Guid riid,
-                   [In, MarshalAs(UnmanagedType.BStr)]
-                  string bstrKey,
-                   [Out, MarshalAs(UnmanagedType.Interface)]
-                  out object ppVal);
         }
 
         [ComImport(),

--- a/src/System.Windows.Forms.Design.Editors/src/Misc/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/Misc/UnsafeNativeMethods.cs
@@ -28,9 +28,6 @@ namespace System.Windows.Forms.Design
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern IntPtr GetFocus();
 
-        [DllImport(ExternDll.Ole32)]
-        public static extern int ReadClassStg(HandleRef pStg, ref Guid pclsid);
-
         public delegate IntPtr HookProc(int nCode, IntPtr wParam, IntPtr lParam);
 
         public const int OBJID_CLIENT = unchecked((int)0xFFFFFFFC);

--- a/src/System.Windows.Forms.Design.Editors/src/System.Windows.Forms.Design.Editors.csproj
+++ b/src/System.Windows.Forms.Design.Editors/src/System.Windows.Forms.Design.Editors.csproj
@@ -67,6 +67,7 @@
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.ILockBytes.cs" Link="Interop\Ole32\Interop.ILockBytes.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IStorage.cs" Link="Interop\Ole32\Interop.IStorage.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IStream.cs" Link="Interop\Ole32\Interop.IStream.cs" />
+    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.ReadClassStg.cs" Link="Interop\Ole32\Interop.ReadClassStg.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.STATFLAG.cs" Link="Interop\Ole32\Interop.STATFLAG.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.STATSTG.cs" Link="Interop\Ole32\Interop.STATSTG.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.STGC.cs" Link="Interop\Ole32\Interop.STGC.cs" />

--- a/src/System.Windows.Forms.Design.Editors/src/System/ComponentModel/Design/MultilineStringEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/ComponentModel/Design/MultilineStringEditor.cs
@@ -512,11 +512,10 @@ namespace System.ComponentModel.Design
                 }
                 else
                 {
-                    Guid realClsid = new Guid();
-                    int hr = UnsafeNativeMethods.ReadClassStg(new HandleRef(null, lpstg), ref realClsid);
-                    Debug.WriteLineIf(RichTextDbg.TraceVerbose, "real clsid:" + realClsid.ToString() + " (hr=" + hr.ToString("X", CultureInfo.InvariantCulture) + ")");
+                    HRESULT hr = Ole32.ReadClassStg(lpstg, out Guid realClsid);
+                    Debug.WriteLineIf(RichTextDbg.TraceVerbose, "real clsid:" + realClsid.ToString() + " (hr=" + hr.ToString("X") + ")");
 
-                    if (!NativeMethods.Succeeded(hr))
+                    if (!hr.Succeeded())
                     {
                         return HRESULT.S_FALSE;
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StringSource.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StringSource.cs
@@ -4,11 +4,12 @@
 
 using System.Runtime.InteropServices.ComTypes;
 using System.Runtime.InteropServices;
+using static Interop;
 
 namespace System.Windows.Forms
 {
     /// <summary>
-    ///  Represents an internal class that is used bu ComboBox and TextBox AutoCompleteCustomSoucr property.
+    ///  Represents an internal class that is used bu ComboBox and TextBox AutoCompleteCustomSource property.
     ///  This class is reponsible for initializing the SHAutoComplete COM object and setting options in it.
     ///  The StringSource contains an array of Strings which is passed to the COM object as the custom source.
     /// </summary>
@@ -39,7 +40,16 @@ namespace System.Windows.Forms
             size = (strings == null) ? 0 : strings.Length;
 
             Guid iid_iunknown = typeof(UnsafeNativeMethods.IAutoComplete2).GUID;
-            object obj = UnsafeNativeMethods.CoCreateInstance(ref autoCompleteClsid, null, NativeMethods.CLSCTX_INPROC_SERVER, ref iid_iunknown);
+            HRESULT hr = Ole32.CoCreateInstance(
+                ref autoCompleteClsid,
+                IntPtr.Zero,
+                Ole32.CLSCTX.INPROC_SERVER,
+                ref iid_iunknown,
+                out object obj);
+            if (!hr.Succeeded())
+            {
+                throw Marshal.GetExceptionForHR((int)hr);
+            }
 
             autoCompleteObject2 = (UnsafeNativeMethods.IAutoComplete2)obj;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
@@ -913,19 +913,25 @@ namespace System.Windows.Forms
             Debug.Assert(ActiveXState == WebBrowserHelper.AXState.Passive, "Wrong start state to transition from");
             if (ActiveXState == WebBrowserHelper.AXState.Passive)
             {
-                //
                 // First, create the ActiveX control
                 Debug.Assert(activeXInstance == null, "activeXInstance must be null");
-                activeXInstance = UnsafeNativeMethods.CoCreateInstance(ref clsid, null, NativeMethods.CLSCTX_INPROC_SERVER, ref NativeMethods.ActiveX.IID_IUnknown);
+                HRESULT hr = Ole32.CoCreateInstance(
+                    ref clsid,
+                    IntPtr.Zero,
+                    Ole32.CLSCTX.INPROC_SERVER,
+                    ref NativeMethods.ActiveX.IID_IUnknown,
+                    out activeXInstance);
+                if (!hr.Succeeded())
+                {
+                    throw Marshal.GetExceptionForHR((int)hr);
+                }
+
                 Debug.Assert(activeXInstance != null, "w/o an exception being thrown we must have an object...");
 
-                //
-                // We are now Loaded!
+                // We are now loaded.
                 ActiveXState = WebBrowserHelper.AXState.Loaded;
 
-                //
-                // Lets give them a chance to cast the ActiveX object
-                // to the appropriate interfaces.
+                // Lets give them a chance to cast the ActiveX object to the appropriate interfaces.
                 AttachInterfacesInternal();
             }
         }


### PR DESCRIPTION
## Proposed changes

- Cleanup CoCreateInstance/CoGetClassObject: don't use `PreserveSig` but instead use `HRESULT`s
- Fix OleInitialize incorrect definition (should take IntPtr not int)
- Fix OleUnitialize incorrect definition (should return `void` not int)
- Cleanup definition of `IClassFactory2`
- Structify `LICINFO`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1805)