### PR TITLE
Cleanup IOleContainer

### DIFF
--- a/src/Common/src/Interop/Ole32/Interop.IOleContainer.cs
+++ b/src/Common/src/Interop/Ole32/Interop.IOleContainer.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal static partial class Ole32
+    {
+        [ComImport]
+        [Guid("0000011B-0000-0000-C000-000000000046")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        public unsafe interface IOleContainer
+        {
+            [PreserveSig]
+            HRESULT ParseDisplayName(
+                IntPtr pbc,
+                string pszDisplayName,
+                uint* pchEaten,
+                IntPtr* ppmkOut);
+
+            [PreserveSig]
+            HRESULT EnumObjects(
+                OLECONTF grfFlags,
+                out IEnumUnknown ppenum);
+
+            [PreserveSig]
+            HRESULT LockContainer(
+                BOOL fLock);
+        }
+    }
+}

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -638,7 +638,8 @@ namespace System.Windows.Forms
                 out object moniker);
 
             [PreserveSig]
-            int GetContainer(out IOleContainer container);
+            HRESULT GetContainer(
+                out Ole32.IOleContainer container);
 
             [PreserveSig]
             int ShowObject();
@@ -700,30 +701,6 @@ namespace System.Windows.Forms
             [PreserveSig]
             HRESULT OnPosRectChange(
                 RECT* lprcPosRect);
-        }
-
-        [ComImport(), Guid("0000011B-0000-0000-C000-000000000046"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        public interface IOleContainer
-        {
-            [PreserveSig]
-            int ParseDisplayName(
-                [In, MarshalAs(UnmanagedType.Interface)]
-                object pbc,
-                [In, MarshalAs(UnmanagedType.BStr)]
-                string pszDisplayName,
-                [Out, MarshalAs(UnmanagedType.LPArray)]
-                int[] pchEaten,
-                [Out, MarshalAs(UnmanagedType.LPArray)]
-                object[] ppmkOut);
-
-            [PreserveSig]
-            HRESULT EnumObjects(
-                Ole32.OLECONTF grfFlags,
-                out Ole32.IEnumUnknown ppenum);
-
-            [PreserveSig]
-            int LockContainer(
-                bool fLock);
         }
 
         [ComImport]

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -81,6 +81,7 @@
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IEnumUnknown.cs" Link="Interop\Ole32\Interop.IEnumUnknown.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.ILockBytes.cs" Link="Interop\Ole32\Interop.ILockBytes.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IOleCommandTarget.cs" Link="Interop\Ole32\Interop.IOleCommandTarget.cs" />
+    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IOleContainer.cs" Link="Interop\Ole32\Interop.IOleContainer.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IPropertyNotifySink.cs" Link="Interop\Ole32\Interop.IPropertyNotifySink.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IStorage.cs" Link="Interop\Ole32\Interop.IStorage.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IStream.cs" Link="Interop\Ole32\Interop.IStream.cs" />

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -4283,11 +4283,11 @@ namespace System.Windows.Forms
                 return NativeMethods.E_NOTIMPL;
             }
 
-            int UnsafeNativeMethods.IOleClientSite.GetContainer(out UnsafeNativeMethods.IOleContainer container)
+            HRESULT UnsafeNativeMethods.IOleClientSite.GetContainer(out Ole32.IOleContainer container)
             {
                 Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in getContainer");
                 container = host.GetParentContainer();
-                return NativeMethods.S_OK;
+                return HRESULT.S_OK;
             }
 
             unsafe int UnsafeNativeMethods.IOleClientSite.ShowObject()
@@ -5505,7 +5505,7 @@ namespace System.Windows.Forms
             }
         }
 
-        internal class AxContainer : UnsafeNativeMethods.IOleContainer, UnsafeNativeMethods.IOleInPlaceFrame, IReflect
+        internal class AxContainer : Ole32.IOleContainer, UnsafeNativeMethods.IOleInPlaceFrame, IReflect
         {
             internal ContainerControl parent;
             private IContainer assocContainer; // associated IContainer...
@@ -6182,19 +6182,18 @@ namespace System.Windows.Forms
             }
 
             // IOleContainer methods:
-
-            int UnsafeNativeMethods.IOleContainer.ParseDisplayName(object pbc, string pszDisplayName, int[] pchEaten, object[] ppmkOut)
+            unsafe HRESULT Ole32.IOleContainer.ParseDisplayName(IntPtr pbc, string pszDisplayName, uint *pchEaten, IntPtr* ppmkOut)
             {
                 Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in ParseDisplayName");
                 if (ppmkOut != null)
                 {
-                    ppmkOut[0] = null;
+                    *ppmkOut = IntPtr.Zero;
                 }
 
-                return NativeMethods.E_NOTIMPL;
+                return HRESULT.E_NOTIMPL;
             }
 
-            HRESULT UnsafeNativeMethods.IOleContainer.EnumObjects(Ole32.OLECONTF grfFlags, out Ole32.IEnumUnknown ppenum)
+            HRESULT Ole32.IOleContainer.EnumObjects(Ole32.OLECONTF grfFlags, out Ole32.IEnumUnknown ppenum)
             {
                 Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in EnumObjects");
                 ppenum = null;
@@ -6216,10 +6215,10 @@ namespace System.Windows.Forms
                 return HRESULT.S_OK;
             }
 
-            int UnsafeNativeMethods.IOleContainer.LockContainer(bool fLock)
+            HRESULT Ole32.IOleContainer.LockContainer(BOOL fLock)
             {
                 Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in LockContainer");
-                return NativeMethods.E_NOTIMPL;
+                return HRESULT.E_NOTIMPL;
             }
 
             // IOleInPlaceFrame methods:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -254,8 +254,7 @@ namespace System.Windows.Forms
                         if (Assembly.GetEntryAssembly() == null)
                         {
                             // Now check for IHTMLDocument2
-
-                            if (NativeMethods.Succeeded(_clientSite.GetContainer(out UnsafeNativeMethods.IOleContainer container)) && container is Mshtml.IHTMLDocument)
+                            if (_clientSite.GetContainer(out Ole32.IOleContainer container).Succeeded() && container is Mshtml.IHTMLDocument)
                             {
                                 s_isIE = true;
                                 Debug.WriteLineIf(CompModSwitches.ActiveX.TraceVerbose, "AxSource:IsIE running under IE");

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.AxSourcingSite.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.AxSourcingSite.cs
@@ -36,16 +36,10 @@ namespace System.Windows.Forms
             {
                 if (service == typeof(HtmlDocument))
                 {
-                    int hr = _clientSite.GetContainer(out UnsafeNativeMethods.IOleContainer iOlecontainer);
-
-                    if (NativeMethods.Succeeded(hr)
-                        && (iOlecontainer is Mshtml.IHTMLDocument))
+                    HRESULT hr = _clientSite.GetContainer(out Ole32.IOleContainer iOlecontainer);
+                    if (hr.Succeeded() && iOlecontainer is Mshtml.IHTMLDocument)
                     {
-                        if (_shimManager == null)
-                        {
-                            _shimManager = new HtmlShimManager();
-                        }
-
+                        _shimManager ??= new HtmlShimManager();
                         return new HtmlDocument(_shimManager, iOlecontainer as Mshtml.IHTMLDocument);
                     }
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserContainer.cs
@@ -11,7 +11,7 @@ using static Interop;
 
 namespace System.Windows.Forms
 {
-    internal class WebBrowserContainer : UnsafeNativeMethods.IOleContainer, UnsafeNativeMethods.IOleInPlaceFrame
+    internal class WebBrowserContainer : Ole32.IOleContainer, UnsafeNativeMethods.IOleInPlaceFrame
     {
         private readonly WebBrowserBase parent;
         private IContainer assocContainer;  // associated IContainer...
@@ -28,20 +28,18 @@ namespace System.Windows.Forms
             this.parent = parent;
         }
 
-        //
         // IOleContainer methods:
-        //
-        int UnsafeNativeMethods.IOleContainer.ParseDisplayName(object pbc, string pszDisplayName, int[] pchEaten, object[] ppmkOut)
+        unsafe HRESULT Ole32.IOleContainer.ParseDisplayName(IntPtr pbc, string pszDisplayName, uint* pchEaten, IntPtr* ppmkOut)
         {
             if (ppmkOut != null)
             {
-                ppmkOut[0] = null;
+                *ppmkOut = IntPtr.Zero;
             }
 
-            return NativeMethods.E_NOTIMPL;
+            return HRESULT.E_NOTIMPL;
         }
 
-        HRESULT UnsafeNativeMethods.IOleContainer.EnumObjects(Ole32.OLECONTF grfFlags, out Ole32.IEnumUnknown ppenum)
+        HRESULT Ole32.IOleContainer.EnumObjects(Ole32.OLECONTF grfFlags, out Ole32.IEnumUnknown ppenum)
         {
             ppenum = null;
             if ((grfFlags & Ole32.OLECONTF.EMBEDDINGS) != 0)
@@ -62,9 +60,9 @@ namespace System.Windows.Forms
             return HRESULT.S_OK;
         }
 
-        int UnsafeNativeMethods.IOleContainer.LockContainer(bool fLock)
+        HRESULT Ole32.IOleContainer.LockContainer(BOOL fLock)
         {
-            return NativeMethods.E_NOTIMPL;
+            return HRESULT.E_NOTIMPL;
         }
 
         // IOleInPlaceFrame methods:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserSiteBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserSiteBase.cs
@@ -184,10 +184,10 @@ namespace System.Windows.Forms
             return NativeMethods.E_NOTIMPL;
         }
 
-        int UnsafeNativeMethods.IOleClientSite.GetContainer(out UnsafeNativeMethods.IOleContainer container)
+        HRESULT UnsafeNativeMethods.IOleClientSite.GetContainer(out Ole32.IOleContainer container)
         {
             container = Host.GetParentContainer();
-            return NativeMethods.S_OK;
+            return HRESULT.S_OK;
         }
 
         unsafe int UnsafeNativeMethods.IOleClientSite.ShowObject()


### PR DESCRIPTION
## Proposed Changes
- Cleanup IOleContainer interface: use HRESULT, move to Ole32, use BOOL
- Follow interop guidelines: remove arrays, use pointers

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2109)