### PR TITLE
Partially revert "Porting DataMemberFieldConverter"  f477b2a

### DIFF
--- a/src/System.Design/src/System.Design.Forwards.cs
+++ b/src/System.Design/src/System.Design.Forwards.cs
@@ -1,10 +1,11 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
 
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.DataGridColumnCollectionEditor))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.DataMemberFieldConverter))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ImageCollectionEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ImageIndexEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ListControlStringCollectionEditor))]

--- a/src/System.Windows.Forms.Design/src/Properties/InternalsVisibleTo.cs
+++ b/src/System.Windows.Forms.Design/src/Properties/InternalsVisibleTo.cs
@@ -4,4 +4,7 @@
 
 using System.Runtime.CompilerServices;
 
+// expose internal types to System.Design for type forwarding
+[assembly: InternalsVisibleTo("System.Design, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+
 [assembly: InternalsVisibleTo("System.Windows.Forms.Design.Tests, PublicKey=00000000000000000400000000000000")]

--- a/src/System.Windows.Forms/src/AssemblyRef.cs
+++ b/src/System.Windows.Forms/src/AssemblyRef.cs
@@ -13,5 +13,4 @@ internal static class AssemblyRef
     internal const string SystemDesign = "System.Design, Version=" + FXAssembly.Version + ", Culture=neutral, PublicKeyToken=" + MicrosoftPublicKey;
     internal const string SystemDrawingDesign = "System.Drawing.Design, Version=" + FXAssembly.Version + ", Culture=neutral, PublicKeyToken=" + MicrosoftPublicKey;
     internal const string SystemDrawing = "System.Drawing, Version=" + FXAssembly.Version + ", Culture=neutral, PublicKeyToken=" + MicrosoftPublicKey;
-    internal const string SystemWinformsDesign = "System.Windows.Forms.Design, Version=" + FXAssembly.Version + ", Culture=neutral, PublicKeyToken=" + MicrosoftPublicKey;
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumn.cs
@@ -186,7 +186,7 @@ namespace System.Windows.Forms
         [
             Browsable(true),
             DefaultValue(""),
-            TypeConverter("System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemWinformsDesign),
+            TypeConverter("System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemDesign),
             Editor("System.Windows.Forms.Design.DataGridViewColumnDataPropertyNameEditor, " + AssemblyRef.SystemDesign, typeof(Drawing.Design.UITypeEditor)),
             SRDescription(nameof(SR.DataGridView_ColumnDataPropertyNameDescr)),
             SRCategory(nameof(SR.CatData))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxColumn.cs
@@ -139,7 +139,7 @@ namespace System.Windows.Forms
             DefaultValue(""),
             SRCategory(nameof(SR.CatData)),
             SRDescription(nameof(SR.DataGridView_ComboBoxColumnDisplayMemberDescr)),
-            TypeConverter("System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemWinformsDesign),
+            TypeConverter("System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemDesign),
             Editor("System.Windows.Forms.Design.DataMemberFieldEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))
         ]
         public string DisplayMember
@@ -353,7 +353,7 @@ namespace System.Windows.Forms
             DefaultValue(""),
             SRCategory(nameof(SR.CatData)),
             SRDescription(nameof(SR.DataGridView_ComboBoxColumnValueMemberDescr)),
-            TypeConverter("System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemWinformsDesign),
+            TypeConverter("System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemDesign),
             Editor("System.Windows.Forms.Design.DataMemberFieldEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))
         ]
         public string ValueMember

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListControl.cs
@@ -103,7 +103,7 @@ namespace System.Windows.Forms
         /// </summary>
         [SRCategory(nameof(SR.CatData))]
         [DefaultValue("")]
-        [TypeConverter("System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemWinformsDesign)]
+        [TypeConverter("System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemDesign)]
         [Editor("System.Windows.Forms.Design.DataMemberFieldEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
         [SRDescription(nameof(SR.ListControlDisplayMemberDescr))]
         public string DisplayMember


### PR DESCRIPTION
Relates to #1545
Closes #2171



## Proposed changes

- Partially revert "Porting DataMemberFieldConverter" f477b2a

Whilst we do not support nor cant be expected to support customers who reference our internals, in some scenarios like `UITypeEditor`s and `TypeConverter`s may still be used by consumers to enhance their runtime experience. E.g. https://github.com/dotnet/winforms/pull/2078#discussion_r337777751

Type forward `DataMemberFieldConverter` to avoid breaking existing customers.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Fixed for those porting .NET desktop apps to 3.0 and then to 3.1
- Unaffected for those porting .NET desktop apps to 3.1

## Regression? 

- Yes

## Risk

- None

<!-- end TELL-MODE -->



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2154)