### PR TITLE
make changing targetframework easier in the future, do not actually override TargetFrameworkVersion and Name which are used elsewhere

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,9 +5,9 @@
   <Import Project="eng\FacadeAssemblies.props" />
 
   <PropertyGroup>
-    <TargetFrameworkName>netcoreapp</TargetFrameworkName>
-    <TargetFrameworkVersion>5.0</TargetFrameworkVersion>
-    <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>
+    <TargetFrameworkPrivateName>netcoreapp</TargetFrameworkPrivateName>
+    <TargetFrameworkPrivateVersion>5.0</TargetFrameworkPrivateVersion>
+    <PrivateTargetFramework>$(TargetFrameworkPrivateName)$(TargetFrameworkPrivateVersion)</PrivateTargetFramework>
     <Product>Microsoft&#xAE; .NET</Product>
     <Copyright>$(CopyrightNetFoundation)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,9 +5,9 @@
   <Import Project="eng\FacadeAssemblies.props" />
 
   <PropertyGroup>
-    <TargetFrameworkPrivateName>netcoreapp</TargetFrameworkPrivateName>
-    <TargetFrameworkPrivateVersion>5.0</TargetFrameworkPrivateVersion>
-    <PrivateTargetFramework>$(TargetFrameworkPrivateName)$(TargetFrameworkPrivateVersion)</PrivateTargetFramework>
+    <PrivateTargetFrameworkName>netcoreapp</PrivateTargetFrameworkName>
+    <PrivateTargetFrameworkVersion>5.0</PrivateTargetFrameworkVersion>
+    <PrivateTargetFramework>$(PrivateTargetFrameworkName)$(PrivateTargetFrameworkVersion)</PrivateTargetFramework>
     <Product>Microsoft&#xAE; .NET</Product>
     <Copyright>$(CopyrightNetFoundation)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/Microsoft.Dotnet.Winforms.ProjectTemplates.csproj
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/Microsoft.Dotnet.Winforms.ProjectTemplates.csproj
@@ -1,9 +1,7 @@
 ﻿<Project InitialTargets="BuildPackage">
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
   <PropertyGroup>
-    <TargetFrameworkName>netcoreapp</TargetFrameworkName>
-    <TargetFrameworkVersion>5.0</TargetFrameworkVersion>
-    <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>
+    <TargetFramework>$(PrivateTargetFramework)</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     

--- a/pkg/Microsoft.Private.Winforms/Microsoft.Private.Winforms.csproj
+++ b/pkg/Microsoft.Private.Winforms/Microsoft.Private.Winforms.csproj
@@ -14,7 +14,7 @@
   -->
 
   <PropertyGroup>
-    <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>
+    <TargetFramework>$(PrivateTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <!-- This is a Packaging Project -->

--- a/src/Accessibility/src/Accessibility.ilproj
+++ b/src/Accessibility/src/Accessibility.ilproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>
+    <TargetFramework>$(PrivateTargetFramework)</TargetFramework>
     <!-- Package this as both a reference and implementation -->
     <PackageAsRefAndLib>true</PackageAsRefAndLib>
     <!-- ILAsm doesn't produce a PDB - https://github.com/dotnet/coreclr/issues/15299 -->

--- a/src/Accessibility/ver/Accessibility-version.csproj
+++ b/src/Accessibility/ver/Accessibility-version.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+  <TargetFramework>$(PrivateTargetFramework)</TargetFramework>
     <!-- this project is intentionally empty, it's only built so that we can 
          use its resources when assembling the Accessibility dll -->
   </PropertyGroup>

--- a/src/System.Design/src/System.Design.Facade.csproj
+++ b/src/System.Design/src/System.Design.Facade.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <AssemblyName>System.Design</AssemblyName>
+    <TargetFramework>$(PrivateTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\System.Windows.Forms.Design.Editors\src\System.Windows.Forms.Design.Editors.csproj" />
     <ProjectReference Include="..\..\System.Windows.Forms.Design\src\System.Windows.Forms.Design.csproj" />
   </ItemGroup>
-  
 </Project>

--- a/src/System.Drawing.Design/src/System.Drawing.Design.Facade.csproj
+++ b/src/System.Drawing.Design/src/System.Drawing.Design.Facade.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <AssemblyName>System.Drawing.Design</AssemblyName>
+    <TargetFramework>$(PrivateTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\System.Windows.Forms.Design.Editors\src\System.Windows.Forms.Design.Editors.csproj" />
     <ProjectReference Include="..\..\System.Windows.Forms\src\System.Windows.Forms.csproj" />
   </ItemGroup>
-  
 </Project>

--- a/src/System.Drawing/src/System.Drawing.Facade.csproj
+++ b/src/System.Drawing/src/System.Drawing.Facade.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <AssemblyName>System.Drawing</AssemblyName>
+    <TargetFramework>$(PrivateTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,5 +13,4 @@
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonPackageVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
   </ItemGroup>
-  
 </Project>

--- a/src/System.Windows.Forms.Design.Editors/src/System.Windows.Forms.Design.Editors.csproj
+++ b/src/System.Windows.Forms.Design.Editors/src/System.Windows.Forms.Design.Editors.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <AssemblyName>System.Windows.Forms.Design.Editors</AssemblyName>
+    <TargetFramework>$(PrivateTargetFramework)</TargetFramework>
     <CLSCompliant>true</CLSCompliant>
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
@@ -90,5 +90,4 @@
     <Compile Include="..\..\Common\src\Interop\User32\Interop.DT.cs" Link="Interop\User32\Interop.DT.cs" />
     <Compile Include="..\..\Common\src\Microsoft\Win32\SafeHandles\CoTaskMemSafeHandle.cs" Link="Microsoft\Win32\SafeHandles\CoTaskMemSafeHandle.cs" />
   </ItemGroup>
-
 </Project>

--- a/src/System.Windows.Forms.Design.Editors/tests/UnitTests/System.Windows.Forms.Design.Editors.Tests.csproj
+++ b/src/System.Windows.Forms.Design.Editors/tests/UnitTests/System.Windows.Forms.Design.Editors.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <AssemblyName>System.Windows.Forms.Design.Editors.Tests</AssemblyName>
+    <TargetFramework>$(PrivateTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>    
@@ -22,5 +22,4 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-
 </Project>

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <AssemblyName>System.Windows.Forms.Design</AssemblyName>    
+    <AssemblyName>System.Windows.Forms.Design</AssemblyName>
+    <TargetFramework>$(PrivateTargetFramework)</TargetFramework>    
     <CLSCompliant>true</CLSCompliant>
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System.Windows.Forms.Design.Tests.csproj
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System.Windows.Forms.Design.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <AssemblyName>System.Windows.Forms.Design.Tests</AssemblyName>
+    <TargetFramework>$(PrivateTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/src/System.Windows.Forms.csproj
+++ b/src/System.Windows.Forms/src/System.Windows.Forms.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <AssemblyName>System.Windows.Forms</AssemblyName>
+    <TargetFramework>$(PrivateTargetFramework)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLSCompliant>true</CLSCompliant>
     <!--the obsolete usage in public surface can't be removed-->

--- a/src/System.Windows.Forms/tests/AccessibilityTests/AccessibilityTests.csproj
+++ b/src/System.Windows.Forms/tests/AccessibilityTests/AccessibilityTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
+    <TargetFramework>$(PrivateTargetFramework)</TargetFramework>
     <OutputType>WinExe</OutputType>
     <RootNamespace>AccessibilityTests</RootNamespace>
     <AssemblyName>AccessibilityTests</AssemblyName>
@@ -9,8 +9,6 @@
     <ApplicationManifest>app1.manifest</ApplicationManifest>
     <UsingToolXliff>false</UsingToolXliff>
   </PropertyGroup>
-
-
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Windows.Forms.csproj" />
@@ -30,5 +28,4 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-
 </Project>

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiButtonTests/MauiButtonTests.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiButtonTests/MauiButtonTests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
+    <TargetFramework>$(PrivateTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
-
 </Project>

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiComboBoxTests/MauiComboBoxTests.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiComboBoxTests/MauiComboBoxTests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  
   <PropertyGroup>
+    <TargetFramework>$(PrivateTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
-
 </Project>

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/System.Windows.Forms.IntegrationTests.Common.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/System.Windows.Forms.IntegrationTests.Common.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
- 
   <PropertyGroup>
+    <TargetFramework>$(PrivateTargetFramework)</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -14,5 +14,4 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\System.Windows.Forms.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/TestHelpers.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/TestHelpers.cs
@@ -28,6 +28,9 @@ namespace System.Windows.Forms.IntegrationTests.Common
             }
         }
 
+        private static string TargetFramework
+            => "netcoreapp5.0";
+
         /// <summary>
         ///  Get the output exe path for a specified project.
         ///  Throws an exception if the path does not exist
@@ -40,7 +43,7 @@ namespace System.Windows.Forms.IntegrationTests.Common
                 throw new ArgumentNullException(nameof(projectName));
 
             var repoRoot = GetRepoRoot();
-            var exePath = Path.Combine(repoRoot, $"artifacts\\bin\\{projectName}\\{Config}\\netcoreapp5.0\\{projectName}.exe");
+            var exePath = Path.Combine(repoRoot, $"artifacts\\bin\\{projectName}\\{Config}\\{TargetFramework}\\{projectName}.exe");
 
             if (!File.Exists(exePath))
                 throw new FileNotFoundException("File does not exist", exePath);

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests/System.Windows.Forms.IntegrationTests.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests/System.Windows.Forms.IntegrationTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
+    <TargetFramework>$(PrivateTargetFramework)</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -9,5 +9,4 @@
     <ProjectReference Include="..\System.Windows.Forms.IntegrationTests.Common\System.Windows.Forms.IntegrationTests.Common.csproj" />
     <ProjectReference Include="..\WinformsControlsTest\WinformsControlsTest.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.Maui.IntegrationTests/System.Windows.Forms.Maui.IntegrationTests.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.Maui.IntegrationTests/System.Windows.Forms.Maui.IntegrationTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
+    <TargetFramework>$(PrivateTargetFramework)</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -8,5 +8,4 @@
     <ProjectReference Include="..\MauiTests\**\*.csproj" />
     <ProjectReference Include="..\System.Windows.Forms.IntegrationTests.Common\System.Windows.Forms.IntegrationTests.Common.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/WinformsControlsTest.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/WinformsControlsTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
+    <TargetFramework>$(PrivateTargetFramework)</TargetFramework>
     <AssemblyName>WinformsControlsTest</AssemblyName>
     <RootNamespace>WinformsControlsTest</RootNamespace>
     <ApplicationIcon />
@@ -151,5 +151,4 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
+++ b/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <AssemblyName>System.Windows.Forms.Tests</AssemblyName>
+    <TargetFramework>$(PrivateTargetFramework)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
@@ -32,5 +32,4 @@
       <LogicalName>System.Windows.Forms.Design.Tests.CustomPropertyTab</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Spoke with Eric about the dangers of overwriting TargetFrameworkVersion and Name with our own values. This is my own fault as I did not realize the risks; other places expect to use these values, so we need to use our own private ones. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1872)