### PR TITLE
Cleanup IErrorInfo and ISupportErrorInfo

### DIFF
--- a/src/Common/src/Interop/OleAut32/Interop.GetErrorInfo.cs
+++ b/src/Common/src/Interop/OleAut32/Interop.GetErrorInfo.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal static partial class Oleaut32
+    {
+        [DllImport(Libraries.Oleaut32, ExactSpelling = true, PreserveSig = false)]
+        public static extern HRESULT GetErrorInfo(uint dwReserved, ref IErrorInfo pperrinfo);
+    }
+}

--- a/src/Common/src/Interop/OleAut32/Interop.IErrorInfo.cs
+++ b/src/Common/src/Interop/OleAut32/Interop.IErrorInfo.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal static partial class Oleaut32
+    {
+        [ComImport]
+        [Guid("1CF2B120-547D-101B-8E65-08002B2BD119")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        public unsafe interface IErrorInfo
+        {
+            [PreserveSig]
+            HRESULT GetGUID(
+                Guid* pguid);
+
+            [PreserveSig]
+            HRESULT GetSource(
+                ref string pBstrSource);
+
+            [PreserveSig]
+            HRESULT GetDescription(
+                ref string pBstrDescription);
+
+            [PreserveSig]
+            HRESULT GetHelpFile(
+                ref string pBstrHelpFile);
+
+            [PreserveSig]
+            HRESULT GetHelpContext(
+                uint* pdwHelpContext);
+        }
+    }
+}

--- a/src/Common/src/Interop/OleAut32/Interop.ISupportErrorInfo.cs
+++ b/src/Common/src/Interop/OleAut32/Interop.ISupportErrorInfo.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal static partial class Oleaut32
+    {
+        [ComImport]
+        [Guid("DF0B3D60-548F-101B-8E65-08002B2BD119")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        public unsafe interface ISupportErrorInfo
+        {
+            [PreserveSig]
+            HRESULT InterfaceSupportsErrorInfo(
+                Guid* riid);
+        }
+    }
+}

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -509,9 +509,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern int GetMenuItemCount(HandleRef hMenu);
 
-        [DllImport(ExternDll.Oleaut32, PreserveSig = false)]
-        public static extern void GetErrorInfo(int reserved, [In, Out] ref IErrorInfo errorInfo);
-
         [DllImport(ExternDll.User32, ExactSpelling = true)]
         public static extern IntPtr GetWindowDC(HandleRef hWnd);
 
@@ -2196,46 +2193,6 @@ namespace System.Windows.Forms
                  string[] pBstrLibName);
 
             void LocalReleaseTLibAttr();
-        }
-
-        [ComImport(),
-         Guid("DF0B3D60-548F-101B-8E65-08002B2BD119"),
-         InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        public interface ISupportErrorInfo
-        {
-            int InterfaceSupportsErrorInfo(
-                    [In] ref Guid riid);
-        }
-
-        [ComImport(),
-         Guid("1CF2B120-547D-101B-8E65-08002B2BD119"),
-         InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        public interface IErrorInfo
-        {
-            [PreserveSig]
-            int GetGUID(
-                       [Out]
-                   out Guid pguid);
-
-            [PreserveSig]
-            int GetSource(
-                         [In, Out, MarshalAs(UnmanagedType.BStr)]
-                     ref string pBstrSource);
-
-            [PreserveSig]
-            int GetDescription(
-                              [In, Out, MarshalAs(UnmanagedType.BStr)]
-                          ref string pBstrDescription);
-
-            [PreserveSig]
-            int GetHelpFile(
-                           [In, Out, MarshalAs(UnmanagedType.BStr)]
-                       ref string pBstrHelpFile);
-
-            [PreserveSig]
-            int GetHelpContext(
-                              [In, Out, MarshalAs(UnmanagedType.U4)]
-                          ref int pdwHelpContext);
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
@@ -1338,7 +1338,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                             if (pDisp is Oleaut32.ISupportErrorInfo iSupportErrorInfo)
                             {
                                 g = typeof(UnsafeNativeMethods.IDispatch).GUID;
-                                if (iSupportErrorInfo.InterfaceSupportsErrorInfo(&g).Succeeded())
+                                if (iSupportErrorInfo.InterfaceSupportsErrorInfo(&g) == HRESULT.S_OK)
                                 {
                                     Oleaut32.IErrorInfo pErrorInfo = null;
                                     Oleaut32.GetErrorInfo(0, ref pErrorInfo);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
@@ -1256,7 +1256,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         ///  property so that getXXX following a setXXX should return the value
         ///  passed in if no exception was thrown in the setXXX call.
         /// </summary>
-        public override void SetValue(object component, object value)
+        public unsafe override void SetValue(object component, object value)
         {
             if (readOnly)
             {
@@ -1335,20 +1335,18 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                             lastValue = value;
                             return;
                         default:
-                            if (pDisp is UnsafeNativeMethods.ISupportErrorInfo iSupportErrorInfo)
+                            if (pDisp is Oleaut32.ISupportErrorInfo iSupportErrorInfo)
                             {
                                 g = typeof(UnsafeNativeMethods.IDispatch).GUID;
-                                if (NativeMethods.Succeeded(iSupportErrorInfo.InterfaceSupportsErrorInfo(ref g)))
+                                if (iSupportErrorInfo.InterfaceSupportsErrorInfo(&g).Succeeded())
                                 {
-                                    UnsafeNativeMethods.IErrorInfo pErrorInfo = null;
-                                    UnsafeNativeMethods.GetErrorInfo(0, ref pErrorInfo);
+                                    Oleaut32.IErrorInfo pErrorInfo = null;
+                                    Oleaut32.GetErrorInfo(0, ref pErrorInfo);
+
                                     string info = null;
-                                    if (pErrorInfo != null)
+                                    if (pErrorInfo != null && pErrorInfo.GetDescription(ref info).Succeeded())
                                     {
-                                        if (NativeMethods.Succeeded(pErrorInfo.GetDescription(ref info)))
-                                        {
-                                            errorInfo = info;
-                                        }
+                                        errorInfo = info;
                                     }
                                 }
                             }


### PR DESCRIPTION
## Proposed changes
- Cleanup `IErrorInfo` and `ISupportErrorInfo`
- Fix bug where we'd get the error info even if we didn't support it. According to the docs, if `ISupportErrorInfo::InterfaceSupportsErrorInfo method` returns `S_FALSE` then it is not supported so we shouldn't get the `IErrorInfo` which would throw
![image](https://user-images.githubusercontent.com/1275900/65696423-192fcc80-e071-11e9-9cc3-6236f24122ee.png)
/cc @JeremyKuhne for the interop fix :)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1980)