### PR TITLE
WIP: [Accessibility][HC] Fixing DataGridViewComboBoxCell text color in HighContrast1/2 themes

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -15079,6 +15079,8 @@ namespace System.Windows.Forms
 
         protected virtual void OnDefaultCellStyleChanged(EventArgs e)
         {
+            IsDefaultCellStyleChanged = true;
+
             if (e is DataGridViewCellStyleChangedEventArgs dgvcsce && !dgvcsce.ChangeAffectsPreferredSize)
             {
                 Invalidate();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -2368,7 +2368,7 @@ namespace System.Windows.Forms
                 DataGridViewCellStyle defaultCellStyle = new DataGridViewCellStyle
                 {
                     BackColor = DefaultBackBrush.Color,
-                    ForeColor = base.ForeColor,
+                    ForeColor = DefaultForeBrush.Color,
                     SelectionBackColor = DefaultSelectionBackBrush.Color,
                     SelectionForeColor = DefaultSelectionForeBrush.Color,
                     Font = base.Font,
@@ -2394,7 +2394,7 @@ namespace System.Windows.Forms
             remove => Events.RemoveHandler(EVENT_DATAGRIDVIEWDEFAULTCELLSTYLECHANGED, value);
         }
 
-        private static SolidBrush DefaultForeBrush
+        internal static SolidBrush DefaultForeBrush
         {
             get
             {
@@ -3423,6 +3423,11 @@ namespace System.Windows.Forms
                 }
             }
         }
+
+        /// <summary>
+        /// Indicates whether a style has been changed by a customer.
+        /// </summary>
+        internal bool IsDefaultCellStyleChanged { get; private set; }
 
         private bool IsEscapeKeyEffective
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -2189,6 +2189,10 @@ namespace System.Windows.Forms
                 {
                     inheritedCellStyleTmp.ForeColor = columnStyle.ForeColor;
                 }
+                else if ((this is DataGridViewButtonCell || this is DataGridViewCheckBoxCell) && !DataGridView.IsDefaultCellStyleChanged)
+                {
+                    inheritedCellStyleTmp.ForeColor = DataGridView.ForeColor;
+                }
                 else
                 {
                     inheritedCellStyleTmp.ForeColor = dataGridViewStyle.ForeColor;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.cs
@@ -913,7 +913,7 @@ namespace System.Windows.Forms
                 Color textColor;
                 if (DataGridView.ApplyVisualStylesToHeaderCells)
                 {
-                    textColor = DataGridViewColumnHeaderCellRenderer.VisualStyleRenderer.GetColor(ColorProperty.TextColor);
+                    textColor = DataGridView.DefaultForeBrush.Color;
                 }
                 else
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.cs
@@ -911,9 +911,9 @@ namespace System.Windows.Forms
                 valBounds.Width -= DATAGRIDVIEWCOLUMNHEADERCELL_horizontalTextMarginLeft + DATAGRIDVIEWCOLUMNHEADERCELL_horizontalTextMarginRight;
 
                 Color textColor;
-                if (DataGridView.ApplyVisualStylesToHeaderCells)
+                if (DataGridView.ApplyVisualStylesToHeaderCells && !SystemInformation.HighContrast)
                 {
-                    textColor = DataGridView.DefaultForeBrush.Color;
+                    textColor = DataGridViewColumnHeaderCellRenderer.VisualStyleRenderer.GetColor(ColorProperty.TextColor);
                 }
                 else
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
@@ -2533,7 +2533,7 @@ namespace System.Windows.Forms
                                 Color textColor;
                                 if (paintPostXPThemes && (drawDropDownButton || drawComboBox))
                                 {
-                                    textColor = DataGridViewComboBoxCellRenderer.VisualStyleRenderer.GetColor(ColorProperty.TextColor);
+                                    textColor = DataGridView.DefaultForeBrush.Color;
                                 }
                                 else
                                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
@@ -2531,13 +2531,13 @@ namespace System.Windows.Forms
                                     flags |= TextFormatFlags.EndEllipsis;
                                 }
                                 Color textColor;
-                                if (paintPostXPThemes && (drawDropDownButton || drawComboBox))
+                                if (paintPostXPThemes && (drawDropDownButton || drawComboBox) && !SystemInformation.HighContrast)
                                 {
-                                    textColor = DataGridView.DefaultForeBrush.Color;
+                                    textColor = DataGridViewComboBoxCellRenderer.VisualStyleRenderer.GetColor(ColorProperty.TextColor);
                                 }
                                 else
                                 {
-                                    textColor = cellSelected ? cellStyle.SelectionForeColor : cellStyle.ForeColor;
+                                    textColor = (cellSelected && (FlatStyle == FlatStyle.Flat || FlatStyle == FlatStyle.Popup)) ? cellStyle.SelectionForeColor : cellStyle.ForeColor;
                                 }
                                 TextRenderer.DrawText(g,
                                                     formattedString,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs
@@ -5,6 +5,8 @@
 using System.Drawing;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Windows.Forms.Internal;
+using static Interop;
 
 namespace System.Windows.Forms
 {
@@ -14,6 +16,8 @@ namespace System.Windows.Forms
     ]
     public class DataGridViewComboBoxEditingControl : ComboBox, IDataGridViewEditingControl
     {
+        private static readonly int PropFlatComboAdapter = PropertyStore.CreateKey();
+
         private DataGridView dataGridView;
         private bool valueChanged;
         private int rowIndex;
@@ -93,6 +97,19 @@ namespace System.Windows.Forms
             }
         }
 
+        private FlatComboAdapter FlatComboBoxAdapter
+        {
+            get
+            {
+                if (!(Properties.GetObject(PropFlatComboAdapter) is FlatComboAdapter comboAdapter) || !comboAdapter.IsValid(this))
+                {
+                    comboAdapter = CreateFlatComboAdapterInstance();
+                    Properties.SetObject(PropFlatComboAdapter, comboAdapter);
+                }
+                return comboAdapter;
+            }
+        }
+
         public virtual bool RepositionEditingControlOnValueChange
         {
             get
@@ -162,6 +179,77 @@ namespace System.Windows.Forms
             base.OnHandleCreated(e);
 
             dataGridView.SetAccessibleObjectParent(this.AccessibilityObject);
+        }
+
+        protected override void WndProc(ref Message m)
+        {
+            switch (m.Msg)
+            {
+                case WindowMessages.WM_PAINT:
+                    if (SystemInformation.HighContrast && GetStyle(ControlStyles.UserPaint) == false && (FlatStyle == FlatStyle.Standard || FlatStyle == FlatStyle.System))
+                    {
+                        using (WindowsRegion dr = new WindowsRegion(FlatComboBoxAdapter.dropDownRect))
+                        {
+                            using (WindowsRegion wr = new WindowsRegion(Bounds))
+                            {
+                                // Stash off the region we have to update (the base is going to clear this off in BeginPaint)
+                                RegionType updateRegionFlags = User32.GetUpdateRgn(Handle, wr.HRegion, BOOL.TRUE);
+
+                                dr.CombineRegion(wr, dr, Gdi32.CombineMode.RGN_DIFF);
+
+                                Rectangle updateRegionBoundingRect = wr.ToRectangle();
+                                FlatComboBoxAdapter.ValidateOwnerDrawRegions(this, updateRegionBoundingRect);
+                                //// Call the base class to do its painting (with a clipped DC).
+
+                                NativeMethods.PAINTSTRUCT ps = new NativeMethods.PAINTSTRUCT();
+                                IntPtr dc;
+                                bool disposeDc = false;
+                                if (m.WParam == IntPtr.Zero)
+                                {
+                                    dc = UnsafeNativeMethods.BeginPaint(new HandleRef(this, Handle), ref ps);
+                                    disposeDc = true;
+                                }
+                                else
+                                {
+                                    dc = m.WParam;
+                                }
+
+                                using (DeviceContext mDC = DeviceContext.FromHdc(dc))
+                                {
+                                    using (WindowsGraphics wg = new WindowsGraphics(mDC))
+                                    {
+                                        if (updateRegionFlags != RegionType.ERROR)
+                                        {
+                                            wg.DeviceContext.SetClip(dr);
+                                        }
+                                        m.WParam = dc;
+                                        DefWndProc(ref m);
+                                        if (updateRegionFlags != RegionType.ERROR)
+                                        {
+                                            wg.DeviceContext.SetClip(wr);
+                                        }
+                                        using (Graphics g = Graphics.FromHdcInternal(dc))
+                                        {
+                                            FlatComboBoxAdapter.DrawFlatCombo(this, g);
+                                        }
+                                    }
+                                }
+
+                                if (disposeDc)
+                                {
+                                    UnsafeNativeMethods.EndPaint(new HandleRef(this, Handle), ref ps);
+                                }
+                            }
+                            return;
+                        }
+                    }
+
+                    base.WndProc(ref m);
+                    break;
+                default:
+                    base.WndProc(ref m);
+                    break;
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1953
**Created instead PR #1954**
Original bug:
- [Bug 820338:](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/820338) Accessibility: [MAS42A] [HC 1/2]: The text color is incorrect in DGV on HC 1/2 theme

**The changes presented when using the manifest file.**
## Proposed changes

- Change default cell fore color (Fixed column header cells, text box cells and combo box cells)
- Set Button HC colors for DataGridViewButtonCell and DataGridViewCheckBoxCell 
- Change DataGridViewComboBoxCell style to get correct HC colors

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A user gets a contrasting text color in HC themes


## Regression? 

- no

## Risk

- low

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->
![image](https://user-images.githubusercontent.com/49272759/66142703-9974a580-e60e-11e9-8835-4a616dc11075.png)

Windows HC1 settings:
![MicrosoftTeams-image](https://user-images.githubusercontent.com/49272759/66216528-50842600-e6ce-11e9-94ab-5e2ed8400dbd.png)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual testing
 

<!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- .NET Core Version: 3.1.0-preview1.19458.7
- Microsoft Windows [Version 10.0.18362.356]


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1966)