### PR TITLE
Update checks for screen.WorkingArea

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScreenTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScreenTests.cs
@@ -210,8 +210,10 @@ namespace System.Windows.Forms.Tests
             Assert.True(screen.Bounds.Height != 0);
             Assert.InRange(screen.DeviceName.Length, 1, 32);
             Assert.Equal(screen.DeviceName, screen.DeviceName.Trim('\0'));
-            Assert.InRange(screen.WorkingArea.Width, screen.Bounds.X, screen.Bounds.Width);
-            Assert.InRange(screen.WorkingArea.Height, screen.Bounds.Y, screen.Bounds.Height);
+            Assert.InRange(screen.WorkingArea.Width, 0, screen.Bounds.Width);
+            Assert.InRange(screen.WorkingArea.Height, 0, screen.Bounds.Height);
+            Assert.InRange(screen.WorkingArea.X, screen.Bounds.X, screen.Bounds.X + screen.Bounds.Width);
+            Assert.InRange(screen.WorkingArea.Y, screen.Bounds.Y, screen.Bounds.Y + screen.Bounds.Width);
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

Update checks for `Screen.WorkingArea` to allow for multiple monitors of different resolutions.

For instance, with two monitors where the right monitor is vertical, `Bounds: {X = 2560 Y = 0 Width = 1440 Height = 2560}`.

## Customer Impact

Test change only.

## Risk

Low.