### PR TITLE
Add Missing Types to Intrinsic TypeDescriptor table

### DIFF
--- a/src/System.Windows.Forms.Design.Editors/tests/UnitTests/System.Windows.Forms.Design.Editors.Tests.csproj
+++ b/src/System.Windows.Forms.Design.Editors/tests/UnitTests/System.Windows.Forms.Design.Editors.Tests.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Common\tests\InternalUtilitiesForTests\InternalUtilitiesForTests.csproj" />
+    <ProjectReference Include="..\..\..\System.Windows.Forms\src\System.Windows.Forms.csproj" />
     <ProjectReference Include="..\..\src\System.Windows.Forms.Design.Editors.csproj" />
     <Compile Include="..\..\..\Common\tests\CommonTestHelper.cs" Link="Common\CommonTestHelper.cs" />
     <Compile Include="..\..\..\Common\tests\CommonMemberDataAttribute.cs" Link="Common\CommonMemberDataAttribute.cs" />

--- a/src/System.Windows.Forms.Design.Editors/tests/UnitTests/System/ComponentModel/Design/CollectionEditorTests.cs
+++ b/src/System.Windows.Forms.Design.Editors/tests/UnitTests/System/ComponentModel/Design/CollectionEditorTests.cs
@@ -42,6 +42,17 @@ namespace System.ComponentModel.Design.Tests
         }
 
         [Fact]
+        public void CollectionEditor_EnsureEditor()
+        {
+            TypeDescriptor.AddEditorTable(typeof(UITypeEditor), UITypeEditor.s_intrinsicEditors);
+
+            IList list = new List<int>();
+            var editor = TypeDescriptor.GetEditor(typeof(IList), typeof(UITypeEditor));
+            Assert.NotNull(editor);
+            Assert.Equal(typeof(CollectionEditor).AssemblyQualifiedName, editor.GetType().ToString());
+        }
+
+        [Fact]
         public void CollectionEditor_Ctor_NullType()
         {
             var editor = new SubCollectionEditor(null);

--- a/src/System.Windows.Forms.Design.Editors/tests/UnitTests/System/Drawing/Design/FontEditorTests.cs
+++ b/src/System.Windows.Forms.Design.Editors/tests/UnitTests/System/Drawing/Design/FontEditorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -44,5 +44,14 @@ namespace System.Drawing.Design.Tests
             var editor = new FontEditor();
             Assert.False(editor.GetPaintValueSupported(context));
         }
+
+        //[Fact]
+        //public void EnsureEditor()
+        //{
+        //    var font = new Font(FontFamily.GenericSansSerif, 3.0f);
+        //    var editor = TypeDescriptor.GetEditor(font, font.GetType());
+        //    Assert.NotNull(editor);
+        //    Assert.Equal("System.Drawing.Design.FontEditor", editor.GetType().ToString());
+        //}
     }
 }

--- a/src/System.Windows.Forms/src/Properties/InternalsVisibleTo.cs
+++ b/src/System.Windows.Forms/src/Properties/InternalsVisibleTo.cs
@@ -5,6 +5,7 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("System.Windows.Forms.Tests, PublicKey=00000000000000000400000000000000")]
+[assembly: InternalsVisibleTo("System.Windows.Forms.Design.Editors.Tests, PublicKey=00000000000000000400000000000000")]
 
 // This is needed in order to Moq internal interfaces for testing
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]

--- a/src/System.Windows.Forms/src/System/Drawing/Design/UITypeEditor.cs
+++ b/src/System.Windows.Forms/src/System/Drawing/Design/UITypeEditor.cs
@@ -5,6 +5,7 @@
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Drawing;
 using System.IO;
 
 namespace System.Drawing.Design
@@ -14,23 +15,30 @@ namespace System.Drawing.Design
     /// </summary>
     public class UITypeEditor
     {
+        // Our set of intrinsic editors.
+        internal static Hashtable s_intrinsicEditors = new Hashtable
+        {
+            // System.ComponentModel.Design editors
+            [typeof(DateTime)] = "System.ComponentModel.Design.DateTimeEditor, " + AssemblyRef.SystemDesign,
+            [typeof(Array)] = "System.ComponentModel.Design.ArrayEditor, " + AssemblyRef.SystemDesign,
+            [typeof(IList)] = "System.ComponentModel.Design.CollectionEditor, " + AssemblyRef.SystemDesign,
+            [typeof(ICollection)] = "System.ComponentModel.Design.CollectionEditor, " + AssemblyRef.SystemDesign,
+            [typeof(byte[])] = "System.ComponentModel.Design.BinaryEditor, " + AssemblyRef.SystemDesign,
+            [typeof(Stream)] = "System.ComponentModel.Design.BinaryEditor, " + AssemblyRef.SystemDesign,
+
+            // System.Windows.Forms.Design editors
+            [typeof(string[])] = "System.Windows.Forms.Design.StringArrayEditor, " + AssemblyRef.SystemDesign,
+            [typeof(Collection<string>)] = "System.Windows.Forms.Design.StringCollectionEditor, " + AssemblyRef.SystemDesign,
+
+            // System.Drawing.Design editors
+            [typeof(Image)] = "System.Drawing.Design.ImageEditor, " + AssemblyRef.SystemDesign,
+            [typeof(Font)] = "System.Drawing.Design.FontEditor, " + AssemblyRef.SystemDesign,
+        };
+
         static UITypeEditor()
         {
-            Hashtable intrinsicEditors = new Hashtable
-            {
-                // Our set of intrinsic editors.
-                [typeof(DateTime)] = "System.ComponentModel.Design.DateTimeEditor, " + AssemblyRef.SystemDesign,
-                [typeof(Array)] = "System.ComponentModel.Design.ArrayEditor, " + AssemblyRef.SystemDesign,
-                [typeof(IList)] = "System.ComponentModel.Design.CollectionEditor, " + AssemblyRef.SystemDesign,
-                [typeof(ICollection)] = "System.ComponentModel.Design.CollectionEditor, " + AssemblyRef.SystemDesign,
-                [typeof(byte[])] = "System.ComponentModel.Design.BinaryEditor, " + AssemblyRef.SystemDesign,
-                [typeof(Stream)] = "System.ComponentModel.Design.BinaryEditor, " + AssemblyRef.SystemDesign,
-                [typeof(string[])] = "System.Windows.Forms.Design.StringArrayEditor, " + AssemblyRef.SystemDesign,
-                [typeof(Collection<string>)] = "System.Windows.Forms.Design.StringCollectionEditor, " + AssemblyRef.SystemDesign
-            };
-
             // Add our intrinsic editors to TypeDescriptor.
-            TypeDescriptor.AddEditorTable(typeof(UITypeEditor), intrinsicEditors);
+            TypeDescriptor.AddEditorTable(typeof(UITypeEditor), s_intrinsicEditors);
         }
 
         /// <summary>


### PR DESCRIPTION
There is an issue in the design repo where certain types did not have the EditorAttribute on them as they did in .NET FX. This is intentional as many of these types were moved down to CoreFX and are fascaded, example: System.Drawing.Image @KlausLoeffelmann first reported this and @DustinCampbell expanded this to include other types.

upon further inspection, a great many types are missing.
* [ ] add test for existing mappings in the table like IList -> CollectionEditor -- **currently everything in this pr**
* [ ] add missing types
* [ ] evaluate what to do about types which are mapped but are not in winforms yet (StringArrayEditor, BinaryEditor)
* [ ] add tests for missing types

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1936)