### PR TITLE
[Accessibility] Adding announcement for PropertyGrid ComboBox Expand and Collapse actions

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
@@ -1256,12 +1256,63 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             internal override bool IsPatternSupported(int patternId)
             {
-                if (patternId == NativeMethods.UIA_ValuePatternId)
+                if (patternId == NativeMethods.UIA_ValuePatternId ||
+                    (patternId == NativeMethods.UIA_ExpandCollapsePatternId && owner.Enumerable))
                 {
                     return true;
                 }
 
                 return base.IsPatternSupported(patternId);
+            }
+
+            internal override void Expand()
+            {
+                if (ExpandCollapseState == UnsafeNativeMethods.ExpandCollapseState.Collapsed)
+                {
+                    ExpandOrCollapse();
+                }
+            }
+
+            internal override void Collapse()
+            {
+                if (ExpandCollapseState == UnsafeNativeMethods.ExpandCollapseState.Expanded)
+                {
+                    ExpandOrCollapse();
+                }
+            }
+
+            private void ExpandOrCollapse()
+            {
+                var propertyGridView = GetPropertyGridView();
+                if (propertyGridView == null)
+                {
+                    return;
+                }
+
+                int row = propertyGridView.GetRowFromGridEntry(_owningPropertyDescriptorGridEntry);
+                if (row != -1)
+                {
+                    propertyGridView.PopupDialog(row);
+                }
+            }
+
+            internal override UnsafeNativeMethods.ExpandCollapseState ExpandCollapseState
+            {
+                get
+                {
+                    var propertyGridView = GetPropertyGridView();
+                    if (propertyGridView == null)
+                    {
+                        return UnsafeNativeMethods.ExpandCollapseState.Collapsed;
+                    }
+
+                    if (_owningPropertyDescriptorGridEntry == propertyGridView.SelectedGridEntry && propertyGridView.DropDownVisible)
+                    {
+                        return UnsafeNativeMethods.ExpandCollapseState.Expanded;
+                    }
+
+                    return UnsafeNativeMethods.ExpandCollapseState.Collapsed;
+                }
             }
 
             internal override object GetPropertyValue(int propertyID)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -1086,6 +1086,19 @@ namespace System.Windows.Forms.PropertyGridInternal
                             SelectRow(selectedRow);
                         }
                     }
+
+                    if (selectedRow != -1)
+                    {
+                        var gridEntry = GetGridEntryFromRow(selectedRow);
+                        if (gridEntry != null)
+                        {
+                            gridEntry.AccessibilityObject.RaiseAutomationEvent(NativeMethods.UIA_AutomationFocusChangedEventId);
+                            gridEntry.AccessibilityObject.RaiseAutomationPropertyChangedEvent(
+                                NativeMethods.UIA_ExpandCollapseExpandCollapseStatePropertyId,
+                                UnsafeNativeMethods.ExpandCollapseState.Expanded,
+                                UnsafeNativeMethods.ExpandCollapseState.Collapsed);
+                        }
+                    }
                 }
             }
             finally
@@ -1944,6 +1957,16 @@ namespace System.Windows.Forms.PropertyGridInternal
             dropDownHolder.FocusComponent();
             SelectEdit(false);
 
+            var gridEntry = GetGridEntryFromRow(selectedRow);
+            if (gridEntry != null)
+            {
+                gridEntry.AccessibilityObject.RaiseAutomationEvent(NativeMethods.UIA_AutomationFocusChangedEventId);
+                gridEntry.AccessibilityObject.RaiseAutomationPropertyChangedEvent(
+                    NativeMethods.UIA_ExpandCollapseExpandCollapseStatePropertyId,
+                    UnsafeNativeMethods.ExpandCollapseState.Collapsed,
+                    UnsafeNativeMethods.ExpandCollapseState.Expanded);
+            }
+
             try
             {
                 DropDownButton.IgnoreMouse = true;
@@ -2440,7 +2463,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             return rect;
         }
 
-        internal /*protected virtual*/ int GetRowFromGridEntry(GridEntry gridEntry)
+        internal int GetRowFromGridEntry(GridEntry gridEntry)
         {
             GridEntryCollection rgipesAll = GetAllGridEntries();
             if (gridEntry == null || rgipesAll == null)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1987

## Proposed changes

- Adding support for UI Automation ExpandCollapse pattern (added ExpandCollapse pattern provider) to PropertyDescriptorGridEntryAccessibleObject.
- Implementing Expand and Collapse action accessible UI and API via Expand and Collapse methods and via exposing ExpandCollapseState property.
- Refactoring accessible navigation methods to get parent PropertyGridView accessible object easier.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Visually impaired customers will be able to distinguish expanded and collapsed ComboBox within the PropertyGrid control.
- Narrator and NVDA accessibility cline apps will announce expand and collapse actions of PropertyGrid ComboBox and the state of ComboBox.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/23213980/65872691-d11eeb80-e389-11e9-8828-9a7d9c480ffa.png)


### After

![image](https://user-images.githubusercontent.com/23213980/65871952-2d810b80-e388-11e9-832e-0300ee0d2cea.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual testing with Screen readers.
- Automation testing (to be performed)
- Unit tests (to be implemented)

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->

- Verified with Accessibility Insights.
 

## Test environment(s) <!-- Remove any that don't apply -->

<!-- use `dotnet --info` -->

.NET Core SDK (reflecting any global.json):
 Version:   3.1.100-preview1-014044
 Commit:    dca04e7030

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.18362
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\3.1.100-preview1-014044\

Host (useful for support):
  Version: 3.1.0-preview1.19463.3
  Commit:  1e35b022cb

.NET Core SDKs installed:
  2.1.700-preview-009601 [C:\Program Files\dotnet\sdk]
  2.1.801 [C:\Program Files\dotnet\sdk]
  3.0.100-preview8-012929 [C:\Program Files\dotnet\sdk]
  3.0.100-preview9-014004 [C:\Program Files\dotnet\sdk]
  3.1.100-preview1-014044 [C:\Program Files\dotnet\sdk]

.NET Core runtimes installed:
  Microsoft.AspNetCore.All 2.1.9 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.All]
  Microsoft.AspNetCore.All 2.1.12 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.All]
  Microsoft.AspNetCore.App 2.1.9 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.AspNetCore.App 2.1.12 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.AspNetCore.App 3.0.0-preview8.19351.9 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.AspNetCore.App 3.0.0-preview9.19424.4 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.AspNetCore.App 3.0.0-rc2.19462.2 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 2.1.9 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 2.1.12 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 3.0.0-preview8-27907-09 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 3.0.0-preview9-19423-09 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 3.1.0-preview1.19463.3 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.WindowsDesktop.App 3.0.0-preview8-27907-09 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
  Microsoft.WindowsDesktop.App 3.0.0-preview9-19423-09 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
  Microsoft.WindowsDesktop.App 3.1.0-preview1.19463.3 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]

To install additional .NET Core runtimes or SDKs:
  https://aka.ms/dotnet-download

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1992)