### PR TITLE
Structify TRACKMOUSEEVENT

### DIFF
--- a/src/Common/src/Interop/User32/Interop.TME.cs
+++ b/src/Common/src/Interop/User32/Interop.TME.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [Flags]
+        public enum TME : uint
+        {
+            HOVER = 0x00000001,
+            LEAVE = 0x00000002,
+            NONCLIENT = 0x00000010,
+            QUERY = 0x40000000,
+            CANCEL = 0x80000000,
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.TrackMouseEvent.cs
+++ b/src/Common/src/Interop/User32/Interop.TrackMouseEvent.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public struct TRACKMOUSEEVENT
+        {
+            public uint cbSize;
+            public TME dwFlags;
+            public IntPtr hwndTrack;
+            public uint dwHoverTime;
+
+            public bool IsDefault()
+            {
+                return cbSize == 0 && dwFlags == 0 && hwndTrack == IntPtr.Zero && dwHoverTime == 0;
+            }
+        }
+
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern BOOL TrackMouseEvent(ref TRACKMOUSEEVENT lpEventTrack);
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -1143,8 +1143,6 @@ namespace System.Windows.Forms
 
         public const int TRANSPARENT = 1,
         OPAQUE = 2,
-        TME_HOVER = 0x00000001,
-        TME_LEAVE = 0x00000002,
         TPM_LEFTBUTTON = 0x0000,
         TPM_RIGHTBUTTON = 0x0002,
         TPM_LEFTALIGN = 0x0000,
@@ -1864,15 +1862,6 @@ namespace System.Windows.Forms
             public int rcImage_top = 0;
             public int rcImage_right = 0;
             public int rcImage_bottom = 0;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public class TRACKMOUSEEVENT
-        {
-            public int cbSize = Marshal.SizeOf<TRACKMOUSEEVENT>();
-            public int dwFlags;
-            public IntPtr hwndTrack;
-            public int dwHoverTime = 100; // Never set this to field ZERO, or to HOVER_DEFAULT, ever!
         }
 
         public delegate IntPtr WndProc(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);

--- a/src/Common/src/SafeNativeMethods.cs
+++ b/src/Common/src/SafeNativeMethods.cs
@@ -336,17 +336,6 @@ namespace System.Windows.Forms
 
         internal delegate bool EnumThreadWindowsCallback(IntPtr hWnd, IntPtr lParam);
 
-        // this is a wrapper that comctl exposes for the NT function since it doesn't exist natively on 95.
-        [DllImport(ExternDll.Comctl32, ExactSpelling = true)]
-
-        private static extern bool _TrackMouseEvent(NativeMethods.TRACKMOUSEEVENT tme);
-
-        public static bool TrackMouseEvent(NativeMethods.TRACKMOUSEEVENT tme)
-        {
-            // only on NT - not on 95 - comctl32 has a wrapper for 95 and NT.
-            return _TrackMouseEvent(tme);
-        }
-
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern bool InvalidateRgn(HandleRef hWnd, HandleRef hrgn, bool erase);
 

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -99,6 +99,8 @@
     <Compile Include="..\..\Common\src\Interop\User32\Interop.ReleaseDC.cs" Link="Interop\User32\Interop.ReleaseDC.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SetWindowPos.cs" Link="Interop\User32\Interop.SetWindowPos.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SWP.cs" Link="Interop\User32\Interop.SWP.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.TME.cs" Link="Interop\User32\Interop.TME.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.TrackMouseEvent.cs" Link="Interop\User32\Interop.TrackMouseEvent.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.WindowMessage.cs" Link="Interop\User32\Interop.WindowMessage.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.WINDOWPOS.cs" Link="Interop\User32\Interop.WINDOWPOS.cs" />
   </ItemGroup>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
@@ -43,7 +43,7 @@ namespace System.Windows.Forms.Design.Behavior
         private BehaviorDragDropEventHandler _beginDragHandler; //fired directly before we call .DoDragDrop()
         private BehaviorDragDropEventHandler _endDragHandler; //fired directly after we call .DoDragDrop()
         private EventHandler _synchronizeEventHandler; //fired when we want to synchronize the selection
-        private NativeMethods.TRACKMOUSEEVENT _trackMouseEvent; //demand created (once) used to track the mouse hover event
+        private User32.TRACKMOUSEEVENT _trackMouseEvent; //demand created (once) used to track the mouse hover event
         private bool _trackingMouseEvent; //state identifying current mouse tracking
         private string[] _testHook_RecentSnapLines; //we keep track of the last snaplines we found - for testing purposes
         private readonly MenuCommandHandler _menuCommandHandler; //private object that handles all menu commands
@@ -86,7 +86,7 @@ namespace System.Windows.Forms.Design.Behavior
             _hitTestedGlyph = null;
             _validDragArgs = null;
             _actionPointer = null;
-            _trackMouseEvent = null;
+            _trackMouseEvent = default;
             _trackingMouseEvent = false;
 
             //create out object that will handle all menucommands
@@ -1577,15 +1577,18 @@ namespace System.Windows.Forms.Design.Behavior
             if (!_trackingMouseEvent)
             {
                 _trackingMouseEvent = true;
-                if (_trackMouseEvent == null)
+                if (_trackMouseEvent.IsDefault())
                 {
-                    _trackMouseEvent = new NativeMethods.TRACKMOUSEEVENT
+                    _trackMouseEvent = new User32.TRACKMOUSEEVENT
                     {
-                        dwFlags = NativeMethods.TME_HOVER,
-                        hwndTrack = _adornerWindow.Handle
+                        cbSize = (uint)Marshal.SizeOf<User32.TRACKMOUSEEVENT>(),
+                        dwFlags = User32.TME.HOVER,
+                        hwndTrack = _adornerWindow.Handle,
+                        dwHoverTime = 100
                     };
                 }
-                SafeNativeMethods.TrackMouseEvent(_trackMouseEvent);
+
+                User32.TrackMouseEvent(ref _trackMouseEvent);
             }
         }
         private void UnHookMouseEvent()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -329,7 +329,7 @@ namespace System.Windows.Forms
         private string _text;                       // See ControlStyles.CacheText for usage notes
         private byte _layoutSuspendCount;
         private byte _requiredScaling;              // bits 0-4: BoundsSpecified stored in RequiredScaling property.  Bit 5: RequiredScalingEnabled property.
-        private NativeMethods.TRACKMOUSEEVENT _trackMouseEvent;
+        private User32.TRACKMOUSEEVENT _trackMouseEvent;
         private short _updateCount;
         private LayoutEventArgs _cachedLayoutEventArgs;
         private Queue _threadCallbackList;
@@ -5217,7 +5217,7 @@ namespace System.Windows.Forms
                 _window.DestroyHandle();
             }
 
-            _trackMouseEvent = null;
+            _trackMouseEvent = default;
         }
 
         /// <summary>
@@ -6325,8 +6325,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Sets up the TrackMouseEvent for listening for the
-        ///  mouse leave event.
+        ///  Sets up the TrackMouseEvent for listening for the mouse leave event.
         /// </summary>
         private void HookMouseEvent()
         {
@@ -6334,16 +6333,18 @@ namespace System.Windows.Forms
             {
                 SetState(States.TrackingMouseEvent, true);
 
-                if (_trackMouseEvent == null)
+                if (_trackMouseEvent.IsDefault())
                 {
-                    _trackMouseEvent = new NativeMethods.TRACKMOUSEEVENT
+                    _trackMouseEvent = new User32.TRACKMOUSEEVENT
                     {
-                        dwFlags = NativeMethods.TME_LEAVE | NativeMethods.TME_HOVER,
-                        hwndTrack = Handle
+                        cbSize = (uint)Marshal.SizeOf<User32.TRACKMOUSEEVENT>(),
+                        dwFlags = User32.TME.LEAVE | User32.TME.HOVER,
+                        hwndTrack = Handle,
+                        dwHoverTime = 100
                     };
                 }
 
-                SafeNativeMethods.TrackMouseEvent(_trackMouseEvent);
+                User32.TrackMouseEvent(ref _trackMouseEvent);
             }
         }
 
@@ -7792,8 +7793,9 @@ namespace System.Windows.Forms
             if (visible)
             {
                 UnhookMouseEvent();
-                _trackMouseEvent = null;
+                _trackMouseEvent = default;
             }
+
             if (_parent != null && visible && !Created)
             {
                 bool isDisposing = GetAnyDisposingInHierarchy();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.cs
@@ -7513,6 +7513,24 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, childCallCount2);
         }
 
+        [Fact]
+        public void Control_ResetMouseEventArgs_InvokeWithoutHandle_Success()
+        {
+            var control = new SubControl();
+            control.ResetMouseEventArgs();
+            control.ResetMouseEventArgs();
+        }
+
+        [Fact]
+        public void Control_ResetMouseEventArgs_InvokeWithHandle_Success()
+        {
+            var control = new SubControl();
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+
+            control.ResetMouseEventArgs();
+            control.ResetMouseEventArgs();
+        }
+
         [Theory]
         [InlineData(ControlStyles.UserPaint, true)]
         [InlineData(ControlStyles.UserPaint, false)]
@@ -7679,6 +7697,8 @@ namespace System.Windows.Forms.Tests
             public new void OnResize(EventArgs e) => base.OnResize(e);
 
             public new void OnVisibleChanged(EventArgs e) => base.OnVisibleChanged(e);
+
+            public new void ResetMouseEventArgs() => base.ResetMouseEventArgs();
 
             public new void SetStyle(ControlStyles flag, bool value) => base.SetStyle(flag, value);
         }


### PR DESCRIPTION
## Proposed Changes
- Convert to struct and update null checks to check for `default` instead
- Use `TrackMouseEvent` in `user32.dll` as this is available in all recent versions of Windows supported by .NET Core

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1919)