### PR TITLE
Cleanup IOleClientSite

### DIFF
--- a/src/Common/src/Interop/Ole32/Interop.IOleClientSite.cs
+++ b/src/Common/src/Interop/Ole32/Interop.IOleClientSite.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal static partial class Ole32
+    {
+        [ComImport]
+        [Guid("00000118-0000-0000-C000-000000000046")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        public unsafe interface IOleClientSite
+        {
+            [PreserveSig]
+            HRESULT SaveObject();
+
+            [PreserveSig]
+            HRESULT GetMoniker(
+                Ole32.OLEGETMONIKER dwAssign,
+                Ole32.OLEWHICHMK dwWhichMoniker,
+                IntPtr* ppmk);
+
+            [PreserveSig]
+            HRESULT GetContainer(
+                out IOleContainer container);
+
+            [PreserveSig]
+            HRESULT ShowObject();
+
+            [PreserveSig]
+            HRESULT OnShowWindow(
+                BOOL fShow);
+
+            [PreserveSig]
+            HRESULT RequestNewObjectLayout();
+        }
+    }
+}

--- a/src/Common/src/Interop/Ole32/Interop.OLEGETMONIKER.cs
+++ b/src/Common/src/Interop/Ole32/Interop.OLEGETMONIKER.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class Ole32
+    {
+        public enum OLEGETMONIKER : uint
+        {
+            ONLYIFTHERE = 1,
+            FORCEASSIGN = 2,
+            UNASSIGN = 3,
+            TEMPFORUSER = 4
+        }
+    }
+}

--- a/src/Common/src/Interop/Ole32/Interop.OLEWHICHMK.cs
+++ b/src/Common/src/Interop/Ole32/Interop.OLEWHICHMK.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class Ole32
+    {
+        public enum OLEWHICHMK : uint
+        {
+            CONTAINER = 1,
+            OBJREL = 2,
+            OBJFULL = 3
+        }
+    }
+}

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -607,35 +607,6 @@ namespace System.Windows.Forms
             }
         }
 
-        [ComImport(), Guid("00000118-0000-0000-C000-000000000046"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        public interface IOleClientSite
-        {
-            [PreserveSig]
-            int SaveObject();
-
-            [PreserveSig]
-            int GetMoniker(
-                [In, MarshalAs(UnmanagedType.U4)]
-                int dwAssign,
-                [In, MarshalAs(UnmanagedType.U4)]
-                int dwWhichMoniker,
-                [Out, MarshalAs(UnmanagedType.Interface)]
-                out object moniker);
-
-            [PreserveSig]
-            HRESULT GetContainer(
-                out Ole32.IOleContainer container);
-
-            [PreserveSig]
-            int ShowObject();
-
-            [PreserveSig]
-            int OnShowWindow(int fShow);
-
-            [PreserveSig]
-            int RequestNewObjectLayout();
-        }
-
         [ComImport]
         [Guid("00000119-0000-0000-C000-000000000046")]
         [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
@@ -1045,11 +1016,12 @@ namespace System.Windows.Forms
         public unsafe interface IOleObject
         {
             [PreserveSig]
-            int SetClientSite(
-                   [In, MarshalAs(UnmanagedType.Interface)]
-                      IOleClientSite pClientSite);
+            HRESULT SetClientSite(
+                Ole32.IOleClientSite pClientSite);
 
-            IOleClientSite GetClientSite();
+            [PreserveSig]
+            HRESULT GetClientSite(
+                out Ole32.IOleClientSite ppClientSite);
 
             [PreserveSig]
             int SetHostNames(
@@ -1063,20 +1035,15 @@ namespace System.Windows.Forms
                 Ole32.OLECLOSE dwSaveOption);
 
             [PreserveSig]
-            int SetMoniker(
-                   [In, MarshalAs(UnmanagedType.U4)]
-                     int dwWhichMoniker,
-                   [In, MarshalAs(UnmanagedType.Interface)]
-                     object pmk);
+            HRESULT SetMoniker(
+                Ole32.OLEWHICHMK dwWhichMoniker,
+                [MarshalAs(UnmanagedType.Interface)] object pmk);
 
             [PreserveSig]
-            int GetMoniker(
-                  [In, MarshalAs(UnmanagedType.U4)]
-                     int dwAssign,
-                  [In, MarshalAs(UnmanagedType.U4)]
-                     int dwWhichMoniker,
-                  [Out, MarshalAs(UnmanagedType.Interface)]
-                     out object moniker);
+            HRESULT GetMoniker(
+                Ole32.OLEGETMONIKER dwAssign,
+                Ole32.OLEWHICHMK dwWhichMoniker,
+                IntPtr* ppmk);
 
             [PreserveSig]
             int InitFromData(
@@ -1096,7 +1063,7 @@ namespace System.Windows.Forms
             HRESULT DoVerb(
                 Ole32.OLEIVERB iVerb,
                 User32.MSG* lpmsg,
-                IOleClientSite pActiveSite,
+                Ole32.IOleClientSite pActiveSite,
                 int lindex,
                 IntPtr hwndParent,
                 RECT* lprcPosRect);
@@ -1162,12 +1129,12 @@ namespace System.Windows.Forms
         public unsafe interface IOleInPlaceObjectWindowless
         {
             [PreserveSig]
-            int SetClientSite(
-                   [In, MarshalAs(UnmanagedType.Interface)]
-                      IOleClientSite pClientSite);
+            HRESULT SetClientSite(
+                Ole32.IOleClientSite pClientSite);
 
             [PreserveSig]
-            int GetClientSite(out IOleClientSite site);
+            HRESULT GetClientSite(
+                out Ole32.IOleClientSite ppClientSite);
 
             [PreserveSig]
             int SetHostNames(
@@ -1181,20 +1148,15 @@ namespace System.Windows.Forms
                     int dwSaveOption);
 
             [PreserveSig]
-            int SetMoniker(
-                   [In, MarshalAs(UnmanagedType.U4)]
-                     int dwWhichMoniker,
-                   [In, MarshalAs(UnmanagedType.Interface)]
-                     object pmk);
+            HRESULT SetMoniker(
+                Ole32.OLEWHICHMK dwWhichMoniker,
+                [MarshalAs(UnmanagedType.Interface)] object pmk);
 
             [PreserveSig]
-            int GetMoniker(
-                  [In, MarshalAs(UnmanagedType.U4)]
-                     int dwAssign,
-                  [In, MarshalAs(UnmanagedType.U4)]
-                     int dwWhichMoniker,
-                  [Out, MarshalAs(UnmanagedType.Interface)]
-                     out object moniker);
+            HRESULT GetMoniker(
+                Ole32.OLEGETMONIKER dwAssign,
+                Ole32.OLEWHICHMK dwWhichMoniker,
+                IntPtr* ppmk);
 
             [PreserveSig]
             int InitFromData(
@@ -1214,7 +1176,7 @@ namespace System.Windows.Forms
             HRESULT DoVerb(
                 int iVerb,
                 User32.MSG* lpmsg,
-                IOleClientSite pActiveSite,
+                Ole32.IOleClientSite pActiveSite,
                 int lindex,
                 IntPtr hwndParent,
                 RECT* lprcPosRect);
@@ -1791,7 +1753,7 @@ namespace System.Windows.Forms
             [MarshalAs(UnmanagedType.U4)]
             public int cbSize = Marshal.SizeOf<tagQACONTAINER>();
 
-            public IOleClientSite pClientSite;
+            public Ole32.IOleClientSite pClientSite;
 
             [MarshalAs(UnmanagedType.Interface)]
             public object pAdviseSink = null;

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -94,6 +94,7 @@
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.ILockBytes.cs" Link="Interop\Ole32\Interop.ILockBytes.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IMPLTYPEFLAG.cs" Link="Interop\Ole32\Interop.IMPLTYPEFLAG.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.INVOKEKIND.cs" Link="Interop\Ole32\Interop.INVOKEKIND.cs" />
+    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IOleClientSite.cs" Link="Interop\Ole32\Interop.IOleClientSite.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IOleCommandTarget.cs" Link="Interop\Ole32\Interop.IOleCommandTarget.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IOleContainer.cs" Link="Interop\Ole32\Interop.IOleContainer.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IOleInPlaceActiveObject.cs" Link="Interop\Ole32\Interop.IOleInPlaceActiveObject.cs" />
@@ -108,10 +109,12 @@
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.OLECMDF.cs" Link="Interop\Ole32\Interop.OLECMDF.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.OLECMDID.cs" Link="Interop\Ole32\Interop.OLECMDID.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.OLECONTF.cs" Link="Interop\Ole32\Interop.OLECONTF.cs" />
+    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.OLEGETMONIKER.cs" Link="Interop\Ole32\Interop.OLEGETMONIKER.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.OLEINPLACEFRAMEINFO.cs" Link="Interop\Ole32\Interop.OLEINPLACEFRAMEINFO.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.OLEIVERB.cs" Link="Interop\Ole32\Interop.OLEIVERB.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.OLEMENUGROUPWIDTHS.cs" Link="Interop\Ole32\Interop.OLEMENUGROUPWIDTHS.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.OLEMISC.cs" Link="Interop\Ole32\Interop.OLEMISC.cs" />
+    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.OLEWHICHMK.cs" Link="Interop\Ole32\Interop.OLEWHICHMK.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.PARAMDESC.cs" Link="Interop\Ole32\Interop.PARAMDESC.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.PARAMFLAG.cs" Link="Interop\Ole32\Interop.PARAMFLAG.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.RevokeDragDrop.cs" Link="Interop\Ole32\Interop.RevokeDragDrop.cs" />

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.cs
@@ -790,19 +790,13 @@ namespace System.Windows.Forms
                 AxHost ctl = null;
                 if (pActiveObject is UnsafeNativeMethods.IOleObject oleObject)
                 {
-                    UnsafeNativeMethods.IOleClientSite clientSite = null;
-                    try
+                    HRESULT hr = oleObject.GetClientSite(out Ole32.IOleClientSite clientSite);
+                    Debug.Assert(hr.Succeeded());
+                    if (clientSite is OleInterfaces)
                     {
-                        clientSite = oleObject.GetClientSite();
-                        if (clientSite is OleInterfaces)
-                        {
-                            ctl = ((OleInterfaces)(clientSite)).GetAxHost();
-                        }
+                        ctl = ((OleInterfaces)(clientSite)).GetAxHost();
                     }
-                    catch (COMException t)
-                    {
-                        Debug.Fail(t.ToString());
-                    }
+
                     if (ctlInEditMode != null)
                     {
                         Debug.Fail("control " + ctlInEditMode.ToString() + " did not reset its edit mode to null");

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.OleInterfaces.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.OleInterfaces.cs
@@ -23,7 +23,7 @@ namespace System.Windows.Forms
         /// </summary>
         private class OleInterfaces :
             Ole32.IOleControlSite,
-            UnsafeNativeMethods.IOleClientSite,
+            Ole32.IOleClientSite,
             UnsafeNativeMethods.IOleInPlaceSite,
             Ole32.ISimpleFrameSite,
             Ole32.IVBGetControl,
@@ -354,27 +354,32 @@ namespace System.Windows.Forms
             }
 
             // IOleClientSite methods:
-            int UnsafeNativeMethods.IOleClientSite.SaveObject()
+            HRESULT Ole32.IOleClientSite.SaveObject()
             {
                 Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in SaveObject");
-                return NativeMethods.E_NOTIMPL;
+                return HRESULT.E_NOTIMPL;
             }
 
-            int UnsafeNativeMethods.IOleClientSite.GetMoniker(int dwAssign, int dwWhichMoniker, out object moniker)
+            unsafe HRESULT Ole32.IOleClientSite.GetMoniker(Ole32.OLEGETMONIKER dwAssign, Ole32.OLEWHICHMK dwWhichMoniker, IntPtr* ppmk)
             {
+                if (ppmk == null)
+                {
+                    return HRESULT.E_POINTER;
+                }
+
                 Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:GetMoniker");
-                moniker = null;
-                return NativeMethods.E_NOTIMPL;
+                *ppmk = IntPtr.Zero;
+                return HRESULT.E_NOTIMPL;
             }
 
-            HRESULT UnsafeNativeMethods.IOleClientSite.GetContainer(out Ole32.IOleContainer container)
+            HRESULT Ole32.IOleClientSite.GetContainer(out Ole32.IOleContainer container)
             {
                 Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in getContainer");
                 container = host.GetParentContainer();
                 return HRESULT.S_OK;
             }
 
-            unsafe int UnsafeNativeMethods.IOleClientSite.ShowObject()
+            unsafe HRESULT Ole32.IOleClientSite.ShowObject()
             {
                 Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in ShowObject");
                 if (host.GetAxState(AxHost.fOwnWindow))
@@ -418,19 +423,19 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.AXWindowlessControl);
                 }
 
-                return NativeMethods.S_OK;
+                return HRESULT.S_OK;
             }
 
-            int UnsafeNativeMethods.IOleClientSite.OnShowWindow(int fShow)
+            HRESULT Ole32.IOleClientSite.OnShowWindow(BOOL fShow)
             {
                 Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in OnShowWindow");
-                return NativeMethods.S_OK;
+                return HRESULT.S_OK;
             }
 
-            int UnsafeNativeMethods.IOleClientSite.RequestNewObjectLayout()
+            HRESULT Ole32.IOleClientSite.RequestNewObjectLayout()
             {
                 Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in RequestNewObjectLayout");
-                return NativeMethods.E_NOTIMPL;
+                return HRESULT.E_NOTIMPL;
             }
 
             // IOleInPlaceSite methods:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -1714,7 +1714,7 @@ namespace System.Windows.Forms
                 Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "Naughty control didn't call showObject...");
                 try
                 {
-                    ((UnsafeNativeMethods.IOleClientSite)oleSite).ShowObject();
+                    ((Ole32.IOleClientSite)oleSite).ShowObject();
                 }
                 catch
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -52,7 +52,7 @@ namespace System.Windows.Forms
             private readonly Control _control;
             private readonly IWindowTarget _controlWindowTarget;
             private IntPtr _clipRegion;
-            private UnsafeNativeMethods.IOleClientSite _clientSite;
+            private Ole32.IOleClientSite _clientSite;
             private Ole32.IOleInPlaceUIWindow _inPlaceUiWindow;
             private Ole32.IOleInPlaceFrame _inPlaceFrame;
             private readonly ArrayList _adviseList;
@@ -330,7 +330,7 @@ namespace System.Windows.Forms
             internal unsafe HRESULT DoVerb(
                 Ole32.OLEIVERB iVerb,
                 User32.MSG* lpmsg,
-                UnsafeNativeMethods.IOleClientSite pActiveSite,
+                Ole32.IOleClientSite pActiveSite,
                 int lindex,
                 IntPtr hwndParent,
                 RECT* lprcPosRect)
@@ -658,10 +658,7 @@ namespace System.Windows.Forms
             /// <summary>
             ///  Implements IOleObject::GetClientSite.
             /// </summary>
-            internal UnsafeNativeMethods.IOleClientSite GetClientSite()
-            {
-                return _clientSite;
-            }
+            internal Ole32.IOleClientSite GetClientSite() => _clientSite;
 
             internal unsafe HRESULT GetControlInfo(NativeMethods.tagCONTROLINFO pCI)
             {
@@ -1928,7 +1925,7 @@ namespace System.Windows.Forms
             /// <summary>
             ///  Implements IOleObject::SetClientSite.
             /// </summary>
-            internal void SetClientSite(UnsafeNativeMethods.IOleClientSite value)
+            internal void SetClientSite(Ole32.IOleClientSite value)
             {
                 if (_clientSite != null)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.AxSourcingSite.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.AxSourcingSite.cs
@@ -11,11 +11,11 @@ namespace System.Windows.Forms
     {
         private class AxSourcingSite : ISite
         {
-            private readonly UnsafeNativeMethods.IOleClientSite _clientSite;
+            private readonly Ole32.IOleClientSite _clientSite;
             private string _name;
             private HtmlShimManager _shimManager;
 
-            internal AxSourcingSite(IComponent component, UnsafeNativeMethods.IOleClientSite clientSite, string name)
+            internal AxSourcingSite(IComponent component, Ole32.IOleClientSite clientSite, string name)
             {
                 Component = component;
                 _clientSite = clientSite;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -13918,17 +13918,18 @@ namespace System.Windows.Forms
             return HRESULT.S_OK;
         }
 
-        int UnsafeNativeMethods.IOleObject.SetClientSite(UnsafeNativeMethods.IOleClientSite pClientSite)
+        HRESULT UnsafeNativeMethods.IOleObject.SetClientSite(Ole32.IOleClientSite pClientSite)
         {
             Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:SetClientSite");
             ActiveXInstance.SetClientSite(pClientSite);
-            return NativeMethods.S_OK;
+            return HRESULT.S_OK;
         }
 
-        UnsafeNativeMethods.IOleClientSite UnsafeNativeMethods.IOleObject.GetClientSite()
+        HRESULT UnsafeNativeMethods.IOleObject.GetClientSite(out Ole32.IOleClientSite ppClientSite)
         {
             Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:GetClientSite");
-            return ActiveXInstance.GetClientSite();
+            ppClientSite = ActiveXInstance.GetClientSite();
+            return HRESULT.S_OK;
         }
 
         int UnsafeNativeMethods.IOleObject.SetHostNames(string szContainerApp, string szContainerObj)
@@ -13946,17 +13947,22 @@ namespace System.Windows.Forms
             return HRESULT.S_OK;
         }
 
-        int UnsafeNativeMethods.IOleObject.SetMoniker(int dwWhichMoniker, object pmk)
+        HRESULT UnsafeNativeMethods.IOleObject.SetMoniker(Ole32.OLEWHICHMK dwWhichMoniker, object pmk)
         {
             Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:SetMoniker");
-            return NativeMethods.E_NOTIMPL;
+            return HRESULT.E_NOTIMPL;
         }
 
-        int UnsafeNativeMethods.IOleObject.GetMoniker(int dwAssign, int dwWhichMoniker, out object moniker)
+        unsafe HRESULT UnsafeNativeMethods.IOleObject.GetMoniker(Ole32.OLEGETMONIKER dwAssign, Ole32.OLEWHICHMK dwWhichMoniker, IntPtr* ppmk)
         {
+            if (ppmk == null)
+            {
+                return HRESULT.E_POINTER;
+            }
+
             Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:GetMoniker");
-            moniker = null;
-            return NativeMethods.E_NOTIMPL;
+            *ppmk = IntPtr.Zero;
+            return HRESULT.E_NOTIMPL;
         }
 
         int UnsafeNativeMethods.IOleObject.InitFromData(IComDataObject pDataObject, int fCreation, int dwReserved)
@@ -13975,7 +13981,7 @@ namespace System.Windows.Forms
         unsafe HRESULT UnsafeNativeMethods.IOleObject.DoVerb(
             Ole32.OLEIVERB iVerb,
             User32.MSG* lpmsg,
-            UnsafeNativeMethods.IOleClientSite pActiveSite,
+            Ole32.IOleClientSite pActiveSite,
             int lindex,
             IntPtr hwndParent,
             RECT* lprcPosRect)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserContainer.cs
@@ -111,19 +111,12 @@ namespace System.Windows.Forms
             WebBrowserBase ctl = null;
             if (pActiveObject is UnsafeNativeMethods.IOleObject oleObject)
             {
-                UnsafeNativeMethods.IOleClientSite clientSite = null;
-                try
+                oleObject.GetClientSite(out Ole32.IOleClientSite clientSite);
+                if (clientSite is WebBrowserSiteBase webBrowserSiteBase)
                 {
-                    clientSite = oleObject.GetClientSite();
-                    if (clientSite is WebBrowserSiteBase webBrowserSiteBase)
-                    {
-                        ctl = webBrowserSiteBase.GetAXHost();
-                    }
+                    ctl = webBrowserSiteBase.Host;
                 }
-                catch (COMException t)
-                {
-                    Debug.Fail(t.ToString());
-                }
+
                 if (ctlInEditMode != null)
                 {
                     Debug.Fail("control " + ctlInEditMode.ToString() + " did not reset its edit mode to null");

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserSiteBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserSiteBase.cs
@@ -25,8 +25,8 @@ namespace System.Windows.Forms
     /// </summary>
     public class WebBrowserSiteBase :
         Ole32.IOleControlSite,
-        UnsafeNativeMethods.IOleClientSite,
         UnsafeNativeMethods.IOleInPlaceSite,
+        Ole32.IOleClientSite,
         Ole32.ISimpleFrameSite,
         Ole32.IPropertyNotifySink,
         IDisposable
@@ -170,27 +170,27 @@ namespace System.Windows.Forms
 
         HRESULT Ole32.IOleControlSite.ShowPropertyFrame() => HRESULT.E_NOTIMPL;
 
-        //
         // IOleClientSite methods:
-        //
-        int UnsafeNativeMethods.IOleClientSite.SaveObject()
+        HRESULT Ole32.IOleClientSite.SaveObject() => HRESULT.E_NOTIMPL;
+
+        unsafe HRESULT Ole32.IOleClientSite.GetMoniker(Ole32.OLEGETMONIKER dwAssign, Ole32.OLEWHICHMK dwWhichMoniker, IntPtr* ppmk)
         {
-            return NativeMethods.E_NOTIMPL;
+            if (ppmk == null)
+            {
+                return HRESULT.E_POINTER;
+            }
+
+            *ppmk = IntPtr.Zero;
+            return HRESULT.E_NOTIMPL;
         }
 
-        int UnsafeNativeMethods.IOleClientSite.GetMoniker(int dwAssign, int dwWhichMoniker, out object moniker)
-        {
-            moniker = null;
-            return NativeMethods.E_NOTIMPL;
-        }
-
-        HRESULT UnsafeNativeMethods.IOleClientSite.GetContainer(out Ole32.IOleContainer container)
+        HRESULT Ole32.IOleClientSite.GetContainer(out Ole32.IOleContainer container)
         {
             container = Host.GetParentContainer();
             return HRESULT.S_OK;
         }
 
-        unsafe int UnsafeNativeMethods.IOleClientSite.ShowObject()
+        unsafe HRESULT Ole32.IOleClientSite.ShowObject()
         {
             if (Host.ActiveXState >= WebBrowserHelper.AXState.InPlaceActive)
             {
@@ -212,18 +212,13 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.AXWindowlessControl);
                 }
             }
-            return NativeMethods.S_OK;
+
+            return HRESULT.S_OK;
         }
 
-        int UnsafeNativeMethods.IOleClientSite.OnShowWindow(int fShow)
-        {
-            return NativeMethods.S_OK;
-        }
+        HRESULT Ole32.IOleClientSite.OnShowWindow(BOOL fShow) => HRESULT.S_OK;
 
-        int UnsafeNativeMethods.IOleClientSite.RequestNewObjectLayout()
-        {
-            return NativeMethods.E_NOTIMPL;
-        }
+        HRESULT Ole32.IOleClientSite.RequestNewObjectLayout() => HRESULT.E_NOTIMPL;
 
         // IOleInPlaceSite methods:
         unsafe HRESULT UnsafeNativeMethods.IOleInPlaceSite.GetWindow(IntPtr* phwnd)
@@ -412,14 +407,6 @@ namespace System.Windows.Forms
                 Debug.Fail(t.ToString());
                 throw;
             }
-        }
-
-        //
-        // Internal helper methods:
-        //
-        internal WebBrowserBase GetAXHost()
-        {
-            return Host;
         }
 
         internal void StartEvents()


### PR DESCRIPTION
## Proposed Changes
- Cleanup IOleClientSite
- Introduce and use `OLEWHICHMK`/`OLEGETMONIKER` enums
- Make IOleObject.GetClientSite `PreserveSig` and remove associated catch blocks for COMException

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2152)