### PR TITLE
Cleanup Hook functions

### DIFF
--- a/src/Common/src/Interop/User32/Interop.CallNextHookEx.cs
+++ b/src/Common/src/Interop/User32/Interop.CallNextHookEx.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern IntPtr CallNextHookEx(IntPtr hhook, User32.HC nCode, IntPtr wparam, IntPtr lparam);
+
+        public static IntPtr CallNextHookEx(HandleRef hhook, User32.HC nCode, IntPtr wparam, IntPtr lparam)
+        {
+            IntPtr result = CallNextHookEx(hhook.Handle, nCode, wparam, lparam);
+            GC.KeepAlive(hhook.Wrapper);
+            return result;
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.HC.cs
+++ b/src/Common/src/Interop/User32/Interop.HC.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public enum HC : int
+        {
+            ACTION = 0,
+            GETNEXT = 1,
+            SKIP = 2,
+            NOREMOVE = 3,
+            NOREM = NOREMOVE,
+            SYSMODALON = 4,
+            SYSMODALOFF = 5,
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.HOOKPROC.cs
+++ b/src/Common/src/Interop/User32/Interop.HOOKPROC.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public delegate IntPtr HOOKPROC(User32.HC nCode, IntPtr wParam, IntPtr lParam);
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.SetWindowsHookExW.cs
+++ b/src/Common/src/Interop/User32/Interop.SetWindowsHookExW.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
+        public static extern IntPtr SetWindowsHookExW(WH idHook, HOOKPROC lpfn, IntPtr hmod, uint dwThreadId);
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.UnhookWindowsHookEx.cs
+++ b/src/Common/src/Interop/User32/Interop.UnhookWindowsHookEx.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
+        public static extern BOOL UnhookWindowsHookEx(IntPtr hhk);
+
+        public static BOOL UnhookWindowsHookEx(HandleRef hhk)
+        {
+            BOOL result = UnhookWindowsHookEx(hhk.Handle);
+            GC.KeepAlive(hhk.Wrapper);
+            return result;
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.WH.cs
+++ b/src/Common/src/Interop/User32/Interop.WH.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public enum WH : int
+        {
+            MSGFILTER = -1,
+            JOURNALRECORD = 0,
+            JOURNALPLAYBACK = 1,
+            KEYBOARD = 2,
+            GETMESSAGE = 3,
+            CALLWNDPROC = 4,
+            CBT = 5,
+            SYSMSGFILTER = 6,
+            MOUSE = 7,
+            HARDWARE = 8,
+            DEBUG = 9,
+            SHELL = 10,
+            FOREGROUNDIDLE = 11,
+            CALLWNDPROCRET = 12,
+            KEYBOARD_LL = 13,
+            MOUSE_LL = 14,
+        }
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -399,9 +399,6 @@ namespace System.Windows.Forms
         CPS_CANCEL = 0x04;
 
         public const int
-        HC_ACTION = 0,
-        HC_GETNEXT = 1,
-        HC_SKIP = 2,
         HTTRANSPARENT = (-1),
         HTNOWHERE = 0,
         HTCLIENT = 1,
@@ -1163,9 +1160,6 @@ namespace System.Windows.Forms
 
         public const int VIEW_E_DRAW = unchecked((int)0x80040140);
 
-        public const int WH_JOURNALPLAYBACK = 1;
-        public const int WH_GETMESSAGE = 3;
-        public const int WH_MOUSE = 7;
         public const int WSF_VISIBLE = 0x0001;
 
         public const int WA_INACTIVE = 0;
@@ -1849,8 +1843,6 @@ namespace System.Windows.Forms
             public WndProc lpfnHook;
             public string lpTemplateName = null;
         }
-
-        public delegate IntPtr HookProc(int nCode, IntPtr wParam, IntPtr lParam);
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
         public class NOTIFYICONDATA

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -155,9 +155,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.Kernel32, ExactSpelling = true, EntryPoint = "RtlMoveMemory", CharSet = CharSet.Unicode)]
         public static extern void CopyMemoryW(IntPtr pdst, char[] psrc, int cb);
 
-        [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-        public static extern IntPtr SetWindowsHookEx(int idHook, NativeMethods.HookProc lpfn, IntPtr hmod, uint dwThreadId);
-
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern int GetKeyboardState(byte[] keystate);
 
@@ -165,13 +162,7 @@ namespace System.Windows.Forms
         public static extern int SetKeyboardState(byte[] keystate);
 
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern bool UnhookWindowsHookEx(HandleRef hhook);
-
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern short GetAsyncKeyState(int vkey);
-
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern IntPtr CallNextHookEx(HandleRef hhook, int code, IntPtr wparam, IntPtr lparam);
 
         [DllImport(ExternDll.Kernel32, CharSet = CharSet.Auto, SetLastError = true)]
         public static extern int GetModuleFileName(HandleRef hModule, StringBuilder buffer, int length);

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -97,6 +97,7 @@
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.STGTY.cs" Link="Interop\Ole32\Interop.STGTY.cs" />
     <Compile Include="..\..\Common\src\Interop\Richedit\Interop.CHARRANGE.cs" Link="Interop\Richedit\Interop.CHARRANGE.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.BeginPaint.cs" Link="Interop\User32\Interop.BeginPaint.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.CallNextHookEx.cs" Link="Interop\User32\Interop.CallNextHookEx.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.ClientToScreen.cs" Link="Interop\User32\Interop.ClientToScreen.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.DefWindowProcW.cs" Link="Interop\User32\Interop.DefWindowProcW.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.EndPaint.cs" Link="Interop\User32\Interop.EndPaint.cs" />
@@ -108,6 +109,8 @@
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetUpdateRgn.cs" Link="Interop\User32\Interop.GetUpdateRgn.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetWindowText.cs" Link="Interop\User32\Interop.GetWindowText.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetWindowThreadProcessId.cs" Link="Interop\User32\Interop.GetWindowThreadProcessId.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.HC.cs" Link="Interop\User32\Interop.HC.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.HOOKPROC.cs" Link="Interop\User32\Interop.HOOKPROC.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.MK.cs" Link="Interop\User32\Interop.MK.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.MSG.cs" Link="Interop\User32\Interop.MSG.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.NMHDR.cs" Link="Interop\User32\Interop.NMHDR.cs" />
@@ -121,9 +124,12 @@
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SBV.cs" Link="Interop\User32\Interop.SBV.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SetActiveWindow.cs" Link="Interop\User32\Interop.SetActiveWindow.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SetWindowPos.cs" Link="Interop\User32\Interop.SetWindowPos.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.SetWindowsHookExW.cs" Link="Interop\User32\Interop.SetWindowsHookExW.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SWP.cs" Link="Interop\User32\Interop.SWP.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.TME.cs" Link="Interop\User32\Interop.TME.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.TrackMouseEvent.cs" Link="Interop\User32\Interop.TrackMouseEvent.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.UnhookWindowsHookEx.cs" Link="Interop\User32\Interop.UnhookWindowsHookEx.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.WH.cs" Link="Interop\User32\Interop.WH.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.WindowMessage.cs" Link="Interop\User32\Interop.WindowMessage.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.WINDOWPOS.cs" Link="Interop\User32\Interop.WINDOWPOS.cs" />
   </ItemGroup>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
@@ -1078,16 +1078,13 @@ namespace System.Windows.Forms.Design.Behavior
                             User32.GetWindowThreadProcessId(adornerWindow, out _thisProcessID);
                         }
 
-                        NativeMethods.HookProc hook = new NativeMethods.HookProc(MouseHookProc);
+                        var hook = new User32.HOOKPROC(MouseHookProc);
                         _mouseHookRoot = GCHandle.Alloc(hook);
-
-#pragma warning disable 618
-                        _mouseHookHandle = UnsafeNativeMethods.SetWindowsHookEx(
-                            NativeMethods.WH_MOUSE,
+                        _mouseHookHandle = User32.SetWindowsHookExW(
+                            User32.WH.MOUSE,
                             hook,
                             IntPtr.Zero,
                             (uint)AppDomain.GetCurrentThreadId());
-#pragma warning restore 618
                         if (_mouseHookHandle != IntPtr.Zero)
                         {
                             _isHooked = true;
@@ -1096,9 +1093,9 @@ namespace System.Windows.Forms.Design.Behavior
                     }
                 }
 
-                private unsafe IntPtr MouseHookProc(int nCode, IntPtr wparam, IntPtr lparam)
+                private unsafe IntPtr MouseHookProc(User32.HC nCode, IntPtr wparam, IntPtr lparam)
                 {
-                    if (_isHooked && nCode == NativeMethods.HC_ACTION)
+                    if (_isHooked && nCode == User32.HC.ACTION)
                     {
                         NativeMethods.MOUSEHOOKSTRUCT mhs = Marshal.PtrToStructure<NativeMethods.MOUSEHOOKSTRUCT>(lparam);
                         if (mhs != null)
@@ -1130,7 +1127,7 @@ namespace System.Windows.Forms.Design.Behavior
                     }
 
                     Debug.Assert(_isHooked, "How did we get here when we are diposed?");
-                    return UnsafeNativeMethods.CallNextHookEx(new HandleRef(this, _mouseHookHandle), nCode, wparam, lparam);
+                    return User32.CallNextHookEx(new HandleRef(this, _mouseHookHandle), nCode, wparam, lparam);
                 }
 
                 private void UnhookMouse()
@@ -1139,7 +1136,7 @@ namespace System.Windows.Forms.Design.Behavior
                     {
                         if (_mouseHookHandle != IntPtr.Zero)
                         {
-                            UnsafeNativeMethods.UnhookWindowsHookEx(new HandleRef(this, _mouseHookHandle));
+                            User32.UnhookWindowsHookEx(new HandleRef(this, _mouseHookHandle));
                             _mouseHookRoot.Free();
                             _mouseHookHandle = IntPtr.Zero;
                             _isHooked = false;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.cs
@@ -1535,7 +1535,7 @@ namespace System.Windows.Forms
             {
                 private IntPtr messageHookHandle = IntPtr.Zero;
                 private bool isHooked = false;
-                private NativeMethods.HookProc hookProc;
+                private User32.HOOKPROC _hookProc;
 
                 public HostedWindowsFormsMessageHook()
                 {
@@ -1587,11 +1587,10 @@ namespace System.Windows.Forms
                             return;
                         }
 
-                        hookProc = new NativeMethods.HookProc(MessageHookProc);
-
-                        messageHookHandle = UnsafeNativeMethods.SetWindowsHookEx(
-                            NativeMethods.WH_GETMESSAGE,
-                            hookProc,
+                        _hookProc = new User32.HOOKPROC(MessageHookProc);
+                        messageHookHandle = User32.SetWindowsHookExW(
+                            User32.WH.GETMESSAGE,
+                            _hookProc,
                             IntPtr.Zero,
                             Kernel32.GetCurrentThreadId());
 
@@ -1603,9 +1602,9 @@ namespace System.Windows.Forms
                     }
                 }
 
-                private unsafe IntPtr MessageHookProc(int nCode, IntPtr wparam, IntPtr lparam)
+                private unsafe IntPtr MessageHookProc(User32.HC nCode, IntPtr wparam, IntPtr lparam)
                 {
-                    if (nCode == NativeMethods.HC_ACTION)
+                    if (nCode == User32.HC.ACTION)
                     {
                         if (isHooked && (User32.PM)wparam == User32.PM.REMOVE)
                         {
@@ -1623,7 +1622,7 @@ namespace System.Windows.Forms
                         }
                     }
 
-                    return UnsafeNativeMethods.CallNextHookEx(new HandleRef(this, messageHookHandle), nCode, wparam, lparam);
+                    return User32.CallNextHookEx(new HandleRef(this, messageHookHandle), nCode, wparam, lparam);
                 }
 
                 private void UninstallMessageHook()
@@ -1632,8 +1631,8 @@ namespace System.Windows.Forms
                     {
                         if (messageHookHandle != IntPtr.Zero)
                         {
-                            UnsafeNativeMethods.UnhookWindowsHookEx(new HandleRef(this, messageHookHandle));
-                            hookProc = null;
+                            User32.UnhookWindowsHookEx(new HandleRef(this, messageHookHandle));
+                            _hookProc = null;
                             messageHookHandle = IntPtr.Zero;
                             isHooked = false;
                         }


### PR DESCRIPTION
## Proposed Changes
- Turn HC_ constants into enum
- Cleanup SetWindowsHookEx and made unicode
- Cleanup CallNextHook
- Cleanup UnhookWindowsHookEx

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2035)