### PR TITLE
Fix issue 1864 - Different accessible names for property grids

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -5159,6 +5159,12 @@ Stack trace where the illegal operation occurred was:
   <data name="PropertyGridDefaultAccessibleName" xml:space="preserve">
     <value>Properties Window</value>
   </data>
+  <data name="PropertyGridDefaultAccessibleNameTemplate" xml:space="preserve">
+    <value>{0} Properties Window</value>
+  </data>
+  <data name="PropertyGridDocCommentAccessibleNameTemplate" xml:space="preserve">
+    <value>{0} Description</value>
+  </data>
   <data name="PropertyGridDisabledItemForeColorDesc" xml:space="preserve">
     <value>The foreground color of disabled text in the grid area.</value>
   </data>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -8651,9 +8651,19 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">Okno vlastností</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridDefaultAccessibleNameTemplate">
+        <source>{0} Properties Window</source>
+        <target state="new">{0} Properties Window</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridDisabledItemForeColorDesc">
         <source>The foreground color of disabled text in the grid area.</source>
         <target state="translated">Barva popředí neaktivního textu v oblasti mřížky</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropertyGridDocCommentAccessibleNameTemplate">
+        <source>{0} Description</source>
+        <target state="new">{0} Description</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyGridDropDownButtonAccessibleName">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -8651,9 +8651,19 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">Eigenschaftenfenster</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridDefaultAccessibleNameTemplate">
+        <source>{0} Properties Window</source>
+        <target state="new">{0} Properties Window</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridDisabledItemForeColorDesc">
         <source>The foreground color of disabled text in the grid area.</source>
         <target state="translated">Die Vordergrundfarbe für gesperrten Text im Rasterbereich.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropertyGridDocCommentAccessibleNameTemplate">
+        <source>{0} Description</source>
+        <target state="new">{0} Description</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyGridDropDownButtonAccessibleName">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -8651,9 +8651,19 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">Ventana Propiedades</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridDefaultAccessibleNameTemplate">
+        <source>{0} Properties Window</source>
+        <target state="new">{0} Properties Window</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridDisabledItemForeColorDesc">
         <source>The foreground color of disabled text in the grid area.</source>
         <target state="translated">Color de primer plano del texto deshabilitado en el área de la cuadrícula.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropertyGridDocCommentAccessibleNameTemplate">
+        <source>{0} Description</source>
+        <target state="new">{0} Description</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyGridDropDownButtonAccessibleName">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -8651,9 +8651,19 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">Fenêtre Propriétés</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridDefaultAccessibleNameTemplate">
+        <source>{0} Properties Window</source>
+        <target state="new">{0} Properties Window</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridDisabledItemForeColorDesc">
         <source>The foreground color of disabled text in the grid area.</source>
         <target state="translated">Couleur de premier plan du texte désactivé de la grille.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropertyGridDocCommentAccessibleNameTemplate">
+        <source>{0} Description</source>
+        <target state="new">{0} Description</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyGridDropDownButtonAccessibleName">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -8651,9 +8651,19 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">Finestra Proprietà</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridDefaultAccessibleNameTemplate">
+        <source>{0} Properties Window</source>
+        <target state="new">{0} Properties Window</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridDisabledItemForeColorDesc">
         <source>The foreground color of disabled text in the grid area.</source>
         <target state="translated">Colore di primo piano del testo disabilitato nell'area della griglia.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropertyGridDocCommentAccessibleNameTemplate">
+        <source>{0} Description</source>
+        <target state="new">{0} Description</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyGridDropDownButtonAccessibleName">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -8651,9 +8651,19 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">プロパティ ウィンドウ</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridDefaultAccessibleNameTemplate">
+        <source>{0} Properties Window</source>
+        <target state="new">{0} Properties Window</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridDisabledItemForeColorDesc">
         <source>The foreground color of disabled text in the grid area.</source>
         <target state="translated">グリッド領域内の無効な文字の前景色。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropertyGridDocCommentAccessibleNameTemplate">
+        <source>{0} Description</source>
+        <target state="new">{0} Description</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyGridDropDownButtonAccessibleName">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -8651,9 +8651,19 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">속성 창</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridDefaultAccessibleNameTemplate">
+        <source>{0} Properties Window</source>
+        <target state="new">{0} Properties Window</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridDisabledItemForeColorDesc">
         <source>The foreground color of disabled text in the grid area.</source>
         <target state="translated">표 영역에 있는 비활성 텍스트의 전경색입니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropertyGridDocCommentAccessibleNameTemplate">
+        <source>{0} Description</source>
+        <target state="new">{0} Description</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyGridDropDownButtonAccessibleName">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -8651,9 +8651,19 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">Okno właściwości</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridDefaultAccessibleNameTemplate">
+        <source>{0} Properties Window</source>
+        <target state="new">{0} Properties Window</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridDisabledItemForeColorDesc">
         <source>The foreground color of disabled text in the grid area.</source>
         <target state="translated">Kolor pierwszego obszaru wyłączonego tekstu w obszarze siatki.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropertyGridDocCommentAccessibleNameTemplate">
+        <source>{0} Description</source>
+        <target state="new">{0} Description</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyGridDropDownButtonAccessibleName">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -8651,9 +8651,19 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">Janela de Propriedades</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridDefaultAccessibleNameTemplate">
+        <source>{0} Properties Window</source>
+        <target state="new">{0} Properties Window</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridDisabledItemForeColorDesc">
         <source>The foreground color of disabled text in the grid area.</source>
         <target state="translated">A cor do primeiro plano do texto desabilitado na área da grade.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropertyGridDocCommentAccessibleNameTemplate">
+        <source>{0} Description</source>
+        <target state="new">{0} Description</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyGridDropDownButtonAccessibleName">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -8652,9 +8652,19 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">Окно свойств</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridDefaultAccessibleNameTemplate">
+        <source>{0} Properties Window</source>
+        <target state="new">{0} Properties Window</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridDisabledItemForeColorDesc">
         <source>The foreground color of disabled text in the grid area.</source>
         <target state="translated">Цвет переднего плана отключенного текста в области таблицы.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropertyGridDocCommentAccessibleNameTemplate">
+        <source>{0} Description</source>
+        <target state="new">{0} Description</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyGridDropDownButtonAccessibleName">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -8651,9 +8651,19 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">Özellikler Penceresi</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridDefaultAccessibleNameTemplate">
+        <source>{0} Properties Window</source>
+        <target state="new">{0} Properties Window</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridDisabledItemForeColorDesc">
         <source>The foreground color of disabled text in the grid area.</source>
         <target state="translated">Kılavuz alanındaki devre dışı metnin ön plan rengi.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropertyGridDocCommentAccessibleNameTemplate">
+        <source>{0} Description</source>
+        <target state="new">{0} Description</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyGridDropDownButtonAccessibleName">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -8651,9 +8651,19 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">属性窗口</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridDefaultAccessibleNameTemplate">
+        <source>{0} Properties Window</source>
+        <target state="new">{0} Properties Window</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridDisabledItemForeColorDesc">
         <source>The foreground color of disabled text in the grid area.</source>
         <target state="translated">网格区域中的禁用文本的前景色。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropertyGridDocCommentAccessibleNameTemplate">
+        <source>{0} Description</source>
+        <target state="new">{0} Description</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyGridDropDownButtonAccessibleName">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -8651,9 +8651,19 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">屬性視窗</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridDefaultAccessibleNameTemplate">
+        <source>{0} Properties Window</source>
+        <target state="new">{0} Properties Window</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridDisabledItemForeColorDesc">
         <source>The foreground color of disabled text in the grid area.</source>
         <target state="translated">方格區域中停用文字的前景色彩。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropertyGridDocCommentAccessibleNameTemplate">
+        <source>{0} Description</source>
+        <target state="new">{0} Description</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyGridDropDownButtonAccessibleName">

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -203,7 +203,7 @@ namespace System.Windows.Forms
                 toolStrip = new PropertyGridToolStrip(this);
                 toolStrip.SuspendLayout();
                 toolStrip.ShowItemToolTips = true;
-                toolStrip.AccessibleName = SR.PropertyGridToolbarAccessibleName;
+
                 toolStrip.AccessibleRole = AccessibleRole.ToolBar;
                 toolStrip.TabStop = true;
                 toolStrip.AllowMerge = false;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -6062,17 +6062,12 @@ namespace System.Windows.Forms
         /// <param name="propertyId">Identifier indicating the property to return</param>
         /// <returns>Returns a ValInfo indicating whether the element supports this property, or has no value for it.</returns>
         internal override object GetPropertyValue(int propertyID)
-        {
-            switch (propertyID)
+            => propertyID switch
             {
-                case NativeMethods.UIA_ControlTypePropertyId:
-                    return NativeMethods.UIA_ToolBarControlTypeId;
-                case NativeMethods.UIA_NamePropertyId:
-                    return Name;
-            }
-
-            return base.GetPropertyValue(propertyID);
-        }
+                NativeMethods.UIA_ControlTypePropertyId => NativeMethods.UIA_ToolBarControlTypeId,
+                NativeMethods.UIA_NamePropertyId => Name,
+                _ => base.GetPropertyValue(propertyID)
+            };
 
         public override string Name
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -5954,6 +5954,36 @@ namespace System.Windows.Forms
 
             return -1;
         }
+
+        internal override object GetPropertyValue(int propertyID)
+        {
+            switch (propertyID)
+            {
+                case NativeMethods.UIA_NamePropertyId:
+                    return Name;
+            }
+
+            return base.GetPropertyValue(propertyID);
+        }
+
+        public override string Name
+        {
+            get
+            {
+                string name = Owner?.AccessibleName;
+                if (name != null)
+                {
+                    return name;
+                }
+
+                return Owner.Name;
+            }
+
+            set
+            {
+                Owner.AccessibleName = value;
+            }
+        }
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -6063,16 +6063,29 @@ namespace System.Windows.Forms
         /// <returns>Returns a ValInfo indicating whether the element supports this property, or has no value for it.</returns>
         internal override object GetPropertyValue(int propertyID)
         {
-            if (propertyID == NativeMethods.UIA_ControlTypePropertyId)
+            switch (propertyID)
             {
-                return NativeMethods.UIA_ToolBarControlTypeId;
-            }
-            else if (propertyID == NativeMethods.UIA_NamePropertyId)
-            {
-                return Name;
+                case NativeMethods.UIA_ControlTypePropertyId:
+                    return NativeMethods.UIA_ToolBarControlTypeId;
+                case NativeMethods.UIA_NamePropertyId:
+                    return Name;
             }
 
             return base.GetPropertyValue(propertyID);
+        }
+
+        public override string Name
+        {
+            get
+            {
+                string name = Owner?.AccessibleName;
+                if (name != null)
+                {
+                    return name;
+                }
+
+                return _parentPropertyGrid?.Name;
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DocComment.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DocComment.cs
@@ -318,7 +318,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return name;
                 }
 
-                return _parentPropertyGrid?.Name;
+                return string.Format(SR.PropertyGridDocCommentAccessibleNameTemplate, _parentPropertyGrid?.Name);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DocComment.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DocComment.cs
@@ -296,17 +296,12 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// <param name="propertyId">Identifier indicating the property to return</param>
         /// <returns>Returns a ValInfo indicating whether the element supports this property, or has no value for it.</returns>
         internal override object GetPropertyValue(int propertyID)
-        {
-            switch (propertyID)
+            => propertyID switch
             {
-                case NativeMethods.UIA_ControlTypePropertyId:
-                    return NativeMethods.UIA_PaneControlTypeId;
-                case NativeMethods.UIA_NamePropertyId:
-                    return Name;
-            }
-
-            return base.GetPropertyValue(propertyID);
-        }
+                NativeMethods.UIA_ControlTypePropertyId => NativeMethods.UIA_PaneControlTypeId,
+                NativeMethods.UIA_NamePropertyId => Name,
+                _ => base.GetPropertyValue(propertyID)
+            };
 
         public override string Name
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DocComment.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DocComment.cs
@@ -297,16 +297,29 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// <returns>Returns a ValInfo indicating whether the element supports this property, or has no value for it.</returns>
         internal override object GetPropertyValue(int propertyID)
         {
-            if (propertyID == NativeMethods.UIA_ControlTypePropertyId)
+            switch (propertyID)
             {
-                return NativeMethods.UIA_PaneControlTypeId;
-            }
-            else if (propertyID == NativeMethods.UIA_NamePropertyId)
-            {
-                return Name;
+                case NativeMethods.UIA_ControlTypePropertyId:
+                    return NativeMethods.UIA_PaneControlTypeId;
+                case NativeMethods.UIA_NamePropertyId:
+                    return Name;
             }
 
             return base.GetPropertyValue(propertyID);
+        }
+
+        public override string Name
+        {
+            get
+            {
+                string name = Owner?.AccessibleName;
+                if (name != null)
+                {
+                    return name;
+                }
+
+                return _parentPropertyGrid?.Name;
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/HotCommands.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/HotCommands.cs
@@ -291,17 +291,12 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// <param name="propertyId">Identifier indicating the property to return</param>
         /// <returns>Returns a ValInfo indicating whether the element supports this property, or has no value for it.</returns>
         internal override object GetPropertyValue(int propertyID)
-        {
-            switch (propertyID)
+            => propertyID switch
             {
-                case NativeMethods.UIA_ControlTypePropertyId:
-                    return NativeMethods.UIA_PaneControlTypeId;
-                case NativeMethods.UIA_NamePropertyId:
-                    return Name;
-            }
-
-            return base.GetPropertyValue(propertyID);
-        }
+                NativeMethods.UIA_ControlTypePropertyId => NativeMethods.UIA_PaneControlTypeId,
+                NativeMethods.UIA_NamePropertyId => Name,
+                _ => base.GetPropertyValue(propertyID)
+            };
 
         public override string Name
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/HotCommands.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/HotCommands.cs
@@ -292,16 +292,29 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// <returns>Returns a ValInfo indicating whether the element supports this property, or has no value for it.</returns>
         internal override object GetPropertyValue(int propertyID)
         {
-            if (propertyID == NativeMethods.UIA_ControlTypePropertyId)
+            switch (propertyID)
             {
-                return NativeMethods.UIA_PaneControlTypeId;
-            }
-            else if (propertyID == NativeMethods.UIA_NamePropertyId)
-            {
-                return Name;
+                case NativeMethods.UIA_ControlTypePropertyId:
+                    return NativeMethods.UIA_PaneControlTypeId;
+                case NativeMethods.UIA_NamePropertyId:
+                    return Name;
             }
 
             return base.GetPropertyValue(propertyID);
+        }
+
+        public override string Name
+        {
+            get
+            {
+                string name = Owner?.AccessibleName;
+                if (name != null)
+                {
+                    return name;
+                }
+
+                return _parentPropertyGrid?.Name;
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -8530,10 +8530,8 @@ namespace System.Windows.Forms.PropertyGridInternal
                     {
                         return name;
                     }
-                    else
-                    {
-                        return SR.PropertyGridDefaultAccessibleName;
-                    }
+
+                    return _owningPropertyGridView?.OwnerGrid?.Name;
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -8494,32 +8494,22 @@ namespace System.Windows.Forms.PropertyGridInternal
             /// <param name="propertyId">Identifier indicating the property to return</param>
             /// <returns>Returns a ValInfo indicating whether the element supports this property, or has no value for it.</returns>
             internal override object GetPropertyValue(int propertyID)
-            {
-                switch (propertyID)
+                => propertyID switch
                 {
-                    case NativeMethods.UIA_ControlTypePropertyId:
-                        return NativeMethods.UIA_TableControlTypeId;
-                    case NativeMethods.UIA_NamePropertyId:
-                        return Name;
-                    case NativeMethods.UIA_IsTablePatternAvailablePropertyId:
-                    case NativeMethods.UIA_IsGridPatternAvailablePropertyId:
-                        return true;
-                }
-
-                return base.GetPropertyValue(propertyID);
-            }
+                    NativeMethods.UIA_ControlTypePropertyId => NativeMethods.UIA_TableControlTypeId,
+                    NativeMethods.UIA_NamePropertyId => Name,
+                    NativeMethods.UIA_IsTablePatternAvailablePropertyId => true,
+                    NativeMethods.UIA_IsGridPatternAvailablePropertyId => true,
+                    _ => base.GetPropertyValue(propertyID)
+                };
 
             internal override bool IsPatternSupported(int patternId)
-            {
-                switch (patternId)
+                => patternId switch
                 {
-                    case NativeMethods.UIA_TablePatternId:
-                    case NativeMethods.UIA_GridPatternId:
-                        return true;
-                }
-
-                return base.IsPatternSupported(patternId);
-            }
+                    NativeMethods.UIA_TablePatternId => true,
+                    NativeMethods.UIA_GridPatternId => true,
+                    _ => base.IsPatternSupported(patternId)
+                };
 
             public override string Name
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -8531,7 +8531,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         return name;
                     }
 
-                    return _owningPropertyGridView?.OwnerGrid?.Name;
+                    return string.Format(SR.PropertyGridDefaultAccessibleNameTemplate, _owningPropertyGridView?.OwnerGrid?.Name);
                 }
             }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1864


## Proposed changes

- Added providing indexable accessible name for PropertyGrid control (by default). New default accessible name equals to default control name, for instance "propertyGrid1", "propertyGrid2" and so on.
- Added providing indexable accessible name for PropertyGrid's inner table.


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- With the fix available, multiple tables in Form have different names. Screen reader will also announce PropertyGrid's names and table names correctly..


## Regression? 

- No

## Risk

- Low

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->
![image](https://user-images.githubusercontent.com/23213980/64702682-a42a9780-d4b3-11e9-83d0-24f3a101e1cd.png)


### After

<!-- TODO -->
![image](https://user-images.githubusercontent.com/23213980/64703167-96294680-d4b4-11e9-963a-250131fffae3.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual testing. Tools: Inspect, Accessibility insights.
- Automation, need QA approval.
- Unit tests (to be implemented)

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->
<!-- use `dotnet --info` -->
  2.1.700-preview-009601 [C:\Program Files\dotnet\sdk]
  2.1.801 [C:\Program Files\dotnet\sdk]
  3.0.100-preview8-012929 [C:\Program Files\dotnet\sdk]
  3.0.100-preview9-014004 [C:\Program Files\dotnet\sdk]

.NET Core runtimes installed:
  Microsoft.AspNetCore.All 2.1.9 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.All]
  Microsoft.AspNetCore.All 2.1.12 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.All]
  Microsoft.AspNetCore.App 2.1.9 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.AspNetCore.App 2.1.12 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.AspNetCore.App 3.0.0-preview8.19351.9 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.AspNetCore.App 3.0.0-preview9.19424.4 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 2.1.9 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 2.1.12 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 3.0.0-preview8-27907-09 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 3.0.0-preview9-19423-09 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.WindowsDesktop.App 3.0.0-preview8-27907-09 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
  Microsoft.WindowsDesktop.App 3.0.0-preview9-19423-09 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]

To install additional .NET Core runtimes or SDKs:
  https://aka.ms/dotnet-download

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1866)