### PR TITLE
Adding test for null for PropertyGridView's SelectedGridEntry

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
@@ -1180,16 +1180,26 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             private UnsafeNativeMethods.IRawElementProviderFragment GetFirstChild()
             {
+                if (_owningPropertyDescriptorGridEntry == null)
+                {
+                    return null;
+                }
+
                 if (_owningPropertyDescriptorGridEntry.ChildCount > 0)
                 {
                     return _owningPropertyDescriptorGridEntry.Children.GetEntry(0).AccessibilityObject;
                 }
 
-                var propertyGridViewAccessibleObject = (PropertyGridView.PropertyGridViewAccessibleObject)Parent;
-                var propertyGridView = propertyGridViewAccessibleObject.Owner as PropertyGridView;
-                if (_owningPropertyDescriptorGridEntry == propertyGridView.SelectedGridEntry)
+                var propertyGridView = GetPropertyGridView();
+                if (propertyGridView == null)
                 {
-                    if (propertyGridView.SelectedGridEntry.Enumerable)
+                    return null;
+                }
+
+                var selectedGridEntry = propertyGridView.SelectedGridEntry;
+                if (_owningPropertyDescriptorGridEntry == selectedGridEntry)
+                {
+                    if (selectedGridEntry.Enumerable)
                     {
                         return propertyGridView.DropDownListBoxAccessibleObject;
                     }
@@ -1202,17 +1212,27 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             private UnsafeNativeMethods.IRawElementProviderFragment GetLastChild()
             {
+                if (_owningPropertyDescriptorGridEntry == null)
+                {
+                    return null;
+                }
+
                 if (_owningPropertyDescriptorGridEntry.ChildCount > 0)
                 {
                     return _owningPropertyDescriptorGridEntry.Children
                         .GetEntry(_owningPropertyDescriptorGridEntry.ChildCount - 1).AccessibilityObject;
                 }
 
-                var propertyGridViewAccessibleObject = (PropertyGridView.PropertyGridViewAccessibleObject)Parent;
-                var propertyGridView = propertyGridViewAccessibleObject.Owner as PropertyGridView;
-                if (_owningPropertyDescriptorGridEntry == propertyGridView.SelectedGridEntry)
+                var propertyGridView = GetPropertyGridView();
+                if (propertyGridView == null)
                 {
-                    if (propertyGridView.SelectedGridEntry.Enumerable && propertyGridView.DropDownButton.Visible)
+                    return null;
+                }
+
+                var selectedGridEntry = propertyGridView.SelectedGridEntry;
+                if (_owningPropertyDescriptorGridEntry == selectedGridEntry)
+                {
+                    if (selectedGridEntry.Enumerable && propertyGridView.DropDownButton.Visible)
                     {
                         return propertyGridView.DropDownButton.AccessibilityObject;
                     }
@@ -1221,6 +1241,17 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
 
                 return null;
+            }
+
+            private PropertyGridView GetPropertyGridView()
+            {
+                var propertyGridViewAccessibleObject = Parent as PropertyGridView.PropertyGridViewAccessibleObject;
+                if (propertyGridViewAccessibleObject == null)
+                {
+                    return null;
+                }
+
+                return propertyGridViewAccessibleObject.Owner as PropertyGridView;
             }
 
             internal override bool IsPatternSupported(int patternId)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -235,7 +235,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return CanCopy && selectedGridEntry.IsTextEditable;
+                return CanCopy && selectedGridEntry != null && selectedGridEntry.IsTextEditable;
             }
         }
 
@@ -1355,7 +1355,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     Edit.Copy();
                 }
-                else
+                else if (selectedGridEntry != null)
                 {
                     Clipboard.SetDataObject(selectedGridEntry.GetPropertyTextValue());
                 }
@@ -3591,7 +3591,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                }
             */
 
-            if (selectedGridEntry.Enumerable &&
+            if (selectedGridEntry != null && selectedGridEntry.Enumerable &&
                 dropDownHolder != null && dropDownHolder.Visible &&
                 (keyCode == Keys.Up || keyCode == Keys.Down))
             {
@@ -6634,7 +6634,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 InstanceCreationEditor ice = e.Link.LinkData as InstanceCreationEditor;
 
                 Debug.Assert(ice != null, "How do we have a link without the InstanceCreationEditor?");
-                if (ice != null)
+                if (ice != null && gridView?.SelectedGridEntry != null)
                 {
                     Type createType = gridView.SelectedGridEntry.PropertyType;
                     if (createType != null)
@@ -7392,7 +7392,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             /// <returns>Returns the element in the specified direction.</returns>
             internal override UnsafeNativeMethods.IRawElementProviderFragment FragmentNavigate(UnsafeNativeMethods.NavigateDirection direction)
             {
-                if (direction == UnsafeNativeMethods.NavigateDirection.Parent)
+                if (direction == UnsafeNativeMethods.NavigateDirection.Parent && _owningPropertyGridView.SelectedGridEntry != null)
                 {
                     return _owningPropertyGridView.SelectedGridEntry.AccessibilityObject;
                 }
@@ -7789,7 +7789,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     {
                         case Keys.Return:
                             bool fwdReturn = !psheet.NeedsCommit;
-                            if (psheet.UnfocusSelection() && fwdReturn)
+                            if (psheet.UnfocusSelection() && fwdReturn && psheet.SelectedGridEntry != null)
                             {
                                 psheet.SelectedGridEntry.OnValueReturnKey();
                             }
@@ -7972,7 +7972,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 /// <returns>Returns the element in the specified direction.</returns>
                 internal override UnsafeNativeMethods.IRawElementProviderFragment FragmentNavigate(UnsafeNativeMethods.NavigateDirection direction)
                 {
-                    if (direction == UnsafeNativeMethods.NavigateDirection.Parent)
+                    if (direction == UnsafeNativeMethods.NavigateDirection.Parent && propertyGridView.SelectedGridEntry != null)
                     {
                         return propertyGridView.SelectedGridEntry.AccessibilityObject;
                     }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1986 


## Proposed changes

- Adding tests SelectedGridEntry property and selectedGridEntry field for null before accessing their properties.
- In some conditions (recreating PropertyGrid) slectedGridEntry may be null and accessing its property leads to NullReference exception. Added the tests where this is necessary.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Before the fix customers may experience application crash in case there are the conditions leading to accessing null-value selected grid entry (submitting new value to the field by enter-press)

## Regression? 

- No

## Risk

- None

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

App crash with the following stack:
Callsatcks:
```cs
  System.Windows.Forms.dll!System.Windows.Forms.PropertyGridInternal.PropertyGridView.GridViewEdit.ProcessDialogKey(System.Windows.Forms.Keys keyData) Unknown
  System.Windows.Forms.dll!System.Windows.Forms.PropertyGridInternal.PropertyGridView.GridViewEdit.OnKeyDown(System.Windows.Forms.KeyEventArgs ke) Unknown
  System.Windows.Forms.dll!System.Windows.Forms.Control.ProcessKeyEventArgs(ref System.Windows.Forms.Message m) Unknown
```

### After

No crash


## Test methodology <!-- How did you ensure quality? -->

- Manual testing.
- Automation tests (to be performed)
- Unit tests (to be implemented)

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

<!-- use `dotnet --info` -->
.NET Core SDK (reflecting any global.json):
Version: 3.1.100-preview1-014044
Commit: dca04e7030
Runtime Environment:
OS Name: Windows
OS Version: 10.0.18362
OS Platform: Windows
RID: win10-x64
Base Path: C:\Program Files\dotnet\sdk\3.1.100-preview1-014044\
Host (useful for support):
Version: 3.1.0-preview1.19463.3
Commit: 1e35b022cb
.NET Core SDKs installed:
2.1.700-preview-009601 [C:\Program Files\dotnet\sdk]
2.1.801 [C:\Program Files\dotnet\sdk]
3.0.100-preview8-012929 [C:\Program Files\dotnet\sdk]
3.0.100-preview9-014004 [C:\Program Files\dotnet\sdk]
3.1.100-preview1-014044 [C:\Program Files\dotnet\sdk]
.NET Core runtimes installed:
Microsoft.AspNetCore.All 2.1.9 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.All]
Microsoft.AspNetCore.All 2.1.12 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.All]
Microsoft.AspNetCore.App 2.1.9 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
Microsoft.AspNetCore.App 2.1.12 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
Microsoft.AspNetCore.App 3.0.0-preview8.19351.9 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
Microsoft.AspNetCore.App 3.0.0-preview9.19424.4 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
Microsoft.AspNetCore.App 3.0.0-rc2.19462.2 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
Microsoft.NETCore.App 2.1.9 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
Microsoft.NETCore.App 2.1.12 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
Microsoft.NETCore.App 3.0.0-preview8-27907-09 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
Microsoft.NETCore.App 3.0.0-preview9-19423-09 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
Microsoft.NETCore.App 3.1.0-preview1.19463.3 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
Microsoft.WindowsDesktop.App 3.0.0-preview8-27907-09 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
Microsoft.WindowsDesktop.App 3.0.0-preview9-19423-09 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
Microsoft.WindowsDesktop.App 3.1.0-preview1.19463.3 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/1994)