### PR TITLE
Porting System.Windows.Forms.Design.ListControlStringCollectionEditor

### DIFF
--- a/src/System.Design/src/System.Design.Forwards.cs
+++ b/src/System.Design/src/System.Design.Forwards.cs
@@ -1,0 +1,7 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ListControlStringCollectionEditor))]

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/SR.resx
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/SR.resx
@@ -148,6 +148,9 @@
   <data name="ColorEditorSystemTab" xml:space="preserve">
     <value>System</value>
   </data>
+  <data name="DataSourceLocksItems" xml:space="preserve">
+    <value>Items collection cannot be modified when the DataSource property is set.</value>
+  </data>
   <data name="DockEditorAccName" xml:space="preserve">
     <value>Dock Picker</value>
   </data>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.cs.xlf
@@ -130,6 +130,11 @@
       <trans-unit id="ContentAlignmentEditorTopRightAccName">
         <source>Top Right</source>
         <target state="new">Top Right</target>
+      <note />
+      </trans-unit>
+      <trans-unit id="DataSourceLocksItems">
+        <source>Items collection cannot be modified when the DataSource property is set.</source>
+        <target state="new">Items collection cannot be modified when the DataSource property is set.</target>
         <note />
       </trans-unit>
       <trans-unit id="DockEditorAccName">

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.de.xlf
@@ -132,6 +132,11 @@
         <target state="new">Top Right</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataSourceLocksItems">
+        <source>Items collection cannot be modified when the DataSource property is set.</source>
+        <target state="new">Items collection cannot be modified when the DataSource property is set.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockEditorAccName">
         <source>Dock Picker</source>
         <target state="translated">Dockungsauswahl</target>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.es.xlf
@@ -132,6 +132,11 @@
         <target state="new">Top Right</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataSourceLocksItems">
+        <source>Items collection cannot be modified when the DataSource property is set.</source>
+        <target state="new">Items collection cannot be modified when the DataSource property is set.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockEditorAccName">
         <source>Dock Picker</source>
         <target state="translated">Selector de acoplamiento</target>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.fr.xlf
@@ -132,6 +132,11 @@
         <target state="new">Top Right</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataSourceLocksItems">
+        <source>Items collection cannot be modified when the DataSource property is set.</source>
+        <target state="new">Items collection cannot be modified when the DataSource property is set.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockEditorAccName">
         <source>Dock Picker</source>
         <target state="translated">Sélecteur de Dock</target>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.it.xlf
@@ -132,6 +132,11 @@
         <target state="new">Top Right</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataSourceLocksItems">
+        <source>Items collection cannot be modified when the DataSource property is set.</source>
+        <target state="new">Items collection cannot be modified when the DataSource property is set.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockEditorAccName">
         <source>Dock Picker</source>
         <target state="translated">Selezione ancoraggio</target>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ja.xlf
@@ -132,6 +132,11 @@
         <target state="new">Top Right</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataSourceLocksItems">
+        <source>Items collection cannot be modified when the DataSource property is set.</source>
+        <target state="new">Items collection cannot be modified when the DataSource property is set.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockEditorAccName">
         <source>Dock Picker</source>
         <target state="translated">ピッカーのドッキング</target>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ko.xlf
@@ -132,6 +132,11 @@
         <target state="new">Top Right</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataSourceLocksItems">
+        <source>Items collection cannot be modified when the DataSource property is set.</source>
+        <target state="new">Items collection cannot be modified when the DataSource property is set.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockEditorAccName">
         <source>Dock Picker</source>
         <target state="translated">도킹 선택기</target>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.pl.xlf
@@ -132,6 +132,11 @@
         <target state="new">Top Right</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataSourceLocksItems">
+        <source>Items collection cannot be modified when the DataSource property is set.</source>
+        <target state="new">Items collection cannot be modified when the DataSource property is set.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockEditorAccName">
         <source>Dock Picker</source>
         <target state="translated">Selektor dokowania</target>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.pt-BR.xlf
@@ -132,6 +132,11 @@
         <target state="new">Top Right</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataSourceLocksItems">
+        <source>Items collection cannot be modified when the DataSource property is set.</source>
+        <target state="new">Items collection cannot be modified when the DataSource property is set.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockEditorAccName">
         <source>Dock Picker</source>
         <target state="translated">Encaixar Seletor</target>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ru.xlf
@@ -132,6 +132,11 @@
         <target state="new">Top Right</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataSourceLocksItems">
+        <source>Items collection cannot be modified when the DataSource property is set.</source>
+        <target state="new">Items collection cannot be modified when the DataSource property is set.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockEditorAccName">
         <source>Dock Picker</source>
         <target state="translated">Средство выбора дока</target>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.tr.xlf
@@ -132,6 +132,11 @@
         <target state="new">Top Right</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataSourceLocksItems">
+        <source>Items collection cannot be modified when the DataSource property is set.</source>
+        <target state="new">Items collection cannot be modified when the DataSource property is set.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockEditorAccName">
         <source>Dock Picker</source>
         <target state="translated">Seçiciyi Yerleştir</target>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.zh-Hans.xlf
@@ -132,6 +132,11 @@
         <target state="new">Top Right</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataSourceLocksItems">
+        <source>Items collection cannot be modified when the DataSource property is set.</source>
+        <target state="new">Items collection cannot be modified when the DataSource property is set.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockEditorAccName">
         <source>Dock Picker</source>
         <target state="translated">停靠选取器</target>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.zh-Hant.xlf
@@ -132,6 +132,11 @@
         <target state="new">Top Right</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataSourceLocksItems">
+        <source>Items collection cannot be modified when the DataSource property is set.</source>
+        <target state="new">Items collection cannot be modified when the DataSource property is set.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockEditorAccName">
         <source>Dock Picker</source>
         <target state="translated">停駐選擇器</target>

--- a/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/ListControlStringCollectionEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/ListControlStringCollectionEditor.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+
+namespace System.Windows.Forms.Design
+{
+    /// <summary>
+    ///  The ListControlStringCollectionEditor override StringCollectionEditor
+    ///  to prevent the string collection from being edited if a DataSource
+    ///  has been set on the control.
+    /// </summary>
+    internal class ListControlStringCollectionEditor : StringCollectionEditor
+    {
+        public ListControlStringCollectionEditor(Type type) : base(type)
+        {
+        }
+
+        public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+        {
+            // If we're trying to edit the items in an object that has a DataSource set, throw an exception
+            ListControl control = context.Instance as ListControl;
+            if (control?.DataSource != null)
+            {
+                throw new ArgumentException(SR.DataSourceLocksItems);
+            }
+
+            return base.EditValue(context, provider, value);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1271 
Related issue: #1115
Have you experienced this same bug with .NET Framework?: No

## Proposed changes

- Add System.Windows.Forms.Design.ListControlStringCollectionEditor class
- Add resources for DataSourceLocksItem
- Implement TypeForwardedTo method

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Changed collection editor for controls which use ListControlStringCollectionEditor (TextBox, ComboBox, ListBox, etc.) to compliance with .Net 4.8.

## Regression? 

- No

## Risk

- No

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
- ComboBox (and others) has ObjectCollectionEditor as Items editor
![image](https://user-images.githubusercontent.com/49272759/66759214-81234700-eea8-11e9-9635-2ac442b7b29c.png)

<!-- TODO -->

### After
- ComboBox (and others) has ListControlStringCollectionEditor as Items editor 
![image](https://user-images.githubusercontent.com/49272759/66755564-e7a46700-eea0-11e9-8b2f-9d6f4eb1ae0c.png)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual UI testing


 

## Test environment(s) <!-- Remove any that don't apply -->

- .Net Core version: 3.1.0-preview1.19458.7
- Microsoft Windows [Version 10.0.18362.418]


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2078)