### PR TITLE
ImeMode.NoControl in Text and Combo boxes on CHS pinyin was switching to ENG

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -1828,6 +1828,11 @@ namespace System.Windows.Forms
                     // once in the combobox and once here.
                     if (fireSetFocus)
                     {
+                        if (!DesignMode && childEdit != null && m.HWnd == childEdit.Handle)
+                        {
+                            WmImeSetFocus();
+                        }
+
                         InvokeGotFocus(this, EventArgs.Empty);
                     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.Ime.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.Ime.cs
@@ -53,12 +53,6 @@ namespace System.Windows.Forms
         private static bool ignoreWmImeNotify;
 
         /// <summary>
-        ///  This flag works around an Issue with the Chinese IME sending IMENotify messages prior to WmInputLangChange
-        ///  which would cause this code to use OnHalf as the default mode overriding .ImeMode property. See WmImeNotify
-        /// </summary>
-        private static bool lastLanguageChinese = false;
-
-        /// <summary>
         ///  The ImeMode in the property store.
         /// </summary>
         internal ImeMode CachedImeMode
@@ -711,11 +705,6 @@ namespace System.Windows.Forms
                 PropagatingImeMode = ImeMode.Off;
             }
 
-            if (ImeModeConversion.InputLanguageTable == ImeModeConversion.ChineseTable)
-            {
-                IgnoreWmImeNotify = false;
-            }
-
             Form form = FindForm();
 
             if (form != null)
@@ -787,24 +776,7 @@ namespace System.Windows.Forms
         /// </summary>
         private void WmImeNotify(ref Message m)
         {
-            ImeMode[] inputLanguageTable = ImeModeConversion.InputLanguageTable;
-
-            // During a change to the Chinese language with Focus already set, the Chinese IME will send several WmImeNotify messages
-            // before ever sending a WmInputLangChange event. Also, the IME will report an IME input context during this time that we
-            // interpret as On = 'OnHalf'. The combination of these causes us to update the default Cached ImeMode to OnHalf, overriding
-            // the control's ImeMode property -- unwanted behavior. We workaround this by skipping our mode synchronization during these
-            // IMENotify messages until we get a WmInputLangChange event.
-            //
-            // If this is the first time here after conversion to chinese language, wait for WmInputLanguageChange
-            // before listening to WmImeNotifys.
-            if ((inputLanguageTable == ImeModeConversion.ChineseTable) && !lastLanguageChinese)
-            {
-                IgnoreWmImeNotify = true;
-            }
-
-            lastLanguageChinese = (inputLanguageTable == ImeModeConversion.ChineseTable);
-
-            if (ImeSupported && inputLanguageTable != ImeModeConversion.UnsupportedTable && !IgnoreWmImeNotify)
+            if (ImeSupported && ImeModeConversion.InputLanguageTable != ImeModeConversion.UnsupportedTable && !IgnoreWmImeNotify)
             {
                 int wparam = (int)m.WParam;
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #
Text box scenario -
a form with 2 textboxes with ImeMode property set to NoControl. In CHS pinyin keyboard, when focus moves to the second textbox, ImeMode is unexpectedly turned off and ENG characters are typed in.

ComboBox scenario - 
1.	Form has 3 controls - TextBox, RadioButton and a CombBox, all with IMEMode property set to NoControl (this means they get the current OS IME mode)
2.	CHS Pinyin is set in the OS (Window key + space bar), before the app is started
3.	When the app is started, user moves focus with mouse from textbox to radio button and then to the ComboBox, 
Result - ComboBox shows ENG characters instead of the IME. 

## Proposed changes

textbox - reverted an old change that regressed this scenario
Combobox - not a regression. The fix is to propagate the WM_SETFOCUS message to the combobox control from the inner text box

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Basic controls don't support pinyin keyboard with default properties on and require user to press `shift` 

## Regression? 

- textbox issue is a regression, combobox is not

## Risk

-low

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

ComboBox:
![image](https://user-images.githubusercontent.com/15823268/65636789-dcdc6d80-df97-11e9-93fb-b739af5d02f0.png)

TextBox:
![image](https://user-images.githubusercontent.com/15823268/65636824-eb2a8980-df97-11e9-93fd-58ffb24ec6a3.png)


### After

![image](https://user-images.githubusercontent.com/15823268/65636866-f8e00f00-df97-11e9-866e-d316f314ceeb.png)



## Test methodology <!-- How did you ensure quality? -->

manual testing of related scenarios

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->
manual testing of the related scenarios

## Test environment(s) <!-- Remove any that don't apply -->
Win7, Win10 RS1(1607), 19H1

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1975)