### PR TITLE
WIP: [Accessibility][HC] Fixing DataGridViewComboBoxCell text color in HighContrast1/2 themes

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -2290,6 +2290,7 @@ namespace System.Windows.Forms
                 if (defaultCellStyle == null)
                 {
                     defaultCellStyle = DefaultDefaultCellStyle;
+                    defaultCellStyle.IsStyleTaken = true;
                     return defaultCellStyle;
                 }
                 else if (defaultCellStyle.BackColor == Color.Empty ||
@@ -2304,6 +2305,9 @@ namespace System.Windows.Forms
                     {
                         Scope = DataGridViewCellStyleScopes.None
                     };
+
+                    defaultCellStyleTmp.UseCustomCellStyle = defaultCellStyle.UseCustomCellStyle;
+
                     if (defaultCellStyle.BackColor == Color.Empty)
                     {
                         defaultCellStyleTmp.BackColor = DefaultBackBrush.Color;
@@ -2335,10 +2339,12 @@ namespace System.Windows.Forms
                         defaultCellStyleTmp.WrapModeInternal = DataGridViewTriState.False;
                     }
                     defaultCellStyleTmp.AddScope(this, DataGridViewCellStyleScopes.DataGridView);
+                    defaultCellStyle.IsStyleTaken = true;
                     return defaultCellStyleTmp;
                 }
                 else
                 {
+                    defaultCellStyle.IsStyleTaken = true;
                     return defaultCellStyle;
                 }
             }
@@ -2350,6 +2356,7 @@ namespace System.Windows.Forms
                 if (value != null)
                 {
                     defaultCellStyle.AddScope(this, DataGridViewCellStyleScopes.DataGridView);
+                    value.UseCustomCellStyle = true;
                 }
                 DataGridViewCellStyleDifferences dgvcsc = cs.GetDifferencesFrom(DefaultCellStyle);
                 if (dgvcsc != DataGridViewCellStyleDifferences.None)
@@ -2367,7 +2374,7 @@ namespace System.Windows.Forms
                 DataGridViewCellStyle defaultCellStyle = new DataGridViewCellStyle
                 {
                     BackColor = DefaultBackBrush.Color,
-                    ForeColor = base.ForeColor,
+                    ForeColor = DefaultForeBrush.Color,
                     SelectionBackColor = DefaultSelectionBackBrush.Color,
                     SelectionForeColor = DefaultSelectionForeBrush.Color,
                     Font = base.Font,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBand.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBand.cs
@@ -90,6 +90,8 @@ namespace System.Windows.Forms
                     Properties.SetObject(s_propDefaultCellStyle, style);
                 }
 
+                style.IsStyleTaken = true;
+
                 return style;
             }
             set
@@ -111,6 +113,11 @@ namespace System.Windows.Forms
                    (style != null && value != null && !style.Equals(DefaultCellStyle))))
                 {
                     DataGridView.OnBandDefaultCellStyleChanged(this);
+
+                    if (value != null)
+                    {
+                        value.UseCustomCellStyle = true;
+                    }
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.cs
@@ -983,16 +983,31 @@ namespace System.Windows.Forms
 
                     if (valBounds.Width > 0 && valBounds.Height > 0)
                     {
-                        Color textColor;
+                        Color foreColor;
+                        Color selectionForeColor;
+
                         if (DataGridView.ApplyVisualStylesToInnerCells &&
-                            (FlatStyle == FlatStyle.System || FlatStyle == FlatStyle.Standard))
+                           (FlatStyle == FlatStyle.System || FlatStyle == FlatStyle.Standard))
                         {
-                            textColor = DataGridViewButtonCellRenderer.DataGridViewButtonRenderer.GetColor(ColorProperty.TextColor);
+                            selectionForeColor = DataGridViewButtonCellRenderer.DataGridViewButtonRenderer.GetColor(ColorProperty.TextColor);
+                            foreColor = DataGridView.ForeColor;
                         }
                         else
                         {
-                            textColor = foreBrush.Color;
+                            selectionForeColor = cellStyle.SelectionForeColor;
+
+                            if (cellStyle.UseCustomCellStyle)
+                            {
+                                foreColor = cellStyle.ForeColor;
+                            }
+                            else
+                            {
+                                foreColor = DataGridView.ForeColor;
+                            }
                         }
+
+                        Color textColor = cellSelected ? selectionForeColor : foreColor;
+
                         TextFormatFlags flags = DataGridViewUtilities.ComputeTextFormatFlagsForCellStyleAlignment(DataGridView.RightToLeftInternal, cellStyle.Alignment, cellStyle.WrapMode);
                         TextRenderer.DrawText(g,
                                               formattedString,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -541,7 +541,7 @@ namespace System.Windows.Forms
                 {
                     State = State & ~DataGridViewElementStates.ReadOnly;
                 }
-                
+
                 DataGridView?.OnDataGridViewElementStateChanged(this, -1, DataGridViewElementStates.ReadOnly);
             }
         }
@@ -687,6 +687,8 @@ namespace System.Windows.Forms
                     dgvcs.AddScope(DataGridView, DataGridViewCellStyleScopes.Cell);
                     Properties.SetObject(PropCellStyle, dgvcs);
                 }
+
+                dgvcs.IsStyleTaken = true;
                 return dgvcs;
             }
             set
@@ -702,6 +704,7 @@ namespace System.Windows.Forms
                     if (value != null)
                     {
                         value.AddScope(DataGridView, DataGridViewCellStyleScopes.Cell);
+                        value.UseCustomCellStyle = true;
                     }
                     Properties.SetObject(PropCellStyle, value);
                 }
@@ -2037,6 +2040,14 @@ namespace System.Windows.Forms
 
             DataGridViewCellStyle dataGridViewStyle = DataGridView.DefaultCellStyle;
             Debug.Assert(dataGridViewStyle != null);
+
+            bool dataGridViewDefaultColorChanged = dataGridViewStyle?.UseCustomCellStyle == true;
+            bool rowDefaultColorChanged = rowStyle?.UseCustomCellStyle == true;
+            bool columnDefaultColorChanged = columnStyle?.UseCustomCellStyle == true;
+            bool cellDefaultColorChanged = cellStyle?.UseCustomCellStyle == true;
+
+            inheritedCellStyleTmp.UseCustomCellStyle = dataGridViewDefaultColorChanged || rowDefaultColorChanged
+                                                                  || columnDefaultColorChanged || cellDefaultColorChanged;
 
             if (includeColors)
             {
@@ -4589,7 +4600,7 @@ namespace System.Windows.Forms
                     {
                         throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                     }
-                    
+
                     return owner.OwningRow?.AccessibilityObject;
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyle.cs
@@ -187,6 +187,11 @@ namespace System.Windows.Forms
             }
         }
 
+        /// <summary>
+        /// Indicates whether a style has been changed by a customer.
+        /// </summary>
+        internal bool UseCustomCellStyle { get; set; }
+
         [
             SRCategory(nameof(SR.CatAppearance))
         ]
@@ -231,6 +236,12 @@ namespace System.Windows.Forms
                 if (!c.Equals(ForeColor))
                 {
                     OnPropertyChanged(DataGridViewCellStylePropertyInternal.ForeColor);
+
+                    if (IsStyleTaken)
+                    {
+                        UseCustomCellStyle = true;
+                        IsStyleTaken = false;
+                    }
                 }
             }
         }
@@ -774,6 +785,12 @@ namespace System.Windows.Forms
             Properties.GetColor(PropSelectionForeColor, out bool found);
             return found;
         }
+
+        /// <summary>
+        /// Indicates whether a customer used {get} block of DefaultCellStyle or Style properties of a DataGridView or its element.
+        /// Used to determine if a style color has been changed by a customer.
+        /// </summary>
+        internal bool IsStyleTaken { get; set; }
 
         public override string ToString()
         {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1953 

## Proposed changes

- Change default cell fore color

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A user gets another text color in HC themes

## Regression? 

- No

## Risk

- No

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://user-images.githubusercontent.com/49272759/65384780-13fc1600-dd2f-11e9-8a5a-724eda60cb02.png)

<!-- TODO -->

### After
![image](https://user-images.githubusercontent.com/49272759/65384784-19596080-dd2f-11e9-90f7-a99bc6ce8617.png)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual testing

## Test environment(s) <!-- Remove any that don't apply -->

- <!-- use `dotnet --info` -->.NET Core Version: 3.1.0-preview1.19458.7
- Microsoft Windows [Version 10.0.18362.356]


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1954)