### PR TITLE
Cleanup INPUT related interop

### DIFF
--- a/src/Common/src/Interop/User32/Interop.GetKeyState.cs
+++ b/src/Common/src/Interop/User32/Interop.GetKeyState.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern short GetKeyState(int keyCode);
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.HARDWAREINPUT.cs
+++ b/src/Common/src/Interop/User32/Interop.HARDWAREINPUT.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public struct HARDWAREINPUT
+        {
+            public uint uMsg;
+            public ushort wParamL;
+            public ushort wParamH;
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.INPUT.cs
+++ b/src/Common/src/Interop/User32/Interop.INPUT.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public struct INPUT
+        {
+            public INPUTENUM type;
+            public INPUTUNION inputUnion;
+
+            // We need to split the field offset out into a union struct to avoid
+            // silent problems in 64 bit
+            [StructLayout(LayoutKind.Explicit)]
+            public struct INPUTUNION
+            {
+                [FieldOffset(0)]
+                public MOUSEINPUT mi;
+
+                [FieldOffset(0)]
+                public KEYBDINPUT ki;
+
+                [FieldOffset(0)]
+                public HARDWAREINPUT hi;
+            }
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.INPUTENUM.cs
+++ b/src/Common/src/Interop/User32/Interop.INPUTENUM.cs
@@ -2,15 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using static Interop;
-
-namespace System.Windows.Forms
+internal static partial class Interop
 {
-    public enum SearchDirectionHint
+    internal static partial class User32
     {
-        Up = User32.VK.UP,
-        Down = User32.VK.DOWN,
-        Left = User32.VK.LEFT,
-        Right = User32.VK.RIGHT
+        public enum INPUTENUM : uint
+        {
+            MOUSE = 0,
+            KEYBOARD = 1,
+            HARDWARE = 2
+        }
     }
 }

--- a/src/Common/src/Interop/User32/Interop.KEYBDINPUT.cs
+++ b/src/Common/src/Interop/User32/Interop.KEYBDINPUT.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public struct KEYBDINPUT
+        {
+            public ushort wVk;
+            public ushort wScan;
+            public KEYEVENTF dwFlags;
+            public uint time;
+            public IntPtr dwExtraInfo;
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.KEYEVENTF.cs
+++ b/src/Common/src/Interop/User32/Interop.KEYEVENTF.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [Flags]
+        public enum KEYEVENTF : uint
+        {
+            EXTENDEDKEY = 0x0001,
+            KEYUP = 0x0002,
+            UNICODE = 0x0004,
+            SCANCODE = 0x0008,
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.MOUSEEVENTF.cs
+++ b/src/Common/src/Interop/User32/Interop.MOUSEEVENTF.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [Flags]
+        public enum MOUSEEVENTF : uint
+        {
+            MOVE = 0x0001,
+            LEFTDOWN = 0x0002,
+            LEFTUP = 0x0004,
+            RIGHTDOWN = 0x0008,
+            RIGHTUP = 0x0010,
+            MIDDLEDOWN = 0x0020,
+            MIDDLEUP = 0x0040,
+            XDOWN = 0x0080,
+            XUP = 0x0100,
+            WHEEL = 0x0800,
+            HWHEEL = 0x1000,
+            MOVE_NOCOALESCE = 0x2000,
+            VIRTUALDESK = 0x4000,
+            ABSOLUTE = 0x8000,
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.MOUSEINPUT.cs
+++ b/src/Common/src/Interop/User32/Interop.MOUSEINPUT.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public struct MOUSEINPUT
+        {
+            public int dx;
+            public int dy;
+            public uint mouseData;
+            public MOUSEEVENTF dwFlags;
+            public uint time;
+            public IntPtr dwExtraInfo;
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.SendInput.cs
+++ b/src/Common/src/Interop/User32/Interop.SendInput.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
+        public unsafe static extern uint SendInput(uint cInputs, INPUT* pInputs, int cbSize);
+
+        public unsafe static uint SendInput(uint cInputs, Span<INPUT> pInputs, int cbSize)
+        {
+            fixed (INPUT* input = &MemoryMarshal.GetReference(pInputs))
+            {
+                return SendInput(cInputs, input, cbSize);
+            }
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.VK.cs
+++ b/src/Common/src/Interop/User32/Interop.VK.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public static class VK
+        {
+            public const int TAB = 0x0009;
+            public const int SHIFT = 0x0010;
+            public const int CONTROL = 0x0011;
+            public const int MENU = 0x0012;
+            public const int CAPITAL = 0x0014;
+            public const int KANA = 0x0015;
+            public const int ESCAPE = 0x001B;
+            public const int PRIOR = 0x0021;
+            public const int NEXT = 0x0022;
+            public const int END = 0x0023;
+            public const int LEFT = 0x0025;
+            public const int HOME = 0x0024;
+            public const int UP = 0x0026;
+            public const int RIGHT = 0x0027;
+            public const int DOWN = 0x0028;
+            public const int NUMLOCK = 0x0090;
+            public const int SCROLL = 0x0091;
+            public const int INSERT = 0x002D;
+            public const int DELETE = 0x002E;
+        }
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -488,12 +488,6 @@ namespace System.Windows.Forms
         IDM_PROPERTIES = 28,
         IDM_SAVEAS = 71;
 
-        public const int INPUT_KEYBOARD = 1;
-
-        public const int KEYEVENTF_EXTENDEDKEY = 0x0001;
-        public const int KEYEVENTF_KEYUP = 0x0002;
-        public const int KEYEVENTF_UNICODE = 0x0004;
-
         public const int LB_ERR = (-1),
         LB_ERRSPACE = (-2),
         LBN_SELCHANGE = 1,
@@ -1251,26 +1245,7 @@ namespace System.Windows.Forms
         USERCLASSTYPE_APPNAME = 3,
         UOI_FLAGS = 1;
 
-        public const int VIEW_E_DRAW = unchecked((int)0x80040140),
-        VK_PRIOR = 0x21,
-        VK_NEXT = 0x22,
-        VK_LEFT = 0x25,
-        VK_UP = 0x26,
-        VK_RIGHT = 0x27,
-        VK_DOWN = 0x28,
-        VK_TAB = 0x09,
-        VK_SHIFT = 0x10,
-        VK_CONTROL = 0x11,
-        VK_MENU = 0x12,
-        VK_CAPITAL = 0x14,
-        VK_KANA = 0x15,
-        VK_ESCAPE = 0x1B,
-        VK_END = 0x23,
-        VK_HOME = 0x24,
-        VK_NUMLOCK = 0x90,
-        VK_SCROLL = 0x91,
-        VK_INSERT = 0x002D,
-        VK_DELETE = 0x002E;
+        public const int VIEW_E_DRAW = unchecked((int)0x80040140);
 
         public const int WH_JOURNALPLAYBACK = 1;
         public const int WH_GETMESSAGE = 3;
@@ -3030,59 +3005,6 @@ namespace System.Windows.Forms
             public int dwExtraInfo = 0;
         }
 
-        #region SendKeys SendInput functionality
-
-        [StructLayout(LayoutKind.Sequential)]
-        public struct MOUSEINPUT
-        {
-            public int dx;
-            public int dy;
-            public int mouseData;
-            public int dwFlags;
-            public int time;
-            public IntPtr dwExtraInfo;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public struct KEYBDINPUT
-        {
-            public short wVk;
-            public short wScan;
-            public int dwFlags;
-            public int time;
-            public IntPtr dwExtraInfo;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public struct HARDWAREINPUT
-        {
-            public int uMsg;
-            public short wParamL;
-            public short wParamH;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public struct INPUT
-        {
-            public int type;
-            public INPUTUNION inputUnion;
-        }
-
-        // We need to split the field offset out into a union struct to avoid
-        // silent problems in 64 bit
-        [StructLayout(LayoutKind.Explicit)]
-        public struct INPUTUNION
-        {
-            [FieldOffset(0)]
-            public MOUSEINPUT mi;
-            [FieldOffset(0)]
-            public KEYBDINPUT ki;
-            [FieldOffset(0)]
-            public HARDWAREINPUT hi;
-        }
-
-        #endregion
-
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
         public unsafe struct CHARFORMATW
         {
@@ -4064,9 +3986,6 @@ namespace System.Windows.Forms
 
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
         public extern static IntPtr SendMessage(IntPtr hWnd, int Msg, int wParam, [In, Out] TV_HITTESTINFO lParam);
-
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern short GetKeyState(int keyCode);
 
         [DllImport(ExternDll.User32, ExactSpelling = true)]
         public static extern bool GetUpdateRect(IntPtr hwnd, ref RECT rc, bool fErase);

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -218,16 +218,10 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern bool BlockInput([In, MarshalAs(UnmanagedType.Bool)] bool fBlockIt);
 
-        [DllImport(ExternDll.User32, ExactSpelling = true, SetLastError = true, CharSet = CharSet.Auto)]
-        public static extern uint SendInput(uint nInputs, NativeMethods.INPUT[] pInputs, int cbSize);
-
         #endregion
 
         [DllImport(ExternDll.User32, ExactSpelling = true)]
         public static extern IntPtr GetDCEx(HandleRef hWnd, HandleRef hrgnClip, int flags);
-
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern short GetKeyState(int keyCode);
 
         [DllImport(ExternDll.Kernel32, CharSet = CharSet.Auto)]
         public static extern uint GetShortPathName(string lpszLongPath, StringBuilder lpszShortPath, uint cchBuffer);

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -97,6 +97,7 @@
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetCapture.cs" Link="Interop\User32\Interop.GetCapture.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetDC.cs" Link="Interop\User32\Interop.GetDC.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetFocus.cs" Link="Interop\User32\Interop.GetFocus.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.GetKeyState.cs" Link="Interop\User32\Interop.GetKeyState.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetUpdateRgn.cs" Link="Interop\User32\Interop.GetUpdateRgn.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetWindowText.cs" Link="Interop\User32\Interop.GetWindowText.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetWindowThreadProcessId.cs" Link="Interop\User32\Interop.GetWindowThreadProcessId.cs" />

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComponentTray.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComponentTray.cs
@@ -2180,7 +2180,7 @@ namespace System.Windows.Forms.Design
                         Capture = true;
                         _mouseDragLast = PointToScreen(new Point(me.X, me.Y));
                         // If the CTRL key isn't down, select this component, otherwise, we wait until the mouse up. Make sure the component is selected
-                        _ctrlSelect = NativeMethods.GetKeyState((int)Keys.ControlKey) != 0;
+                        _ctrlSelect = User32.GetKeyState((int)Keys.ControlKey) != 0;
                         if (!_ctrlSelect)
                         {
                             ISelectionService sel = (ISelectionService)_tray.GetService(typeof(ISelectionService));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -384,7 +384,7 @@ namespace System.Windows.Forms
                             }
 #endif
 
-                            if (lpmsg->message == User32.WindowMessage.WM_KEYDOWN && lpmsg->wParam == (IntPtr)NativeMethods.VK_TAB)
+                            if (lpmsg->message == User32.WindowMessage.WM_KEYDOWN && lpmsg->wParam == (IntPtr)User32.VK.TAB)
                             {
                                 target.SelectNextControl(null, Control.ModifierKeys != Keys.Shift, true, true, true);
                             }
@@ -2334,17 +2334,17 @@ namespace System.Windows.Forms
                 if (_clientSite is Ole32.IOleControlSite ioleClientSite)
                 {
                     Ole32.KEYMODIFIERS keyState = 0;
-                    if (UnsafeNativeMethods.GetKeyState(NativeMethods.VK_SHIFT) < 0)
+                    if (User32.GetKeyState(User32.VK.SHIFT) < 0)
                     {
                         keyState |= Ole32.KEYMODIFIERS.SHIFT;
                     }
 
-                    if (UnsafeNativeMethods.GetKeyState(NativeMethods.VK_CONTROL) < 0)
+                    if (User32.GetKeyState(User32.VK.CONTROL) < 0)
                     {
                         keyState |= Ole32.KEYMODIFIERS.CONTROL;
                     }
 
-                    if (UnsafeNativeMethods.GetKeyState(NativeMethods.VK_MENU) < 0)
+                    if (User32.GetKeyState(User32.VK.MENU) < 0)
                     {
                         keyState |= Ole32.KEYMODIFIERS.ALT;
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -3001,17 +3001,17 @@ namespace System.Windows.Forms
             {
                 Keys modifiers = 0;
 
-                if (UnsafeNativeMethods.GetKeyState((int)Keys.ShiftKey) < 0)
+                if (User32.GetKeyState((int)Keys.ShiftKey) < 0)
                 {
                     modifiers |= Keys.Shift;
                 }
 
-                if (UnsafeNativeMethods.GetKeyState((int)Keys.ControlKey) < 0)
+                if (User32.GetKeyState((int)Keys.ControlKey) < 0)
                 {
                     modifiers |= Keys.Control;
                 }
 
-                if (UnsafeNativeMethods.GetKeyState((int)Keys.Menu) < 0)
+                if (User32.GetKeyState((int)Keys.Menu) < 0)
                 {
                     modifiers |= Keys.Alt;
                 }
@@ -3030,27 +3030,27 @@ namespace System.Windows.Forms
             {
                 MouseButtons buttons = (MouseButtons)0;
 
-                if (UnsafeNativeMethods.GetKeyState((int)Keys.LButton) < 0)
+                if (User32.GetKeyState((int)Keys.LButton) < 0)
                 {
                     buttons |= MouseButtons.Left;
                 }
 
-                if (UnsafeNativeMethods.GetKeyState((int)Keys.RButton) < 0)
+                if (User32.GetKeyState((int)Keys.RButton) < 0)
                 {
                     buttons |= MouseButtons.Right;
                 }
 
-                if (UnsafeNativeMethods.GetKeyState((int)Keys.MButton) < 0)
+                if (User32.GetKeyState((int)Keys.MButton) < 0)
                 {
                     buttons |= MouseButtons.Middle;
                 }
 
-                if (UnsafeNativeMethods.GetKeyState((int)Keys.XButton1) < 0)
+                if (User32.GetKeyState((int)Keys.XButton1) < 0)
                 {
                     buttons |= MouseButtons.XButton1;
                 }
 
-                if (UnsafeNativeMethods.GetKeyState((int)Keys.XButton2) < 0)
+                if (User32.GetKeyState((int)Keys.XButton2) < 0)
                 {
                     buttons |= MouseButtons.XButton2;
                 }
@@ -6803,7 +6803,7 @@ namespace System.Windows.Forms
         {
             if (keyVal == Keys.Insert || keyVal == Keys.NumLock || keyVal == Keys.CapsLock || keyVal == Keys.Scroll)
             {
-                int result = UnsafeNativeMethods.GetKeyState((int)keyVal);
+                int result = User32.GetKeyState((int)keyVal);
 
                 // If the high-order bit is 1, the key is down; otherwise, it is up.
                 // If the low-order bit is 1, the key is toggled. A key, such as the CAPS LOCK key,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RadioButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RadioButton.cs
@@ -7,6 +7,7 @@ using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Windows.Forms.ButtonInternal;
 using System.Windows.Forms.Layout;
+using static Interop;
 
 namespace System.Windows.Forms
 {
@@ -446,7 +447,7 @@ namespace System.Windows.Forms
             //
             if (MouseButtons == MouseButtons.None)
             {
-                if (UnsafeNativeMethods.GetKeyState((int)Keys.Tab) >= 0)
+                if (User32.GetKeyState((int)Keys.Tab) >= 0)
                 {
                     //We enter the radioButton by using arrow keys
                     //Paint in raised state...

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.cs
@@ -649,15 +649,15 @@ namespace System.Windows.Forms
             // SKEvents are sent as sent as 1 or 2 inputs
             // currentInput[0] represents the SKEvent
             // currentInput[1] is a KeyUp to prevent all identical WM_CHARs to be sent as one message
-            NativeMethods.INPUT[] currentInput = new NativeMethods.INPUT[2];
+            Span<User32.INPUT> currentInput = stackalloc User32.INPUT[2];
 
             // all events are Keyboard events
-            currentInput[0].type = NativeMethods.INPUT_KEYBOARD;
-            currentInput[1].type = NativeMethods.INPUT_KEYBOARD;
+            currentInput[0].type = User32.INPUTENUM.KEYBOARD;
+            currentInput[1].type = User32.INPUTENUM.KEYBOARD;
 
             // set KeyUp values for currentInput[1]
-            currentInput[1].inputUnion.ki.wVk = (short)0;
-            currentInput[1].inputUnion.ki.dwFlags = NativeMethods.KEYEVENTF_UNICODE | NativeMethods.KEYEVENTF_KEYUP;
+            currentInput[1].inputUnion.ki.wVk = 0;
+            currentInput[1].inputUnion.ki.dwFlags = User32.KEYEVENTF.UNICODE | User32.KEYEVENTF.KEYUP;
 
             // initialize unused members
             currentInput[0].inputUnion.ki.dwExtraInfo = IntPtr.Zero;
@@ -666,7 +666,7 @@ namespace System.Windows.Forms
             currentInput[1].inputUnion.ki.time = 0;
 
             // send each of our SKEvents using SendInput
-            int INPUTSize = Marshal.SizeOf<NativeMethods.INPUT>();
+            int INPUTSize = Marshal.SizeOf<User32.INPUT>();
 
             // need these outside the lock below
             uint eventsSent = 0;
@@ -699,13 +699,13 @@ namespace System.Windows.Forms
                             // for WM_CHAR, send a KEYEVENTF_UNICODE instead of a Keyboard event
                             // to support extended ascii characters with no keyboard equivalent.
                             // send currentInput[1] in this case
-                            currentInput[0].inputUnion.ki.wVk = (short)0;
-                            currentInput[0].inputUnion.ki.wScan = (short)skEvent.paramL;
-                            currentInput[0].inputUnion.ki.dwFlags = NativeMethods.KEYEVENTF_UNICODE;
-                            currentInput[1].inputUnion.ki.wScan = (short)skEvent.paramL;
+                            currentInput[0].inputUnion.ki.wVk = 0;
+                            currentInput[0].inputUnion.ki.wScan = (ushort)skEvent.paramL;
+                            currentInput[0].inputUnion.ki.dwFlags = User32.KEYEVENTF.UNICODE;
+                            currentInput[1].inputUnion.ki.wScan = (ushort)skEvent.paramL;
 
                             // call SendInput, increment the eventsSent but subtract 1 for the extra one sent
-                            eventsSent += UnsafeNativeMethods.SendInput(2, currentInput, INPUTSize) - 1;
+                            eventsSent += User32.SendInput(2, currentInput, INPUTSize) - 1;
                         }
                         else
                         {
@@ -715,19 +715,19 @@ namespace System.Windows.Forms
                             // add KeyUp flag if we have a KeyUp
                             if (skEvent.wm == WindowMessages.WM_KEYUP || skEvent.wm == WindowMessages.WM_SYSKEYUP)
                             {
-                                currentInput[0].inputUnion.ki.dwFlags |= NativeMethods.KEYEVENTF_KEYUP;
+                                currentInput[0].inputUnion.ki.dwFlags |= User32.KEYEVENTF.KEYUP;
                             }
 
                             // Sets KEYEVENTF_EXTENDEDKEY flag if necessary
                             if (IsExtendedKey(skEvent))
                             {
-                                currentInput[0].inputUnion.ki.dwFlags |= NativeMethods.KEYEVENTF_EXTENDEDKEY;
+                                currentInput[0].inputUnion.ki.dwFlags |= User32.KEYEVENTF.EXTENDEDKEY;
                             }
 
-                            currentInput[0].inputUnion.ki.wVk = (short)skEvent.paramL;
+                            currentInput[0].inputUnion.ki.wVk = (ushort)skEvent.paramL;
 
                             // send only currentInput[0]
-                            eventsSent += UnsafeNativeMethods.SendInput(1, currentInput, INPUTSize);
+                            eventsSent += User32.SendInput(1, currentInput, INPUTSize);
 
                             CheckGlobalKeys(skEvent);
                         }
@@ -828,16 +828,16 @@ namespace System.Windows.Forms
 
         private static bool IsExtendedKey(SKEvent skEvent)
         {
-            return (skEvent.paramL == NativeMethods.VK_UP) ||
-                   (skEvent.paramL == NativeMethods.VK_DOWN) ||
-                   (skEvent.paramL == NativeMethods.VK_LEFT) ||
-                   (skEvent.paramL == NativeMethods.VK_RIGHT) ||
-                   (skEvent.paramL == NativeMethods.VK_PRIOR) ||
-                   (skEvent.paramL == NativeMethods.VK_NEXT) ||
-                   (skEvent.paramL == NativeMethods.VK_HOME) ||
-                   (skEvent.paramL == NativeMethods.VK_END) ||
-                   (skEvent.paramL == NativeMethods.VK_INSERT) ||
-                   (skEvent.paramL == NativeMethods.VK_DELETE);
+            return (skEvent.paramL == User32.VK.UP) ||
+                   (skEvent.paramL == User32.VK.DOWN) ||
+                   (skEvent.paramL == User32.VK.LEFT) ||
+                   (skEvent.paramL == User32.VK.RIGHT) ||
+                   (skEvent.paramL == User32.VK.PRIOR) ||
+                   (skEvent.paramL == User32.VK.NEXT) ||
+                   (skEvent.paramL == User32.VK.HOME) ||
+                   (skEvent.paramL == User32.VK.END) ||
+                   (skEvent.paramL == User32.VK.INSERT) ||
+                   (skEvent.paramL == User32.VK.DELETE);
         }
 
         private static void ClearGlobalKeys()
@@ -879,41 +879,41 @@ namespace System.Windows.Forms
             }
 
             // INPUT struct for resetting the keyboard
-            NativeMethods.INPUT[] keyboardInput = new NativeMethods.INPUT[2];
+            Span<User32.INPUT> keyboardInput = stackalloc User32.INPUT[2];
 
-            keyboardInput[0].type = NativeMethods.INPUT_KEYBOARD;
+            keyboardInput[0].type = User32.INPUTENUM.KEYBOARD;
             keyboardInput[0].inputUnion.ki.dwFlags = 0;
 
-            keyboardInput[1].type = NativeMethods.INPUT_KEYBOARD;
-            keyboardInput[1].inputUnion.ki.dwFlags = NativeMethods.KEYEVENTF_KEYUP;
+            keyboardInput[1].type = User32.INPUTENUM.KEYBOARD;
+            keyboardInput[1].inputUnion.ki.dwFlags = User32.KEYEVENTF.KEYUP;
 
             // SendInputs to turn on or off these keys.  Inputs are pairs because KeyUp is sent for each one
             if (capslockChanged)
             {
-                keyboardInput[0].inputUnion.ki.wVk = NativeMethods.VK_CAPITAL;
-                keyboardInput[1].inputUnion.ki.wVk = NativeMethods.VK_CAPITAL;
-                UnsafeNativeMethods.SendInput(2, keyboardInput, INPUTSize);
+                keyboardInput[0].inputUnion.ki.wVk = User32.VK.CAPITAL;
+                keyboardInput[1].inputUnion.ki.wVk = User32.VK.CAPITAL;
+                User32.SendInput(2, keyboardInput, INPUTSize);
             }
 
             if (numlockChanged)
             {
-                keyboardInput[0].inputUnion.ki.wVk = NativeMethods.VK_NUMLOCK;
-                keyboardInput[1].inputUnion.ki.wVk = NativeMethods.VK_NUMLOCK;
-                UnsafeNativeMethods.SendInput(2, keyboardInput, INPUTSize);
+                keyboardInput[0].inputUnion.ki.wVk = User32.VK.NUMLOCK;
+                keyboardInput[1].inputUnion.ki.wVk = User32.VK.NUMLOCK;
+                User32.SendInput(2, keyboardInput, INPUTSize);
             }
 
             if (scrollLockChanged)
             {
-                keyboardInput[0].inputUnion.ki.wVk = NativeMethods.VK_SCROLL;
-                keyboardInput[1].inputUnion.ki.wVk = NativeMethods.VK_SCROLL;
-                UnsafeNativeMethods.SendInput(2, keyboardInput, INPUTSize);
+                keyboardInput[0].inputUnion.ki.wVk = User32.VK.SCROLL;
+                keyboardInput[1].inputUnion.ki.wVk = User32.VK.SCROLL;
+                User32.SendInput(2, keyboardInput, INPUTSize);
             }
 
             if (kanaChanged)
             {
-                keyboardInput[0].inputUnion.ki.wVk = NativeMethods.VK_KANA;
-                keyboardInput[1].inputUnion.ki.wVk = NativeMethods.VK_KANA;
-                UnsafeNativeMethods.SendInput(2, keyboardInput, INPUTSize);
+                keyboardInput[0].inputUnion.ki.wVk = User32.VK.KANA;
+                keyboardInput[1].inputUnion.ki.wVk = User32.VK.KANA;
+                User32.SendInput(2, keyboardInput, INPUTSize);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -2940,7 +2940,7 @@ namespace System.Windows.Forms
                         if (ParentInternal.LastMouseDownedItem == this)
                         {
                             // Same as Control.MouseButtons == MouseButtons.Left, but slightly more efficient.
-                            if (UnsafeNativeMethods.GetKeyState((int)Keys.LButton) < 0)
+                            if (User32.GetKeyState((int)Keys.LButton) < 0)
                             {
                                 Push(true);
                             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.cs
@@ -1954,7 +1954,7 @@ namespace System.Windows.Forms
             else
             {
                 // this is the same as Control.ModifierKeys - but we save two p/invokes.
-                if (UnsafeNativeMethods.GetKeyState((int)Keys.ShiftKey) < 0 && (keyData == Keys.None))
+                if (User32.GetKeyState((int)Keys.ShiftKey) < 0 && (keyData == Keys.None))
                 {
                     // If it's Shift+F10 and we're already InMenuMode, then we
                     // need to cancel this message, otherwise we'll enter the native modal menu loop.


### PR DESCRIPTION
## Proposed Changes
- Move `INPUT`, `MOUSEINPUT` and `KEYBDINPUT` to Interop
- Cleanup `VK_` constants
- Cleanup `GetKeyState`
- Cleanup `SendInput`
- Avoid allocating arrays, prefer stackallocated `Span<INPUT>`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1972)