### PR TITLE
Add ListView tests and tests for other Control properties

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHostTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHostTests.cs
@@ -51,11 +51,13 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.DesignMode);
             Assert.Equal(new Rectangle(0, 0, 75, 23), control.DisplayRectangle);
             Assert.Equal(DockStyle.None, control.Dock);
+            Assert.False(control.DoubleBuffered);
             Assert.False(control.EditMode);
             Assert.True(control.Enabled);
             Assert.NotNull(control.Events);
             Assert.Same(control.Events, control.Events);
             Assert.Equal(Control.DefaultFont, control.Font);
+            Assert.Equal(control.Font.Height, control.FontHeight);
             Assert.Equal(Control.DefaultForeColor, control.ForeColor);
             Assert.False(control.HasAboutBox);
             Assert.False(control.HasChildren);
@@ -69,6 +71,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(Padding.Empty, control.Padding);
             Assert.Null(control.Parent);
             Assert.Equal("Microsoft\u00AE .NET", control.ProductName);
+            Assert.False(control.RecreatingHandle);
+            Assert.Null(control.Region);
+            Assert.False(control.ResizeRedraw);
             Assert.Equal(75, control.Right);
             Assert.False(control.RightToLeft);
             Assert.Equal(RightToLeft.No, ((Control)control).RightToLeft);
@@ -80,6 +85,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, control.Top);
             Assert.True(control.Visible);
             Assert.Equal(75, control.Width);
+
+            Assert.False(control.IsHandleCreated);
         }
 
         [StaTheory]
@@ -119,11 +126,13 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.DesignMode);
             Assert.Equal(new Rectangle(0, 0, 75, 23), control.DisplayRectangle);
             Assert.Equal(DockStyle.None, control.Dock);
+            Assert.False(control.DoubleBuffered);
             Assert.False(control.EditMode);
             Assert.True(control.Enabled);
             Assert.NotNull(control.Events);
             Assert.Same(control.Events, control.Events);
             Assert.Equal(Control.DefaultFont, control.Font);
+            Assert.Equal(control.Font.Height, control.FontHeight);
             Assert.Equal(Control.DefaultForeColor, control.ForeColor);
             Assert.False(control.HasAboutBox);
             Assert.False(control.HasChildren);
@@ -137,6 +146,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(Padding.Empty, control.Padding);
             Assert.Null(control.Parent);
             Assert.Equal("Microsoft\u00AE .NET", control.ProductName);
+            Assert.False(control.RecreatingHandle);
+            Assert.Null(control.Region);
+            Assert.False(control.ResizeRedraw);
             Assert.Equal(75, control.Right);
             Assert.False(control.RightToLeft);
             Assert.Equal(RightToLeft.No, ((Control)control).RightToLeft);
@@ -148,6 +160,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, control.Top);
             Assert.True(control.Visible);
             Assert.Equal(75, control.Width);
+
+            Assert.False(control.IsHandleCreated);
         }
 
         [StaFact]
@@ -980,6 +994,12 @@ namespace System.Windows.Forms.Tests
 
             public new bool DesignMode => base.DesignMode;
 
+            public new bool DoubleBuffered
+            {
+                get => base.DoubleBuffered;
+                set => base.DoubleBuffered = value;
+            }
+
             public new EventHandlerList Events => base.Events;
 
             public new int FontHeight
@@ -992,6 +1012,12 @@ namespace System.Windows.Forms.Tests
             {
                 get => base.ImeModeBase;
                 set => base.ImeModeBase = value;
+            }
+
+            public new bool ResizeRedraw
+            {
+                get => base.ResizeRedraw;
+                set => base.ResizeRedraw = value;
             }
 
             public new void AttachInterfaces() => base.AttachInterfaces();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -57,7 +57,7 @@ namespace System.Windows.Forms.Tests
             Assert.Null(control.FormatInfo);
             Assert.Empty(control.FormatString);
             Assert.False(control.FormattingEnabled);
-            Assert.Same(Control.DefaultFont, control.Font);
+            Assert.Equal(Control.DefaultFont, control.Font);
             Assert.Equal(SystemColors.WindowText, control.ForeColor);
             Assert.True(control.Height > 0);
             Assert.True(control.IntegralHeight);
@@ -395,7 +395,7 @@ namespace System.Windows.Forms.Tests
 
             // Set null.
             control.Font = null;
-            Assert.Same(Control.DefaultFont, control.Font);
+            Assert.Equal(Control.DefaultFont, control.Font);
             Assert.Equal(3, callCount);
 
             // Remove handler.

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ContainerControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ContainerControlTests.cs
@@ -36,7 +36,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(Rectangle.Empty, control.Bounds);
             Assert.False(control.CanEnableIme);
             Assert.True(control.CanRaiseEvents);
-            Assert.True(control.CanProcessMnemonic());
             Assert.True(control.CausesValidation);
             Assert.Equal(Rectangle.Empty, control.ClientRectangle);
             Assert.Equal(Size.Empty, control.ClientSize);
@@ -64,10 +63,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, control.DockPadding.Bottom);
             Assert.Equal(0, control.DockPadding.Left);
             Assert.Equal(0, control.DockPadding.Right);
+            Assert.False(control.DoubleBuffered);
             Assert.True(control.Enabled);
             Assert.NotNull(control.Events);
             Assert.Same(control.Events, control.Events);
             Assert.Equal(Control.DefaultFont, control.Font);
+            Assert.Equal(control.Font.Height, control.FontHeight);
             Assert.Equal(Control.DefaultForeColor, control.ForeColor);
             Assert.False(control.HasChildren);
             Assert.Equal(0, control.Height);
@@ -79,6 +80,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, control.Left);
             Assert.Equal(Point.Empty, control.Location);
             Assert.Equal(Padding.Empty, control.Padding);
+            Assert.False(control.RecreatingHandle);
+            Assert.Null(control.Region);
+            Assert.False(control.ResizeRedraw);
             Assert.Equal(0, control.Right);
             Assert.Equal(RightToLeft.No, control.RightToLeft);
             Assert.Null(control.Site);
@@ -92,6 +96,27 @@ namespace System.Windows.Forms.Tests
             Assert.Same(control.VerticalScroll, control.VerticalScroll);
             Assert.False(control.VScroll);
             Assert.Equal(0, control.Width);
+
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [Fact]
+        public void ContainerControl_CreateParams_GetDefault_ReturnsExpected()
+        {
+            var control = new SubContainerControl();
+            CreateParams createParams = control.CreateParams;
+            Assert.Null(createParams.Caption);
+            Assert.Null(createParams.ClassName);
+            Assert.Equal(0x8, createParams.ClassStyle);
+            Assert.Equal(0x10000, createParams.ExStyle);
+            Assert.Equal(0, createParams.Height);
+            Assert.Equal(IntPtr.Zero, createParams.Parent);
+            Assert.Null(createParams.Param);
+            Assert.Equal(0x56010000, createParams.Style);
+            Assert.Equal(0, createParams.Width);
+            Assert.Equal(0, createParams.X);
+            Assert.Equal(0, createParams.Y);
+            Assert.Same(createParams, control.CreateParams);
         }
 
         [Fact]
@@ -403,7 +428,7 @@ namespace System.Windows.Forms.Tests
 
             // Set null.
             control.Font = null;
-            Assert.Same(Control.DefaultFont, control.Font);
+            Assert.Equal(Control.DefaultFont, control.Font);
             Assert.Equal(3, callCount);
 
             // Remove handler.
@@ -646,6 +671,12 @@ namespace System.Windows.Forms.Tests
 
             public new bool DesignMode => base.DesignMode;
 
+            public new bool DoubleBuffered
+            {
+                get => base.DoubleBuffered;
+                set => base.DoubleBuffered = value;
+            }
+
             public new EventHandlerList Events => base.Events;
 
             public new int FontHeight
@@ -654,7 +685,17 @@ namespace System.Windows.Forms.Tests
                 set => base.FontHeight = value;
             }
 
-            public new ImeMode ImeModeBase => base.ImeModeBase;
+            public new ImeMode ImeModeBase
+            {
+                get => base.ImeModeBase;
+                set => base.ImeModeBase = value;
+            }
+
+            public new bool ResizeRedraw
+            {
+                get => base.ResizeRedraw;
+                set => base.ResizeRedraw = value;
+            }
 
             public new bool HScroll
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.cs
@@ -49,10 +49,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(DpiHelper.DeviceDpi, control._deviceDpi);
             Assert.Equal(Rectangle.Empty, control.DisplayRectangle);
             Assert.Equal(DockStyle.None, control.Dock);
+            Assert.False(control.DoubleBuffered);
             Assert.True(control.Enabled);
             Assert.NotNull(control.Events);
             Assert.Same(control.Events, control.Events);
             Assert.Equal(Control.DefaultFont, control.Font);
+            Assert.Equal(control.Font.Height, control.FontHeight);
             Assert.Equal(Control.DefaultForeColor, control.ForeColor);
             Assert.False(control.HasChildren);
             Assert.Equal(0, control.Height);
@@ -64,6 +66,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(Padding.Empty, control.Padding);
             Assert.Null(control.Parent);
             Assert.Equal("Microsoft\u00AE .NET", control.ProductName);
+            Assert.False(control.RecreatingHandle);
+            Assert.Null(control.Region);
+            Assert.False(control.ResizeRedraw);
             Assert.Equal(BoundsSpecified.All, control.RequiredScaling);
             Assert.True(control.RequiredScalingEnabled);
             Assert.Equal(0, control.Right);
@@ -115,10 +120,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(DpiHelper.DeviceDpi, control._deviceDpi);
             Assert.Equal(Rectangle.Empty, control.DisplayRectangle);
             Assert.Equal(DockStyle.None, control.Dock);
+            Assert.False(control.DoubleBuffered);
             Assert.True(control.Enabled);
             Assert.NotNull(control.Events);
             Assert.Same(control.Events, control.Events);
             Assert.Equal(Control.DefaultFont, control.Font);
+            Assert.Equal(control.Font.Height, control.FontHeight);
             Assert.Equal(Control.DefaultForeColor, control.ForeColor);
             Assert.False(control.HasChildren);
             Assert.Equal(0, control.Height);
@@ -130,6 +137,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(Padding.Empty, control.Padding);
             Assert.Null(control.Parent);
             Assert.Equal("Microsoft\u00AE .NET", control.ProductName);
+            Assert.False(control.RecreatingHandle);
+            Assert.Null(control.Region);
+            Assert.False(control.ResizeRedraw);
             Assert.Equal(BoundsSpecified.All, control.RequiredScaling);
             Assert.True(control.RequiredScalingEnabled);
             Assert.Equal(0, control.Right);
@@ -142,6 +152,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, control.Top);
             Assert.True(control.Visible);
             Assert.Equal(0, control.Width);
+
+            Assert.False(control.IsHandleCreated);
         }
 
         public static IEnumerable<object[]> Ctor_String_Int_Int_Int_Int_TestData()
@@ -188,10 +200,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(DpiHelper.DeviceDpi, control._deviceDpi);
             Assert.Equal(new Rectangle(0, 0, width, height), control.DisplayRectangle);
             Assert.Equal(DockStyle.None, control.Dock);
+            Assert.False(control.DoubleBuffered);
             Assert.True(control.Enabled);
             Assert.NotNull(control.Events);
             Assert.Same(control.Events, control.Events);
             Assert.Equal(Control.DefaultFont, control.Font);
+            Assert.Equal(control.Font.Height, control.FontHeight);
             Assert.Equal(Control.DefaultForeColor, control.ForeColor);
             Assert.False(control.HasChildren);
             Assert.Equal(height, control.Height);
@@ -203,6 +217,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(Padding.Empty, control.Padding);
             Assert.Null(control.Parent);
             Assert.Equal("Microsoft\u00AE .NET", control.ProductName);
+            Assert.False(control.RecreatingHandle);
+            Assert.Null(control.Region);
+            Assert.False(control.ResizeRedraw);
             Assert.Equal(BoundsSpecified.All, control.RequiredScaling);
             Assert.True(control.RequiredScalingEnabled);
             Assert.Equal(left + width, control.Right);
@@ -215,6 +232,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(top, control.Top);
             Assert.True(control.Visible);
             Assert.Equal(width, control.Width);
+
+            Assert.False(control.IsHandleCreated);
         }
 
         public static IEnumerable<object[]> Ctor_Control_String_TestData()
@@ -261,10 +280,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(DpiHelper.DeviceDpi, control._deviceDpi);
             Assert.Equal(Rectangle.Empty, control.DisplayRectangle);
             Assert.Equal(DockStyle.None, control.Dock);
+            Assert.False(control.DoubleBuffered);
             Assert.True(control.Enabled);
             Assert.NotNull(control.Events);
             Assert.Same(control.Events, control.Events);
             Assert.Equal(Control.DefaultFont, control.Font);
+            Assert.Equal(control.Font.Height, control.FontHeight);
             Assert.Equal(Control.DefaultForeColor, control.ForeColor);
             Assert.False(control.HasChildren);
             Assert.Equal(0, control.Height);
@@ -276,6 +297,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(Padding.Empty, control.Padding);
             Assert.Same(parent, control.Parent);
             Assert.Equal("Microsoft\u00AE .NET", control.ProductName);
+            Assert.False(control.RecreatingHandle);
+            Assert.Null(control.Region);
+            Assert.False(control.ResizeRedraw);
             Assert.Equal(BoundsSpecified.All, control.RequiredScaling);
             Assert.True(control.RequiredScalingEnabled);
             Assert.Equal(0, control.Right);
@@ -288,6 +312,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, control.Top);
             Assert.True(control.Visible);
             Assert.Equal(0, control.Width);
+
+            Assert.False(control.IsHandleCreated);
         }
 
         public static IEnumerable<object[]> Ctor_Control_String_Int_Int_Int_Int_TestData()
@@ -334,10 +360,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(DpiHelper.DeviceDpi, control._deviceDpi);
             Assert.Equal(new Rectangle(0, 0, width, height), control.DisplayRectangle);
             Assert.Equal(DockStyle.None, control.Dock);
+            Assert.False(control.DoubleBuffered);
             Assert.True(control.Enabled);
             Assert.NotNull(control.Events);
             Assert.Same(control.Events, control.Events);
             Assert.Equal(Control.DefaultFont, control.Font);
+            Assert.Equal(control.Font.Height, control.FontHeight);
             Assert.Equal(Control.DefaultForeColor, control.ForeColor);
             Assert.False(control.HasChildren);
             Assert.Equal(height, control.Height);
@@ -349,6 +377,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(Padding.Empty, control.Padding);
             Assert.Same(parent, control.Parent);
             Assert.Equal("Microsoft\u00AE .NET", control.ProductName);
+            Assert.False(control.RecreatingHandle);
+            Assert.Null(control.Region);
+            Assert.False(control.ResizeRedraw);
             Assert.Equal(BoundsSpecified.All, control.RequiredScaling);
             Assert.True(control.RequiredScalingEnabled);
             Assert.Equal(left + width, control.Right);
@@ -361,6 +392,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(top, control.Top);
             Assert.True(control.Visible);
             Assert.Equal(width, control.Width);
+
+            Assert.False(control.IsHandleCreated);
         }
 
         [Fact]
@@ -7596,6 +7629,12 @@ namespace System.Windows.Forms.Tests
 
             public new bool DesignMode => base.DesignMode;
 
+            public new bool DoubleBuffered
+            {
+                get => base.DoubleBuffered;
+                set => base.DoubleBuffered = value;
+            }
+
             public new EventHandlerList Events => base.Events;
 
             public new int FontHeight
@@ -7608,6 +7647,12 @@ namespace System.Windows.Forms.Tests
             {
                 get => base.ImeModeBase;
                 set => base.ImeModeBase = value;
+            }
+
+            public new bool ResizeRedraw
+            {
+                get => base.ResizeRedraw;
+                set => base.ResizeRedraw = value;
             }
 
             public new bool GetStyle(ControlStyles flag) => base.GetStyle(flag);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridTableStyleTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridTableStyleTests.cs
@@ -33,7 +33,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(SystemColors.Control, style.GridLineColor);
             Assert.Equal(DataGridLineStyle.Solid, style.GridLineStyle);
             Assert.Equal(SystemColors.Control, style.HeaderBackColor);
-            Assert.Same(Control.DefaultFont, style.HeaderFont);
+            Assert.Equal(Control.DefaultFont, style.HeaderFont);
             Assert.Equal(SystemColors.ControlText, style.HeaderForeColor);
             Assert.Equal(SystemColors.HotTrack, style.LinkColor);
             Assert.Equal(SystemColors.HotTrack, style.LinkHoverColor);
@@ -69,7 +69,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(SystemColors.Control, style.GridLineColor);
             Assert.Equal(DataGridLineStyle.Solid, style.GridLineStyle);
             Assert.Equal(SystemColors.Control, style.HeaderBackColor);
-            Assert.Same(Control.DefaultFont, style.HeaderFont);
+            Assert.Equal(Control.DefaultFont, style.HeaderFont);
             Assert.Equal(SystemColors.ControlText, style.HeaderForeColor);
             Assert.Equal(SystemColors.HotTrack, style.LinkColor);
             Assert.Equal(SystemColors.HotTrack, style.LinkHoverColor);
@@ -100,7 +100,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(SystemColors.Control, style.GridLineColor);
             Assert.Equal(DataGridLineStyle.Solid, style.GridLineStyle);
             Assert.Equal(SystemColors.Control, style.HeaderBackColor);
-            Assert.Same(Control.DefaultFont, style.HeaderFont);
+            Assert.Equal(Control.DefaultFont, style.HeaderFont);
             Assert.Equal(SystemColors.ControlText, style.HeaderForeColor);
             Assert.Equal(SystemColors.HotTrack, style.LinkColor);
             Assert.Equal(SystemColors.HotTrack, style.LinkHoverColor);
@@ -952,11 +952,11 @@ namespace System.Windows.Forms.Tests
 
             // Set null.
             style.HeaderFont = null;
-            Assert.Same(Control.DefaultFont, style.HeaderFont);
+            Assert.Equal(Control.DefaultFont, style.HeaderFont);
 
             // Set null again.
             style.HeaderFont = null;
-            Assert.Same(Control.DefaultFont, style.HeaderFont);
+            Assert.Equal(Control.DefaultFont, style.HeaderFont);
 
             // Set different.
             style.HeaderFont = font1;
@@ -1041,12 +1041,12 @@ namespace System.Windows.Forms.Tests
 
             // Set null.
             style.HeaderFont = null;
-            Assert.Same(Control.DefaultFont, style.HeaderFont);
+            Assert.Equal(Control.DefaultFont, style.HeaderFont);
             Assert.Equal(2, callCount);
 
             // Set null again.
             style.HeaderFont = null;
-            Assert.Same(Control.DefaultFont, style.HeaderFont);
+            Assert.Equal(Control.DefaultFont, style.HeaderFont);
             Assert.Equal(2, callCount);
 
             // Set different.
@@ -4134,13 +4134,13 @@ namespace System.Windows.Forms.Tests
 
             // Reset default.
             style.ResetHeaderFont();
-            Assert.Same(Control.DefaultFont, style.HeaderFont);
+            Assert.Equal(Control.DefaultFont, style.HeaderFont);
 
             // Reset custom.
             style.HeaderFont = font;
             Assert.Same(font, style.HeaderFont);
             style.ResetHeaderFont();
-            Assert.Same(Control.DefaultFont, style.HeaderFont);
+            Assert.Equal(Control.DefaultFont, style.HeaderFont);
         }
 
         [Fact]
@@ -4190,7 +4190,7 @@ namespace System.Windows.Forms.Tests
 
             // Reset default.
             style.ResetHeaderFont();
-            Assert.Same(Control.DefaultFont, style.HeaderFont);
+            Assert.Equal(Control.DefaultFont, style.HeaderFont);
             Assert.Equal(0, callCount);
 
             // Reset custom.
@@ -4198,7 +4198,7 @@ namespace System.Windows.Forms.Tests
             Assert.Same(font, style.HeaderFont);
             Assert.Equal(1, callCount);
             style.ResetHeaderFont();
-            Assert.Same(Control.DefaultFont, style.HeaderFont);
+            Assert.Equal(Control.DefaultFont, style.HeaderFont);
             Assert.Equal(2, callCount);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridTests.cs
@@ -51,7 +51,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(SystemColors.Control, dataGrid.GridLineColor);
             Assert.Equal(DataGridLineStyle.Solid, dataGrid.GridLineStyle);
             Assert.Equal(SystemColors.Control, dataGrid.HeaderBackColor);
-            Assert.Same(Control.DefaultFont, dataGrid.HeaderFont);
+            Assert.Equal(Control.DefaultFont, dataGrid.HeaderFont);
             Assert.Equal(SystemColors.ControlText, dataGrid.HeaderForeColor);
             Assert.Equal(SystemColors.ControlText, dataGrid.HeaderForeColor);
             Assert.Equal(80, dataGrid.Height);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/ComponentEditorPageTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/ComponentEditorPageTests.cs
@@ -64,11 +64,13 @@ namespace System.Windows.Forms.Design.Tests
             Assert.Equal(0, page.DockPadding.Bottom);
             Assert.Equal(0, page.DockPadding.Left);
             Assert.Equal(0, page.DockPadding.Right);
+            Assert.False(page.DoubleBuffered);
             Assert.True(page.Enabled);
             Assert.NotNull(page.Events);
             Assert.Same(page.Events, page.Events);
             Assert.True(page.FirstActivate);
             Assert.Equal(Control.DefaultFont, page.Font);
+            Assert.Equal(page.Font.Height, page.FontHeight);
             Assert.Equal(Control.DefaultForeColor, page.ForeColor);
             Assert.False(page.HasChildren);
             Assert.Equal(100, page.Height);
@@ -85,6 +87,9 @@ namespace System.Windows.Forms.Design.Tests
             Assert.Equal(Point.Empty, page.Location);
             Assert.Equal(Padding.Empty, page.Padding);
             Assert.Null(page.PageSite);
+            Assert.False(page.RecreatingHandle);
+            Assert.Null(page.Region);
+            Assert.False(page.ResizeRedraw);
             Assert.Equal(200, page.Right);
             Assert.Equal(RightToLeft.No, page.RightToLeft);
             Assert.Equal(new Size(200, 100), page.Size);
@@ -98,6 +103,8 @@ namespace System.Windows.Forms.Design.Tests
             Assert.Same(page.VerticalScroll, page.VerticalScroll);
             Assert.False(page.VScroll);
             Assert.Equal(200, page.Width);
+
+            Assert.False(page.IsHandleCreated);
         }
 
         [Fact]
@@ -754,6 +761,12 @@ namespace System.Windows.Forms.Design.Tests
 
             public new bool DesignMode => base.DesignMode;
 
+            public new bool DoubleBuffered
+            {
+                get => base.DoubleBuffered;
+                set => base.DoubleBuffered = value;
+            }
+
             public new EventHandlerList Events => base.Events;
 
             public new bool FirstActivate
@@ -762,7 +775,23 @@ namespace System.Windows.Forms.Design.Tests
                 set => base.FirstActivate = value;
             }
 
-            public new ImeMode ImeModeBase => base.ImeModeBase;
+            public new int FontHeight
+            {
+                get => base.FontHeight;
+                set => base.FontHeight = value;
+            }
+
+            public new ImeMode ImeModeBase
+            {
+                get => base.ImeModeBase;
+                set => base.ImeModeBase = value;
+            }
+
+            public new bool ResizeRedraw
+            {
+                get => base.ResizeRedraw;
+                set => base.ResizeRedraw = value;
+            }
 
             public new bool HScroll
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FlowLayoutPanelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FlowLayoutPanelTests.cs
@@ -1,5 +1,4 @@
-﻿
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -60,11 +59,13 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, panel.DockPadding.Bottom);
             Assert.Equal(0, panel.DockPadding.Left);
             Assert.Equal(0, panel.DockPadding.Right);
+            Assert.False(panel.DoubleBuffered);
             Assert.True(panel.Enabled);
             Assert.NotNull(panel.Events);
             Assert.Same(panel.Events, panel.Events);
             Assert.Equal(FlowDirection.LeftToRight, panel.FlowDirection);
             Assert.Equal(Control.DefaultFont, panel.Font);
+            Assert.Equal(panel.Font.Height, panel.FontHeight);
             Assert.Equal(Control.DefaultForeColor, panel.ForeColor);
             Assert.False(panel.HasChildren);
             Assert.Equal(100, panel.Height);
@@ -79,6 +80,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(Point.Empty, panel.Location);
             Assert.Equal(new Padding(3), panel.Margin);
             Assert.Equal(Padding.Empty, panel.Padding);
+            Assert.False(panel.RecreatingHandle);
+            Assert.Null(panel.Region);
+            Assert.False(panel.ResizeRedraw);
             Assert.Equal(200, panel.Right);
             Assert.Equal(RightToLeft.No, panel.RightToLeft);
             Assert.Null(panel.Site);
@@ -93,6 +97,8 @@ namespace System.Windows.Forms.Tests
             Assert.False(panel.VScroll);
             Assert.Equal(200, panel.Width);
             Assert.True(panel.WrapContents);
+
+            Assert.False(panel.IsHandleCreated);
         }
 
         [Fact]
@@ -249,14 +255,36 @@ namespace System.Windows.Forms.Tests
 
             public new bool DesignMode => base.DesignMode;
 
+            public new bool DoubleBuffered
+            {
+                get => base.DoubleBuffered;
+                set => base.DoubleBuffered = value;
+            }
+
             public new EventHandlerList Events => base.Events;
 
-            public new ImeMode ImeModeBase => base.ImeModeBase;
+            public new int FontHeight
+            {
+                get => base.FontHeight;
+                set => base.FontHeight = value;
+            }
+
+            public new ImeMode ImeModeBase
+            {
+                get => base.ImeModeBase;
+                set => base.ImeModeBase = value;
+            }
 
             public new bool HScroll
             {
                 get => base.HScroll;
                 set => base.HScroll = value;
+            }
+
+            public new bool ResizeRedraw
+            {
+                get => base.ResizeRedraw;
+                set => base.ResizeRedraw = value;
             }
 
             public new bool VScroll

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HScrollBarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HScrollBarTests.cs
@@ -57,10 +57,12 @@ namespace System.Windows.Forms.Tests
             Assert.True(scrollBar.DisplayRectangle.Width > 0);
             Assert.True(scrollBar.DisplayRectangle.Height > 0);
             Assert.Equal(DockStyle.None, scrollBar.Dock);
+            Assert.False(scrollBar.DoubleBuffered);
             Assert.True(scrollBar.Enabled);
             Assert.NotNull(scrollBar.Events);
             Assert.Same(scrollBar.Events, scrollBar.Events);
             Assert.Equal(Control.DefaultFont, scrollBar.Font);
+            Assert.Equal(scrollBar.Font.Height, scrollBar.FontHeight);
             Assert.Equal(Control.DefaultForeColor, scrollBar.ForeColor);
             Assert.False(scrollBar.HasChildren);
             Assert.True(scrollBar.Height > 0);
@@ -73,6 +75,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(100, scrollBar.Maximum);
             Assert.Equal(0, scrollBar.Minimum);
             Assert.Equal(Padding.Empty, scrollBar.Padding);
+            Assert.False(scrollBar.RecreatingHandle);
+            Assert.Null(scrollBar.Region);
+            Assert.False(scrollBar.ResizeRedraw);
             Assert.True(scrollBar.Right > 0);
             Assert.Equal(RightToLeft.No, scrollBar.RightToLeft);
             Assert.True(scrollBar.ScaleScrollBarForDpiChange);
@@ -87,6 +92,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, scrollBar.Value);
             Assert.True(scrollBar.Visible);
             Assert.True(scrollBar.Width > 0);
+
+            Assert.False(scrollBar.IsHandleCreated);
         }
 
         [Fact]
@@ -190,9 +197,31 @@ namespace System.Windows.Forms.Tests
 
             public new bool DesignMode => base.DesignMode;
 
+            public new bool DoubleBuffered
+            {
+                get => base.DoubleBuffered;
+                set => base.DoubleBuffered = value;
+            }
+
             public new EventHandlerList Events => base.Events;
 
-            public new ImeMode ImeModeBase => base.ImeModeBase;
+            public new int FontHeight
+            {
+                get => base.FontHeight;
+                set => base.FontHeight = value;
+            }
+
+            public new ImeMode ImeModeBase
+            {
+                get => base.ImeModeBase;
+                set => base.ImeModeBase = value;
+            }
+
+            public new bool ResizeRedraw
+            {
+                get => base.ResizeRedraw;
+                set => base.ResizeRedraw = value;
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxTests.cs
@@ -51,7 +51,7 @@ namespace System.Windows.Forms.Tests
             Assert.Null(control.FormatInfo);
             Assert.Empty(control.FormatString);
             Assert.False(control.FormattingEnabled);
-            Assert.Same(Control.DefaultFont, control.Font);
+            Assert.Equal(Control.DefaultFont, control.Font);
             Assert.Equal(SystemColors.WindowText, control.ForeColor);
             Assert.True(control.Height > 0);
             Assert.Equal(0, control.HorizontalExtent);
@@ -396,7 +396,7 @@ namespace System.Windows.Forms.Tests
 
             // Set null.
             control.Font = null;
-            Assert.Same(Control.DefaultFont, control.Font);
+            Assert.Equal(Control.DefaultFont, control.Font);
             Assert.Equal(3, callCount);
 
             // Remove handler.

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListControlTests.cs
@@ -38,7 +38,7 @@ namespace System.Windows.Forms.Tests
         //     Assert.Null(control.FormatInfo);
         //     Assert.Empty(control.FormatString);
         //     Assert.False(control.FormattingEnabled);
-        //     Assert.Same(Control.DefaultFont, control.Font);
+        //     Assert.Equal(Control.DefaultFont, control.Font);
         //     Assert.Equal(SystemColors.ControlText, control.ForeColor);
         //     Assert.Equal(0, control.Height);
         //     Assert.Equal(Point.Empty, control.Location);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using System.Drawing;
+using WinForms.Common.Tests;
 using Xunit;
 
 namespace System.Windows.Forms.Tests
@@ -12,12 +14,439 @@ namespace System.Windows.Forms.Tests
         [Fact]
         public void ListView_Ctor_Default()
         {
-            var listView = new ListView();
-            Assert.Equal(Point.Empty, listView.Location);
-            Assert.Equal(121, listView.Width);
-            Assert.Equal(97, listView.Height);
-            Assert.Empty(listView.Items);
+            var listView = new SubListView();
+            Assert.Equal(ItemActivation.Standard, listView.Activation);
+            Assert.Equal(ListViewAlignment.Top, listView.Alignment);
+            Assert.False(listView.AllowColumnReorder);
+            Assert.False(listView.AllowDrop);
+            Assert.Equal(AnchorStyles.Top | AnchorStyles.Left, listView.Anchor);
+            Assert.True(listView.AutoArrange);
+            Assert.False(listView.AutoSize);
+            Assert.Equal(SystemColors.Window, listView.BackColor);
+            Assert.Null(listView.BackgroundImage);
+            Assert.Equal(ImageLayout.Tile, listView.BackgroundImageLayout);
+            Assert.False(listView.BackgroundImageTiled);
+            Assert.Null(listView.BindingContext);
+            Assert.Equal(BorderStyle.Fixed3D, listView.BorderStyle);
+            Assert.Equal(97, listView.Bottom);
+            Assert.Equal(new Rectangle(0, 0, 121, 97), listView.Bounds);
+            Assert.True(listView.CanEnableIme);
+            Assert.True(listView.CanRaiseEvents);
+            Assert.True(listView.CausesValidation);
+            Assert.False(listView.CheckBoxes);
+            Assert.Empty(listView.CheckedIndices);
+            Assert.Same(listView.CheckedIndices, listView.CheckedIndices);
+            Assert.Empty(listView.CheckedItems);
+            Assert.Same(listView.CheckedItems, listView.CheckedItems);
+            Assert.Equal(new Size(117, 93), listView.ClientSize);
+            Assert.Equal(new Rectangle(0, 0, 117, 93), listView.ClientRectangle);
             Assert.Empty(listView.Columns);
+            Assert.Same(listView.Columns, listView.Columns);
+            Assert.Null(listView.Container);
+            Assert.Null(listView.ContextMenu);
+            Assert.Null(listView.ContextMenuStrip);
+            Assert.Empty(listView.Controls);
+            Assert.Same(listView.Controls, listView.Controls);
+            Assert.False(listView.Created);
+            Assert.Equal(Cursors.Default, listView.Cursor);
+            Assert.Same(Cursors.Default, listView.DefaultCursor);
+            Assert.Equal(ImeMode.Inherit, listView.DefaultImeMode);
+            Assert.Equal(new Padding(3), listView.DefaultMargin);
+            Assert.Equal(Size.Empty, listView.DefaultMaximumSize);
+            Assert.Equal(Size.Empty, listView.DefaultMinimumSize);
+            Assert.Equal(Padding.Empty, listView.DefaultPadding);
+            Assert.Equal(new Size(121, 97), listView.DefaultSize);
+            Assert.False(listView.DesignMode);
+            Assert.Equal(new Rectangle(0, 0, 117, 93), listView.DisplayRectangle);
+            Assert.Equal(DockStyle.None, listView.Dock);
+            Assert.False(listView.DoubleBuffered);
+            Assert.True(listView.Enabled);
+            Assert.NotNull(listView.Events);
+            Assert.Same(listView.Events, listView.Events);
+            Assert.Equal(Control.DefaultFont, listView.Font);
+            Assert.Equal(listView.Font.Height, listView.FontHeight);
+            Assert.Equal(SystemColors.WindowText, listView.ForeColor);
+            Assert.False(listView.FullRowSelect);
+            Assert.False(listView.GridLines);
+            Assert.Empty(listView.Groups);
+            Assert.Same(listView.Groups, listView.Groups);
+            Assert.False(listView.HasChildren);
+            Assert.Equal(ColumnHeaderStyle.Clickable, listView.HeaderStyle);
+            Assert.Equal(97, listView.Height);
+            Assert.False(listView.HideSelection);
+            Assert.False(listView.HotTracking);
+            Assert.False(listView.HoverSelection);
+            Assert.Equal(ImeMode.NoControl, listView.ImeMode);
+            Assert.Equal(ImeMode.NoControl, listView.ImeModeBase);
+            Assert.NotNull(listView.InsertionMark);
+            Assert.Same(listView.InsertionMark, listView.InsertionMark);
+            Assert.Empty(listView.Items);
+            Assert.Same(listView.Items, listView.Items);
+            Assert.False(listView.LabelEdit);
+            Assert.True(listView.LabelWrap);
+            Assert.Null(listView.LargeImageList);
+            Assert.Equal(0, listView.Left);
+            Assert.Null(listView.ListViewItemSorter);
+            Assert.Equal(Point.Empty, listView.Location);
+            Assert.Equal(new Padding(3), listView.Margin);
+            Assert.True(listView.MultiSelect);
+            Assert.False(listView.OwnerDraw);
+            Assert.Equal(Padding.Empty, listView.Padding);
+            Assert.Null(listView.Parent);
+            Assert.Equal("Microsoft\u00AE .NET", listView.ProductName);
+            Assert.False(listView.RecreatingHandle);
+            Assert.Null(listView.Region);
+            Assert.False(listView.ResizeRedraw);
+            Assert.Equal(121, listView.Right);
+            Assert.Equal(RightToLeft.No, listView.RightToLeft);
+            Assert.False(listView.RightToLeftLayout);
+            Assert.True(listView.Scrollable);
+            Assert.Empty(listView.SelectedIndices);
+            Assert.Same(listView.SelectedIndices, listView.SelectedIndices);
+            Assert.Empty(listView.SelectedItems);
+            Assert.Same(listView.SelectedItems, listView.SelectedItems);
+            Assert.True(listView.ShowGroups);
+            Assert.False(listView.ShowItemToolTips);
+            Assert.Null(listView.SmallImageList);
+            Assert.Null(listView.Site);
+            Assert.Equal(new Size(121, 97), listView.Size);
+            Assert.Equal(SortOrder.None, listView.Sorting);
+            Assert.Null(listView.StateImageList);
+            Assert.Equal(0, listView.TabIndex);
+            Assert.True(listView.TabStop);
+            Assert.Empty(listView.Text);
+            Assert.Equal(Size.Empty, listView.TileSize);
+            Assert.Equal(0, listView.Top);
+            Assert.Throws<InvalidOperationException>(() => listView.TopItem);
+            Assert.True(listView.UseCompatibleStateImageBehavior);
+            Assert.Equal(View.LargeIcon, listView.View);
+            Assert.Equal(0, listView.VirtualListSize);
+            Assert.False(listView.VirtualMode);
+            Assert.True(listView.Visible);
+            Assert.Equal(121, listView.Width);
+
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [Fact]
+        public void ListView_CreateParams_GetDefault_ReturnsExpected()
+        {
+            var control = new SubListView();
+            CreateParams createParams = control.CreateParams;
+            Assert.Null(createParams.Caption);
+            Assert.Equal("SysListView32", createParams.ClassName);
+            Assert.Equal(0x8, createParams.ClassStyle);
+            Assert.Equal(0x200, createParams.ExStyle);
+            Assert.Equal(97, createParams.Height);
+            Assert.Equal(IntPtr.Zero, createParams.Parent);
+            Assert.Null(createParams.Param);
+            Assert.Equal(0x56010148, createParams.Style);
+            Assert.Equal(121, createParams.Width);
+            Assert.Equal(0, createParams.X);
+            Assert.Equal(0, createParams.Y);
+            Assert.Same(createParams, control.CreateParams);
+        }
+
+        [Theory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(ItemActivation))]
+        public void ListView_Activation_Set_GetReturnsExpected(ItemActivation value)
+        {
+            var listView = new ListView
+            {
+                Activation = value
+            };
+            Assert.Equal(value, listView.Activation);
+
+            // Set same.
+            listView.Activation = value;
+            Assert.Equal(value, listView.Activation);
+        }
+
+        [Theory]
+        [InlineData(ItemActivation.Standard, 0)]
+        [InlineData(ItemActivation.OneClick, 1)]
+        [InlineData(ItemActivation.TwoClick, 1)]
+        public void ListView_Activation_SetWithHandle_GetReturnsExpected(ItemActivation value, int expectedInvalidatedCallCount)
+        {
+            var listView = new ListView();
+            Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            int invalidatedCallCount = 0;
+            listView.Invalidated += (sender, e) => invalidatedCallCount++;
+
+            listView.Activation = value;
+            Assert.Equal(value, listView.Activation);
+            Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
+
+            // Set same.
+            listView.Activation = value;
+            Assert.Equal(value, listView.Activation);
+            Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
+        }
+
+        [Fact]
+        public void ListView_Activation_SetHotTrackingOneClick_Nop()
+        {
+            var listView = new ListView
+            {
+                HotTracking = true,
+                Activation = ItemActivation.OneClick
+            };
+            Assert.Equal(ItemActivation.OneClick, listView.Activation);
+
+            // Set same.
+            listView.Activation = ItemActivation.OneClick;
+            Assert.Equal(ItemActivation.OneClick, listView.Activation);
+        }
+
+        [Theory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryDataInvalid), typeof(ItemActivation))]
+        public void ListView_Activation_SetInvalidValue_ThrowsInvalidEnumArgumentException(ItemActivation value)
+        {
+            var listView = new ListView();
+            Assert.Throws<InvalidEnumArgumentException>("value", () => listView.Activation = value);
+        }
+
+        [Theory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryDataInvalid), typeof(ItemActivation))]
+        public void ListView_Activation_SetHotTrackingInvalidValue_ThrowsInvalidEnumArgumentException(ItemActivation value)
+        {
+            var listView = new ListView
+            {
+                HotTracking = true
+            };
+            Assert.Throws<InvalidEnumArgumentException>("value", () => listView.Activation = value);
+        }
+
+        [Theory]
+        [InlineData(ItemActivation.Standard)]
+        [InlineData(ItemActivation.TwoClick)]
+        public void ListView_Activation_SetHotTrackingNotOneClick_ThrowsArgumentException(ItemActivation value)
+        {
+            var listView = new ListView
+            {
+                HotTracking = true
+            };
+            Assert.Throws<ArgumentException>("value", () => listView.Activation = value);
+            Assert.Equal(ItemActivation.OneClick, listView.Activation);
+        }
+
+        [Theory]
+        [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void ListView_DoubleBuffered_Get_ReturnsExpected(bool value)
+        {
+            var control = new SubListView();
+            control.SetStyle(ControlStyles.OptimizedDoubleBuffer, value);
+            Assert.Equal(value, control.DoubleBuffered);
+        }
+
+        [Theory]
+        [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void ListView_DoubleBuffered_Set_GetReturnsExpected(bool value)
+        {
+            var control = new SubListView
+            {
+                DoubleBuffered = value
+            };
+            Assert.Equal(value, control.DoubleBuffered);
+            Assert.Equal(value, control.GetStyle(ControlStyles.OptimizedDoubleBuffer));
+
+            // Set same.
+            control.DoubleBuffered = value;
+            Assert.Equal(value, control.DoubleBuffered);
+            Assert.Equal(value, control.GetStyle(ControlStyles.OptimizedDoubleBuffer));
+
+            // Set different.
+            control.DoubleBuffered = !value;
+            Assert.Equal(!value, control.DoubleBuffered);
+            Assert.Equal(!value, control.GetStyle(ControlStyles.OptimizedDoubleBuffer));
+        }
+
+        [Theory]
+        [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void ListView_HotTracking_Set_GetReturnsExpected(bool value)
+        {
+            var listView = new ListView
+            {
+                HotTracking = value
+            };
+            Assert.Equal(value, listView.HotTracking);
+
+            // Set same.
+            listView.HotTracking = value;
+            Assert.Equal(value, listView.HotTracking);
+
+            // Set different.
+            listView.HotTracking = !value;
+            Assert.Equal(!value, listView.HotTracking);
+        }
+
+        [Theory]
+        [InlineData(true, 3, 4)]
+        [InlineData(false, 0, 3)]
+        public void ListView_HotTracking_SetWithHandle_GetReturnsExpected(bool value, int expectedInvalidatedCallCount1, int expectedInvalidatedCallCount2)
+        {
+            var listView = new ListView();
+            Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            int invalidatedCallCount = 0;
+            listView.Invalidated += (sender, e) => invalidatedCallCount++;
+
+            listView.HotTracking = value;
+            Assert.Equal(value, listView.HotTracking);
+            Assert.Equal(expectedInvalidatedCallCount1, invalidatedCallCount);
+
+            // Set same.
+            listView.HotTracking = value;
+            Assert.Equal(value, listView.HotTracking);
+            Assert.Equal(expectedInvalidatedCallCount1, invalidatedCallCount);
+
+            // Set different.
+            listView.HotTracking = !value;
+            Assert.Equal(!value, listView.HotTracking);
+            Assert.Equal(expectedInvalidatedCallCount2, invalidatedCallCount);
+        }
+
+        [Fact]
+        public void ListView_HotTracking_Set_SetsHoverSelectionAndActivationIfTrue()
+        {
+            var listView = new ListView
+            {
+                HotTracking = true
+            };
+            Assert.True(listView.HotTracking);
+            Assert.True(listView.HoverSelection);
+            Assert.Equal(ItemActivation.OneClick, listView.Activation);
+
+            // Set same.
+            listView.HotTracking = true;
+            Assert.True(listView.HotTracking);
+            Assert.True(listView.HoverSelection);
+            Assert.Equal(ItemActivation.OneClick, listView.Activation);
+
+            // Set different.
+            listView.HotTracking = false;
+            Assert.False(listView.HotTracking);
+            Assert.True(listView.HoverSelection);
+            Assert.Equal(ItemActivation.OneClick, listView.Activation);
+        }
+
+        [Theory]
+        [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void ListView_HoverSelection_Set_GetReturnsExpected(bool value)
+        {
+            var listView = new ListView
+            {
+                HoverSelection = value
+            };
+            Assert.Equal(value, listView.HoverSelection);
+
+            // Set same.
+            listView.HoverSelection = value;
+            Assert.Equal(value, listView.HoverSelection);
+
+            // Set different.
+            listView.HoverSelection = !value;
+            Assert.Equal(!value, listView.HoverSelection);
+        }
+
+        [Theory]
+        [InlineData(true, 1)]
+        [InlineData(false, 0)]
+        public void ListView_HoverSelection_SetWithHandle_GetReturnsExpected(bool value, int expectedInvalidatedCallCount)
+        {
+            var listView = new ListView();
+            Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            int invalidatedCallCount = 0;
+            listView.Invalidated += (sender, e) => invalidatedCallCount++;
+
+            listView.HoverSelection = value;
+            Assert.Equal(value, listView.HoverSelection);
+            Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
+
+            // Set same.
+            listView.HoverSelection = value;
+            Assert.Equal(value, listView.HoverSelection);
+            Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
+        }
+
+        [Fact]
+        public void ListView_HoverSelection_SetHotTrackingTrue_Nop()
+        {
+            var listView = new ListView
+            {
+                HotTracking = true,
+                HoverSelection = true
+            };
+            Assert.True(listView.HoverSelection);
+
+            // Set same.
+            listView.HoverSelection = true;
+            Assert.True(listView.HoverSelection);
+        }
+
+        [Fact]
+        public void ListView_HoverSelection_SetHotTrackingFalse_ThrowsArgumentException()
+        {
+            var listView = new ListView
+            {
+                HotTracking = true
+            };
+            Assert.Throws<ArgumentException>("value", () => listView.HoverSelection = false);
+            Assert.True(listView.HoverSelection);
+        }
+
+        private class SubListView : ListView
+        {
+            public new bool CanEnableIme => base.CanEnableIme;
+
+            public new bool CanRaiseEvents => base.CanRaiseEvents;
+
+            public new CreateParams CreateParams => base.CreateParams;
+
+            public new Cursor DefaultCursor => base.DefaultCursor;
+
+            public new ImeMode DefaultImeMode => base.DefaultImeMode;
+
+            public new Padding DefaultMargin => base.DefaultMargin;
+
+            public new Size DefaultMaximumSize => base.DefaultMaximumSize;
+
+            public new Size DefaultMinimumSize => base.DefaultMinimumSize;
+
+            public new Padding DefaultPadding => base.DefaultPadding;
+
+            public new Size DefaultSize => base.DefaultSize;
+
+            public new bool DesignMode => base.DesignMode;
+
+            public new bool DoubleBuffered
+            {
+                get => base.DoubleBuffered;
+                set => base.DoubleBuffered = value;
+            }
+
+            public new EventHandlerList Events => base.Events;
+
+            public new int FontHeight
+            {
+                get => base.FontHeight;
+                set => base.FontHeight = value;
+            }
+
+            public new ImeMode ImeModeBase
+            {
+                get => base.ImeModeBase;
+                set => base.ImeModeBase = value;
+            }
+
+            public new bool ResizeRedraw
+            {
+                get => base.ResizeRedraw;
+                set => base.ResizeRedraw = value;
+            }
+
+            public new bool GetStyle(ControlStyles flag) => base.GetStyle(flag);
+
+            public new void SetStyle(ControlStyles flag, bool value) => base.SetStyle(flag, value);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PanelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PanelTests.cs
@@ -59,10 +59,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, panel.DockPadding.Bottom);
             Assert.Equal(0, panel.DockPadding.Left);
             Assert.Equal(0, panel.DockPadding.Right);
+            Assert.False(panel.DoubleBuffered);
             Assert.True(panel.Enabled);
             Assert.NotNull(panel.Events);
             Assert.Same(panel.Events, panel.Events);
             Assert.Equal(Control.DefaultFont, panel.Font);
+            Assert.Equal(panel.Font.Height, panel.FontHeight);
             Assert.Equal(Control.DefaultForeColor, panel.ForeColor);
             Assert.False(panel.HasChildren);
             Assert.Equal(100, panel.Height);
@@ -74,6 +76,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, panel.Left);
             Assert.Equal(Point.Empty, panel.Location);
             Assert.Equal(Padding.Empty, panel.Padding);
+            Assert.False(panel.RecreatingHandle);
+            Assert.Null(panel.Region);
+            Assert.False(panel.ResizeRedraw);
             Assert.Equal(200, panel.Right);
             Assert.Equal(RightToLeft.No, panel.RightToLeft);
             Assert.Equal(new Size(200, 100), panel.Size);
@@ -86,6 +91,27 @@ namespace System.Windows.Forms.Tests
             Assert.Same(panel.VerticalScroll, panel.VerticalScroll);
             Assert.False(panel.VScroll);
             Assert.Equal(200, panel.Width);
+
+            Assert.False(panel.IsHandleCreated);
+        }
+
+        [Fact]
+        public void Panel_CreateParams_GetDefault_ReturnsExpected()
+        {
+            var control = new SubPanel();
+            CreateParams createParams = control.CreateParams;
+            Assert.Null(createParams.Caption);
+            Assert.Null(createParams.ClassName);
+            Assert.Equal(0x8, createParams.ClassStyle);
+            Assert.Equal(0x10000, createParams.ExStyle);
+            Assert.Equal(100, createParams.Height);
+            Assert.Equal(IntPtr.Zero, createParams.Parent);
+            Assert.Null(createParams.Param);
+            Assert.Equal(0x56000000, createParams.Style);
+            Assert.Equal(200, createParams.Width);
+            Assert.Equal(0, createParams.X);
+            Assert.Equal(0, createParams.Y);
+            Assert.Same(createParams, control.CreateParams);
         }
 
         [Theory]
@@ -600,14 +626,36 @@ namespace System.Windows.Forms.Tests
 
             public new bool DesignMode => base.DesignMode;
 
+            public new bool DoubleBuffered
+            {
+                get => base.DoubleBuffered;
+                set => base.DoubleBuffered = value;
+            }
+
             public new EventHandlerList Events => base.Events;
 
-            public new ImeMode ImeModeBase => base.ImeModeBase;
+            public new int FontHeight
+            {
+                get => base.FontHeight;
+                set => base.FontHeight = value;
+            }
+
+            public new ImeMode ImeModeBase
+            {
+                get => base.ImeModeBase;
+                set => base.ImeModeBase = value;
+            }
 
             public new bool HScroll
             {
                 get => base.HScroll;
                 set => base.HScroll = value;
+            }
+
+            public new bool ResizeRedraw
+            {
+                get => base.ResizeRedraw;
+                set => base.ResizeRedraw = value;
             }
 
             public new bool VScroll

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PictureBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PictureBoxTests.cs
@@ -53,12 +53,14 @@ namespace System.Windows.Forms.Tests
             Assert.False(pictureBox.DesignMode);
             Assert.Equal(new Rectangle(0, 0, 100, 50), pictureBox.DisplayRectangle);
             Assert.Equal(DockStyle.None, pictureBox.Dock);
+            Assert.True(pictureBox.DoubleBuffered);
             Assert.True(pictureBox.Enabled);
             Assert.NotNull(pictureBox.ErrorImage);
             Assert.Same(pictureBox.ErrorImage, pictureBox.ErrorImage);
             Assert.NotNull(pictureBox.Events);
             Assert.Same(pictureBox.Events, pictureBox.Events);
             Assert.Equal(Control.DefaultFont, pictureBox.Font);
+            Assert.Equal(pictureBox.FontHeight, pictureBox.FontHeight);
             Assert.Equal(Control.DefaultForeColor, pictureBox.ForeColor);
             Assert.False(pictureBox.HasChildren);
             Assert.Null(pictureBox.Image);
@@ -73,8 +75,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(Padding.Empty, pictureBox.Padding);
             Assert.Null(pictureBox.Parent);
             Assert.Equal("Microsoft\u00AE .NET", pictureBox.ProductName);
-            Assert.Equal(BoundsSpecified.All, pictureBox.RequiredScaling);
-            Assert.True(pictureBox.RequiredScalingEnabled);
+            Assert.False(pictureBox.RecreatingHandle);
+            Assert.Null(pictureBox.Region);
+            Assert.False(pictureBox.ResizeRedraw);
             Assert.Equal(100, pictureBox.Right);
             Assert.Equal(RightToLeft.No, pictureBox.RightToLeft);
             Assert.Null(pictureBox.Site);
@@ -87,6 +90,8 @@ namespace System.Windows.Forms.Tests
             Assert.True(pictureBox.Visible);
             Assert.False(pictureBox.WaitOnLoad);
             Assert.Equal(100, pictureBox.Width);
+
+            Assert.False(pictureBox.IsHandleCreated);
         }
 
         [Theory]
@@ -491,7 +496,7 @@ namespace System.Windows.Forms.Tests
 
             // Set null.
             control.Font = null;
-            Assert.Same(Control.DefaultFont, control.Font);
+            Assert.Equal(Control.DefaultFont, control.Font);
             Assert.Equal(3, callCount);
 
             // Remove handler.
@@ -2570,6 +2575,12 @@ namespace System.Windows.Forms.Tests
 
             public new bool DesignMode => base.DesignMode;
 
+            public new bool DoubleBuffered
+            {
+                get => base.DoubleBuffered;
+                set => base.DoubleBuffered = value;
+            }
+
             public new EventHandlerList Events => base.Events;
 
             public new int FontHeight
@@ -2582,6 +2593,12 @@ namespace System.Windows.Forms.Tests
             {
                 get => base.ImeModeBase;
                 set => base.ImeModeBase = value;
+            }
+
+            public new bool ResizeRedraw
+            {
+                get => base.ResizeRedraw;
+                set => base.ResizeRedraw = value;
             }
 
             public new bool GetStyle(ControlStyles flag) => base.GetStyle(flag);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBarTests.cs
@@ -48,10 +48,12 @@ namespace System.Windows.Forms.Tests
             Assert.False(scrollBar.DesignMode);
             Assert.Equal(Rectangle.Empty, scrollBar.DisplayRectangle);
             Assert.Equal(DockStyle.None, scrollBar.Dock);
+            Assert.False(scrollBar.DoubleBuffered);
             Assert.True(scrollBar.Enabled);
             Assert.NotNull(scrollBar.Events);
             Assert.Same(scrollBar.Events, scrollBar.Events);
             Assert.Equal(Control.DefaultFont, scrollBar.Font);
+            Assert.Equal(scrollBar.Font.Height, scrollBar.FontHeight);
             Assert.Equal(Control.DefaultForeColor, scrollBar.ForeColor);
             Assert.False(scrollBar.HasChildren);
             Assert.Equal(0, scrollBar.Height);
@@ -64,6 +66,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(Padding.Empty, scrollBar.Margin);
             Assert.Equal(0, scrollBar.Minimum);
             Assert.Equal(Padding.Empty, scrollBar.Padding);
+            Assert.False(scrollBar.RecreatingHandle);
+            Assert.Null(scrollBar.Region);
+            Assert.False(scrollBar.ResizeRedraw);
             Assert.Equal(0, scrollBar.Right);
             Assert.Equal(RightToLeft.No, scrollBar.RightToLeft);
             Assert.True(scrollBar.ScaleScrollBarForDpiChange);
@@ -77,6 +82,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, scrollBar.Value);
             Assert.True(scrollBar.Visible);
             Assert.Equal(0, scrollBar.Width);
+
+            Assert.False(scrollBar.IsHandleCreated);
         }
 
         [Fact]
@@ -445,7 +452,7 @@ namespace System.Windows.Forms.Tests
 
             // Set null.
             control.Font = null;
-            Assert.Same(Control.DefaultFont, control.Font);
+            Assert.Equal(Control.DefaultFont, control.Font);
             Assert.Equal(3, callCount);
 
             // Remove handler.
@@ -1982,6 +1989,12 @@ namespace System.Windows.Forms.Tests
 
             public new bool DesignMode => base.DesignMode;
 
+            public new bool DoubleBuffered
+            {
+                get => base.DoubleBuffered;
+                set => base.DoubleBuffered = value;
+            }
+
             public new EventHandlerList Events => base.Events;
 
             public new int FontHeight
@@ -1990,7 +2003,17 @@ namespace System.Windows.Forms.Tests
                 set => base.FontHeight = value;
             }
 
-            public new ImeMode ImeModeBase => base.ImeModeBase;
+            public new ImeMode ImeModeBase
+            {
+                get => base.ImeModeBase;
+                set => base.ImeModeBase = value;
+            }
+
+            public new bool ResizeRedraw
+            {
+                get => base.ResizeRedraw;
+                set => base.ResizeRedraw = value;
+            }
 
             public new void OnClick(EventArgs e) => base.OnClick(e);
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollableControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollableControlTests.cs
@@ -57,10 +57,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, control.DockPadding.Bottom);
             Assert.Equal(0, control.DockPadding.Left);
             Assert.Equal(0, control.DockPadding.Right);
+            Assert.False(control.DoubleBuffered);
             Assert.True(control.Enabled);
             Assert.NotNull(control.Events);
             Assert.Same(control.Events, control.Events);
             Assert.Equal(Control.DefaultFont, control.Font);
+            Assert.Equal(control.Font.Height, control.FontHeight);
             Assert.Equal(Control.DefaultForeColor, control.ForeColor);
             Assert.False(control.HasChildren);
             Assert.Equal(0, control.Height);
@@ -72,6 +74,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, control.Left);
             Assert.Equal(Point.Empty, control.Location);
             Assert.Equal(Padding.Empty, control.Padding);
+            Assert.False(control.RecreatingHandle);
+            Assert.Null(control.Region);
+            Assert.False(control.ResizeRedraw);
             Assert.Equal(0, control.Right);
             Assert.Equal(RightToLeft.No, control.RightToLeft);
             Assert.Null(control.Site);
@@ -85,6 +90,8 @@ namespace System.Windows.Forms.Tests
             Assert.Same(control.VerticalScroll, control.VerticalScroll);
             Assert.False(control.VScroll);
             Assert.Equal(0, control.Width);
+
+            Assert.False(control.IsHandleCreated);
         }
 
         [Fact]
@@ -728,14 +735,36 @@ namespace System.Windows.Forms.Tests
 
             public new bool DesignMode => base.DesignMode;
 
+            public new bool DoubleBuffered
+            {
+                get => base.DoubleBuffered;
+                set => base.DoubleBuffered = value;
+            }
+
             public new EventHandlerList Events => base.Events;
 
-            public new ImeMode ImeModeBase => base.ImeModeBase;
+            public new int FontHeight
+            {
+                get => base.FontHeight;
+                set => base.FontHeight = value;
+            }
+
+            public new ImeMode ImeModeBase
+            {
+                get => base.ImeModeBase;
+                set => base.ImeModeBase = value;
+            }
 
             public new bool HScroll
             {
                 get => base.HScroll;
                 set => base.HScroll = value;
+            }
+
+            public new bool ResizeRedraw
+            {
+                get => base.ResizeRedraw;
+                set => base.ResizeRedraw = value;
             }
 
             public new bool VScroll

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
@@ -54,6 +54,7 @@ namespace System.Windows.Forms.Tests
             Assert.NotNull(control.Events);
             Assert.Same(control.Events, control.Events);
             Assert.Equal(Control.DefaultFont, control.Font);
+            Assert.Equal(control.Font.Height, control.FontHeight);
             Assert.Equal(Control.DefaultForeColor, control.ForeColor);
             Assert.False(control.HasChildren);
             Assert.Equal(100, control.Height);
@@ -66,6 +67,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(Point.Empty, control.Location);
             Assert.False(control.Multiline);
             Assert.Equal(new Point(6, 3), control.Padding);
+            Assert.False(control.RecreatingHandle);
+            Assert.Null(control.Region);
+            Assert.False(control.ResizeRedraw);
             Assert.Equal(200, control.Right);
             Assert.Equal(RightToLeft.No, control.RightToLeft);
             Assert.False(control.RightToLeftLayout);
@@ -86,6 +90,25 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(200, control.Width);
 
             Assert.False(control.IsHandleCreated);
+        }
+
+        [Fact]
+        public void TabControl_CreateParams_GetDefault_ReturnsExpected()
+        {
+            var control = new SubTabControl();
+            CreateParams createParams = control.CreateParams;
+            Assert.Null(createParams.Caption);
+            Assert.Equal("SysTabControl32", createParams.ClassName);
+            Assert.Equal(0x8, createParams.ClassStyle);
+            Assert.Equal(0, createParams.ExStyle);
+            Assert.Equal(100, createParams.Height);
+            Assert.Equal(IntPtr.Zero, createParams.Parent);
+            Assert.Null(createParams.Param);
+            Assert.Equal(0x56010800, createParams.Style);
+            Assert.Equal(200, createParams.Width);
+            Assert.Equal(0, createParams.X);
+            Assert.Equal(0, createParams.Y);
+            Assert.Same(createParams, control.CreateParams);
         }
 
         [Theory]
@@ -256,11 +279,31 @@ namespace System.Windows.Forms.Tests
 
             public new bool DesignMode => base.DesignMode;
 
-            public new bool DoubleBuffered => base.DoubleBuffered;
+            public new bool DoubleBuffered
+            {
+                get => base.DoubleBuffered;
+                set => base.DoubleBuffered = value;
+            }
 
             public new EventHandlerList Events => base.Events;
 
-            public new ImeMode ImeModeBase => base.ImeModeBase;
+            public new int FontHeight
+            {
+                get => base.FontHeight;
+                set => base.FontHeight = value;
+            }
+
+            public new ImeMode ImeModeBase
+            {
+                get => base.ImeModeBase;
+                set => base.ImeModeBase = value;
+            }
+
+            public new bool ResizeRedraw
+            {
+                get => base.ResizeRedraw;
+                set => base.ResizeRedraw = value;
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPageTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPageTests.cs
@@ -66,6 +66,7 @@ namespace System.Windows.Forms.Tests
             Assert.NotNull(page.Events);
             Assert.Same(page.Events, page.Events);
             Assert.Equal(Control.DefaultFont, page.Font);
+            Assert.Equal(page.Font.Height, page.FontHeight);
             Assert.Equal(Control.DefaultForeColor, page.ForeColor);
             Assert.False(page.HasChildren);
             Assert.Equal(100, page.Height);
@@ -77,6 +78,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, page.Left);
             Assert.Equal(Point.Empty, page.Location);
             Assert.Equal(Padding.Empty, page.Padding);
+            Assert.False(page.RecreatingHandle);
+            Assert.Null(page.Region);
+            Assert.False(page.ResizeRedraw);
             Assert.Equal(200, page.Right);
             Assert.Equal(RightToLeft.No, page.RightToLeft);
             Assert.Equal(new Size(200, 100), page.Size);
@@ -90,6 +94,27 @@ namespace System.Windows.Forms.Tests
             Assert.Same(page.VerticalScroll, page.VerticalScroll);
             Assert.False(page.VScroll);
             Assert.Equal(200, page.Width);
+
+            Assert.False(page.IsHandleCreated);
+        }
+
+        [Fact]
+        public void TabPage_CreateParams_GetDefault_ReturnsExpected()
+        {
+            var control = new SubTabPage();
+            CreateParams createParams = control.CreateParams;
+            Assert.Null(createParams.Caption);
+            Assert.Null(createParams.ClassName);
+            Assert.Equal(0x8, createParams.ClassStyle);
+            Assert.Equal(0x10000, createParams.ExStyle);
+            Assert.Equal(100, createParams.Height);
+            Assert.Equal(IntPtr.Zero, createParams.Parent);
+            Assert.Null(createParams.Param);
+            Assert.Equal(0x56000000, createParams.Style);
+            Assert.Equal(200, createParams.Width);
+            Assert.Equal(0, createParams.X);
+            Assert.Equal(0, createParams.Y);
+            Assert.Same(createParams, control.CreateParams);
         }
 
         [Theory]
@@ -865,16 +890,36 @@ namespace System.Windows.Forms.Tests
 
             public new bool DesignMode => base.DesignMode;
 
-            public new bool DoubleBuffered => base.DoubleBuffered;
+            public new bool DoubleBuffered
+            {
+                get => base.DoubleBuffered;
+                set => base.DoubleBuffered = value;
+            }
 
             public new EventHandlerList Events => base.Events;
 
-            public new ImeMode ImeModeBase => base.ImeModeBase;
+            public new int FontHeight
+            {
+                get => base.FontHeight;
+                set => base.FontHeight = value;
+            }
+
+            public new ImeMode ImeModeBase
+            {
+                get => base.ImeModeBase;
+                set => base.ImeModeBase = value;
+            }
 
             public new bool HScroll
             {
                 get => base.HScroll;
                 set => base.HScroll = value;
+            }
+
+            public new bool ResizeRedraw
+            {
+                get => base.ResizeRedraw;
+                set => base.ResizeRedraw = value;
             }
 
             public new bool VScroll

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
@@ -67,10 +67,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, toolStrip.DockPadding.Bottom);
             Assert.Equal(0, toolStrip.DockPadding.Left);
             Assert.Equal(1, toolStrip.DockPadding.Right);
+            Assert.True(toolStrip.DoubleBuffered);
             Assert.True(toolStrip.Enabled);
             Assert.NotNull(toolStrip.Events);
             Assert.Same(toolStrip.Events, toolStrip.Events);
             Assert.Equal(Control.DefaultFont, toolStrip.Font);
+            Assert.Equal(toolStrip.Font.Height, toolStrip.FontHeight);
             Assert.Equal(Control.DefaultForeColor, toolStrip.ForeColor);
             Assert.Equal(ToolStripGripStyle.Visible, toolStrip.GripStyle);
             Assert.Equal(ToolStripGripDisplayStyle.Vertical, toolStrip.GripDisplayStyle);
@@ -106,9 +108,12 @@ namespace System.Windows.Forms.Tests
             Assert.NotNull(toolStrip.OverflowButton);
             Assert.Same(toolStrip.OverflowButton, toolStrip.OverflowButton);
             Assert.Equal(new Padding(0, 0, 1, 0), toolStrip.Padding);
+            Assert.False(toolStrip.RecreatingHandle);
+            Assert.Null(toolStrip.Region);
             Assert.NotNull(toolStrip.Renderer);
             Assert.Same(toolStrip.Renderer, toolStrip.Renderer);
             Assert.Equal(ToolStripRenderMode.ManagerRenderMode, toolStrip.RenderMode);
+            Assert.False(toolStrip.ResizeRedraw);
             Assert.Equal(100, toolStrip.Right);
             Assert.Equal(RightToLeft.No, toolStrip.RightToLeft);
             Assert.True(toolStrip.ShowItemToolTips);
@@ -126,6 +131,8 @@ namespace System.Windows.Forms.Tests
             Assert.False(toolStrip.VScroll);
             Assert.Equal(100, toolStrip.Width);
             Assert.True(ToolStripManager.ToolStrips.Contains(toolStrip));
+
+            Assert.False(toolStrip.IsHandleCreated);
         }
 
         public static IEnumerable<object[]> Ctor_ToolStripItemArray_TestData()
@@ -186,10 +193,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, toolStrip.DockPadding.Bottom);
             Assert.Equal(0, toolStrip.DockPadding.Left);
             Assert.Equal(1, toolStrip.DockPadding.Right);
+            Assert.True(toolStrip.DoubleBuffered);
             Assert.True(toolStrip.Enabled);
             Assert.NotNull(toolStrip.Events);
             Assert.Same(toolStrip.Events, toolStrip.Events);
             Assert.Equal(Control.DefaultFont, toolStrip.Font);
+            Assert.Equal(toolStrip.Font.Height, toolStrip.FontHeight);
             Assert.Equal(Control.DefaultForeColor, toolStrip.ForeColor);
             Assert.Equal(ToolStripGripStyle.Visible, toolStrip.GripStyle);
             Assert.Equal(ToolStripGripDisplayStyle.Vertical, toolStrip.GripDisplayStyle);
@@ -226,9 +235,12 @@ namespace System.Windows.Forms.Tests
             Assert.NotNull(toolStrip.OverflowButton);
             Assert.Same(toolStrip.OverflowButton, toolStrip.OverflowButton);
             Assert.Equal(new Padding(0, 0, 1, 0), toolStrip.Padding);
+            Assert.False(toolStrip.RecreatingHandle);
+            Assert.Null(toolStrip.Region);
             Assert.NotNull(toolStrip.Renderer);
             Assert.Same(toolStrip.Renderer, toolStrip.Renderer);
             Assert.Equal(ToolStripRenderMode.ManagerRenderMode, toolStrip.RenderMode);
+            Assert.False(toolStrip.ResizeRedraw);
             Assert.Equal(100, toolStrip.Right);
             Assert.Equal(RightToLeft.No, toolStrip.RightToLeft);
             Assert.True(toolStrip.ShowItemToolTips);
@@ -246,6 +258,8 @@ namespace System.Windows.Forms.Tests
             Assert.False(toolStrip.VScroll);
             Assert.Equal(100, toolStrip.Width);
             Assert.True(ToolStripManager.ToolStrips.Contains(toolStrip));
+
+            Assert.False(toolStrip.IsHandleCreated);
         }
 
         [Fact]
@@ -258,6 +272,25 @@ namespace System.Windows.Forms.Tests
         public void ToolStrip_Ctor_NullValueInItems_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("value", () => new ToolStrip(new ToolStripItem[] { null }));
+        }
+
+        [Fact]
+        public void ToolStrip_CreateParams_GetDefault_ReturnsExpected()
+        {
+            var control = new SubToolStrip();
+            CreateParams createParams = control.CreateParams;
+            Assert.Null(createParams.Caption);
+            Assert.Null(createParams.ClassName);
+            Assert.Equal(0x8, createParams.ClassStyle);
+            Assert.Equal(0x10000, createParams.ExStyle);
+            Assert.Equal(25, createParams.Height);
+            Assert.Equal(IntPtr.Zero, createParams.Parent);
+            Assert.Null(createParams.Param);
+            Assert.Equal(0x56000000, createParams.Style);
+            Assert.Equal(100, createParams.Width);
+            Assert.Equal(0, createParams.X);
+            Assert.Equal(0, createParams.Y);
+            Assert.Same(createParams, control.CreateParams);
         }
 
         [Theory]
@@ -356,9 +389,25 @@ namespace System.Windows.Forms.Tests
 
             public new ToolStripItemCollection DisplayedItems => base.DisplayedItems;
 
+            public new bool DoubleBuffered
+            {
+                get => base.DoubleBuffered;
+                set => base.DoubleBuffered = value;
+            }
+
             public new EventHandlerList Events => base.Events;
 
-            public new ImeMode ImeModeBase => base.ImeModeBase;
+            public new int FontHeight
+            {
+                get => base.FontHeight;
+                set => base.FontHeight = value;
+            }
+
+            public new ImeMode ImeModeBase
+            {
+                get => base.ImeModeBase;
+                set => base.ImeModeBase = value;
+            }
 
             public new bool HScroll
             {
@@ -367,6 +416,12 @@ namespace System.Windows.Forms.Tests
             }
 
             public new Size MaxItemSize => base.MaxItemSize;
+
+            public new bool ResizeRedraw
+            {
+                get => base.ResizeRedraw;
+                set => base.ResizeRedraw = value;
+            }
 
             public new bool VScroll
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/VScrollBarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/VScrollBarTests.cs
@@ -57,10 +57,12 @@ namespace System.Windows.Forms.Tests
             Assert.True(scrollBar.DisplayRectangle.Width > 0);
             Assert.True(scrollBar.DisplayRectangle.Height > 0);
             Assert.Equal(DockStyle.None, scrollBar.Dock);
+            Assert.False(scrollBar.DoubleBuffered);
             Assert.True(scrollBar.Enabled);
             Assert.NotNull(scrollBar.Events);
             Assert.Same(scrollBar.Events, scrollBar.Events);
             Assert.Equal(Control.DefaultFont, scrollBar.Font);
+            Assert.Equal(scrollBar.Font.Height, scrollBar.FontHeight);
             Assert.Equal(Control.DefaultForeColor, scrollBar.ForeColor);
             Assert.False(scrollBar.HasChildren);
             Assert.True(scrollBar.Height > 0);
@@ -73,6 +75,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(100, scrollBar.Maximum);
             Assert.Equal(0, scrollBar.Minimum);
             Assert.Equal(Padding.Empty, scrollBar.Padding);
+            Assert.False(scrollBar.RecreatingHandle);
+            Assert.Null(scrollBar.Region);
+            Assert.False(scrollBar.ResizeRedraw);
             Assert.True(scrollBar.Right > 0);
             Assert.Equal(RightToLeft.No, scrollBar.RightToLeft);
             Assert.True(scrollBar.ScaleScrollBarForDpiChange);
@@ -87,6 +92,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, scrollBar.Value);
             Assert.True(scrollBar.Visible);
             Assert.True(scrollBar.Width > 0);
+
+            Assert.False(scrollBar.IsHandleCreated);
         }
 
         [Fact]
@@ -183,9 +190,31 @@ namespace System.Windows.Forms.Tests
 
             public new bool DesignMode => base.DesignMode;
 
+            public new bool DoubleBuffered
+            {
+                get => base.DoubleBuffered;
+                set => base.DoubleBuffered = value;
+            }
+
             public new EventHandlerList Events => base.Events;
 
-            public new ImeMode ImeModeBase => base.ImeModeBase;
+            public new int FontHeight
+            {
+                get => base.FontHeight;
+                set => base.FontHeight = value;
+            }
+
+            public new ImeMode ImeModeBase
+            {
+                get => base.ImeModeBase;
+                set => base.ImeModeBase = value;
+            }
+
+            public new bool ResizeRedraw
+            {
+                get => base.ResizeRedraw;
+                set => base.ResizeRedraw = value;
+            }
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes
- Add ListView tests and tests for other Control properties

Extracted from https://github.com/dotnet/winforms/pull/1925 

Fixes https://github.com/dotnet/winforms/pull/1935

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1935)