### PR TITLE
Clean up Capture method

### DIFF
--- a/src/Common/src/Interop/User32/Interop.SetCapture.cs
+++ b/src/Common/src/Interop/User32/Interop.SetCapture.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Windows.Forms;
 
 internal static partial class Interop
 {
@@ -12,10 +13,10 @@ internal static partial class Interop
         [DllImport(Libraries.User32, ExactSpelling = true)]
         public static extern IntPtr SetCapture(IntPtr hWnd);
 
-        public static IntPtr SetCapture(HandleRef hWnd)
+        public static IntPtr SetCapture(IHandle handle)
         {
-            IntPtr result = SetCapture(hWnd.Handle);
-            GC.KeepAlive(hWnd.Wrapper);
+            IntPtr result = SetCapture(handle.Handle);
+            GC.KeepAlive(handle);
             return result;
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
@@ -851,7 +851,7 @@ namespace System.Windows.Forms
 
             // Hitting tab while holding down the space key.
             SetFlag(FlagMouseDown, false);
-            CaptureInternal = false;
+            Capture = false;
 
             Invalidate();
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -1841,54 +1841,60 @@ namespace System.Windows.Forms
                     DefChildWndProc(ref m);
                     if (childEdit != null && m.HWnd == childEdit.Handle)
                     {
-                        UnsafeNativeMethods.SendMessage(new HandleRef(this, childEdit.Handle), EditMessages.EM_SETMARGINS,
-                                                  NativeMethods.EC_LEFTMARGIN | NativeMethods.EC_RIGHTMARGIN, 0);
+                        UnsafeNativeMethods.SendMessage(
+                            new HandleRef(this, childEdit.Handle),
+                            EditMessages.EM_SETMARGINS,
+                            NativeMethods.EC_LEFTMARGIN | NativeMethods.EC_RIGHTMARGIN,
+                            0);
                     }
                     break;
                 case WindowMessages.WM_LBUTTONDBLCLK:
-                    //the Listbox gets  WM_LBUTTONDOWN - WM_LBUTTONUP -WM_LBUTTONDBLCLK - WM_LBUTTONUP...
-                    //sequence for doubleclick...
-                    //Set MouseEvents...
+                    // The Listbox gets WM_LBUTTONDOWN - WM_LBUTTONUP -WM_LBUTTONDBLCLK - WM_LBUTTONUP
+                    // sequence for doubleclick.
+
+                    // Set MouseEvents
                     mousePressed = true;
                     mouseEvents = true;
-                    CaptureInternal = true;
-                    //Call the DefWndProc() so that mousemove messages get to the windows edit
-                    //
+                    Capture = true;
+
+                    // Call the DefWndProc() so that mousemove messages get to the windows edit
                     DefChildWndProc(ref m);
-                    //the up gets fired from "Combo-box's WndPrc --- So Convert these Coordinates to Combobox coordianate...
-                    //
+
+                    // The message gets fired from Combo-box's WndPrc - convert to Combobox coordinates
                     Point Ptlc = EditToComboboxMapping(m);
                     OnMouseDown(new MouseEventArgs(MouseButtons.Left, 1, Ptlc.X, Ptlc.Y, 0));
                     break;
 
                 case WindowMessages.WM_MBUTTONDBLCLK:
-                    //the Listbox gets  WM_LBUTTONDOWN - WM_LBUTTONUP -WM_LBUTTONDBLCLK - WM_LBUTTONUP...
-                    //sequence for doubleclick...
-                    //Set MouseEvents...
+                    // The Listbox gets  WM_LBUTTONDOWN - WM_LBUTTONUP -WM_LBUTTONDBLCLK - WM_LBUTTONUP
+                    // sequence for doubleclick
+
+                    // Set MouseEvents
                     mousePressed = true;
                     mouseEvents = true;
-                    CaptureInternal = true;
-                    //Call the DefWndProc() so that mousemove messages get to the windows edit
-                    //
+                    Capture = true;
+
+                    // Call the DefWndProc() so that mousemove messages get to the windows edit
                     DefChildWndProc(ref m);
-                    //the up gets fired from "Combo-box's WndPrc --- So Convert these Coordinates to Combobox coordianate...
-                    //
+
+                    // The message gets fired from Combo-box's WndPrc - convert to Combobox coordinates
                     Point Ptmc = EditToComboboxMapping(m);
                     OnMouseDown(new MouseEventArgs(MouseButtons.Middle, 1, Ptmc.X, Ptmc.Y, 0));
                     break;
 
                 case WindowMessages.WM_RBUTTONDBLCLK:
-                    //the Listbox gets  WM_LBUTTONDOWN - WM_LBUTTONUP -WM_LBUTTONDBLCLK - WM_LBUTTONUP...
-                    //sequence for doubleclick...
-                    //Set MouseEvents...
+                    // The Listbox gets  WM_LBUTTONDOWN - WM_LBUTTONUP -WM_LBUTTONDBLCLK - WM_LBUTTONUP
+                    // sequence for doubleclick
+
+                    // Set MouseEvents.
                     mousePressed = true;
                     mouseEvents = true;
-                    CaptureInternal = true;
-                    //Call the DefWndProc() so that mousemove messages get to the windows edit
-                    //
+                    Capture = true;
+
+                    // Call the DefWndProc() so that mousemove messages get to the windows edit
                     DefChildWndProc(ref m);
-                    //the up gets fired from "Combo-box's WndPrc --- So Convert these Coordinates to Combobox coordianate...
-                    //
+
+                    // The message gets fired from Combo-box's WndPrc - convert to Combobox coordinates
                     Point Ptrc = EditToComboboxMapping(m);
                     OnMouseDown(new MouseEventArgs(MouseButtons.Right, 1, Ptrc.X, Ptrc.Y, 0));
                     break;
@@ -1896,36 +1902,34 @@ namespace System.Windows.Forms
                 case WindowMessages.WM_LBUTTONDOWN:
                     mousePressed = true;
                     mouseEvents = true;
-                    //set the mouse capture .. this is the Child Wndproc..
-                    //
-                    CaptureInternal = true;
+
+                    // Set the mouse capture as this is the child Wndproc.
+                    Capture = true;
                     DefChildWndProc(ref m);
-                    //the up gets fired from "Combo-box's WndPrc --- So Convert these Coordinates to Combobox coordianate...
-                    //
+
+                    // The message gets fired from Combo-box's WndPrc - convert to Combobox coordinates
                     Point Ptl = EditToComboboxMapping(m);
 
                     OnMouseDown(new MouseEventArgs(MouseButtons.Left, 1, Ptl.X, Ptl.Y, 0));
                     break;
                 case WindowMessages.WM_LBUTTONUP:
                     // Get the mouse location
-                    //
-                    RECT r = new RECT();
-                    UnsafeNativeMethods.GetWindowRect(new HandleRef(this, Handle), ref r);
-                    Rectangle ClientRect = new Rectangle(r.left, r.top, r.right - r.left, r.bottom - r.top);
-                    // Get the mouse location
-                    //
+                    RECT rect = new RECT();
+                    UnsafeNativeMethods.GetWindowRect(new HandleRef(this, Handle), ref rect);
+                    Rectangle clientRect = rect;
+
                     int x = NativeMethods.Util.SignedLOWORD(m.LParam);
                     int y = NativeMethods.Util.SignedHIWORD(m.LParam);
                     Point pt = new Point(x, y);
                     pt = PointToScreen(pt);
-                    // combo box gets a WM_LBUTTONUP for focus change ...
-                    // So check MouseEvents....
+
+                    // Combobox gets a WM_LBUTTONUP for focus change- check MouseEvents
                     if (mouseEvents && !ValidationCancelled)
                     {
                         mouseEvents = false;
                         if (mousePressed)
                         {
-                            if (ClientRect.Contains(pt))
+                            if (clientRect.Contains(pt))
                             {
                                 mousePressed = false;
                                 OnClick(new MouseEventArgs(MouseButtons.Left, 1, NativeMethods.Util.SignedLOWORD(m.LParam), NativeMethods.Util.SignedHIWORD(m.LParam), 0));
@@ -1939,11 +1943,11 @@ namespace System.Windows.Forms
                             }
                         }
                     }
-                    DefChildWndProc(ref m);
-                    CaptureInternal = false;
 
-                    //the up gets fired from "Combo-box's WndPrc --- So Convert these Coordinates to Combobox coordianate...
-                    //
+                    DefChildWndProc(ref m);
+                    Capture = false;
+
+                    // The message gets fired from Combo-box's WndPrc - convert to Combobox coordinates
                     pt = EditToComboboxMapping(m);
 
                     OnMouseUp(new MouseEventArgs(MouseButtons.Left, 1, pt.X, pt.Y, 0));
@@ -1951,12 +1955,12 @@ namespace System.Windows.Forms
                 case WindowMessages.WM_MBUTTONDOWN:
                     mousePressed = true;
                     mouseEvents = true;
-                    //set the mouse capture .. this is the Child Wndproc..
-                    //
-                    CaptureInternal = true;
+
+                    // Set the mouse capture as this is the child Wndproc.
+                    Capture = true;
                     DefChildWndProc(ref m);
-                    //the up gets fired from "Combo-box's WndPrc --- So Convert these Coordinates to Combobox coordianate...
-                    //
+
+                    // The message gets fired from Combo-box's WndPrc - convert to Combobox coordinates
                     Point P = EditToComboboxMapping(m);
 
                     OnMouseDown(new MouseEventArgs(MouseButtons.Middle, 1, P.X, P.Y, 0));
@@ -1965,17 +1969,15 @@ namespace System.Windows.Forms
                     mousePressed = true;
                     mouseEvents = true;
 
-                    //set the mouse capture .. this is the Child Wndproc..
-                    //
-
                     if (ContextMenu != null || ContextMenuStrip != null)
                     {
-                        CaptureInternal = true;
+                        // Set the mouse capture as this is the child Wndproc.
+                        Capture = true;
                     }
 
                     DefChildWndProc(ref m);
-                    //the up gets fired from "Combo-box's WndPrc --- So Convert these Coordinates to Combobox coordianate...
-                    //
+
+                    // The message gets fired from Combo-box's WndPrc - convert to Combobox coordinates
                     Point Pt = EditToComboboxMapping(m);
 
                     OnMouseDown(new MouseEventArgs(MouseButtons.Right, 1, Pt.X, Pt.Y, 0));
@@ -1983,25 +1985,25 @@ namespace System.Windows.Forms
                 case WindowMessages.WM_MBUTTONUP:
                     mousePressed = false;
                     mouseEvents = false;
-                    //set the mouse capture .. this is the Child Wndproc..
-                    //
-                    CaptureInternal = false;
+
+                    // Set the mouse capture as this is the child Wndproc.
+                    Capture = false;
                     DefChildWndProc(ref m);
                     OnMouseUp(new MouseEventArgs(MouseButtons.Middle, 1, NativeMethods.Util.SignedLOWORD(m.LParam), NativeMethods.Util.SignedHIWORD(m.LParam), 0));
                     break;
                 case WindowMessages.WM_RBUTTONUP:
                     mousePressed = false;
                     mouseEvents = false;
-                    //set the mouse capture .. this is the Child Wndproc..
-                    //
+
                     if (ContextMenu != null)
                     {
-                        CaptureInternal = false;
+                        // Set the mouse capture as this is the child Wndproc.
+                        Capture = false;
                     }
 
                     DefChildWndProc(ref m);
-                    //the up gets fired from "Combo-box's WndPrc --- So Convert these Coordinates to Combobox coordianate...
-                    //
+
+                    // The message gets fired from Combo-box's WndPrc - convert to Combobox coordinates
                     Point ptRBtnUp = EditToComboboxMapping(m);
 
                     OnMouseUp(new MouseEventArgs(MouseButtons.Right, 1, ptRBtnUp.X, ptRBtnUp.Y, 0));
@@ -2021,8 +2023,8 @@ namespace System.Windows.Forms
 
                 case WindowMessages.WM_MOUSEMOVE:
                     Point point = EditToComboboxMapping(m);
-                    //Call the DefWndProc() so that mousemove messages get to the windows edit
-                    //
+
+                    // Call the DefWndProc() so that mousemove messages get to the windows edit control
                     DefChildWndProc(ref m);
                     OnMouseEnterInternal(EventArgs.Empty);
                     OnMouseMove(new MouseEventArgs(MouseButtons, 0, point.X, point.Y, 0));
@@ -2053,7 +2055,6 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Helper to handle MouseEnter.
         /// </summary>
-        /// <param name="args"></param>
         private void OnMouseEnterInternal(EventArgs args)
         {
             if (!mouseInEdit)
@@ -2064,9 +2065,8 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Helper to handle mouseleave
+        ///  Helper to handle MouseLeave.
         /// </summary>
-        /// <param name="args"></param>
         private void OnMouseLeaveInternal(EventArgs args)
         {
             RECT rect = new RECT();
@@ -3916,7 +3916,7 @@ namespace System.Windows.Forms
                     }
                     else
                     {
-                        CaptureInternal = false;
+                        Capture = false;
                         DefWndProc(ref m);
                     }
                     break;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -1246,20 +1246,14 @@ namespace System.Windows.Forms
         ]
         public bool Capture
         {
-            get => CaptureInternal;
-            set => CaptureInternal = value;
-        }
-
-        internal bool CaptureInternal
-        {
             get => IsHandleCreated && User32.GetCapture() == Handle;
             set
             {
-                if (CaptureInternal != value)
+                if (Capture != value)
                 {
                     if (value)
                     {
-                        User32.SetCapture(new HandleRef(this, Handle));
+                        User32.SetCapture(this);
                     }
                     else
                     {
@@ -3028,7 +3022,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                MouseButtons buttons = (MouseButtons)0;
+                MouseButtons buttons = default;
 
                 if (User32.GetKeyState((int)Keys.LButton) < 0)
                 {
@@ -12461,8 +12455,8 @@ namespace System.Windows.Forms
 
             if (!GetExtendedState(ExtendedStates.MaintainsOwnCaptureMode))
             {
-                //CaptureInternal is set usually in MouseDown (ToolStrip main exception)
-                CaptureInternal = true;
+                // Capture is set usually in MouseDown (ToolStrip main exception)
+                Capture = true;
             }
 
             if (realState != MouseButtons)
@@ -12470,8 +12464,8 @@ namespace System.Windows.Forms
                 return;
             }
 
-            // control should be enabled when this method is entered, but may have become
-            // disabled during its lifetime (e.g. through a Click or Focus listener)
+            // Control should be enabled when this method is entered, but may have become
+            // disabled during its lifetime (e.g. through a Click or Focus listener).
             if (Enabled)
             {
                 OnMouseDown(new MouseEventArgs(button, clicks, NativeMethods.Util.SignedLOWORD(m.LParam), NativeMethods.Util.SignedHIWORD(m.LParam), 0));
@@ -12627,13 +12621,14 @@ namespace System.Windows.Forms
             }
             finally
             {
-                //Always Reset the States.DOUBLECLICKFIRED in UP.. Since we get UP - DOWN - DBLCLK - UP sequqnce
-                //The Flag is set in L_BUTTONDBLCLK in the controls WndProc() ...
+                // Always reset the States.DoubleClickFired in UP.. Since we get UP - DOWN - DBLCLK - UP sequence
+                // The flag is set in L_BUTTONDBLCLK in the controls WndProc() ...
                 SetState(States.DoubleClickFired, false);
                 SetState(States.MousePressed, false);
                 SetState(States.ValidationCancelled, false);
-                //CaptureInternal is Resetted while exiting the MouseUp
-                CaptureInternal = false;
+
+                // Capture is reset while exiting MouseUp
+                Capture = false;
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGrid.cs
@@ -5291,7 +5291,7 @@ namespace System.Windows.Forms
                 clip.Width = layout.Data.X + layout.Data.Width - leftEdge - 2;
             }
 
-            CaptureInternal = true;
+            Capture = true;
             Cursor.Clip = RectangleToScreen(clip);
             gridState[GRIDSTATE_trackColResize] = true;
             trackColAnchor = x;
@@ -5414,7 +5414,7 @@ namespace System.Windows.Forms
             finally
             {
                 Cursor.Clip = Rectangle.Empty;
-                CaptureInternal = false;
+                Capture = false;
                 gridState[GRIDSTATE_layoutSuspended] = false;
             }
 
@@ -5529,7 +5529,7 @@ namespace System.Windows.Forms
             clip.Y = topEdge + 3;
             clip.Height = layout.Data.Y + layout.Data.Height - topEdge - 2;
 
-            CaptureInternal = true;
+            Capture = true;
             Cursor.Clip = RectangleToScreen(clip);
             gridState[GRIDSTATE_trackRowResize] = true;
             trackRowAnchor = y;
@@ -5584,7 +5584,7 @@ namespace System.Windows.Forms
             finally
             {
                 Cursor.Clip = Rectangle.Empty;
-                CaptureInternal = false;
+                Capture = false;
             }
             // OnRowResize(EventArgs.Empty);
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -3355,7 +3355,7 @@ namespace System.Windows.Forms
 
         private void CaptureMouse(Rectangle cursorClip)
         {
-            CaptureInternal = true;
+            Capture = true;
             Cursor.Clip = RectangleToScreen(cursorClip);
         }
 
@@ -25170,7 +25170,7 @@ namespace System.Windows.Forms
         private void RealeaseMouse()
         {
             Cursor.Clip = Rectangle.Empty;
-            CaptureInternal = false;
+            Capture = false;
         }
 
         private void RemoveIndividualReadOnlyCellsInColumn(int columnIndex)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -7195,13 +7195,14 @@ namespace System.Windows.Forms
                     break;
                 case WindowMessages.WM_CAPTURECHANGED:
                     base.WndProc(ref m);
-                    // This is a work-around for the Win32 scroll bar; it
-                    // doesn't release it's capture in response to a CAPTURECHANGED
-                    // message, so we force capture away if no button is down.
-                    //
-                    if (CaptureInternal && MouseButtons == (MouseButtons)0)
+
+                    // This is a work-around for the Win32 scroll bar; it doesn't release
+                    // it's capture in response to a CAPTURECHANGED message, so we force
+                    // capture away if no button is down.
+                    
+                    if (Capture && MouseButtons == MouseButtons.None)
                     {
-                        CaptureInternal = false;
+                        Capture = false;
                     }
                     break;
                 case WindowMessages.WM_GETDPISCALEDSIZE:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
@@ -1076,7 +1076,7 @@ namespace System.Windows.Forms
                         FocusLink = (Link)links[i];
                         InvalidateLink(FocusLink);
                     }
-                    CaptureInternal = true;
+                    Capture = true;
                     break;
                 }
             }
@@ -1108,7 +1108,7 @@ namespace System.Windows.Forms
                 {
                     ((Link)links[i]).State &= (~LinkState.Active);
                     InvalidateLink((Link)links[i]);
-                    CaptureInternal = false;
+                    Capture = false;
 
                     Link clicked = PointInLink(e.X, e.Y);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -6335,11 +6335,12 @@ namespace System.Windows.Forms
                         //just maintain state and fire double click.. in final mouseUp...
                         listViewState[LISTVIEWSTATE_doubleclickFired] = true;
                     }
-                    //fire Up in the Wndproc !!
+
+                    // Fire mouse up in the Wndproc
                     listViewState[LISTVIEWSTATE_mouseUpFired] = false;
-                    //problem getting the UP... outside the control...
-                    //
-                    CaptureInternal = true;
+
+                    // Make sure we get the mouse up if it happens outside the control.
+                    Capture = true;
                     break;
 
                 case NativeMethods.LVN_KEYDOWN:
@@ -6570,7 +6571,7 @@ namespace System.Windows.Forms
                     // Ensure that the itemCollectionChangedInMouseDown is not set
                     // before processing the mousedown event.
                     ItemCollectionChangedInMouseDown = false;
-                    CaptureInternal = true;
+                    Capture = true;
                     WmMouseDown(ref m, MouseButtons.Left, 2);
                     break;
 
@@ -6607,7 +6608,7 @@ namespace System.Windows.Forms
                     ItemCollectionChangedInMouseDown = false;
 
                     listViewState[LISTVIEWSTATE_mouseUpFired] = true;
-                    CaptureInternal = false;
+                    Capture = false;
                     break;
                 case WindowMessages.WM_MBUTTONDBLCLK:
                     WmMouseDown(ref m, MouseButtons.Middle, 2);
@@ -6629,7 +6630,7 @@ namespace System.Windows.Forms
                         OnMouseUp(new MouseEventArgs(downButton, 1, NativeMethods.Util.SignedLOWORD(m.LParam), NativeMethods.Util.SignedHIWORD(m.LParam), 0));
                         listViewState[LISTVIEWSTATE_mouseUpFired] = true;
                     }
-                    CaptureInternal = false;
+                    Capture = false;
                     base.WndProc(ref m);
                     break;
                 case WindowMessages.WM_MOUSEHOVER:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -3332,22 +3332,21 @@ namespace System.Windows.Forms
             }
         }
 
-        //
         protected override void OnMouseDown(MouseEventArgs me)
         {
             SnappableControl target = DividerInside(me.X, me.Y);
             if (target != null && me.Button == MouseButtons.Left)
             {
-                // capture mouse.
-                CaptureInternal = true;
+                // Capture the mouse.
+                Capture = true;
                 targetMove = target;
                 dividerMoveY = me.Y;
                 DividerDraw(dividerMoveY);
             }
+
             base.OnMouseDown(me);
         }
 
-        //
         protected override void OnMouseMove(MouseEventArgs me)
         {
             if (dividerMoveY == -1)
@@ -3371,10 +3370,10 @@ namespace System.Windows.Forms
                 dividerMoveY = yNew;
                 DividerDraw(dividerMoveY);
             }
+
             base.OnMouseMove(me);
         }
 
-        //
         protected override void OnMouseUp(MouseEventArgs me)
         {
             if (dividerMoveY == -1)
@@ -3404,8 +3403,8 @@ namespace System.Windows.Forms
                 gridView.Invalidate(new Rectangle(0, gridView.Size.Height - cyDivider, Size.Width, cyDivider));
             }
 
-            // end the move
-            CaptureInternal = false;
+            // End the move
+            Capture = false;
             dividerMoveY = -1;
             targetMove = null;
             base.OnMouseUp(me);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -962,7 +962,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (GetFlag(FlagIsSplitterMove))
             {
                 SetFlag(FlagIsSplitterMove, false);
-                CaptureInternal = false;
+                Capture = false;
 
                 if (selectedRow != -1)
                 {
@@ -3635,7 +3635,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 UnfocusSelection();
                 SetFlag(FlagIsSplitterMove, true);
                 tipInfo = -1;
-                CaptureInternal = true;
+                Capture = true;
                 return;
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
@@ -1371,7 +1371,7 @@ namespace System.Windows.Forms
             }
             if (!IsSplitterFixed && IsSplitterMovable && splitterClick)
             {
-                CaptureInternal = false;
+                Capture = false;
 
                 if (splitterDrag)
                 {
@@ -2279,7 +2279,7 @@ namespace System.Windows.Forms
             }
             Application.AddMessageFilter(splitContainerMessageFilter);
 
-            CaptureInternal = true;
+            Capture = true;
             DrawSplitBar(DRAW_START);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.cs
@@ -949,7 +949,7 @@ namespace System.Windows.Forms
                 }
                 Application.AddMessageFilter(splitterMessageFilter);
 
-                CaptureInternal = true;
+                Capture = true;
                 DrawSplitBar(DRAW_START);
             }
         }
@@ -961,7 +961,7 @@ namespace System.Windows.Forms
         {
             DrawSplitBar(DRAW_END);
             splitTarget = null;
-            CaptureInternal = false;
+            Capture = false;
             if (splitterMessageFilter != null)
             {
                 Application.RemoveMessageFilter(splitterMessageFilter);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -3801,7 +3801,7 @@ namespace System.Windows.Forms
                     // set capture only when we know we're not on a dropdown (already effectively have capture due to modal menufilter)
                     // and the item in question requires the mouse to be in the same item to be clicked.
                     SetToolStripState(STATE_LASTMOUSEDOWNEDITEMCAPTURE, true);
-                    CaptureInternal = true;
+                    Capture = true;
                 }
                 MenuAutoExpand = true;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
@@ -1878,7 +1878,7 @@ namespace System.Windows.Forms
 
                         if (!openingEventCancelled)
                         {
-                            // do the actual work to open the window.
+                            // Do the actual work to open the window.
                             if (TopLevel)
                             {
                                 ReparentToActiveToolStripWindow();
@@ -1891,14 +1891,15 @@ namespace System.Windows.Forms
                                 // in the parent, make sure it retains where the mouse really was.
                                 OwnerToolStrip.SnapMouseLocation();
 
-                                // Make sure that mouse capture
-                                // transitions between the owner and dropdown.
-                                if (OwnerToolStrip.CaptureInternal)
+                                // Make sure that mouse capture transitions between the owner and dropdown.
+                                if (OwnerToolStrip.Capture)
                                 {
-                                    CaptureInternal = true;
+                                    Capture = true;
                                 }
                             }
+
                             base.SetVisibleCore(visible);
+
                             if (TopLevel)
                             {
                                 ApplyTopMost(true);
@@ -2006,16 +2007,16 @@ namespace System.Windows.Forms
                                 }
                                 finally
                                 {
-                                    // rRmove ourselves from the active dropdown list.
+                                    // Remove ourselves from the active dropdown list.
                                     OwnerToolStrip?.ActiveDropDowns.Remove(this);
                                     ActiveDropDowns.Clear();
 
-                                    // If the user traps the click event and starts
-                                    // pumping their own messages by calling Application.DoEvents, we
-                                    // should release mouse capture.
-                                    if (CaptureInternal)
+                                    // If the user traps the click event and starts pumping their
+                                    // own messages by calling Application.DoEvents, we should
+                                    // release mouse capture.
+                                    if (Capture)
                                     {
-                                        CaptureInternal = false;
+                                        Capture = false;
                                     }
                                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.cs
@@ -760,7 +760,7 @@ namespace System.Windows.Forms
                 try
                 {
                     CurrentFeedbackRect.Show(screenLocation);
-                    toolStripToDrag.CaptureInternal = true;
+                    toolStripToDrag.Capture = true;
                 }
                 finally
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -3304,13 +3304,15 @@ namespace System.Windows.Forms
                     break;
                 case WindowMessages.WM_LBUTTONDBLCLK:
                     WmMouseDown(ref m, MouseButtons.Left, 2);
-                    //just maintain state and fire double click.. in final mouseUp...
+
+                    // Just maintain state and fire double click in final mouseUp.
                     treeViewState[TREEVIEWSTATE_doubleclickFired] = true;
-                    //fire Up in the Wndproc !!
+
+                    // Fire mouse up in the Wndproc.
                     treeViewState[TREEVIEWSTATE_mouseUpFired] = false;
-                    //problem getting the UP... outside the control...
-                    //
-                    CaptureInternal = true;
+
+                    // Make sure we get the mouse up if it happens outside the control.
+                    Capture = true;
                     break;
                 case WindowMessages.WM_LBUTTONDOWN:
                     try
@@ -3322,7 +3324,8 @@ namespace System.Windows.Forms
                     {
                         treeViewState[TREEVIEWSTATE_ignoreSelects] = false;
                     }
-                    //Always Reset the MouseupFired....
+
+                    // Always reset the MouseupFired.
                     treeViewState[TREEVIEWSTATE_mouseUpFired] = false;
                     NativeMethods.TV_HITTESTINFO tvhip = new NativeMethods.TV_HITTESTINFO
                     {
@@ -3363,8 +3366,8 @@ namespace System.Windows.Forms
                         pt_y = NativeMethods.Util.SignedHIWORD(m.LParam)
                     };
                     IntPtr hnode = UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TVM_HITTEST, 0, tvhi);
-                    //Important for CheckBoxes ... click needs to be fired ...
-                    //
+
+                    // Important for CheckBoxes. Click needs to be fired.
                     if (hnode != IntPtr.Zero)
                     {
                         if (!ValidationCancelled && !treeViewState[TREEVIEWSTATE_doubleclickFired] & !treeViewState[TREEVIEWSTATE_mouseUpFired])
@@ -3401,18 +3404,18 @@ namespace System.Windows.Forms
 
                     treeViewState[TREEVIEWSTATE_doubleclickFired] = false;
                     treeViewState[TREEVIEWSTATE_mouseUpFired] = false;
-                    CaptureInternal = false;
+                    Capture = false;
 
-                    //always clear our hit-tested node we cached on mouse down
+                    // Always clear our hit-tested node we cached on mouse down
                     hNodeMouseDown = IntPtr.Zero;
                     break;
                 case WindowMessages.WM_MBUTTONDBLCLK:
-                    //fire Up in the Wndproc !!
+                    // Fire mouse up in the Wndproc.
                     treeViewState[TREEVIEWSTATE_mouseUpFired] = false;
                     WmMouseDown(ref m, MouseButtons.Middle, 2);
                     break;
                 case WindowMessages.WM_MBUTTONDOWN:
-                    //Always Reset the MouseupFired....
+                    // Always reset MouseupFired.
                     treeViewState[TREEVIEWSTATE_mouseUpFired] = false;
                     WmMouseDown(ref m, MouseButtons.Middle, 1);
                     downButton = MouseButtons.Middle;
@@ -3425,13 +3428,15 @@ namespace System.Windows.Forms
                     break;
                 case WindowMessages.WM_RBUTTONDBLCLK:
                     WmMouseDown(ref m, MouseButtons.Right, 2);
-                    //just maintain state and fire double click.. in final mouseUp...
+
+                    // Just maintain state and fire double click in the final mouseUp.
                     treeViewState[TREEVIEWSTATE_doubleclickFired] = true;
-                    //fire Up in the Wndproc !!
+
+                    // Fire mouse up in the Wndproc
                     treeViewState[TREEVIEWSTATE_mouseUpFired] = false;
-                    //problem getting the UP... outside the control...
-                    //
-                    CaptureInternal = true;
+
+                    // Make sure we get the mouse up if it happens outside the control.
+                    Capture = true;
                     break;
                 case WindowMessages.WM_RBUTTONDOWN:
                     //Always Reset the MouseupFired....

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
@@ -1428,40 +1428,30 @@ namespace System.Windows.Forms
 
             // Called when the mouse button is pressed - we need to start
             // spinning the value of the updown.
-            //
             private void BeginButtonPress(MouseEventArgs e)
             {
-
                 int half_height = Size.Height / 2;
 
                 if (e.Y < half_height)
                 {
-
                     // Up button
-                    //
                     pushed = captured = ButtonID.Up;
                     Invalidate();
-
                 }
                 else
                 {
-
                     // Down button
-                    //
                     pushed = captured = ButtonID.Down;
                     Invalidate();
                 }
 
                 // Capture the mouse
-                //
-                CaptureInternal = true;
+                Capture = true;
 
                 // Generate UpDown event
-                //
                 OnUpDown(new UpDownEventArgs((int)pushed));
 
                 // Start the timer for new updown events
-                //
                 StartTimer();
             }
 
@@ -1472,10 +1462,8 @@ namespace System.Windows.Forms
 
             // Called when the mouse button is released - we need to stop
             // spinning the value of the updown.
-            //
             private void EndButtonPress()
             {
-
                 pushed = ButtonID.None;
                 captured = ButtonID.None;
 
@@ -1483,7 +1471,7 @@ namespace System.Windows.Forms
                 StopTimer();
 
                 // Release the mouse
-                CaptureInternal = false;
+                Capture = false;
 
                 // Redraw the buttons
                 Invalidate();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.cs
@@ -5338,24 +5338,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, cont.Capture);
         }
 
-        /// <summary>
-        ///  Data for the CaptureInternalGetSet test
-        /// </summary>
-        public static TheoryData<bool> CaptureInternalGetSetData =>
-            CommonTestHelper.GetBoolTheoryData();
-
-        [Theory]
-        [MemberData(nameof(CaptureInternalGetSetData))]
-        public void Control_CaptureInternalGetSet(bool expected)
-        {
-            var cont = new Control
-            {
-                CaptureInternal = expected
-            };
-
-            Assert.Equal(expected, cont.CaptureInternal);
-        }
-
         #endregion
 
         #region CanProcessMnemonic


### PR DESCRIPTION
CaptureInternal was only necessary for perf on framework as the public property asserted code permissions. Removed it and cleaned up some comments around the changed code. Also removed the unnecessary HandleRef.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2143)