### PR TITLE
Fix conditional order of precedence

### DIFF
--- a/eng/Shipping.ruleset
+++ b/eng/Shipping.ruleset
@@ -96,7 +96,6 @@
     <Rule Id="SA1302" Action="None" />
     <Rule Id="SA1303" Action="None" />
     <Rule Id="SA1304" Action="None" />
-    <Rule Id="SA1408" Action="None" />
     <Rule Id="SA1306" Action="None" />
     <Rule Id="SA1307" Action="None" />
     <Rule Id="SA1308" Action="None" />
@@ -114,6 +113,7 @@
     <Rule Id="SA1405" Action="None" />
     <Rule Id="SA1406" Action="None" />
     <Rule Id="SA1407" Action="None" />
+    <Rule Id="SA1408" Action="Warning" />
     <Rule Id="SA1410" Action="None" />
     <Rule Id="SA1411" Action="None" />
     <Rule Id="SA1412" Action="None" />

--- a/src/Common/src/OsVersion.cs
+++ b/src/Common/src/OsVersion.cs
@@ -37,6 +37,6 @@ namespace System.Windows.Forms
         /// </summary>
         public static bool IsWindows8_1OrGreater
             => s_versionInfo.dwMajorVersion >= 10
-                || s_versionInfo.dwMajorVersion == 6 && s_versionInfo.dwMinorVersion == 3;
+                || (s_versionInfo.dwMajorVersion == 6 && s_versionInfo.dwMinorVersion == 3);
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DragAssistanceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DragAssistanceManager.cs
@@ -6,7 +6,6 @@ using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 
 namespace System.Windows.Forms.Design.Behavior
@@ -650,8 +649,8 @@ namespace System.Windows.Forms.Design.Behavior
             {
                 // If a distance is 0 or if it is to our left and we're heading right or if it is to our right and we're heading left then we can null this value out
                 if (distances[i] == 0 ||
-                  distances[i] > 0 && direction > 0 ||
-                  distances[i] < 0 && direction < 0)
+                  (distances[i] > 0 && direction > 0) ||
+                  (distances[i] < 0 && direction < 0))
                 {
                     distances[i] = INVALID_VALUE;
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/SnapLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/SnapLine.cs
@@ -141,10 +141,10 @@ namespace System.Windows.Forms.Design.Behavior
             // check for our special-cased margin filter
             if (line1.Filter.Contains(Margin))
             {
-                if (line1.Filter.Equals(MarginRight) && (line2.Filter.Equals(MarginLeft) || line2.Filter.Equals(PaddingRight)) ||
-                  line1.Filter.Equals(MarginLeft) && (line2.Filter.Equals(MarginRight) || line2.Filter.Equals(PaddingLeft)) ||
-                  line1.Filter.Equals(MarginTop) && (line2.Filter.Equals(MarginBottom) || line2.Filter.Equals(PaddingTop)) ||
-                  line1.Filter.Equals(MarginBottom) && (line2.Filter.Equals(MarginTop) || line2.Filter.Equals(PaddingBottom)))
+                if ((line1.Filter.Equals(MarginRight) && (line2.Filter.Equals(MarginLeft) || line2.Filter.Equals(PaddingRight))) ||
+                  (line1.Filter.Equals(MarginLeft) && (line2.Filter.Equals(MarginRight) || line2.Filter.Equals(PaddingLeft))) ||
+                  (line1.Filter.Equals(MarginTop) && (line2.Filter.Equals(MarginBottom) || line2.Filter.Equals(PaddingTop))) ||
+                  (line1.Filter.Equals(MarginBottom) && (line2.Filter.Equals(MarginTop) || line2.Filter.Equals(PaddingBottom))))
                 {
                     return true;
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -1727,8 +1727,8 @@ namespace System.Windows.Forms.Design
             // CONSIDER - I really don't like this one bit. We need a
             //          : centralized handler so we can do a global override for the tab order
             //          : UI, but the designer is a natural fit for an object oriented UI.
-            if (m.Msg >= WindowMessages.WM_MOUSEFIRST && m.Msg <= WindowMessages.WM_MOUSELAST
-                || m.Msg >= WindowMessages.WM_NCMOUSEMOVE && m.Msg <= WindowMessages.WM_NCMBUTTONDBLCLK
+            if ((m.Msg >= WindowMessages.WM_MOUSEFIRST && m.Msg <= WindowMessages.WM_MOUSELAST)
+                || (m.Msg >= WindowMessages.WM_NCMOUSEMOVE && m.Msg <= WindowMessages.WM_NCMBUTTONDBLCLK)
                 || m.Msg == WindowMessages.WM_SETCURSOR)
             {
                 if (_eventSvc == null)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripKeyboardHandlingService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripKeyboardHandlingService.cs
@@ -6,7 +6,6 @@ using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Windows.Forms.Design.Behavior;
@@ -322,7 +321,7 @@ namespace System.Windows.Forms.Design
                                 if (found == null || found.TabIndex > parentControls[c].TabIndex)
                                 {
                                     // Finally, check to make sure that if this tab index is the same as ctl, that we've already encountered ctl in the z-order.  If it isn't the same, than we're more than happy with it.
-                                    if (parentControls[c].Site != null && parentControls[c].TabIndex != targetIndex || hitCtl)
+                                    if ((parentControls[c].Site != null && parentControls[c].TabIndex != targetIndex) || hitCtl)
                                     {
                                         found = parentControls[c];
                                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -528,9 +528,11 @@ namespace System.Windows.Forms
             get
             {
                 int ocState = GetOcState();
+#pragma warning disable SA1408 // Conditional expressions should declare precedence
                 return (axState[fOwnWindow] &&
                        (ocState > OC_RUNNING || (IsUserMode() && ocState >= OC_RUNNING)) ||
                        ocState >= OC_INPLACE);
+#pragma warning restore SA1408 // Conditional expressions should declare precedence
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -3988,15 +3988,16 @@ namespace System.Windows.Forms
 
                     base.WndProc(ref m);
                     break;
+
                 case WindowMessages.WM_PRINTCLIENT:
                     // all the fancy stuff we do in OnPaint has to happen again in OnPrint.
-                    if (GetStyle(ControlStyles.UserPaint) == false && FlatStyle == FlatStyle.Flat || FlatStyle == FlatStyle.Popup)
+                    if (!GetStyle(ControlStyles.UserPaint) && (FlatStyle == FlatStyle.Flat || FlatStyle == FlatStyle.Popup))
                     {
                         DefWndProc(ref m);
 
                         if ((unchecked((int)(long)m.LParam) & NativeMethods.PRF_CLIENT) == NativeMethods.PRF_CLIENT)
                         {
-                            if (GetStyle(ControlStyles.UserPaint) == false && FlatStyle == FlatStyle.Flat || FlatStyle == FlatStyle.Popup)
+                            if (!GetStyle(ControlStyles.UserPaint) && (FlatStyle == FlatStyle.Flat || FlatStyle == FlatStyle.Popup))
                             {
                                 using (Graphics g = Graphics.FromHdcInternal(m.WParam))
                                 {
@@ -4008,12 +4009,12 @@ namespace System.Windows.Forms
                     }
                     base.WndProc(ref m);
                     return;
+
                 case WindowMessages.WM_SETCURSOR:
                     base.WndProc(ref m);
                     break;
 
                 case WindowMessages.WM_SETFONT:
-                    //(
                     if (Width == 0)
                     {
                         suppressNextWindosPos = true;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
@@ -1371,14 +1371,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                                 }
                                 else
                                 {
-                                    errorInfo = strMessage.ToString();
-                                    // strip of any trailing cr/lf
-                                    while (errorInfo.Length > 0 &&
-                                            errorInfo[errorInfo.Length - 1] == '\n' ||
-                                            errorInfo[errorInfo.Length - 1] == '\r')
-                                    {
-                                        errorInfo = errorInfo.Substring(0, errorInfo.Length - 1);
-                                    }
+                                    errorInfo = TrimNewline(strMessage);
                                 }
                             }
                             throw new ExternalException(errorInfo, (int)hr);
@@ -1394,6 +1387,17 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             {
                 gcHandle.Free();
             }
+        }
+
+        private static string TrimNewline(StringBuilder errorInfo)
+        {
+            int index = errorInfo.Length - 1;
+            while (index >= 0 && (errorInfo[index] == '\n' || errorInfo[index] == '\r'))
+            {
+                index--;
+            }
+
+            return errorInfo.ToString(0, index + 1);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -22,9 +22,9 @@ using System.Windows.Forms.Internal;
 using System.Windows.Forms.Layout;
 using Accessibility;
 using Microsoft.Win32;
+using static Interop;
 using Encoding = System.Text.Encoding;
 using IComDataObject = System.Runtime.InteropServices.ComTypes.IDataObject;
-using static Interop;
 
 namespace System.Windows.Forms
 {
@@ -9123,10 +9123,10 @@ namespace System.Windows.Forms
                 }
 
                 // Next, use input flags to decide whether to validate the control itself
-                if ((validationConstraints & ValidationConstraints.Selectable) == ValidationConstraints.Selectable && !c.GetStyle(ControlStyles.Selectable) ||
-                    (validationConstraints & ValidationConstraints.Enabled) == ValidationConstraints.Enabled && !c.Enabled ||
-                    (validationConstraints & ValidationConstraints.Visible) == ValidationConstraints.Visible && !c.Visible ||
-                    (validationConstraints & ValidationConstraints.TabStop) == ValidationConstraints.TabStop && !c.TabStop)
+                if (((validationConstraints & ValidationConstraints.Selectable) == ValidationConstraints.Selectable && !c.GetStyle(ControlStyles.Selectable)) ||
+                    ((validationConstraints & ValidationConstraints.Enabled) == ValidationConstraints.Enabled && !c.Enabled) ||
+                    ((validationConstraints & ValidationConstraints.Visible) == ValidationConstraints.Visible && !c.Visible) ||
+                    ((validationConstraints & ValidationConstraints.TabStop) == ValidationConstraints.TabStop && !c.TabStop))
                 {
                     continue;
                 }
@@ -11147,7 +11147,7 @@ namespace System.Windows.Forms
                         User32.ShowWindow(Handle, value ? ShowParams : User32.SW.HIDE);
                     }
                 }
-                else if (IsHandleCreated || value && _parent != null && _parent.Created)
+                else if (IsHandleCreated || (value && _parent?.Created == true))
                 {
                     // We want to mark the control as visible so that CreateControl
                     // knows that we are going to be displayed... however in case

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -10634,7 +10634,9 @@ namespace System.Windows.Forms
 
         private Control GetNextSelectableControl(Control ctl, bool forward, bool tabStopOnly, bool nested, bool wrap)
         {
+#pragma warning disable SA1408 // Conditional expressions should declare precedence
             if (!Contains(ctl) || !nested && ctl._parent != this)
+#pragma warning restore SA1408 // Conditional expressions should declare precedence
             {
                 ctl = null;
             }
@@ -12858,7 +12860,9 @@ namespace System.Windows.Forms
                         {
                             try
                             {
+#pragma warning disable SA1408 // Conditional expressions should declare precedence
                                 if ((m.WParam == IntPtr.Zero) && GetStyle(ControlStyles.AllPaintingInWmPaint) || doubleBuffered)
+#pragma warning restore SA1408 // Conditional expressions should declare precedence
                                 {
                                     PaintWithErrorHandling(pevent, PaintLayerBackground);
                                     // Consider: This condition could be elimiated,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGrid.cs
@@ -3961,9 +3961,9 @@ namespace System.Windows.Forms
                 try
                 {
                     Set_ListManager(DataSource, DataMember, true, false);     // we do not want to create columns
-                                                                                        // if the columns are already created
-                                                                                        // the grid should not rely on OnBindingContextChanged
-                                                                                        // to create columns.
+                                                                              // if the columns are already created
+                                                                              // the grid should not rely on OnBindingContextChanged
+                                                                              // to create columns.
                 }
                 catch
                 {
@@ -5654,7 +5654,9 @@ namespace System.Windows.Forms
             // 1. the user was editing or navigating around the data grid and
             // 2. this is not the result of moving focus inside the data grid and
             // 3. if the user was scrolling
+#pragma warning disable SA1408 // Conditional expressions should declare precedence
             if (!gridState[GRIDSTATE_isEditing] && !gridState[GRIDSTATE_isNavigating] || (gridState[GRIDSTATE_editControlChanging] && !gridState[GRIDSTATE_isScrolling]))
+#pragma warning restore SA1408 // Conditional expressions should declare precedence
             {
                 return true;
             }
@@ -7011,9 +7013,11 @@ namespace System.Windows.Forms
             int previousLastTotallyVisibleCol = lastTotallyVisibleCol;
 
             while (col < firstVisibleCol
+#pragma warning disable SA1408 // Conditional expressions should declare precedence
                 || col == firstVisibleCol && negOffset != 0
                 || lastTotallyVisibleCol == -1 && col > firstVisibleCol
                 || lastTotallyVisibleCol > -1 && col > lastTotallyVisibleCol)
+#pragma warning restore SA1408 // Conditional expressions should declare precedence
             {
 
                 ScrollToColumn(col);
@@ -9622,8 +9626,10 @@ namespace System.Windows.Forms
                 }
             }
 
+#pragma warning disable SA1408 // Conditional expressions should declare precedence
             if (lastTotallyVisibleCol == nVisibleCols - 1 && columns > 0 ||
                 firstVisibleCol == 0 && columns < 0 && negOffset == 0)
+#pragma warning restore SA1408 // Conditional expressions should declare precedence
             {
                 return;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridTableStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridTableStyle.cs
@@ -636,7 +636,7 @@ namespace System.Windows.Forms
                     throw new ArgumentException(string.Format(SR.DataGridDefaultTableSet, nameof(HeaderFont)));
                 }
 
-                if (value == null && headerFont != null || (value != null && !value.Equals(headerFont)))
+                if ((value == null && headerFont != null) || (value != null && !value.Equals(headerFont)))
                 {
                     headerFont = value;
                     OnHeaderFontChanged(EventArgs.Empty);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -3434,7 +3434,9 @@ namespace System.Windows.Forms
                        dataGridViewOper[DATAGRIDVIEWOPER_trackColRelocation] ||
                        IsCurrentCellDirty ||
                        ((VirtualMode || DataSource != null) && IsCurrentRowDirty) ||
+#pragma warning disable SA1408 // Conditional expressions should declare precedence
                        (EditMode != DataGridViewEditMode.EditOnEnter && editingControl != null ||
+#pragma warning restore SA1408 // Conditional expressions should declare precedence
                        dataGridViewState1[DATAGRIDVIEWSTATE1_newRowEdited]);
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.cs
@@ -808,7 +808,9 @@ namespace System.Windows.Forms
                     int state = (int)HeaderItemState.Normal;
 
                     // Set the state to Pressed/Hot only if the column can be sorted or selected
+#pragma warning disable SA1408 // Conditional expressions should declare precedence
                     if (OwningColumn != null && OwningColumn.SortMode != DataGridViewColumnSortMode.NotSortable ||
+#pragma warning restore SA1408 // Conditional expressions should declare precedence
                         DataGridView.SelectionMode == DataGridViewSelectionMode.FullColumnSelect ||
                         DataGridView.SelectionMode == DataGridViewSelectionMode.ColumnHeaderSelect)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs
@@ -121,7 +121,9 @@ namespace System.Windows.Forms
         {
             if ((keyData & Keys.KeyCode) == Keys.Down ||
                 (keyData & Keys.KeyCode) == Keys.Up ||
+#pragma warning disable SA1408 // Conditional expressions should declare precedence
                 (DroppedDown && ((keyData & Keys.KeyCode) == Keys.Escape) || (keyData & Keys.KeyCode) == Keys.Enter))
+#pragma warning restore SA1408 // Conditional expressions should declare precedence
             {
                 return true;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DockAndAnchorLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DockAndAnchorLayout.cs
@@ -81,7 +81,7 @@ namespace System.Windows.Forms.Layout
             Rectangle oldBounds = GetCachedBounds(element);
             Point location = oldBounds.Location;
 
-            Debug.Assert((CommonProperties.GetAutoSizeMode(element) == AutoSizeMode.GrowAndShrink || newSize.Height >= oldBounds.Height && newSize.Width >= oldBounds.Width),
+            Debug.Assert((CommonProperties.GetAutoSizeMode(element) == AutoSizeMode.GrowAndShrink || (newSize.Height >= oldBounds.Height && newSize.Width >= oldBounds.Width)),
                 "newSize expected to be >= current size.");
 
             if ((direction & GrowthDirection.Left) != GrowthDirection.None)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -8959,7 +8959,7 @@ namespace System.Windows.Forms
             /// <summary>
             ///  Searches for Controls by their Name property, builds up an array
             ///  of all the controls that match.
-                    /// </summary>
+            /// </summary>
             public ListViewItem[] Find(string key, bool searchAllSubItems)
             {
                 ArrayList foundItems = FindInternal(key, searchAllSubItems, this, new ArrayList());
@@ -8973,7 +8973,7 @@ namespace System.Windows.Forms
             /// <summary>
             ///  Searches for Controls by their Name property, builds up an arraylist
             ///  of all the controls that match.
-                    /// </summary>
+            /// </summary>
             private ArrayList FindInternal(string key, bool searchAllSubItems, ListViewItemCollection listViewItems, ArrayList foundItems)
             {
                 if ((listViewItems == null) || (foundItems == null))
@@ -9378,7 +9378,9 @@ namespace System.Windows.Forms
                     owner.ItemCollectionChangedInMouseDown = true;
                 }
 
+#pragma warning disable SA1408 // Conditional expressions should declare precedence
                 if (comparer != null || (owner.Sorting != SortOrder.None) && !owner.VirtualMode)
+#pragma warning restore SA1408 // Conditional expressions should declare precedence
                 {
                     owner.Sort();
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MdiWindowListStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MdiWindowListStrip.cs
@@ -110,9 +110,12 @@ namespace System.Windows.Forms
                         {
                             visibleChildren++;
                             if ((activeFormAdded && (formsAddedToMenu < maxMenuForms)) ||   // don't exceed max
+#pragma warning disable SA1408 // Conditional expressions should declare precedence
                                 (!activeFormAdded && (formsAddedToMenu < (maxMenuForms - 1)) ||   // save room for active if it's not in yet
+#pragma warning restore SA1408 // Conditional expressions should declare precedence
                                 (forms[i].Equals(activeMdiChild))))
-                            {                            // there's always room for activeMdiChild
+                            {
+                                // there's always room for activeMdiChild
                                 string text = WindowsFormsUtils.EscapeTextWithAmpersands(mdiParent.MdiChildren[i].Text);
                                 text = text ?? string.Empty;
                                 ToolStripMenuItem windowListItem = new ToolStripMenuItem(mdiParent.MdiChildren[i])

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MenuItem.cs
@@ -4,9 +4,9 @@
 
 using System.Collections;
 using System.ComponentModel;
-using System.Globalization;
 using System.Diagnostics;
 using System.Drawing;
+using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Threading;
 using static Interop;
@@ -1127,8 +1127,10 @@ namespace System.Windows.Forms
                         if (forms[i].Visible)
                         {
                             visibleChildren++;
-                            if ((activeFormAdded && (formsAddedToMenu < MaxMenuForms)) ||  // don't exceed max
-                                (!activeFormAdded && (formsAddedToMenu < (MaxMenuForms - 1)) ||  // save room for active if it's not in yet
+                            if ((activeFormAdded && (formsAddedToMenu < MaxMenuForms)) ||   // don't exceed max
+#pragma warning disable SA1408 // Conditional expressions should declare precedence
+                                (!activeFormAdded && (formsAddedToMenu < (MaxMenuForms - 1)) ||   // save room for active if it's not in yet
+#pragma warning restore SA1408 // Conditional expressions should declare precedence
                                 (forms[i].Equals(activeMdiChild))))
                             {
                                 // there's always room for activeMdiChild

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDown.cs
@@ -517,8 +517,7 @@ namespace System.Windows.Forms
             {
                 // Digits are OK
             }
-            else if (keyInput.Equals(decimalSeparator) || keyInput.Equals(groupSeparator) ||
-                     keyInput.Equals(negativeSign))
+            else if (keyInput.Equals(decimalSeparator) || keyInput.Equals(groupSeparator) || keyInput.Equals(negativeSign))
             {
                 // Decimal separator is OK
             }
@@ -526,7 +525,7 @@ namespace System.Windows.Forms
             {
                 // Backspace key is OK
             }
-            else if (Hexadecimal && ((e.KeyChar >= 'a' && e.KeyChar <= 'f') || e.KeyChar >= 'A' && e.KeyChar <= 'F'))
+            else if (Hexadecimal && ((e.KeyChar >= 'a' && e.KeyChar <= 'f') || (e.KeyChar >= 'A' && e.KeyChar <= 'F')))
             {
                 // Hexadecimal digits are OK
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -1282,7 +1282,9 @@ namespace System.Windows.Forms
                             // or Guid.Emtpy, assume the classes are different.
                             //
                             if (classesSame &&
+#pragma warning disable SA1408 // Conditional expressions should declare precedence
                                 (oldType != newType || oldType.IsCOMObject && newType.IsCOMObject))
+#pragma warning restore SA1408 // Conditional expressions should declare precedence
                             {
                                 classesSame = false;
                             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -3617,7 +3617,7 @@ namespace System.Windows.Forms
                 for (int i = 0; i < currentObjects.Length; i++)
                 {
                     Type typeChanged = e.TypeChanged;
-                    if (currentObjects[i] == e.ComponentChanged || typeChanged != null && typeChanged.IsAssignableFrom(currentObjects[i].GetType()))
+                    if (currentObjects[i] == e.ComponentChanged || typeChanged?.IsAssignableFrom(currentObjects[i].GetType()) == true)
                     {
                         // clear our property hashes
                         ClearCachedProps();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollableControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollableControl.cs
@@ -972,10 +972,10 @@ namespace System.Windows.Forms
         {
             bool needLayout = false;
 
-            if (!horiz && HScroll
-                || horiz && !HScroll
-                || !vert && VScroll
-                || vert && !VScroll)
+            if ((!horiz && HScroll)
+                || (horiz && !HScroll)
+                || (!vert && VScroll)
+                || (vert && !VScroll))
             {
 
                 needLayout = true;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollableControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollableControl.cs
@@ -783,8 +783,10 @@ namespace System.Windows.Forms
             _displayRect.X = x;
             _displayRect.Y = y;
 
-            if (xDelta != 0 || yDelta != 0 && IsHandleCreated)
+            if (IsHandleCreated && (xDelta != 0 || yDelta != 0))
             {
+                Debug.Assert(IsHandleCreated, "Handle is not created");
+
                 RECT rcClip = ClientRectangle;
                 RECT rcUpdate = ClientRectangle;
                 User32.ScrollWindowEx(

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
@@ -1131,9 +1131,8 @@ namespace System.Windows.Forms
                     return;
                 }
                 //valid Keys that move the splitter...
-                if (e.KeyData == Keys.Right || e.KeyData == Keys.Down ||
-                    e.KeyData == Keys.Left || e.KeyData == Keys.Up
-                    && splitterFocused)
+                if (splitterFocused &&
+                    (e.KeyData == Keys.Right || e.KeyData == Keys.Down || e.KeyData == Keys.Left || e.KeyData == Keys.Up))
                 {
                     if (splitBegin)
                     {
@@ -1141,13 +1140,13 @@ namespace System.Windows.Forms
                     }
 
                     //left OR up
-                    if (e.KeyData == Keys.Left || e.KeyData == Keys.Up && splitterFocused)
+                    if (splitterFocused && (e.KeyData == Keys.Left || e.KeyData == Keys.Up))
                     {
                         splitterDistance -= SplitterIncrement;
                         splitterDistance = (splitterDistance < Panel1MinSize) ? splitterDistance + SplitterIncrement : Math.Max(splitterDistance, BORDERSIZE);
                     }
                     //right OR down
-                    if (e.KeyData == Keys.Right || e.KeyData == Keys.Down && splitterFocused)
+                    if (splitterFocused && (e.KeyData == Keys.Right || e.KeyData == Keys.Down))
                     {
                         splitterDistance += SplitterIncrement;
                         if (Orientation == Orientation.Vertical)
@@ -1198,9 +1197,8 @@ namespace System.Windows.Forms
             base.OnKeyUp(e);
             if (splitBegin && IsSplitterMovable)
             {
-                if (e.KeyData == Keys.Right || e.KeyData == Keys.Down ||
-                    e.KeyData == Keys.Left || e.KeyData == Keys.Up
-                    && splitterFocused)
+                if (splitterFocused &&
+                    (e.KeyData == Keys.Right || e.KeyData == Keys.Down || e.KeyData == Keys.Left || e.KeyData == Keys.Up))
                 {
                     DrawSplitBar(DRAW_END);
                     ApplySplitterDistance();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
@@ -2013,7 +2013,9 @@ namespace System.Windows.Forms
         private bool SelectNextControlInContainer(Control ctl, bool forward, bool tabStopOnly,
                                       bool nested, bool wrap)
         {
+#pragma warning disable SA1408 // Conditional expressions should declare precedence
             if (!Contains(ctl) || !nested && ctl.ParentInternal != this)
+#pragma warning restore SA1408 // Conditional expressions should declare precedence
             {
                 ctl = null;
             }
@@ -2109,7 +2111,9 @@ namespace System.Windows.Forms
         private bool SelectNextControlInPanel(Control ctl, bool forward, bool tabStopOnly,
                                       bool nested, bool wrap)
         {
+#pragma warning disable SA1408 // Conditional expressions should declare precedence
             if (!Contains(ctl) || !nested && ctl.ParentInternal != this)
+#pragma warning restore SA1408 // Conditional expressions should declare precedence
             {
                 ctl = null;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
@@ -119,7 +119,9 @@ namespace System.Windows.Forms
                     if (parent != null)
                     {
                         ToolStripDropDownDirection dropDownDirection = parent.DefaultDropDownDirection;
+#pragma warning disable SA1408 // Conditional expressions should declare precedence
                         if (OppositeDropDownAlign || RightToLeft != parent.RightToLeft && (RightToLeft != RightToLeft.Inherit))
+#pragma warning restore SA1408 // Conditional expressions should declare precedence
                         {
                             dropDownDirection = RTLTranslateDropDownDirection(dropDownDirection, RightToLeft);
                         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSplitStackLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSplitStackLayout.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Drawing;
 using System.Diagnostics;
+using System.Drawing;
 using System.Globalization;
 using System.Windows.Forms.Layout;
 
@@ -424,7 +424,9 @@ namespace System.Windows.Forms
 
             Size toolStripPreferredSize = displayRectangle.Size;
             DockStyle dock = toolStrip.Dock;
+#pragma warning disable SA1408 // Conditional expressions should declare precedence
             if (toolStrip.AutoSize && (!toolStrip.IsInToolStripPanel && (dock == DockStyle.Left) || (dock == DockStyle.Right)))
+#pragma warning restore SA1408 // Conditional expressions should declare precedence
             {
                 // if we're autosizing, make sure we pad out items to the preferred width, not the
                 // width of the display rectangle.

--- a/src/System.Windows.Forms/tests/UnitTests/OsVersionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/OsVersionTests.cs
@@ -1,0 +1,86 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    public class OsVersionTests
+    {
+        private static Interop.NtDll.RTL_OSVERSIONINFOEX s_realVersionInfo;
+        private static FieldInfo s_fiVersionInfo;
+        private static Type s_typeOsVersion;
+
+        static OsVersionTests()
+        {
+            // invoke the call and populate the backing field that we're going to replace
+            bool _ = OsVersion.IsWindows8_1OrGreater;
+
+            s_typeOsVersion = typeof(OsVersion);
+            s_fiVersionInfo = s_typeOsVersion.GetField("s_versionInfo", Reflection.BindingFlags.Static | Reflection.BindingFlags.NonPublic);
+            Assert.NotNull(s_fiVersionInfo);
+
+            s_realVersionInfo = (Interop.NtDll.RTL_OSVERSIONINFOEX)s_fiVersionInfo.GetValue(null);
+        }
+
+        [StaTheory]
+        [InlineData(5, 0, 0, false)]
+        [InlineData(6, 0, 0, false)]
+        [InlineData(10, 0, 0, false)]
+        [InlineData(10, 0, 14393, true)]
+        [InlineData(10, 0, 15063, true)]
+        [InlineData(11, 0, 20000, true)] // it is a bit of a leap of faith that we have another OS version and its build number increments in sequence
+        public void IsWindows10_1607OrGreater(uint major, uint minor, uint buildNumber, bool expected)
+        {
+            PerformAssert(major, minor, buildNumber, () => Assert.Equal(expected, OsVersion.IsWindows10_1607OrGreater));
+        }
+
+        [StaTheory]
+        [InlineData(5, 0, 0, false)]
+        [InlineData(6, 0, 0, false)]
+        [InlineData(10, 0, 0, false)]
+        [InlineData(10, 0, 14393, false)]
+        [InlineData(10, 0, 15063, true)]
+        [InlineData(11, 0, 20000, true)] // it is a bit of a leap of faith that we have another OS version and its build number increments in sequence
+        public void IsWindows10_1703OrGreater(uint major, uint minor, uint buildNumber, bool expected)
+        {
+            PerformAssert(major, minor, buildNumber, () => Assert.Equal(expected, OsVersion.IsWindows10_1703OrGreater));
+        }
+
+        [StaTheory]
+        [InlineData(5, 0, 0, false)]
+        [InlineData(6, 2, 0, false)]
+        [InlineData(6, 3, 0, true)]
+        [InlineData(10, 0, 0, true)]
+        [InlineData(10, 0, 14393, true)]
+        [InlineData(10, 0, 15063, true)]
+        [InlineData(11, 0, 20000, true)] // it is a bit of a leap of faith that we have another OS version and its build number increments in sequence
+        public void IsWindows8_1OrGreater(uint major, uint minor, uint buildNumber, bool expected)
+        {
+            PerformAssert(major, minor, buildNumber, () => Assert.Equal(expected, OsVersion.IsWindows8_1OrGreater));
+        }
+
+        private void PerformAssert(uint major, uint minor, uint buildNumber, Action assertion)
+        {
+            try
+            {
+                Interop.NtDll.RTL_OSVERSIONINFOEX verInfo = new Interop.NtDll.RTL_OSVERSIONINFOEX
+                {
+                    dwMajorVersion = major,
+                    dwMinorVersion = minor,
+                    dwBuildNumber = buildNumber
+                };
+                s_fiVersionInfo.SetValue(null, verInfo);
+
+                assertion();
+            }
+            finally
+            {
+                // restore the real OS version
+                s_fiVersionInfo.SetValue(null, s_realVersionInfo);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComponentModel/Com2Interop/Com2PropertyDescriptorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComponentModel/Com2Interop/Com2PropertyDescriptorTests.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using System.Text;
+using Xunit;
+
+namespace System.Windows.Forms.ComponentModel.Com2Interop.Tests
+{
+    public class Com2PropertyDescriptorTests
+    {
+        private static MethodInfo s_miVersionInfo;
+        private static Type s_typeCom2PropertyDescriptor;
+
+        static Com2PropertyDescriptorTests()
+        {
+            s_typeCom2PropertyDescriptor = typeof(Com2PropertyDescriptor);
+            s_miVersionInfo = s_typeCom2PropertyDescriptor.GetMethod("TrimNewline", BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.NotNull(s_miVersionInfo);
+        }
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("\r", "")]
+        [InlineData("\n", "")]
+        [InlineData("\r\r\r\r", "")]
+        [InlineData("\n\n\n\n", "")]
+        [InlineData("\r\r\n\n\r\n\r\n", "")]
+        [InlineData("bla bla bla", "bla bla bla")]
+        [InlineData("bla bla bla\r\r\r\r\r\n\n\r\n\r\n\r\n", "bla bla bla")]
+        [InlineData("bla bla bla\r\n\nr\n\r\n\r\n", "bla bla bla\r\n\nr")]
+        public void TrimNewline_should_remove_all_trailing_CR_LF(string message, string expected)
+        {
+            string result = (string)s_miVersionInfo.Invoke(null, new[] { new StringBuilder(message) });
+
+            Assert.Equal(expected, result);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->



## Proposed changes

- fix warning SA1408: Conditional expressions should declare precedence
As per docs `&&` operator has precedence over `||` and thus the following changes are to increase readability and make SCA happy. The code was correct, it could not have been interpreted any different. 
- `ScrollableControl.SetDisplayRectLocation` had an incorrect order of precedence by which a `ScrollWindowEx` message could get sent to the control even though the control did not have a valid handle.
Fixes #1955
- `COM2PropertyDescriptor.SetValue` had an incorrect order of precedence that would lead to IOORE if error info string was empty.
Extract the code in question in a standalone method so it could be tested. After the tests, the implementation is rewritten to reduce allocations.
An alternative and significantly shorter implementation is considered: `strMessage.ToString().TrimEnd('\r', '\n')` however uses significantly more memory, though it is slightly more performant.
    ```
    |      Method |       Mean |      Error |     StdDev | Ratio |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
    |------------ |-----------:|-----------:|-----------:|------:|-------:|-------:|------:|----------:|
    |    Original | 1,923.3 ns | 13.6586 ns | 12.1080 ns |  1.00 | 3.0899 | 0.0076 |     - |   19384 B |
    |    Proposed |   207.7 ns |  0.8548 ns |  0.7995 ns |  0.11 | 0.0725 |      - |     - |     456 B |
    |    Alt trim |   165.8 ns |  1.3424 ns |  1.1900 ns |  0.09 | 0.1631 | 0.0005 |     - |    1024 B |
    ```
*  `ComboBox.WndProc` appears to may have handled `WM_PRINTCLIENT` incorrectly in cases a combo had `FlatStyle.Popup` but with `UserPaint` style applied.
Fix the logic by handling `WM_PRINTCLIENT` message only if 
    * the control is painted by the system, and
    * the control has flat style set to `Flat` or `Popup`
* `SplitContainer.OnKeyDown`

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- We did not have any reported issues directly attributable to the updated code. 
The issue #1955 was found by @hughbe while developing unit tests. 
Other cases were discovered after [SCA SA1408 rule](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1408.md) was enabled.

## Regression? 

- No, it is likely the code had issues for a long time

## Risk

- Consumers who may have developed workarounds for the issues discovered may now be getting unexpected results.

<!-- end TELL-MODE -->



## Test methodology <!-- How did you ensure quality? -->

- manual
- CTI


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1985)