### PR TITLE
[Accessibility][ScreenReader]: Fixing tooltip text announcing by NVDA/Narrator

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -621,6 +621,17 @@ namespace System.Windows.Forms
             _delayTimes[(int)ComCtl32.TTDT.INITIAL] = _delayTimes[(int)ComCtl32.TTDT.AUTOMATIC];
         }
 
+        /// <summary>
+        ///  ScreenReader announces ToolTip text for an element
+        /// </summary>
+        private void AnnounceText(Control tool, string text)
+        {
+            tool?.AccessibilityObject?.RaiseAutomationNotification(
+                Automation.AutomationNotificationKind.ActionCompleted,
+                Automation.AutomationNotificationProcessing.All,
+                ToolTipTitle + " " + text);
+        }
+
         private void HandleCreated(object sender, EventArgs eventargs)
         {
             // Reset the toplevel control when the owner's handle is recreated.
@@ -2066,6 +2077,11 @@ namespace System.Windows.Forms
             {
                 // The dataGridView cancelled the tooltip.
                 e.Cancel = true;
+            }
+
+            if (!e.Cancel)
+            {
+                AnnounceText(toolControl, GetCaptionForTool(toolControl));
             }
 
             // We need to re-get the rectangle of the tooltip here because


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #2073
Original bug: [987952](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/987952)

## Proposed changes

- Add AnnounceText method to raise UIA notification (ScreenReader says notification text) when a tooltip is shown

<del>- Add IToolTip interface and implement it to unite elements (Control, ToolStripItem, DataGridViewElement) which can have a tooltip (this is necessary to the correct, simple and short implementation of raising UIA notification.)</del>

> ScreenReader reads the tooltip text of elements of in turn.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A user can hear a text of a shown tooltip

## Regression? 

- No

## Risk

- No

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://user-images.githubusercontent.com/49272759/66658882-11fce700-ec4b-11e9-95ab-769287de4313.png)

<!-- TODO -->

### After
- **A screen reader announces a text with a title of all tooltips (mouse and keyboard). &#x1F4D7;**

![image](https://user-images.githubusercontent.com/49272759/66658891-16c19b00-ec4b-11e9-91aa-47ad841fb406.png)

![2](https://user-images.githubusercontent.com/49272759/66658939-2ccf5b80-ec4b-11e9-9cf2-8246ce386889.gif)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual UI testing


## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Using NVDA and Narrator
<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- .NET Core Version: 3.1.0-preview1.19458.7
- Microsoft Windows [Version 10.0.18362.356]

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2074)