### PR TITLE
Cleanup ICategorizeProperties

### DIFF
--- a/src/Common/src/Interop/VSSDK/Interop.ICategorizeProperties.cs
+++ b/src/Common/src/Interop/VSSDK/Interop.ICategorizeProperties.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal static partial class VSSDK
+    {
+        [ComImport]
+        [Guid("4D07FC10-F931-11CE-B001-00AA006884E5")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        public unsafe interface ICategorizeProperties
+        {
+            [PreserveSig]
+            HRESULT MapPropertyToCategory(
+                Ole32.DispatchID dispid,
+                PROPCAT* ppropcat);
+
+            [PreserveSig]
+            HRESULT GetCategoryName(
+                PROPCAT propcat,
+                uint lcid,
+                out string pbstrName);
+        }
+    }
+}

--- a/src/Common/src/Interop/VSSDK/Interop.PROPCAT.cs
+++ b/src/Common/src/Interop/VSSDK/Interop.PROPCAT.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal partial class Interop
+{
+    internal static partial class VSSDK
+    {
+        public enum PROPCAT : int
+        {
+            Nil = unchecked((int)0xFFFFFFFF),
+            Misc = unchecked((int)0xFFFFFFFE),
+            Font = unchecked((int)0xFFFFFFFD),
+            Position = unchecked((int)0xFFFFFFFC),
+            Appearance = unchecked((int)0xFFFFFFFB),
+            Behavior = unchecked((int)0xFFFFFFFA),
+            Data = unchecked((int)0xFFFFFFF9),
+            List = unchecked((int)0xFFFFFFF8),
+            Text = unchecked((int)0xFFFFFFF7),
+            Scale = unchecked((int)0xFFFFFFF6),
+            DDE = unchecked((int)0xFFFFFFF5),
+        }
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -2070,24 +2070,6 @@ namespace System.Windows.Forms
 
         }
 
-        [ComImport]
-        [Guid("4D07FC10-F931-11CE-B001-00AA006884E5")]
-        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        public interface ICategorizeProperties
-        {
-            [PreserveSig]
-            HRESULT MapPropertyToCategory(
-                Ole32.DispatchID dispID,
-                ref int categoryID);
-
-            [PreserveSig]
-            int GetCategoryName(
-                int propcat,
-                [In, MarshalAs(UnmanagedType.U4)]
-                int lcid,
-                out string categoryName);
-        }
-
         [StructLayout(LayoutKind.Sequential)/*leftover(noAutoOffset)*/]
         public sealed class tagOLEVERB
         {
@@ -2981,17 +2963,6 @@ namespace System.Windows.Forms
             public const int QACONTAINER_AUTOCLIP = 0x20;
             public const int QACONTAINER_MESSAGEREFLECT = 0x40;
             public const int QACONTAINER_SUPPORTSMNEMONICS = 0x80;
-            public const int PROPCAT_Nil = unchecked((int)0xFFFFFFFF);
-            public const int PROPCAT_Misc = unchecked((int)0xFFFFFFFE);
-            public const int PROPCAT_Font = unchecked((int)0xFFFFFFFD);
-            public const int PROPCAT_Position = unchecked((int)0xFFFFFFFC);
-            public const int PROPCAT_Appearance = unchecked((int)0xFFFFFFFB);
-            public const int PROPCAT_Behavior = unchecked((int)0xFFFFFFFA);
-            public const int PROPCAT_Data = unchecked((int)0xFFFFFFF9);
-            public const int PROPCAT_List = unchecked((int)0xFFFFFFF8);
-            public const int PROPCAT_Text = unchecked((int)0xFFFFFFF7);
-            public const int PROPCAT_Scale = unchecked((int)0xFFFFFFF6);
-            public const int PROPCAT_DDE = unchecked((int)0xFFFFFFF5);
             public const int ALIGN_MIN = 0x0;
             public const int ALIGN_NO_CHANGE = 0x0;
             public const int ALIGN_TOP = 0x1;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -2597,41 +2597,37 @@ namespace System.Windows.Forms
                 return null;
             }
 
-            try
+            VSSDK.PROPCAT propcat = 0;
+            HRESULT hr = icp.MapPropertyToCategory(dispid, &propcat);
+            if (hr != HRESULT.S_OK || propcat == 0)
             {
-                VSSDK.PROPCAT propcat = 0;
-                HRESULT hr = icp.MapPropertyToCategory(dispid, &propcat);
-                if (propcat != 0)
+                return null;
+            }
+
+            int index = -(int)propcat;
+            if (index > 0 && index < categoryNames.Length && categoryNames[index] != null)
+            {
+                return categoryNames[index];
+            }
+
+            if (objectDefinedCategoryNames != null)
+            {
+                CategoryAttribute rval = (CategoryAttribute)objectDefinedCategoryNames[propcat];
+                if (rval != null)
                 {
-                    int index = -(int)propcat;
-                    if (index > 0 && index < categoryNames.Length && categoryNames[index] != null)
-                    {
-                        return categoryNames[index];
-                    }
-
-                    if (objectDefinedCategoryNames != null)
-                    {
-                        CategoryAttribute rval = (CategoryAttribute)objectDefinedCategoryNames[propcat];
-                        if (rval != null)
-                        {
-                            return rval;
-                        }
-                    }
-
-                    hr = icp.GetCategoryName(propcat, (uint)CultureInfo.CurrentCulture.LCID, out string name);
-                    if (hr == HRESULT.S_OK && name != null)
-                    {
-                        var rval = new CategoryAttribute(name);
-                        objectDefinedCategoryNames ??= new Hashtable();
-                        objectDefinedCategoryNames.Add(propcat, rval);
-                        return rval;
-                    }
+                    return rval;
                 }
             }
-            catch (Exception t)
+
+            hr = icp.GetCategoryName(propcat, (uint)CultureInfo.CurrentCulture.LCID, out string name);
+            if (hr == HRESULT.S_OK && name != null)
             {
-                Debug.Fail(t.ToString());
+                var rval = new CategoryAttribute(name);
+                objectDefinedCategoryNames ??= new Hashtable();
+                objectDefinedCategoryNames.Add(propcat, rval);
+                return rval;
             }
+
             return null;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ICategorizePropertiesHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ICategorizePropertiesHandler.cs
@@ -10,57 +10,49 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 {
     internal class Com2ICategorizePropertiesHandler : Com2ExtendedBrowsingHandler
     {
-        public override Type Interface
-        {
-            get
-            {
-                return typeof(NativeMethods.ICategorizeProperties);
-            }
-        }
+        public override Type Interface => typeof(VSSDK.ICategorizeProperties);
 
-        private string GetCategoryFromObject(object obj, Ole32.DispatchID dispid)
+        private unsafe string GetCategoryFromObject(object obj, Ole32.DispatchID dispid)
         {
             if (obj == null)
             {
                 return null;
             }
 
-            if (obj is NativeMethods.ICategorizeProperties catObj)
+            if (obj is VSSDK.ICategorizeProperties catObj)
             {
                 try
                 {
-                    int categoryID = 0;
-
-                    if (catObj.MapPropertyToCategory(dispid, ref categoryID) == HRESULT.S_OK)
+                    VSSDK.PROPCAT categoryID = 0;
+                    if (catObj.MapPropertyToCategory(dispid, &categoryID) == HRESULT.S_OK)
                     {
-
                         switch (categoryID)
                         {
-                            case NativeMethods.ActiveX.PROPCAT_Nil:
-                                return "";
-                            case NativeMethods.ActiveX.PROPCAT_Misc:
+                            case VSSDK.PROPCAT.Nil:
+                                return string.Empty;
+                            case VSSDK.PROPCAT.Misc:
                                 return SR.PropertyCategoryMisc;
-                            case NativeMethods.ActiveX.PROPCAT_Font:
+                            case VSSDK.PROPCAT.Font:
                                 return SR.PropertyCategoryFont;
-                            case NativeMethods.ActiveX.PROPCAT_Position:
+                            case VSSDK.PROPCAT.Position:
                                 return SR.PropertyCategoryPosition;
-                            case NativeMethods.ActiveX.PROPCAT_Appearance:
+                            case VSSDK.PROPCAT.Appearance:
                                 return SR.PropertyCategoryAppearance;
-                            case NativeMethods.ActiveX.PROPCAT_Behavior:
+                            case VSSDK.PROPCAT.Behavior:
                                 return SR.PropertyCategoryBehavior;
-                            case NativeMethods.ActiveX.PROPCAT_Data:
+                            case VSSDK.PROPCAT.Data:
                                 return SR.PropertyCategoryData;
-                            case NativeMethods.ActiveX.PROPCAT_List:
+                            case VSSDK.PROPCAT.List:
                                 return SR.PropertyCategoryList;
-                            case NativeMethods.ActiveX.PROPCAT_Text:
+                            case VSSDK.PROPCAT.Text:
                                 return SR.PropertyCategoryText;
-                            case NativeMethods.ActiveX.PROPCAT_Scale:
+                            case VSSDK.PROPCAT.Scale:
                                 return SR.PropertyCategoryScale;
-                            case NativeMethods.ActiveX.PROPCAT_DDE:
+                            case VSSDK.PROPCAT.DDE:
                                 return SR.PropertyCategoryDDE;
                         }
 
-                        if (NativeMethods.S_OK == catObj.GetCategoryName(categoryID, CultureInfo.CurrentCulture.LCID, out string categoryName))
+                        if (catObj.GetCategoryName(categoryID, (uint)CultureInfo.CurrentCulture.LCID, out string categoryName) == HRESULT.S_OK)
                         {
                             return categoryName;
                         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ICategorizePropertiesHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ICategorizePropertiesHandler.cs
@@ -14,54 +14,48 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
         private unsafe string GetCategoryFromObject(object obj, Ole32.DispatchID dispid)
         {
-            if (obj == null)
+            if (!(obj is VSSDK.ICategorizeProperties catObj))
             {
                 return null;
             }
 
-            if (obj is VSSDK.ICategorizeProperties catObj)
+            VSSDK.PROPCAT categoryID = 0;
+            if (catObj.MapPropertyToCategory(dispid, &categoryID) != HRESULT.S_OK)
             {
-                try
-                {
-                    VSSDK.PROPCAT categoryID = 0;
-                    if (catObj.MapPropertyToCategory(dispid, &categoryID) == HRESULT.S_OK)
-                    {
-                        switch (categoryID)
-                        {
-                            case VSSDK.PROPCAT.Nil:
-                                return string.Empty;
-                            case VSSDK.PROPCAT.Misc:
-                                return SR.PropertyCategoryMisc;
-                            case VSSDK.PROPCAT.Font:
-                                return SR.PropertyCategoryFont;
-                            case VSSDK.PROPCAT.Position:
-                                return SR.PropertyCategoryPosition;
-                            case VSSDK.PROPCAT.Appearance:
-                                return SR.PropertyCategoryAppearance;
-                            case VSSDK.PROPCAT.Behavior:
-                                return SR.PropertyCategoryBehavior;
-                            case VSSDK.PROPCAT.Data:
-                                return SR.PropertyCategoryData;
-                            case VSSDK.PROPCAT.List:
-                                return SR.PropertyCategoryList;
-                            case VSSDK.PROPCAT.Text:
-                                return SR.PropertyCategoryText;
-                            case VSSDK.PROPCAT.Scale:
-                                return SR.PropertyCategoryScale;
-                            case VSSDK.PROPCAT.DDE:
-                                return SR.PropertyCategoryDDE;
-                        }
-
-                        if (catObj.GetCategoryName(categoryID, (uint)CultureInfo.CurrentCulture.LCID, out string categoryName) == HRESULT.S_OK)
-                        {
-                            return categoryName;
-                        }
-                    }
-                }
-                catch
-                {
-                }
+                return null;
             }
+    
+            switch (categoryID)
+            {
+                case VSSDK.PROPCAT.Nil:
+                    return string.Empty;
+                case VSSDK.PROPCAT.Misc:
+                    return SR.PropertyCategoryMisc;
+                case VSSDK.PROPCAT.Font:
+                    return SR.PropertyCategoryFont;
+                case VSSDK.PROPCAT.Position:
+                    return SR.PropertyCategoryPosition;
+                case VSSDK.PROPCAT.Appearance:
+                    return SR.PropertyCategoryAppearance;
+                case VSSDK.PROPCAT.Behavior:
+                    return SR.PropertyCategoryBehavior;
+                case VSSDK.PROPCAT.Data:
+                    return SR.PropertyCategoryData;
+                case VSSDK.PROPCAT.List:
+                    return SR.PropertyCategoryList;
+                case VSSDK.PROPCAT.Text:
+                    return SR.PropertyCategoryText;
+                case VSSDK.PROPCAT.Scale:
+                    return SR.PropertyCategoryScale;
+                case VSSDK.PROPCAT.DDE:
+                    return SR.PropertyCategoryDDE;
+            }
+
+            if (catObj.GetCategoryName(categoryID, (uint)CultureInfo.CurrentCulture.LCID, out string categoryName) == HRESULT.S_OK)
+            {
+                return categoryName;
+            }
+
             return null;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2Properties.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2Properties.cs
@@ -62,12 +62,14 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// <summary>
         ///  These are the interfaces we recognize for extended browsing.
         /// </summary>
-        private static readonly Type[] extendedInterfaces = new Type[]{
-                                                        typeof(NativeMethods.ICategorizeProperties),
-                                                        typeof(NativeMethods.IProvidePropertyBuilder),
-                                                        typeof(Ole32.IPerPropertyBrowsing),
-                                                        typeof(NativeMethods.IVsPerPropertyBrowsing),
-                                                        typeof(NativeMethods.IManagedPerPropertyBrowsing)};
+        private static readonly Type[] extendedInterfaces = new Type[]
+        {
+            typeof(VSSDK.ICategorizeProperties),
+            typeof(NativeMethods.IProvidePropertyBuilder),
+            typeof(Ole32.IPerPropertyBrowsing),
+            typeof(NativeMethods.IVsPerPropertyBrowsing),
+            typeof(NativeMethods.IManagedPerPropertyBrowsing)
+        };
 
         /// <summary>
         ///  These are the classes of handlers corresponding to the extended


### PR DESCRIPTION
## Proposed Changes
- Cleanup ICategorizeProperties to match interop standards
- Remove catch blocks from these interop code as 1) they are bad code smell and 2) they are not necessary as the interface methods are `PreserveSig` and should not throw

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2022)