### PR TITLE
add missing system drawing design editor associations

### DIFF
--- a/src/System.Windows.Forms/src/System/Drawing/Design/UITypeEditor.cs
+++ b/src/System.Windows.Forms/src/System/Drawing/Design/UITypeEditor.cs
@@ -5,6 +5,7 @@
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Drawing.Imaging;
 using System.IO;
 
 namespace System.Drawing.Design
@@ -16,9 +17,10 @@ namespace System.Drawing.Design
     {
         static UITypeEditor()
         {
+            // Our set of intrinsic editors.
             Hashtable intrinsicEditors = new Hashtable
             {
-                // Our set of intrinsic editors.
+                // System.ComponentModel type Editors
                 [typeof(DateTime)] = "System.ComponentModel.Design.DateTimeEditor, " + AssemblyRef.SystemDesign,
                 [typeof(Array)] = "System.ComponentModel.Design.ArrayEditor, " + AssemblyRef.SystemDesign,
                 [typeof(IList)] = "System.ComponentModel.Design.CollectionEditor, " + AssemblyRef.SystemDesign,
@@ -26,7 +28,17 @@ namespace System.Drawing.Design
                 [typeof(byte[])] = "System.ComponentModel.Design.BinaryEditor, " + AssemblyRef.SystemDesign,
                 [typeof(Stream)] = "System.ComponentModel.Design.BinaryEditor, " + AssemblyRef.SystemDesign,
                 [typeof(string[])] = "System.Windows.Forms.Design.StringArrayEditor, " + AssemblyRef.SystemDesign,
-                [typeof(Collection<string>)] = "System.Windows.Forms.Design.StringCollectionEditor, " + AssemblyRef.SystemDesign
+
+                // System.Windows.Forms type Editors
+                [typeof(Collection<string>)] = "System.Windows.Forms.Design.StringCollectionEditor, " + AssemblyRef.SystemDesign,
+
+                // System.Drawing.Design type Editors
+                [typeof(Bitmap)] = "System.Drawing.Design.BitmapEditor, " + AssemblyRef.SystemDrawingDesign,
+                [typeof(Color)] = "System.Drawing.Design.ColorEditor, " + AssemblyRef.SystemDrawingDesign,
+                [typeof(Font)] = "System.Drawing.Design.FontEditor, " + AssemblyRef.SystemDrawingDesign,
+                // no way to add Font.Name and associate it with FontNameEditor
+                [typeof(Image)] = "System.Drawing.Design.ImageEditor, " + AssemblyRef.SystemDrawingDesign,
+                [typeof(Metafile)] = "System.Drawing.Design.MetafileEditor, " + AssemblyRef.SystemDrawingDesign,
             };
 
             // Add our intrinsic editors to TypeDescriptor.


### PR DESCRIPTION
I believe we need to service these into 3.0. These associations will not exist at runtime meaning anyone with a property grid in their application trying to pull up an editor for any of these types or for that matter simply anyone trying to use `TypeDescriptor.GetEditor` for these types in an application will *not* get an editor.

This is a breaking change in compatibility against the classic framework. 

Further, it impacts our designer's ability to rely on the runtime.

## Proposed changes
- add editor entries corresponding types in System.Drawing to our ported editors

## Customer Impact
- Customers will be able to rely on common patterns to retrieve an editor for expected types. 

## Regression? 

- Yes 

## Risk
- minimal. This PR uses existing code paths and simply adds missing entries. 

## Test methodology <!-- How did you ensure quality? -->
- TBD, see https://github.com/dotnet/winforms/pull/2089#issuecomment-542843786

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2102)