### PR TITLE
Fixing availability of ShowCellToolTips and ShowCellErrors setters

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -4409,32 +4409,36 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (ShowCellErrors != value)
+                if (dataGridViewState2[DATAGRIDVIEWSTATE2_showCellErrors] != value)
                 {
                     dataGridViewState2[DATAGRIDVIEWSTATE2_showCellErrors] = value;
 
                     // Put this into OnShowCellErrorsChanged if created.
                     if (IsHandleCreated && !DesignMode)
                     {
-                        if (value && !ShowRowErrors && !ShowCellToolTips)
+                        if (!ShowRowErrors && !ShowCellToolTips)
                         {
-                            // the tool tip hasn't yet been activated
-                            // activate it now
-                            toolTipControl.Activate(!string.IsNullOrEmpty(toolTipCaption));
+                            if (value)
+                            {
+                                // The tool tip hasn't yet been activated
+                                // activate it now
+                                toolTipControl.Activate(!string.IsNullOrEmpty(toolTipCaption));
+                            }
+                            else
+                            {
+                                // There is no reason to keep the tool tip activated
+                                // deactivate it
+                                toolTipCaption = string.Empty;
+                                toolTipControl.Activate(false /*activate*/);
+                            }
                         }
-
-                        if (!value && !ShowRowErrors && !ShowCellToolTips)
+                        else
                         {
-                            // there is no reason to keep the tool tip activated
-                            // deactivate it
-                            toolTipCaption = string.Empty;
-                            toolTipControl.Activate(false /*activate*/);
-                        }
-
-                        if (!value && (ShowRowErrors || ShowCellToolTips))
-                        {
-                            // reset the tool tip
-                            toolTipControl.Activate(!string.IsNullOrEmpty(toolTipCaption));
+                            if (!value)
+                            {
+                                // Reset the tool tip
+                                toolTipControl.Activate(!string.IsNullOrEmpty(toolTipCaption));
+                            }
                         }
 
                         // Some autosizing may have to be applied since the potential presence of error icons influences the preferred sizes.
@@ -4463,35 +4467,39 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (ShowCellToolTips != value)
+                if (dataGridViewState2[DATAGRIDVIEWSTATE2_showCellToolTips] != value)
                 {
                     dataGridViewState2[DATAGRIDVIEWSTATE2_showCellToolTips] = value;
 
                     if (IsHandleCreated && !DesignMode)
                     {
-                        if (value && !ShowRowErrors && !ShowCellErrors)
+                        if (!ShowRowErrors && !ShowCellErrors)
                         {
-                            // the tool tip hasn't yet been activated
-                            // activate it now
-                            toolTipControl.Activate(!string.IsNullOrEmpty(toolTipCaption) /*activate*/);
+                            if (value)
+                            {
+                                // The tool tip hasn't yet been activated
+                                // activate it now
+                                toolTipControl.Activate(!string.IsNullOrEmpty(toolTipCaption) /*activate*/);
+                            }
+                            else
+                            {
+                                // There is no reason to keep the tool tip activated
+                                // deactivate it
+                                toolTipCaption = string.Empty;
+                                toolTipControl.Activate(false /*activate*/);
+                            }
                         }
-
-                        if (!value && !ShowRowErrors && !ShowCellErrors)
+                        else
                         {
-                            // there is no reason to keep the tool tip activated
-                            // deactivate it
-                            toolTipCaption = string.Empty;
-                            toolTipControl.Activate(false /*activate*/);
-                        }
+                            if (!value)
+                            {
+                                bool activate = !string.IsNullOrEmpty(toolTipCaption);
+                                Point mouseCoord = System.Windows.Forms.Control.MousePosition;
+                                activate &= ClientRectangle.Contains(PointToClient(mouseCoord));
 
-                        if (!value && (ShowRowErrors || ShowCellErrors))
-                        {
-                            bool activate = !string.IsNullOrEmpty(toolTipCaption);
-                            Point mouseCoord = System.Windows.Forms.Control.MousePosition;
-                            activate &= ClientRectangle.Contains(PointToClient(mouseCoord));
-
-                            // reset the tool tip
-                            toolTipControl.Activate(activate);
+                                // Reset the tool tip
+                                toolTipControl.Activate(activate);
+                            }
                         }
                     }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Change implementation of the `set` blocks of `ShowCellToolTips` and `ShowCellErrors` properties in `DataGridView.cs` to avoid possible problems

> ❗️ We must not use getters in setters.
We already had a serious bug (#1661) due to such use.


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- No


## Regression? 

- No

## Risk

- No

 

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.18362.295]
- .Net Core version: 3.0.0-rc1-19455-02


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1853)