### PR TITLE
Cleanup IAutoComplete2

### DIFF
--- a/src/Common/src/Interop/Shell32/Interop.AUTOCOMPLETEOPTIONS.cs
+++ b/src/Common/src/Interop/Shell32/Interop.AUTOCOMPLETEOPTIONS.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class Shell32
+    {
+        [Flags]
+        public enum AUTOCOMPLETEOPTIONS : uint
+        {
+            NONE = 0x00,
+            AUTOSUGGEST = 0x01,
+            AUTOAPPEND = 0x02,
+            SEARCH = 0x04,
+            FILTERPREFIXES = 0x08,
+            USETAB = 0x10,
+            UPDOWNKEYDROPSLIST = 0x20,
+            RTLREADING = 0x40,
+            WORD_FILTER = 0x80,
+            NOPREFIXFILTERING = 0x100,
+        }
+    }
+}

--- a/src/Common/src/Interop/Shell32/Interop.IAutoComplete2.cs
+++ b/src/Common/src/Interop/Shell32/Interop.IAutoComplete2.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+
+internal static partial class Interop
+{
+    internal static partial class Shell32
+    {
+        [ComImport]
+        [Guid("EAC04BC0-3791-11d2-BB95-0060977B464C")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        public unsafe interface IAutoComplete2
+        {
+            [PreserveSig]
+            HRESULT Init(
+                IntPtr hwndEdit,
+                IEnumString punkACL,
+                [MarshalAs(UnmanagedType.LPWStr)] string pwszRegKeyPath,
+                [MarshalAs(UnmanagedType.LPWStr)] string pwszQuickComplete);
+
+            [PreserveSig]
+            HRESULT Enable(
+                BOOL fEnable);
+
+            [PreserveSig]
+            HRESULT SetOptions(
+                AUTOCOMPLETEOPTIONS dwFlag);
+
+            [PreserveSig]
+            HRESULT GetOptions(
+                AUTOCOMPLETEOPTIONS* pdwFlag);
+        }
+    }
+}

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -1818,23 +1818,6 @@ namespace System.Windows.Forms
                out IEnumOLEVERB ppenum);
         }
 
-        [ComImport(), Guid("EAC04BC0-3791-11d2-BB95-0060977B464C"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        public interface IAutoComplete2
-        {
-            int Init(
-                    [In] HandleRef hwndEdit,          // hwnd of editbox or editbox deriviative.
-                    [In] IEnumString punkACL,          // Pointer to object containing string to complete from. (IEnumString *)
-                    [In] string pwszRegKeyPath,       //
-                    [In] string pwszQuickComplete
-                    );
-
-            void Enable([In] bool fEnable);            // Is it enabled?
-
-            int SetOptions([In] int dwFlag);
-
-            void GetOptions([Out] IntPtr pdwFlag);
-        }
-
         public abstract class CharBuffer
         {
             public static CharBuffer CreateBuffer(int size)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AutoCompleteMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AutoCompleteMode.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using static Interop;
+
 namespace System.Windows.Forms
 {
     /// <summary>
@@ -12,19 +14,19 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Disables the AutoComplete Feature for ComboBox and TextBox.
         /// </summary>
-        None = 0,
+        None = (int)Shell32.AUTOCOMPLETEOPTIONS.NONE,
 
         /// <summary>
         ///  Displays the auxiliary drop-down list associated with the edit control,
         ///  this drop-down is populated with one or more suggested completed strings.
         /// </summary>
-        Suggest = 0x1,
+        Suggest = (int)Shell32.AUTOCOMPLETEOPTIONS.AUTOSUGGEST,
 
         /// <summary>
         ///  Appends the remainder of the most likely candidate string to the existing
         ///  characters, hightlighting the appended characters.
         /// </summary>
-        Append = 0x2,
+        Append = (int)Shell32.AUTOCOMPLETEOPTIONS.AUTOAPPEND,
 
         /// <summary>
         ///  The AutoSuggest and AutoAppend are applied in conjuction.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -3324,7 +3324,7 @@ namespace System.Windows.Forms
                             if (stringSource == null)
                             {
                                 stringSource = new StringSource(GetStringsForAutoComplete(AutoCompleteCustomSource));
-                                if (!stringSource.Bind(new HandleRef(this, childEdit.Handle), (int)AutoCompleteMode))
+                                if (!stringSource.Bind(new HandleRef(this, childEdit.Handle), (Shell32.AUTOCOMPLETEOPTIONS)AutoCompleteMode))
                                 {
                                     throw new ArgumentException(SR.AutoCompleteFailure);
                                 }
@@ -3353,7 +3353,7 @@ namespace System.Windows.Forms
                                 if (stringSource == null)
                                 {
                                     stringSource = new StringSource(GetStringsForAutoComplete(Items));
-                                    if (!stringSource.Bind(new HandleRef(this, childEdit.Handle), (int)AutoCompleteMode))
+                                    if (!stringSource.Bind(new HandleRef(this, childEdit.Handle), (Shell32.AUTOCOMPLETEOPTIONS)AutoCompleteMode))
                                     {
                                         throw new ArgumentException(SR.AutoCompleteFailureListItems);
                                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
@@ -775,7 +775,7 @@ namespace System.Windows.Forms
                             if (stringSource == null)
                             {
                                 stringSource = new StringSource(GetStringsForAutoComplete());
-                                if (!stringSource.Bind(new HandleRef(this, Handle), (int)AutoCompleteMode))
+                                if (!stringSource.Bind(new HandleRef(this, Handle), (Shell32.AUTOCOMPLETEOPTIONS)AutoCompleteMode))
                                 {
                                     throw new ArgumentException(SR.AutoCompleteFailure);
                                 }


### PR DESCRIPTION
## Proposed Changes
- Cleanup IAutoComplete2 interface
- Harden against invalid pointers
- Check HRESULTs rather than catch throwing PInvokes

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2031)