### PR TITLE
Cleanup COMRECT interop in some IOle interfaces

### DIFF
--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -2468,14 +2468,6 @@ namespace System.Windows.Forms
                 bottom = r.Bottom;
             }
 
-            public COMRECT(int left, int top, int right, int bottom)
-            {
-                this.left = left;
-                this.top = top;
-                this.right = right;
-                this.bottom = bottom;
-            }
-
             public override string ToString()
             {
                 return "Left = " + left + " Top " + top + " Right = " + right + " Bottom = " + bottom;

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -2476,11 +2476,6 @@ namespace System.Windows.Forms
                 this.bottom = bottom;
             }
 
-            public static COMRECT FromXYWH(int x, int y, int width, int height)
-            {
-                return new COMRECT(x, y, x + width, y + height);
-            }
-
             public override string ToString()
             {
                 return "Left = " + left + " Top " + top + " Right = " + right + " Bottom = " + bottom;

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -932,7 +932,7 @@ namespace System.Windows.Forms
             int OnUIActivate();
 
             [PreserveSig]
-            int GetWindowContext(
+            HRESULT GetWindowContext(
                 [Out, MarshalAs(UnmanagedType.Interface)]
                 out IOleInPlaceFrame ppFrame,
                 [Out, MarshalAs(UnmanagedType.Interface)]
@@ -962,7 +962,7 @@ namespace System.Windows.Forms
             int DeactivateAndUndo();
 
             [PreserveSig]
-            int OnPosRectChange(
+            HRESULT OnPosRectChange(
                 [In]
                 NativeMethods.COMRECT lprcPosRect);
         }
@@ -1645,7 +1645,8 @@ namespace System.Windows.Forms
             [PreserveSig]
             int UIDeactivate();
 
-            void SetObjectRects(
+            [PreserveSig]
+            HRESULT SetObjectRects(
                    [In]
                       NativeMethods.COMRECT lprcPosRect,
                    [In]

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -933,14 +933,10 @@ namespace System.Windows.Forms
 
             [PreserveSig]
             HRESULT GetWindowContext(
-                [Out, MarshalAs(UnmanagedType.Interface)]
                 out IOleInPlaceFrame ppFrame,
-                [Out, MarshalAs(UnmanagedType.Interface)]
                 out IOleInPlaceUIWindow ppDoc,
-                [Out]
-                NativeMethods.COMRECT lprcPosRect,
-                [Out]
-                NativeMethods.COMRECT lprcClipRect,
+                RECT* lprcPosRect,
+                RECT* lprcClipRect,
                 [In, Out]
                 NativeMethods.tagOIFI lpFrameInfo);
 
@@ -963,8 +959,7 @@ namespace System.Windows.Forms
 
             [PreserveSig]
             HRESULT OnPosRectChange(
-                [In]
-                NativeMethods.COMRECT lprcPosRect);
+                RECT* lprcPosRect);
         }
 
         [ComImport(), Guid("40A050A0-3C31-101B-A82E-08002B2B2337"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
@@ -1647,15 +1642,13 @@ namespace System.Windows.Forms
 
             [PreserveSig]
             HRESULT SetObjectRects(
-                   [In]
-                      NativeMethods.COMRECT lprcPosRect,
-                   [In]
-                      NativeMethods.COMRECT lprcClipRect);
+                RECT* lprcPosRect,
+                RECT* lprcClipRect);
 
             void ReactivateAndUndo();
         }
 
-        [ComImport()]
+        [ComImport]
         [Guid("00000112-0000-0000-C000-000000000046")]
         [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
         public unsafe interface IOleObject
@@ -1715,7 +1708,7 @@ namespace System.Windows.Forms
                 IOleClientSite pActiveSite,
                 int lindex,
                 IntPtr hwndParent,
-                NativeMethods.COMRECT lprcPosRect);
+                RECT* lprcPosRect);
 
             [PreserveSig]
             int EnumVerbs(out IEnumOLEVERB e);
@@ -1830,7 +1823,7 @@ namespace System.Windows.Forms
                 IOleClientSite pActiveSite,
                 int lindex,
                 IntPtr hwndParent,
-                NativeMethods.COMRECT lprcPosRect);
+                RECT* lprcPosRect);
 
             [PreserveSig]
             int EnumVerbs(out IEnumOLEVERB e);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -13882,11 +13882,11 @@ namespace System.Windows.Forms
             return ActiveXInstance.UIDeactivate();
         }
 
-        HRESULT UnsafeNativeMethods.IOleInPlaceObject.SetObjectRects(NativeMethods.COMRECT lprcPosRect, NativeMethods.COMRECT lprcClipRect)
+        unsafe HRESULT UnsafeNativeMethods.IOleInPlaceObject.SetObjectRects(RECT* lprcPosRect, RECT* lprcClipRect)
         {
             if (lprcClipRect != null)
             {
-                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:SetObjectRects(" + lprcClipRect.left + ", " + lprcClipRect.top + ", " + lprcClipRect.right + ", " + lprcClipRect.bottom + ")");
+                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:SetObjectRects(" + lprcClipRect->left + ", " + lprcClipRect->top + ", " + lprcClipRect->right + ", " + lprcClipRect->bottom + ")");
             }
 
             Debug.Indent();
@@ -13960,7 +13960,7 @@ namespace System.Windows.Forms
             UnsafeNativeMethods.IOleClientSite pActiveSite,
             int lindex,
             IntPtr hwndParent,
-            NativeMethods.COMRECT lprcPosRect)
+            RECT* lprcPosRect)
         {
             // In Office they are internally casting an iverb to a short and not
             // doing the proper sign extension.  So, we do it here.
@@ -13977,7 +13977,7 @@ namespace System.Windows.Forms
                 Debug.WriteLine("     activeSite: " + pActiveSite);
                 Debug.WriteLine("     index: " + lindex);
                 Debug.WriteLine("     hwndParent: " + hwndParent);
-                Debug.WriteLine("     posRect: " + (lprcPosRect != null ? lprcPosRect.ToString() : "null"));
+                Debug.WriteLine("     posRect: " + (lprcPosRect != null ? (*lprcPosRect).ToString() : "null"));
             }
 #endif
             Debug.Indent();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -13882,12 +13882,17 @@ namespace System.Windows.Forms
             return ActiveXInstance.UIDeactivate();
         }
 
-        void UnsafeNativeMethods.IOleInPlaceObject.SetObjectRects(NativeMethods.COMRECT lprcPosRect, NativeMethods.COMRECT lprcClipRect)
+        HRESULT UnsafeNativeMethods.IOleInPlaceObject.SetObjectRects(NativeMethods.COMRECT lprcPosRect, NativeMethods.COMRECT lprcClipRect)
         {
-            Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:SetObjectRects(" + lprcClipRect.left + ", " + lprcClipRect.top + ", " + lprcClipRect.right + ", " + lprcClipRect.bottom + ")");
+            if (lprcClipRect != null)
+            {
+                Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:SetObjectRects(" + lprcClipRect.left + ", " + lprcClipRect.top + ", " + lprcClipRect.right + ", " + lprcClipRect.bottom + ")");
+            }
+
             Debug.Indent();
-            ActiveXInstance.SetObjectRects(lprcPosRect, lprcClipRect);
+            HRESULT hr = ActiveXInstance.SetObjectRects(lprcPosRect, lprcClipRect);
             Debug.Unindent();
+            return hr;
         }
 
         void UnsafeNativeMethods.IOleInPlaceObject.ReactivateAndUndo()
@@ -13949,7 +13954,13 @@ namespace System.Windows.Forms
             return NativeMethods.E_NOTIMPL;
         }
 
-        unsafe HRESULT UnsafeNativeMethods.IOleObject.DoVerb(int iVerb, User32.MSG* lpmsg, UnsafeNativeMethods.IOleClientSite pActiveSite, int lindex, IntPtr hwndParent, NativeMethods.COMRECT lprcPosRect)
+        unsafe HRESULT UnsafeNativeMethods.IOleObject.DoVerb(
+            int iVerb,
+            User32.MSG* lpmsg,
+            UnsafeNativeMethods.IOleClientSite pActiveSite,
+            int lindex,
+            IntPtr hwndParent,
+            NativeMethods.COMRECT lprcPosRect)
         {
             // In Office they are internally casting an iverb to a short and not
             // doing the proper sign extension.  So, we do it here.
@@ -13966,14 +13977,13 @@ namespace System.Windows.Forms
                 Debug.WriteLine("     activeSite: " + pActiveSite);
                 Debug.WriteLine("     index: " + lindex);
                 Debug.WriteLine("     hwndParent: " + hwndParent);
-                Debug.WriteLine("     posRect: " + lprcPosRect);
+                Debug.WriteLine("     posRect: " + (lprcPosRect != null ? lprcPosRect.ToString() : "null"));
             }
 #endif
             Debug.Indent();
             try
             {
-                ActiveXInstance.DoVerb(iVerb, lpmsg, pActiveSite, lindex, hwndParent, lprcPosRect);
-                return HRESULT.S_OK;
+                return ActiveXInstance.DoVerb(iVerb, lpmsg, pActiveSite, lindex, hwndParent, lprcPosRect);
             }
             catch (Exception e)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
@@ -199,7 +199,7 @@ namespace System.Windows.Forms
         /// <remarks>
         /// We have to resize the ActiveX control when our size changes.
         /// </remarks>
-        internal override void OnBoundsUpdate(int x, int y, int width, int height)
+        internal unsafe override void OnBoundsUpdate(int x, int y, int width, int height)
         {
             // If the ActiveX control is already InPlaceActive, make sure
             // it's bounds also change.
@@ -209,9 +209,9 @@ namespace System.Windows.Forms
                 {
                     webBrowserBaseChangingSize.Width = width;
                     webBrowserBaseChangingSize.Height = height;
-                    NativeMethods.COMRECT posRect = new NativeMethods.COMRECT(new Rectangle(0, 0, width, height));
-                    NativeMethods.COMRECT clipRect = WebBrowserHelper.GetClipRect();
-                    AXInPlaceObject.SetObjectRects(posRect, clipRect);
+                    RECT posRect = new Rectangle(0, 0, width, height);
+                    RECT clipRect = WebBrowserHelper.GetClipRect();
+                    AXInPlaceObject.SetObjectRects(&posRect, &clipRect);
                 }
                 finally
                 {
@@ -710,8 +710,8 @@ namespace System.Windows.Forms
 
         internal unsafe bool DoVerb(int verb)
         {
-            var posRect = new NativeMethods.COMRECT(Bounds);
-            HRESULT hr = axOleObject.DoVerb(verb, null, ActiveXSite, 0, Handle, posRect);
+            RECT posRect = Bounds;
+            HRESULT hr = axOleObject.DoVerb(verb, null, ActiveXSite, 0, Handle, &posRect);
             Debug.Assert(hr == HRESULT.S_OK, string.Format(CultureInfo.CurrentCulture, "DoVerb call failed for verb 0x{0:X}", verb));
             return hr == HRESULT.S_OK;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
@@ -196,12 +196,11 @@ namespace System.Windows.Forms
             }
         }
 
-        //
-        // We have to resize the ActiveX control when our size changes.
-        //
+        /// <remarks>
+        /// We have to resize the ActiveX control when our size changes.
+        /// </remarks>
         internal override void OnBoundsUpdate(int x, int y, int width, int height)
         {
-            //
             // If the ActiveX control is already InPlaceActive, make sure
             // it's bounds also change.
             if (ActiveXState >= WebBrowserHelper.AXState.InPlaceActive)
@@ -210,7 +209,9 @@ namespace System.Windows.Forms
                 {
                     webBrowserBaseChangingSize.Width = width;
                     webBrowserBaseChangingSize.Height = height;
-                    AXInPlaceObject.SetObjectRects(new NativeMethods.COMRECT(new Rectangle(0, 0, width, height)), WebBrowserHelper.GetClipRect());
+                    NativeMethods.COMRECT posRect = new NativeMethods.COMRECT(new Rectangle(0, 0, width, height));
+                    NativeMethods.COMRECT clipRect = WebBrowserHelper.GetClipRect();
+                    AXInPlaceObject.SetObjectRects(posRect, clipRect);
                 }
                 finally
                 {
@@ -709,7 +710,8 @@ namespace System.Windows.Forms
 
         internal unsafe bool DoVerb(int verb)
         {
-            HRESULT hr = axOleObject.DoVerb(verb, null, ActiveXSite, 0, Handle, new NativeMethods.COMRECT(Bounds));
+            var posRect = new NativeMethods.COMRECT(Bounds);
+            HRESULT hr = axOleObject.DoVerb(verb, null, ActiveXSite, 0, Handle, posRect);
             Debug.Assert(hr == HRESULT.S_OK, string.Format(CultureInfo.CurrentCulture, "DoVerb call failed for verb 0x{0:X}", verb));
             return hr == HRESULT.S_OK;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserHelper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserHelper.cs
@@ -134,10 +134,9 @@ namespace System.Windows.Forms
         }
 
         // Returns a big COMRECT
-        internal static NativeMethods.COMRECT GetClipRect()
+        internal static RECT GetClipRect()
         {
-            return new NativeMethods.COMRECT(new Rectangle(0, 0, 32000, 32000));
+            return new Rectangle(0, 0, 32000, 32000);
         }
     }
 }
-


### PR DESCRIPTION
## Proposed changes

- Avoid allocations of COMRECT and instead use optional pointers
- Harden code to invalid pointers passed

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1886)