### PR TITLE
Removed dead code from ImageList

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -3623,9 +3623,6 @@ Stack trace where the illegal operation occurred was:
   <data name="ImageListBitmap" xml:space="preserve">
     <value>Image must be a Bitmap.</value>
   </data>
-  <data name="ImageListCantRecreate" xml:space="preserve">
-    <value>Unless the list is empty, '{0}' cannot be changed once the ImageList has been used.</value>
-  </data>
   <data name="ImageListColorDepthDescr" xml:space="preserve">
     <value>The number of colors to use to render images.</value>
   </data>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -5996,11 +5996,6 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">Obrázek musí být rastrová mapa.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImageListCantRecreate">
-        <source>Unless the list is empty, '{0}' cannot be changed once the ImageList has been used.</source>
-        <target state="translated">Pokud seznam není prázdný, {0} nelze změnit poté, co byl použit seznam ImageList.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImageListColorDepthDescr">
         <source>The number of colors to use to render images.</source>
         <target state="translated">Počet barev použitých k vykreslování obrázků.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -5996,11 +5996,6 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">Das Bild muss eine Bitmap sein.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImageListCantRecreate">
-        <source>Unless the list is empty, '{0}' cannot be changed once the ImageList has been used.</source>
-        <target state="translated">{0} kann nach der Verwendung der ImageList nur noch geändert werden, wenn die Liste leer ist.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImageListColorDepthDescr">
         <source>The number of colors to use to render images.</source>
         <target state="translated">Die Zahl der zum Darstellen von Bildern zu verwendenden Farben.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -5996,11 +5996,6 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">La imagen debe ser un mapa de bits.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImageListCantRecreate">
-        <source>Unless the list is empty, '{0}' cannot be changed once the ImageList has been used.</source>
-        <target state="translated">No se puede cambiar '{0}' una vez que se ha utilizado ImageList, a menos que la lista esté vacía.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImageListColorDepthDescr">
         <source>The number of colors to use to render images.</source>
         <target state="translated">Número de colores utilizado para presentar imágenes.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -5996,11 +5996,6 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">L'image doit être une bitmap.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImageListCantRecreate">
-        <source>Unless the list is empty, '{0}' cannot be changed once the ImageList has been used.</source>
-        <target state="translated">Sauf si la liste est vide, '{0}' ne peut pas être modifié une fois que ImageList a été utilisé.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImageListColorDepthDescr">
         <source>The number of colors to use to render images.</source>
         <target state="translated">Le nombre de couleurs à utiliser pour restituer les images.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -5996,11 +5996,6 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">L'immagine deve essere una bitmap.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImageListCantRecreate">
-        <source>Unless the list is empty, '{0}' cannot be changed once the ImageList has been used.</source>
-        <target state="translated">Se l'elenco non è vuoto, non è possibile modificare '{0}' dopo che ImageList è stato utilizzato.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImageListColorDepthDescr">
         <source>The number of colors to use to render images.</source>
         <target state="translated">Il numero di colori da utilizzare per il rendering delle immagini.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -5996,11 +5996,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">イメージはビットマップでなければなりません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImageListCantRecreate">
-        <source>Unless the list is empty, '{0}' cannot be changed once the ImageList has been used.</source>
-        <target state="translated">リストが空でない限り、'{0}' は一度 ImageList が使用された後は、変更できません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImageListColorDepthDescr">
         <source>The number of colors to use to render images.</source>
         <target state="translated">イメージの表示に使用する色の数です。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -5996,11 +5996,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">이미지는 비트맵이어야 합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImageListCantRecreate">
-        <source>Unless the list is empty, '{0}' cannot be changed once the ImageList has been used.</source>
-        <target state="translated">목록이 비어 있지 않으면 ImageList를 사용한 후에 '{0}'을(를) 변경할 수 없습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImageListColorDepthDescr">
         <source>The number of colors to use to render images.</source>
         <target state="translated">이미지를 렌더링하는 데 사용할 색 수입니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -5996,11 +5996,6 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">Obraz musi mieć format mapy bitowej.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImageListCantRecreate">
-        <source>Unless the list is empty, '{0}' cannot be changed once the ImageList has been used.</source>
-        <target state="translated">Po użyciu elementu ImageList nie można zmienić listy '{0}', chyba że jest ona pusta.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImageListColorDepthDescr">
         <source>The number of colors to use to render images.</source>
         <target state="translated">Liczba kolorów używanych do realizacji obrazów.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -5996,11 +5996,6 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">A imagem deve ser um bitmap.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImageListCantRecreate">
-        <source>Unless the list is empty, '{0}' cannot be changed once the ImageList has been used.</source>
-        <target state="translated">A menos que a lista esteja vazia, '{0}' não pode ser alterado após o uso de ImageList.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImageListColorDepthDescr">
         <source>The number of colors to use to render images.</source>
         <target state="translated">O número de cores para renderizar imagens.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -5997,11 +5997,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">Изображение должно быть растровым.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImageListCantRecreate">
-        <source>Unless the list is empty, '{0}' cannot be changed once the ImageList has been used.</source>
-        <target state="translated">После использования ImageList '{0}' не может изменяться, кроме случая, когда список пуст.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImageListColorDepthDescr">
         <source>The number of colors to use to render images.</source>
         <target state="translated">Число цветов, используемых для отрисовки изображений.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -5996,11 +5996,6 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">Resim bir Bit Eşlem olmalı.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImageListCantRecreate">
-        <source>Unless the list is empty, '{0}' cannot be changed once the ImageList has been used.</source>
-        <target state="translated">Liste boş değilse, ImageList bir kez kullanıldıktan sonra '{0}' değiştirilemez.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImageListColorDepthDescr">
         <source>The number of colors to use to render images.</source>
         <target state="translated">Resimleri işlemek için kullanılacak renk sayısı.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -5996,11 +5996,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">图像必须是位图。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImageListCantRecreate">
-        <source>Unless the list is empty, '{0}' cannot be changed once the ImageList has been used.</source>
-        <target state="translated">除非列表为空，否则一旦使用了 ImageList，就不能更改“{0}”。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImageListColorDepthDescr">
         <source>The number of colors to use to render images.</source>
         <target state="translated">用来呈现图像的颜色数。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -5996,11 +5996,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">影像必須為點陣圖。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ImageListCantRecreate">
-        <source>Unless the list is empty, '{0}' cannot be changed once the ImageList has been used.</source>
-        <target state="translated">除非清單是空的，否則一旦使用 ImageList 就無法變更 '{0}'。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ImageListColorDepthDescr">
         <source>The number of colors to use to render images.</source>
         <target state="translated">用來呈現影像的色彩數目。</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
@@ -956,11 +956,6 @@ namespace System.Windows.Forms
                 originals = new ArrayList(); // spoof it into thinking this is the first CreateHandle
             }
 
-            if (originals == null)
-            {
-                throw new InvalidOperationException(string.Format(SR.ImageListCantRecreate, reason));
-            }
-
             DestroyHandle();
             CreateHandle();
             OnRecreateHandle(EventArgs.Empty);


### PR DESCRIPTION
## Proposed Changes
- We initialize `originals` to non-null directly above

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2045)