### PR TITLE
Extract misc Ole32 data types

### DIFF
--- a/src/Common/src/Interop/Ole32/Interop.ELEMDESC.cs
+++ b/src/Common/src/Interop/Ole32/Interop.ELEMDESC.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class Ole32
+    {
+        public struct ELEMDESC
+        {
+            public TYPEDESC tdesc;
+            public PARAMDESC paramdesc;
+        }
+    }
+}

--- a/src/Common/src/Interop/Ole32/Interop.FUNCDESC.cs
+++ b/src/Common/src/Interop/Ole32/Interop.FUNCDESC.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class Ole32
+    {
+        public unsafe struct FUNCDESC
+        {
+            public DispatchID memid;
+            public IntPtr lprgscode;
+            public ELEMDESC* lprgelemdescParam;
+            public FUNCKIND funckind;
+            public INVOKEKIND invkind;
+            public CALLCONV callconv;
+            public short cParams;
+            public short cParamsOpt;
+            public short oVft;
+            public short cScodes;
+            public ELEMDESC elemdescFunc;
+            public FUNCFLAGS wFuncFlags;
+        }
+    }
+}

--- a/src/Common/src/Interop/Ole32/Interop.IDLDESC.cs
+++ b/src/Common/src/Interop/Ole32/Interop.IDLDESC.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class Ole32
+    {
+        public struct IDLDESC
+        {
+            public IntPtr dwReserved;
+            public IDLFLAG wIDLFlags;
+        }
+    }
+}

--- a/src/Common/src/Interop/Ole32/Interop.PARAMDESC.cs
+++ b/src/Common/src/Interop/Ole32/Interop.PARAMDESC.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class Ole32
+    {
+        public struct PARAMDESC
+        {
+            public IntPtr pparamdescex;
+            public PARAMFLAG wParamFlags;
+        }
+    }
+}

--- a/src/Common/src/Interop/Ole32/Interop.TYPEATTR.cs
+++ b/src/Common/src/Interop/Ole32/Interop.TYPEATTR.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class Ole32
+    {
+        public struct TYPEATTR
+        {
+            public Guid guid;
+            public uint lcid;
+            public uint dwReserved;
+            public DispatchID memidConstructor;
+            public DispatchID memidDestructor;
+            public IntPtr lpstrSchema;
+            public uint cbSizeInstance;
+            public TYPEKIND typekind;
+            public short cFuncs;
+            public short cVars;
+            public short cImplTypes;
+            public short cbSizeVft;
+            public short cbAlignment;
+            public short wTypeFlags;
+            public short wMajorVerNum;
+            public short wMinorVerNum;
+            public TYPEDESC tdescAlias;
+            public IDLDESC idldescType;
+        }
+    }
+}

--- a/src/Common/src/Interop/Ole32/Interop.TYPEDESC.cs
+++ b/src/Common/src/Interop/Ole32/Interop.TYPEDESC.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class Ole32
+    {
+        public struct TYPEDESC
+        {
+            public IntPtr unionMember;
+            public VARENUM vt;
+        }
+    }
+}

--- a/src/Common/src/Interop/Ole32/Interop.VARDESC.cs
+++ b/src/Common/src/Interop/Ole32/Interop.VARDESC.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class Ole32
+    {
+        public struct VARDESC
+        {
+            public DispatchID memid;
+            public IntPtr lpstrSchema;
+            public IntPtr unionMember;
+            public ELEMDESC elemdescVar;
+            public VARFLAGS wVarFlags;
+            public VARKIND varkind;
+        }
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -1921,47 +1921,6 @@ namespace System.Windows.Forms
             public int scode = 0;
         }
 
-        [StructLayout(LayoutKind.Sequential)]
-        public struct tagFUNCDESC
-        {
-            public Ole32.DispatchID memid;
-
-            public IntPtr lprgscode;
-
-            // This is marked as NATIVE_TYPE_PTR,
-            // but the EE doesn't look for that, tries to handle it as
-            // a ELEMENT_TYPE_VALUECLASS and fails because it
-            // isn't a NATIVE_TYPE_NESTEDSTRUCT
-            /*[MarshalAs(UnmanagedType.PTR)]*/
-
-            public    /*NativeMethods.tagELEMDESC*/ IntPtr lprgelemdescParam;
-
-            public Ole32.FUNCKIND funckind;
-            public Ole32.INVOKEKIND invkind;
-            public Ole32.CALLCONV callconv;
-            [MarshalAs(UnmanagedType.I2)]
-            public short cParams;
-            [MarshalAs(UnmanagedType.I2)]
-            public short cParamsOpt;
-            [MarshalAs(UnmanagedType.I2)]
-            public short oVft;
-            [MarshalAs(UnmanagedType.I2)]
-            public short cScodesi;
-            public tagELEMDESC elemdescFunc;
-            public Ole32.FUNCFLAGS wFuncFlags;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public struct tagVARDESC
-        {
-            public Ole32.DispatchID memid;
-            public IntPtr lpstrSchema;
-            public IntPtr unionMember;
-            public tagELEMDESC elemdescVar;
-            public Ole32.VARFLAGS wVarFlags;
-            public Ole32.VARKIND varkind;
-        }
-
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
         public class TOOLTIPTEXT
         {
@@ -2589,20 +2548,6 @@ namespace System.Windows.Forms
             }
         }
 
-        [StructLayout(LayoutKind.Sequential)]
-        public struct tagTYPEDESC
-        {
-            public IntPtr unionMember;
-            public Ole32.VARENUM vt;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public struct tagPARAMDESC
-        {
-            public IntPtr pparamdescex;
-            public Ole32.PARAMFLAG wParamFlags;
-        }
-
         public delegate bool MonitorEnumProc(IntPtr monitor, IntPtr hdc, IntPtr lprcMonitor, IntPtr lParam);
 
         [ComImport]
@@ -2640,84 +2585,6 @@ namespace System.Windows.Forms
         {
             [PreserveSig]
             HRESULT GetClassInfo(out UnsafeNativeMethods.ITypeInfo ppTI);
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public struct tagTYPEATTR
-        {
-            public Guid guid;
-            [MarshalAs(UnmanagedType.U4)]
-            public int lcid;
-            [MarshalAs(UnmanagedType.U4)]
-            public int dwReserved;
-            public int memidConstructor;
-            public int memidDestructor;
-            public IntPtr lpstrSchema;
-            [MarshalAs(UnmanagedType.U4)]
-            public int cbSizeInstance;
-            public Ole32.TYPEKIND typekind;
-            [MarshalAs(UnmanagedType.U2)]
-            public short cFuncs;
-            [MarshalAs(UnmanagedType.U2)]
-            public short cVars;
-            [MarshalAs(UnmanagedType.U2)]
-            public short cImplTypes;
-            [MarshalAs(UnmanagedType.U2)]
-            public short cbSizeVft;
-            [MarshalAs(UnmanagedType.U2)]
-            public short cbAlignment;
-            [MarshalAs(UnmanagedType.U2)]
-            public short wTypeFlags;
-            [MarshalAs(UnmanagedType.U2)]
-            public short wMajorVerNum;
-            [MarshalAs(UnmanagedType.U2)]
-            public short wMinorVerNum;
-
-            //these are inline too
-            //public    NativeMethods.tagTYPEDESC tdescAlias;
-            [MarshalAs(UnmanagedType.U4)]
-            public int tdescAlias_unionMember;
-
-            public Ole32.VARENUM tdescAlias_vt;
-
-            //public    NativeMethods.tagIDLDESC idldescType;
-            [MarshalAs(UnmanagedType.U4)]
-            public int idldescType_dwReserved;
-
-            public Ole32.IDLFLAG idldescType_wIDLFlags;
-
-            public tagTYPEDESC Get_tdescAlias()
-            {
-                tagTYPEDESC td;
-                td.unionMember = (IntPtr)tdescAlias_unionMember;
-                td.vt = tdescAlias_vt;
-                return td;
-            }
-
-            public tagIDLDESC Get_idldescType()
-            {
-                tagIDLDESC id = new tagIDLDESC
-                {
-                    dwReserved = idldescType_dwReserved,
-                    wIDLFlags = idldescType_wIDLFlags
-                };
-                return id;
-            }
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public unsafe struct tagELEMDESC
-        {
-            public tagTYPEDESC tdesc;
-            public tagPARAMDESC paramdesc;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public struct tagIDLDESC
-        {
-            [MarshalAs(UnmanagedType.U4)]
-            public int dwReserved;
-            public Ole32.IDLFLAG wIDLFlags;
         }
 
         public struct RGBQUAD

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -82,6 +82,8 @@
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.DispatchId.cs" Link="Interop\Ole32\Interop.DispatchId.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.DISPPARAMS.cs" Link="Interop\Ole32\Interop.DISPPARAMS.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.DVASPECT.cs" Link="Interop\Ole32\Interop.DVASPECT.cs" />
+    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.ELEMDESC.cs" Link="Interop\Ole32\Interop.ELEMDESC.cs" />
+    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.FUNCDESC.cs" Link="Interop\Ole32\Interop.FUNCDESC.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.FUNCFLAGS.cs" Link="Interop\Ole32\Interop.FUNCFLAGS.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.FUNCKIND.cs" Link="Interop\Ole32\Interop.FUNCKIND.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IDLFLAG.cs" Link="Interop\Ole32\Interop.IDLFLAG.cs" />
@@ -105,6 +107,7 @@
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.OLEINPLACEFRAMEINFO.cs" Link="Interop\Ole32\Interop.OLEINPLACEFRAMEINFO.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.OLEMENUGROUPWIDTHS.cs" Link="Interop\Ole32\Interop.OLEMENUGROUPWIDTHS.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.OLEMISC.cs" Link="Interop\Ole32\Interop.OLEMISC.cs" />
+    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.PARAMDESC.cs" Link="Interop\Ole32\Interop.PARAMDESC.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.PARAMFLAG.cs" Link="Interop\Ole32\Interop.PARAMFLAG.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.RevokeDragDrop.cs" Link="Interop\Ole32\Interop.RevokeDragDrop.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.STATFLAG.cs" Link="Interop\Ole32\Interop.STATFLAG.cs" />
@@ -113,6 +116,8 @@
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.STGM.cs" Link="Interop\Ole32\Interop.STGM.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.STGTY.cs" Link="Interop\Ole32\Interop.STGTY.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.TYPEKIND.cs" Link="Interop\Ole32\Interop.TYPEKIND.cs" />
+    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.TYPEDESC.cs" Link="Interop\Ole32\Interop.TYPEDESC.cs" />
+    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.VARDESC.cs" Link="Interop\Ole32\Interop.VARDESC.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.VARENUM.cs" Link="Interop\Ole32\Interop.VARENUM.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.VARFLAGS.cs" Link="Interop\Ole32\Interop.VARFLAGS.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.VARKIND.cs" Link="Interop\Ole32\Interop.VARKIND.cs" />


### PR DESCRIPTION
## Proposed Changes
- Extract `ELEMDESC`, `IDLDESC`, `PARAMDESC`, `TYPEDESC`, `VARDESC` and friends to `Interop.Ole32` namespace
- Structify `DISPPARAMS`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1961)