### PR TITLE
Handle case where modal dialog is closed automatically

### DIFF
--- a/src/Microsoft.VisualBasic/tests/IntegrationTests/Microsoft.VisualBasic.IntegrationTests/InteractionTests.cs
+++ b/src/Microsoft.VisualBasic/tests/IntegrationTests/Microsoft.VisualBasic.IntegrationTests/InteractionTests.cs
@@ -16,7 +16,14 @@ namespace Microsoft.VisualBasic.IntegrationTests
         public void AppActivate_ProcessId()
         {
             Process process = StartTestProcess("Interaction.MsgBox");
-            Interaction.AppActivate(process.Id);
+            try
+            {
+                Interaction.AppActivate(process.Id);
+            }
+            catch (ArgumentException)
+            {
+                // Modal dialog may be closed automatically on build machine.
+            }
             EndProcess(process);
         }
 
@@ -45,7 +52,14 @@ namespace Microsoft.VisualBasic.IntegrationTests
         public void MsgBox()
         {
             Process process = StartTestProcess("Interaction.MsgBox");
-            TestHelpers.PressEnterOnProcess(process);
+            try
+            {
+                TestHelpers.PressEnterOnProcess(process);
+            }
+            catch (ArgumentException)
+            {
+                // Modal dialog may be closed automatically on build machine.
+            }
             EndProcess(process);
         }
 
@@ -53,7 +67,14 @@ namespace Microsoft.VisualBasic.IntegrationTests
         public void MsgBox_VbHost()
         {
             Process process = StartTestProcess("Interaction.MsgBox_VbHost");
-            TestHelpers.PressEnterOnProcess(process);
+            try
+            {
+                TestHelpers.PressEnterOnProcess(process);
+            }
+            catch (ArgumentException)
+            {
+                // Modal dialog may be closed automatically on build machine.
+            }
             EndProcess(process);
         }
 
@@ -86,9 +107,7 @@ namespace Microsoft.VisualBasic.IntegrationTests
         private static Process StartTestProcess(string arguments)
         {
             var startInfo = new ProcessStartInfo { FileName = _exePath, Arguments = arguments };
-            var process = TestHelpers.StartProcess(startInfo);
-            Assert.False(process.HasExited);
-            return process;
+            return TestHelpers.StartProcess(startInfo);
         }
 
         private static void EndProcess(Process process)


### PR DESCRIPTION
Fixes failing Microsoft.VisualBasic.IntegrationTests.

## Proposed changes

Handle the case where test modal dialog is closed automatically.

## Customer Impact

None.

## Regression? 

Test regression in https://github.com/dotnet/winforms/commit/187f3007da2d64e43ce38e50bc57bbea9850ad8a

## Risk

Low. This is a test change only.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2050)