### PR TITLE
Porting System.ComponentModel.Design.DateTimeEditor

### DIFF
--- a/src/System.Windows.Forms.Design.Editors/src/System/ComponentModel/Design/DateTimeEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/ComponentModel/Design/DateTimeEditor.cs
@@ -1,0 +1,156 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Drawing.Design;
+using System.Windows.Forms;
+using System.Windows.Forms.Design;
+
+namespace System.ComponentModel.Design
+{
+    /// <summary>
+    ///  This date/time editor is a UITypeEditor suitable for
+    ///  visually editing DateTime objects.
+    /// </summary>
+    public class DateTimeEditor : UITypeEditor
+    {
+        /// <summary>
+        ///  Edits the given object value using the editor style provided by
+        ///  GetEditorStyle.  A service provider is provided so that any
+        ///  required editing services can be obtained.
+        /// </summary>
+        public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+        {
+            if (provider == null)
+            {
+                return value;
+            }
+
+            IWindowsFormsEditorService edSvc = (IWindowsFormsEditorService)provider.GetService(typeof(IWindowsFormsEditorService));
+
+            if (edSvc == null)
+            {
+                return value;
+            }
+
+            using (DateTimeUI dateTimeUI = new DateTimeUI())
+            {
+                dateTimeUI.Start(edSvc, value);
+                edSvc.DropDownControl(dateTimeUI);
+                value = dateTimeUI.Value;
+                dateTimeUI.End();
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        ///  Retrieves the editing style of the Edit method.  If the method
+        ///  is not supported, this will return None.
+        /// </summary>
+        public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context)
+        {
+            return UITypeEditorEditStyle.DropDown;
+        }
+
+        /// <summary>
+        ///  UI we drop down to pick dates.
+        /// </summary>
+        private class DateTimeUI : Control
+        {
+            private MonthCalendar _monthCalendar = new DateTimeMonthCalendar();
+            private object _value;
+            private IWindowsFormsEditorService _edSvc;
+
+            public DateTimeUI()
+            {
+                InitializeComponent();
+                Size = _monthCalendar.SingleMonthSize;
+                _monthCalendar.Resize += MonthCalResize;
+            }
+
+            public object Value
+            {
+                get
+                {
+                    return _value;
+                }
+            }
+
+            public void End()
+            {
+                _edSvc = null;
+                _value = null;
+            }
+
+            private void MonthCalKeyDown(object sender, KeyEventArgs e)
+            {
+                switch (e.KeyCode)
+                {
+                    case Keys.Enter:
+                        OnDateSelected(sender, null);
+                        break;
+                }
+            }
+
+            protected override void RescaleConstantsForDpi(int deviceDpiOld, int deviceDpiNew)
+            {
+                base.RescaleConstantsForDpi(deviceDpiOld, deviceDpiNew);
+
+                //Resizing the editor to fit to the SingleMonth size after Dpi changed.
+                Size = _monthCalendar.SingleMonthSize;
+            }
+
+            private void InitializeComponent()
+            {
+                _monthCalendar.DateSelected += OnDateSelected;
+                _monthCalendar.KeyDown += MonthCalKeyDown;
+                Controls.Add(_monthCalendar);
+            }
+
+            private void MonthCalResize(object sender, EventArgs e)
+            {
+                Size = _monthCalendar.Size;
+            }
+
+            private void OnDateSelected(object sender, DateRangeEventArgs e)
+            {
+                _value = _monthCalendar.SelectionStart;
+                _edSvc.CloseDropDown();
+            }
+
+            protected override void OnGotFocus(EventArgs e)
+            {
+                base.OnGotFocus(e);
+                _monthCalendar.Focus();
+            }
+
+            public void Start(IWindowsFormsEditorService edSvc, object value)
+            {
+                _edSvc = edSvc;
+                _value = value;
+
+                if (value != null)
+                {
+                    DateTime dt = (DateTime)value;
+                    _monthCalendar.SetDate((dt.Equals(DateTime.MinValue)) ? DateTime.Today : dt);
+                }
+            }
+
+            class DateTimeMonthCalendar : MonthCalendar
+            {
+                protected override bool IsInputKey(Keys keyData)
+                {
+                    switch (keyData)
+                    {
+                        case Keys.Enter:
+                            return true;
+                    }
+                    
+                    return base.IsInputKey(keyData);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #2019
Related issue: #1115
Have you experienced this same bug with .NET Framework?: No

## Proposed changes

- Add System.ComponentModel.Design.DateTimeEditor class
- Make code refactoring

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Changed DateTime editor to compliance with .Net 4.8.

## Regression? 

- Yes

## Risk

- Low

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
- TextBox editor:
![image](https://user-images.githubusercontent.com/49272759/67389897-31c5d080-f5a4-11e9-91a4-5e93fb0717dd.png)

<!-- TODO -->

### After
- DateTime editor:
![image](https://user-images.githubusercontent.com/49272759/67385877-99781d80-f59c-11e9-847f-3b0b5f911ed4.png)


<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual UI testing



 

## Test environment(s) <!-- Remove any that don't apply -->

- .Net Core version: 3.1.0-preview1.19458.7
- Microsoft Windows [Version 10.0.18362.418]


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2165)