### PR TITLE
Cleanup GetDoubleClickTime

### DIFF
--- a/src/Common/src/Interop/User32/Interop.GetDoubleClickTime.cs
+++ b/src/Common/src/Interop/User32/Interop.GetDoubleClickTime.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern uint GetDoubleClickTime();
+    }
+}

--- a/src/Common/src/SafeNativeMethods.cs
+++ b/src/Common/src/SafeNativeMethods.cs
@@ -246,9 +246,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.User32, ExactSpelling = true)]
         public static extern bool GetClientRect(HandleRef hWnd, ref RECT rect);
 
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern int GetDoubleClickTime();
-
         [DllImport(ExternDll.User32, ExactSpelling = true)]
         public static extern bool ValidateRect(HandleRef hWnd, ref RECT rect);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SystemInformation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SystemInformation.cs
@@ -347,7 +347,7 @@ namespace System.Windows.Forms
         ///  Gets the maximum number of milliseconds allowed between mouse clicks for a
         ///  double-click.
         /// </summary>
-        public static int DoubleClickTime => SafeNativeMethods.GetDoubleClickTime();
+        public static int DoubleClickTime => unchecked((int)User32.GetDoubleClickTime());
 
         /// <summary>
         ///  Gets the dimensions in pixels, of the grid used to arrange icons in a large


### PR DESCRIPTION
## Proposed Changes
- Cleanup GetDoubleClickTime and correct interop definition to be uint not int

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2025)