### PR TITLE
Cleanup InitCommonControls and InitCommonControlsEx

### DIFF
--- a/src/Common/src/Interop/ComCtl32/Interop.ICC.cs
+++ b/src/Common/src/Interop/ComCtl32/Interop.ICC.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        public enum ICC : uint
+        {
+            LISTVIEW_CLASSES = 0x00000001,
+            TREEVIEW_CLASSES = 0x00000002,
+            BAR_CLASSES = 0x00000004,
+            TAB_CLASSES = 0x00000008,
+            UPDOWN_CLASS = 0x00000010,
+            PROGRESS_CLASS = 0x00000020,
+            HOTKEY_CLASS = 0x00000040,
+            ANIMATE_CLASS = 0x00000080,
+            WIN95_CLASSES = 0x000000FF,
+            DATE_CLASSES = 0x00000100,
+            USEREX_CLASSES = 0x00000200,
+            COOL_CLASSES = 0x00000400,
+            INTERNET_CLASSES = 0x00000800,
+            PAGESCROLLER_CLASS = 0x00001000,
+            NATIVEFNTCTL_CLASS = 0x00002000,
+            STANDARD_CLASSES = 0x00004000,
+            LINK_CLASS = 0x00008000,
+        }
+    }
+}

--- a/src/Common/src/Interop/ComCtl32/Interop.InitCommonControls.cs
+++ b/src/Common/src/Interop/ComCtl32/Interop.InitCommonControls.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class ComCtl32
+    {
+        [DllImport(Libraries.Comctl32, ExactSpelling = true)]
+        public static extern void InitCommonControls();
+    }
+}

--- a/src/Common/src/Interop/ComCtl32/Interop.InitCommonControlsEx.cs
+++ b/src/Common/src/Interop/ComCtl32/Interop.InitCommonControlsEx.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class ComCtl32
+    {
+        [DllImport(Libraries.Comctl32, ExactSpelling = true, EntryPoint = "InitCommonControlsEx")]
+        private static extern BOOL InitCommonControlsExInternal(ref INITCOMMONCONTROLSEX picce);
+
+        public static BOOL InitCommonControlsEx(ref INITCOMMONCONTROLSEX picce)
+        {
+            picce.dwSize = (uint)Marshal.SizeOf<INITCOMMONCONTROLSEX>();
+            return InitCommonControlsExInternal(ref picce);
+        }
+
+        public struct INITCOMMONCONTROLSEX
+        {
+            public uint dwSize;
+            public ICC dwICC;
+        }
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -453,12 +453,6 @@ namespace System.Windows.Forms
         ICON_BIG = 1,
         IMAGE_ICON = 1,
         IMAGE_CURSOR = 2,
-        ICC_LISTVIEW_CLASSES = 0x00000001,
-        ICC_TREEVIEW_CLASSES = 0x00000002,
-        ICC_BAR_CLASSES = 0x00000004,
-        ICC_TAB_CLASSES = 0x00000008,
-        ICC_PROGRESS_CLASS = 0x00000020,
-        ICC_DATE_CLASSES = 0x00000100,
         ILC_MASK = 0x0001,
         ILC_COLOR = 0x0000,
         ILC_COLOR4 = 0x0004,
@@ -1702,13 +1696,6 @@ namespace System.Windows.Forms
                 IntPtr hwndBldrOwner,
                 [Out, In, MarshalAs(UnmanagedType.Struct)] ref object pvarValue,
                 BOOL* actionCommitted);
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public class INITCOMMONCONTROLSEX
-        {
-            public int dwSize = 8; //ndirect.DllLib.sizeOf(this);
-            public int dwICC;
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/Common/src/SafeNativeMethods.cs
+++ b/src/Common/src/SafeNativeMethods.cs
@@ -93,12 +93,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static unsafe extern bool SetWindowExtEx(IntPtr hDC, int x, int y, Size *size);
 
-        [DllImport(ExternDll.Comctl32)]
-        public static extern void InitCommonControls();
-
-        [DllImport(ExternDll.Comctl32)]
-        public static extern bool InitCommonControlsEx(NativeMethods.INITCOMMONCONTROLSEX icc);
-
 #if DEBUG
         private static readonly ArrayList validImageListHandles = ArrayList.Synchronized(new ArrayList());
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridToolTip.cs
@@ -31,13 +31,13 @@ namespace System.Windows.Forms
         {
             if (tipWindow == null || tipWindow.Handle == IntPtr.Zero)
             {
-                NativeMethods.INITCOMMONCONTROLSEX icc = new NativeMethods.INITCOMMONCONTROLSEX
+                var icc = new ComCtl32.INITCOMMONCONTROLSEX
                 {
-                    dwICC = NativeMethods.ICC_TAB_CLASSES
+                    dwICC = ComCtl32.ICC.TAB_CLASSES
                 };
-                icc.dwSize = Marshal.SizeOf(icc);
-                SafeNativeMethods.InitCommonControlsEx(icc);
-                CreateParams cparams = new CreateParams
+                ComCtl32.InitCommonControlsEx(ref icc);
+
+                var cparams = new CreateParams
                 {
                     Parent = dataGrid.Handle,
                     ClassName = NativeMethods.TOOLTIPS_CLASS,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
@@ -1128,11 +1128,11 @@ namespace System.Windows.Forms
 
                 try
                 {
-                    NativeMethods.INITCOMMONCONTROLSEX icc = new NativeMethods.INITCOMMONCONTROLSEX
+                    var icc = new ComCtl32.INITCOMMONCONTROLSEX
                     {
-                        dwICC = NativeMethods.ICC_DATE_CLASSES
+                        dwICC = ComCtl32.ICC.DATE_CLASSES
                     };
-                    SafeNativeMethods.InitCommonControlsEx(icc);
+                    ComCtl32.InitCommonControlsEx(ref icc);
                 }
                 finally
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
@@ -884,12 +884,12 @@ namespace System.Windows.Forms
 
                     CreateHandle(cparams);
 
-                    NativeMethods.INITCOMMONCONTROLSEX icc = new NativeMethods.INITCOMMONCONTROLSEX
+                    var icc = new ComCtl32.INITCOMMONCONTROLSEX
                     {
-                        dwICC = NativeMethods.ICC_TAB_CLASSES
+                        dwICC = ComCtl32.ICC.TAB_CLASSES
                     };
-                    icc.dwSize = Marshal.SizeOf(icc);
-                    SafeNativeMethods.InitCommonControlsEx(icc);
+                    ComCtl32.InitCommonControlsEx(ref icc);
+
                     cparams = new CreateParams
                     {
                         Parent = Handle,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
@@ -580,7 +580,7 @@ namespace System.Windows.Forms
 
             try
             {
-                SafeNativeMethods.InitCommonControls();
+                ComCtl32.InitCommonControls();
                 nativeImageList = new NativeImageList(SafeNativeMethods.ImageList_Create(imageSize.Width, imageSize.Height, flags, INITIAL_CAPACITY, GROWBY));
             }
             finally

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageListStreamer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageListStreamer.cs
@@ -56,7 +56,7 @@ namespace System.Windows.Forms
 
                                 lock (internalSyncObject)
                                 {
-                                    SafeNativeMethods.InitCommonControls();
+                                    ComCtl32.InitCommonControls();
                                     nativeImageList = new ImageList.NativeImageList(
                                         SafeNativeMethods.ImageList_Read(new Ole32.GPStream(ms)));
                                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -2554,11 +2554,11 @@ namespace System.Windows.Forms
 
                 try
                 {
-                    NativeMethods.INITCOMMONCONTROLSEX icc = new NativeMethods.INITCOMMONCONTROLSEX
+                    var icc = new ComCtl32.INITCOMMONCONTROLSEX
                     {
-                        dwICC = NativeMethods.ICC_LISTVIEW_CLASSES
+                        dwICC = ComCtl32.ICC.LISTVIEW_CLASSES
                     };
-                    SafeNativeMethods.InitCommonControlsEx(icc);
+                    ComCtl32.InitCommonControlsEx(ref icc);
                 }
                 finally
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -1339,11 +1339,11 @@ namespace System.Windows.Forms
                 IntPtr userCookie = UnsafeNativeMethods.ThemingScope.Activate();
                 try
                 {
-                    NativeMethods.INITCOMMONCONTROLSEX icc = new NativeMethods.INITCOMMONCONTROLSEX
+                    var icc = new ComCtl32.INITCOMMONCONTROLSEX
                     {
-                        dwICC = NativeMethods.ICC_DATE_CLASSES
+                        dwICC = ComCtl32.ICC.DATE_CLASSES
                     };
-                    SafeNativeMethods.InitCommonControlsEx(icc);
+                    ComCtl32.InitCommonControlsEx(ref icc);
                 }
                 finally
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ProgressBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ProgressBar.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Windows.Forms.Layout;
 using Microsoft.Win32;
+using static Interop;
 
 namespace System.Windows.Forms
 {
@@ -673,11 +674,11 @@ namespace System.Windows.Forms
                 IntPtr userCookie = UnsafeNativeMethods.ThemingScope.Activate();
                 try
                 {
-                    NativeMethods.INITCOMMONCONTROLSEX icc = new NativeMethods.INITCOMMONCONTROLSEX
+                    var icc = new ComCtl32.INITCOMMONCONTROLSEX
                     {
-                        dwICC = NativeMethods.ICC_PROGRESS_CLASS
+                        dwICC = ComCtl32.ICC.PROGRESS_CLASS
                     };
-                    SafeNativeMethods.InitCommonControlsEx(icc);
+                    ComCtl32.InitCommonControlsEx(ref icc);
                 }
                 finally
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridToolTip.cs
@@ -89,12 +89,13 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                NativeMethods.INITCOMMONCONTROLSEX icc = new NativeMethods.INITCOMMONCONTROLSEX
+                var icc = new ComCtl32.INITCOMMONCONTROLSEX
                 {
-                    dwICC = NativeMethods.ICC_TAB_CLASSES
+                    dwICC = ComCtl32.ICC.TAB_CLASSES
                 };
-                SafeNativeMethods.InitCommonControlsEx(icc);
-                CreateParams cp = new CreateParams
+                ComCtl32.InitCommonControlsEx(ref icc);
+
+                var cp = new CreateParams
                 {
                     Parent = IntPtr.Zero,
                     ClassName = NativeMethods.TOOLTIPS_CLASS

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
@@ -594,11 +594,11 @@ namespace System.Windows.Forms
 
                 try
                 {
-                    NativeMethods.INITCOMMONCONTROLSEX icc = new NativeMethods.INITCOMMONCONTROLSEX
+                    var icc = new ComCtl32.INITCOMMONCONTROLSEX
                     {
-                        dwICC = NativeMethods.ICC_BAR_CLASSES
+                        dwICC = ComCtl32.ICC.BAR_CLASSES
                     };
-                    SafeNativeMethods.InitCommonControlsEx(icc);
+                    ComCtl32.InitCommonControlsEx(ref icc);
                 }
                 finally
                 {
@@ -1653,12 +1653,13 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    NativeMethods.INITCOMMONCONTROLSEX icc = new NativeMethods.INITCOMMONCONTROLSEX
+                    var icc = new ComCtl32.INITCOMMONCONTROLSEX
                     {
-                        dwICC = NativeMethods.ICC_TAB_CLASSES
+                        dwICC = ComCtl32.ICC.TAB_CLASSES
                     };
-                    SafeNativeMethods.InitCommonControlsEx(icc);
-                    CreateParams cp = new CreateParams
+                    ComCtl32.InitCommonControlsEx(ref icc);
+
+                    var cp = new CreateParams
                     {
                         Parent = IntPtr.Zero,
                         ClassName = NativeMethods.TOOLTIPS_CLASS

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -1090,11 +1090,11 @@ namespace System.Windows.Forms
                 IntPtr userCookie = UnsafeNativeMethods.ThemingScope.Activate();
                 try
                 {
-                    NativeMethods.INITCOMMONCONTROLSEX icc = new NativeMethods.INITCOMMONCONTROLSEX
+                    var icc = new ComCtl32.INITCOMMONCONTROLSEX
                     {
-                        dwICC = NativeMethods.ICC_TAB_CLASSES
+                        dwICC = ComCtl32.ICC.TAB_CLASSES
                     };
-                    SafeNativeMethods.InitCommonControlsEx(icc);
+                    ComCtl32.InitCommonControlsEx(ref icc);
                 }
                 finally
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolBar.cs
@@ -1046,11 +1046,11 @@ namespace System.Windows.Forms
                 IntPtr userCookie = UnsafeNativeMethods.ThemingScope.Activate();
                 try
                 {
-                    NativeMethods.INITCOMMONCONTROLSEX icc = new NativeMethods.INITCOMMONCONTROLSEX
+                    var icc = new ComCtl32.INITCOMMONCONTROLSEX
                     {
-                        dwICC = NativeMethods.ICC_BAR_CLASSES
+                        dwICC = ComCtl32.ICC.BAR_CLASSES
                     };
-                    SafeNativeMethods.InitCommonControlsEx(icc);
+                    ComCtl32.InitCommonControlsEx(ref icc);
                 }
                 finally
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -736,11 +736,11 @@ namespace System.Windows.Forms
             try
             {
 
-                var icc = new NativeMethods.INITCOMMONCONTROLSEX
+                var icc = new ComCtl32.INITCOMMONCONTROLSEX
                 {
-                    dwICC = NativeMethods.ICC_TAB_CLASSES
+                    dwICC = ComCtl32.ICC.TAB_CLASSES
                 };
-                SafeNativeMethods.InitCommonControlsEx(icc);
+                ComCtl32.InitCommonControlsEx(ref icc);
 
                 CreateParams cp = CreateParams; // Avoid reentrant call to CreateHandle
                 if (GetHandleCreated())

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -812,11 +812,11 @@ namespace System.Windows.Forms
                 IntPtr userCookie = UnsafeNativeMethods.ThemingScope.Activate();
                 try
                 {
-                    NativeMethods.INITCOMMONCONTROLSEX icc = new NativeMethods.INITCOMMONCONTROLSEX
+                    var icc = new ComCtl32.INITCOMMONCONTROLSEX
                     {
-                        dwICC = NativeMethods.ICC_BAR_CLASSES
+                        dwICC = ComCtl32.ICC.BAR_CLASSES
                     };
-                    SafeNativeMethods.InitCommonControlsEx(icc);
+                    ComCtl32.InitCommonControlsEx(ref icc);
                 }
                 finally
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -1664,11 +1664,11 @@ namespace System.Windows.Forms
                 IntPtr userCookie = UnsafeNativeMethods.ThemingScope.Activate();
                 try
                 {
-                    NativeMethods.INITCOMMONCONTROLSEX icc = new NativeMethods.INITCOMMONCONTROLSEX
+                    var icc = new ComCtl32.INITCOMMONCONTROLSEX
                     {
-                        dwICC = NativeMethods.ICC_TREEVIEW_CLASSES
+                        dwICC = ComCtl32.ICC.TREEVIEW_CLASSES
                     };
-                    SafeNativeMethods.InitCommonControlsEx(icc);
+                    ComCtl32.InitCommonControlsEx(ref icc);
                 }
                 finally
                 {


### PR DESCRIPTION
## Proposed Changes
- Cleanup `InitCommonControls` and `InitCommonControlsEx`
- Cleanup enum usages
- Structify `INITCOMMONCONTROLSEX`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1971)