### PR TITLE
Fixing editors unit tests and the branch building

### DIFF
--- a/src/System.Design/src/System.Design.Forwards.cs
+++ b/src/System.Design/src/System.Design.Forwards.cs
@@ -4,4 +4,10 @@
 
 using System.Runtime.CompilerServices;
 
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.DataGridColumnCollectionEditor))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ImageCollectionEditor))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ImageIndexEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ListControlStringCollectionEditor))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.StringArrayEditor))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.StringCollectionEditor))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.TabPageCollectionEditor))]

--- a/src/System.Windows.Forms.Design.Editors/tests/UnitTests/EnsureEditorsTests.cs
+++ b/src/System.Windows.Forms.Design.Editors/tests/UnitTests/EnsureEditorsTests.cs
@@ -114,7 +114,6 @@ namespace System.Windows.Forms.Design.Editors.Tests
         [InlineData(typeof(ToolStripTextBox), "Lines", typeof(StringArrayEditor))]
         [InlineData(typeof(TreeNode), "ImageIndex", typeof(ImageIndexEditor))]
         [InlineData(typeof(TreeNode), "ImageKey", typeof(ImageIndexEditor))]
-        [InlineData(typeof(TreeNode), "ImageIndexEditor", typeof(ImageIndexEditor))]
         [InlineData(typeof(TreeNode), "SelectedImageKey", typeof(ImageIndexEditor))]
         [InlineData(typeof(TreeNode), "StateImageKey", typeof(ImageIndexEditor))]
         [InlineData(typeof(TreeNode), "StateImageIndex", typeof(ImageIndexEditor))]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes `release/3.1-uitypeeditors` branch unit tests to correct building.


## Proposed changes

- Remove `ImageIndexEditor` property test case because `TreeNode` hasn't this property
- Add `TypeForwardedTo` statements to get correct editors

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- No, fixed only tests

## Risk

- Low

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

- Unit tests


## Test environment(s) <!-- Remove any that don't apply -->

- .Net Core version: 3.1.0-preview1.19458.7
- Microsoft Windows [Version 10.0.18362.418]


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2183)