### PR TITLE
Cleanup OleCreatePropertyFrameIndirect

### DIFF
--- a/src/Common/src/Interop/OleAut32/Interop.OCPFIPARAMS.cs
+++ b/src/Common/src/Interop/OleAut32/Interop.OCPFIPARAMS.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal static partial class Oleaut32
+    {
+        public unsafe struct OCPFIPARAMS
+        {
+            public uint cbStructSize;
+            public IntPtr hwndOwner;
+            public int x;
+            public int y;
+            public char* lpszCaption;
+            public uint cObjects;
+            public IntPtr ppUnk;
+            public uint cPages;
+            public IntPtr lpPages;
+            public uint lcid;
+            public Ole32.DispatchID dispidInitialProperty;
+        }
+    }
+}

--- a/src/Common/src/Interop/OleAut32/Interop.OleCreatePropertyFrameIndirect.cs
+++ b/src/Common/src/Interop/OleAut32/Interop.OleCreatePropertyFrameIndirect.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal static partial class Oleaut32
+    {
+        [DllImport(Libraries.Oleaut32, ExactSpelling = true)]
+        public static extern void OleCreatePropertyFrameIndirect(ref OCPFIPARAMS lpParams);
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -2992,22 +2992,6 @@ namespace System.Windows.Forms
             // public RECT rcBound; // Note that we don't define this field as part of the marshaling
         }
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-        public class OCPFIPARAMS
-        {
-            public int cbSizeOfStruct = Marshal.SizeOf<OCPFIPARAMS>();
-            public IntPtr hwndOwner;
-            public int x = 0;
-            public int y = 0;
-            public string lpszCaption;
-            public int cObjects = 1;
-            public IntPtr ppUnk;
-            public int pageCount = 1;
-            public IntPtr uuid;
-            public int lcid = Application.CurrentCulture.LCID;
-            public Ole32.DispatchID dispidInitial;
-        }
-
         [ComVisible(true), StructLayout(LayoutKind.Sequential)]
         public class DOCHOSTUIINFO
         {

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -74,9 +74,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.Comdlg32, SetLastError = true, CharSet = CharSet.Auto)]
         public static extern int PrintDlgEx([In, Out] NativeMethods.PRINTDLGEX lppdex);
 
-        [DllImport(ExternDll.Oleaut32, ExactSpelling = true)]
-        public static extern void OleCreatePropertyFrameIndirect(NativeMethods.OCPFIPARAMS p);
-
         [DllImport(ExternDll.Shell32, CharSet = CharSet.Auto)]
         public static extern int DragQueryFile(HandleRef hDrop, int iFile, StringBuilder lpszFile, int cch);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -3311,25 +3311,24 @@ namespace System.Windows.Forms
             return false;
         }
 
-        unsafe private void ShowPropertyPageForDispid(Ole32.DispatchID dispid, Guid guid)
+        private unsafe void ShowPropertyPageForDispid(Ole32.DispatchID dispid, Guid guid)
         {
-            try
+            IntPtr pUnk = Marshal.GetIUnknownForObject(GetOcx());
+            fixed (char* pName = Name)
             {
-                IntPtr pUnk = Marshal.GetIUnknownForObject(GetOcx());
-                NativeMethods.OCPFIPARAMS opcparams = new NativeMethods.OCPFIPARAMS
+                var opcparams = new Oleaut32.OCPFIPARAMS
                 {
+                    cbStructSize = (uint)Marshal.SizeOf<Oleaut32.OCPFIPARAMS>(),
                     hwndOwner = (ContainingControl == null) ? IntPtr.Zero : ContainingControl.Handle,
-                    lpszCaption = Name,
-                    ppUnk = (IntPtr)(long)&pUnk,
-                    uuid = (IntPtr)(long)&guid,
-                    dispidInitial = dispid
+                    lpszCaption = pName,
+                    cObjects = 1,
+                    ppUnk = (IntPtr)(&pUnk),
+                    cPages = 1,
+                    lpPages = (IntPtr)(&guid),
+                    lcid = (uint)Application.CurrentCulture.LCID,
+                    dispidInitialProperty = dispid
                 };
-                UnsafeNativeMethods.OleCreatePropertyFrameIndirect(opcparams);
-            }
-            catch (Exception t)
-            {
-                Debug.Fail(t.ToString());
-                throw t;
+                Oleaut32.OleCreatePropertyFrameIndirect(ref opcparams);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -3314,21 +3314,28 @@ namespace System.Windows.Forms
         private unsafe void ShowPropertyPageForDispid(Ole32.DispatchID dispid, Guid guid)
         {
             IntPtr pUnk = Marshal.GetIUnknownForObject(GetOcx());
-            fixed (char* pName = Name)
+            try
             {
-                var opcparams = new Oleaut32.OCPFIPARAMS
+                fixed (char* pName = Name)
                 {
-                    cbStructSize = (uint)Marshal.SizeOf<Oleaut32.OCPFIPARAMS>(),
-                    hwndOwner = (ContainingControl == null) ? IntPtr.Zero : ContainingControl.Handle,
-                    lpszCaption = pName,
-                    cObjects = 1,
-                    ppUnk = (IntPtr)(&pUnk),
-                    cPages = 1,
-                    lpPages = (IntPtr)(&guid),
-                    lcid = (uint)Application.CurrentCulture.LCID,
-                    dispidInitialProperty = dispid
-                };
-                Oleaut32.OleCreatePropertyFrameIndirect(ref opcparams);
+                    var opcparams = new Oleaut32.OCPFIPARAMS
+                    {
+                        cbStructSize = (uint)Marshal.SizeOf<Oleaut32.OCPFIPARAMS>(),
+                        hwndOwner = (ContainingControl == null) ? IntPtr.Zero : ContainingControl.Handle,
+                        lpszCaption = pName,
+                        cObjects = 1,
+                        ppUnk = (IntPtr)(&pUnk),
+                        cPages = 1,
+                        lpPages = (IntPtr)(&guid),
+                        lcid = (uint)Application.CurrentCulture.LCID,
+                        dispidInitialProperty = dispid
+                    };
+                    Oleaut32.OleCreatePropertyFrameIndirect(ref opcparams);
+                }
+            }
+            finally
+            {
+                Marshal.Release(pUnk);
             }
         }
 


### PR DESCRIPTION
## Proposed Changes
- Cleanup `OleCreatePropertyFrameIndirect`
- Cleanup and structify `OCPFIPARAMS`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1979)