### PR TITLE
Convert PictureBox WebRequest methods to HttpClient

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
@@ -556,9 +556,8 @@ namespace System.Windows.Forms
             _contentLength = -1;
             _tempDownloadStream = new MemoryStream();
 
-            WebRequest req = WebRequest.Create(CalculateUri(_imageLocation));
-
-            HttpClient client = new HttpClient();
+            using HttpClient client = new HttpClient();
+            
             client.GetAsync(CalculateUri(_imageLocation))
                     .ContinueWith(req => GetResponseCallback(req));
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
@@ -11,6 +11,7 @@ using System.Net;
 using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows.Forms.Layout;
 using static Interop;
 
@@ -606,7 +607,7 @@ namespace System.Windows.Forms
 
         private void LoadProgressDelegate(object arg) => OnLoadProgressChanged((ProgressChangedEventArgs)arg);
 
-        private async void GetResponseCallback(IAsyncResult result)
+        private async Task GetResponseCallback(IAsyncResult result)
         {
             if (_pictureBoxState[CancellationPendingState])
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
@@ -557,7 +557,7 @@ namespace System.Windows.Forms
             _contentLength = -1;
             _tempDownloadStream = new MemoryStream();
 
-            using HttpClient client = new HttpClient();
+            HttpClient client = new HttpClient();
             
             client.GetAsync(CalculateUri(_imageLocation))
                     .ContinueWith(req => GetResponseCallback(req));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
@@ -11,7 +11,6 @@ using System.Net;
 using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Windows.Forms.Layout;
 using static Interop;
 


### PR DESCRIPTION
Fixes #1756 
This change follows the suggestion from #1756 to change the `WebRequest` methods in `PictureBox.cs` to `HttpClient`.

## Proposed changes

- Move `WebRequest` methods to asynchronous `HttpClient` Get methods.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Low/None. Customer should not see any visible changes

## Regression? 

- Yes

## Risk

- Low

<!-- end TELL-MODE -->




## Test methodology <!-- How did you ensure quality? -->

- Ran unit tests.
- Validated tests were accurate after update (no changes were needed)


 

## Test environment(s) <!-- Remove any that don't apply -->

 <!-- use `dotnet --info` -->

```
.NET Core SDK (reflecting any global.json):
 Version:   5.0.100-alpha1-014723
 Commit:    5504e0070a

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.18362
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\5.0.100-alpha1-014723\

Host (useful for support):
  Version: 5.0.0-alpha1.19470.7
  Commit:  c25b8b41ec

.NET Core SDKs installed:
  5.0.100-alpha1-014723 [C:\Program Files\dotnet\sdk]

.NET Core runtimes installed:

  Microsoft.AspNetCore.App 5.0.0-alpha1.19470.6 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 5.0.0-alpha1.19470.7 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.WindowsDesktop.App 5.0.0-alpha1.19470.7 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

<!-- Mention language, UI scaling, or anything else that might be relevant -->

- The move towards requires the `GetResponseCallback` method to be made `async` to deal with the requirement of `HttpClient` to use `async` methods.
- Default behavior of `HttpClient` is to cache all results. No changes were made to headers as this covers the task.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1952)