### PR TITLE
Fix NoAssertContext deadlock

### DIFF
--- a/src/Common/tests/InternalUtilitiesForTests/InternalUtilitiesForTests.csproj
+++ b/src/Common/tests/InternalUtilitiesForTests/InternalUtilitiesForTests.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
+    <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
     <PackageReference Include="xunit.stafact" Version="$(XUnitStaFactPackageVersion)" />
     <PackageReference Include="xunit.assert" Version="$(XUnitAssertVersion)" />
     <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsPackageVersion)" />

--- a/src/Common/tests/InternalUtilitiesForTests/src/NoAssertContext.cs
+++ b/src/Common/tests/InternalUtilitiesForTests/src/NoAssertContext.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Threading;
 
@@ -13,25 +13,37 @@ namespace System
     /// </summary>
     public sealed class NoAssertContext : IDisposable
     {
+        // For any given thread we don't need to lock to decide how to route messages, as any messages for that
+        // given thread will not happen while we're in the constructor or dispose method on that thread. That
+        // means we can safely check to see if we've hooked our thread without locking (outside of using a
+        // concurrent collection to make sure the collection is in a known state).
+        //
+        // We do, however need to lock around hooking/unhooking our custom listener to make sure that we
+        // are rerouting correctly if multiple threads are creating/disposing this class concurrently.
+
         private static readonly object s_lock = new object();
-        private static readonly HashSet<int> s_suppressedThreads = new HashSet<int>();
-        private static TraceListener s_defaultListener;
+        private static bool s_hooked;
+
+        private static readonly ConcurrentDictionary<int, int> s_suppressedThreads = new ConcurrentDictionary<int, int>();
+
+        // "Default" is the listener that terminates the process when debug assertions fail.
+        private static readonly TraceListener s_defaultListener = Trace.Listeners["Default"];
         private static readonly NoAssertListener s_noAssertListener = new NoAssertListener();
 
         public NoAssertContext()
         {
+            s_suppressedThreads.AddOrUpdate(Thread.CurrentThread.ManagedThreadId, 1, (key, oldValue) => oldValue + 1);
+
+            // Lock to make sure we are hooked properly if two threads come into the constructor/dispose at the same time.
             lock (s_lock)
             {
-                s_suppressedThreads.Add(Thread.CurrentThread.ManagedThreadId);
-                if (s_suppressedThreads.Count == 1)
+                if (!s_hooked)
                 {
                     // Hook our custom listener first so we don't lose assertions from other threads when
                     // we disconnect the default listener.
                     Trace.Listeners.Add(s_noAssertListener);
-
-                    // "Default" is the listener that terminates the process when debug assertions fail.
-                    s_defaultListener = Trace.Listeners["Default"];
                     Trace.Listeners.Remove(s_defaultListener);
+                    s_hooked = true;
                 }
             }
         }
@@ -40,16 +52,27 @@ namespace System
         {
             GC.SuppressFinalize(this);
 
+            int currentThread = Thread.CurrentThread.ManagedThreadId;
+            if (s_suppressedThreads.TryRemove(currentThread, out int count))
+            {
+                if (count > 1)
+                {
+                    // We're in a nested assert context on a given thread, re-add with a decremented count.
+                    // This doesn't need to be atomic as we're currently on the thread that would care about
+                    // being rerouted.
+                    s_suppressedThreads.TryAdd(currentThread, --count);
+                }
+            }
+
             lock (s_lock)
             {
-                s_suppressedThreads.Remove(Thread.CurrentThread.ManagedThreadId);
-                if (s_suppressedThreads.Count == 0 && s_defaultListener != null)
+                if (s_hooked && s_suppressedThreads.Count == 0)
                 {
-                    // Add the default listener back first to make sure we don't lose any
-                    // asserts from other threads.
+                    // We're the first to hit the need to unhook. Add the default listener back first to
+                    // ensure we don't lose any asserts from other threads.
                     Trace.Listeners.Add(s_defaultListener);
                     Trace.Listeners.Remove(s_noAssertListener);
-                    s_defaultListener = null;
+                    s_hooked = false;
                 }
             }
         }
@@ -69,23 +92,17 @@ namespace System
 
             public override void Fail(string message)
             {
-                lock (s_lock)
+                if (!s_suppressedThreads.TryGetValue(Thread.CurrentThread.ManagedThreadId, out _))
                 {
-                    if (!s_suppressedThreads.Contains(Thread.CurrentThread.ManagedThreadId))
-                    {
-                        s_defaultListener?.Fail(message);
-                    }
+                    s_defaultListener.Fail(message);
                 }
             }
 
             public override void Fail(string message, string detailMessage)
             {
-                lock (s_lock)
+                if (!s_suppressedThreads.TryGetValue(Thread.CurrentThread.ManagedThreadId, out _))
                 {
-                    if (!s_suppressedThreads.Contains(Thread.CurrentThread.ManagedThreadId))
-                    {
-                        s_defaultListener?.Fail(message, detailMessage);
-                    }
+                    s_defaultListener.Fail(message, detailMessage);
                 }
             }
 
@@ -93,17 +110,17 @@ namespace System
 
             public override void Write(string message)
             {
-                lock (s_lock)
+                if (!s_suppressedThreads.TryGetValue(Thread.CurrentThread.ManagedThreadId, out _))
                 {
-                    s_defaultListener?.Write(message);
+                    s_defaultListener.Write(message);
                 }
             }
 
             public override void WriteLine(string message)
             {
-                lock (s_lock)
+                if (!s_suppressedThreads.TryGetValue(Thread.CurrentThread.ManagedThreadId, out _))
                 {
-                    s_defaultListener?.WriteLine(message);
+                    s_defaultListener.WriteLine(message);
                 }
             }
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationTests.cs
@@ -32,7 +32,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(state, Application.VisualStyleState);
         }
 
-        [Theory]
+        [Theory(Skip = "Deadlock, see: https://github.com/dotnet/winforms/issues/2192")]
         [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(VisualStyleState))]
         [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryDataInvalid), typeof(VisualStyleState))]
         public void Application_VisualStyleState_Set_ReturnsExpected(VisualStyleState value)


### PR DESCRIPTION
The assert context listener would deadlock sometimes and wasn't particularly efficient. @weltkante discovered this in #2184 and encouraged me to rethink how to approach this.

Fixes #1999

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2191)