### PR TITLE
Structify SELCHANGE

### DIFF
--- a/src/Common/src/Interop/Richedit/Interop.SEL.cs
+++ b/src/Common/src/Interop/Richedit/Interop.SEL.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal partial class Interop
+{
+    internal static partial class Richedit
+    {
+        [Flags]
+        public enum SEL : ushort
+        {
+            EMPTY = 0x0000,
+            TEXT = 0x0001,
+            OBJECT = 0x0002,
+            MULTICHAR = 0x0004,
+            MULTIOBJECT = 0x0008,
+        }
+    }
+}

--- a/src/Common/src/Interop/Richedit/Interop.SELCHANGE.cs
+++ b/src/Common/src/Interop/Richedit/Interop.SELCHANGE.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal partial class Interop
+{
+    internal static partial class Richedit
+    {
+        public struct SELCHANGE
+        {
+            public User32.NMHDR nmhdr;
+            public CHARRANGE chrg;
+            public SEL seltyp;
+        }
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -2631,14 +2631,6 @@ namespace System.Windows.Forms
             public uint codepage;       // Code page for translation (CP_ACP for default, 1200 for Unicode)
         }
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi, Pack = 4)]
-        public class SELCHANGE
-        {
-            public User32.NMHDR nmhdr;
-            public Interop.Richedit.CHARRANGE chrg;
-            public int seltyp = 0;
-        }
-
         [StructLayout(LayoutKind.Sequential)]
         public class PARAFORMAT
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -3610,8 +3610,8 @@ namespace System.Windows.Forms
                         break;
 
                     case RichTextBoxConstants.EN_SELCHANGE:
-                        NativeMethods.SELCHANGE selChange = (NativeMethods.SELCHANGE)m.GetLParam(typeof(NativeMethods.SELCHANGE));
-                        WmSelectionChange(selChange);
+                        Richedit.SELCHANGE* selChange = (Richedit.SELCHANGE*)m.LParam;
+                        WmSelectionChange(*selChange);
                         break;
 
                     case RichTextBoxConstants.EN_PROTECTED:
@@ -3734,7 +3734,7 @@ namespace System.Windows.Forms
             return es;
         }
 
-        private void WmSelectionChange(NativeMethods.SELCHANGE selChange)
+        private void WmSelectionChange(Richedit.SELCHANGE selChange)
         {
             int selStart = selChange.chrg.cpMin;
             int selEnd = selChange.chrg.cpMax;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxConstants.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxConstants.cs
@@ -431,12 +431,6 @@ namespace System.Windows.Forms
          */
         internal const int PFA_JUSTIFY = 4;        /* New paragraph-alignment option 2.0 (*) */
 
-        internal const int SEL_EMPTY = 0x0000;
-        internal const int SEL_TEXT = 0x0001;
-        internal const int SEL_OBJECT = 0x0002;
-        internal const int SEL_MULTICHAR = 0x0004;
-        internal const int SEL_MULTIOBJECT = 0x0008;
-
         internal const int tomTrue = -1,
                             tomFalse = 0,
                             tomNone = 0,


### PR DESCRIPTION
## Proposed Changes
- Structify SELCHANGE
- Correct definition to use `WORD` instead of `int`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2080)