### PR TITLE
Cleanup clipboard interop and add tests

### DIFF
--- a/src/Common/src/Interop/Kernel32/Interop.GMEM.cs
+++ b/src/Common/src/Interop/Kernel32/Interop.GMEM.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [Flags]
+        public enum GMEM : uint
+        {
+            FIXED = 0x0000,
+            MOVEABLE = 0x0002,
+            NOCOMPACT = 0x0010,
+            NODISCARD = 0x0020,
+            ZEROINIT = 0x0040,
+            MODIFY = 0x0080,
+            DISCARDABLE = 0x0100,
+            NOT_BANKED = 0x1000,
+            SHARE = 0x2000,
+            DDESHARE = 0x2000,
+            NOTIFY = 0x4000,
+            LOWER = NOT_BANKED,
+            DISCARDED = 0x4000,
+            LOCKCOUNT = 0x00ff,
+            INVALID_HANDLE = 0x8000,
+
+            GHND = MOVEABLE | ZEROINIT,
+            GPTR = FIXED | ZEROINIT,
+        }
+    }
+}

--- a/src/Common/src/Interop/Kernel32/Interop.GlobalAlloc.cs
+++ b/src/Common/src/Interop/Kernel32/Interop.GlobalAlloc.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
+        public static extern IntPtr GlobalAlloc(GMEM uFlags, uint dwBytes);
+    }
+}

--- a/src/Common/src/Interop/Kernel32/Interop.GlobalFree.cs
+++ b/src/Common/src/Interop/Kernel32/Interop.GlobalFree.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
+        public static extern IntPtr GlobalFree(IntPtr hMem);
+    }
+}

--- a/src/Common/src/Interop/Kernel32/Interop.GlobalLock.cs
+++ b/src/Common/src/Interop/Kernel32/Interop.GlobalLock.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
+        public static extern IntPtr GlobalLock(IntPtr hMem);
+    }
+}

--- a/src/Common/src/Interop/Kernel32/Interop.GlobalReAlloc.cs
+++ b/src/Common/src/Interop/Kernel32/Interop.GlobalReAlloc.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
+        public static extern IntPtr GlobalReAlloc(IntPtr hMem, uint dwBytes, GMEM uFlags);
+    }
+}

--- a/src/Common/src/Interop/Kernel32/Interop.GlobalSize.cs
+++ b/src/Common/src/Interop/Kernel32/Interop.GlobalSize.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
+        public static extern int GlobalSize(IntPtr hMem);
+    }
+}

--- a/src/Common/src/Interop/Kernel32/Interop.GlobalUnlock.cs
+++ b/src/Common/src/Interop/Kernel32/Interop.GlobalUnlock.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
+        public static extern BOOL GlobalUnlock(IntPtr hMem);
+    }
+}

--- a/src/Common/src/Interop/Ole32/Interop.OleFlushClipboard.cs
+++ b/src/Common/src/Interop/Ole32/Interop.OleFlushClipboard.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Ole32
+    {
+        [DllImport(Libraries.Ole32, ExactSpelling = true)]
+        public static extern HRESULT OleFlushClipboard();
+    }
+}

--- a/src/Common/src/Interop/Ole32/Interop.OleGetClipboard.cs
+++ b/src/Common/src/Interop/Ole32/Interop.OleGetClipboard.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+
+internal static partial class Interop
+{
+    internal static partial class Ole32
+    {
+        [DllImport(Libraries.Ole32, ExactSpelling = true)]
+        public static extern HRESULT OleGetClipboard(ref IDataObject data);
+    }
+}

--- a/src/Common/src/Interop/Ole32/Interop.OleSetClipboard.cs
+++ b/src/Common/src/Interop/Ole32/Interop.OleSetClipboard.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+
+internal static partial class Interop
+{
+    internal static partial class Ole32
+    {
+        [DllImport(Libraries.Ole32, ExactSpelling = true)]
+        public static extern HRESULT OleSetClipboard(IDataObject pDataObj);
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -356,22 +356,7 @@ namespace System.Windows.Forms
         public const int FADF_DISPATCH = (0x400);
         public const int FADF_VARIANT = (unchecked((int)0x800));
 
-        public const int GMEM_FIXED = 0x0000,
-        GMEM_MOVEABLE = 0x0002,
-        GMEM_NOCOMPACT = 0x0010,
-        GMEM_NODISCARD = 0x0020,
-        GMEM_ZEROINIT = 0x0040,
-        GMEM_MODIFY = 0x0080,
-        GMEM_DISCARDABLE = 0x0100,
-        GMEM_NOT_BANKED = 0x1000,
-        GMEM_SHARE = 0x2000,
-        GMEM_DDESHARE = 0x2000,
-        GMEM_NOTIFY = 0x4000,
-        GMEM_LOWER = GMEM_NOT_BANKED,
-        GMEM_VALID_FLAGS = 0x7F72,
-        GMEM_INVALID_HANDLE = 0x8000,
-        GHND = (GMEM_MOVEABLE | GMEM_ZEROINIT),
-        GPTR = (GMEM_FIXED | GMEM_ZEROINIT),
+        public const int
         GCL_WNDPROC = (-24),
         GWL_WNDPROC = (-4),
         GWL_HWNDPARENT = (-8),

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -74,15 +74,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.Comdlg32, SetLastError = true, CharSet = CharSet.Auto)]
         public static extern int PrintDlgEx([In, Out] NativeMethods.PRINTDLGEX lppdex);
 
-        [DllImport(ExternDll.Ole32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern int OleGetClipboard(ref IComDataObject data);
-
-        [DllImport(ExternDll.Ole32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern int OleSetClipboard(IComDataObject pDataObj);
-
-        [DllImport(ExternDll.Ole32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern int OleFlushClipboard();
-
         [DllImport(ExternDll.Oleaut32, ExactSpelling = true)]
         public static extern void OleCreatePropertyFrameIndirect(NativeMethods.OCPFIPARAMS p);
 
@@ -265,24 +256,6 @@ namespace System.Windows.Forms
 
         [DllImport(ExternDll.Kernel32, CharSet = CharSet.Auto)]
         public static extern void GetTempFileName(string tempDirName, string prefixName, int unique, StringBuilder sb);
-
-        [DllImport(ExternDll.Kernel32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern IntPtr GlobalAlloc(int uFlags, int dwBytes);
-
-        [DllImport(ExternDll.Kernel32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern IntPtr GlobalReAlloc(HandleRef handle, int bytes, int flags);
-
-        [DllImport(ExternDll.Kernel32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern IntPtr GlobalLock(HandleRef handle);
-
-        [DllImport(ExternDll.Kernel32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern bool GlobalUnlock(HandleRef handle);
-
-        [DllImport(ExternDll.Kernel32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern IntPtr GlobalFree(HandleRef handle);
-
-        [DllImport(ExternDll.Kernel32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern int GlobalSize(HandleRef handle);
 
         [DllImport(ExternDll.Imm32, CharSet = CharSet.Auto)]
         public static extern bool ImmSetConversionStatus(HandleRef hIMC, int conversion, int sentence);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -7066,8 +7066,8 @@ namespace System.Windows.Forms
                 IntPtr hglobal = IntPtr.Zero;
                 if (buffer != null)
                 {
-                    hglobal = UnsafeNativeMethods.GlobalAlloc(NativeMethods.GMEM_MOVEABLE, length);
-                    IntPtr pointer = UnsafeNativeMethods.GlobalLock(new HandleRef(null, hglobal));
+                    hglobal = Kernel32.GlobalAlloc(Kernel32.GMEM.MOVEABLE, (uint)length);
+                    IntPtr pointer = Kernel32.GlobalLock(hglobal);
                     try
                     {
                         if (pointer != IntPtr.Zero)
@@ -7077,10 +7077,10 @@ namespace System.Windows.Forms
                     }
                     finally
                     {
-                        UnsafeNativeMethods.GlobalUnlock(new HandleRef(null, hglobal));
+                        Kernel32.GlobalUnlock(hglobal);
                     }
                 }
-                bool failed = false;
+
                 try
                 {
                     iLockBytes = Ole32.CreateILockBytesOnHGlobal(hglobal, true);
@@ -7101,21 +7101,17 @@ namespace System.Windows.Forms
                             0);
                     }
                 }
-                catch (Exception t)
-                {
-                    Debug.Fail(t.ToString());
-                    failed = true;
-                }
-                if (failed)
+                catch (Exception)
                 {
                     if (iLockBytes == null && hglobal != IntPtr.Zero)
                     {
-                        UnsafeNativeMethods.GlobalFree(new HandleRef(null, hglobal));
+                        Kernel32.GlobalFree(hglobal);
                     }
                     else
                     {
                         iLockBytes = null;
                     }
+
                     storage = null;
                 }
             }
@@ -7210,7 +7206,7 @@ namespace System.Windows.Forms
                     length = (int)stat.cbSize;
                     buffer = new byte[length];
                     IntPtr hglobal = Ole32.GetHGlobalFromILockBytes(iLockBytes);
-                    IntPtr pointer = UnsafeNativeMethods.GlobalLock(new HandleRef(null, hglobal));
+                    IntPtr pointer = Kernel32.GlobalLock(hglobal);
                     try
                     {
                         if (pointer != IntPtr.Zero)
@@ -7225,7 +7221,7 @@ namespace System.Windows.Forms
                     }
                     finally
                     {
-                        UnsafeNativeMethods.GlobalUnlock(new HandleRef(null, hglobal));
+                        Kernel32.GlobalUnlock(hglobal);
                     }
                 }
                 finally

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
@@ -643,10 +643,9 @@ namespace System.Windows.Forms
                 if ((formatetc.tymed & TYMED.TYMED_HGLOBAL) != 0)
                 {
                     medium.tymed = TYMED.TYMED_HGLOBAL;
-                    medium.unionmember = UnsafeNativeMethods.GlobalAlloc(NativeMethods.GMEM_MOVEABLE
-                                                             | NativeMethods.GMEM_DDESHARE
-                                                             | NativeMethods.GMEM_ZEROINIT,
-                                                             1);
+                    medium.unionmember = Kernel32.GlobalAlloc(
+                        Kernel32.GMEM.MOVEABLE | Kernel32.GMEM.DDESHARE | Kernel32.GMEM.ZEROINIT,
+                        1);
                     if (medium.unionmember == IntPtr.Zero)
                     {
                         throw new OutOfMemoryException();
@@ -658,7 +657,7 @@ namespace System.Windows.Forms
                     }
                     catch
                     {
-                        UnsafeNativeMethods.GlobalFree(new HandleRef(medium, medium.unionmember));
+                        Kernel32.GlobalFree(medium.unionmember);
                         medium.unionmember = IntPtr.Zero;
                         throw;
                     }
@@ -854,15 +853,17 @@ namespace System.Windows.Forms
         {
             if (handle != IntPtr.Zero)
             {
-                UnsafeNativeMethods.GlobalFree(new HandleRef(null, handle));
+                Kernel32.GlobalFree(handle);
             }
+
             int size = (int)stream.Length;
-            handle = UnsafeNativeMethods.GlobalAlloc(NativeMethods.GMEM_MOVEABLE | NativeMethods.GMEM_DDESHARE, size);
+            handle = Kernel32.GlobalAlloc(Kernel32.GMEM.MOVEABLE | Kernel32.GMEM.DDESHARE, (uint)size);
             if (handle == IntPtr.Zero)
             {
-                return (NativeMethods.E_OUTOFMEMORY);
+                return NativeMethods.E_OUTOFMEMORY;
             }
-            IntPtr ptr = UnsafeNativeMethods.GlobalLock(new HandleRef(null, handle));
+
+            IntPtr ptr = Kernel32.GlobalLock(handle);
             if (ptr == IntPtr.Zero)
             {
                 return (NativeMethods.E_OUTOFMEMORY);
@@ -875,7 +876,7 @@ namespace System.Windows.Forms
             }
             finally
             {
-                UnsafeNativeMethods.GlobalUnlock(new HandleRef(null, handle));
+                Kernel32.GlobalUnlock(handle);
             }
             return NativeMethods.S_OK;
         }
@@ -899,37 +900,36 @@ namespace System.Windows.Forms
             }
 
             IntPtr currentPtr = IntPtr.Zero;
-            int baseStructSize = 4 + 8 + 4 + 4;
-            int sizeInBytes = baseStructSize;
+            uint baseStructSize = 4 + 8 + 4 + 4;
+            uint sizeInBytes = baseStructSize;
 
             // First determine the size of the array
             for (int i = 0; i < files.Length; i++)
             {
-                sizeInBytes += (files[i].Length + 1) * 2;
+                sizeInBytes += ((uint)files[i].Length + 1) * 2;
             }
             sizeInBytes += 2;
 
             // Alloc the Win32 memory
-            //
-            IntPtr newHandle = UnsafeNativeMethods.GlobalReAlloc(new HandleRef(null, handle),
-                                                  sizeInBytes,
-                                                  NativeMethods.GMEM_MOVEABLE | NativeMethods.GMEM_DDESHARE);
+            IntPtr newHandle = Kernel32.GlobalReAlloc(
+                handle,
+                sizeInBytes,
+                Kernel32.GMEM.MOVEABLE | Kernel32.GMEM.DDESHARE);
             if (newHandle == IntPtr.Zero)
             {
-                return (NativeMethods.E_OUTOFMEMORY);
+                return NativeMethods.E_OUTOFMEMORY;
             }
-            IntPtr basePtr = UnsafeNativeMethods.GlobalLock(new HandleRef(null, newHandle));
+
+            IntPtr basePtr = Kernel32.GlobalLock(newHandle);
             if (basePtr == IntPtr.Zero)
             {
-                return (NativeMethods.E_OUTOFMEMORY);
+                return NativeMethods.E_OUTOFMEMORY;
             }
+
             currentPtr = basePtr;
 
             // Write out the struct...
-            //
-            int[] structData = new int[] { baseStructSize, 0, 0, 0, 0 };
-
-            structData[4] = unchecked((int)0xFFFFFFFF);
+            int[] structData = new int[] { (int)baseStructSize, 0, 0, 0, unchecked((int)0xFFFFFFFF) };
             Marshal.Copy(structData, 0, currentPtr, structData.Length);
             currentPtr = (IntPtr)((long)currentPtr + baseStructSize);
 
@@ -945,7 +945,7 @@ namespace System.Windows.Forms
             Marshal.Copy(new char[] { '\0' }, 0, currentPtr, 1);
             currentPtr = (IntPtr)((long)currentPtr + 2);
 
-            UnsafeNativeMethods.GlobalUnlock(new HandleRef(null, newHandle));
+            Kernel32.GlobalUnlock(newHandle);
             return NativeMethods.S_OK;
         }
 
@@ -962,20 +962,20 @@ namespace System.Windows.Forms
             IntPtr newHandle = IntPtr.Zero;
             if (unicode)
             {
-                int byteSize = (str.Length * 2 + 2);
-                newHandle = UnsafeNativeMethods.GlobalReAlloc(new HandleRef(null, handle),
-                                                  byteSize,
-                                                  NativeMethods.GMEM_MOVEABLE
-                                                  | NativeMethods.GMEM_DDESHARE
-                                                  | NativeMethods.GMEM_ZEROINIT);
+                uint byteSize = (uint)str.Length * 2 + 2;
+                newHandle = Kernel32.GlobalReAlloc(
+                    handle,
+                    byteSize,
+                    Kernel32.GMEM.MOVEABLE | Kernel32.GMEM.DDESHARE | Kernel32.GMEM.ZEROINIT);
                 if (newHandle == IntPtr.Zero)
                 {
-                    return (NativeMethods.E_OUTOFMEMORY);
+                    return NativeMethods.E_OUTOFMEMORY;
                 }
-                IntPtr ptr = UnsafeNativeMethods.GlobalLock(new HandleRef(null, newHandle));
+
+                IntPtr ptr = Kernel32.GlobalLock(newHandle);
                 if (ptr == IntPtr.Zero)
                 {
-                    return (NativeMethods.E_OUTOFMEMORY);
+                    return NativeMethods.E_OUTOFMEMORY;
                 }
 
                 char[] chars = str.ToCharArray(0, str.Length);
@@ -989,27 +989,29 @@ namespace System.Windows.Forms
                 byte[] strBytes = new byte[pinvokeSize];
                 UnsafeNativeMethods.WideCharToMultiByte(0 /*CP_ACP*/, 0, str, str.Length, strBytes, strBytes.Length, IntPtr.Zero, IntPtr.Zero);
 
-                newHandle = UnsafeNativeMethods.GlobalReAlloc(new HandleRef(null, handle),
-                                                  pinvokeSize + 1,
-                                                  NativeMethods.GMEM_MOVEABLE
-                                                  | NativeMethods.GMEM_DDESHARE
-                                                  | NativeMethods.GMEM_ZEROINIT);
+                newHandle = Kernel32.GlobalReAlloc(
+                    handle,
+                    (uint)pinvokeSize + 1,
+                    
+                    Kernel32.GMEM.MOVEABLE | Kernel32.GMEM.DDESHARE | Kernel32.GMEM.ZEROINIT);
                 if (newHandle == IntPtr.Zero)
                 {
-                    return (NativeMethods.E_OUTOFMEMORY);
+                    return NativeMethods.E_OUTOFMEMORY;
                 }
-                IntPtr ptr = UnsafeNativeMethods.GlobalLock(new HandleRef(null, newHandle));
+
+                IntPtr ptr = Kernel32.GlobalLock(newHandle);
                 if (ptr == IntPtr.Zero)
                 {
-                    return (NativeMethods.E_OUTOFMEMORY);
+                    return NativeMethods.E_OUTOFMEMORY;
                 }
+
                 UnsafeNativeMethods.CopyMemory(ptr, strBytes, pinvokeSize);
                 Marshal.Copy(new byte[] { 0 }, 0, (IntPtr)((long)ptr + pinvokeSize), 1);
             }
 
             if (newHandle != IntPtr.Zero)
             {
-                UnsafeNativeMethods.GlobalUnlock(new HandleRef(null, newHandle));
+                Kernel32.GlobalUnlock(newHandle);
             }
             return NativeMethods.S_OK;
         }
@@ -1024,21 +1026,21 @@ namespace System.Windows.Forms
 
             UTF8Encoding encoding = new UTF8Encoding();
             byte[] bytes = encoding.GetBytes(str);
-
-            newHandle = UnsafeNativeMethods.GlobalReAlloc(new HandleRef(null, handle),
-                                                    bytes.Length + 1,
-                                                    NativeMethods.GMEM_MOVEABLE
-                                                    | NativeMethods.GMEM_DDESHARE
-                                                    | NativeMethods.GMEM_ZEROINIT);
+            newHandle = Kernel32.GlobalReAlloc(
+                handle,
+                (uint)bytes.Length + 1,
+                Kernel32.GMEM.MOVEABLE | Kernel32.GMEM.DDESHARE | Kernel32.GMEM.ZEROINIT);
             if (newHandle == IntPtr.Zero)
             {
-                return (NativeMethods.E_OUTOFMEMORY);
+                return NativeMethods.E_OUTOFMEMORY;
             }
-            IntPtr ptr = UnsafeNativeMethods.GlobalLock(new HandleRef(null, newHandle));
+
+            IntPtr ptr = Kernel32.GlobalLock(newHandle);
             if (ptr == IntPtr.Zero)
             {
-                return (NativeMethods.E_OUTOFMEMORY);
+                return NativeMethods.E_OUTOFMEMORY;
             }
+
             try
             {
                 UnsafeNativeMethods.CopyMemory(ptr, bytes, bytes.Length);
@@ -1046,8 +1048,9 @@ namespace System.Windows.Forms
             }
             finally
             {
-                UnsafeNativeMethods.GlobalUnlock(new HandleRef(null, newHandle));
+                Kernel32.GlobalUnlock(newHandle);
             }
+
             return NativeMethods.S_OK;
         }
 
@@ -1325,13 +1328,12 @@ namespace System.Windows.Forms
                     Marshal.Release(medium.unionmember);
                     pStream.Stat(out Ole32.STATSTG sstg, Ole32.STATFLAG.STATFLAG_DEFAULT);
 
-                    IntPtr hglobal = UnsafeNativeMethods.GlobalAlloc(NativeMethods.GMEM_MOVEABLE
-                                                      | NativeMethods.GMEM_DDESHARE
-                                                      | NativeMethods.GMEM_ZEROINIT,
-                                                      (int)sstg.cbSize);
-                    IntPtr ptr = UnsafeNativeMethods.GlobalLock(new HandleRef(innerData, hglobal));
+                    IntPtr hglobal = Kernel32.GlobalAlloc(
+                        Kernel32.GMEM.MOVEABLE | Kernel32.GMEM.DDESHARE | Kernel32.GMEM.ZEROINIT,
+                        (uint)sstg.cbSize);
+                    IntPtr ptr = Kernel32.GlobalLock(hglobal);
                     pStream.Read((byte*)ptr, (uint)sstg.cbSize, null);
-                    UnsafeNativeMethods.GlobalUnlock(new HandleRef(innerData, hglobal));
+                    Kernel32.GlobalUnlock(hglobal);
 
                     return GetDataFromHGLOBAL(format, hglobal);
                 }
@@ -1348,11 +1350,7 @@ namespace System.Windows.Forms
 
                 if (hglobal != IntPtr.Zero)
                 {
-                    //=----------------------------------------------------------------=
                     // Convert from OLE to IW objects
-                    //=----------------------------------------------------------------=
-                    // Add any new formats here...
-
                     if (format.Equals(DataFormats.Text)
                         || format.Equals(DataFormats.Rtf)
                         || format.Equals(DataFormats.OemText))
@@ -1385,7 +1383,7 @@ namespace System.Windows.Forms
                         data = ReadObjectFromHandle(hglobal, DataObject.RestrictDeserializationToSafeTypes(format));
                     }
 
-                    UnsafeNativeMethods.GlobalFree(new HandleRef(null, hglobal));
+                    Kernel32.GlobalFree(hglobal);
                 }
 
                 return data;
@@ -1536,14 +1534,14 @@ namespace System.Windows.Forms
             /// </summary>
             private Stream ReadByteStreamFromHandle(IntPtr handle, out bool isSerializedObject)
             {
-                IntPtr ptr = UnsafeNativeMethods.GlobalLock(new HandleRef(null, handle));
+                IntPtr ptr = Kernel32.GlobalLock(handle);
                 if (ptr == IntPtr.Zero)
                 {
                     throw new ExternalException(SR.ExternalException, NativeMethods.E_OUTOFMEMORY);
                 }
                 try
                 {
-                    int size = UnsafeNativeMethods.GlobalSize(new HandleRef(null, handle));
+                    int size = Kernel32.GlobalSize(handle);
                     byte[] bytes = new byte[size];
                     Marshal.Copy(ptr, bytes, 0, size);
                     int index = 0;
@@ -1581,7 +1579,7 @@ namespace System.Windows.Forms
                 }
                 finally
                 {
-                    UnsafeNativeMethods.GlobalUnlock(new HandleRef(null, handle));
+                    Kernel32.GlobalUnlock(handle);
                 }
             }
 
@@ -1591,20 +1589,13 @@ namespace System.Windows.Forms
             /// </summary>
             private object ReadObjectFromHandle(IntPtr handle, bool restrictDeserialization)
             {
-                object value = null;
-
                 Stream stream = ReadByteStreamFromHandle(handle, out bool isSerializedObject);
-
                 if (isSerializedObject)
                 {
-                    value = ReadObjectFromHandleDeserializer(stream, restrictDeserialization);
+                    return ReadObjectFromHandleDeserializer(stream, restrictDeserialization);
                 }
-                else
-                {
-                    value = stream;
-                }
-
-                return value;
+                
+                return stream;
             }
 
             private static object ReadObjectFromHandleDeserializer(Stream stream, bool restrictDeserialization)
@@ -1659,7 +1650,7 @@ namespace System.Windows.Forms
             {
                 string stringData = null;
 
-                IntPtr ptr = UnsafeNativeMethods.GlobalLock(new HandleRef(null, handle));
+                IntPtr ptr = Kernel32.GlobalLock(handle);
                 try
                 {
                     if (unicode)
@@ -1673,7 +1664,7 @@ namespace System.Windows.Forms
                 }
                 finally
                 {
-                    UnsafeNativeMethods.GlobalUnlock(new HandleRef(null, handle));
+                    Kernel32.GlobalUnlock(handle);
                 }
 
                 return stringData;
@@ -1681,19 +1672,16 @@ namespace System.Windows.Forms
 
             private unsafe string ReadHtmlFromHandle(IntPtr handle)
             {
-                string stringData = null;
-                IntPtr ptr = UnsafeNativeMethods.GlobalLock(new HandleRef(null, handle));
+                IntPtr ptr = Kernel32.GlobalLock(handle);
                 try
                 {
-                    int size = UnsafeNativeMethods.GlobalSize(new HandleRef(null, handle));
-                    stringData = Encoding.UTF8.GetString((byte*)ptr, size);
+                    int size = Kernel32.GlobalSize(handle);
+                    return Encoding.UTF8.GetString((byte*)ptr, size);
                 }
                 finally
                 {
-                    UnsafeNativeMethods.GlobalUnlock(new HandleRef(null, handle));
+                    Kernel32.GlobalUnlock(handle);
                 }
-
-                return stringData;
             }
 
             //=------------------------------------------------------------------------=

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
@@ -1676,7 +1676,7 @@ namespace System.Windows.Forms
                 try
                 {
                     int size = Kernel32.GlobalSize(handle);
-                    return Encoding.UTF8.GetString((byte*)ptr, size);
+                    return Encoding.UTF8.GetString((byte*)ptr, size - 1);
                 }
                 finally
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PageSetupDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PageSetupDialog.cs
@@ -340,8 +340,8 @@ namespace System.Windows.Forms
             }
             finally
             {
-                UnsafeNativeMethods.GlobalFree(new HandleRef(data, data.hDevMode));
-                UnsafeNativeMethods.GlobalFree(new HandleRef(data, data.hDevNames));
+                Kernel32.GlobalFree(data.hDevMode);
+                Kernel32.GlobalFree(data.hDevNames);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintDialog.cs
@@ -5,6 +5,7 @@
 using System.ComponentModel;
 using System.Drawing.Printing;
 using System.Runtime.InteropServices;
+using static Interop;
 
 namespace System.Windows.Forms
 {
@@ -336,8 +337,7 @@ namespace System.Windows.Forms
             data.ExclusionFlags = 0;
             data.nPageRanges = 0;
             data.nMaxPageRanges = 1;
-            data.pageRanges = UnsafeNativeMethods.GlobalAlloc(NativeMethods.GPTR,
-                                                              data.nMaxPageRanges * Marshal.SizeOf<NativeMethods.PRINTPAGERANGE>());
+            data.pageRanges = Kernel32.GlobalAlloc(Kernel32.GMEM.GPTR, (uint)(data.nMaxPageRanges * Marshal.SizeOf<NativeMethods.PRINTPAGERANGE>()));
             data.nMinPage = 0;
             data.nMaxPage = 9999;
             data.nCopies = 1;
@@ -451,8 +451,8 @@ namespace System.Windows.Forms
             }
             finally
             {
-                UnsafeNativeMethods.GlobalFree(new HandleRef(data, data.hDevMode));
-                UnsafeNativeMethods.GlobalFree(new HandleRef(data, data.hDevNames));
+                Kernel32.GlobalFree(data.hDevMode);
+                Kernel32.GlobalFree(data.hDevNames);
             }
         }
 
@@ -562,17 +562,17 @@ namespace System.Windows.Forms
             {
                 if (data.hDevMode != IntPtr.Zero)
                 {
-                    UnsafeNativeMethods.GlobalFree(new HandleRef(data, data.hDevMode));
+                    Kernel32.GlobalFree(data.hDevMode);
                 }
 
                 if (data.hDevNames != IntPtr.Zero)
                 {
-                    UnsafeNativeMethods.GlobalFree(new HandleRef(data, data.hDevNames));
+                    Kernel32.GlobalFree(data.hDevNames);
                 }
 
                 if (data.pageRanges != IntPtr.Zero)
                 {
-                    UnsafeNativeMethods.GlobalFree(new HandleRef(data, data.pageRanges));
+                    Kernel32.GlobalFree(data.pageRanges);
                 }
             }
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
@@ -1,0 +1,477 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Moq;
+using WinForms.Common.Tests;
+using Xunit;
+using IComDataObject = System.Runtime.InteropServices.ComTypes.IDataObject;
+
+namespace System.Windows.Forms.Tests
+{
+    public class ClipboardTests
+    {
+        [StaFact]
+        public void Clipboard_Clear_InvokeMultipleTimes_Success()
+        {
+            Clipboard.Clear();
+            Assert.False(Clipboard.ContainsAudio());
+            Assert.False(Clipboard.ContainsData("format"));
+            Assert.False(Clipboard.ContainsFileDropList());
+            Assert.False(Clipboard.ContainsImage());
+            Assert.False(Clipboard.ContainsText());
+
+            Clipboard.Clear();
+            Assert.False(Clipboard.ContainsAudio());
+            Assert.False(Clipboard.ContainsData("format"));
+            Assert.False(Clipboard.ContainsFileDropList());
+            Assert.False(Clipboard.ContainsImage());
+            Assert.False(Clipboard.ContainsText());
+        }
+
+        [Fact]
+        public void Clipboard_Clear_NotSta_ThrowsThreadStateException()
+        {
+            Assert.Throws<ThreadStateException>(() => Clipboard.Clear());
+        }
+
+        [Fact]
+        public void Clipboard_ContainsAudio_InvokeMultipleTimes_Success()
+        {
+            bool result = Clipboard.ContainsAudio();
+            Assert.Equal(result, Clipboard.ContainsAudio());
+        }
+
+        [Theory]
+        [CommonMemberData(nameof(CommonTestHelper.GetStringWithNullTheoryData))]
+        public void Clipboard_ContainsData_InvokeMultipleTimes_Success(string format)
+        {
+            bool result = Clipboard.ContainsData(format);
+            Assert.Equal(result, Clipboard.ContainsData(format));
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Clipboard_ContainsFileDropList_InvokeMultipleTimes_Success()
+        {
+            bool result = Clipboard.ContainsFileDropList();
+            Assert.Equal(result, Clipboard.ContainsFileDropList());
+        }
+
+        [Fact]
+        public void Clipboard_ContainsImage_InvokeMultipleTimes_Success()
+        {
+            bool result = Clipboard.ContainsImage();
+            Assert.Equal(result, Clipboard.ContainsImage());
+        }
+
+        [Fact]
+        public void Clipboard_ContainsText_InvokeMultipleTimes_Success()
+        {
+            bool result = Clipboard.ContainsText();
+            Assert.Equal(result, Clipboard.ContainsText());
+        }
+
+        [Theory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(TextDataFormat))]
+        public void Clipboard_ContainsText_InvokeTextDataFormatMultipleTimes_Success(TextDataFormat format)
+        {
+            bool result = Clipboard.ContainsText(format);
+            Assert.Equal(result, Clipboard.ContainsText(format));
+        }
+
+        [Theory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryDataInvalid), typeof(TextDataFormat))]
+        public void Clipboard_ContainsText_InvalidFormat_ThrowsInvalidEnumArgumentException(TextDataFormat format)
+        {
+            Assert.Throws<InvalidEnumArgumentException>("format", () => Clipboard.ContainsText(format));
+        }
+
+        [Fact]
+        public void Clipboard_GetAudioStream_InvokeMultipleTimes_Success()
+        {
+            Stream result = Clipboard.GetAudioStream();
+            Assert.Equal(result, Clipboard.GetAudioStream());
+        }
+
+        [Theory]
+        [CommonMemberData(nameof(CommonTestHelper.GetStringWithNullTheoryData))]
+        public void Clipboard_GetData_InvokeMultipleTimes_Success(string format)
+        {
+            object result = Clipboard.GetData(format);
+            Assert.Equal(result, Clipboard.GetData(format));
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Clipboard_GetDataObject_InvokeMultipleTimes_Success()
+        {
+            object result = Clipboard.GetDataObject();
+            Assert.Equal(result, Clipboard.GetDataObject());
+        }
+
+        [Fact]
+        public void Clipboard_GetFileDropList_InvokeMultipleTimes_Success()
+        {
+            bool result = Clipboard.ContainsFileDropList();
+            Assert.Equal(result, Clipboard.ContainsFileDropList());
+        }
+
+        [Fact]
+        public void Clipboard_GetImage_InvokeMultipleTimes_Success()
+        {
+            bool result = Clipboard.ContainsImage();
+            Assert.Equal(result, Clipboard.ContainsImage());
+        }
+
+        [Fact]
+        public void Clipboard_GetText_InvokeMultipleTimes_Success()
+        {
+            bool result = Clipboard.ContainsText();
+            Assert.Equal(result, Clipboard.ContainsText());
+        }
+
+        [Theory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(TextDataFormat))]
+        public void Clipboard_GetText_InvokeTextDataFormatMultipleTimes_Success(TextDataFormat format)
+        {
+            string result = Clipboard.GetText(format);
+            Assert.Equal(result, Clipboard.GetText(format));
+        }
+
+        [Theory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryDataInvalid), typeof(TextDataFormat))]
+        public void Clipboard_GetText_InvalidFormat_ThrowsInvalidEnumArgumentException(TextDataFormat format)
+        {
+            Assert.Throws<InvalidEnumArgumentException>("format", () => Clipboard.GetText(format));
+        }
+
+        [StaFact]
+        public void Clipboard_SetAudio_InvokeByteArray_GetReturnsExpected()
+        {
+            byte[] audioBytes = new byte[] { 1, 2, 3 };
+            Clipboard.SetAudio(audioBytes);
+            Assert.Equal(audioBytes, Assert.IsType<MemoryStream>(Clipboard.GetAudioStream()).ToArray());
+            Assert.Equal(audioBytes, Assert.IsType<MemoryStream>(Clipboard.GetData(DataFormats.WaveAudio)).ToArray());
+            Assert.True(Clipboard.ContainsAudio());
+            Assert.True(Clipboard.ContainsData(DataFormats.WaveAudio));
+        }
+
+        [StaFact]
+        public void Clipboard_SetAudio_InvokeEmptyByteArray_GetReturnsExpected()
+        {
+            byte[] audioBytes = new byte[0];
+            Clipboard.SetAudio(audioBytes);
+            Assert.Null(Clipboard.GetAudioStream());
+            Assert.Null(Clipboard.GetData(DataFormats.WaveAudio));
+            Assert.True(Clipboard.ContainsAudio());
+            Assert.True(Clipboard.ContainsData(DataFormats.WaveAudio));
+        }
+
+        [Fact]
+        public void Clipboard_SetAudio_NullAudioBytes_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("audioBytes", () => Clipboard.SetAudio((byte[])null));
+        }
+
+        [StaFact]
+        public void Clipboard_SetAudio_InvokeStream_GetReturnsExpected()
+        {
+            byte[] audioBytes = new byte[] { 1, 2, 3 };
+            using (var audioStream = new MemoryStream(audioBytes))
+            {
+                Clipboard.SetAudio(audioStream);
+                Assert.Equal(audioBytes, Assert.IsType<MemoryStream>(Clipboard.GetAudioStream()).ToArray());
+                Assert.Equal(audioBytes, Assert.IsType<MemoryStream>(Clipboard.GetData(DataFormats.WaveAudio)).ToArray());
+                Assert.True(Clipboard.ContainsAudio());
+                Assert.True(Clipboard.ContainsData(DataFormats.WaveAudio));
+            }
+        }
+
+        [StaFact]
+        public void Clipboard_SetAudio_InvokeEmptyStream_GetReturnsExpected()
+        {
+            var audioStream = new MemoryStream();
+            Clipboard.SetAudio(audioStream);
+            Assert.Null(Clipboard.GetAudioStream());
+            Assert.Null(Clipboard.GetData(DataFormats.WaveAudio));
+            Assert.True(Clipboard.ContainsAudio());
+            Assert.True(Clipboard.ContainsData(DataFormats.WaveAudio));
+        }
+
+        [Fact]
+        public void Clipboard_SetAudio_NullAudioStream_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("audioStream", () => Clipboard.SetAudio((Stream)null));
+        }
+
+        [Fact]
+        public void Clipboard_SetAudio_NotSta_ThrowsThreadStateException()
+        {
+            Assert.Throws<ThreadStateException>(() => Clipboard.SetAudio(new byte[0]));
+            Assert.Throws<ThreadStateException>(() => Clipboard.SetAudio(new MemoryStream()));
+        }
+
+        [StaTheory]
+        [InlineData("format", null)]
+        [InlineData("format", 1)]
+        public void Clipboard_SetData_Invoke_GetReturnsExpected(string format, object data)
+        {
+            Clipboard.SetData(format, data);
+            Assert.Equal(data, Clipboard.GetData(format));
+            Assert.True(Clipboard.ContainsData(format));
+        }
+
+        [Fact]
+        public void Clipboard_SetData_NullFormat_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("format", () => Clipboard.SetData(null, null));
+        }
+
+        [Fact]
+        public void Clipboard_SetData_EmptyFormat_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>("format", () => Clipboard.SetData(string.Empty, null));
+        }
+
+        [Fact]
+        public void Clipboard_SetData_NotSta_ThrowsThreadStateException()
+        {
+            Assert.Throws<ThreadStateException>(() => Clipboard.SetData("format", null));
+        }
+
+        [StaTheory]
+        [InlineData(1)]
+        [InlineData("data")]
+        public void Clipboard_SetDataObject_InvokeObjectNotIComDataObject_GetReturnsExpected(object data)
+        {
+            Clipboard.SetDataObject(data);
+            Assert.Equal(data, Clipboard.GetDataObject().GetData(data.GetType()));
+            Assert.True(Clipboard.ContainsData(data.GetType().FullName));
+        }
+
+        [StaTheory]
+        [InlineData(1)]
+        [InlineData("data")]
+        public void Clipboard_SetDataObject_InvokeObjectIComDataObject_GetReturnsExpected(object data)
+        {
+            var dataObject = new DataObject(data);
+            Clipboard.SetDataObject(dataObject);
+            Assert.Equal(data, Clipboard.GetDataObject().GetData(data.GetType()));
+            Assert.True(Clipboard.ContainsData(data.GetType().FullName));
+        }
+
+        [StaTheory]
+        [InlineData(1, true)]
+        [InlineData(1, false)]
+        [InlineData("data", true)]
+        [InlineData("data", false)]
+        public void Clipboard_SetDataObject_InvokeObjectBoolNotIComDataObject_GetReturnsExpected(object data, bool copy)
+        {
+            Clipboard.SetDataObject(data, copy);
+            Assert.Equal(data, Clipboard.GetDataObject().GetData(data.GetType()));
+            Assert.True(Clipboard.ContainsData(data.GetType().FullName));
+        }
+
+        [StaTheory]
+        [InlineData(1, true, 0, 0)]
+        [InlineData(1, false, 1, 2)]
+        [InlineData("data", true, 0, 0)]
+        [InlineData("data", false, 1, 2)]
+        public void Clipboard_SetDataObject_InvokeObjectBoolIComDataObject_GetReturnsExpected(object data, bool copy, int retryTimes, int retryDelay)
+        {
+            var dataObject = new DataObject(data);
+            Clipboard.SetDataObject(dataObject, copy, retryTimes, retryDelay);
+            Assert.Equal(data, Clipboard.GetDataObject().GetData(data.GetType()));
+            Assert.True(Clipboard.ContainsData(data.GetType().FullName));
+        }
+
+        [StaTheory]
+        [InlineData(1, true, 0, 0)]
+        [InlineData(1, false, 1, 2)]
+        [InlineData("data", true, 0, 0)]
+        [InlineData("data", false, 1, 2)]
+        public void Clipboard_SetDataObject_InvokeObjectBoolIntIntNotIComDataObject_GetReturnsExpected(object data, bool copy, int retryTimes, int retryDelay)
+        {
+            Clipboard.SetDataObject(data, copy, retryTimes, retryDelay);
+            Assert.Equal(data, Clipboard.GetDataObject().GetData(data.GetType()));
+            Assert.True(Clipboard.ContainsData(data.GetType().FullName));
+        }
+
+        [StaFact]
+        public void Clipboard_SetDataObject_NullData_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("data", () => Clipboard.SetDataObject(null));
+            Assert.Throws<ArgumentNullException>("data", () => Clipboard.SetDataObject(null, copy: true));
+            Assert.Throws<ArgumentNullException>("data", () => Clipboard.SetDataObject(null, copy: true, retryTimes: 10, retryDelay: 0));
+        }
+
+        [StaFact]
+        public void Clipboard_SetDataObject_NegativeRetryTimes_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("retryTimes", () => Clipboard.SetDataObject(new object(), copy: true, retryTimes: -1, retryDelay: 0));
+        }
+
+        [StaFact]
+        public void Clipboard_SetDataObject_NegativeRetryDelay_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("retryDelay", () => Clipboard.SetDataObject(new object(), copy: true, retryTimes: 10, retryDelay: -1));
+        }
+
+        [Fact]
+        public void Clipboard_SetDataObject_NotSta_ThrowsThreadStateException()
+        {
+            Assert.Throws<ThreadStateException>(() => Clipboard.SetDataObject(null));
+            Assert.Throws<ThreadStateException>(() => Clipboard.SetDataObject(null, copy: true));
+            Assert.Throws<ThreadStateException>(() => Clipboard.SetDataObject(null, copy: true, retryTimes: 10, retryDelay: 0));
+        }
+
+        [StaFact]
+        public void Clipboard_SetFileDropList_Invoke_GetReturnsExpected()
+        {
+            var filePaths = new StringCollection
+            {
+                "filePath"
+            };
+            Clipboard.SetFileDropList(filePaths);
+            Assert.Equal(filePaths, Clipboard.GetFileDropList());
+            Assert.True(Clipboard.ContainsFileDropList());
+        }
+
+        [Fact]
+        public void Clipboard_SetFileDropList_NullFilePaths_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("filePaths", () => Clipboard.SetFileDropList(null));
+        }
+
+        [Fact]
+        public void Clipboard_SetFileDropList_EmptyFilePaths_ThrowsArgumentException()
+        {
+            var filePaths = new StringCollection();
+            Assert.Throws<ArgumentException>(null, () => Clipboard.SetFileDropList(filePaths));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("\0")]
+        public void Clipboard_SetFileDropList_InvalidFileInPaths_ThrowsArgumentException(string filePath)
+        {
+            var filePaths = new StringCollection
+            {
+                filePath
+            };
+            Assert.Throws<ArgumentException>(null, () => Clipboard.SetFileDropList(filePaths));
+        }
+
+        [Fact]
+        public void Clipboard_SetFileDropList_NotSta_ThrowsThreadStateException()
+        {
+            var filePaths = new StringCollection
+            {
+                "filePath"
+            };
+            Assert.Throws<ThreadStateException>(() => Clipboard.SetFileDropList(filePaths));
+        }
+
+        [StaFact]
+        public void Clipboard_SetImage_InvokeBitmap_GetReturnsExpected()
+        {
+            using (var bitmap = new Bitmap(10, 10))
+            {
+                bitmap.SetPixel(1, 2, Color.FromArgb(0x01, 0x02, 0x03, 0x04));
+                Clipboard.SetImage(bitmap);
+                Bitmap result = Assert.IsType<Bitmap>(Clipboard.GetImage());
+                Assert.Equal(bitmap.Size, result.Size);
+                Assert.Equal(Color.FromArgb(0xFF, 0xD2, 0xD2, 0xD2), result.GetPixel(1, 2));
+                Assert.True(Clipboard.ContainsImage());
+            }
+        }
+
+        [StaFact]
+        public void Clipboard_SetImage_InvokeMetafile_GetReturnsExpected()
+        {
+            using (var metafile = new Metafile("bitmaps/telescope_01.wmf"))
+            {
+                Clipboard.SetImage(metafile);
+                Assert.Null(Clipboard.GetImage());
+                Assert.True(Clipboard.ContainsImage());
+            }
+        }
+
+        [StaFact]
+        public void Clipboard_SetImage_InvokeEnhancedMetafile_GetReturnsExpected()
+        {
+            using (var metafile = new Metafile("bitmaps/milkmateya01.emf"))
+            {
+                Clipboard.SetImage(metafile);
+                Assert.Null(Clipboard.GetImage());
+                Assert.True(Clipboard.ContainsImage());
+            }
+        }
+
+        [StaFact]
+        public void Clipboard_SetImage_NullImage_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("image", () => Clipboard.SetImage(null));
+        }
+
+        [Fact]
+        public void Clipboard_SetImage_NotSta_ThrowsThreadStateException()
+        {
+            using (var bitmap = new Bitmap(10, 10))
+            using (var metafile = new Metafile("bitmaps/telescope_01.wmf"))
+            using (var enhancedMetafile = new Metafile("bitmaps/milkmateya01.emf"))
+            {
+                Assert.Throws<ThreadStateException>(() => Clipboard.SetImage(bitmap));
+                Assert.Throws<ThreadStateException>(() => Clipboard.SetImage(metafile));
+                Assert.Throws<ThreadStateException>(() => Clipboard.SetImage(enhancedMetafile));
+            }
+        }
+
+        [StaFact]
+        public void Clipboard_SetText_InvokeString_GetReturnsExpected()
+        {
+            Clipboard.SetText("text");
+            Assert.Equal("text", Clipboard.GetText());
+            Assert.True(Clipboard.ContainsText());
+        }
+
+        [StaTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(TextDataFormat))]
+        public void Clipboard_SetText_InvokeStringTextDataFormat_GetReturnsExpected(TextDataFormat format)
+        {
+            Clipboard.SetText("text", format);
+            Assert.Equal("text", Clipboard.GetText(format));
+            Assert.True(Clipboard.ContainsText(format));
+        }
+
+        [Theory]
+        [CommonMemberData(nameof(CommonTestHelper.GetNullOrEmptyStringTheoryData))]
+        public void Clipboard_SetText_NullOrEmptyText_ThrowsArgumentNullException(string text)
+        {
+            Assert.Throws<ArgumentNullException>("text", () => Clipboard.SetText(text));
+            Assert.Throws<ArgumentNullException>("text", () => Clipboard.SetText(text, TextDataFormat.Text));
+        }
+
+        [Theory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryDataInvalid), typeof(TextDataFormat))]
+        public void Clipboard_SetText_InvalidFormat_ThrowsInvalidEnumArgumentException(TextDataFormat format)
+        {
+            Assert.Throws<InvalidEnumArgumentException>("format", () => Clipboard.SetText("text", format));
+        }
+
+        [Fact]
+        public void Clipboard_SetText_NotSta_ThrowsThreadStateException()
+        {
+            Assert.Throws<ThreadStateException>(() => Clipboard.SetText("text"));
+            Assert.Throws<ThreadStateException>(() => Clipboard.SetText("text", TextDataFormat.Text));
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes
- Cleanup Ole32 Clipboard and HGlobal related interop
- Add Clipboard tests
- Fix #1951

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1950)