### PR TITLE
Cleanup ComputerName and UserName interop

### DIFF
--- a/src/Common/src/ExternDll.cs
+++ b/src/Common/src/ExternDll.cs
@@ -7,7 +7,6 @@ namespace System
     internal static class ExternDll
     {
         public const string Activeds = "activeds.dll";
-        public const string Advapi32 = "advapi32.dll";
         public const string Comctl32 = "comctl32.dll";
         public const string Comdlg32 = "comdlg32.dll";
         public const string Gdi32 = "gdi32.dll";

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -445,12 +445,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
         public static extern IntPtr DefMDIChildProc(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
 
-        [DllImport(ExternDll.Kernel32, CharSet = CharSet.Auto)]
-        public static extern bool GetComputerName(StringBuilder lpBuffer, int[] nSize);
-
-        [DllImport(ExternDll.Advapi32, CharSet = CharSet.Auto)]
-        public static extern bool GetUserName(StringBuilder lpBuffer, int[] nSize);
-
         [DllImport(ExternDll.User32, ExactSpelling = true)]
         public static extern IntPtr GetProcessWindowStation();
 

--- a/src/System.Windows.Forms.Design.Editors/src/Misc/ExternDll.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/Misc/ExternDll.cs
@@ -36,7 +36,6 @@ namespace System
 
 #else
         public const string Activeds = "activeds.dll";
-        public const string Advapi32 = "advapi32.dll";
         public const string Comctl32 = "comctl32.dll";
         public const string Comdlg32 = "comdlg32.dll";
         public const string Gdi32 = "gdi32.dll";

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SystemInformation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SystemInformation.cs
@@ -619,15 +619,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Gets the computer name of the current system.
         /// </summary>
-        public static string ComputerName
-        {
-            get
-            {
-                var sb = new StringBuilder(256);
-                UnsafeNativeMethods.GetComputerName(sb, new int[] { sb.Capacity });
-                return sb.ToString();
-            }
-        }
+        public static string ComputerName => Environment.MachineName;
 
         /// <summary>
         ///  Gets the user's domain name.
@@ -669,15 +661,7 @@ namespace System.Windows.Forms
         ///  Gets the user name for the current thread, that is, the name of the user currently logged onto
         ///  the system.
         /// </summary>
-        public static string UserName
-        {
-            get
-            {
-                var sb = new StringBuilder(256);
-                UnsafeNativeMethods.GetUserName(sb, new int[] { sb.Capacity });
-                return sb.ToString();
-            }
-        }
+        public static string UserName => Environment.UserName;
 
         private static void EnsureSystemEvents()
         {


### PR DESCRIPTION
## Proposed Changes
- Cleanup GetComputerName and make unicode
- Cleanup GetUserName and make unicode

## Test Methodology
Existing tests
```cs
        [Fact]
        public void SystemInformation_ComputerName_Get_ReturnsExpected()
        {
            string name = SystemInformation.ComputerName;
            Assert.InRange(name.Length, 1, 256);
            Assert.Equal(name, name.Trim('\0'));
            Assert.Equal(name, SystemInformation.ComputerName);
        }

        [Fact]
        public void SystemInformation_UserName_Get_ReturnsExpected()
        {
            string name = SystemInformation.UserName;
            Assert.InRange(name.Length, 1, 256);
            Assert.Equal(name, name.Trim('\0'));
            Assert.Equal(name, SystemInformation.UserName);
        }
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2027)