### PR TITLE
Remove duplicate GetCursor interop

### DIFF
--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -3180,12 +3180,6 @@ namespace System.Windows.Forms
         public static extern bool GetUpdateRect(IntPtr hwnd, ref RECT rc, bool fErase);
 
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern IntPtr GetCursor();
-
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern bool GetCursorPos(out Point pt);
-
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern IntPtr SetParent(IntPtr hWnd, IntPtr hWndParent);
     }
 }

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -103,6 +103,8 @@
     <Compile Include="..\..\Common\src\Interop\User32\Interop.EndPaint.cs" Link="Interop\User32\Interop.EndPaint.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetActiveWindow.cs" Link="Interop\User32\Interop.GetActiveWindow.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetCapture.cs" Link="Interop\User32\Interop.GetCapture.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.GetCursor.cs" Link="Interop\User32\Interop.GetCursor.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.GetCursorPos.cs" Link="Interop\User32\Interop.GetCursorPos.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetDC.cs" Link="Interop\User32\Interop.GetDC.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetFocus.cs" Link="Interop\User32\Interop.GetFocus.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetKeyState.cs" Link="Interop\User32\Interop.GetKeyState.cs" />

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
@@ -816,7 +816,7 @@ namespace System.Windows.Forms.Design.Behavior
                 if (!IsLocalDrag(e))
                 {
                     _behaviorService._validDragArgs = e;
-                    NativeMethods.GetCursorPos(out Point pt);
+                    User32.GetCursorPos(out Point pt);
                     NativeMethods.MapWindowPoints(IntPtr.Zero, Handle, ref pt, 1);
                     _behaviorService.PropagateHitTest(pt);
 
@@ -850,7 +850,7 @@ namespace System.Windows.Forms.Design.Behavior
                 if (!IsLocalDrag(e))
                 {
                     _behaviorService._validDragArgs = e;
-                    NativeMethods.GetCursorPos(out Point pt);
+                    User32.GetCursorPos(out Point pt);
                     NativeMethods.MapWindowPoints(IntPtr.Zero, Handle, ref pt, 1);
                     _behaviorService.PropagateHitTest(pt);
                 }
@@ -1407,7 +1407,7 @@ namespace System.Windows.Forms.Design.Behavior
 
                 if (_toolboxSvc != null && _toolboxSvc.SetCursor())
                 {
-                    cursor = new Cursor(NativeMethods.GetCursor());
+                    cursor = new Cursor(User32.GetCursor());
                 }
             }
             _adornerWindow.Cursor = cursor;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
@@ -541,7 +541,7 @@ namespace System.Windows.Forms.Design
                 if (tbx != null && tbx.GetSelectedToolboxItem((IDesignerHost)GetService(typeof(IDesignerHost))) != null)
                 {
                     tbx.SelectedToolboxItemUsed();
-                    NativeMethods.GetCursorPos(out Point p);
+                    User32.GetCursorPos(out Point p);
                     IntPtr hwnd = NativeMethods.WindowFromPoint(p.X, p.Y);
                     if (hwnd != IntPtr.Zero)
                     {


### PR DESCRIPTION
## Proposed Changes
- Remove duplicate GetCursor/GetCursorPos interop

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2083)