### PR TITLE
Rename and structify OLEINPLACEFRAMEINFO

### DIFF
--- a/src/Common/src/Interop/Ole32/Interop.OLEINPLACEFRAMEINFO.cs
+++ b/src/Common/src/Interop/Ole32/Interop.OLEINPLACEFRAMEINFO.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class Ole32
+    {
+        public struct OLEINPLACEFRAMEINFO
+        {
+            public uint cb;
+            public BOOL fMDIApp;
+            public IntPtr hwndFrame;
+            public IntPtr hAccel;
+            public uint cAccelEntries;
+        }
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -1922,21 +1922,6 @@ namespace System.Windows.Forms
         }
 
         [StructLayout(LayoutKind.Sequential)/*leftover(noAutoOffset)*/]
-        public sealed class tagOIFI
-        {
-            [MarshalAs(UnmanagedType.U4)/*leftover(offset=0, cb)*/]
-            public int cb;
-
-            public bool fMDIApp;
-            public IntPtr hwndFrame;
-            public IntPtr hAccel;
-
-            [MarshalAs(UnmanagedType.U4)/*leftover(offset=16, cAccelEntries)*/]
-            public int cAccelEntries;
-
-        }
-
-        [StructLayout(LayoutKind.Sequential)/*leftover(noAutoOffset)*/]
         public sealed class tagOLEVERB
         {
             public int lVerb;

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -693,8 +693,7 @@ namespace System.Windows.Forms
                 out IOleInPlaceUIWindow ppDoc,
                 RECT* lprcPosRect,
                 RECT* lprcClipRect,
-                [In, Out]
-                NativeMethods.tagOIFI lpFrameInfo);
+                Ole32.OLEINPLACEFRAMEINFO* lpFrameInfo);
 
             [PreserveSig]
             HRESULT Scroll(

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -89,6 +89,7 @@
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.OLECMDF.cs" Link="Interop\Ole32\Interop.OLECMDF.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.OLECMDID.cs" Link="Interop\Ole32\Interop.OLECMDID.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.OLECONTF.cs" Link="Interop\Ole32\Interop.OLECONTF.cs" />
+    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.OLEINPLACEFRAMEINFO.cs" Link="Interop\Ole32\Interop.OLEINPLACEFRAMEINFO.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.RevokeDragDrop.cs" Link="Interop\Ole32\Interop.RevokeDragDrop.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.STATFLAG.cs" Link="Interop\Ole32\Interop.STATFLAG.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.STATSTG.cs" Link="Interop\Ole32\Interop.STATSTG.cs" />

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -4387,7 +4387,7 @@ namespace System.Windows.Forms
                 out UnsafeNativeMethods.IOleInPlaceUIWindow ppDoc,
                 RECT* lprcPosRect,
                 RECT* lprcClipRect,
-                NativeMethods.tagOIFI lpFrameInfo)
+                Ole32.OLEINPLACEFRAMEINFO* lpFrameInfo)
             {
                 ppDoc = null;
                 ppFrame = host.GetParentContainer();
@@ -4401,11 +4401,11 @@ namespace System.Windows.Forms
                 *lprcClipRect = WebBrowserHelper.GetClipRect();
                 if (lpFrameInfo != null)
                 {
-                    lpFrameInfo.cb = Marshal.SizeOf<NativeMethods.tagOIFI>();
-                    lpFrameInfo.fMDIApp = false;
-                    lpFrameInfo.hAccel = IntPtr.Zero;
-                    lpFrameInfo.cAccelEntries = 0;
-                    lpFrameInfo.hwndFrame = host.ParentInternal.Handle;
+                    lpFrameInfo->cb = (uint)Marshal.SizeOf<Ole32.OLEINPLACEFRAMEINFO>();
+                    lpFrameInfo->fMDIApp = BOOL.FALSE;
+                    lpFrameInfo->hAccel = IntPtr.Zero;
+                    lpFrameInfo->cAccelEntries = 0;
+                    lpFrameInfo->hwndFrame = host.ParentInternal.Handle;
                 }
 
                 return HRESULT.S_OK;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -878,9 +878,9 @@ namespace System.Windows.Forms
                 if (!_activeXState[s_inPlaceVisible])
                 {
                     Debug.WriteLineIf(CompModSwitches.ActiveX.TraceVerbose, "\tActiveXImpl:InPlaceActivate --> inplacevisible");
-                    NativeMethods.tagOIFI inPlaceFrameInfo = new NativeMethods.tagOIFI
+                    var inPlaceFrameInfo = new Ole32.OLEINPLACEFRAMEINFO
                     {
-                        cb = Marshal.SizeOf<NativeMethods.tagOIFI>()
+                        cb = (uint)Marshal.SizeOf<Ole32.OLEINPLACEFRAMEINFO>()
                     };
 
                     // We are entering a secure context here.
@@ -911,7 +911,7 @@ namespace System.Windows.Forms
                         out UnsafeNativeMethods.IOleInPlaceUIWindow pWindow,
                         &posRect,
                         &clipRect,
-                        inPlaceFrameInfo);
+                        &inPlaceFrameInfo);
 
                     SetObjectRects(&posRect, &clipRect);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserSiteBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserSiteBase.cs
@@ -267,7 +267,7 @@ namespace System.Windows.Forms
             out UnsafeNativeMethods.IOleInPlaceUIWindow ppDoc,
             RECT* lprcPosRect,
             RECT* lprcClipRect,
-            NativeMethods.tagOIFI lpFrameInfo)
+            Ole32.OLEINPLACEFRAMEINFO* lpFrameInfo)
         {
             ppDoc = null;
             ppFrame = Host.GetParentContainer();
@@ -281,11 +281,11 @@ namespace System.Windows.Forms
             *lprcClipRect = WebBrowserHelper.GetClipRect();
             if (lpFrameInfo != null)
             {
-                lpFrameInfo.cb = Marshal.SizeOf<NativeMethods.tagOIFI>();
-                lpFrameInfo.fMDIApp = false;
-                lpFrameInfo.hAccel = IntPtr.Zero;
-                lpFrameInfo.cAccelEntries = 0;
-                lpFrameInfo.hwndFrame = (Host.ParentInternal == null) ? IntPtr.Zero : Host.ParentInternal.Handle;
+                lpFrameInfo->cb = (uint)Marshal.SizeOf<Ole32.OLEINPLACEFRAMEINFO>();
+                lpFrameInfo->fMDIApp = BOOL.FALSE;
+                lpFrameInfo->hAccel = IntPtr.Zero;
+                lpFrameInfo->cAccelEntries = 0;
+                lpFrameInfo->hwndFrame = (Host.ParentInternal == null) ? IntPtr.Zero : Host.ParentInternal.Handle;
             }
 
             return HRESULT.S_OK;


### PR DESCRIPTION
## Proposed Changes
- Rename tagOIFI to OLEINPLACEFRAMEINFO
- Structify
- Cleanup

https://docs.microsoft.com/en-us/windows/win32/api/oleidl/ns-oleidl-oleinplaceframeinfo

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2064)