### PR TITLE
Structify NMTVDISPINFOW

### DIFF
--- a/src/Common/src/Interop/ComCtl32/Interop.NMTVDISPINFOW.cs
+++ b/src/Common/src/Interop/ComCtl32/Interop.NMTVDISPINFOW.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        public struct NMTVDISPINFOW
+        {
+            public User32.NMHDR hdr;
+            public TVITEMW item;
+        }
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -2044,13 +2044,6 @@ namespace System.Windows.Forms
             public short tdExtDevmodeOffset = 0;
         }
 
-        [StructLayout(LayoutKind.Sequential)]
-        public class NMTVDISPINFO
-        {
-            public User32.NMHDR hdr;
-            public ComCtl32.TVITEMW item;
-        }
-
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
         public class TCITEM_T
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -2638,7 +2638,7 @@ namespace System.Windows.Forms
             }
         }
 
-        private IntPtr TvnBeginLabelEdit(NativeMethods.NMTVDISPINFO nmtvdi)
+        private IntPtr TvnBeginLabelEdit(ComCtl32.NMTVDISPINFOW nmtvdi)
         {
             // Check for invalid node handle
             if (nmtvdi.item.hItem == IntPtr.Zero)
@@ -2657,7 +2657,7 @@ namespace System.Windows.Forms
             return (IntPtr)(e.CancelEdit ? 1 : 0);
         }
 
-        private IntPtr TvnEndLabelEdit(NativeMethods.NMTVDISPINFO nmtvdi)
+        private IntPtr TvnEndLabelEdit(ComCtl32.NMTVDISPINFOW nmtvdi)
         {
             editNode = null;
 
@@ -3083,10 +3083,10 @@ namespace System.Windows.Forms
                         TvnBeginDrag(MouseButtons.Right, nmtv);
                         break;
                     case NativeMethods.TVN_BEGINLABELEDIT:
-                        m.Result = TvnBeginLabelEdit((NativeMethods.NMTVDISPINFO)m.GetLParam(typeof(NativeMethods.NMTVDISPINFO)));
+                        m.Result = TvnBeginLabelEdit(*(ComCtl32.NMTVDISPINFOW*)m.LParam);
                         break;
                     case NativeMethods.TVN_ENDLABELEDIT:
-                        m.Result = TvnEndLabelEdit((NativeMethods.NMTVDISPINFO)m.GetLParam(typeof(NativeMethods.NMTVDISPINFO)));
+                        m.Result = TvnEndLabelEdit(*(ComCtl32.NMTVDISPINFOW*)m.LParam);
                         break;
                     case NativeMethods.NM_CLICK:
                     case NativeMethods.NM_RCLICK:


### PR DESCRIPTION
## Proposed Changes
- Turn NMTVDISPINFOW into a (blittable) struct
- Rename to NMTVDISPINFOW
- Move to interop

https://docs.microsoft.com/en-us/windows/win32/api/commctrl/ns-commctrl-nmtvdispinfow

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2070)