### PR TITLE
Remove new HandleRef(null, ...) usage in Control.PrintToMetaFile

### DIFF
--- a/src/Common/src/SafeNativeMethods.cs
+++ b/src/Common/src/SafeNativeMethods.cs
@@ -24,7 +24,7 @@ namespace System.Windows.Forms
         public static extern int GetDIBits(IntPtr hdc, IntPtr hbm, int uStartScan, int cScanLines, byte[] lpvBits, ref NativeMethods.BITMAPINFO_FLAT bmi, int uUsage);
 
         [DllImport(ExternDll.Gdi32)]
-        public static extern int StretchDIBits(HandleRef hdc, int XDest, int YDest, int nDestWidth, int nDestHeight, int XSrc, int YSrc, int nSrcWidth, int nSrcHeight, byte[] lpBits, ref NativeMethods.BITMAPINFO_FLAT lpBitsInfo, int iUsage, int dwRop);
+        public static extern int StretchDIBits(IntPtr hdc, int XDest, int YDest, int nDestWidth, int nDestHeight, int XSrc, int YSrc, int nSrcWidth, int nSrcHeight, byte[] lpBits, ref NativeMethods.BITMAPINFO_FLAT lpBitsInfo, int iUsage, int dwRop);
 
         [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true)]
         public static extern IntPtr CreateCompatibleBitmap(HandleRef hDC, int width, int height);
@@ -162,10 +162,10 @@ namespace System.Windows.Forms
         public static unsafe extern bool SetWindowOrgEx(IntPtr hdc, int x, int y, Point *lppt);
 
         [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern bool GetViewportOrgEx(HandleRef hdc, out Point lppoint);
+        public static extern bool GetViewportOrgEx(IntPtr hdc, out Point lppoint);
 
         [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern int SetMapMode(HandleRef hDC, int nMapMode);
+        public static extern int SetMapMode(IntPtr hDC, int nMapMode);
 
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern bool IsWindowEnabled(HandleRef hWnd);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -480,7 +480,7 @@ namespace System.Windows.Forms
                     // use.
                     SafeNativeMethods.LPtoDP(new HandleRef(null, hdcDraw), ref rc, 2);
 
-                    iMode = SafeNativeMethods.SetMapMode(new HandleRef(null, hdcDraw), NativeMethods.MM_ANISOTROPIC);
+                    iMode = SafeNativeMethods.SetMapMode(hdcDraw, NativeMethods.MM_ANISOTROPIC);
                     SafeNativeMethods.SetWindowOrgEx(hdcDraw, 0, 0, &pW);
                     SafeNativeMethods.SetWindowExtEx(hdcDraw, _control.Width, _control.Height, &sWindowExt);
                     SafeNativeMethods.SetViewportOrgEx(hdcDraw, rc.left, rc.top, &pVp);
@@ -501,7 +501,7 @@ namespace System.Windows.Forms
                     }
                     else
                     {
-                        _control.PrintToMetaFile(new HandleRef(null, hdcDraw), flags);
+                        _control.PrintToMetaFile(hdcDraw, flags);
                     }
                 }
                 finally
@@ -513,7 +513,7 @@ namespace System.Windows.Forms
                         SafeNativeMethods.SetWindowExtEx(hdcDraw, sWindowExt.Width, sWindowExt.Height, null);
                         SafeNativeMethods.SetViewportOrgEx(hdcDraw, pVp.X, pVp.Y, null);
                         SafeNativeMethods.SetViewportExtEx(hdcDraw, sViewportExt.Width, sViewportExt.Height, null);
-                        SafeNativeMethods.SetMapMode(new HandleRef(null, hdcDraw), iMode);
+                        SafeNativeMethods.SetMapMode(hdcDraw, iMode);
                     }
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.MetafileDCWrapper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.MetafileDCWrapper.cs
@@ -26,10 +26,10 @@ namespace System.Windows.Forms
         {
             private IntPtr _hBitmap = IntPtr.Zero;
             private IntPtr _hOriginalBmp = IntPtr.Zero;
-            private readonly HandleRef _hMetafileDC;
+            private readonly IntPtr _hMetafileDC;
             private RECT _destRect;
 
-            internal MetafileDCWrapper(HandleRef hOriginalDC, Size size)
+            internal MetafileDCWrapper(IntPtr hOriginalDC, Size size)
             {
                 Debug.Assert(Gdi32.GetObjectType(hOriginalDC) == Gdi32.ObjectType.OBJ_ENHMETADC,
                     "Why wrap a non-Enhanced MetaFile DC?");
@@ -56,7 +56,7 @@ namespace System.Windows.Forms
 
             void IDisposable.Dispose()
             {
-                if (HDC == IntPtr.Zero || _hMetafileDC.Handle == IntPtr.Zero || _hBitmap == IntPtr.Zero)
+                if (HDC == IntPtr.Zero || _hMetafileDC == IntPtr.Zero || _hBitmap == IntPtr.Zero)
                 {
                     return;
                 }
@@ -87,7 +87,7 @@ namespace System.Windows.Forms
             internal IntPtr HDC { get; private set; } = IntPtr.Zero;
 
             // ported form VB6 (Ctls\PortUtil\StdCtl.cpp:6176)
-            private unsafe bool DICopy(HandleRef hdcDest, IntPtr hdcSrc, RECT rect, bool bStretch)
+            private unsafe bool DICopy(IntPtr hdcDest, IntPtr hdcSrc, RECT rect, bool bStretch)
             {
                 long i;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -9368,7 +9368,7 @@ namespace System.Windows.Forms
             return false;
         }
 
-        private void PrintToMetaFile(HandleRef hDC, IntPtr lParam)
+        private void PrintToMetaFile(IntPtr hDC, IntPtr lParam)
         {
             Debug.Assert(Gdi32.GetObjectType(hDC) == Gdi32.ObjectType.OBJ_ENHMETADC,
                 "PrintToMetaFile() called with a non-Enhanced MetaFile DC.");
@@ -9403,7 +9403,7 @@ namespace System.Windows.Forms
             }
         }
 
-        internal virtual void PrintToMetaFileRecursive(HandleRef hDC, IntPtr lParam, Rectangle bounds)
+        private protected virtual void PrintToMetaFileRecursive(IntPtr hDC, IntPtr lParam, Rectangle bounds)
         {
             // We assume the target does not want us to offset the root control in the metafile.
 
@@ -9439,12 +9439,12 @@ namespace System.Windows.Forms
             }
         }
 
-        private void PrintToMetaFile_SendPrintMessage(HandleRef hDC, IntPtr lParam)
+        private void PrintToMetaFile_SendPrintMessage(IntPtr hDC, IntPtr lParam)
         {
             if (GetStyle(ControlStyles.UserPaint))
             {
                 // We let user paint controls paint directly into the metafile
-                SendMessage(WindowMessages.WM_PRINT, hDC.Handle, lParam);
+                SendMessage(WindowMessages.WM_PRINT, hDC, lParam);
             }
             else
             {
@@ -9460,10 +9460,8 @@ namespace System.Windows.Forms
                 // System controls must be painted into a temporary bitmap
                 // which is then copied into the metafile.  (Old GDI line drawing
                 // is 1px thin, which causes borders to disappear, etc.)
-                using (MetafileDCWrapper dcWrapper = new MetafileDCWrapper(hDC, Size))
-                {
-                    SendMessage(WindowMessages.WM_PRINT, dcWrapper.HDC, lParam);
-                }
+                using MetafileDCWrapper dcWrapper = new MetafileDCWrapper(hDC, Size);
+                SendMessage(WindowMessages.WM_PRINT, dcWrapper.HDC, lParam);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
@@ -1593,17 +1593,13 @@ namespace System.Windows.Forms
             Animate();
         }
 
-        internal override void PrintToMetaFileRecursive(HandleRef hDC, IntPtr lParam, Rectangle bounds)
+        private protected override void PrintToMetaFileRecursive(IntPtr hDC, IntPtr lParam, Rectangle bounds)
         {
             base.PrintToMetaFileRecursive(hDC, lParam, bounds);
 
-            using (WindowsFormsUtils.DCMapping mapping = new WindowsFormsUtils.DCMapping(hDC, bounds))
-            {
-                using (Graphics g = Graphics.FromHdcInternal(hDC.Handle))
-                {
-                    ControlPaint.PrintBorder(g, new Rectangle(Point.Empty, Size), BorderStyle, Border3DStyle.SunkenOuter);
-                }
-            }
+            using var mapping = new WindowsFormsUtils.DCMapping(hDC, bounds);
+            using Graphics g = Graphics.FromHdcInternal(hDC);
+            ControlPaint.PrintBorder(g, new Rectangle(Point.Empty, Size), BorderStyle, Border3DStyle.SunkenOuter);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Panel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Panel.cs
@@ -226,17 +226,13 @@ namespace System.Windows.Forms
             base.OnResize(eventargs);
         }
 
-        internal override void PrintToMetaFileRecursive(HandleRef hDC, IntPtr lParam, Rectangle bounds)
+        private protected override void PrintToMetaFileRecursive(IntPtr hDC, IntPtr lParam, Rectangle bounds)
         {
             base.PrintToMetaFileRecursive(hDC, lParam, bounds);
 
-            using (WindowsFormsUtils.DCMapping mapping = new WindowsFormsUtils.DCMapping(hDC, bounds))
-            {
-                using (Graphics g = Graphics.FromHdcInternal(hDC.Handle))
-                {
-                    ControlPaint.PrintBorder(g, new Rectangle(Point.Empty, Size), BorderStyle, Border3DStyle.Sunken);
-                }
-            }
+            using var mapping = new WindowsFormsUtils.DCMapping(hDC, bounds);
+            using Graphics g = Graphics.FromHdcInternal(hDC);
+            ControlPaint.PrintBorder(g, new Rectangle(Point.Empty, Size), BorderStyle, Border3DStyle.Sunken);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -3079,7 +3079,7 @@ namespace System.Windows.Forms
 
         // This function will print to the PrinterDC. ToolStrip have there own buffered painting and doesnt play very well
         // with the DC translations done by base Control class. Hence we do our own Painting and the BitBLT the DC into the printerDc.
-        internal override void PrintToMetaFileRecursive(HandleRef hDC, IntPtr lParam, Rectangle bounds)
+        private protected override void PrintToMetaFileRecursive(IntPtr hDC, IntPtr lParam, Rectangle bounds)
         {
             using (Bitmap image = new Bitmap(bounds.Width, bounds.Height))
             using (Graphics g = Graphics.FromImage(image))
@@ -3090,8 +3090,7 @@ namespace System.Windows.Forms
                     (IntPtr)(NativeMethods.PRF_CHILDREN | NativeMethods.PRF_CLIENT | NativeMethods.PRF_ERASEBKGND | NativeMethods.PRF_NONCLIENT));
 
                 //now BLT the result to the destination bitmap.
-                IntPtr desthDC = hDC.Handle;
-                SafeNativeMethods.BitBlt(new HandleRef(this, desthDC), bounds.X, bounds.Y, bounds.Width, bounds.Height,
+                SafeNativeMethods.BitBlt(new HandleRef(this, hDC), bounds.X, bounds.Y, bounds.Width, bounds.Height,
                                              new HandleRef(g, imageHdc), 0, 0, NativeMethods.SRCCOPY);
                 g.ReleaseHdcInternal(imageHdc);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WinFormsUtils.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WinFormsUtils.cs
@@ -558,7 +558,7 @@ namespace System.Windows.Forms
         ///  mapping.Graphics.DrawRectangle(Pens.Black, rect);
         ///  }
         ///  }
-        ///  finally { g.ReleaseHdc(hDC.Handle);}
+        ///  finally { g.ReleaseHdc(hDC);}
         ///
         ///  PERF: DCMapping is a structure so that it will allocate on the stack rather than in GC managed
         ///  memory. This way disposing the object does not force a GC. Since DCMapping objects aren't
@@ -571,9 +571,9 @@ namespace System.Windows.Forms
             private Graphics _graphics;
             private Rectangle _translatedBounds;
 
-            public unsafe DCMapping(HandleRef hDC, Rectangle bounds)
+            public unsafe DCMapping(IntPtr hDC, Rectangle bounds)
             {
-                if (hDC.Handle == IntPtr.Zero)
+                if (hDC == IntPtr.Zero)
                 {
                     throw new ArgumentNullException(nameof(hDC));
                 }
@@ -583,7 +583,7 @@ namespace System.Windows.Forms
 
                 _translatedBounds = bounds;
                 _graphics = null;
-                _dc = DeviceContext.FromHdc(hDC.Handle);
+                _dc = DeviceContext.FromHdc(hDC);
                 _dc.SaveHdc();
 
                 // Retrieve the x-coordinates and y-coordinates of the viewport origin for the specified device context.


### PR DESCRIPTION
## Proposed Changes
- Remove new HandleRef(null, ...) usage in Control.PrintToMetaFile
- Update dependencies to use IntPtr instead of HandleRef because a `new HandleRef(null, HDC)` has the same meaning as `HDC`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2028)