### PR TITLE
Cleanup SendKeys interop

### DIFF
--- a/src/Common/src/Interop/User32/Interop.BlockInput.cs
+++ b/src/Common/src/Interop/User32/Interop.BlockInput.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern BOOL BlockInput(BOOL fBlockIt);
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.EVENTMSG.cs
+++ b/src/Common/src/Interop/User32/Interop.EVENTMSG.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public struct EVENTMSG
+        {
+            public WindowMessage message;
+            public uint paramL;
+            public uint paramH;
+            public uint time;
+            public IntPtr hwnd;
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.GetAsyncKeyState.cs
+++ b/src/Common/src/Interop/User32/Interop.GetAsyncKeyState.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern short GetAsyncKeyState(int vkey);
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.GetKeyboardState.cs
+++ b/src/Common/src/Interop/User32/Interop.GetKeyboardState.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern BOOL GetKeyboardState(byte[] lpKeyState);
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.OemKeyScan.cs
+++ b/src/Common/src/Interop/User32/Interop.OemKeyScan.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern uint OemKeyScan(ushort wAsciiVal);
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.SetKeyboardState.cs
+++ b/src/Common/src/Interop/User32/Interop.SetKeyboardState.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern BOOL SetKeyboardState(byte[] lpKeyState);
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -3002,16 +3002,6 @@ namespace System.Windows.Forms
                                 IntPtr piidSource);
         }
 
-        [StructLayout(LayoutKind.Sequential)]
-        public class EVENTMSG
-        {
-            public int message;
-            public int paramL;
-            public int paramH;
-            public int time;
-            public IntPtr hwnd;
-        }
-
         [ComImport]
         [Guid("B196B283-BAB4-101A-B69C-00AA00341D07")]
         [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]

--- a/src/Common/src/SafeNativeMethods.cs
+++ b/src/Common/src/SafeNativeMethods.cs
@@ -14,9 +14,6 @@ namespace System.Windows.Forms
 {
     internal static class SafeNativeMethods
     {
-        [DllImport(ExternDll.User32)]
-        public static extern int OemKeyScan(short wAsciiVal);
-
         [DllImport(ExternDll.Gdi32)]
         public static extern int GetSystemPaletteEntries(IntPtr hdc, int iStartIndex, int nEntries, byte[] lppe);
 

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -189,12 +189,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.User32, ExactSpelling = true)]
         public static extern IntPtr ChildWindowFromPointEx(IntPtr hwndParent, Point pt, int uFlags);
 
-        #region SendKeys SendInput functionality
-
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern bool BlockInput([In, MarshalAs(UnmanagedType.Bool)] bool fBlockIt);
-
-        #endregion
 
         [DllImport(ExternDll.User32, ExactSpelling = true)]
         public static extern IntPtr GetDCEx(HandleRef hWnd, HandleRef hrgnClip, int flags);

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -155,9 +155,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.Kernel32, ExactSpelling = true, EntryPoint = "RtlMoveMemory", CharSet = CharSet.Unicode)]
         public static extern void CopyMemoryW(IntPtr pdst, char[] psrc, int cb);
 
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern short GetAsyncKeyState(int vkey);
-
         [DllImport(ExternDll.Kernel32, CharSet = CharSet.Auto, SetLastError = true)]
         public static extern int GetModuleFileName(HandleRef hModule, StringBuilder buffer, int length);
 

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -156,12 +156,6 @@ namespace System.Windows.Forms
         public static extern void CopyMemoryW(IntPtr pdst, char[] psrc, int cb);
 
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern int GetKeyboardState(byte[] keystate);
-
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern int SetKeyboardState(byte[] keystate);
-
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern short GetAsyncKeyState(int vkey);
 
         [DllImport(ExternDll.Kernel32, CharSet = CharSet.Auto, SetLastError = true)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -14557,7 +14557,7 @@ namespace System.Windows.Forms
             {
                 t_tempKeyboardStateArray = new byte[256];
             }
-            UnsafeNativeMethods.GetKeyboardState(t_tempKeyboardStateArray);
+            User32.GetKeyboardState(t_tempKeyboardStateArray);
             return IsKeyDown(Keys.Tab)
                 || IsKeyDown(Keys.Up)
                 || IsKeyDown(Keys.Down)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.cs
@@ -182,7 +182,7 @@ namespace System.Windows.Forms
             }
             else
             {
-                int oemVal = SafeNativeMethods.OemKeyScan((short)(0xFF & (int)character));
+                uint oemVal = User32.OemKeyScan((ushort)(0xFF & (int)character));
                 for (int i = 0; i < repeat; i++)
                 {
                     AddEvent(new SKEvent(WindowMessages.WM_CHAR, character, (int)(oemVal & 0xFFFF), hwnd));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.cs
@@ -329,16 +329,15 @@ namespace System.Windows.Forms
             }
         }
 
-        private static byte[] GetKeyboardState()
+        private static byte[] KeyboardState
         {
-            byte[] keystate = new byte[256];
-            UnsafeNativeMethods.GetKeyboardState(keystate);
-            return keystate;
-        }
-
-        private static void SetKeyboardState(byte[] keystate)
-        {
-            UnsafeNativeMethods.SetKeyboardState(keystate);
+            get
+            {
+                var keystate = new byte[256];
+                User32.GetKeyboardState(keystate);
+                return keystate;
+            }
+            set => User32.SetKeyboardState(value);
         }
 
         /// <summary>
@@ -348,13 +347,13 @@ namespace System.Windows.Forms
         /// </summary>
         private static void ClearKeyboardState()
         {
-            byte[] keystate = GetKeyboardState();
+            byte[] keystate = KeyboardState;
 
             keystate[(int)Keys.Capital] = 0;
             keystate[(int)Keys.NumLock] = 0;
             keystate[(int)Keys.Scroll] = 0;
 
-            SetKeyboardState(keystate);
+            KeyboardState = keystate;
         }
 
         /// <summary>
@@ -748,7 +747,7 @@ namespace System.Windows.Forms
                 }
                 finally
                 {
-                    SetKeyboardState(oldKeyboardState);
+                    KeyboardState = oldKeyboardState;
 
                     // unblock input if it was previously blocked
                     if (blockInputSuccess)
@@ -975,7 +974,7 @@ namespace System.Windows.Forms
 
             LoadSendMethodFromConfig();
 
-            byte[] oldstate = GetKeyboardState();
+            byte[] oldstate = KeyboardState;
 
             if (sendMethod.Value != SendMethodTypes.SendInput)
             {
@@ -992,7 +991,7 @@ namespace System.Windows.Forms
                 {
                     ClearKeyboardState();
                     InstallHook();
-                    SetKeyboardState(oldstate);
+                    KeyboardState = oldstate;
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.cs
@@ -1144,7 +1144,7 @@ namespace System.Windows.Forms
             {
                 NativeMethods.EVENTMSG eventmsg = Marshal.PtrToStructure<NativeMethods.EVENTMSG>(lparam);
 
-                if (UnsafeNativeMethods.GetAsyncKeyState((int)Keys.Pause) != 0)
+                if (User32.GetAsyncKeyState((int)Keys.Pause) != 0)
                 {
                     SendKeys.s_stopHook = true;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.cs
@@ -158,21 +158,21 @@ namespace System.Windows.Forms
             {
                 if (haveKeys[HAVESHIFT] == 0 && (vk & SHIFTKEYSCAN) != 0)
                 {
-                    AddEvent(new SKEvent(WindowMessages.WM_KEYDOWN, (int)Keys.ShiftKey, fStartNewChar, hwnd));
+                    AddEvent(new SKEvent(User32.WindowMessage.WM_KEYDOWN, (uint)Keys.ShiftKey, fStartNewChar, hwnd));
                     fStartNewChar = false;
                     haveKeys[HAVESHIFT] = UNKNOWN_GROUPING;
                 }
 
                 if (haveKeys[HAVECTRL] == 0 && (vk & CTRLKEYSCAN) != 0)
                 {
-                    AddEvent(new SKEvent(WindowMessages.WM_KEYDOWN, (int)Keys.ControlKey, fStartNewChar, hwnd));
+                    AddEvent(new SKEvent(User32.WindowMessage.WM_KEYDOWN, (uint)Keys.ControlKey, fStartNewChar, hwnd));
                     fStartNewChar = false;
                     haveKeys[HAVECTRL] = UNKNOWN_GROUPING;
                 }
 
                 if (haveKeys[HAVEALT] == 0 && (vk & ALTKEYSCAN) != 0)
                 {
-                    AddEvent(new SKEvent(WindowMessages.WM_KEYDOWN, (int)Keys.Menu, fStartNewChar, hwnd));
+                    AddEvent(new SKEvent(User32.WindowMessage.WM_KEYDOWN, (uint)Keys.Menu, fStartNewChar, hwnd));
                     fStartNewChar = false;
                     haveKeys[HAVEALT] = UNKNOWN_GROUPING;
                 }
@@ -185,7 +185,7 @@ namespace System.Windows.Forms
                 uint oemVal = User32.OemKeyScan((ushort)(0xFF & (int)character));
                 for (int i = 0; i < repeat; i++)
                 {
-                    AddEvent(new SKEvent(WindowMessages.WM_CHAR, character, (int)(oemVal & 0xFFFF), hwnd));
+                    AddEvent(new SKEvent(User32.WindowMessage.WM_CHAR, character, (oemVal & 0xFFFF), hwnd));
                 }
             }
 
@@ -204,9 +204,9 @@ namespace System.Windows.Forms
         {
             for (int i = 0; i < repeat; i++)
             {
-                AddEvent(new SKEvent(altnoctrldown ? WindowMessages.WM_SYSKEYDOWN : WindowMessages.WM_KEYDOWN, vk, fStartNewChar, hwnd));
+                AddEvent(new SKEvent(altnoctrldown ? User32.WindowMessage.WM_SYSKEYDOWN : User32.WindowMessage.WM_KEYDOWN, (uint)vk, fStartNewChar, hwnd));
                 // fStartNewChar = false;
-                AddEvent(new SKEvent(altnoctrldown ? WindowMessages.WM_SYSKEYUP : WindowMessages.WM_KEYUP, vk, fStartNewChar, hwnd));
+                AddEvent(new SKEvent(altnoctrldown ? User32.WindowMessage.WM_SYSKEYUP : User32.WindowMessage.WM_KEYUP, (uint)vk, fStartNewChar, hwnd));
             }
         }
 
@@ -218,17 +218,17 @@ namespace System.Windows.Forms
         {
             if (haveKeys[HAVESHIFT] == level)
             {
-                AddEvent(new SKEvent(WindowMessages.WM_KEYUP, (int)Keys.ShiftKey, false, hwnd));
+                AddEvent(new SKEvent(User32.WindowMessage.WM_KEYUP, (int)Keys.ShiftKey, false, hwnd));
                 haveKeys[HAVESHIFT] = 0;
             }
             if (haveKeys[HAVECTRL] == level)
             {
-                AddEvent(new SKEvent(WindowMessages.WM_KEYUP, (int)Keys.ControlKey, false, hwnd));
+                AddEvent(new SKEvent(User32.WindowMessage.WM_KEYUP, (int)Keys.ControlKey, false, hwnd));
                 haveKeys[HAVECTRL] = 0;
             }
             if (haveKeys[HAVEALT] == level)
             {
-                AddEvent(new SKEvent(WindowMessages.WM_SYSKEYUP, (int)Keys.Menu, false, hwnd));
+                AddEvent(new SKEvent(User32.WindowMessage.WM_SYSKEYUP, (int)Keys.Menu, false, hwnd));
                 haveKeys[HAVEALT] = 0;
             }
         }
@@ -507,21 +507,21 @@ namespace System.Windows.Forms
                             // Unlike AddSimpleKey, the bit mask uses Keys, rather than scan keys
                             if (haveKeys[HAVESHIFT] == 0 && (vk & (int)Keys.Shift) != 0)
                             {
-                                AddEvent(new SKEvent(WindowMessages.WM_KEYDOWN, (int)Keys.ShiftKey, fStartNewChar, hwnd));
+                                AddEvent(new SKEvent(User32.WindowMessage.WM_KEYDOWN, (uint)Keys.ShiftKey, fStartNewChar, hwnd));
                                 fStartNewChar = false;
                                 haveKeys[HAVESHIFT] = UNKNOWN_GROUPING;
                             }
 
                             if (haveKeys[HAVECTRL] == 0 && (vk & (int)Keys.Control) != 0)
                             {
-                                AddEvent(new SKEvent(WindowMessages.WM_KEYDOWN, (int)Keys.ControlKey, fStartNewChar, hwnd));
+                                AddEvent(new SKEvent(User32.WindowMessage.WM_KEYDOWN, (uint)Keys.ControlKey, fStartNewChar, hwnd));
                                 fStartNewChar = false;
                                 haveKeys[HAVECTRL] = UNKNOWN_GROUPING;
                             }
 
                             if (haveKeys[HAVEALT] == 0 && (vk & (int)Keys.Alt) != 0)
                             {
-                                AddEvent(new SKEvent(WindowMessages.WM_KEYDOWN, (int)Keys.Menu, fStartNewChar, hwnd));
+                                AddEvent(new SKEvent(User32.WindowMessage.WM_KEYDOWN, (uint)Keys.Menu, fStartNewChar, hwnd));
                                 fStartNewChar = false;
                                 haveKeys[HAVEALT] = UNKNOWN_GROUPING;
                             }
@@ -547,7 +547,7 @@ namespace System.Windows.Forms
                             throw new ArgumentException(string.Format(SR.InvalidSendKeysString, keys));
                         }
 
-                        AddEvent(new SKEvent(WindowMessages.WM_KEYDOWN, (int)Keys.ShiftKey, fStartNewChar, hwnd));
+                        AddEvent(new SKEvent(User32.WindowMessage.WM_KEYDOWN, (uint)Keys.ShiftKey, fStartNewChar, hwnd));
                         fStartNewChar = false;
                         haveKeys[HAVESHIFT] = UNKNOWN_GROUPING;
                         break;
@@ -558,7 +558,7 @@ namespace System.Windows.Forms
                             throw new ArgumentException(string.Format(SR.InvalidSendKeysString, keys));
                         }
 
-                        AddEvent(new SKEvent(WindowMessages.WM_KEYDOWN, (int)Keys.ControlKey, fStartNewChar, hwnd));
+                        AddEvent(new SKEvent(User32.WindowMessage.WM_KEYDOWN, (uint)Keys.ControlKey, fStartNewChar, hwnd));
                         fStartNewChar = false;
                         haveKeys[HAVECTRL] = UNKNOWN_GROUPING;
                         break;
@@ -569,7 +569,7 @@ namespace System.Windows.Forms
                             throw new ArgumentException(string.Format(SR.InvalidSendKeysString, keys));
                         }
 
-                        AddEvent(new SKEvent((haveKeys[HAVECTRL] != 0) ? WindowMessages.WM_KEYDOWN : WindowMessages.WM_SYSKEYDOWN,
+                        AddEvent(new SKEvent((haveKeys[HAVECTRL] != 0) ? User32.WindowMessage.WM_KEYDOWN : User32.WindowMessage.WM_SYSKEYDOWN,
                                              (int)Keys.Menu, fStartNewChar, hwnd));
                         fStartNewChar = false;
                         haveKeys[HAVEALT] = UNKNOWN_GROUPING;
@@ -695,7 +695,7 @@ namespace System.Windows.Forms
 
                         currentInput[0].inputUnion.ki.dwFlags = 0;
 
-                        if (skEvent.wm == WindowMessages.WM_CHAR)
+                        if (skEvent.wm == User32.WindowMessage.WM_CHAR)
                         {
                             // for WM_CHAR, send a KEYEVENTF_UNICODE instead of a Keyboard event
                             // to support extended ascii characters with no keyboard equivalent.
@@ -714,7 +714,7 @@ namespace System.Windows.Forms
                             currentInput[0].inputUnion.ki.wScan = 0;
 
                             // add KeyUp flag if we have a KeyUp
-                            if (skEvent.wm == WindowMessages.WM_KEYUP || skEvent.wm == WindowMessages.WM_SYSKEYUP)
+                            if (skEvent.wm == User32.WindowMessage.WM_KEYUP || skEvent.wm == User32.WindowMessage.WM_SYSKEYUP)
                             {
                                 currentInput[0].inputUnion.ki.dwFlags |= User32.KEYEVENTF.KEYUP;
                             }
@@ -784,13 +784,13 @@ namespace System.Windows.Forms
                 SKEvent skEvent = (SKEvent)previousEvents.Dequeue();
 
                 bool isOn;
-                if ((skEvent.wm == WindowMessages.WM_KEYUP) ||
-                    (skEvent.wm == WindowMessages.WM_SYSKEYUP))
+                if ((skEvent.wm == User32.WindowMessage.WM_KEYUP) ||
+                    (skEvent.wm == User32.WindowMessage.WM_SYSKEYUP))
                 {
                     isOn = false;
                 }
-                else if ((skEvent.wm == WindowMessages.WM_KEYDOWN) ||
-                         (skEvent.wm == WindowMessages.WM_SYSKEYDOWN))
+                else if ((skEvent.wm == User32.WindowMessage.WM_KEYDOWN) ||
+                         (skEvent.wm == User32.WindowMessage.WM_SYSKEYDOWN))
                 {
                     isOn = true;
                 }
@@ -815,15 +815,15 @@ namespace System.Windows.Forms
 
             if (shift)
             {
-                AddEvent(new SKEvent(WindowMessages.WM_KEYUP, (int)Keys.ShiftKey, false, IntPtr.Zero));
+                AddEvent(new SKEvent(User32.WindowMessage.WM_KEYUP, (int)Keys.ShiftKey, false, IntPtr.Zero));
             }
             else if (ctrl)
             {
-                AddEvent(new SKEvent(WindowMessages.WM_KEYUP, (int)Keys.ControlKey, false, IntPtr.Zero));
+                AddEvent(new SKEvent(User32.WindowMessage.WM_KEYUP, (int)Keys.ControlKey, false, IntPtr.Zero));
             }
             else if (alt)
             {
-                AddEvent(new SKEvent(WindowMessages.WM_SYSKEYUP, (int)Keys.Menu, false, IntPtr.Zero));
+                AddEvent(new SKEvent(User32.WindowMessage.WM_SYSKEYUP, (int)Keys.Menu, false, IntPtr.Zero));
             }
         }
 
@@ -851,7 +851,7 @@ namespace System.Windows.Forms
 
         private static void CheckGlobalKeys(SKEvent skEvent)
         {
-            if (skEvent.wm == WindowMessages.WM_KEYDOWN)
+            if (skEvent.wm == User32.WindowMessage.WM_KEYDOWN)
             {
                 switch (skEvent.paramL)
                 {
@@ -1090,24 +1090,24 @@ namespace System.Windows.Forms
         /// </summary>
         private class SKEvent
         {
-            internal int wm;
-            internal int paramL;
-            internal int paramH;
+            internal User32.WindowMessage wm;
+            internal uint paramL;
+            internal uint paramH;
             internal IntPtr hwnd;
 
-            public SKEvent(int a, int b, bool c, IntPtr hwnd)
+            public SKEvent(User32.WindowMessage wm, uint paramL, bool paramH, IntPtr hwnd)
             {
-                wm = a;
-                paramL = b;
-                paramH = c ? 1 : 0;
+                this.wm = wm;
+                this.paramL = paramL;
+                this.paramH = paramH ? 1u : 0;
                 this.hwnd = hwnd;
             }
 
-            public SKEvent(int a, int b, int c, IntPtr hwnd)
+            public SKEvent(User32.WindowMessage wm, uint paramL, uint paramH, IntPtr hwnd)
             {
-                wm = a;
-                paramL = b;
-                paramH = c;
+                this.wm = wm;
+                this.paramL = paramL;
+                this.paramH = paramH;
                 this.hwnd = hwnd;
             }
         }
@@ -1140,9 +1140,9 @@ namespace System.Windows.Forms
             //
             private bool gotNextEvent = false;
 
-            public virtual IntPtr Callback(User32.HC nCode, IntPtr wparam, IntPtr lparam)
+            public unsafe virtual IntPtr Callback(User32.HC nCode, IntPtr wparam, IntPtr lparam)
             {
-                NativeMethods.EVENTMSG eventmsg = Marshal.PtrToStructure<NativeMethods.EVENTMSG>(lparam);
+                User32.EVENTMSG* eventmsg = (User32.EVENTMSG*)lparam;
 
                 if (User32.GetAsyncKeyState((int)Keys.Pause) != 0)
                 {
@@ -1174,12 +1174,11 @@ namespace System.Windows.Forms
 #endif
 
                         SKEvent evt = (SKEvent)SendKeys.events.Peek();
-                        eventmsg.message = evt.wm;
-                        eventmsg.paramL = evt.paramL;
-                        eventmsg.paramH = evt.paramH;
-                        eventmsg.hwnd = evt.hwnd;
-                        eventmsg.time = (int)Kernel32.GetTickCount();
-                        Marshal.StructureToPtr(eventmsg, lparam, true);
+                        eventmsg->message = evt.wm;
+                        eventmsg->paramL = evt.paramL;
+                        eventmsg->paramH = evt.paramH;
+                        eventmsg->hwnd = evt.hwnd;
+                        eventmsg->time = Kernel32.GetTickCount();
                         break;
 
                     default:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.cs
@@ -682,7 +682,7 @@ namespace System.Windows.Forms
             lock (events.SyncRoot)
             {
                 // block keyboard and mouse input events from reaching applications.
-                bool blockInputSuccess = UnsafeNativeMethods.BlockInput(true);
+                BOOL blockInputSuccess = User32.BlockInput(BOOL.TRUE);
 
                 try
                 {
@@ -750,9 +750,9 @@ namespace System.Windows.Forms
                     KeyboardState = oldKeyboardState;
 
                     // unblock input if it was previously blocked
-                    if (blockInputSuccess)
+                    if (blockInputSuccess.IsTrue())
                     {
-                        UnsafeNativeMethods.BlockInput(false);
+                        User32.BlockInput(BOOL.FALSE);
                     }
                 }
             }


### PR DESCRIPTION
## Proposed Changes
- Cleanup GetKeyboardState/SetKeyboardState
- Cleanup BlockInput
- Cleanup GetAsyncKeyState
- Cleanup OemKeyScan
- Structify EVENTMSG

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2065)