### PR TITLE
Scope `EnsureSerializableAttribute` tests to user-generated types

### DIFF
--- a/src/Common/tests/InternalUtilitiesForTests/src/BinarySerialization.cs
+++ b/src/Common/tests/InternalUtilitiesForTests/src/BinarySerialization.cs
@@ -4,7 +4,9 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization.Formatters;
 using System.Runtime.Serialization.Formatters.Binary;
 using Xunit;
@@ -13,21 +15,38 @@ namespace System
 {
     public static class BinarySerialization
     {
-        public static void EnsureSerializableAttribute(Assembly assemblyUnderTest, List<string> serializableTypes)
+        public static void EnsureSerializableAttribute(Assembly assemblyUnderTest, HashSet<string> serializableTypes)
         {
             foreach (Type type in assemblyUnderTest.GetTypes())
             {
-                var serializableAttribute = Attribute.GetCustomAttribute(type, typeof(SerializableAttribute));
+                var attributes = Attribute.GetCustomAttributes(type);
+
+                if (!attributes.Any(a => a is SerializableAttribute))
+                {
+                    // the type isn't marked as serialisable, verify it is not one of the types
+                    // that we expect to be serializable
+                    if (serializableTypes.Contains(type.FullName))
+                    {
+                        throw new NotSupportedException($"Serializable attribute is expected on {type.FullName}");
+                    }
+
+                    continue;
+                }
+
+                if (attributes.Any(a => a is CompilerGeneratedAttribute))
+                {
+                    // ignore compiler generated types, we have no control over them
+                    continue;
+                }
 
                 // Ensure SerializableAttribute is not added to any types not in the known list.
                 if (serializableTypes.Contains(type.FullName))
                 {
-                    Assert.NotNull(serializableAttribute);
+                    // we have marked the type as serialisable, all good
+                    continue;
                 }
-                else
-                {
-                    Assert.True(null == serializableAttribute, $"Serializable attribute is not expected on {type.FullName}");
-                }
+
+                throw new NotSupportedException($"Serializable attribute is not expected on {type.FullName}");
             }
         }
 

--- a/src/System.Windows.Forms.Design.Editors/tests/UnitTests/SerializableAttributeTest.cs
+++ b/src/System.Windows.Forms.Design.Editors/tests/UnitTests/SerializableAttributeTest.cs
@@ -15,7 +15,7 @@ namespace System.Windows.Forms.Design.Editors.Tests.Serialization
         {
             BinarySerialization.EnsureSerializableAttribute(
                 typeof(ArrayEditor).Assembly,
-                new List<string>
+                new HashSet<string>
                 {
                     // This Assembly does not have any serializable types.
                 });

--- a/src/System.Windows.Forms.Design/tests/UnitTests/SerializableAttributeTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/SerializableAttributeTests.cs
@@ -13,8 +13,8 @@ namespace System.Windows.Forms.Design.Tests.Serialization
         public void EnsureSerializableAttribute()
         {
             BinarySerialization.EnsureSerializableAttribute(
-                typeof(Behavior.Behavior).Assembly, 
-                new List<string>
+                typeof(Behavior.Behavior).Assembly,
+                new HashSet<string>
                 {
                     { "System.Windows.Forms.Design.Behavior.DesignerActionKeyboardBehavior+<>c"}
                 });

--- a/src/System.Windows.Forms/tests/UnitTests/SerializableAttributeTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/SerializableAttributeTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Resources;
 using Xunit;
 
 namespace System.Windows.Forms.Tests.Serialization
@@ -15,7 +14,7 @@ namespace System.Windows.Forms.Tests.Serialization
         {
             BinarySerialization.EnsureSerializableAttribute(
                 typeof(ListViewItem).Assembly,
-                new List<string>
+                new HashSet<string>
                 {
                     // This state is serialized to communicate to the native control
                     { typeof(AxHost.State).FullName},


### PR DESCRIPTION


## Proposed changes

As discovered in #1133, our tests checking types with `SerializableAttribute` were made a little too greedy and considered compiler-generated types.

Relax the tests to only verify no `SerializableAttribute` applied to user-generated types

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- None, tests related changes

<!-- end TELL-MODE -->

/cc: @kpreisser


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2000)