### PR TITLE
Fix 2185 port missing code DOM serializers

### DIFF
--- a/src/System.Windows.Forms.Design/src/Resources/SR.resx
+++ b/src/System.Windows.Forms.Design/src/Resources/SR.resx
@@ -753,4 +753,80 @@
   <data name="ToolStripSelectMenuItem" xml:space="preserve">
     <value>'{0}'</value>
   </data>
+  <data name="CodeDomDesignerLoaderPropGenerateMember" xml:space="preserve">
+    <value>Indicates if a member variable will be generated for this component.</value>
+  </data>
+  <data name="CodeDomDesignerLoaderPropModifiers" xml:space="preserve">
+    <value>Indicates the visibility level of the object.</value>
+  </data>
+  <data name="LocalizationProviderManualReload" xml:space="preserve">
+    <value>You must close and re-open the designer for this change to take effect.</value>
+  </data>
+  <data name="LocalizationProviderMissingService" xml:space="preserve">
+    <value>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</value>
+  </data>
+  <data name="BasicDesignerLoaderDifferentHost" xml:space="preserve">
+    <value>The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</value>
+  </data>
+  <data name="BasicDesignerLoaderMissingService" xml:space="preserve">
+    <value>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</value>
+  </data>
+  <data name="BasicDesignerLoaderNotInitialized" xml:space="preserve">
+    <value>The designer loader has not been initialized yet.  You may only call this method after initialization.</value>
+  </data>
+  <data name="BasicDesignerLoaderAlreadyLoaded" xml:space="preserve">
+    <value>The designer is already loaded.</value>
+  </data>
+  <data name="CodeDomDesignerLoaderBadSerializationObject" xml:space="preserve">
+    <value>The serialization data object is not of the proper type.</value>
+  </data>
+  <data name="CodeDomDesignerLoaderDocumentFailureTypeDesignerNotInstalled" xml:space="preserve">
+    <value>	{0} --- The designer for base class '{1}' is not installed.</value>
+  </data>
+  <data name="CodeDomDesignerLoaderDocumentFailureTypeNotDesignable" xml:space="preserve">
+    <value>	{0} --- The base class '{1}' cannot be designed.</value>
+  </data>
+  <data name="CodeDomDesignerLoaderDocumentFailureTypeNotFound" xml:space="preserve">
+    <value>	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</value>
+  </data>
+  <data name="CodeDomDesignerLoaderDupComponentName" xml:space="preserve">
+    <value>There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</value>
+  </data>
+  <data name="CodeDomDesignerLoaderInvalidBlankIdentifier" xml:space="preserve">
+    <value>Empty identifiers are not valid.</value>
+  </data>
+  <data name="CodeDomDesignerLoaderInvalidIdentifier" xml:space="preserve">
+    <value>'{0}' is not a valid identifier.</value>
+  </data>
+  <data name="CodeDomDesignerLoaderNoLanguageSupport" xml:space="preserve">
+    <value>The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</value>
+  </data>
+  <data name="CodeDomDesignerLoaderNoRootSerializer" xml:space="preserve">
+    <value>The designer could not be shown for this file because none of the classes within it can be designed.</value>
+  </data>
+  <data name="CodeDomDesignerLoaderNoRootSerializerWithFailures" xml:space="preserve">
+    <value>The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</value>
+  </data>
+  <data name="CodeDomDesignerLoaderNoTypeResolution" xml:space="preserve">
+    <value>The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</value>
+  </data>
+  <data name="CodeDomDesignerLoaderSerializerTypeNotFirstType" xml:space="preserve">
+    <value>The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</value>
+  </data>
+  <data name="EventBindingServiceBadArgType" xml:space="preserve">
+    <value>The event {0} expects an argument type of {1}.</value>
+  </data>
+  <data name="EventBindingServiceEventReadOnly" xml:space="preserve">
+    <value>The event {0} is read-only and cannot be changed.</value>
+  </data>
+  <data name="EventBindingServiceMissingService" xml:space="preserve">
+    <value>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</value>
+  </data>
+  <data name="EventBindingServiceNoSite" xml:space="preserve">
+    <value>Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</value>
+  </data>
+  <data name="EventBindingServiceSetValue" xml:space="preserve">
+    <value>Set {0}.{1} event</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.cs.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../SR.resx">
     <body>
+      <trans-unit id="BasicDesignerLoaderAlreadyLoaded">
+        <source>The designer is already loaded.</source>
+        <target state="new">The designer is already loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderDifferentHost">
+        <source>The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</source>
+        <target state="new">The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderNotInitialized">
+        <source>The designer loader has not been initialized yet.  You may only call this method after initialization.</source>
+        <target state="new">The designer loader has not been initialized yet.  You may only call this method after initialization.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BehaviorServiceCopyControl">
         <source>Copy and move {0}</source>
         <target state="translated">Kopírování a přesun - {0}</target>
@@ -45,6 +65,78 @@
       <trans-unit id="CodeDomComponentSerializationServiceUnknownStore">
         <source>This type of serialization store is not supported.  Use a store returned by the CreateStore method.</source>
         <target state="translated">Tento typ úložiště serializací není podporován. Použijte úložiště vrácené metodou CreateStore.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderBadSerializationObject">
+        <source>The serialization data object is not of the proper type.</source>
+        <target state="new">The serialization data object is not of the proper type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeDesignerNotInstalled">
+        <source>	{0} --- The designer for base class '{1}' is not installed.</source>
+        <target state="new">	{0} --- The designer for base class '{1}' is not installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotDesignable">
+        <source>	{0} --- The base class '{1}' cannot be designed.</source>
+        <target state="new">	{0} --- The base class '{1}' cannot be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotFound">
+        <source>	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</source>
+        <target state="new">	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDupComponentName">
+        <source>There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</source>
+        <target state="new">There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidBlankIdentifier">
+        <source>Empty identifiers are not valid.</source>
+        <target state="new">Empty identifiers are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidIdentifier">
+        <source>'{0}' is not a valid identifier.</source>
+        <target state="new">'{0}' is not a valid identifier.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoLanguageSupport">
+        <source>The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</source>
+        <target state="new">The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializer">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializerWithFailures">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoTypeResolution">
+        <source>The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</source>
+        <target state="new">The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropGenerateMember">
+        <source>Indicates if a member variable will be generated for this component.</source>
+        <target state="new">Indicates if a member variable will be generated for this component.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropModifiers">
+        <source>Indicates the visibility level of the object.</source>
+        <target state="new">Indicates the visibility level of the object.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderSerializerTypeNotFirstType">
+        <source>The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</source>
+        <target state="new">The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandSetAlignByPrimary">
@@ -493,6 +585,31 @@
         <target state="translated">Změna velikosti součástí (počet: {0})</target>
         <note />
       </trans-unit>
+      <trans-unit id="EventBindingServiceBadArgType">
+        <source>The event {0} expects an argument type of {1}.</source>
+        <target state="new">The event {0} expects an argument type of {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceEventReadOnly">
+        <source>The event {0} is read-only and cannot be changed.</source>
+        <target state="new">The event {0} is read-only and cannot be changed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceNoSite">
+        <source>Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</source>
+        <target state="new">Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceSetValue">
+        <source>Set {0}.{1} event</source>
+        <target state="new">Set {0}.{1} event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">Zprostředkovatel rozšířeného objektu {0} již byl přidán jako rozšiřující objekt. V případě přidání dalšího by došlo k duplicitě vlastností.</target>
@@ -511,6 +628,16 @@
       <trans-unit id="InvalidBoundArgument">
         <source>'{1}' is not a valid value for '{0}'. '{0}' should be between {2} and {3}.</source>
         <target state="translated">Hodnota {1} není platnou hodnotou pro argument {0}. Hodnota {0} musí být v rozsahu od {2} do {3}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderManualReload">
+        <source>You must close and re-open the designer for this change to take effect.</source>
+        <target state="new">You must close and re-open the designer for this change to take effect.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
         <note />
       </trans-unit>
       <trans-unit id="None">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.de.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../SR.resx">
     <body>
+      <trans-unit id="BasicDesignerLoaderAlreadyLoaded">
+        <source>The designer is already loaded.</source>
+        <target state="new">The designer is already loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderDifferentHost">
+        <source>The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</source>
+        <target state="new">The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderNotInitialized">
+        <source>The designer loader has not been initialized yet.  You may only call this method after initialization.</source>
+        <target state="new">The designer loader has not been initialized yet.  You may only call this method after initialization.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BehaviorServiceCopyControl">
         <source>Copy and move {0}</source>
         <target state="translated">{0} kopieren und verschieben</target>
@@ -45,6 +65,78 @@
       <trans-unit id="CodeDomComponentSerializationServiceUnknownStore">
         <source>This type of serialization store is not supported.  Use a store returned by the CreateStore method.</source>
         <target state="translated">Dieser Typ von Serialisierungsspeicher wird nicht unterstützt. Verwenden Sie einen Speicher, der von der CreateStore-Methode zurückgegeben wird.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderBadSerializationObject">
+        <source>The serialization data object is not of the proper type.</source>
+        <target state="new">The serialization data object is not of the proper type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeDesignerNotInstalled">
+        <source>	{0} --- The designer for base class '{1}' is not installed.</source>
+        <target state="new">	{0} --- The designer for base class '{1}' is not installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotDesignable">
+        <source>	{0} --- The base class '{1}' cannot be designed.</source>
+        <target state="new">	{0} --- The base class '{1}' cannot be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotFound">
+        <source>	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</source>
+        <target state="new">	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDupComponentName">
+        <source>There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</source>
+        <target state="new">There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidBlankIdentifier">
+        <source>Empty identifiers are not valid.</source>
+        <target state="new">Empty identifiers are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidIdentifier">
+        <source>'{0}' is not a valid identifier.</source>
+        <target state="new">'{0}' is not a valid identifier.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoLanguageSupport">
+        <source>The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</source>
+        <target state="new">The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializer">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializerWithFailures">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoTypeResolution">
+        <source>The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</source>
+        <target state="new">The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropGenerateMember">
+        <source>Indicates if a member variable will be generated for this component.</source>
+        <target state="new">Indicates if a member variable will be generated for this component.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropModifiers">
+        <source>Indicates the visibility level of the object.</source>
+        <target state="new">Indicates the visibility level of the object.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderSerializerTypeNotFirstType">
+        <source>The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</source>
+        <target state="new">The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandSetAlignByPrimary">
@@ -493,6 +585,31 @@
         <target state="translated">{0}-Komponentengröße festlegen</target>
         <note />
       </trans-unit>
+      <trans-unit id="EventBindingServiceBadArgType">
+        <source>The event {0} expects an argument type of {1}.</source>
+        <target state="new">The event {0} expects an argument type of {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceEventReadOnly">
+        <source>The event {0} is read-only and cannot be changed.</source>
+        <target state="new">The event {0} is read-only and cannot be changed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceNoSite">
+        <source>Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</source>
+        <target state="new">Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceSetValue">
+        <source>Set {0}.{1} event</source>
+        <target state="new">Set {0}.{1} event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">Der Extenderanbieter {0} wurde bereits als Extender hinzugefügt. Wenn ein weiterer hinzugefügt wird, führt dies zu doppelten Eigenschaften.</target>
@@ -511,6 +628,16 @@
       <trans-unit id="InvalidBoundArgument">
         <source>'{1}' is not a valid value for '{0}'. '{0}' should be between {2} and {3}.</source>
         <target state="translated">{1} ist kein gültiger Wert für {0}. {0} sollte zwischen {2} und {3} liegen.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderManualReload">
+        <source>You must close and re-open the designer for this change to take effect.</source>
+        <target state="new">You must close and re-open the designer for this change to take effect.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
         <note />
       </trans-unit>
       <trans-unit id="None">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.es.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../SR.resx">
     <body>
+      <trans-unit id="BasicDesignerLoaderAlreadyLoaded">
+        <source>The designer is already loaded.</source>
+        <target state="new">The designer is already loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderDifferentHost">
+        <source>The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</source>
+        <target state="new">The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderNotInitialized">
+        <source>The designer loader has not been initialized yet.  You may only call this method after initialization.</source>
+        <target state="new">The designer loader has not been initialized yet.  You may only call this method after initialization.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BehaviorServiceCopyControl">
         <source>Copy and move {0}</source>
         <target state="translated">Copiar y mover {0}</target>
@@ -45,6 +65,78 @@
       <trans-unit id="CodeDomComponentSerializationServiceUnknownStore">
         <source>This type of serialization store is not supported.  Use a store returned by the CreateStore method.</source>
         <target state="translated">No se admite este tipo de almacén de serialización. Utilice un almacén devuelto por el método CreateStore.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderBadSerializationObject">
+        <source>The serialization data object is not of the proper type.</source>
+        <target state="new">The serialization data object is not of the proper type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeDesignerNotInstalled">
+        <source>	{0} --- The designer for base class '{1}' is not installed.</source>
+        <target state="new">	{0} --- The designer for base class '{1}' is not installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotDesignable">
+        <source>	{0} --- The base class '{1}' cannot be designed.</source>
+        <target state="new">	{0} --- The base class '{1}' cannot be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotFound">
+        <source>	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</source>
+        <target state="new">	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDupComponentName">
+        <source>There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</source>
+        <target state="new">There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidBlankIdentifier">
+        <source>Empty identifiers are not valid.</source>
+        <target state="new">Empty identifiers are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidIdentifier">
+        <source>'{0}' is not a valid identifier.</source>
+        <target state="new">'{0}' is not a valid identifier.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoLanguageSupport">
+        <source>The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</source>
+        <target state="new">The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializer">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializerWithFailures">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoTypeResolution">
+        <source>The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</source>
+        <target state="new">The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropGenerateMember">
+        <source>Indicates if a member variable will be generated for this component.</source>
+        <target state="new">Indicates if a member variable will be generated for this component.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropModifiers">
+        <source>Indicates the visibility level of the object.</source>
+        <target state="new">Indicates the visibility level of the object.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderSerializerTypeNotFirstType">
+        <source>The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</source>
+        <target state="new">The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandSetAlignByPrimary">
@@ -493,6 +585,31 @@
         <target state="translated">Ajustar el tamaño de {0} componentes</target>
         <note />
       </trans-unit>
+      <trans-unit id="EventBindingServiceBadArgType">
+        <source>The event {0} expects an argument type of {1}.</source>
+        <target state="new">The event {0} expects an argument type of {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceEventReadOnly">
+        <source>The event {0} is read-only and cannot be changed.</source>
+        <target state="new">The event {0} is read-only and cannot be changed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceNoSite">
+        <source>Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</source>
+        <target state="new">Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceSetValue">
+        <source>Set {0}.{1} event</source>
+        <target state="new">Set {0}.{1} event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">El proveedor extensor {0} ya se ha agregado como extensor. Si agrega otro habría propiedades duplicadas.</target>
@@ -511,6 +628,16 @@
       <trans-unit id="InvalidBoundArgument">
         <source>'{1}' is not a valid value for '{0}'. '{0}' should be between {2} and {3}.</source>
         <target state="translated">'{1}' no es un valor válido para '{0}'. '{0}' debería estar entre {2} y {3}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderManualReload">
+        <source>You must close and re-open the designer for this change to take effect.</source>
+        <target state="new">You must close and re-open the designer for this change to take effect.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
         <note />
       </trans-unit>
       <trans-unit id="None">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.fr.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../SR.resx">
     <body>
+      <trans-unit id="BasicDesignerLoaderAlreadyLoaded">
+        <source>The designer is already loaded.</source>
+        <target state="new">The designer is already loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderDifferentHost">
+        <source>The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</source>
+        <target state="new">The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderNotInitialized">
+        <source>The designer loader has not been initialized yet.  You may only call this method after initialization.</source>
+        <target state="new">The designer loader has not been initialized yet.  You may only call this method after initialization.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BehaviorServiceCopyControl">
         <source>Copy and move {0}</source>
         <target state="translated">Copier et déplacer {0}</target>
@@ -45,6 +65,78 @@
       <trans-unit id="CodeDomComponentSerializationServiceUnknownStore">
         <source>This type of serialization store is not supported.  Use a store returned by the CreateStore method.</source>
         <target state="translated">Ce type de magasin de sérialisation n'est pas pris en charge. Utilisez un magasin retourné par la méthode CreateStore.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderBadSerializationObject">
+        <source>The serialization data object is not of the proper type.</source>
+        <target state="new">The serialization data object is not of the proper type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeDesignerNotInstalled">
+        <source>	{0} --- The designer for base class '{1}' is not installed.</source>
+        <target state="new">	{0} --- The designer for base class '{1}' is not installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotDesignable">
+        <source>	{0} --- The base class '{1}' cannot be designed.</source>
+        <target state="new">	{0} --- The base class '{1}' cannot be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotFound">
+        <source>	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</source>
+        <target state="new">	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDupComponentName">
+        <source>There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</source>
+        <target state="new">There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidBlankIdentifier">
+        <source>Empty identifiers are not valid.</source>
+        <target state="new">Empty identifiers are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidIdentifier">
+        <source>'{0}' is not a valid identifier.</source>
+        <target state="new">'{0}' is not a valid identifier.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoLanguageSupport">
+        <source>The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</source>
+        <target state="new">The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializer">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializerWithFailures">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoTypeResolution">
+        <source>The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</source>
+        <target state="new">The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropGenerateMember">
+        <source>Indicates if a member variable will be generated for this component.</source>
+        <target state="new">Indicates if a member variable will be generated for this component.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropModifiers">
+        <source>Indicates the visibility level of the object.</source>
+        <target state="new">Indicates the visibility level of the object.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderSerializerTypeNotFirstType">
+        <source>The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</source>
+        <target state="new">The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandSetAlignByPrimary">
@@ -493,6 +585,31 @@
         <target state="translated">Redimensionner les composants {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="EventBindingServiceBadArgType">
+        <source>The event {0} expects an argument type of {1}.</source>
+        <target state="new">The event {0} expects an argument type of {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceEventReadOnly">
+        <source>The event {0} is read-only and cannot be changed.</source>
+        <target state="new">The event {0} is read-only and cannot be changed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceNoSite">
+        <source>Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</source>
+        <target state="new">Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceSetValue">
+        <source>Set {0}.{1} event</source>
+        <target state="new">Set {0}.{1} event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">Le fournisseur d'extendeurs {0} a déjà été ajouté en tant qu'extendeur. L'ajout d'un autre créerait des propriétés en double.</target>
@@ -511,6 +628,16 @@
       <trans-unit id="InvalidBoundArgument">
         <source>'{1}' is not a valid value for '{0}'. '{0}' should be between {2} and {3}.</source>
         <target state="translated">'{1}' n'est pas une valeur valide pour '{0}'. '{0}' doit être compris entre {2} et {3}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderManualReload">
+        <source>You must close and re-open the designer for this change to take effect.</source>
+        <target state="new">You must close and re-open the designer for this change to take effect.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
         <note />
       </trans-unit>
       <trans-unit id="None">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.it.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../SR.resx">
     <body>
+      <trans-unit id="BasicDesignerLoaderAlreadyLoaded">
+        <source>The designer is already loaded.</source>
+        <target state="new">The designer is already loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderDifferentHost">
+        <source>The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</source>
+        <target state="new">The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderNotInitialized">
+        <source>The designer loader has not been initialized yet.  You may only call this method after initialization.</source>
+        <target state="new">The designer loader has not been initialized yet.  You may only call this method after initialization.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BehaviorServiceCopyControl">
         <source>Copy and move {0}</source>
         <target state="translated">Copia e sposta {0}</target>
@@ -45,6 +65,78 @@
       <trans-unit id="CodeDomComponentSerializationServiceUnknownStore">
         <source>This type of serialization store is not supported.  Use a store returned by the CreateStore method.</source>
         <target state="translated">Questo tipo di archivio di serializzazione non è supportato. Usare un archivio restituito dal metodo CreateStore.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderBadSerializationObject">
+        <source>The serialization data object is not of the proper type.</source>
+        <target state="new">The serialization data object is not of the proper type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeDesignerNotInstalled">
+        <source>	{0} --- The designer for base class '{1}' is not installed.</source>
+        <target state="new">	{0} --- The designer for base class '{1}' is not installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotDesignable">
+        <source>	{0} --- The base class '{1}' cannot be designed.</source>
+        <target state="new">	{0} --- The base class '{1}' cannot be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotFound">
+        <source>	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</source>
+        <target state="new">	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDupComponentName">
+        <source>There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</source>
+        <target state="new">There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidBlankIdentifier">
+        <source>Empty identifiers are not valid.</source>
+        <target state="new">Empty identifiers are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidIdentifier">
+        <source>'{0}' is not a valid identifier.</source>
+        <target state="new">'{0}' is not a valid identifier.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoLanguageSupport">
+        <source>The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</source>
+        <target state="new">The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializer">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializerWithFailures">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoTypeResolution">
+        <source>The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</source>
+        <target state="new">The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropGenerateMember">
+        <source>Indicates if a member variable will be generated for this component.</source>
+        <target state="new">Indicates if a member variable will be generated for this component.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropModifiers">
+        <source>Indicates the visibility level of the object.</source>
+        <target state="new">Indicates the visibility level of the object.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderSerializerTypeNotFirstType">
+        <source>The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</source>
+        <target state="new">The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandSetAlignByPrimary">
@@ -493,6 +585,31 @@
         <target state="translated">Ridimensiona {0} componenti</target>
         <note />
       </trans-unit>
+      <trans-unit id="EventBindingServiceBadArgType">
+        <source>The event {0} expects an argument type of {1}.</source>
+        <target state="new">The event {0} expects an argument type of {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceEventReadOnly">
+        <source>The event {0} is read-only and cannot be changed.</source>
+        <target state="new">The event {0} is read-only and cannot be changed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceNoSite">
+        <source>Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</source>
+        <target state="new">Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceSetValue">
+        <source>Set {0}.{1} event</source>
+        <target state="new">Set {0}.{1} event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">Il provider di Extender {0} è già stato aggiunto come Extender. Aggiungendone un altro si creerebbero proprietà duplicate.</target>
@@ -511,6 +628,16 @@
       <trans-unit id="InvalidBoundArgument">
         <source>'{1}' is not a valid value for '{0}'. '{0}' should be between {2} and {3}.</source>
         <target state="translated">'{1}' non è un valore valido per '{0}'. '{0}' deve essere compreso tra {2} e {3}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderManualReload">
+        <source>You must close and re-open the designer for this change to take effect.</source>
+        <target state="new">You must close and re-open the designer for this change to take effect.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
         <note />
       </trans-unit>
       <trans-unit id="None">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ja.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../SR.resx">
     <body>
+      <trans-unit id="BasicDesignerLoaderAlreadyLoaded">
+        <source>The designer is already loaded.</source>
+        <target state="new">The designer is already loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderDifferentHost">
+        <source>The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</source>
+        <target state="new">The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderNotInitialized">
+        <source>The designer loader has not been initialized yet.  You may only call this method after initialization.</source>
+        <target state="new">The designer loader has not been initialized yet.  You may only call this method after initialization.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BehaviorServiceCopyControl">
         <source>Copy and move {0}</source>
         <target state="translated">{0} のコピーおよび移動</target>
@@ -45,6 +65,78 @@
       <trans-unit id="CodeDomComponentSerializationServiceUnknownStore">
         <source>This type of serialization store is not supported.  Use a store returned by the CreateStore method.</source>
         <target state="translated">シリアル化ストアのこの型はサポートされていません。  CreateStore メソッドによって返されたストアを使用してください。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderBadSerializationObject">
+        <source>The serialization data object is not of the proper type.</source>
+        <target state="new">The serialization data object is not of the proper type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeDesignerNotInstalled">
+        <source>	{0} --- The designer for base class '{1}' is not installed.</source>
+        <target state="new">	{0} --- The designer for base class '{1}' is not installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotDesignable">
+        <source>	{0} --- The base class '{1}' cannot be designed.</source>
+        <target state="new">	{0} --- The base class '{1}' cannot be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotFound">
+        <source>	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</source>
+        <target state="new">	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDupComponentName">
+        <source>There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</source>
+        <target state="new">There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidBlankIdentifier">
+        <source>Empty identifiers are not valid.</source>
+        <target state="new">Empty identifiers are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidIdentifier">
+        <source>'{0}' is not a valid identifier.</source>
+        <target state="new">'{0}' is not a valid identifier.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoLanguageSupport">
+        <source>The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</source>
+        <target state="new">The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializer">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializerWithFailures">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoTypeResolution">
+        <source>The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</source>
+        <target state="new">The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropGenerateMember">
+        <source>Indicates if a member variable will be generated for this component.</source>
+        <target state="new">Indicates if a member variable will be generated for this component.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropModifiers">
+        <source>Indicates the visibility level of the object.</source>
+        <target state="new">Indicates the visibility level of the object.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderSerializerTypeNotFirstType">
+        <source>The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</source>
+        <target state="new">The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandSetAlignByPrimary">
@@ -493,6 +585,31 @@
         <target state="translated">{0} コンポーネントのサイズを変更</target>
         <note />
       </trans-unit>
+      <trans-unit id="EventBindingServiceBadArgType">
+        <source>The event {0} expects an argument type of {1}.</source>
+        <target state="new">The event {0} expects an argument type of {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceEventReadOnly">
+        <source>The event {0} is read-only and cannot be changed.</source>
+        <target state="new">The event {0} is read-only and cannot be changed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceNoSite">
+        <source>Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</source>
+        <target state="new">Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceSetValue">
+        <source>Set {0}.{1} event</source>
+        <target state="new">Set {0}.{1} event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">拡張プロバイダー {0} はエクステンダーとして既に追加されています。  もう 1 つ追加すると、プロパティが重複します。</target>
@@ -511,6 +628,16 @@
       <trans-unit id="InvalidBoundArgument">
         <source>'{1}' is not a valid value for '{0}'. '{0}' should be between {2} and {3}.</source>
         <target state="translated">'{1}' は '{0}' に有効な値ではありません。'{0}' は {2} と {3} の間でなければなりません。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderManualReload">
+        <source>You must close and re-open the designer for this change to take effect.</source>
+        <target state="new">You must close and re-open the designer for this change to take effect.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
         <note />
       </trans-unit>
       <trans-unit id="None">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ko.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../SR.resx">
     <body>
+      <trans-unit id="BasicDesignerLoaderAlreadyLoaded">
+        <source>The designer is already loaded.</source>
+        <target state="new">The designer is already loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderDifferentHost">
+        <source>The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</source>
+        <target state="new">The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderNotInitialized">
+        <source>The designer loader has not been initialized yet.  You may only call this method after initialization.</source>
+        <target state="new">The designer loader has not been initialized yet.  You may only call this method after initialization.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BehaviorServiceCopyControl">
         <source>Copy and move {0}</source>
         <target state="translated">{0} 복사 및 이동</target>
@@ -45,6 +65,78 @@
       <trans-unit id="CodeDomComponentSerializationServiceUnknownStore">
         <source>This type of serialization store is not supported.  Use a store returned by the CreateStore method.</source>
         <target state="translated">이러한 형식의 serialization 저장소는 지원되지 않습니다. CreateStore 메서드에서 반환된 저장소를 사용하십시오.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderBadSerializationObject">
+        <source>The serialization data object is not of the proper type.</source>
+        <target state="new">The serialization data object is not of the proper type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeDesignerNotInstalled">
+        <source>	{0} --- The designer for base class '{1}' is not installed.</source>
+        <target state="new">	{0} --- The designer for base class '{1}' is not installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotDesignable">
+        <source>	{0} --- The base class '{1}' cannot be designed.</source>
+        <target state="new">	{0} --- The base class '{1}' cannot be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotFound">
+        <source>	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</source>
+        <target state="new">	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDupComponentName">
+        <source>There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</source>
+        <target state="new">There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidBlankIdentifier">
+        <source>Empty identifiers are not valid.</source>
+        <target state="new">Empty identifiers are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidIdentifier">
+        <source>'{0}' is not a valid identifier.</source>
+        <target state="new">'{0}' is not a valid identifier.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoLanguageSupport">
+        <source>The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</source>
+        <target state="new">The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializer">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializerWithFailures">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoTypeResolution">
+        <source>The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</source>
+        <target state="new">The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropGenerateMember">
+        <source>Indicates if a member variable will be generated for this component.</source>
+        <target state="new">Indicates if a member variable will be generated for this component.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropModifiers">
+        <source>Indicates the visibility level of the object.</source>
+        <target state="new">Indicates the visibility level of the object.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderSerializerTypeNotFirstType">
+        <source>The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</source>
+        <target state="new">The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandSetAlignByPrimary">
@@ -493,6 +585,31 @@
         <target state="translated">{0}개 구성 요소 크기 조정</target>
         <note />
       </trans-unit>
+      <trans-unit id="EventBindingServiceBadArgType">
+        <source>The event {0} expects an argument type of {1}.</source>
+        <target state="new">The event {0} expects an argument type of {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceEventReadOnly">
+        <source>The event {0} is read-only and cannot be changed.</source>
+        <target state="new">The event {0} is read-only and cannot be changed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceNoSite">
+        <source>Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</source>
+        <target state="new">Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceSetValue">
+        <source>Set {0}.{1} event</source>
+        <target state="new">Set {0}.{1} event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">Extender 공급자 {0}이(가) Extender로 이미 추가되었습니다. 다른 공급자를 추가하면 속성이 중복됩니다.</target>
@@ -511,6 +628,16 @@
       <trans-unit id="InvalidBoundArgument">
         <source>'{1}' is not a valid value for '{0}'. '{0}' should be between {2} and {3}.</source>
         <target state="translated">'{1}'은(는) '{0}'에 사용할 수 없는 값입니다. '{0}'은(는) {2}에서 {3} 사이에 있어야 합니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderManualReload">
+        <source>You must close and re-open the designer for this change to take effect.</source>
+        <target state="new">You must close and re-open the designer for this change to take effect.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
         <note />
       </trans-unit>
       <trans-unit id="None">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pl.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../SR.resx">
     <body>
+      <trans-unit id="BasicDesignerLoaderAlreadyLoaded">
+        <source>The designer is already loaded.</source>
+        <target state="new">The designer is already loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderDifferentHost">
+        <source>The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</source>
+        <target state="new">The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderNotInitialized">
+        <source>The designer loader has not been initialized yet.  You may only call this method after initialization.</source>
+        <target state="new">The designer loader has not been initialized yet.  You may only call this method after initialization.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BehaviorServiceCopyControl">
         <source>Copy and move {0}</source>
         <target state="translated">Skopiuj i przenieś {0}</target>
@@ -45,6 +65,78 @@
       <trans-unit id="CodeDomComponentSerializationServiceUnknownStore">
         <source>This type of serialization store is not supported.  Use a store returned by the CreateStore method.</source>
         <target state="translated">Ten typ magazynu serializacji nie jest obsługiwany. Użyj magazynu zwracanego przez metodę CreateStore.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderBadSerializationObject">
+        <source>The serialization data object is not of the proper type.</source>
+        <target state="new">The serialization data object is not of the proper type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeDesignerNotInstalled">
+        <source>	{0} --- The designer for base class '{1}' is not installed.</source>
+        <target state="new">	{0} --- The designer for base class '{1}' is not installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotDesignable">
+        <source>	{0} --- The base class '{1}' cannot be designed.</source>
+        <target state="new">	{0} --- The base class '{1}' cannot be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotFound">
+        <source>	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</source>
+        <target state="new">	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDupComponentName">
+        <source>There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</source>
+        <target state="new">There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidBlankIdentifier">
+        <source>Empty identifiers are not valid.</source>
+        <target state="new">Empty identifiers are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidIdentifier">
+        <source>'{0}' is not a valid identifier.</source>
+        <target state="new">'{0}' is not a valid identifier.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoLanguageSupport">
+        <source>The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</source>
+        <target state="new">The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializer">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializerWithFailures">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoTypeResolution">
+        <source>The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</source>
+        <target state="new">The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropGenerateMember">
+        <source>Indicates if a member variable will be generated for this component.</source>
+        <target state="new">Indicates if a member variable will be generated for this component.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropModifiers">
+        <source>Indicates the visibility level of the object.</source>
+        <target state="new">Indicates the visibility level of the object.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderSerializerTypeNotFirstType">
+        <source>The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</source>
+        <target state="new">The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandSetAlignByPrimary">
@@ -493,6 +585,31 @@
         <target state="translated">Zmień rozmiar {0} składników</target>
         <note />
       </trans-unit>
+      <trans-unit id="EventBindingServiceBadArgType">
+        <source>The event {0} expects an argument type of {1}.</source>
+        <target state="new">The event {0} expects an argument type of {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceEventReadOnly">
+        <source>The event {0} is read-only and cannot be changed.</source>
+        <target state="new">The event {0} is read-only and cannot be changed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceNoSite">
+        <source>Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</source>
+        <target state="new">Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceSetValue">
+        <source>Set {0}.{1} event</source>
+        <target state="new">Set {0}.{1} event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">Dostawca rozszerzony {0} został już dodany jako rozszerzenie. Dodanie kolejnego dostawcy spowodowałoby zduplikowanie właściwości.</target>
@@ -511,6 +628,16 @@
       <trans-unit id="InvalidBoundArgument">
         <source>'{1}' is not a valid value for '{0}'. '{0}' should be between {2} and {3}.</source>
         <target state="translated">'{1}' nie jest prawidłową wartością dla '{0}'. Wartość '{0}' powinna należeć do zakresu od {2} do {3}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderManualReload">
+        <source>You must close and re-open the designer for this change to take effect.</source>
+        <target state="new">You must close and re-open the designer for this change to take effect.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
         <note />
       </trans-unit>
       <trans-unit id="None">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pt-BR.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../SR.resx">
     <body>
+      <trans-unit id="BasicDesignerLoaderAlreadyLoaded">
+        <source>The designer is already loaded.</source>
+        <target state="new">The designer is already loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderDifferentHost">
+        <source>The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</source>
+        <target state="new">The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderNotInitialized">
+        <source>The designer loader has not been initialized yet.  You may only call this method after initialization.</source>
+        <target state="new">The designer loader has not been initialized yet.  You may only call this method after initialization.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BehaviorServiceCopyControl">
         <source>Copy and move {0}</source>
         <target state="translated">Copiar e mover {0}</target>
@@ -45,6 +65,78 @@
       <trans-unit id="CodeDomComponentSerializationServiceUnknownStore">
         <source>This type of serialization store is not supported.  Use a store returned by the CreateStore method.</source>
         <target state="translated">Não há suporte para esse tipo de repositório de serialização. Use um repositório retornado pelo método CreateStore.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderBadSerializationObject">
+        <source>The serialization data object is not of the proper type.</source>
+        <target state="new">The serialization data object is not of the proper type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeDesignerNotInstalled">
+        <source>	{0} --- The designer for base class '{1}' is not installed.</source>
+        <target state="new">	{0} --- The designer for base class '{1}' is not installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotDesignable">
+        <source>	{0} --- The base class '{1}' cannot be designed.</source>
+        <target state="new">	{0} --- The base class '{1}' cannot be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotFound">
+        <source>	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</source>
+        <target state="new">	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDupComponentName">
+        <source>There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</source>
+        <target state="new">There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidBlankIdentifier">
+        <source>Empty identifiers are not valid.</source>
+        <target state="new">Empty identifiers are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidIdentifier">
+        <source>'{0}' is not a valid identifier.</source>
+        <target state="new">'{0}' is not a valid identifier.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoLanguageSupport">
+        <source>The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</source>
+        <target state="new">The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializer">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializerWithFailures">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoTypeResolution">
+        <source>The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</source>
+        <target state="new">The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropGenerateMember">
+        <source>Indicates if a member variable will be generated for this component.</source>
+        <target state="new">Indicates if a member variable will be generated for this component.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropModifiers">
+        <source>Indicates the visibility level of the object.</source>
+        <target state="new">Indicates the visibility level of the object.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderSerializerTypeNotFirstType">
+        <source>The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</source>
+        <target state="new">The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandSetAlignByPrimary">
@@ -493,6 +585,31 @@
         <target state="translated">Dimensionar componentes {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="EventBindingServiceBadArgType">
+        <source>The event {0} expects an argument type of {1}.</source>
+        <target state="new">The event {0} expects an argument type of {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceEventReadOnly">
+        <source>The event {0} is read-only and cannot be changed.</source>
+        <target state="new">The event {0} is read-only and cannot be changed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceNoSite">
+        <source>Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</source>
+        <target state="new">Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceSetValue">
+        <source>Set {0}.{1} event</source>
+        <target state="new">Set {0}.{1} event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">O provedor do extensor {0} já foi adicionado como extensor. A inclusão de outro resultará em propriedades duplicadas.</target>
@@ -511,6 +628,16 @@
       <trans-unit id="InvalidBoundArgument">
         <source>'{1}' is not a valid value for '{0}'. '{0}' should be between {2} and {3}.</source>
         <target state="translated">'{1}' não é um valor válido para '{0}'. '{0}' deve estar entre {2} e {3}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderManualReload">
+        <source>You must close and re-open the designer for this change to take effect.</source>
+        <target state="new">You must close and re-open the designer for this change to take effect.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
         <note />
       </trans-unit>
       <trans-unit id="None">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ru.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../SR.resx">
     <body>
+      <trans-unit id="BasicDesignerLoaderAlreadyLoaded">
+        <source>The designer is already loaded.</source>
+        <target state="new">The designer is already loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderDifferentHost">
+        <source>The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</source>
+        <target state="new">The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderNotInitialized">
+        <source>The designer loader has not been initialized yet.  You may only call this method after initialization.</source>
+        <target state="new">The designer loader has not been initialized yet.  You may only call this method after initialization.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BehaviorServiceCopyControl">
         <source>Copy and move {0}</source>
         <target state="translated">Копировать и переместить {0}</target>
@@ -45,6 +65,78 @@
       <trans-unit id="CodeDomComponentSerializationServiceUnknownStore">
         <source>This type of serialization store is not supported.  Use a store returned by the CreateStore method.</source>
         <target state="translated">Этот тип хранилища сериализованных объектов не поддерживается.  Используйте хранилище, возвращенное методом CreateStore.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderBadSerializationObject">
+        <source>The serialization data object is not of the proper type.</source>
+        <target state="new">The serialization data object is not of the proper type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeDesignerNotInstalled">
+        <source>	{0} --- The designer for base class '{1}' is not installed.</source>
+        <target state="new">	{0} --- The designer for base class '{1}' is not installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotDesignable">
+        <source>	{0} --- The base class '{1}' cannot be designed.</source>
+        <target state="new">	{0} --- The base class '{1}' cannot be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotFound">
+        <source>	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</source>
+        <target state="new">	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDupComponentName">
+        <source>There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</source>
+        <target state="new">There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidBlankIdentifier">
+        <source>Empty identifiers are not valid.</source>
+        <target state="new">Empty identifiers are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidIdentifier">
+        <source>'{0}' is not a valid identifier.</source>
+        <target state="new">'{0}' is not a valid identifier.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoLanguageSupport">
+        <source>The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</source>
+        <target state="new">The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializer">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializerWithFailures">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoTypeResolution">
+        <source>The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</source>
+        <target state="new">The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropGenerateMember">
+        <source>Indicates if a member variable will be generated for this component.</source>
+        <target state="new">Indicates if a member variable will be generated for this component.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropModifiers">
+        <source>Indicates the visibility level of the object.</source>
+        <target state="new">Indicates the visibility level of the object.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderSerializerTypeNotFirstType">
+        <source>The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</source>
+        <target state="new">The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandSetAlignByPrimary">
@@ -493,6 +585,31 @@
         <target state="translated">Изменить размер {0} компонентов</target>
         <note />
       </trans-unit>
+      <trans-unit id="EventBindingServiceBadArgType">
+        <source>The event {0} expects an argument type of {1}.</source>
+        <target state="new">The event {0} expects an argument type of {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceEventReadOnly">
+        <source>The event {0} is read-only and cannot be changed.</source>
+        <target state="new">The event {0} is read-only and cannot be changed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceNoSite">
+        <source>Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</source>
+        <target state="new">Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceSetValue">
+        <source>Set {0}.{1} event</source>
+        <target state="new">Set {0}.{1} event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">Поставщик расширений {0} уже добавлен в качестве расширения.  Добавление другого поставщика приведет к появлению повторяющихся свойств.</target>
@@ -511,6 +628,16 @@
       <trans-unit id="InvalidBoundArgument">
         <source>'{1}' is not a valid value for '{0}'. '{0}' should be between {2} and {3}.</source>
         <target state="translated">'{1}' не является допустимым значением для '{0}'. Значение '{0}' должно лежать в диапазоне от {2} до {3}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderManualReload">
+        <source>You must close and re-open the designer for this change to take effect.</source>
+        <target state="new">You must close and re-open the designer for this change to take effect.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
         <note />
       </trans-unit>
       <trans-unit id="None">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.tr.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../SR.resx">
     <body>
+      <trans-unit id="BasicDesignerLoaderAlreadyLoaded">
+        <source>The designer is already loaded.</source>
+        <target state="new">The designer is already loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderDifferentHost">
+        <source>The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</source>
+        <target state="new">The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderNotInitialized">
+        <source>The designer loader has not been initialized yet.  You may only call this method after initialization.</source>
+        <target state="new">The designer loader has not been initialized yet.  You may only call this method after initialization.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BehaviorServiceCopyControl">
         <source>Copy and move {0}</source>
         <target state="translated">{0} kopyala ve taşı</target>
@@ -45,6 +65,78 @@
       <trans-unit id="CodeDomComponentSerializationServiceUnknownStore">
         <source>This type of serialization store is not supported.  Use a store returned by the CreateStore method.</source>
         <target state="translated">Bu tür serileştirme deposu desteklenmiyor. CreateStore metodu tarafından döndürülen bir depo kullanın.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderBadSerializationObject">
+        <source>The serialization data object is not of the proper type.</source>
+        <target state="new">The serialization data object is not of the proper type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeDesignerNotInstalled">
+        <source>	{0} --- The designer for base class '{1}' is not installed.</source>
+        <target state="new">	{0} --- The designer for base class '{1}' is not installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotDesignable">
+        <source>	{0} --- The base class '{1}' cannot be designed.</source>
+        <target state="new">	{0} --- The base class '{1}' cannot be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotFound">
+        <source>	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</source>
+        <target state="new">	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDupComponentName">
+        <source>There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</source>
+        <target state="new">There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidBlankIdentifier">
+        <source>Empty identifiers are not valid.</source>
+        <target state="new">Empty identifiers are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidIdentifier">
+        <source>'{0}' is not a valid identifier.</source>
+        <target state="new">'{0}' is not a valid identifier.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoLanguageSupport">
+        <source>The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</source>
+        <target state="new">The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializer">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializerWithFailures">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoTypeResolution">
+        <source>The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</source>
+        <target state="new">The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropGenerateMember">
+        <source>Indicates if a member variable will be generated for this component.</source>
+        <target state="new">Indicates if a member variable will be generated for this component.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropModifiers">
+        <source>Indicates the visibility level of the object.</source>
+        <target state="new">Indicates the visibility level of the object.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderSerializerTypeNotFirstType">
+        <source>The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</source>
+        <target state="new">The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandSetAlignByPrimary">
@@ -493,6 +585,31 @@
         <target state="translated">{0} bileşeni boyutlandır</target>
         <note />
       </trans-unit>
+      <trans-unit id="EventBindingServiceBadArgType">
+        <source>The event {0} expects an argument type of {1}.</source>
+        <target state="new">The event {0} expects an argument type of {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceEventReadOnly">
+        <source>The event {0} is read-only and cannot be changed.</source>
+        <target state="new">The event {0} is read-only and cannot be changed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceNoSite">
+        <source>Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</source>
+        <target state="new">Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceSetValue">
+        <source>Set {0}.{1} event</source>
+        <target state="new">Set {0}.{1} event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">{0} uzatma sağlayıcısı zaten bir uzatma olarak eklendi. Bir uzatma daha eklemek yinelenen özelliklere neden olabilir.</target>
@@ -511,6 +628,16 @@
       <trans-unit id="InvalidBoundArgument">
         <source>'{1}' is not a valid value for '{0}'. '{0}' should be between {2} and {3}.</source>
         <target state="translated">'{1}' değeri '{0}' öğesi için geçerli değil. '{0}' değeri {2} ile {3} arasında olmalıdır.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderManualReload">
+        <source>You must close and re-open the designer for this change to take effect.</source>
+        <target state="new">You must close and re-open the designer for this change to take effect.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
         <note />
       </trans-unit>
       <trans-unit id="None">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hans.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-HANS" original="../SR.resx">
     <body>
+      <trans-unit id="BasicDesignerLoaderAlreadyLoaded">
+        <source>The designer is already loaded.</source>
+        <target state="new">The designer is already loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderDifferentHost">
+        <source>The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</source>
+        <target state="new">The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderNotInitialized">
+        <source>The designer loader has not been initialized yet.  You may only call this method after initialization.</source>
+        <target state="new">The designer loader has not been initialized yet.  You may only call this method after initialization.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BehaviorServiceCopyControl">
         <source>Copy and move {0}</source>
         <target state="translated">复制并移动 {0}</target>
@@ -45,6 +65,78 @@
       <trans-unit id="CodeDomComponentSerializationServiceUnknownStore">
         <source>This type of serialization store is not supported.  Use a store returned by the CreateStore method.</source>
         <target state="translated">不支持这种类型的序列化存储区。请使用 CreateStore 方法返回的存储区。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderBadSerializationObject">
+        <source>The serialization data object is not of the proper type.</source>
+        <target state="new">The serialization data object is not of the proper type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeDesignerNotInstalled">
+        <source>	{0} --- The designer for base class '{1}' is not installed.</source>
+        <target state="new">	{0} --- The designer for base class '{1}' is not installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotDesignable">
+        <source>	{0} --- The base class '{1}' cannot be designed.</source>
+        <target state="new">	{0} --- The base class '{1}' cannot be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotFound">
+        <source>	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</source>
+        <target state="new">	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDupComponentName">
+        <source>There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</source>
+        <target state="new">There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidBlankIdentifier">
+        <source>Empty identifiers are not valid.</source>
+        <target state="new">Empty identifiers are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidIdentifier">
+        <source>'{0}' is not a valid identifier.</source>
+        <target state="new">'{0}' is not a valid identifier.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoLanguageSupport">
+        <source>The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</source>
+        <target state="new">The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializer">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializerWithFailures">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoTypeResolution">
+        <source>The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</source>
+        <target state="new">The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropGenerateMember">
+        <source>Indicates if a member variable will be generated for this component.</source>
+        <target state="new">Indicates if a member variable will be generated for this component.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropModifiers">
+        <source>Indicates the visibility level of the object.</source>
+        <target state="new">Indicates the visibility level of the object.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderSerializerTypeNotFirstType">
+        <source>The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</source>
+        <target state="new">The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandSetAlignByPrimary">
@@ -493,6 +585,31 @@
         <target state="translated">调整 {0} 组件的大小</target>
         <note />
       </trans-unit>
+      <trans-unit id="EventBindingServiceBadArgType">
+        <source>The event {0} expects an argument type of {1}.</source>
+        <target state="new">The event {0} expects an argument type of {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceEventReadOnly">
+        <source>The event {0} is read-only and cannot be changed.</source>
+        <target state="new">The event {0} is read-only and cannot be changed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceNoSite">
+        <source>Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</source>
+        <target state="new">Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceSetValue">
+        <source>Set {0}.{1} event</source>
+        <target state="new">Set {0}.{1} event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">扩展程序提供程序 {0} 已添加为扩展程序。添加其他扩展程序提供程序将导致重复的属性。</target>
@@ -511,6 +628,16 @@
       <trans-unit id="InvalidBoundArgument">
         <source>'{1}' is not a valid value for '{0}'. '{0}' should be between {2} and {3}.</source>
         <target state="translated">“{1}”不是“{0}”的有效值。“{0}”应介于 {2} 和 {3} 之间。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderManualReload">
+        <source>You must close and re-open the designer for this change to take effect.</source>
+        <target state="new">You must close and re-open the designer for this change to take effect.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
         <note />
       </trans-unit>
       <trans-unit id="None">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hant.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-HANT" original="../SR.resx">
     <body>
+      <trans-unit id="BasicDesignerLoaderAlreadyLoaded">
+        <source>The designer is already loaded.</source>
+        <target state="new">The designer is already loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderDifferentHost">
+        <source>The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</source>
+        <target state="new">The designer loader has already been loaded from another host.  You can only have one designer loader for each host.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BasicDesignerLoaderNotInitialized">
+        <source>The designer loader has not been initialized yet.  You may only call this method after initialization.</source>
+        <target state="new">The designer loader has not been initialized yet.  You may only call this method after initialization.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BehaviorServiceCopyControl">
         <source>Copy and move {0}</source>
         <target state="translated">複製並移動 {0}</target>
@@ -45,6 +65,78 @@
       <trans-unit id="CodeDomComponentSerializationServiceUnknownStore">
         <source>This type of serialization store is not supported.  Use a store returned by the CreateStore method.</source>
         <target state="translated">不支援這種類型的序列化存放區。請使用 CreateStore 方法傳回的存放區。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderBadSerializationObject">
+        <source>The serialization data object is not of the proper type.</source>
+        <target state="new">The serialization data object is not of the proper type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeDesignerNotInstalled">
+        <source>	{0} --- The designer for base class '{1}' is not installed.</source>
+        <target state="new">	{0} --- The designer for base class '{1}' is not installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotDesignable">
+        <source>	{0} --- The base class '{1}' cannot be designed.</source>
+        <target state="new">	{0} --- The base class '{1}' cannot be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDocumentFailureTypeNotFound">
+        <source>	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</source>
+        <target state="new">	{0} --- The base class '{1}' could not be loaded.  Ensure the assembly has been referenced and that all projects have been built.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderDupComponentName">
+        <source>There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</source>
+        <target state="new">There is already a component named '{0}'.  Components must have unique names, and names must be case-insensitive.  A name also cannot conflict with the name of any component in an inherited class.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidBlankIdentifier">
+        <source>Empty identifiers are not valid.</source>
+        <target state="new">Empty identifiers are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderInvalidIdentifier">
+        <source>'{0}' is not a valid identifier.</source>
+        <target state="new">'{0}' is not a valid identifier.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoLanguageSupport">
+        <source>The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</source>
+        <target state="new">The language did not provide a code parser for this file.  Please make sure that this file type supports a designer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializer">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoRootSerializerWithFailures">
+        <source>The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</source>
+        <target state="new">The designer could not be shown for this file because none of the classes within it can be designed.  The designer inspected the following classes in the file: 
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderNoTypeResolution">
+        <source>The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</source>
+        <target state="new">The designer loader did not supply a type resolution service, which is a requirement for CodeDom serialization.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropGenerateMember">
+        <source>Indicates if a member variable will be generated for this component.</source>
+        <target state="new">Indicates if a member variable will be generated for this component.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderPropModifiers">
+        <source>Indicates the visibility level of the object.</source>
+        <target state="new">Indicates the visibility level of the object.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeDomDesignerLoaderSerializerTypeNotFirstType">
+        <source>The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</source>
+        <target state="new">The class {0} can be designed, but is not the first class in the file.  Visual Studio requires that designers use the first class in the file.  Move the class code so that it is the first class in the file and try loading the designer again.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandSetAlignByPrimary">
@@ -493,6 +585,31 @@
         <target state="translated">調整 {0} 元件的大小</target>
         <note />
       </trans-unit>
+      <trans-unit id="EventBindingServiceBadArgType">
+        <source>The event {0} expects an argument type of {1}.</source>
+        <target state="new">The event {0} expects an argument type of {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceEventReadOnly">
+        <source>The event {0} is read-only and cannot be changed.</source>
+        <target state="new">The event {0} is read-only and cannot be changed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceNoSite">
+        <source>Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</source>
+        <target state="new">Events cannot be set on the object passed to the event binding service because a site associated with the object could not be located.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EventBindingServiceSetValue">
+        <source>Set {0}.{1} event</source>
+        <target state="new">Set {0}.{1} event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">已經將擴充性提供者 {0} 加入做為擴充項。加入另一個會產生重複的屬性。</target>
@@ -511,6 +628,16 @@
       <trans-unit id="InvalidBoundArgument">
         <source>'{1}' is not a valid value for '{0}'. '{0}' should be between {2} and {3}.</source>
         <target state="translated">'{1}' 不是 '{0}' 的有效值。'{0}' 應該介於 {2} 與 {3} 之間。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderManualReload">
+        <source>You must close and re-open the designer for this change to take effect.</source>
+        <target state="new">You must close and re-open the designer for this change to take effect.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalizationProviderMissingService">
+        <source>The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</source>
+        <target state="new">The service {0} is required but could not be found.  If you have removed this service ensure that you provide a replacement.</target>
         <note />
       </trans-unit>
       <trans-unit id="None">

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ActiveDesignSurfaceChangedEventArgs.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ActiveDesignSurfaceChangedEventArgs.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ComponentModel.Design
+{
+    /// <summary>
+    ///  The event args for the ActiveDesignSurface event.
+    /// </summary>
+    public class ActiveDesignSurfaceChangedEventArgs : EventArgs
+    {
+        /// <summary>
+        ///  Creates a new ActiveDesignSurfaceChangedEventArgs instance.
+        /// </summary>
+        public ActiveDesignSurfaceChangedEventArgs(DesignSurface oldSurface, DesignSurface newSurface)
+        {
+            OldSurface = oldSurface;
+            NewSurface = newSurface;
+        }
+
+        /// <summary>
+        ///  Gets the design surface that is losing activation.
+        /// </summary>
+        public DesignSurface OldSurface { get; }
+
+        /// <summary>
+        ///  Gets the design surface that is gaining activation.
+        /// </summary>
+        public DesignSurface NewSurface { get; }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ActiveDesignSurfaceChangedEventHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ActiveDesignSurfaceChangedEventHandler.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ComponentModel.Design
+{
+    /// <summary>
+    ///  An event handler for the ActiveDesignSurfaceChanged event.
+    /// </summary>
+    public delegate void ActiveDesignSurfaceChangedEventHandler(object sender, ActiveDesignSurfaceChangedEventArgs e);
+}

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CodeMarkerEvent.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CodeMarkerEvent.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ComponentModel.Design
+{
+    internal enum CodeMarkerEvent
+    {
+        perfFXDesignCreateComponentEnd = 7501,
+        perfFXDesignPropertyBrowserPopulationStart = 7502,
+        perfFXDesignPropertyBrowserPopulationEnd = 7503,
+        perfFXDesignShowCode = 7505,
+        perfFXDesignFromCodeToDesignStart = 7506,
+        perfFXDesignFromCodeToDesign = 7507,
+        perfFXDesignFlushStart = 7508,
+        perfFXDesignFlushEnd = 7509,
+        perfFXBindEventDesignToCode = 7511,
+        perfFXGenerateCodeTreeEnd = 7513,
+        perfFXIntegrateSerializedTreeEnd = 7515,
+        perfFXOnLoadedStart = 7516,
+        perfFXOnLoadedEnd = 7517,
+        perfFXCreateEditorStart = 7518,
+        perfFXCreateEditorEnd = 7519,
+        perfFXParseEnd = 7520,
+        perfFXPerformLoadStart = 7521,
+        perfFXPerformLoadEnd = 7522,
+        perfFXEmitMethodEnd = 7523,
+        perfFXFormatMethodEnd = 7524,
+        perfFXCodeGenerationEnd = 7525,
+        perfFXGetDocumentType = 7526,
+        perfFXDeserializeStart = 7527,
+        perfFXDeserializeEnd = 7528,
+        perfFXGetFileDocDataStart = 7529,
+        perfFXGetFileDocDataEnd = 7530,
+        perfFXCreateDesignerStart = 7531,
+        perfFXCreateDesignerEnd = 7532,
+        perfFXCreateDesignSurface = 7533,
+        perfFXCreateDesignSurfaceEnd = 7534,
+        perfFXNotifyStartupServices = 7535,
+        perfFXNotifyStartupServicesEnd = 7536,
+        perfFXGetGlobalObjects = 7537,
+        perfFXGetGlobalObjectsEnd = 7538,
+        perfFXDesignPropertyBrowserCreate = 7539,
+        perfFXDesignPropertyBrowserCreateEnd = 7540,
+        perfFXDesignPropertyBrowserLoadState = 7541,
+        perfFXDesignPBOnSelectionChanged = 7542,
+        perfFXDesignPBOnSelectionChangedEnd = 7543,
+        perfFXDesignElementHostDesignerSetChildEnd = 7544
+    }
+}
+

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurfaceCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurfaceCollection.cs
@@ -1,0 +1,101 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+
+namespace System.ComponentModel.Design
+{
+    /// <summary>
+    ///  Provides a read-only collection of design surfaces.
+    /// </summary>
+    public sealed class DesignSurfaceCollection : ICollection
+    {
+        private readonly DesignerCollection _designers;
+
+        /// <summary>
+        ///  Initializes a new instance of the DesignSurfaceCollection class
+        /// </summary>
+        internal DesignSurfaceCollection(DesignerCollection designers)
+        {
+            _designers = designers ?? new DesignerCollection(null);
+        }
+
+        /// <summary>
+        ///  Gets number of design surfaces in the collection.
+        /// </summary>
+        public int Count => _designers.Count;
+
+        /// <summary>
+        ///  Gets or sets the document at the specified index.
+        /// </summary>
+        public DesignSurface this[int index]
+        {
+            get
+            {
+                IDesignerHost host = _designers[index];
+                if (host.GetService(typeof(DesignSurface)) is DesignSurface surface)
+                {
+                    return surface;
+                }
+
+                throw new NotSupportedException();
+            }
+        }
+
+        /// <summary>
+        ///  Creates and retrieves a new enumerator for this collection.
+        /// </summary>
+        public IEnumerator GetEnumerator() => new DesignSurfaceEnumerator(_designers.GetEnumerator());
+
+        int ICollection.Count => Count;
+
+        bool ICollection.IsSynchronized => false;
+
+        object ICollection.SyncRoot => null;
+
+        void ICollection.CopyTo(Array array, int index)
+        {
+            foreach (DesignSurface surface in this)
+            {
+                array.SetValue(surface, index++);
+            }
+        }
+
+        public void CopyTo(DesignSurface[] array, int index) => ((ICollection)this).CopyTo(array, index);
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        /// <summary>
+        ///  Enumerator that performs the conversion from designer host 
+        ///  to design surface.
+        /// </summary>
+        private class DesignSurfaceEnumerator : IEnumerator
+        {
+            private readonly IEnumerator _designerEnumerator;
+
+            internal DesignSurfaceEnumerator(IEnumerator designerEnumerator)
+            {
+                _designerEnumerator = designerEnumerator;
+            }
+
+            public object Current
+            {
+                get
+                {
+                    IDesignerHost host = (IDesignerHost)_designerEnumerator.Current;
+                    if (host.GetService(typeof(DesignSurface)) is DesignSurface surface)
+                    {
+                        return surface;
+                    }
+
+                    throw new NotSupportedException();
+                }
+            }
+
+            public bool MoveNext() => _designerEnumerator.MoveNext();
+
+            public void Reset() => _designerEnumerator.Reset();
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurfaceEvent.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurfaceEvent.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ComponentModel.Design
+{
+    /// <summary>
+    ///  Event handler for the DesignSurface event.
+    /// </summary>
+    public delegate void DesignSurfaceEventHandler(object sender, DesignSurfaceEventArgs e);
+
+    /// <summary>
+    ///  Event args for the DesignSurface event.
+    /// </summary>
+    public class DesignSurfaceEventArgs : EventArgs
+    {
+        /// <summary>
+        ///  Creates a new DesignSurfaceEventArgs for the given design surface.
+        /// </summary>
+        public DesignSurfaceEventArgs(DesignSurface surface)
+        {
+            Surface = surface ?? throw new ArgumentNullException(nameof(surface));
+        }
+
+        /// <summary>
+        ///  The design surface passed into the constructor.
+        /// </summary>
+        public DesignSurface Surface { get; }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurfaceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurfaceManager.cs
@@ -1,0 +1,481 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace System.ComponentModel.Design
+{
+    /// <summary>
+    ///  A service container that supports "fixed" services.  Fixed 
+    ///  services cannot be removed.
+    /// </summary>
+    public class DesignSurfaceManager : IServiceProvider, IDisposable
+    {
+        private readonly IServiceProvider _parentProvider;
+        private ServiceContainer _serviceContainer;
+        private ActiveDesignSurfaceChangedEventHandler _activeDesignSurfaceChanged;
+        private DesignSurfaceEventHandler _designSurfaceCreated;
+        private DesignSurfaceEventHandler _designSurfaceDisposed;
+        private EventHandler _selectionChanged;
+
+        /// <summary>
+        ///  Creates a new designer application.
+        /// </summary>
+        public DesignSurfaceManager()
+            : this(null)
+        {
+        }
+
+        /// <summary>
+        ///  Creates a new designer application and provides a
+        ///  parent service provider.
+        /// </summary>
+        public DesignSurfaceManager(IServiceProvider parentProvider)
+        {
+            _parentProvider = parentProvider;
+
+            ServiceCreatorCallback callback = new ServiceCreatorCallback(OnCreateService);
+            ServiceContainer.AddService(typeof(IDesignerEventService), callback);
+        }
+
+        /// <summary>
+        ///  This property should be set by the designer's user interface
+        ///  whenever a designer becomes the active window.  The default
+        ///  implementation of this property works with the default
+        ///  implementation of IDesignerEventService to notify interested
+        ///  parties that a new designer is now active.  If you provide
+        ///  your own implementation of IDesignerEventService you should
+        ///  override this property to notify your service appropriately.
+        /// </summary>
+        public virtual DesignSurface ActiveDesignSurface
+        {
+            get
+            {
+                IDesignerEventService eventService = EventService;
+                if (eventService == null)
+                {
+                    return null;
+                }
+
+                IDesignerHost activeHost = eventService.ActiveDesigner;
+                if (activeHost == null)
+                {
+                    return null;
+                }
+
+                return activeHost.GetService(typeof(DesignSurface)) as DesignSurface;
+            }
+            set
+            {
+                // If we are providing IDesignerEventService, then we are responsible for 
+                // notifying it of new designers coming into place.  If we aren't 
+                // the ones providing the event service, then whoever is providing 
+                // it will be responsible for updating it when new designers
+                // are created.
+                if (EventService is DesignerEventService eventService)
+                {
+                    eventService.OnActivateDesigner(value);
+                }
+            }
+        }
+
+        /// <summary>
+        ///  A collection of design surfaces.  This is offered
+        ///  for convience, and simply maps to IDesignerEventService.
+        /// </summary>
+        public DesignSurfaceCollection DesignSurfaces
+        {
+            get
+            {
+                IDesignerEventService eventService = EventService;
+                if (eventService != null)
+                {
+                    return new DesignSurfaceCollection(eventService.Designers);
+                }
+
+                return new DesignSurfaceCollection(null);
+            }
+        }
+
+        /// <summary>
+        ///  We access this a lot.
+        /// </summary>
+        private IDesignerEventService EventService => GetService(typeof(IDesignerEventService)) as IDesignerEventService;
+
+        /// <summary>
+        ///  Provides access to the designer application's 
+        ///  ServiceContainer. This property allows 
+        ///  inheritors to add their own services.
+        /// </summary>
+        protected ServiceContainer ServiceContainer
+        {
+            get
+            {
+                if (_serviceContainer == null)
+                {
+                    _serviceContainer = new ServiceContainer(_parentProvider);
+                }
+
+                return _serviceContainer;
+            }
+        }
+
+        /// <summary>
+        ///  This event is raised when a new design surface gains
+        ///  activation.  This is mapped through IDesignerEventService.
+        /// </summary>
+        public event ActiveDesignSurfaceChangedEventHandler ActiveDesignSurfaceChanged
+        {
+            add
+            {
+                if (_activeDesignSurfaceChanged == null)
+                {
+                    IDesignerEventService eventService = EventService;
+                    if (eventService != null)
+                    {
+                        eventService.ActiveDesignerChanged += new ActiveDesignerEventHandler(OnActiveDesignerChanged);
+                    }
+                }
+
+                _activeDesignSurfaceChanged += value;
+            }
+            remove
+            {
+                _activeDesignSurfaceChanged -= value;
+                if (_activeDesignSurfaceChanged != null)
+                {
+                    return;
+                }
+
+                IDesignerEventService eventService = EventService;
+                if (eventService != null)
+                {
+                    eventService.ActiveDesignerChanged -= new ActiveDesignerEventHandler(OnActiveDesignerChanged);
+                }
+            }
+        }
+
+        /// <summary>
+        ///  This event is raised when a new design surface is
+        ///  created.  This is mapped through IDesignerEventService.
+        /// </summary>
+        public event DesignSurfaceEventHandler DesignSurfaceCreated
+        {
+            add
+            {
+                if (_designSurfaceCreated == null)
+                {
+                    IDesignerEventService eventService = EventService;
+                    if (eventService != null)
+                    {
+                        eventService.DesignerCreated += new DesignerEventHandler(OnDesignerCreated);
+                    }
+                }
+
+                _designSurfaceCreated += value;
+            }
+            remove
+            {
+                _designSurfaceCreated -= value;
+                if (_designSurfaceCreated != null)
+                {
+                    return;
+                }
+
+                IDesignerEventService eventService = EventService;
+                if (eventService != null)
+                {
+                    eventService.DesignerCreated -= new DesignerEventHandler(OnDesignerCreated);
+                }
+            }
+        }
+
+        /// <summary>
+        ///  This event is raised when a design surface is disposed.
+        ///  This is mapped through IDesignerEventService.
+        /// </summary>
+        public event DesignSurfaceEventHandler DesignSurfaceDisposed
+        {
+            add
+            {
+                if (_designSurfaceDisposed == null)
+                {
+                    IDesignerEventService eventService = EventService;
+                    if (eventService != null)
+                    {
+                        eventService.DesignerDisposed += new DesignerEventHandler(OnDesignerDisposed);
+                    }
+                }
+
+                _designSurfaceDisposed += value;
+            }
+            remove
+            {
+                _designSurfaceDisposed -= value;
+                if (_designSurfaceDisposed != null)
+                {
+                    return;
+                }
+
+                IDesignerEventService eventService = EventService;
+                if (eventService != null)
+                {
+                    eventService.DesignerDisposed -= new DesignerEventHandler(OnDesignerDisposed);
+                }
+            }
+        }
+
+        /// <summary>
+        ///  This event is raised when the active designer's
+        ///  selection of component set changes.  This is mapped
+        ///  through IDesignerEventService.
+        /// </summary>
+        public event EventHandler SelectionChanged
+        {
+            add
+            {
+                if (_selectionChanged == null)
+                {
+                    IDesignerEventService eventService = EventService;
+                    if (eventService != null)
+                    {
+                        eventService.SelectionChanged += new EventHandler(OnSelectionChanged);
+                    }
+                }
+
+                _selectionChanged += value;
+            }
+            remove
+            {
+                _selectionChanged -= value;
+                if (_selectionChanged != null)
+                {
+                    return;
+                }
+
+                IDesignerEventService eventService = EventService;
+                if (eventService != null)
+                {
+                    eventService.SelectionChanged -= new EventHandler(OnSelectionChanged);
+                }
+            }
+        }
+
+        /// <summary>
+        ///  Public method to create a design surface.
+        /// </summary>
+        public DesignSurface CreateDesignSurface()
+        {
+            DesignSurface surface = CreateDesignSurfaceCore(this);
+
+            // If we are providing IDesignerEventService, then we are responsible for 
+            // notifying it of new designers coming into place.  If we aren't 
+            // the ones providing the event service, then whoever is providing 
+            // it will be responsible for updating it when new designers are created.
+            if (GetService(typeof(IDesignerEventService)) is DesignerEventService eventService)
+            {
+                eventService.OnCreateDesigner(surface);
+            }
+
+            return surface;
+        }
+
+        /// <summary>
+        ///  Public method to create a design surface.  This method
+        ///  takes an additional service provider.  This service 
+        ///  provider will be combined with the service provider 
+        ///  already contained within DesignSurfaceManager.  Service
+        ///  requests will go to this provider first, and then bubble
+        ///  up to the service provider owned by DesignSurfaceManager.
+        ///  This allows for services to be tailored for each design surface.
+        /// </summary>
+        public DesignSurface CreateDesignSurface(IServiceProvider parentProvider)
+        {
+            if (parentProvider == null)
+            {
+                throw new ArgumentNullException(nameof(parentProvider));
+            }
+
+            IServiceProvider mergedProvider = new MergedServiceProvider(parentProvider, this);
+
+            DesignSurface surface = CreateDesignSurfaceCore(mergedProvider);
+
+            // If we are providing IDesignerEventService, then we are responsible for 
+            // notifying it of new designers coming into place.  If we aren't 
+            // the ones providing the event service, then whoever is providing 
+            // it will be responsible for updating it when new designers are created.
+            DesignerEventService eventService = GetService(typeof(IDesignerEventService)) as DesignerEventService;
+            if (eventService != null)
+            {
+                eventService.OnCreateDesigner(surface);
+            }
+
+            return surface;
+        }
+
+        /// <summary>
+        ///  Creates an instance of a design surface.  This can be 
+        ///  overridden to provide a derived version of DesignSurface.
+        /// </summary>
+        protected virtual DesignSurface CreateDesignSurfaceCore(IServiceProvider parentProvider) => new DesignSurface(parentProvider);
+
+        /// <summary>
+        ///  Disposes the designer application.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        /// <summary>
+        ///  Protected override of Dispose that allows for cleanup.
+        /// </summary>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposing || _serviceContainer == null)
+            {
+                return;
+            }
+
+            _serviceContainer.Dispose();
+            _serviceContainer = null;
+        }
+
+        /// <summary>
+        ///  Retrieves a service in this design surface's service
+        ///  container.
+        /// </summary>
+        public object GetService(Type serviceType) => _serviceContainer?.GetService(serviceType);
+
+        /// <summary>
+        ///  Private method that demand-creates services we offer.
+        /// </summary>
+        /// <param name="container">
+        ///  The service container requesting the service.
+        /// </param>
+        /// <param name="serviceType">
+        ///  The type of service being requested.
+        /// </param>
+        /// <returns>
+        ///  A new instance of the service.  It is an error to call this with
+        ///  a service type it doesn't know how to create
+        /// </returns>
+        private object OnCreateService(IServiceContainer container, Type serviceType)
+        {
+
+            if (serviceType == typeof(IDesignerEventService))
+            {
+                return new DesignerEventService();
+            }
+
+            Debug.Fail("Demand created service not supported: " + serviceType.Name);
+            return null;
+        }
+
+        /// <summary>
+        ///  Handles the IDesignerEventService event and relays it to
+        ///  DesignSurfaceManager's similar event.
+        /// </summary>
+        private void OnActiveDesignerChanged(object sender, ActiveDesignerEventArgs e)
+        {
+            Debug.Assert(_activeDesignSurfaceChanged != null, "Should have detached this event handler.");
+            if (_activeDesignSurfaceChanged != null)
+            {
+
+                DesignSurface newSurface = null;
+                DesignSurface oldSurface = null;
+
+                if (e.OldDesigner != null)
+                {
+                    oldSurface = e.OldDesigner.GetService(typeof(DesignSurface)) as DesignSurface;
+                }
+
+                if (e.NewDesigner != null)
+                {
+                    newSurface = e.NewDesigner.GetService(typeof(DesignSurface)) as DesignSurface;
+                }
+
+                _activeDesignSurfaceChanged(this, new ActiveDesignSurfaceChangedEventArgs(oldSurface, newSurface));
+            }
+        }
+
+        /// <summary>
+        ///  Handles the IDesignerEventService event and relays it to
+        ///  DesignSurfaceManager's similar event.
+        /// </summary>
+        private void OnDesignerCreated(object sender, DesignerEventArgs e)
+        {
+            Debug.Assert(_designSurfaceCreated != null, "Should have detached this event handler.");
+            if (_designSurfaceCreated == null)
+            {
+                return;
+            }
+
+            if (e.Designer.GetService(typeof(DesignSurface)) is DesignSurface surface)
+            {
+                _designSurfaceCreated(this, new DesignSurfaceEventArgs(surface));
+            }
+        }
+
+        /// <summary>
+        ///  Handles the IDesignerEventService event and relays it to
+        ///  DesignSurfaceManager's similar event.
+        /// </summary>
+        private void OnDesignerDisposed(object sender, DesignerEventArgs e)
+        {
+            Debug.Assert(_designSurfaceDisposed != null, "Should have detached this event handler.");
+            if (_designSurfaceDisposed == null)
+            {
+                return;
+            }
+
+            if (e.Designer.GetService(typeof(DesignSurface)) is DesignSurface surface)
+            {
+                _designSurfaceDisposed(this, new DesignSurfaceEventArgs(surface));
+            }
+        }
+
+        /// <summary>
+        ///  Handles the IDesignerEventService event and relays it to
+        ///  DesignSurfaceManager's similar event.
+        /// </summary>
+        private void OnSelectionChanged(object sender, EventArgs e)
+        {
+            Debug.Assert(_selectionChanged != null, "Should have detached this event handler.");
+            _selectionChanged?.Invoke(this, e);
+        }
+
+        /// <summary>
+        ///  Simple service provider that merges two providers together.  
+        /// </summary>
+        private sealed class MergedServiceProvider : IServiceProvider
+        {
+            private IServiceProvider _primaryProvider;
+            private IServiceProvider _secondaryProvider;
+
+            internal MergedServiceProvider(IServiceProvider primaryProvider, IServiceProvider secondaryProvider)
+            {
+                _primaryProvider = primaryProvider;
+                _secondaryProvider = secondaryProvider;
+            }
+
+            object IServiceProvider.GetService(Type serviceType)
+            {
+                if (serviceType == null)
+                {
+                    throw new ArgumentNullException(nameof(serviceType));
+                }
+
+                object service = _primaryProvider.GetService(serviceType);
+
+                if (service == null)
+                {
+                    service = _secondaryProvider.GetService(serviceType);
+                }
+
+                return service;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerEventService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerEventService.cs
@@ -1,0 +1,463 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Diagnostics;
+
+namespace System.ComponentModel.Design
+{
+    /// <summary>
+    ///  This service tracks individual designer events.  The class itself
+    ///  receives event information by direct calls from DesignerApplication.
+    ///  Those wishing to replace this service may do so but need to override
+    ///  the appropriate virtual methods on DesignerApplication.
+    /// </summary>
+    internal sealed class DesignerEventService : IDesignerEventService
+    {
+        private static readonly object s_eventActiveDesignerChanged = new object();
+        private static readonly object s_eventDesignerCreated = new object();
+        private static readonly object s_eventDesignerDisposed = new object();
+        private static readonly object s_eventSelectionChanged = new object();
+
+        private ArrayList _designerList;                    // read write list used as data for the collection
+        private DesignerCollection _designerCollection;     // public read only view of the above list
+        private IDesignerHost _activeDesigner;              // the currently active designer.  Can be null
+        private EventHandlerList _events;                   // list of events.  Can be null
+        private bool _inTransaction;                        // true if we are in a transaction
+        private bool _deferredSelChange;                    // true if we have a deferred selection change notification pending
+
+        /// <summary>
+        ///  Internal ctor to prevent semitrust from creating us.
+        /// </summary>
+        internal DesignerEventService()
+        {
+        }
+
+        /// <summary>
+        ///  This is called by the DesignerApplication class when
+        ///  a designer is activated.  The passed in designer can
+        ///  be null to signify no designer is currently active.
+        /// </summary>
+        internal void OnActivateDesigner(DesignSurface surface)
+        {
+            IDesignerHost host = null;
+            if (surface != null)
+            {
+                host = surface.GetService(typeof(IDesignerHost)) as IDesignerHost;
+                Debug.Assert(host != null, "Design surface did not provide us with a designer host");
+            }
+
+            // If the designer host is not in our collection, add it.  
+            if (host != null && (_designerList == null || !_designerList.Contains(host)))
+            {
+                OnCreateDesigner(surface);
+            }
+
+            if (_activeDesigner == host)
+            {
+                return;
+            }
+
+            IDesignerHost oldDesigner = _activeDesigner;
+            _activeDesigner = host;
+
+            if (oldDesigner != null)
+            {
+                SinkChangeEvents(oldDesigner, false);
+            }
+
+            if (_activeDesigner != null)
+            {
+                SinkChangeEvents(_activeDesigner, true);
+            }
+
+            if (_events != null)
+            {
+                (_events[s_eventActiveDesignerChanged] as ActiveDesignerEventHandler)?.Invoke(this, new ActiveDesignerEventArgs(oldDesigner, host));
+            }
+
+            // Activating a new designer automatically pushes a new selection.
+            //
+            OnSelectionChanged(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        ///  Called when a component is added or removed from the active designer.
+        ///  We raise a selection change event here.
+        /// </summary>
+        private void OnComponentAddedRemoved(object sender, ComponentEventArgs ce)
+        {
+            if (ce.Component is IComponent comp)
+            {
+                ISite site = comp.Site;
+                if (site != null)
+                {
+                    if (site.Container is IDesignerHost host && host.Loading)
+                    {
+                        _deferredSelChange = true;
+                        return;
+                    }
+                }
+            }
+
+            OnSelectionChanged(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        ///  Called when a component has changed on the active designer. Here
+        ///  we grab the active selection service and see if the component that
+        ///  has changed is also selected.  If it is, then we raise a global
+        ///  selection changed event.
+        /// </summary>
+        private void OnComponentChanged(object sender, ComponentChangedEventArgs ce)
+        {
+            if (!(ce.Component is IComponent comp))
+            {
+                return;
+            }
+
+            ISite site = comp.Site;
+            if (site == null)
+            {
+                return;
+            }
+
+            if (site.GetService(typeof(ISelectionService)) is ISelectionService ss && ss.GetComponentSelected(comp))
+            {
+                OnSelectionChanged(this, EventArgs.Empty);
+            }
+        }
+
+        /// <summary>
+        ///  This is called by the DesignerApplication class when
+        ///  a designer is created.  Activation generally follows.
+        /// </summary>
+        internal void OnCreateDesigner(DesignSurface surface)
+        {
+            Debug.Assert(surface != null, "DesignerApplication should not pass null here");
+            IDesignerHost host = surface.GetService(typeof(IDesignerHost)) as IDesignerHost;
+            Debug.Assert(host != null, "Design surface did not provide us with a designer host");
+
+            if (_designerList == null)
+            {
+                _designerList = new ArrayList();
+            }
+
+            _designerList.Add(host);
+
+            // Hookup an object disposed handler on the design surface so we know when it's gone.
+            surface.Disposed += new EventHandler(OnDesignerDisposed);
+
+            if (_events == null)
+            {
+                return;
+            }
+
+            if (_events[s_eventDesignerCreated] is DesignerEventHandler eh)
+            {
+                eh(this, new DesignerEventArgs(host));
+            }
+        }
+
+        /// <summary>
+        ///  Called by DesignSurface when it is about to be disposed.  
+        /// </summary>
+        private void OnDesignerDisposed(object sender, EventArgs e)
+        {
+            DesignSurface surface = (DesignSurface)sender;
+            surface.Disposed -= new EventHandler(OnDesignerDisposed);
+
+            // Detatch the selection change and add/remove events, if we were monitoring such events
+            SinkChangeEvents(surface, false);
+
+            IDesignerHost host = surface.GetService(typeof(IDesignerHost)) as IDesignerHost;
+            Debug.Assert(host != null, "Design surface removed host too early in dispose");
+            if (host == null)
+            {
+                return;
+            }
+
+            if (_events != null)
+            {
+                if (_events[s_eventDesignerDisposed] is DesignerEventHandler eh)
+                {
+                    eh(this, new DesignerEventArgs(host));
+                }
+            }
+
+            if (_designerList != null)
+            {
+                _designerList.Remove(host);
+            }
+        }
+
+        /// <summary>
+        ///  Called by the active designer's selection service when the selection changes.
+        ///  Also called directly by us when the active designer changes, as this is
+        ///  also a change to the global selection context.
+        /// </summary>
+        private void OnSelectionChanged(object sender, EventArgs e)
+        {
+            if (_inTransaction)
+            {
+                _deferredSelChange = true;
+                return;
+            }
+
+            if (_events == null)
+            {
+                return;
+            }
+
+            if (_events[s_eventSelectionChanged] is EventHandler eh)
+            {
+                eh(this, e);
+            }
+        }
+
+        /// <summary>
+        ///  Called by the designer host when it is done loading
+        ///  Here we queue up selection notification.
+        /// </summary>
+        private void OnLoadComplete(object sender, EventArgs e)
+        {
+            if (!_deferredSelChange)
+            {
+                return;
+            }
+
+            _deferredSelChange = false;
+            OnSelectionChanged(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        ///  Called by the designer host when it is entering or leaving a batch
+        ///  operation.  Here we queue up selection notification and we turn off
+        ///  our UI.
+        /// </summary>
+        private void OnTransactionClosed(object sender, DesignerTransactionCloseEventArgs e)
+        {
+            if (!e.LastTransaction)
+            {
+                return;
+            }
+
+            _inTransaction = false;
+            if (!_deferredSelChange)
+            {
+                return;
+            }
+
+            _deferredSelChange = false;
+            OnSelectionChanged(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        ///  Called by the designer host when it is entering or leaving a batch
+        ///  operation.  Here we queue up selection notification and we turn off
+        ///  our UI.
+        /// </summary>
+        private void OnTransactionOpened(object sender, EventArgs e)
+        {
+            _inTransaction = true;
+        }
+
+        /// <summary>
+        ///  Sinks or unsinks selection and component change events from the 
+        ///  provided service provider.  We need to raise global selection change
+        ///  notifications.  A global selection change should be raised whenever
+        ///  the selection of the active designer changes, whenever a component
+        ///  is added or removed from the active designer, or whenever the
+        ///  active designer itself changes.
+        /// </summary>
+        private void SinkChangeEvents(IServiceProvider provider, bool sink)
+        {
+            ISelectionService ss = provider.GetService(typeof(ISelectionService)) as ISelectionService;
+            IComponentChangeService cs = provider.GetService(typeof(IComponentChangeService)) as IComponentChangeService;
+            IDesignerHost host = provider.GetService(typeof(IDesignerHost)) as IDesignerHost;
+
+            if (sink)
+            {
+                if (ss != null)
+                {
+                    ss.SelectionChanged += new EventHandler(OnSelectionChanged);
+                }
+
+                if (cs != null)
+                {
+                    ComponentEventHandler ce = new ComponentEventHandler(OnComponentAddedRemoved);
+                    cs.ComponentAdded += ce;
+                    cs.ComponentRemoved += ce;
+                    cs.ComponentChanged += new ComponentChangedEventHandler(OnComponentChanged);
+                }
+
+                if (host != null)
+                {
+                    host.TransactionOpened += new EventHandler(OnTransactionOpened);
+                    host.TransactionClosed += new DesignerTransactionCloseEventHandler(OnTransactionClosed);
+                    host.LoadComplete += new EventHandler(OnLoadComplete);
+                    if (host.InTransaction)
+                    {
+                        OnTransactionOpened(host, EventArgs.Empty);
+                    }
+                }
+            }
+            else
+            {
+                if (ss != null)
+                {
+                    ss.SelectionChanged -= new EventHandler(OnSelectionChanged);
+                }
+
+                if (cs != null)
+                {
+                    ComponentEventHandler ce = new ComponentEventHandler(OnComponentAddedRemoved);
+                    cs.ComponentAdded -= ce;
+                    cs.ComponentRemoved -= ce;
+                    cs.ComponentChanged -= new ComponentChangedEventHandler(OnComponentChanged);
+                }
+
+                if (host != null)
+                {
+                    host.TransactionOpened -= new EventHandler(OnTransactionOpened);
+                    host.TransactionClosed -= new DesignerTransactionCloseEventHandler(OnTransactionClosed);
+                    host.LoadComplete -= new EventHandler(OnLoadComplete);
+                    if (host.InTransaction)
+                    {
+                        OnTransactionClosed(host, new DesignerTransactionCloseEventArgs(false, true));
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///  Gets the currently active designer.
+        /// </summary>
+        IDesignerHost IDesignerEventService.ActiveDesigner => _activeDesigner;
+
+        /// <summary>
+        ///  Gets or
+        ///  sets a collection of running design documents in the development environment.
+        /// </summary>
+        DesignerCollection IDesignerEventService.Designers
+        {
+            get
+            {
+                if (_designerList == null)
+                {
+                    _designerList = new ArrayList();
+                }
+
+                if (_designerCollection == null)
+                {
+                    _designerCollection = new DesignerCollection(_designerList);
+                }
+
+                return _designerCollection;
+            }
+        }
+
+        /// <summary>
+        ///  Adds an event that will be raised when the currently active designer
+        ///  changes.
+        /// </summary>
+        event ActiveDesignerEventHandler IDesignerEventService.ActiveDesignerChanged
+        {
+            add
+            {
+                if (_events == null)
+                {
+                    _events = new EventHandlerList();
+                }
+
+                _events[s_eventActiveDesignerChanged] = Delegate.Combine((Delegate)_events[s_eventActiveDesignerChanged], value);
+            }
+            remove
+            {
+                if (_events == null)
+                {
+                    return;
+                }
+
+                _events[s_eventActiveDesignerChanged] = Delegate.Remove((Delegate)_events[s_eventActiveDesignerChanged], value);
+            }
+        }
+
+        /// <summary>
+        ///  Adds an event that will be raised when a designer is created.
+        /// </summary>
+        event DesignerEventHandler IDesignerEventService.DesignerCreated
+        {
+            add
+            {
+                if (_events == null)
+                {
+                    _events = new EventHandlerList();
+                }
+
+                _events[s_eventDesignerCreated] = Delegate.Combine((Delegate)_events[s_eventDesignerCreated], value);
+            }
+            remove
+            {
+                if (_events == null)
+                {
+                    return;
+                }
+
+                _events[s_eventDesignerCreated] = Delegate.Remove((Delegate)_events[s_eventDesignerCreated], value);
+            }
+        }
+
+        /// <summary>
+        ///  Adds an event that will be raised when a designer is disposed.
+        /// </summary>
+        event DesignerEventHandler IDesignerEventService.DesignerDisposed
+        {
+            add
+            {
+                if (_events == null)
+                {
+                    _events = new EventHandlerList();
+                }
+
+                _events[s_eventDesignerDisposed] = Delegate.Combine((Delegate)_events[s_eventDesignerDisposed], value);
+            }
+            remove
+            {
+                if (_events == null)
+                {
+                    return;
+                }
+
+                _events[s_eventDesignerDisposed] = Delegate.Remove((Delegate)_events[s_eventDesignerDisposed], value);
+            }
+        }
+
+        /// <summary>
+        ///  Adds an event that will be raised when the global selection changes.
+        /// </summary>
+        event EventHandler IDesignerEventService.SelectionChanged
+        {
+            add
+            {
+                if (_events == null)
+                {
+                    _events = new EventHandlerList();
+                }
+
+                _events[s_eventSelectionChanged] = Delegate.Combine((Delegate)_events[s_eventSelectionChanged], value);
+            }
+            remove
+            {
+                if (_events == null)
+                {
+                    return;
+                }
+
+                _events[s_eventSelectionChanged] = Delegate.Remove((Delegate)_events[s_eventSelectionChanged], value);
+            }
+        }
+    }
+}
+

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/EventBindingService.EventPropertyDescriptor.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/EventBindingService.EventPropertyDescriptor.cs
@@ -1,0 +1,478 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Globalization;
+
+namespace System.ComponentModel.Design
+{
+    public abstract partial class EventBindingService
+    {
+        /// <summary>
+        ///  This is an EventDescriptor cleverly wrapped in a PropertyDescriptor
+        ///  of type String.  Note that we now handle subobjects by storing their
+        ///  event information in their base component's site's dictionary.
+        ///  Note also that when a value is set for this property we will code-gen
+        ///  the event method.  If the property is set to a new value we will
+        ///  remove the old event method ONLY if it is empty.
+        /// </summary>
+        private class EventPropertyDescriptor : PropertyDescriptor
+        {
+            private readonly EventBindingService _eventSvc;
+            private TypeConverter _converter;
+
+            /// <summary>
+            ///  Creates a new EventPropertyDescriptor.
+            /// </summary>
+            internal EventPropertyDescriptor(EventDescriptor eventDesc, EventBindingService eventSvc) : base(eventDesc, null)
+            {
+                Event = eventDesc;
+                _eventSvc = eventSvc;
+            }
+
+            /// <summary>
+            ///  Indicates whether reset will change the value of the component.  If there
+            ///  is a DefaultValueAttribute, then this will return true if getValue returns
+            ///  something different than the default value.  If there is a reset method and
+            ///  a shouldPersist method, this will return what shouldPersist returns.
+            ///  If there is just a reset method, this always returns true.  If none of these
+            ///  cases apply, this returns false.
+            /// </summary>
+            public override bool CanResetValue(object component) => GetValue(component) != null;
+
+            /// <summary>
+            ///  Retrieves the type of the component this PropertyDescriptor is bound to.
+            /// </summary>
+            public override Type ComponentType => Event.ComponentType;
+
+            /// <summary>
+            ///  Retrieves the type converter for this property.
+            /// </summary>
+            public override TypeConverter Converter
+            {
+                get
+                {
+                    if (_converter == null)
+                    {
+                        _converter = new EventConverter(Event);
+                    }
+
+                    return _converter;
+                }
+            }
+
+            /// <summary>
+            ///  Retrieves the event descriptor we are representing.
+            /// </summary>
+            internal EventDescriptor Event { get; }
+
+            /// <summary>
+            ///  Indicates whether this property is read only.
+            /// </summary>
+            public override bool IsReadOnly => Attributes[typeof(ReadOnlyAttribute)].Equals(ReadOnlyAttribute.Yes);
+
+            /// <summary>
+            ///  Retrieves the type of the property.
+            /// </summary>
+            public override Type PropertyType => Event.EventType;
+
+            /// <summary>
+            ///  Retrieves the current value of the property on component,
+            ///  invoking the getXXX method.  An exception in the getXXX
+            ///  method will pass through.
+            /// </summary>
+            public override object GetValue(object component)
+            {
+                if (component == null)
+                {
+                    throw new ArgumentNullException(nameof(component));
+                }
+
+                // We must locate the sited component, because we store data on the dictionary
+                // service for the component.
+                ISite site = null;
+
+                if (component is IComponent)
+                {
+                    site = ((IComponent)component).Site;
+                }
+
+                if (site == null)
+                {
+                    if (_eventSvc._provider.GetService(typeof(IReferenceService)) is IReferenceService rs)
+                    {
+                        IComponent baseComponent = rs.GetComponent(component);
+
+                        if (baseComponent != null)
+                        {
+                            site = baseComponent.Site;
+                        }
+                    }
+                }
+
+                if (site == null)
+                {
+                    // Object not sited, so we weren't able to set a value on it.  Setting a value will fail.
+                    return null;
+                }
+
+                IDictionaryService ds = (IDictionaryService)site.GetService(typeof(IDictionaryService));
+
+                if (ds == null)
+                {
+                    // No dictionary service, so we weren't able to set a value on it. Setting a value will fail.
+                    return null;
+                }
+
+                return (string)ds.GetValue(new ReferenceEventClosure(component, this));
+            }
+
+            /// <summary>
+            ///  Will reset the default value for this property on the component.  If
+            ///  there was a default value passed in as a DefaultValueAttribute, that
+            ///  value will be set as the value of the property on the component.  If
+            ///  there was no default value passed in, a ResetXXX method will be looked
+            ///  for.  If one is found, it will be invoked.  If one is not found, this
+            ///  is a nop.
+            /// </summary>
+            public override void ResetValue(object component) => SetValue(component, null);
+
+            /// <summary>
+            ///  This will set value to be the new value of this property on the
+            ///  component by invoking the setXXX method on the component.  If the
+            ///  value specified is invalid, the component should throw an exception
+            ///  which will be passed up.  The component designer should design the
+            ///  property so that getXXX following a setXXX should return the value
+            ///  passed in if no exception was thrown in the setXXX call.
+            /// </summary>
+            public override void SetValue(object component, object value)
+            {
+                // Argument, state checking.  Is it ok to set this event?
+                if (IsReadOnly)
+                {
+                    Exception ex = new InvalidOperationException(string.Format(SR.EventBindingServiceEventReadOnly, Name));
+                    ex.HelpLink = SR.EventBindingServiceEventReadOnly;
+
+                    throw ex;
+                }
+
+                if (value != null && !(value is string))
+                {
+                    Exception ex = new ArgumentException(string.Format(SR.EventBindingServiceBadArgType, Name, typeof(string).Name));
+                    ex.HelpLink = SR.EventBindingServiceBadArgType;
+
+                    throw ex;
+                }
+
+                string name = (string)value;
+
+                if (name != null && name.Length == 0)
+                {
+                    name = null;
+                }
+
+                // Obtain the site for the component.  Note that this can be a site
+                // to a parent component if we can get to the reference service.
+                ISite site = null;
+
+                if (component is IComponent)
+                {
+                    site = ((IComponent)component).Site;
+                }
+
+                if (site == null && (_eventSvc._provider.GetService(typeof(IReferenceService)) is IReferenceService rs))
+                {
+                    IComponent baseComponent = rs.GetComponent(component);
+
+                    if (baseComponent != null)
+                    {
+                        site = baseComponent.Site;
+                    }
+                }
+
+                if (site == null)
+                {
+                    Exception ex = new InvalidOperationException(SR.EventBindingServiceNoSite);
+                    ex.HelpLink = SR.EventBindingServiceNoSite;
+
+                    throw ex;
+                }
+
+                // The dictionary service is where we store the actual event method name.
+                if (!(site.GetService(typeof(IDictionaryService)) is IDictionaryService ds))
+                {
+                    Exception ex = new InvalidOperationException(string.Format(SR.EventBindingServiceMissingService, typeof(IDictionaryService).Name));
+                    ex.HelpLink = SR.EventBindingServiceMissingService;
+
+                    throw ex;
+                }
+
+                // Get the old method name, ensure that they are different, and then continue.
+                ReferenceEventClosure key = new ReferenceEventClosure(component, this);
+                string oldName = (string)ds.GetValue(key);
+
+                if (object.ReferenceEquals(oldName, name))
+                {
+                    return;
+                }
+
+                if (oldName != null && name != null && oldName.Equals(name))
+                {
+                    return;
+                }
+
+                // Before we continue our work, ensure that the name is actually valid.
+                if (name != null)
+                {
+                    _eventSvc.ValidateMethodName(name);
+                }
+
+                // If there is a designer host, create a transaction so there is a
+                // nice name for this change.  We don't want a name like
+                // "Change property 'Click', because to users, this isn't a property.
+                DesignerTransaction trans = null;
+
+                if (site.GetService(typeof(IDesignerHost)) is IDesignerHost host)
+                {
+                    trans = host.CreateTransaction(string.Format(SR.EventBindingServiceSetValue, site.Name, name));
+                }
+
+                try
+                {
+                    // Ok, the names are different.  Fire a changing event to make
+                    // sure it's OK to perform the change.
+                    IComponentChangeService change = site.GetService(typeof(IComponentChangeService)) as IComponentChangeService;
+
+                    if (change != null)
+                    {
+                        try
+                        {
+                            change.OnComponentChanging(component, this);
+                            change.OnComponentChanging(component, Event);
+                        }
+                        catch (CheckoutException coEx)
+                        {
+                            if (coEx == CheckoutException.Canceled)
+                            {
+                                return;
+                            }
+
+                            throw;
+                        }
+                    }
+
+                    // Less chance of success of adding a new method name, so
+                    // don't release the old name until we verify that adding
+                    // the new one actually succeeded.
+                    if (name != null)
+                    {
+                        _eventSvc.UseMethod((IComponent)component, Event, name);
+                    }
+
+                    if (oldName != null)
+                    {
+                        _eventSvc.FreeMethod((IComponent)component, Event, oldName);
+                    }
+
+                    ds.SetValue(key, name);
+
+                    if (change != null)
+                    {
+                        change.OnComponentChanged(component, Event, null, null);
+                        change.OnComponentChanged(component, this, oldName, name);
+                    }
+
+                    OnValueChanged(component, EventArgs.Empty);
+
+                    if (trans != null)
+                    {
+                        trans.Commit();
+                    }
+                }
+                finally
+                {
+                    if (trans != null)
+                    {
+                        ((IDisposable)trans).Dispose();
+                    }
+                }
+            }
+
+            /// <summary>
+            ///  Indicates whether the value of this property needs to be persisted. In
+            ///  other words, it indicates whether the state of the property is distinct
+            ///  from when the component is first instantiated. If there is a default
+            ///  value specified in this PropertyDescriptor, it will be compared against the
+            ///  property's current value to determine this.  If there is't, the
+            ///  shouldPersistXXX method is looked for and invoked if found.  If both
+            ///  these routes fail, true will be returned.
+            ///  If this returns false, a tool should not persist this property's value.
+            /// </summary>
+            public override bool ShouldSerializeValue(object component) => CanResetValue(component);
+
+            /// <summary>
+            ///  Implements a type converter for event objects.
+            /// </summary>
+            private class EventConverter : TypeConverter
+            {
+                private readonly EventDescriptor _evt;
+
+                /// <summary>
+                ///  Creates a new EventConverter.
+                /// </summary>
+                internal EventConverter(EventDescriptor evt)
+                {
+                    _evt = evt;
+                }
+
+                /// <summary>
+                ///  Determines if this converter can convert an object in the given source
+                ///  type to the native type of the converter.
+                /// </summary>
+                public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+                {
+                    if (sourceType == typeof(string))
+                    {
+                        return true;
+                    }
+
+                    return base.CanConvertFrom(context, sourceType);
+                }
+
+                /// <summary>
+                ///  Determines if this converter can convert an object to the given destination type.
+                /// </summary>
+                public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+                {
+                    if (destinationType == typeof(string))
+                    {
+                        return true;
+                    }
+
+                    return base.CanConvertTo(context, destinationType);
+                }
+
+                /// <summary>
+                ///  Converts the given object to the converter's native type.
+                /// </summary>
+                public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+                {
+                    if (value == null)
+                    {
+                        return value;
+                    }
+
+                    if (value is string)
+                    {
+                        if (((string)value).Length == 0)
+                        {
+                            return null;
+                        }
+
+                        return value;
+                    }
+
+                    return base.ConvertFrom(context, culture, value);
+                }
+
+                /// <summary>
+                ///  Converts the given object to another type.  The most common types to convert
+                ///  are to and from a string object.  The default implementation will make a call
+                ///  to ToString on the object if the object is valid and if the destination
+                ///  type is string.  If this cannot convert to the desitnation type, this will
+                ///  throw a NotSupportedException.
+                /// </summary>
+                public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+                {
+                    if (destinationType == typeof(string))
+                    {
+                        return value ?? string.Empty;
+                    }
+
+                    return base.ConvertTo(context, culture, value, destinationType);
+                }
+
+                /// <summary>
+                ///  Retrieves a collection containing a set of standard values
+                ///  for the data type this validator is designed for.  This
+                ///  will return null if the data type does not support a
+                ///  standard set of values.
+                /// </summary>
+                public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+                {
+                    // We cannot cache this because it depends on the contents of the source file.
+                    string[] eventMethods = null;
+
+                    if (context != null)
+                    {
+                        IEventBindingService ebs = (IEventBindingService)context.GetService(typeof(IEventBindingService));
+
+                        if (ebs != null)
+                        {
+                            ICollection methods = ebs.GetCompatibleMethods(_evt);
+                            eventMethods = new string[methods.Count];
+                            int i = 0;
+
+                            foreach (string s in methods)
+                            {
+                                eventMethods[i++] = s;
+                            }
+                        }
+                    }
+
+                    return new StandardValuesCollection(eventMethods);
+                }
+
+                /// <summary>
+                ///  Determines if the list of standard values returned from
+                ///  GetStandardValues is an exclusive list.  If the list
+                ///  is exclusive, then no other values are valid, such as
+                ///  in an enum data type.  If the list is not exclusive,
+                ///  then there are other valid values besides the list of
+                ///  standard values GetStandardValues provides.
+                /// </summary>
+                public override bool GetStandardValuesExclusive(ITypeDescriptorContext context) => false;
+
+                /// <summary>
+                ///  Determines if this object supports a standard set of values
+                ///  that can be picked from a list.
+                /// </summary>
+                public override bool GetStandardValuesSupported(ITypeDescriptorContext context) => true;
+            }
+
+            /// <summary>
+            ///  This is a combination of a reference and a property, so that it can be used
+            ///  as the key of a hashtable.  This is because we may have subobjects that share
+            ///  the same property.
+            /// </summary>
+            private class ReferenceEventClosure
+            {
+                private readonly object _reference;
+                private readonly EventPropertyDescriptor _propertyDescriptor;
+
+                public ReferenceEventClosure(object reference, EventPropertyDescriptor prop)
+                {
+                    _reference = reference;
+                    _propertyDescriptor = prop;
+                }
+
+                public override int GetHashCode()
+                {
+                    return _reference.GetHashCode() * _propertyDescriptor.GetHashCode();
+                }
+
+                public override bool Equals(object otherClosure)
+                {
+                    if (otherClosure is ReferenceEventClosure typedClosure)
+                    {
+                        return typedClosure._reference == _reference &&
+                               typedClosure._propertyDescriptor.Equals(_propertyDescriptor);
+                    }
+
+                    return false;
+                }
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/EventBindingService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/EventBindingService.cs
@@ -1,0 +1,303 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Windows.Forms;
+
+namespace System.ComponentModel.Design
+{
+    /// <summary>
+    ///  This class provides a default implementation of the event
+    ///  binding service.
+    /// </summary>
+    public abstract partial class EventBindingService : IEventBindingService
+    {
+        private IServiceProvider _provider;
+        private IComponent _showCodeComponent;
+        private EventDescriptor _showCodeEventDescriptor;
+        private string _showCodeMethodName;
+        private static readonly CodeMarkers s_codemarker = CodeMarkers.Instance;
+
+        /// <summary>
+        ///  You must provide a service provider to the binding
+        ///  service.
+        /// </summary>
+        protected EventBindingService(IServiceProvider provider)
+        {
+            _provider = provider ?? throw new ArgumentNullException(nameof(provider));
+        }
+
+        /// <summary>
+        ///  Creates a unique method name.  The name must be
+        ///  compatible with the script language being used and
+        ///  it must not conflict with any other name in the user's
+        ///  code.
+        /// </summary>
+        protected abstract string CreateUniqueMethodName(IComponent component, EventDescriptor e);
+
+        /// <summary>
+        ///  This provides a notification that a particular method
+        ///  is no longer being used by an event handler.  Some implementations
+        ///  may want to remove the event hander when no events are using
+        ///  it.  By overriding UseMethod and FreeMethod, an implementation
+        ///  can know when a method is no longer needed.
+        /// </summary>
+        protected virtual void FreeMethod(IComponent component, EventDescriptor e, string methodName)
+        { }
+
+        /// <summary>
+        ///  Returns a collection of strings.  Each string is
+        ///  the method name of a method whose signature is
+        ///  compatible with the delegate contained in the
+        ///  event descriptor.  This should return an empty
+        ///  collection if no names are compatible.
+        /// </summary>
+        protected abstract ICollection GetCompatibleMethods(EventDescriptor e);
+
+        /// <summary>
+        ///  Gets the requested service from our service provider.
+        /// </summary>
+        protected object GetService(Type serviceType) => _provider?.GetService(serviceType);
+
+        /// <summary>
+        ///  Shows the user code.  This method does not show any
+        ///  particular code; generally it shows the last code the
+        ///  user typed.  This returns true if it was possible to 
+        ///  show the code, or false if not.
+        /// </summary>
+        protected abstract bool ShowCode();
+
+        /// <summary>
+        ///  Shows the user code at the given line number.  Line
+        ///  numbers are one-based.  This returns true if it was
+        ///  possible to show the code, or false if not.
+        /// </summary>
+        protected abstract bool ShowCode(int lineNumber);
+
+        /// <summary>
+        ///  Shows the body of the user code with the given method
+        ///  name. This returns true if it was possible to show
+        ///  the code, or false if not.
+        /// </summary>
+        protected abstract bool ShowCode(IComponent component, EventDescriptor e, string methodName);
+
+        /// <summary>
+        ///  This provides a notification that a particular method
+        ///  is being used by an event handler.  Some implementations
+        ///  may want to remove the event hander when no events are using
+        ///  it.  By overriding UseMethod and FreeMethod, an implementation
+        ///  can know when a method is no longer needed.
+        /// </summary>
+        protected virtual void UseMethod(IComponent component, EventDescriptor e, string methodName)
+        { }
+
+        /// <summary>
+        ///  This validates that the provided method name is valid for
+        ///  the language / script being used.  The default does nothing.
+        ///  You may override this and throw an exception if the name
+        ///  is invalid for your use.
+        /// </summary>
+        protected virtual void ValidateMethodName(string methodName)
+        { }
+
+        /// <summary>
+        ///  This creates a name for an event handling method for the given component
+        ///  and event.  The name that is created is guaranteed to be unique in the user's source
+        ///  code.
+        /// </summary>
+        string IEventBindingService.CreateUniqueMethodName(IComponent component, EventDescriptor e)
+        {
+            if (component == null)
+            {
+                throw new ArgumentNullException(nameof(component));
+            }
+
+            if (e == null)
+            {
+                throw new ArgumentNullException(nameof(e));
+            }
+
+            return CreateUniqueMethodName(component, e);
+        }
+
+        /// <summary>
+        ///  Retrieves a collection of strings.  Each string is the name of a method
+        ///  in user code that has a signature that is compatible with the given event.
+        /// </summary>
+        ICollection IEventBindingService.GetCompatibleMethods(EventDescriptor e)
+        {
+            if (e == null)
+            {
+                throw new ArgumentNullException(nameof(e));
+            }
+
+            return GetCompatibleMethods(e);
+        }
+
+        /// <summary>
+        ///  For properties that are representing events, this will return the event
+        ///  that the property represents.
+        /// </summary>
+        EventDescriptor IEventBindingService.GetEvent(PropertyDescriptor property)
+        {
+            if (property is EventPropertyDescriptor)
+            {
+                return ((EventPropertyDescriptor)property).Event;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///  Returns true if the given event has a generic argument or return value in its raise method.
+        /// </summary>
+        private bool HasGenericArgument(EventDescriptor ed)
+        {
+            if (ed == null || ed.ComponentType == null)
+            {
+                return false;
+            }
+
+            EventInfo evInfo = ed.ComponentType.GetEvent(ed.Name);
+
+            if (evInfo == null || !evInfo.EventHandlerType.IsGenericType)
+            {
+                return false;
+            }
+
+            Type[] args = evInfo.EventHandlerType.GetGenericArguments();
+
+            if (args != null && args.Length > 0)
+            {
+                for (int i = 0; i < args.Length; i++)
+                {
+                    if (args[i].IsGenericType)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        ///  Converts a set of events to a set of properties.
+        /// </summary>
+        PropertyDescriptorCollection IEventBindingService.GetEventProperties(EventDescriptorCollection events)
+        {
+            if (events == null)
+            {
+                throw new ArgumentNullException(nameof(events));
+            }
+
+            List<PropertyDescriptor> props = new List<PropertyDescriptor>(events.Count);
+
+            // We cache the property descriptors here for speed.  Create those for
+            // events that we don't have yet.
+            for (int i = 0; i < events.Count; i++)
+            {
+                if (HasGenericArgument(events[i]))
+                {
+                    continue;
+                }
+
+                PropertyDescriptor prop = new EventPropertyDescriptor(events[i], this);
+                props.Add(prop);
+            }
+
+            return new PropertyDescriptorCollection(props.ToArray());
+        }
+
+        /// <summary>
+        ///  Converts a single event to a property.
+        /// </summary>
+        PropertyDescriptor IEventBindingService.GetEventProperty(EventDescriptor e)
+        {
+            if (e == null)
+            {
+                throw new ArgumentNullException(nameof(e));
+            }
+
+            PropertyDescriptor prop = new EventPropertyDescriptor(e, this);
+
+            return prop;
+        }
+
+        /// <summary>
+        ///  Displays the user code for this designer.  This will return true if the user
+        ///  code could be displayed, or false otherwise.
+        /// </summary>
+        bool IEventBindingService.ShowCode()
+        {
+            return ShowCode();
+        }
+
+        /// <summary>
+        ///  Displays the user code for the designer.  This will return true if the user
+        ///  code could be displayed, or false otherwise.
+        /// </summary>
+        bool IEventBindingService.ShowCode(int lineNumber)
+        {
+            return ShowCode(lineNumber);
+        }
+
+        /// <summary>
+        ///  Displays the user code for the given event.  This will return true if the user
+        ///  code could be displayed, or false otherwise.
+        /// </summary>
+        bool IEventBindingService.ShowCode(IComponent component, EventDescriptor e)
+        {
+            if (component == null)
+            {
+                throw new ArgumentNullException(nameof(component));
+            }
+
+            if (e == null)
+            {
+                throw new ArgumentNullException(nameof(e));
+            }
+
+            PropertyDescriptor prop = ((IEventBindingService)this).GetEventProperty(e);
+            string methodName = (string)prop.GetValue(component);
+            
+            if (methodName == null)
+            {
+                return false;   // the event is not bound to a method.
+            }
+
+            Debug.Assert(_showCodeComponent == null && _showCodeEventDescriptor == null && _showCodeMethodName == null, "show code already pending");
+            _showCodeComponent = component;
+            _showCodeEventDescriptor = e;
+            _showCodeMethodName = methodName;
+            Application.Idle += new EventHandler(ShowCodeIdle);
+
+            return true;
+        }
+
+        /// <summary>
+        ///  Displays the user code for the given event.  This will return true if the user
+        ///  code could be displayed, or false otherwise.
+        /// </summary>
+        private void ShowCodeIdle(object sender, EventArgs e)
+        {
+            Application.Idle -= new EventHandler(ShowCodeIdle);
+
+            try
+            {
+                ShowCode(_showCodeComponent, _showCodeEventDescriptor, _showCodeMethodName);
+            }
+            finally
+            {
+                _showCodeComponent = null;
+                _showCodeEventDescriptor = null;
+                _showCodeMethodName = null;
+                s_codemarker.CodeMarker((int)(CodeMarkerEvent.perfFXDesignShowCode));
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/BasicDesignerLoader.ReloadOptions.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/BasicDesignerLoader.ReloadOptions.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ComponentModel.Design.Serialization
+{
+    public abstract partial class BasicDesignerLoader
+    {
+        /// <summary>
+        ///  A list of flags that indicate rules to apply when requesting 
+        ///  that the designer reload itself.
+        /// </summary>
+        [Flags]
+        protected enum ReloadOptions
+        {
+            /// <summary>
+            ///  Peform the default behavior.
+            /// </summary>
+            Default = 0x00,
+
+            /// <summary>
+            ///  If this flag is set, any error encoutered during the
+            ///  reload will automatically put the designer loader in
+            ///  the modified state.
+            /// </summary>
+            ModifyOnError = 0x01,
+
+            /// <summary>
+            ///  If this flag is set, a reload will occur.  If the
+            ///  flag is not set a reload will only occur if the
+            ///  IsReloadNeeded method returns true.
+            /// </summary>
+            Force = 0x02,
+
+            /// <summary>
+            ///  If this flag is set, any pending changes in the
+            ///  designer will be abandonded.  If this flag is not
+            ///  set, designer changes will be flushed through the
+            ///  designer loader before reloading the design surface.
+            /// </summary>
+            NoFlush = 0x04,
+        }
+    }
+}
+

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/BasicDesignerLoader.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/BasicDesignerLoader.cs
@@ -1,0 +1,989 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Reflection;
+using System.Windows.Forms;
+
+namespace System.ComponentModel.Design.Serialization
+{
+    /// <summary>
+    ///  This is a class that derives from DesignerLoader but provides some default functionality.  
+    ///  This class tracks changes from the loader host and sets its "Modified" bit to true when a 
+    ///  change occurs.  Also, this class implements IDesignerLoaderService to support multiple 
+    ///  load dependencies.  To use BaseDesignerLoader, you need to implement the PerformLoad 
+    ///  and PerformFlush methods.
+    /// </summary>
+    public abstract partial class BasicDesignerLoader : DesignerLoader, IDesignerLoaderService
+    {
+        private static readonly int s_stateLoaded = BitVector32.CreateMask();                                       // Have we loaded, or tried to load, the document?
+        private static readonly int s_stateLoadFailed = BitVector32.CreateMask(s_stateLoaded);                      // True if we loaded, but had a fatal error.
+        private static readonly int s_stateFlushInProgress = BitVector32.CreateMask(s_stateLoadFailed);             // True if we are in the process of flushing code.
+        private static readonly int s_stateModified = BitVector32.CreateMask(s_stateFlushInProgress);               // True if the designer is modified.
+        private static readonly int s_stateReloadSupported = BitVector32.CreateMask(s_stateModified);               // True if the serializer supports reload.
+        private static readonly int s_stateActiveDocument = BitVector32.CreateMask(s_stateReloadSupported);         // Is this the currently active document?
+        private static readonly int s_stateDeferredReload = BitVector32.CreateMask(s_stateActiveDocument);          // Set to true if a reload was requested but we aren't the active doc.
+        private static readonly int s_stateReloadAtIdle = BitVector32.CreateMask(s_stateDeferredReload);            // Set if we are waiting to reload at idle.  Prevents multiple idle event handlers.
+        private static readonly int s_stateForceReload = BitVector32.CreateMask(s_stateReloadAtIdle);               // True if we should always reload, False if we should check the code dom for changes first.
+        private static readonly int s_stateFlushReload = BitVector32.CreateMask(s_stateForceReload);                // True if we should flush before reloading.
+        private static readonly int s_stateModifyIfErrors = BitVector32.CreateMask(s_stateFlushReload);             // True if we we should modify the buffer if we have fatal errors after load.
+        private static readonly int s_stateEnableComponentEvents = BitVector32.CreateMask(s_stateModifyIfErrors);   // True if we are currently listening to OnComponent* events
+
+        // State for the designer loader.
+        private BitVector32 _state = new BitVector32();
+        private IDesignerLoaderHost _host;
+        private int _loadDependencyCount;
+        private string _baseComponentClassName;
+        private bool _hostInitialized;
+        private bool _loading;
+
+        // State for serialization.
+        private DesignerSerializationManager _serializationManager;
+        private IDisposable _serializationSession;
+
+        /// <summary>
+        ///  Creates a new BasicDesignerLoader
+        /// </summary>
+        protected BasicDesignerLoader()
+        {
+            _state[s_stateFlushInProgress] = false;
+            _state[s_stateReloadSupported] = true;
+            _state[s_stateEnableComponentEvents] = false;
+            _hostInitialized = false;
+            _loading = false;
+        }
+
+        /// <summary>
+        ///  This protected property indicates if there have been any
+        ///  changes made to the design surface.  The Flush method 
+        ///  gets the value of this property to determine if it needs
+        ///  to generate a code dom tree.  This property is set by
+        ///  the designer loader when it detects a change to the 
+        ///  design surface.  You can override this to perform
+        ///  additional work, such as checking out a file from source
+        ///  code control.
+        /// </summary>
+        protected virtual bool Modified
+        {
+            get => _state[s_stateModified];
+            set => _state[s_stateModified] = value;
+        }
+
+        /// <summary>
+        ///  Returns the loader host that was given to this designer loader. This can be null if BeginLoad has not
+        ///  been called yet, or if this designer loader has been disposed.
+        /// </summary>
+        protected IDesignerLoaderHost LoaderHost
+        {
+            get
+            {
+                if (_host != null)
+                {
+                    return _host;
+                }
+
+                if (_hostInitialized)
+                {
+                    throw new ObjectDisposedException(GetType().Name);
+                }
+
+                throw new InvalidOperationException(SR.BasicDesignerLoaderNotInitialized);
+            }
+        }
+
+        /// <summary>
+        ///  Returns true when the designer is in the process of loading.  
+        ///  Clients that are sinking notifications from the designer often 
+        ///  want to ignore them while the desingner is loading
+        ///  and only respond to them if they result from user interatcions.
+        /// </summary>
+        public override bool Loading => _loadDependencyCount > 0 || _loading;
+
+        /// <summary>
+        ///  Provides an object whose public properties will be made available to the designer serialization manager's
+        ///  Properties property.  The default value of this property is null.
+        /// </summary>
+        protected object PropertyProvider
+        {
+            get
+            {
+                if (_serializationManager == null)
+                {
+                    throw new InvalidOperationException(SR.BasicDesignerLoaderNotInitialized);
+                }
+
+                return _serializationManager.PropertyProvider;
+            }
+            set
+            {
+                if (_serializationManager == null)
+                {
+                    throw new InvalidOperationException(SR.BasicDesignerLoaderNotInitialized);
+                }
+
+                _serializationManager.PropertyProvider = value;
+            }
+        }
+
+        /// <summary>
+        ///  Calling Reload doesn't actually perform a reload immediately - it just schedules an asynchronous
+        ///  reload. This property is used to determine if there is currently a reload pending.
+        /// </summary>
+        protected bool ReloadPending => _state[s_stateReloadAtIdle];
+
+        /// <summary>
+        ///  Called by the designer host to begin the loading process.  
+        ///  The designer host passes in an instance of a designer loader 
+        ///  host.  This loader host allows the designer loader to reload 
+        ///  the design document and also allows the designer loader to indicate
+        ///  that it has finished loading the design document.
+        /// </summary>
+        public override void BeginLoad(IDesignerLoaderHost host)
+        {
+            if (host == null)
+            {
+                throw new ArgumentNullException(nameof(host));
+            }
+
+            if (_state[s_stateLoaded])
+            {
+                Exception ex = new InvalidOperationException(SR.BasicDesignerLoaderAlreadyLoaded);
+                ex.HelpLink = SR.BasicDesignerLoaderAlreadyLoaded;
+
+                throw ex;
+            }
+
+            if (_host != null && _host != host)
+            {
+                Exception ex = new InvalidOperationException(SR.BasicDesignerLoaderDifferentHost);
+                ex.HelpLink = SR.BasicDesignerLoaderDifferentHost;
+
+                throw ex;
+            }
+
+            _state[s_stateLoaded | s_stateLoadFailed] = false;
+            _loadDependencyCount = 0;
+
+            if (_host == null)
+            {
+                _host = host;
+                _hostInitialized = true;
+                _serializationManager = new DesignerSerializationManager(_host);
+
+                // Add our services.  We do IDesignerSerializationManager separate because
+                // it is not something the user can replace.
+                DesignSurfaceServiceContainer dsc = GetService(typeof(DesignSurfaceServiceContainer)) as DesignSurfaceServiceContainer;
+
+                if (dsc != null)
+                {
+                    dsc.AddFixedService(typeof(IDesignerSerializationManager), _serializationManager);
+                }
+                else
+                {
+                    IServiceContainer sc = GetService(typeof(IServiceContainer)) as IServiceContainer;
+
+                    if (sc == null)
+                    {
+                        ThrowMissingService(typeof(IServiceContainer));
+                    }
+
+                    sc.AddService(typeof(IDesignerSerializationManager), _serializationManager);
+                }
+
+                Initialize();
+                host.Activated += new EventHandler(OnDesignerActivate);
+                host.Deactivated += new EventHandler(OnDesignerDeactivate);
+            }
+
+            // Now that we're initialized, let's begin the load.  We assume 
+            // we support reload until the codeLoader tells us we
+            // can't.  That way, we will do the reload if we didn't get a
+            // valid loader to start with.
+            //
+            // StartTimingMark();
+            bool successful = true;
+            ArrayList localErrorList = null;
+            IDesignerLoaderService ls = GetService(typeof(IDesignerLoaderService)) as IDesignerLoaderService;
+
+            try
+            {
+                if (ls != null)
+                {
+                    ls.AddLoadDependency();
+                }
+                else
+                {
+                    _loading = true;
+                    OnBeginLoad();
+                }
+
+                PerformLoad(_serializationManager);
+            }
+            catch (Exception e)
+            {
+                while (e is TargetInvocationException)
+                {
+                    e = e.InnerException;
+                }
+
+                localErrorList = new ArrayList();
+                localErrorList.Add(e);
+                successful = false;
+            }
+
+            if (ls != null)
+            {
+                ls.DependentLoadComplete(successful, localErrorList);
+            }
+            else
+            {
+                OnEndLoad(successful, localErrorList);
+                _loading = false;
+            }
+        }
+
+        /// <summary>
+        ///  Disposes this designer loader.  The designer host will call 
+        ///  this method when the design document itself is being destroyed.  
+        ///  Once called, the designer loader will never be called again.
+        ///  This implementation removes any previously added services.  It
+        ///  does not flush changes, which allows for fast teardown of a 
+        ///  designer that wasn't saved.
+        /// </summary>
+        public override void Dispose()
+        {
+            if (_state[s_stateReloadAtIdle])
+            {
+                Application.Idle -= new EventHandler(OnIdle);
+            }
+
+            UnloadDocument();
+            IComponentChangeService cs = (IComponentChangeService)GetService(typeof(IComponentChangeService));
+
+            if (cs != null)
+            {
+                cs.ComponentAdded -= new ComponentEventHandler(OnComponentAdded);
+                cs.ComponentAdding -= new ComponentEventHandler(OnComponentAdding);
+                cs.ComponentRemoving -= new ComponentEventHandler(OnComponentRemoving);
+                cs.ComponentRemoved -= new ComponentEventHandler(OnComponentRemoved);
+                cs.ComponentChanged -= new ComponentChangedEventHandler(OnComponentChanged);
+                cs.ComponentChanging -= new ComponentChangingEventHandler(OnComponentChanging);
+                cs.ComponentRename -= new ComponentRenameEventHandler(OnComponentRename);
+            }
+
+            if (_host != null)
+            {
+                _host.RemoveService(typeof(IDesignerLoaderService));
+                _host.Activated -= new EventHandler(OnDesignerActivate);
+                _host.Deactivated -= new EventHandler(OnDesignerDeactivate);
+                _host = null;
+            }
+        }
+
+        /// <summary>
+        ///  The designer host will call this periodically when it wants to
+        ///  ensure that any changes that have been made to the document
+        ///  have been saved by the designer loader.  This method allows
+        ///  designer loaders to implement a lazy-write scheme to improve
+        ///  performance.  This designer loader implements lazy writes by
+        ///  listening to component change events.  If a component has 
+        ///  changed it sets a "modified" bit.  When Flush is called the
+        ///  loader will write out a new code dom tree.
+        /// </summary>
+        public override void Flush()
+        {
+            if (_state[s_stateFlushInProgress] || !_state[s_stateLoaded] || !Modified)
+            {
+                return;
+            }
+
+            _state[s_stateFlushInProgress] = true;
+            Cursor oldCursor = Cursor.Current;
+            Cursor.Current = Cursors.WaitCursor;
+
+            try
+            {
+                IDesignerLoaderHost host = _host;
+                Debug.Assert(host != null, "designer loader was asked to flush after it has been disposed.");
+
+                // If the host has a null root component, it probably failed
+                // its last load.  In that case, there is nothing to flush.
+                bool shouldChangeModified = true;
+
+                if (host != null && host.RootComponent != null)
+                {
+                    using (_serializationManager.CreateSession())
+                    {
+                        try
+                        {
+                            PerformFlush(_serializationManager);
+                        }
+                        catch (CheckoutException)
+                        {
+                            shouldChangeModified = false; // don't need to report that one it already has shown an error message
+                            throw;
+                        }
+                        catch (Exception ex)
+                        {
+                            _serializationManager.Errors.Add(ex);
+                        }
+
+                        ICollection errors = _serializationManager.Errors;
+
+                        if (errors != null && errors.Count > 0)
+                        {
+                            ReportFlushErrors(errors);
+                        }
+                    }
+                }
+
+                if (shouldChangeModified)
+                {
+                    Modified = false;
+                }
+            }
+            finally
+            {
+                _state[s_stateFlushInProgress] = false;
+                Cursor.Current = oldCursor;
+            }
+        }
+
+        /// <summary>
+        ///  Helper method that gives access to the service provider.
+        /// </summary>
+        protected object GetService(Type serviceType)
+        {
+            object service = null;
+
+            if (_host != null)
+            {
+                service = _host.GetService(serviceType);
+            }
+
+            return service;
+        }
+
+        /// <summary>
+        ///  This method is called immediately after the first time
+        ///  BeginLoad is invoked.  This is an appopriate place to
+        ///  add custom services to the loader host.  Remember to
+        ///  remove any custom services you add here by overriding
+        ///  Dispose.
+        /// </summary>
+        protected virtual void Initialize() => LoaderHost.AddService(typeof(IDesignerLoaderService), this);
+
+        /// <summary>
+        ///  This method an be overridden to provide some intelligent
+        ///  logic to determine if a reload is required.  This method is
+        ///  called when someone requests a reload but doesn't force
+        ///  the reload.  It gives the loader an opportunity to scan
+        ///  the underlying storage to determine if a reload is acutually
+        ///  needed.  The default implementation of this method always
+        ///  returns true.
+        /// </summary>
+        protected virtual bool IsReloadNeeded() => true;
+
+        /// <summary>
+        ///  This method should be called by the designer loader service
+        ///  when the first dependent load has started.  This initializes
+        ///  the state of the code dom loader and prepares it for loading.
+        ///  By default, the designer loader provides
+        ///  IDesignerLoaderService itself, so this is called automatically.
+        ///  If you provide your own loader service, or if you choose not
+        ///  to provide a loader service, you are responsible for calling
+        ///  this method.  BeginLoad will automatically call this, either
+        ///  indirectly by calling AddLoadDependency if IDesignerLoaderService
+        ///  is available, or directly if it is not.
+        /// </summary>
+        protected virtual void OnBeginLoad()
+        {
+            _serializationSession = _serializationManager.CreateSession();
+            _state[s_stateLoaded] = false;
+
+            // Make sure that we're removed any event sinks we added after we finished the load.
+            // Make sure that we're removed any event sinks we added after we finished the load.
+            EnableComponentNotification(false);
+            IComponentChangeService cs = (IComponentChangeService)GetService(typeof(IComponentChangeService));
+
+            if (cs == null)
+            {
+                return;
+            }
+
+            cs.ComponentAdded -= new ComponentEventHandler(OnComponentAdded);
+            cs.ComponentAdding -= new ComponentEventHandler(OnComponentAdding);
+            cs.ComponentRemoving -= new ComponentEventHandler(OnComponentRemoving);
+            cs.ComponentRemoved -= new ComponentEventHandler(OnComponentRemoved);
+            cs.ComponentChanged -= new ComponentChangedEventHandler(OnComponentChanged);
+            cs.ComponentChanging -= new ComponentChangingEventHandler(OnComponentChanging);
+            cs.ComponentRename -= new ComponentRenameEventHandler(OnComponentRename);
+        }
+
+        /// <summary>
+        /// This method can be used to Enable or Disable component notification by the DesignerLoader.
+        /// </summary>
+        protected virtual bool EnableComponentNotification(bool enable)
+        {
+            bool previouslyEnabled = _state[s_stateEnableComponentEvents];
+
+            if (!previouslyEnabled && enable)
+            {
+                _state[s_stateEnableComponentEvents] = true;
+            }
+            else if (previouslyEnabled && !enable)
+            {
+                _state[s_stateEnableComponentEvents] = false;
+            }
+
+            return previouslyEnabled;
+        }
+
+        /// <summary>
+        ///  This method is called immediately before the document is unloaded.
+        ///  The document may be unloaded in preparation for reload, or 
+        ///  if the document failed the load.  If you added document-specific
+        ///  services in OnBeginLoad or OnEndLoad, you should remove them
+        ///  here.
+        /// </summary>
+        protected virtual void OnBeginUnload()
+        { }
+
+        /// <summary>
+        ///  This is called whenever a new component is added to the design surface.
+        /// </summary>
+        private void OnComponentAdded(object sender, ComponentEventArgs e)
+        {
+            // We check the loader host here.  We do not actually listen to
+            // this event until the loader has finished loading but if we
+            // succeeded the load and the loader then failed later, we might
+            // be listening when asked to unload.
+            if (_state[s_stateEnableComponentEvents] && !LoaderHost.Loading)
+            {
+                Modified = true;
+            }
+        }
+
+        /// <summary>
+        ///  This is called right before a component is added to the design surface.
+        /// </summary>
+        private void OnComponentAdding(object sender, ComponentEventArgs e)
+        {
+            // We check the loader host here.  We do not actually listen to
+            // this event until the loader has finished loading but if we
+            // succeeded the load and the loader then failed later, we might
+            // be listening when asked to unload.
+            if (_state[s_stateEnableComponentEvents] && !LoaderHost.Loading)
+            {
+                OnModifying();
+            }
+        }
+
+        /// <summary>
+        ///  This is called whenever a component on the design surface changes.
+        /// </summary>
+        private void OnComponentChanged(object sender, ComponentChangedEventArgs e)
+        {
+            // We check the loader host here.  We do not actually listen to
+            // this event until the loader has finished loading but if we
+            // succeeded the load and the loader then failed later, we might
+            // be listening when asked to unload.
+            if (_state[s_stateEnableComponentEvents] && !LoaderHost.Loading)
+            {
+                Modified = true;
+            }
+        }
+
+        /// <summary>
+        ///  This is called right before a component on the design surface changes.
+        /// </summary>
+        private void OnComponentChanging(object sender, ComponentChangingEventArgs e)
+        {
+            // We check the loader host here.  We do not actually listen to
+            // this event until the loader has finished loading but if we
+            // succeeded the load and the loader then failed later, we might
+            // be listening when asked to unload.
+            if (_state[s_stateEnableComponentEvents] && !LoaderHost.Loading)
+            {
+                OnModifying();
+            }
+        }
+
+        /// <summary>
+        ///  This is called whenever a component is removed from the design surface.
+        /// </summary>
+        private void OnComponentRemoved(object sender, ComponentEventArgs e)
+        {
+            // We check the loader host here.  We do not actually listen to
+            // this event until the loader has finished loading but if we
+            // succeeded the load and the loader then failed later, we might
+            // be listening when asked to unload.
+            if (_state[s_stateEnableComponentEvents] && !LoaderHost.Loading)
+            {
+                Modified = true;
+            }
+        }
+
+        /// <summary>
+        ///  This is called right before a component is removed from the design surface.
+        /// </summary>
+        private void OnComponentRemoving(object sender, ComponentEventArgs e)
+        {
+            // We check the loader host here.  We do not actually listen to
+            // this event until the loader has finished loading but if we
+            // succeeded the load and the loader then failed later, we might
+            // be listening when asked to unload.
+            if (_state[s_stateEnableComponentEvents] && !LoaderHost.Loading)
+            {
+                OnModifying();
+            }
+        }
+
+        /// <summary>
+        ///  Raised by the host when a component is renamed.  Here we modify ourselves
+        ///  and then whack the component declaration.  At the next code gen
+        ///  cycle we will recreate the declaration.
+        /// </summary>
+        private void OnComponentRename(object sender, ComponentRenameEventArgs e)
+        {
+            // We check the loader host here.  We do not actually listen to
+            // this event until the loader has finished loading but if we
+            // succeeded the load and the loader then failed later, we might
+            // be listening when asked to unload.
+            if (_state[s_stateEnableComponentEvents] && !LoaderHost.Loading)
+            {
+                OnModifying();
+                Modified = true;
+            }
+        }
+
+        /// <summary>
+        ///  Called when this document becomes active.  here we check to see if
+        ///  someone else has modified the contents of our buffer.  If so, we
+        ///  ask the designer to reload.
+        /// </summary>
+        private void OnDesignerActivate(object sender, EventArgs e)
+        {
+            _state[s_stateActiveDocument] = true;
+
+            if (!_state[s_stateDeferredReload] || _host == null)
+            {
+                return;
+            }
+
+            _state[s_stateDeferredReload] = false;
+            ReloadOptions flags = ReloadOptions.Default;
+
+            if (_state[s_stateForceReload])
+            {
+                flags |= ReloadOptions.Force;
+            }
+
+            if (!_state[s_stateFlushReload])
+            {
+                flags |= ReloadOptions.NoFlush;
+            }
+
+            if (_state[s_stateModifyIfErrors])
+            {
+                flags |= ReloadOptions.ModifyOnError;
+            }
+
+            Reload(flags);
+        }
+
+        /// <summary>
+        ///  Called when this document loses activation.  We just remember this
+        ///  for later.
+        /// </summary>
+        private void OnDesignerDeactivate(object sender, EventArgs e) => _state[s_stateActiveDocument] = false;
+
+        /// <summary>
+        ///  This method should be called by the designer loader service
+        ///  when all dependent loads have been completed.  This
+        ///  "shuts down" the loading process that was initiated by
+        ///  BeginLoad.  By default, the designer loader provides
+        ///  IDesignerLoaderService itself, so this is called automatically.
+        ///  If you provide your own loader service, or if you choose not
+        ///  to provide a loader service, you are responsible for calling
+        ///  this method.  BeginLoad will automatically call this, either
+        ///  indirectly by calling DependentLoadComplete if IDesignerLoaderService
+        ///  is available, or directly if it is not.
+        /// </summary>
+        protected virtual void OnEndLoad(bool successful, ICollection errors)
+        {
+            //we don't want successful to be true here if there were load errors.
+            //this may allow a situation where we have a dirtied WSOD and might allow
+            //a user to save a partially loaded designer docdata.
+            successful = successful && (errors == null || errors.Count == 0)
+                                    && (_serializationManager.Errors == null
+                                    || _serializationManager.Errors.Count == 0);
+            try
+            {
+                _state[s_stateLoaded] = true;
+                IDesignerLoaderHost2 lh2 = GetService(typeof(IDesignerLoaderHost2)) as IDesignerLoaderHost2;
+
+                if (!successful && (lh2 == null || !lh2.IgnoreErrorsDuringReload))
+                {
+                    // Can we even show the Continue Ignore errors in DTEL?
+                    if (lh2 != null)
+                    {
+                        lh2.CanReloadWithErrors = LoaderHost.RootComponent != null;
+                    }
+
+                    UnloadDocument();
+                }
+                else
+                {
+                    successful = true;
+                }
+
+                // Inform the serialization manager that we are all done.  The serialization 
+                // manager clears state at this point to help enforce a stateless serialization
+                // mechanism.
+                if (errors != null)
+                {
+                    foreach (object err in errors)
+                    {
+                        _serializationManager.Errors.Add(err);
+                    }
+                }
+
+                errors = _serializationManager.Errors;
+            }
+            finally
+            {
+                _serializationSession.Dispose();
+                _serializationSession = null;
+            }
+
+            if (successful)
+            {
+                // After a successful load we will want to monitor a bunch of events so we know when
+                // to make the loader modified.
+                IComponentChangeService cs = (IComponentChangeService)GetService(typeof(IComponentChangeService));
+
+                if (cs != null)
+                {
+                    cs.ComponentAdded += new ComponentEventHandler(OnComponentAdded);
+                    cs.ComponentAdding += new ComponentEventHandler(OnComponentAdding);
+                    cs.ComponentRemoving += new ComponentEventHandler(OnComponentRemoving);
+                    cs.ComponentRemoved += new ComponentEventHandler(OnComponentRemoved);
+                    cs.ComponentChanged += new ComponentChangedEventHandler(OnComponentChanged);
+                    cs.ComponentChanging += new ComponentChangingEventHandler(OnComponentChanging);
+                    cs.ComponentRename += new ComponentRenameEventHandler(OnComponentRename);
+                }
+
+                EnableComponentNotification(true);
+            }
+
+            LoaderHost.EndLoad(_baseComponentClassName, successful, errors);
+
+            // if we got errors in the load, set ourselves as modified so we'll regen code.  If this fails, we don't
+            // care; the Modified bit was only a hint.
+            if (_state[s_stateModifyIfErrors] && errors != null && errors.Count > 0)
+            {
+                try
+                {
+                    OnModifying();
+                    Modified = true;
+                }
+                catch (CheckoutException ex)
+                {
+                    if (ex != CheckoutException.Canceled)
+                    {
+                        throw;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///  This method is called in response to a component changing, adding or removing event to indicate
+        ///  that the designer is about to be modified.  Those interested in implementing source code
+        ///  control may do so by overriding this method.  A call to OnModifying does not mean that the
+        ///  Modified property will later be set to true; it is merly an intention to do so.
+        /// </summary>
+        protected virtual void OnModifying()
+        { }
+
+        /// <summary>
+        ///  Invoked by the loader host when it actually performs the reload, but before
+        ///  the reload actually happens.  Here we unload our part of the loader
+        ///  and get us ready for the pending reload.
+        /// </summary>
+        private void OnIdle(object sender, EventArgs e)
+        {
+            Application.Idle -= new EventHandler(OnIdle);
+
+            if (!_state[s_stateReloadAtIdle])
+            {
+                return;
+            }
+
+            _state[s_stateReloadAtIdle] = false;
+
+            //check to see if we are actually the active document.
+            DesignSurfaceManager mgr = (DesignSurfaceManager)GetService(typeof(DesignSurfaceManager));
+            DesignSurface thisSurface = (DesignSurface)GetService(typeof(DesignSurface));
+            Debug.Assert(mgr != null && thisSurface != null);
+
+            if (mgr != null && thisSurface != null)
+            {
+                if (!object.ReferenceEquals(mgr.ActiveDesignSurface, thisSurface))
+                {
+                    //somehow, we got deactivated and weren't told.
+                    _state[s_stateActiveDocument] = false;
+                    _state[s_stateDeferredReload] = true; //reload on activate
+                    return;
+                }
+            }
+
+            IDesignerLoaderHost host = LoaderHost;
+
+            if (host == null)
+            {
+                return;
+            }
+
+            if (!_state[s_stateForceReload] && !IsReloadNeeded())
+            {
+                return;
+            }
+
+            try
+            {
+                if (_state[s_stateFlushReload])
+                {
+                    Flush();
+                }
+
+                UnloadDocument();
+                host.Reload();
+            }
+            finally
+            {
+                _state[s_stateForceReload | s_stateModifyIfErrors | s_stateFlushReload] = false;
+            }
+        }
+
+        /// <summary>
+        ///  This method is called when it is time to flush the 
+        ///  contents of the loader.  You should save any state
+        ///  at this time.
+        /// </summary>
+        protected abstract void PerformFlush(IDesignerSerializationManager serializationManager);
+
+        /// <summary>
+        ///  This method is called when it is time to load the
+        ///  design surface.  If you are loading asynchronously 
+        ///  you should ask for IDesignerLoaderService and call 
+        ///  AddLoadDependency.  When loading asynchronously you
+        ///  should at least create the root component during
+        ///  PerformLoad.  The DesignSurface is only able to provide
+        ///  a view when there is a root component.
+        /// </summary>
+        protected abstract void PerformLoad(IDesignerSerializationManager serializationManager);
+
+        /// <summary>
+        ///  This method schedules a reload of the designer.
+        ///  Designer reloading happens asynchronously in order
+        ///  to unwind the stack before the reload begins.  If
+        ///  force is true, a reload is always performed.  If
+        ///  it is false, a reload is only performed if the
+        ///  underlying code dom tree has changed in a way that
+        ///  would affect the form.
+        ///  If flush is true, the designer is flushed before performing
+        ///  a reload.  If false, any designer changes are abandonded.
+        ///  If ModifyOnError is true, the designer loader will be put
+        ///  in the modified state if any errors happened during the 
+        ///  load.
+        /// </summary>
+        protected void Reload(ReloadOptions flags)
+        {
+            _state[s_stateForceReload] = ((flags & ReloadOptions.Force) != 0);
+            _state[s_stateFlushReload] = ((flags & ReloadOptions.NoFlush) == 0);
+            _state[s_stateModifyIfErrors] = ((flags & ReloadOptions.ModifyOnError) != 0);
+
+            // Our implementation of Reload only reloads if we are the 
+            // active designer.  Otherwise, we wait until we become
+            // active and reload at that time.  We also never do a 
+            // reload if we are flushing code.
+            if (_state[s_stateFlushInProgress])
+            {
+                return;
+            }
+
+            if (!_state[s_stateActiveDocument])
+            {
+                _state[s_stateDeferredReload] = true;
+                return;
+            }
+
+            if (_state[s_stateReloadAtIdle])
+            {
+                return;
+            }
+
+            Application.Idle += new EventHandler(OnIdle);
+            _state[s_stateReloadAtIdle] = true;
+        }
+
+        /// <summary>
+        ///  This method is called during flush if one or more errors occurred while
+        ///  flushing changes.  The values in the errors collection may either be
+        ///  exceptions or objects whose ToString value describes the error.  The default
+        ///  implementation of this method takes last exception in the collection and
+        ///  raises it as an exception.
+        /// </summary>
+        protected virtual void ReportFlushErrors(ICollection errors)
+        {
+            object lastError = null;
+
+            foreach (object e in errors)
+            {
+                lastError = e;
+            }
+
+            Debug.Assert(lastError != null, "Someone embedded a null in the error collection");
+
+            if (lastError == null)
+            {
+                return;
+            }
+
+            Exception ex = lastError as Exception;
+
+            if (ex == null)
+            {
+                ex = new InvalidOperationException(lastError.ToString());
+            }
+
+            throw ex;
+        }
+
+        /// <summary>
+        ///  This property provides the name the designer surface
+        ///  will use for the base class.  Normally this is a fully
+        ///  qualified name such as "Project1.Form1".  You should set
+        ///  this before finishing the load.  Generally this is set
+        ///  during PerformLoad.
+        /// </summary>
+        protected void SetBaseComponentClassName(string name)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            _baseComponentClassName = name;
+        }
+
+        /// <summary>
+        ///  Simple helper routine that will throw an exception if we need a service, but cannot get
+        ///  to it.  You should only throw for missing services that are absolutely essential for
+        ///  operation.  If there is a way to gracefully degrade, then you should do it.
+        /// </summary>
+        private void ThrowMissingService(Type serviceType)
+        {
+            Exception ex = new InvalidOperationException(string.Format(SR.BasicDesignerLoaderMissingService, serviceType.Name));
+            ex.HelpLink = SR.BasicDesignerLoaderMissingService;
+
+            throw ex;
+        }
+
+        /// <summary>
+        ///  This method will be called when the document is to be unloaded.  It
+        ///  does not dispose us, but it gets us ready for a dispose or a reload.
+        /// </summary>
+        private void UnloadDocument()
+        {
+            OnBeginUnload();
+            _state[s_stateLoaded] = false;
+            _baseComponentClassName = null;
+        }
+
+        /// <summary>
+        ///  Adds a load dependency to this loader.  This indicates that some other
+        ///  object is also participating in the load, and that the designer loader
+        ///  should not call EndLoad on the loader host until all load dependencies
+        ///  have called DependentLoadComplete on the designer loader.
+        /// </summary>
+        void IDesignerLoaderService.AddLoadDependency()
+        {
+            if (_serializationManager == null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            if (_loadDependencyCount++ == 0)
+            {
+                OnBeginLoad();
+            }
+        }
+
+        /// <summary>
+        ///  This is called by any object that has previously called
+        ///  AddLoadDependency to signal that the dependent load has completed.
+        ///  The caller should pass either an empty collection or null to indicate
+        ///  a successful load, or a collection of exceptions that indicate the
+        ///  reason(s) for failure.
+        /// </summary>
+        void IDesignerLoaderService.DependentLoadComplete(bool successful, ICollection errorCollection)
+        {
+            if (_loadDependencyCount == 0)
+            {
+                throw new InvalidOperationException();
+            }
+
+            // If the dependent load failed, remember it.  There may be multiple
+            // dependent loads.  If any one fails, we're sunk.
+            if (!successful)
+            {
+                _state[s_stateLoadFailed] = true;
+            }
+
+            if (--_loadDependencyCount == 0)
+            {
+                // We have just completed the last dependent load.  Report this.
+                OnEndLoad(!_state[s_stateLoadFailed], errorCollection);
+                return;
+            }
+
+            if (errorCollection == null)
+            {
+                return;
+            }
+
+            // Otherwise, add these errors to the serialization manager.
+            foreach (object err in errorCollection)
+            {
+                _serializationManager.Errors.Add(err);
+            }
+        }
+
+        /// <summary>
+        ///  This can be called by an outside object to request that the loader
+        ///  reload the design document.  If it supports reloading and wants to
+        ///  comply with the reload, the designer loader should return true.  Otherwise
+        ///  it should return false, indicating that the reload will not occur.
+        ///  Callers should not rely on the reload happening immediately; the
+        ///  designer loader may schedule this for some other time, or it may
+        ///  try to reload at once.
+        /// </summary>
+        bool IDesignerLoaderService.Reload()
+        {
+            if (!_state[s_stateReloadSupported] || _loadDependencyCount != 0)
+            {
+                return false;
+            }
+
+            Reload(ReloadOptions.Force);
+
+            return true;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.ModifierConverter.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.ModifierConverter.cs
@@ -1,0 +1,169 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CodeDom;
+using System.CodeDom.Compiler;
+using System.Collections;
+using System.Globalization;
+
+namespace System.ComponentModel.Design.Serialization
+{
+    public abstract partial class CodeDomDesignerLoader
+    {
+        private class ModifierConverter : TypeConverter
+        {
+            /// <summary>
+            ///  <para>Gets a value indicating whether this converter can
+            ///  convert an object in the given source type to the native type of the converter
+            ///  using the context.</para>
+            /// </summary>
+            public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+                => GetConverter(context).CanConvertFrom(context, sourceType);
+
+            /// <summary>
+            ///  <para>Gets a value indicating whether this converter can
+            ///  convert an object to the given destination type using the context.</para>
+            /// </summary>
+            public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+                => GetConverter(context).CanConvertTo(context, destinationType);
+
+            /// <summary>
+            ///  <para>Converts the given object to the converter's native type.</para>
+            /// </summary>
+            public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+                => GetConverter(context).ConvertFrom(context, culture, value);
+
+            /// <summary>
+            ///  <para>Converts the given value object to
+            ///  the specified destination type using the specified context and arguments.</para>
+            /// </summary>
+            public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+                => GetConverter(context).ConvertTo(context, culture, value, destinationType);
+
+            /// <summary>
+            /// <para>Re-creates an <see cref='System.Object'/> given a set of property values for the
+            ///  object.</para>
+            /// </summary>
+            public override object CreateInstance(ITypeDescriptorContext context, IDictionary propertyValues)
+                => GetConverter(context).CreateInstance(context, propertyValues);
+
+            /// <summary>
+            ///  Returns the type converter for the member attributes enum.  We search the context
+            ///  for a code dom provider that can provide us more information.
+            /// </summary>
+            private TypeConverter GetConverter(ITypeDescriptorContext context)
+            {
+                TypeConverter modifierConverter = null;
+
+                if (context != null)
+                {
+                    CodeDomProvider provider = (CodeDomProvider)context.GetService(typeof(CodeDomProvider));
+
+                    if (provider != null)
+                    {
+                        modifierConverter = provider.GetConverter(typeof(MemberAttributes));
+                    }
+                }
+
+                if (modifierConverter == null)
+                {
+                    modifierConverter = TypeDescriptor.GetConverter(typeof(MemberAttributes));
+                }
+
+                return modifierConverter;
+            }
+
+            /// <summary>
+            ///  <para>Gets a value indicating whether changing a value on this object requires a 
+            ///  call to <see cref='System.ComponentModel.TypeConverter.CreateInstance'/> to create a new value,
+            ///  using the specified context.</para>
+            /// </summary>
+            public override bool GetCreateInstanceSupported(ITypeDescriptorContext context)
+                => GetConverter(context).GetCreateInstanceSupported(context);
+
+            /// <summary>
+            ///  <para>Gets a collection of properties for
+            ///  the type of array specified by the value parameter using the specified context and
+            ///  attributes.</para>
+            /// </summary>
+            public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object value, Attribute[] attributes)
+                => GetConverter(context).GetProperties(context, value, attributes);
+
+            /// <summary>
+            ///  <para>Gets a value indicating
+            ///  whether this object supports properties using the
+            ///  specified context.</para>
+            /// </summary>
+            public override bool GetPropertiesSupported(ITypeDescriptorContext context)
+                => GetConverter(context).GetPropertiesSupported(context);
+
+            /// <summary>
+            ///  <para>Gets a collection of standard values for the data type this type converter is
+            ///  designed for.</para>
+            /// </summary>
+            public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+            {
+                // We restrict the set of standard values to those within the access mask.
+                StandardValuesCollection values = GetConverter(context).GetStandardValues(context);
+
+                if (values != null && values.Count > 0)
+                {
+                    bool needMassage = false;
+
+                    foreach (MemberAttributes value in values)
+                    {
+                        if ((value & MemberAttributes.AccessMask) == 0)
+                        {
+                            needMassage = true;
+                            break;
+                        }
+                    }
+
+                    if (needMassage)
+                    {
+                        ArrayList list = new ArrayList(values.Count);
+
+                        foreach (MemberAttributes value in values)
+                        {
+                            if ((value & MemberAttributes.AccessMask) != 0 && value != MemberAttributes.AccessMask)
+                            {
+                                list.Add(value);
+                            }
+                        }
+
+                        values = new StandardValuesCollection(list);
+                    }
+                }
+
+                return values;
+            }
+
+            /// <summary>
+            ///  <para>Gets a value indicating whether the collection of standard values returned from
+            ///  <see cref='System.ComponentModel.TypeConverter.GetStandardValues'/> is an exclusive 
+            ///  list of possible values, using the specified context.</para>
+            /// </summary>
+            public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
+                => GetConverter(context).GetStandardValuesExclusive(context);
+
+            /// <summary>
+            ///  <para>Gets a value indicating
+            ///  whether this object
+            ///  supports a standard set of values that can be picked
+            ///  from a list using the specified context.</para>
+            /// </summary>
+            public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+                => GetConverter(context).GetStandardValuesSupported(context);
+
+            /// <summary>
+            ///  <para>Gets
+            ///  a value indicating whether the given value object is valid for this type.</para>
+            /// </summary>
+            public override bool IsValid(ITypeDescriptorContext context, object value)
+                => GetConverter(context).IsValid(context, value);
+        }
+    }
+}
+
+

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.ModifiersExtenderProvider.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.ModifiersExtenderProvider.cs
@@ -1,0 +1,225 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CodeDom;
+using System.Windows.Forms;
+
+namespace System.ComponentModel.Design.Serialization
+{
+    public abstract partial class CodeDomDesignerLoader
+    {
+        /// <summary>
+        ///  This extender provider provides the "Modifiers" property.
+        /// </summary>
+        [ProvideProperty("Modifiers", typeof(IComponent))]
+        [ProvideProperty("GenerateMember", typeof(IComponent))]
+        private class ModifiersExtenderProvider : IExtenderProvider
+        {
+            private IDesignerHost _host;
+
+            /// <summary>
+            ///  Determines if ths extender provider can extend the given object.  We extend
+            ///  all objects, so we always return true.
+            /// </summary>
+            public bool CanExtend(object o)
+            {
+                if (!(o is IComponent c))
+                {
+                    return false;
+                }
+
+                // We don't add modifiers to the base component.
+                IComponent baseComponent = GetBaseComponent(c);
+
+                if (o == baseComponent)
+                {
+                    return false;
+                }
+
+                // Now see if this object is inherited.  If so, then we don't want to
+                // extend.
+                if (!TypeDescriptor.GetAttributes(o)[typeof(InheritanceAttribute)].Equals(InheritanceAttribute.NotInherited))
+                {
+                    return false;
+                }
+
+                return true;
+            }
+
+            private IComponent GetBaseComponent(IComponent c)
+            {
+                IComponent baseComponent = null;
+
+                if (c == null)
+                {
+                    return null;
+                }
+
+                if (_host == null)
+                {
+                    ISite site = c.Site;
+                    
+                    if (site != null)
+                    {
+                        _host = (IDesignerHost)site.GetService(typeof(IDesignerHost));
+                    }
+                }
+
+                if (_host != null)
+                {
+                    baseComponent = _host.RootComponent;
+                }
+
+                return baseComponent;
+            }
+
+            /// <summary>
+            ///  This is an extender property that we offer to all components
+            ///  on the form.  It implements the "GenerateMember" property, which
+            ///  is a boolean that, if true, causes a field member to be generated for
+            ///  the object.
+            /// </summary>
+            [DesignOnly(true), DefaultValue(true), SRDescription(nameof(SR.CodeDomDesignerLoaderPropGenerateMember)), Category("Design")]
+            [HelpKeyword("Designer_GenerateMember")]
+            public bool GetGenerateMember(IComponent comp)
+            {
+                ISite site = comp.Site;
+
+                if (site == null)
+                {
+                    return true;
+
+                }
+
+                IDictionaryService dictionary = (IDictionaryService)site.GetService(typeof(IDictionaryService));
+
+                if (dictionary != null)
+                {
+                    object value = dictionary.GetValue("GenerateMember");
+
+                    if (value is bool)
+                    {
+                        return (bool)value;
+                    }
+                }
+
+                return true;
+            }
+
+            /// <summary>
+            ///  This is an extender property that we offer to all components
+            ///  on the form.  It implements the "Modifiers" property, which
+            ///  is an enum represneing the "public/protected/private" scope
+            ///  of a component.
+            /// </summary>
+            [DesignOnly(true), TypeConverter(typeof(ModifierConverter)), DefaultValue(MemberAttributes.Private), SRDescription(nameof(SR.CodeDomDesignerLoaderPropModifiers)), Category("Design")]
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+            [HelpKeyword("Designer_Modifiers")]
+            public MemberAttributes GetModifiers(IComponent comp)
+            {
+                ISite site = comp.Site;
+
+                if (site != null)
+                {
+                    IDictionaryService dictionary = (IDictionaryService)site.GetService(typeof(IDictionaryService));
+
+                    if (dictionary != null)
+                    {
+                        object value = dictionary.GetValue("Modifiers");
+
+                        if (value is MemberAttributes)
+                        {
+                            return (MemberAttributes)value;
+                        }
+                    }
+                }
+
+                // Check to see if someone offered up a "DefaultModifiers" property so we can
+                // decide a default.
+                PropertyDescriptorCollection props = TypeDescriptor.GetProperties(comp);
+                PropertyDescriptor prop = props["DefaultModifiers"];
+
+                if (prop != null && prop.PropertyType == typeof(MemberAttributes))
+                {
+                    return (MemberAttributes)prop.GetValue(comp);
+                }
+
+                return MemberAttributes.Private;
+            }
+
+            /// <summary>
+            ///  This is an extender property that we offer to all components
+            ///  on the form.  It implements the "GenerateMember" property, which
+            ///  is a boolean that, if true, causes a field member to be generated for
+            ///  the object.
+            /// </summary>
+            public void SetGenerateMember(IComponent comp, bool generate)
+            {
+                ISite site = comp.Site;
+
+                if (site == null)
+                {
+                    return;
+                }
+
+                IDictionaryService dictionary = (IDictionaryService)site.GetService(typeof(IDictionaryService));
+                bool oldValue = GetGenerateMember(comp);
+
+                if (dictionary != null)
+                {
+                    dictionary.SetValue("GenerateMember", generate);
+                }
+
+                // If the old value was true and the new value is false, we've got
+                // to remove the existing member declaration for this
+                // component
+                if (!oldValue || generate)
+                {
+                    return;
+                }
+
+                string compName = site.Name;
+
+                if (!(site.GetService(typeof(CodeTypeDeclaration)) is CodeTypeDeclaration typeDecl) || compName == null)
+                {
+                    return;
+                }
+
+                foreach (CodeTypeMember member in typeDecl.Members)
+                {
+                    if (member is CodeMemberField field && field.Name.Equals(compName))
+                    {
+                        typeDecl.Members.Remove(field);
+                        break;
+                    }
+                }
+            }
+
+            /// <summary>
+            ///  This is an extender property that we offer to all components
+            ///  on the form.  It implements the "Modifiers" property, which
+            ///  is an enum represneing the "public/protected/private" scope
+            ///  of a component.
+            /// </summary>
+            public void SetModifiers(IComponent comp, MemberAttributes modifiers)
+            {
+                ISite site = comp.Site;
+
+                if (site == null)
+                {
+                    return;
+                }
+
+                IDictionaryService dictionary = (IDictionaryService)site.GetService(typeof(IDictionaryService));
+                
+                if (dictionary != null)
+                {
+                    dictionary.SetValue("Modifiers", modifiers);
+                }
+            }
+        }
+    }
+}
+
+

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.ModifiersInheritedExtenderProvider.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.ModifiersInheritedExtenderProvider.cs
@@ -1,0 +1,163 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CodeDom;
+using System.Diagnostics;
+using System.Reflection;
+using System.Windows.Forms;
+
+namespace System.ComponentModel.Design.Serialization
+{
+    public abstract partial class CodeDomDesignerLoader
+    {
+        /// <summary>
+        ///  This extender provider offers up read-only versions of
+        ///  "Modifiers" for inherited components.
+        /// </summary>
+        [ProvideProperty("Modifiers", typeof(IComponent))]
+        private class ModifiersInheritedExtenderProvider : IExtenderProvider
+        {
+            private IDesignerHost _host;
+
+            /// <summary>
+            ///  Determines if ths extender provider can extend the given object.  We extend
+            ///  all objects, so we always return true.
+            /// </summary>
+            public bool CanExtend(object o)
+            {
+                if (!(o is IComponent c))
+                {
+                    return false;
+                }
+
+                // We don't add modifiers to the base component.
+                IComponent baseComponent = GetBaseComponent(c);
+
+                if (o == baseComponent)
+                {
+                    return false;
+                }
+
+                // Now see if this object is inherited.  If so, then we are interested in it.
+                AttributeCollection attributes = TypeDescriptor.GetAttributes(o);
+
+                if (!attributes[typeof(InheritanceAttribute)].Equals(InheritanceAttribute.NotInherited))
+                {
+                    return true;
+                }
+
+                return false;
+            }
+
+            private IComponent GetBaseComponent(IComponent c)
+            {
+                IComponent baseComponent = null;
+
+                if (c == null)
+                {
+                    return null;
+                }
+
+                if (_host == null)
+                {
+                    ISite site = c.Site;
+
+                    if (site != null)
+                    {
+                        _host = (IDesignerHost)site.GetService(typeof(IDesignerHost));
+                    }
+                }
+
+                if (_host != null)
+                {
+                    baseComponent = _host.RootComponent;
+                }
+
+                return baseComponent;
+            }
+
+            /// <summary>
+            ///  This is an extender property that we offer to all components
+            ///  on the form.  It implements the "Modifiers" property, which
+            ///  is an enum represneing the "public/protected/private" scope
+            ///  of a component.
+            /// </summary>
+            [DesignOnly(true), TypeConverter(typeof(ModifierConverter)), DefaultValue(MemberAttributes.Private), SRDescription(nameof(SR.CodeDomDesignerLoaderPropModifiers)), Category("Design")]
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+            public MemberAttributes GetModifiers(IComponent comp)
+            {
+                IComponent baseComponent = GetBaseComponent(comp);
+                Debug.Assert(baseComponent != null, "Root component was null");
+                Type baseType = baseComponent.GetType();
+                ISite site = comp.Site;
+
+                if (site == null)
+                {
+                    return MemberAttributes.Private;
+                }
+
+                string name = site.Name;
+
+                if (name == null)
+                {
+                    return MemberAttributes.Private;
+                }
+
+                FieldInfo field = TypeDescriptor.GetReflectionType(baseType).GetField(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
+                
+                if (field != null)
+                {
+                    if (field.IsPrivate)
+                        return MemberAttributes.Private;
+
+                    if (field.IsPublic)
+                        return MemberAttributes.Public;
+
+                    if (field.IsFamily)
+                        return MemberAttributes.Family;
+
+                    if (field.IsAssembly)
+                        return MemberAttributes.Assembly;
+
+                    if (field.IsFamilyOrAssembly)
+                        return MemberAttributes.FamilyOrAssembly;
+
+                    if (field.IsFamilyAndAssembly)
+                        return MemberAttributes.FamilyAndAssembly;
+                }
+
+                // Visual Basic uses a property called Foo and generates a field called _Foo. We need to check the 
+                // visibility of this accessor to fix the modifiers up.
+                PropertyInfo prop = TypeDescriptor.GetReflectionType(baseType).GetProperty(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
+                MethodInfo[] accessors = prop?.GetAccessors(true);
+                if (accessors == null || accessors.Length == 0 || accessors[0] == null)
+                {
+                    return MemberAttributes.Private;
+                }
+
+                MethodInfo mi = accessors[0];
+                
+                if (mi.IsPrivate)
+                    return MemberAttributes.Private;
+
+                if (mi.IsPublic)
+                    return MemberAttributes.Public;
+
+                if (mi.IsFamily)
+                    return MemberAttributes.Family;
+
+                if (mi.IsAssembly)
+                    return MemberAttributes.Assembly;
+
+                if (mi.IsFamilyOrAssembly)
+                    return MemberAttributes.FamilyOrAssembly;
+
+                if (mi.IsFamilyAndAssembly)
+                    return MemberAttributes.FamilyAndAssembly;
+
+                return MemberAttributes.Private;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.cs
@@ -1,0 +1,1392 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CodeDom;
+using System.CodeDom.Compiler;
+using System.Collections;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Windows.Forms.Design;
+
+namespace System.ComponentModel.Design.Serialization
+{
+    /// <summary>
+    ///  DesignerLoader.  This class is responsible for loading a designer document.  
+    ///  Where and how this load occurs is a private matter for the designer loader.
+    ///  The designer loader will be handed to an IDesignerHost instance.  This instance, 
+    ///  when it is ready to load the document, will call BeginLoad, passing an instance
+    ///  of IDesignerLoaderHost.  The designer loader will load up the design surface
+    ///  using the host interface, and call EndLoad on the interface when it is done.
+    ///  The error collection passed into EndLoad should be empty or null to indicate a
+    ///  successful load, or it should contain a collection of exceptions that 
+    ///  describe the error.
+    ///
+    ///  Once a document is loaded, the designer loader is also responsible for
+    ///  writing any changes made to the document back whatever storage the
+    ///  loader used when loading the document.  
+    /// </summary>
+    public abstract partial class CodeDomDesignerLoader : BasicDesignerLoader, INameCreationService, IDesignerSerializationService
+    {
+        private static readonly TraceSwitch s_traceCDLoader = new TraceSwitch("CodeDomDesignerLoader", "Trace CodeDomDesignerLoader");
+        private static readonly CodeMarkers s_codemarkers = CodeMarkers.Instance;
+        private static readonly int s_stateCodeDomDirty = BitVector32.CreateMask();                                 // True if the code dom tree is dirty, meaning it must be integrated back with the code file.
+        private static readonly int s_stateCodeParserChecked = BitVector32.CreateMask(s_stateCodeDomDirty);         // True if we have searched for a parser.
+        private static readonly int s_stateOwnTypeResolution = BitVector32.CreateMask(s_stateCodeParserChecked);    // True if we have added our own type resolution service
+
+        // State for the designer loader.
+        private BitVector32 _state = new BitVector32();
+        private IExtenderProvider[] _extenderProviders;
+        private IExtenderProviderService _extenderProviderService;
+
+        // State for the code dom parser / generator
+        private ICodeGenerator _codeGenerator;
+
+        // The following fields are setup by EnsureDocument and deleted by ClearDocument.
+        private CodeDomSerializer _rootSerializer;
+        private TypeCodeDomSerializer _typeSerializer;
+        private CodeCompileUnit _documentCompileUnit;
+        private CodeNamespace _documentNamespace;
+        private CodeTypeDeclaration _documentType;
+
+        /// <summary>
+        ///  This abstract property returns the code dom provider that should
+        ///  be used by this designer loader.
+        /// </summary>
+        protected abstract CodeDomProvider CodeDomProvider { get; }
+
+        /// <summary>
+        ///  The TypeResolutionService property returns a type resolution service that the code dom 
+        ///  serializers will use when resolving types.  The CodeDomDesignerLoader automatically 
+        ///  adds this type resolver as a service to the service container during Initialize if it
+        ///  is non-null.  While the type resolution service is optional in many scenarios, it is required for 
+        ///  code interpretation because source code contains type names, but no assembly references.
+        /// </summary>
+        protected abstract ITypeResolutionService TypeResolutionService { get; }
+
+        /// <summary>
+        ///  This is the reverse of EnsureDocument.  It clears the document state which will
+        ///  cause us to parse the next time we need to access it.
+        /// </summary>
+        private void ClearDocument()
+        {
+            if (_documentType != null)
+            {
+                LoaderHost.RemoveService(typeof(CodeTypeDeclaration));
+                _documentType = null;
+                _documentNamespace = null;
+                _documentCompileUnit = null;
+                _rootSerializer = null;
+                _typeSerializer = null;
+            }
+        }
+
+        /// <summary>
+        ///  Disposes this designer loader.  The designer host will call 
+        ///  this method when the design document itself is being destroyed.  
+        ///  Once called, the designer loader will never be called again.
+        ///  This implementation flushes any changes and removes any
+        ///  previously added services.
+        /// </summary>
+        public override void Dispose()
+        {
+            if (GetService(typeof(IComponentChangeService)) is IComponentChangeService cs)
+            {
+                cs.ComponentRemoved -= new ComponentEventHandler(this.OnComponentRemoved);
+                cs.ComponentRename -= new ComponentRenameEventHandler(OnComponentRename);
+            }
+
+            if (GetService(typeof(IDesignerHost)) is IDesignerHost host)
+            {
+                host.RemoveService(typeof(INameCreationService));
+                host.RemoveService(typeof(IDesignerSerializationService));
+                host.RemoveService(typeof(ComponentSerializationService));
+
+                if (_state[s_stateOwnTypeResolution])
+                {
+                    host.RemoveService(typeof(ITypeResolutionService));
+                    _state[s_stateOwnTypeResolution] = false;
+                }
+            }
+
+            if (_extenderProviderService != null)
+            {
+                foreach (IExtenderProvider p in _extenderProviders)
+                {
+                    _extenderProviderService.RemoveExtenderProvider(p);
+                }
+            }
+
+            base.Dispose();
+        }
+
+        /// <summary>
+        ///  Internal debug method to dump a code dom tree to text.
+        /// </summary>
+#if DEBUG
+        internal static void DumpTypeDeclaration(CodeTypeDeclaration typeDecl)
+        {
+            if (typeDecl == null || !s_traceCDLoader.TraceVerbose)
+            {
+                return;
+            }
+
+#pragma warning disable 618
+            ICodeGenerator codeGenerator = new Microsoft.CSharp.CSharpCodeProvider().CreateGenerator();
+#pragma warning restore 618
+            StringWriter sw = new StringWriter(CultureInfo.InvariantCulture);
+
+            try
+            {
+                codeGenerator.GenerateCodeFromType(typeDecl, sw, null);
+            }
+            catch (Exception ex)
+            {
+                sw.WriteLine("Error during declaration dump: " + ex.Message);
+            }
+
+            // spit this line by line so it respects the indent.
+            StringReader sr = new StringReader(sw.ToString());
+
+            for (string ln = sr.ReadLine(); ln != null; ln = sr.ReadLine())
+            {
+                Debug.WriteLine(ln);
+            }
+        }
+#endif
+
+        /// returns true if the given type has a root designer.
+        private bool HasRootDesignerAttribute(Type t)
+        {
+            AttributeCollection attributes = TypeDescriptor.GetAttributes(t);
+
+            for (int i = 0; i < attributes.Count; i++)
+            {
+                if (attributes[i] is DesignerAttribute da)
+                {
+                    Type attributeBaseType = Type.GetType(da.DesignerBaseTypeName);
+
+                    if (attributeBaseType != null && attributeBaseType == typeof(IRootDesigner))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        ///  This ensures that we can load the code dom elements into a
+        ///  document.  It ensures that there is a code dom provider, that
+        ///  the provider can parse the code, and that the returned 
+        ///  code compile unit contains a class that can be deserialized
+        ///  through a code dom serializer.  During all of this checking
+        ///  it establishes state in our member variables so that 
+        ///  calls after it can assume that the variables are set.  This
+        ///  will throw a human readable exception if any part of the
+        ///  process fails.
+        /// </summary>
+        private void EnsureDocument(IDesignerSerializationManager manager)
+        {
+            Debug.Assert(manager != null, "Should pass a serialization manager into EnsureDocument");
+
+            // If we do not yet have the compile unit, ask for it.
+            if (_documentCompileUnit == null)
+            {
+                Debug.Assert(_documentType == null && _documentNamespace == null, "We have no compile unit but we still have a type or namespace.  Our state is inconsistent.");
+                _documentCompileUnit = Parse();
+
+                if (_documentCompileUnit == null)
+                {
+                    Exception ex = new NotSupportedException(SR.CodeDomDesignerLoaderNoLanguageSupport);
+                    ex.HelpLink = SR.CodeDomDesignerLoaderNoLanguageSupport;
+
+                    throw ex;
+                }
+            }
+
+            // Search namespaces and types to identify something that we can load.
+            if (_documentType == null)
+            {
+                // We keep track of any failures here.  If we failed to find a type this
+                // array list will contain a list of strings listing what we have tried.
+                ArrayList failures = null;
+                bool firstClass = true;
+
+                if (_documentCompileUnit.UserData[typeof(InvalidOperationException)] != null)
+                {
+                    if (_documentCompileUnit.UserData[typeof(InvalidOperationException)] is InvalidOperationException invalidOp)
+                    {
+                        _documentCompileUnit = null; // not efficient but really a corner case...
+
+                        throw invalidOp;
+                    }
+                }
+
+                // Look in the compile unit for a class we can load.  The first one we find
+                // that has an appropriate serializer attribute, we take.
+                foreach (CodeNamespace ns in _documentCompileUnit.Namespaces)
+                {
+                    foreach (CodeTypeDeclaration typeDecl in ns.Types)
+                    {
+                        // Uncover the base type of this class.  In case we totally fail
+                        // we document each time we were unable to load a particular class.
+                        Type baseType = null;
+
+                        foreach (CodeTypeReference typeRef in typeDecl.BaseTypes)
+                        {
+                            Type t = LoaderHost.GetType(CodeDomSerializerBase.GetTypeNameFromCodeTypeReference(manager, typeRef));
+
+                            if (t != null && !(t.IsInterface))
+                            {
+                                baseType = t;
+                                break;
+                            }
+
+                            if (t == null)
+                            {
+                                if (failures == null)
+                                {
+                                    failures = new ArrayList();
+                                }
+
+                                failures.Add(string.Format(SR.CodeDomDesignerLoaderDocumentFailureTypeNotFound, typeDecl.Name, typeRef.BaseType));
+                            }
+                        }
+
+                        // We have a potential type.  The next step is to examine the type's attributes
+                        // and see if there is a root designer serializer attribute that supports the
+                        // code dom.
+                        if (baseType != null)
+                        {
+                            bool foundAttribute = false;
+
+                            // Backwards Compat:  RootDesignerSerializer is obsolete, but we need to still
+                            // be compatible and read it.
+                            // Walk the member attributes for this type, looking for an appropriate serializer attribute.
+#pragma warning disable 0618
+                            AttributeCollection attributes = TypeDescriptor.GetAttributes(baseType);
+
+                            foreach (Attribute attr in attributes)
+                            {
+                                if (attr is RootDesignerSerializerAttribute)
+                                {
+                                    RootDesignerSerializerAttribute ra = (RootDesignerSerializerAttribute)attr;
+                                    string typeName = ra.SerializerBaseTypeName;
+
+                                    // This serializer must support a CodeDomSerializer or we're not interested.
+                                    if (typeName != null && LoaderHost.GetType(typeName) == typeof(CodeDomSerializer))
+                                    {
+                                        Type serializerType = LoaderHost.GetType(ra.SerializerTypeName);
+
+                                        if (serializerType != null)
+                                        {
+                                            foundAttribute = true;
+
+                                            if (firstClass)
+                                            {
+                                                _rootSerializer = (CodeDomSerializer)Activator.CreateInstance(serializerType, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.CreateInstance, null, null, null);
+                                                break;
+                                            }
+                                            else
+                                            {
+                                                throw new InvalidOperationException(string.Format(SR.CodeDomDesignerLoaderSerializerTypeNotFirstType, typeDecl.Name));
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+#pragma warning restore 0618
+
+                            //add a check for root designer -- this allows an extra level of checking so we can skip classes
+                            //that cannot be designed.
+                            if (_rootSerializer == null && HasRootDesignerAttribute(baseType))
+                            {
+                                _typeSerializer = manager.GetSerializer(baseType, typeof(TypeCodeDomSerializer)) as TypeCodeDomSerializer;
+
+                                if (!firstClass && _typeSerializer != null)
+                                {
+                                    _typeSerializer = null;
+                                    _documentCompileUnit = null;
+
+                                    throw new InvalidOperationException(string.Format(SR.CodeDomDesignerLoaderSerializerTypeNotFirstType, typeDecl.Name));
+                                }
+                            }
+
+                            // If we didn't find a serializer for this type, report it.
+                            if (_rootSerializer == null && _typeSerializer == null)
+                            {
+                                if (failures == null)
+                                {
+                                    failures = new ArrayList();
+                                }
+
+                                if (foundAttribute)
+                                {
+                                    failures.Add(string.Format(SR.CodeDomDesignerLoaderDocumentFailureTypeDesignerNotInstalled, typeDecl.Name, baseType.FullName));
+                                }
+                                else
+                                {
+                                    failures.Add(string.Format(SR.CodeDomDesignerLoaderDocumentFailureTypeNotDesignable, typeDecl.Name, baseType.FullName));
+                                }
+                            }
+                        }
+
+                        // If we found a serializer, then we're done.  Save this type and namespace for later use.
+                        if (_rootSerializer != null || _typeSerializer != null)
+                        {
+                            _documentNamespace = ns;
+                            _documentType = typeDecl;
+                            break;
+                        }
+
+                        firstClass = false;
+                    }
+
+                    if (_documentType != null)
+                    {
+                        break;
+                    }
+                }
+
+                // If we did not get a document type, throw, because we're unable to continue.
+                if (_documentType == null)
+                {
+                    // The entire compile unit needs to be thrown away so 
+                    // we can later reparse.
+                    _documentCompileUnit = null;
+
+                    // Did we get any reasons why we can't load this document?  If so, synthesize a nice
+                    // description to the user.
+                    Exception ex;
+
+                    if (failures != null)
+                    {
+                        StringBuilder builder = new StringBuilder();
+
+                        foreach (string failure in failures)
+                        {
+                            builder.Append("\r\n");
+                            builder.Append(failure);
+                        }
+
+                        ex = new InvalidOperationException(string.Format(SR.CodeDomDesignerLoaderNoRootSerializerWithFailures, builder.ToString()));
+                        ex.HelpLink = SR.CodeDomDesignerLoaderNoRootSerializer;
+                    }
+                    else
+                    {
+                        ex = new InvalidOperationException(SR.CodeDomDesignerLoaderNoRootSerializer);
+                        ex.HelpLink = SR.CodeDomDesignerLoaderNoRootSerializer;
+                    }
+
+                    throw ex;
+                }
+                else
+                {
+                    // We are successful.  At this point, we want to provide some of these
+                    // code dom elements as services for outside parties to use.
+                    LoaderHost.AddService(typeof(CodeTypeDeclaration), _documentType);
+                }
+            }
+
+            s_codemarkers.CodeMarker((int)CodeMarkerEvent.perfFXGetDocumentType);
+        }
+
+        /// <summary>
+        ///  Takes the given code element and integrates it into the existing CodeDom
+        ///  tree stored in _documentCompileUnit.  This returns true if any changes
+        ///  were made to the tree.
+        /// </summary>
+        private bool IntegrateSerializedTree(IDesignerSerializationManager manager, CodeTypeDeclaration newDecl)
+        {
+            EnsureDocument(manager);
+            CodeTypeDeclaration docDecl = _documentType;
+            bool caseInsensitive = false;
+            bool codeDomDirty = false;
+            CodeDomProvider provider = CodeDomProvider;
+
+            if (provider != null)
+            {
+                caseInsensitive = ((provider.LanguageOptions & LanguageOptions.CaseInsensitive) != 0);
+            }
+
+            // Update the class name of the code type, in case it is different.
+            if (!string.Equals(docDecl.Name, newDecl.Name, caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
+            {
+                docDecl.Name = newDecl.Name;
+                codeDomDirty = true;
+            }
+
+            if (!docDecl.Attributes.Equals(newDecl.Attributes))
+            {
+                docDecl.Attributes = newDecl.Attributes;
+                codeDomDirty = true;
+            }
+
+            // Now, hash up the member names in the document and use this
+            // when determining what to add and what to replace.  In addition,
+            // we also build up a set of indexes into approximate locations for
+            // inserting fields and methods.
+            int fieldInsertLocation = 0;
+            bool lockField = false;
+            int methodInsertLocation = 0;
+            bool lockMethod = false;
+            IDictionary docMemberHash = new HybridDictionary(docDecl.Members.Count, caseInsensitive);
+            int memberCount = docDecl.Members.Count;
+
+            for (int i = 0; i < memberCount; i++)
+            {
+                CodeTypeMember member = docDecl.Members[i];
+                string memberName;
+
+                if (member is CodeConstructor)
+                {
+                    memberName = ".ctor";
+                }
+                else if (member is CodeTypeConstructor)
+                {
+                    memberName = ".cctor";
+                }
+                else
+                {
+                    memberName = member.Name;
+                }
+
+                docMemberHash[memberName] = i;
+
+                if (member is CodeMemberField)
+                {
+                    if (!lockField)
+                    {
+                        fieldInsertLocation = i;
+                    }
+                }
+                else
+                {
+                    if (fieldInsertLocation > 0)
+                    {
+                        lockField = true;
+                    }
+                }
+
+                if (member is CodeMemberMethod)
+                {
+                    if (!lockMethod)
+                    {
+                        methodInsertLocation = i;
+                    }
+                }
+                else
+                {
+                    if (methodInsertLocation > 0)
+                    {
+                        lockMethod = true;
+                    }
+                }
+            }
+
+            // Now start looking through the new declaration and process it.
+            // We are index driven, so if we need to add new values we put
+            // them into an array list, and post process them.
+            ArrayList newElements = new ArrayList();
+
+            foreach (CodeTypeMember member in newDecl.Members)
+            {
+                string memberName;
+
+                if (member is CodeConstructor)
+                {
+                    memberName = ".ctor";
+                }
+                else
+                {
+                    memberName = member.Name;
+                }
+
+                object existingSlot = docMemberHash[memberName];
+
+                if (existingSlot != null)
+                {
+                    int slot = (int)existingSlot;
+                    CodeTypeMember existingMember = docDecl.Members[slot];
+
+                    if (existingMember == member)
+                    {
+                        continue;
+                    }
+
+                    if (member is CodeMemberField)
+                    {
+                        if (existingMember is CodeMemberField)
+                        {
+                            CodeMemberField docField = (CodeMemberField)existingMember;
+                            CodeMemberField newField = (CodeMemberField)member;
+
+                            // We will be case-sensitive always in working out whether to replace the field
+                            if ((string.Equals(newField.Name, docField.Name)) && newField.Attributes == docField.Attributes && TypesEqual(newField.Type, docField.Type))
+                            {
+                                continue;
+                            }
+                            else
+                            {
+                                docDecl.Members[slot] = member;
+                            }
+                        }
+                        else
+                        {
+                            // We adding a field with the same name as a method. This should cause a
+                            // compile error, but we don't want to clobber the existing method.
+                            newElements.Add(member);
+                        }
+                    }
+                    else if (member is CodeMemberMethod)
+                    {
+                        if (existingMember is CodeMemberMethod)
+                        {
+                            // If there is an existing constructor, preserve it.
+                            if (!(existingMember is CodeConstructor))
+                            {
+                                // For methods, we do not want to replace the method; rather, we
+                                // just want to replace its contents.  This helps to preserve
+                                // the layout of the file.
+                                CodeMemberMethod existingMethod = (CodeMemberMethod)existingMember;
+                                CodeMemberMethod newMethod = (CodeMemberMethod)member;
+
+                                existingMethod.Statements.Clear();
+                                existingMethod.Statements.AddRange(newMethod.Statements);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        docDecl.Members[slot] = member;
+                    }
+
+                    codeDomDirty = true;
+                }
+                else
+                {
+                    newElements.Add(member);
+                }
+            }
+
+            // Now, process all new elements.
+            foreach (CodeTypeMember member in newElements)
+            {
+                if (member is CodeMemberField)
+                {
+                    if (fieldInsertLocation >= docDecl.Members.Count)
+                    {
+                        docDecl.Members.Add(member);
+                    }
+                    else
+                    {
+                        docDecl.Members.Insert(fieldInsertLocation, member);
+                    }
+
+                    fieldInsertLocation++;
+                    methodInsertLocation++;
+                    codeDomDirty = true;
+                }
+                else if (member is CodeMemberMethod)
+                {
+                    if (methodInsertLocation >= docDecl.Members.Count)
+                    {
+                        docDecl.Members.Add(member);
+                    }
+                    else
+                    {
+                        docDecl.Members.Insert(methodInsertLocation, member);
+                    }
+
+                    methodInsertLocation++;
+                    codeDomDirty = true;
+                }
+                else
+                {
+                    // For rare members, just add them to the end.
+                    docDecl.Members.Add(member);
+                    codeDomDirty = true;
+                }
+            }
+
+            return codeDomDirty;
+        }
+
+        /// <summary>
+        ///  This method is called immediately after the first time
+        ///  BeginLoad is invoked.  This is an appopriate place to
+        ///  add custom services to the loader host.  Remember to
+        ///  remove any custom services you add here by overriding
+        ///  Dispose.
+        /// </summary>
+        protected override void Initialize()
+        {
+            base.Initialize();
+
+            ServiceCreatorCallback callback = new ServiceCreatorCallback(OnCreateService);
+
+            LoaderHost.AddService(typeof(ComponentSerializationService), callback);
+            LoaderHost.AddService(typeof(INameCreationService), this);
+            LoaderHost.AddService(typeof(IDesignerSerializationService), this);
+
+            // The code dom desinger loader requires a working ITypeResolutionService to
+            // function.  See if someone added one already, and if not, provide
+            // our own.
+            if (GetService(typeof(ITypeResolutionService)) == null)
+            {
+                ITypeResolutionService trs = TypeResolutionService;
+
+                if (trs == null)
+                {
+                    throw new InvalidOperationException(SR.CodeDomDesignerLoaderNoTypeResolution);
+                }
+
+                LoaderHost.AddService(typeof(ITypeResolutionService), trs);
+                _state[s_stateOwnTypeResolution] = true;
+            }
+
+            _extenderProviderService = GetService(typeof(IExtenderProviderService)) as IExtenderProviderService;
+
+            if (_extenderProviderService != null)
+            {
+                _extenderProviders = new IExtenderProvider[] {
+                    new ModifiersExtenderProvider(),
+                    new ModifiersInheritedExtenderProvider()
+                };
+
+                foreach (IExtenderProvider p in _extenderProviders)
+                {
+                    _extenderProviderService.AddExtenderProvider(p);
+                }
+            }
+        }
+
+        /// <summary>
+        ///  Determines if the designer needs to be reloaded.  It does this
+        ///  by examining the code dom tree for changes.  This does not check
+        ///  for outside infleuences; the caller should already think a reload
+        ///  is needed -- this is just a last optimization.
+        /// </summary>
+        protected override bool IsReloadNeeded()
+        {
+            if (!base.IsReloadNeeded())
+            {
+                return false;
+            }
+
+            // If we have no document, we definitely need a reload.
+            if (_documentType == null)
+            {
+                return true;
+            }
+
+            // If we can't get to a code dom provider, or if that provider doesn't
+            // implement ICodeDomDesignerReload, we can't optimize the reload, so we
+            // just assume it is needed.
+            if (!(CodeDomProvider is ICodeDomDesignerReload reloader))
+            {
+                return true;
+            }
+
+            bool reload = true;
+
+            // Parse the file and see if we actually need to reload.
+            string oldTypeName = _documentType.Name;
+
+            // StartTimingMark();
+            try
+            {
+                ClearDocument();
+                EnsureDocument(GetService(typeof(IDesignerSerializationManager)) as IDesignerSerializationManager);
+            }
+            catch
+            {
+                // If the document is not in a state where we can get any information
+                // from it, we will assume this is a reload.  The error will then
+                // be displayed to the user when the designer does actually
+                // reload.
+            }
+
+            // EndTimingMark("Reload Parse I");
+            if (_documentCompileUnit != null)
+            {
+                reload = reloader.ShouldReloadDesigner(_documentCompileUnit);
+                reload |= (_documentType == null || !_documentType.Name.Equals(oldTypeName));
+            }
+
+            return reload;
+        }
+
+        /// <summary>
+        ///  This method should be called by the designer loader service
+        ///  when the first dependent load has started.  This initializes
+        ///  the state of the code dom loader and prepares it for loading.
+        ///  By default, the designer loader provides
+        ///  IDesignerLoaderService itself, so this is called automatically.
+        ///  If you provide your own loader service, or if you choose not
+        ///  to provide a loader service, you are responsible for calling
+        ///  this method.  BeginLoad will automatically call this, either
+        ///  indirectly by calling AddLoadDependency if IDesignerLoaderService
+        ///  is available, or directly if it is not.
+        /// </summary>
+        protected override void OnBeginLoad()
+        {
+            // Make sure that we're removed any event sinks we added after we finished the load.
+            IComponentChangeService cs = (IComponentChangeService)GetService(typeof(IComponentChangeService));
+
+            if (cs != null)
+            {
+                cs.ComponentRemoved -= new ComponentEventHandler(this.OnComponentRemoved);
+                cs.ComponentRename -= new ComponentRenameEventHandler(OnComponentRename);
+            }
+
+            base.OnBeginLoad();
+        }
+
+        /// <summary>
+        ///  This method is called immediately before the document is unloaded.
+        ///  The document may be unloaded in preparation for reload, or 
+        ///  if the document failed the load.  If you added document-specific
+        ///  services in OnBeginLoad or OnEndLoad, you should remove them
+        ///  here.
+        /// </summary>
+        protected override void OnBeginUnload()
+        {
+            base.OnBeginUnload();
+            ClearDocument();
+        }
+
+        /// <summary>
+        ///  This is called whenever a component is removed from the design surface.
+        /// </summary>
+        private void OnComponentRemoved(object sender, ComponentEventArgs e)
+        {
+            string name = e.Component.Site.Name;
+            RemoveDeclaration(name);
+        }
+
+        /// <summary>
+        ///  Raised by the host when a component is renamed.  Here we dirty ourselves
+        ///  and then whack the component declaration.  At the next code gen
+        ///  cycle we will recreate the declaration.
+        /// </summary>
+        private void OnComponentRename(object sender, ComponentRenameEventArgs e)
+        {
+            OnComponentRename(e.Component, e.OldName, e.NewName);
+        }
+
+        /// <summary>
+        ///  Callback to create our demand-created services.
+        /// </summary>
+        private object OnCreateService(IServiceContainer container, Type serviceType)
+        {
+            if (serviceType == typeof(ComponentSerializationService))
+            {
+                return new CodeDomComponentSerializationService(LoaderHost);
+            }
+
+            Debug.Fail("Called to create unknown service.");
+
+            return null;
+        }
+
+        /// <summary>
+        ///  This method should be called by the designer loader service
+        ///  when all dependent loads have been completed.  This
+        ///  "shuts down" the loading process that was initiated by
+        ///  BeginLoad.  By default, the designer loader provides
+        ///  IDesignerLoaderService itself, so this is called automatically.
+        ///  If you provide your own loader service, or if you choose not
+        ///  to provide a loader service, you are responsible for calling
+        ///  this method.  BeginLoad will automatically call this, either
+        ///  indirectly by calling DependentLoadComplete if IDesignerLoaderService
+        ///  is available, or directly if it is not.
+        /// </summary>
+        protected override void OnEndLoad(bool successful, ICollection errors)
+        {
+            base.OnEndLoad(successful, errors);
+
+            if (!successful)
+            {
+                return;
+            }
+
+            // After a successful load we will want to monitor a bunch of events so we know when
+            // to make the loader dirty.
+            IComponentChangeService cs = (IComponentChangeService)GetService(typeof(IComponentChangeService));
+
+            if (cs == null)
+            {
+                return;
+            }
+
+            cs.ComponentRemoved += new ComponentEventHandler(this.OnComponentRemoved);
+            cs.ComponentRename += new ComponentRenameEventHandler(OnComponentRename);
+        }
+
+        /// <summary>
+        ///  This abstract method is called when it is time to
+        ///  parse the source code and create a CodeDom tree.
+        /// </summary>
+        protected abstract CodeCompileUnit Parse();
+
+        /// <summary>
+        ///  Overrides BasicDesignerLoader's PerformFlush method to actual
+        ///  write out the code dom tree.
+        /// </summary>
+        protected override void PerformFlush(IDesignerSerializationManager manager)
+        {
+            CodeTypeDeclaration typeDecl = null;
+
+            // Ask the serializer for the root component to serialize.  This should return
+            // a CodeTypeDeclaration, which we will plug into our existing code DOM tree.
+            Debug.Assert(_rootSerializer != null || _typeSerializer != null, "What are we saving right now?  Base component has no serializer: " + LoaderHost.RootComponent.GetType().FullName);
+
+            if (_rootSerializer != null)
+            {
+                typeDecl = _rootSerializer.Serialize(manager, LoaderHost.RootComponent) as CodeTypeDeclaration;
+                Debug.Assert(typeDecl != null, "Root CodeDom serializer must return a CodeTypeDeclaration");
+            }
+            else if (_typeSerializer != null)
+            {
+                typeDecl = _typeSerializer.Serialize(manager, LoaderHost.RootComponent, LoaderHost.Container.Components);
+            }
+#if DEBUG
+            if (s_traceCDLoader.TraceVerbose)
+            {
+                Debug.WriteLine("****************** Pre-integrated tree **********************");
+                DumpTypeDeclaration(typeDecl);
+                EnsureDocument(manager);
+                Debug.WriteLine("****************** Live tree **********************");
+                DumpTypeDeclaration(_documentType);
+            }
+#endif
+            s_codemarkers.CodeMarker((int)CodeMarkerEvent.perfFXGenerateCodeTreeEnd);
+
+            // Now we must integrate the code DOM tree from the serializer with
+            // our own tree.  If changes were made to the tree this will
+            // return true.
+            if (typeDecl != null && IntegrateSerializedTree(manager, typeDecl))
+            {
+                s_codemarkers.CodeMarker((int)CodeMarkerEvent.perfFXIntegrateSerializedTreeEnd);
+#if DEBUG
+                if (s_traceCDLoader.TraceVerbose)
+                {
+                    Debug.WriteLine("****************** Integrated tree **********************");
+                    DumpTypeDeclaration(_documentType);
+                }
+#endif
+                // EndTimingMark("Serialize tree");
+                // StartTimingMark();
+                Write(_documentCompileUnit);
+                // EndTimingMark("Generate unit total");
+            }
+            else
+            {
+                Debug.WriteLineIf(s_traceCDLoader.TraceVerbose, "No need to integrate tree; no changes detected");
+            }
+        }
+
+        /// <summary>
+        ///  Overrides BasicDesignerLoader's PerformLoad method to deserialize the
+        ///  classes from the code dom.
+        /// </summary>
+        protected override void PerformLoad(IDesignerSerializationManager manager)
+        {
+            // This ensures that all of the state for the document is available.  This
+            // will throw if state we need to load cannot be obtained.
+            EnsureDocument(manager);
+
+            // Ok, now we have a document, and a root serializer and a namespace.  Or,
+            // at least we better.
+            Debug.Assert(_documentType != null, "EnsureDocument didn't create a document type");
+            Debug.Assert(_documentNamespace != null, "EnsureDocument didn't create a document namespace");
+            Debug.Assert(_rootSerializer != null || _typeSerializer != null, "EnsureDocument didn't create a root serializer");
+
+            // StartTimingMark();
+            s_codemarkers.CodeMarker((int)CodeMarkerEvent.perfFXDeserializeStart);
+
+            if (_rootSerializer != null)
+            {
+                _rootSerializer.Deserialize(manager, _documentType);
+            }
+            else
+            {
+                _typeSerializer.Deserialize(manager, _documentType);
+            }
+
+            s_codemarkers.CodeMarker((int)CodeMarkerEvent.perfFXDeserializeEnd);
+
+            // EndTimingMark("Deserialize document");
+            string baseComp = string.Format(CultureInfo.CurrentCulture, "{0}.{1}", _documentNamespace.Name, _documentType.Name);
+            SetBaseComponentClassName(baseComp);
+        }
+
+        /// <summary>
+        ///  This virtual method gets override in the VsCodeDomDesignerLoader to call the RenameElement on the 
+        ///  ChangeNotificationService to rename the component name through out the project scope.
+        /// </summary>
+        protected virtual void OnComponentRename(object component, string oldName, string newName)
+        {
+            if (LoaderHost.RootComponent == component)
+            {
+                if (_documentType != null)
+                {
+                    _documentType.Name = newName;
+                }
+
+                return;
+            }
+
+            if (_documentType == null)
+            {
+                return;
+            }
+
+            CodeTypeMemberCollection members = _documentType.Members;
+
+            for (int i = 0; i < members.Count; i++)
+            {
+                if (members[i] is CodeMemberField && members[i].Name.Equals(oldName)
+                                                  && ((CodeMemberField)members[i]).Type.BaseType.Equals(TypeDescriptor.GetClassName(component)))
+                {
+                    members[i].Name = newName;
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        ///  This is called when a component is deleted or renamed.  We remove
+        ///  the component's declaration here, if it exists.
+        /// </summary>
+        private void RemoveDeclaration(string name)
+        {
+            if (_documentType == null)
+            {
+                return;
+            }
+
+            CodeTypeMemberCollection members = _documentType.Members;
+
+            for (int i = 0; i < members.Count; i++)
+            {
+                if (members[i] is CodeMemberField && members[i].Name.Equals(name))
+                {
+                    ((IList)members).RemoveAt(i);
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        ///  Simple helper routine that will throw an exception if we need a service, but cannot get
+        ///  to it.  You should only throw for missing services that are absolutely essential for
+        ///  operation.  If there is a way to gracefully degrade, then you should do it.
+        /// </summary>
+        private void ThrowMissingService(Type serviceType)
+        {
+            Exception ex = new InvalidOperationException(string.Format(SR.BasicDesignerLoaderMissingService, serviceType.Name));
+            ex.HelpLink = SR.BasicDesignerLoaderMissingService;
+
+            throw ex;
+        }
+
+        /// <summary>
+        ///  Determines of two type references are equal.
+        /// </summary>
+        private static bool TypesEqual(CodeTypeReference typeLeft, CodeTypeReference typeRight)
+        {
+            if (typeLeft.ArrayRank != typeRight.ArrayRank)
+            {
+                return false;
+            }
+
+            if (!typeLeft.BaseType.Equals(typeRight.BaseType))
+            {
+                return false;
+            }
+
+            if (typeLeft.TypeArguments != null && typeRight.TypeArguments == null)
+            {
+                return false;
+            }
+
+            if (typeLeft.TypeArguments == null && typeRight.TypeArguments != null)
+            {
+                return false;
+            }
+
+            if (typeLeft.TypeArguments != null && typeRight.TypeArguments != null)
+            {
+                if (typeLeft.TypeArguments.Count != typeRight.TypeArguments.Count)
+                {
+                    return false;
+                }
+
+                for (int i = 0; i < typeLeft.TypeArguments.Count; i++)
+                {
+                    if (!TypesEqual(typeLeft.TypeArguments[i], typeRight.TypeArguments[i]))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            if (typeLeft.ArrayRank > 0)
+            {
+                return TypesEqual(typeLeft.ArrayElementType, typeRight.ArrayElementType);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        ///  This abstract method is called in response to a Flush
+        ///  call when the designer loader is dirty.  It will pass
+        ///  a new CodeCompileUnit that represents the source code
+        ///  needed to recreate the current designer's component
+        ///  graph.
+        /// </summary>
+        protected abstract void Write(CodeCompileUnit unit);
+
+        /// <summary>
+        ///  Deserializes the provided serialization data object and
+        ///  returns a collection of objects contained within that
+        ///  data.
+        /// </summary>
+        ICollection IDesignerSerializationService.Deserialize(object serializationData)
+        {
+            if (!(serializationData is SerializationStore))
+            {
+                Exception ex = new ArgumentException(SR.CodeDomDesignerLoaderBadSerializationObject);
+                ex.HelpLink = SR.CodeDomDesignerLoaderBadSerializationObject;
+
+                throw ex;
+            }
+
+            ComponentSerializationService css = GetService(typeof(ComponentSerializationService)) as ComponentSerializationService;
+
+            if (css == null)
+            {
+                ThrowMissingService(typeof(ComponentSerializationService));
+            }
+
+            return css.Deserialize((SerializationStore)serializationData, LoaderHost.Container);
+        }
+
+        /// <summary>
+        ///  Serializes the given collection of objects and 
+        ///  stores them in an opaque serialization data object.
+        ///  The returning object fully supports runtime serialization.
+        /// </summary>
+        object IDesignerSerializationService.Serialize(ICollection objects)
+        {
+            if (objects == null)
+            {
+                objects = new object[0];
+            }
+
+            ComponentSerializationService css = GetService(typeof(ComponentSerializationService)) as ComponentSerializationService;
+
+            if (css == null)
+            {
+                ThrowMissingService(typeof(ComponentSerializationService));
+            }
+
+            SerializationStore store = css.CreateStore();
+
+            using (store)
+            {
+                foreach (object o in objects)
+                {
+                    css.Serialize(store, o);
+                }
+            }
+
+            return store;
+        }
+
+        /// <summary>
+        ///  Creates a new name that is unique to all the components
+        ///  in the given container.  The name will be used to create
+        ///  an object of the given data type, so the service may
+        ///  derive a name from the data type's name.
+        /// </summary>
+        string INameCreationService.CreateName(IContainer container, Type dataType)
+        {
+            if (dataType == null)
+            {
+                throw new ArgumentNullException(nameof(dataType));
+            }
+
+            string finalName;
+            string baseName = dataType.Name;
+
+            // Create a base member name that is a camel casing of the
+            // data type name.
+            StringBuilder b = new StringBuilder(baseName.Length);
+
+            for (int i = 0; i < baseName.Length; i++)
+            {
+                if (char.IsUpper(baseName[i]) && (i == 0 || i == baseName.Length - 1 || char.IsUpper(baseName[i + 1])))
+                {
+                    b.Append(char.ToLower(baseName[i], CultureInfo.CurrentCulture));
+                }
+                else
+                {
+                    b.Append(baseName.Substring(i));
+                    break;
+                }
+            }
+
+            b.Replace('`', '_');
+            baseName = b.ToString();
+
+            // Now hash up all of the member variable names using a case insensitve hash.
+            CodeTypeDeclaration type = _documentType;
+            Hashtable memberHash = new Hashtable(StringComparer.CurrentCultureIgnoreCase);
+
+            if (type != null)
+            {
+                foreach (CodeTypeMember member in type.Members)
+                {
+                    memberHash[member.Name] = member;
+                }
+            }
+
+            // VSWhidbey 95065: Only attempt to build a unique name here if we have a valid container
+            // against which to check the result. Otherwise, the name build here might be appended to
+            // with yet another iterator elsewhere. FWIW, this check is identical to the check used in
+            // BaseDesignerLoader's implementation of INameCreationService.CreateName().
+            if (container != null)
+            {
+                int idx = 0;
+                bool conflict;
+
+                // Now loop until we find a name that hasn't been used.
+                do
+                {
+                    idx++;
+                    conflict = false;
+                    finalName = string.Format(CultureInfo.CurrentCulture, "{0}{1}", baseName, idx.ToString(CultureInfo.InvariantCulture));
+
+                    if (container != null && container.Components[finalName] != null)
+                    {
+                        conflict = true;
+                    }
+
+                    if (!conflict && memberHash[finalName] != null)
+                    {
+                        conflict = true;
+                    }
+
+                } while (conflict);
+            }
+            else
+            {
+                finalName = baseName;
+            }
+
+            // And validate the new name against the code dom's code
+            // generator to ensure it's not a keyword.
+            if (_codeGenerator == null)
+            {
+                CodeDomProvider provider = CodeDomProvider;
+
+                if (provider != null)
+                {
+#pragma warning disable 618
+                    _codeGenerator = provider.CreateGenerator();
+#pragma warning restore 618
+                }
+            }
+
+            if (_codeGenerator != null)
+            {
+                finalName = _codeGenerator.CreateValidIdentifier(finalName);
+            }
+
+            return finalName;
+        }
+
+        /// <summary>
+        ///  Determines if the given name is valid.  A name 
+        ///  creation service may have rules defining a valid
+        ///  name, and this method allows the sevice to enforce
+        ///  those rules.
+        /// </summary>
+        bool INameCreationService.IsValidName(string name)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (name.Length == 0)
+            {
+                return false;
+            }
+
+            if (_codeGenerator == null)
+            {
+                CodeDomProvider provider = CodeDomProvider;
+
+                if (provider != null)
+                {
+#pragma warning disable 618
+                    _codeGenerator = provider.CreateGenerator();
+#pragma warning restore 618
+                }
+            }
+
+            if (_codeGenerator != null)
+            {
+                if (!_codeGenerator.IsValidIdentifier(name))
+                {
+                    return false;
+                }
+
+                if (!_codeGenerator.IsValidIdentifier(name + "Handler"))
+                {
+                    return false;
+                }
+            }
+
+            // We don't validate against the type members if we're loading,
+            // because during load these members are being added by the 
+            // parser, so of course there will be duplicates.
+            if (!Loading)
+            {
+                CodeTypeDeclaration type = _documentType;
+
+                if (type != null)
+                {
+                    foreach (CodeTypeMember member in type.Members)
+                    {
+                        if (string.Equals(member.Name, name, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return false;
+                        }
+                    }
+                }
+
+                // If the designer has been modified there is a chance that
+                // the document type does not have all the necessary
+                // members in it yet.  So, we need to check the container
+                // as well.
+                if (Modified && LoaderHost.Container.Components[name] != null)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        ///  Determines if the given name is valid.  A name 
+        ///  creation service may have rules defining a valid
+        ///  name, and this method allows the sevice to enforce
+        ///  those rules.  It is similar to IsValidName, except
+        ///  that this method will throw an exception if the
+        ///  name is invalid.  This allows implementors to provide
+        ///  rich information in the exception message.
+        /// </summary>
+        void INameCreationService.ValidateName(string name)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (name.Length == 0)
+            {
+                Exception ex = new ArgumentException(SR.CodeDomDesignerLoaderInvalidBlankIdentifier);
+                ex.HelpLink = SR.CodeDomDesignerLoaderInvalidIdentifier;
+
+                throw ex;
+            }
+
+            if (_codeGenerator == null)
+            {
+                CodeDomProvider provider = CodeDomProvider;
+
+                if (provider != null)
+                {
+#pragma warning disable 618
+                    _codeGenerator = provider.CreateGenerator();
+#pragma warning restore 618
+                }
+            }
+
+            if (_codeGenerator != null)
+            {
+                _codeGenerator.ValidateIdentifier(name);
+
+                try
+                {
+                    // We add something arbitrary and try to validate that. This is because we want to make sure
+                    // adding something is going to be fine, if not our event handler name generation will break in
+                    // case this identifier is something like a VB escaped keyword. For example, [public] is fine
+                    // but [public]_Click is not.
+                    _codeGenerator.ValidateIdentifier(name + "_");
+                }
+                catch
+                {
+                    // we have to change the exception back to the original name
+                    Exception ex = new ArgumentException(string.Format(SR.CodeDomDesignerLoaderInvalidIdentifier, name));
+                    ex.HelpLink = SR.CodeDomDesignerLoaderInvalidIdentifier;
+
+                    throw ex;
+                }
+            }
+
+            if (Loading)
+            {
+                return;
+            }
+
+            // We don't validate against the type members if we're loading,
+            // because during load these members are being added by the 
+            // parser, so of course there will be duplicates.
+            bool dup = false;
+            CodeTypeDeclaration type = _documentType;
+
+            if (type != null)
+            {
+                foreach (CodeTypeMember member in type.Members)
+                {
+                    if (string.Equals(member.Name, name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        dup = true;
+                        break;
+                    }
+                }
+            }
+
+            // If the designer has been modified there is a chance that
+            // the document type does not have all the necessary
+            // members in it yet.  So, we need to check the container
+            // as well.
+            if (!dup && Modified && LoaderHost.Container.Components[name] != null)
+            {
+                dup = true;
+            }
+
+            if (dup)
+            {
+                Exception ex = new ArgumentException(string.Format(SR.CodeDomDesignerLoaderDupComponentName, name));
+                ex.HelpLink = SR.CodeDomDesignerLoaderDupComponentName;
+
+                throw ex;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomLocalizationModel.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomLocalizationModel.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ComponentModel.Design.Serialization
+{
+    /// <summary>
+    ///  Determines the localization model to be used by the CodeDom resource adapter.
+    /// </summary>
+    public enum CodeDomLocalizationModel
+    {
+        /// <summary>
+        ///  Indicates that the localization provider should ignore localized properties.  It
+        ///  will still write out resources for objects that do not support code generation and are
+        ///  serializable.
+        /// </summary>
+        None = 0,
+        
+        /// <summary>
+        ///  Indicates that the localization provider will write out localizaed properties by assigning a resource to
+        ///  each property.  This model is fast when the number of properties is small, but scales poorly
+        ///  as the number of properties containing default values grows.
+        /// </summary>
+        PropertyAssignment = 1,
+
+        /// <summary>
+        ///  Indicates that the localization provider will write localized property values into a resource file and
+        ///  use the ComponentResourceManager class to reflect on properties by name to fill
+        ///  them at runtime.  This uses reflection at runtime so it can be slow, but it scales better for
+        ///  large numbers of properties with default values.
+        /// </summary>
+        PropertyReflection = 2
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomLocalizationProvider.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomLocalizationProvider.cs
@@ -1,0 +1,578 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Globalization;
+using System.Resources;
+using System.Windows.Forms;
+using System.Windows.Forms.Design;
+
+namespace System.ComponentModel.Design.Serialization
+{
+    /// <summary>
+    ///  This is a serialization provider that provides a localization feature.  This provider
+    ///  adds two properties to the root component:  Language and Localizable.  If Localizable
+    ///  is set to true this provider will change the way that component properties are generated
+    ///  and will route their values to a resource file.  Two localization models are 
+    ///  supported.
+    /// </summary>
+    public sealed class CodeDomLocalizationProvider : IDisposable, IDesignerSerializationProvider
+    {
+        private IExtenderProviderService _providerService;
+        private CodeDomLocalizationModel _model;
+        private CultureInfo[] _supportedCultures;
+        private LanguageExtenders _extender;
+        private Hashtable _memberSerializers;
+        private Hashtable _nopMemberSerializers;
+
+        /// <summary>
+        ///  Creates a new adapter and attaches it to the serialization manager.  This 
+        ///  will add itself as a serializer for resources into the serialization manager, and, 
+        ///  if not already added, will add itself as an extender provider to the roost component 
+        ///  and provide the Language and Localizable properties.  The latter piece is only 
+        ///  supplied if CodeDomLocalizationModel is not �none�.  
+        /// </summary>
+        public CodeDomLocalizationProvider(IServiceProvider provider, CodeDomLocalizationModel model)
+        {
+            if (provider == null)
+            {
+                throw new ArgumentNullException(nameof(provider));
+            }
+
+            _model = model;
+            Initialize(provider);
+        }
+
+        /// <summary>
+        ///  Creates a new adapter and attaches it to the serialization manager.  This 
+        ///  will add itself as a serializer for resources into the serialization manager, and, 
+        ///  if not already added, will add itself as an extender provider to the roost component 
+        ///  and provide the Language and Localizable properties.  The latter piece is only 
+        ///  supplied if CodeDomLocalizationModel is not �none�.  
+        /// </summary>
+        public CodeDomLocalizationProvider(IServiceProvider provider, CodeDomLocalizationModel model, CultureInfo[] supportedCultures)
+        {
+            if (provider == null)
+            {
+                throw new ArgumentNullException(nameof(provider));
+            }
+
+            if (supportedCultures == null)
+            {
+                throw new ArgumentNullException(nameof(supportedCultures));
+            }
+
+            _model = model;
+            _supportedCultures = (CultureInfo[])supportedCultures.Clone();
+            Initialize(provider);
+        }
+
+        /// <summary>
+        ///  Disposes this object.
+        /// </summary>
+        public void Dispose()
+        {
+            if (_providerService != null && _extender != null)
+            {
+                _providerService.RemoveExtenderProvider(_extender);
+                _providerService = null;
+                _extender = null;
+            }
+        }
+
+        /// <summary>
+        ///  Adds our extended properties.
+        /// </summary>
+        private void Initialize(IServiceProvider provider)
+        {
+            _providerService = provider.GetService(typeof(IExtenderProviderService)) as IExtenderProviderService;
+
+            if (_providerService == null)
+            {
+                throw new NotSupportedException(string.Format(SR.LocalizationProviderMissingService, typeof(IExtenderProviderService).Name));
+            }
+
+            _extender = new LanguageExtenders(provider, _supportedCultures);
+            _providerService.AddExtenderProvider(_extender);
+        }
+
+        #region IDesignerSerializationProvider Members
+        /// <summary>
+        ///  Returns a code dom serializer
+        /// </summary>
+        private object GetCodeDomSerializer(IDesignerSerializationManager manager, object currentSerializer, Type objectType, Type serializerType)
+        {
+            if (currentSerializer == null)
+            {
+                return null;
+            }
+
+            // Always do default processing for the resource manager.
+            if (typeof(ResourceManager).IsAssignableFrom(objectType))
+            {
+                return null;
+            }
+
+            // Here's how this works.  We have two different types of serializers to offer :  a 
+            // serializer that writes out code like this:
+            //
+            //      this.Button1.Text = rm.GetString("Button1_Text");
+            //
+            // And one that writes out like this:
+            //
+            //      rm.ApplyResources(Button1, "Button1");
+            //
+            // The first serializer is used for serializable objects that have no serializer of their
+            // own, and for localizable properties when the CodeDomLocalizationModel is set to PropertyAssignment.
+            // The second serializer is used only for localizaing properties when the CodeDomLocalizationModel
+            // is set to PropertyReflection
+
+            // Compute a localization model based on the property, localization mode,
+            // and what (if any) serializer already exists
+            CodeDomLocalizationModel model = CodeDomLocalizationModel.None;
+            object modelObj = manager.Context[typeof(CodeDomLocalizationModel)];
+
+            if (modelObj != null)
+            {
+                model = (CodeDomLocalizationModel)modelObj;
+            }
+
+            //Nifty, but this causes everything to be loc'd because our provider
+            //comes in before the default one
+            //if (model == CodeDomLocalizationModel.None && currentSerializer == null) {
+            //    model = CodeDomLocalizationModel.PropertyAssignment;
+            //}
+
+            if (model != CodeDomLocalizationModel.None)
+            {
+                return new LocalizationCodeDomSerializer(model, currentSerializer);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///  Returns a code dom serializer for members.
+        /// </summary>
+        private object GetMemberCodeDomSerializer(IDesignerSerializationManager manager, object currentSerializer, Type objectType, Type serializerType)
+        {
+            CodeDomLocalizationModel model = _model;
+
+            if (!typeof(PropertyDescriptor).IsAssignableFrom(objectType))
+            {
+                return null;
+            }
+
+            // Ok, we got a property descriptor.  If we're being localized
+            // we provide a different type of serializer.  But, we only
+            // do this if we were given a current serializer.  Otherwise
+            // we don't know how to perform the serialization.
+            // We can only provide a custom serializer if we have an existing one
+            // to base off of.
+            if (currentSerializer == null)
+            {
+                return null;
+            }
+
+            // If we've already provided this serializer, don't do it again
+            if (currentSerializer is ResourcePropertyMemberCodeDomSerializer)
+            {
+                return null;
+            }
+
+            // We only care if we're localizable
+            if (_extender == null || !_extender.GetLocalizable(null))
+            {
+                return null;
+            }
+
+            // Fish the property out of the context to see if the property is localizable.
+            PropertyDescriptor serializingProperty = manager.Context[typeof(PropertyDescriptor)] as PropertyDescriptor;
+
+            if (serializingProperty == null || !serializingProperty.IsLocalizable)
+            {
+                model = CodeDomLocalizationModel.None;
+            }
+
+            if (_memberSerializers == null)
+            {
+                _memberSerializers = new Hashtable();
+            }
+
+            if (_nopMemberSerializers == null)
+            {
+                _nopMemberSerializers = new Hashtable();
+            }
+
+            object newSerializer = null;
+
+            if (model == CodeDomLocalizationModel.None)
+            {
+                newSerializer = _nopMemberSerializers[currentSerializer];
+            }
+            else
+            {
+                newSerializer = _memberSerializers[currentSerializer];
+            }
+
+            if (newSerializer == null)
+            {
+                newSerializer = new ResourcePropertyMemberCodeDomSerializer((MemberCodeDomSerializer)currentSerializer, _extender, model);
+
+                if (model == CodeDomLocalizationModel.None)
+                {
+                    _nopMemberSerializers[currentSerializer] = newSerializer;
+                }
+                else
+                {
+                    _memberSerializers[currentSerializer] = newSerializer;
+                }
+            }
+
+            return newSerializer;
+        }
+
+        /// <summary>
+        ///  Returns an appropriate serializer for the object.  
+        /// </summary>
+        object IDesignerSerializationProvider.GetSerializer(IDesignerSerializationManager manager, object currentSerializer, Type objectType, Type serializerType)
+        {
+            if (serializerType == typeof(CodeDomSerializer))
+            {
+                return GetCodeDomSerializer(manager, currentSerializer, objectType, serializerType);
+            }
+            else if (serializerType == typeof(MemberCodeDomSerializer))
+            {
+                return GetMemberCodeDomSerializer(manager, currentSerializer, objectType, serializerType);
+            }
+
+            return null; // don't understand this type of serializer.
+        }
+        #endregion
+
+        #region LanguageExtenders class
+        /// <summary>
+        ///  The design time language and localizable properties.
+        /// </summary>
+        [ProvideProperty("Language", typeof(IComponent))]
+        [ProvideProperty("LoadLanguage", typeof(IComponent))]
+        [ProvideProperty("Localizable", typeof(IComponent))]
+        internal class LanguageExtenders : IExtenderProvider
+        {
+            private IServiceProvider _serviceProvider;
+            private IDesignerHost _host;
+            private IComponent _lastRoot;
+            private TypeConverter.StandardValuesCollection _supportedCultures;
+            private bool _localizable;
+            private CultureInfo _language;
+            private CultureInfo _loadLanguage;
+            private CultureInfo _defaultLanguage;
+
+            public LanguageExtenders(IServiceProvider serviceProvider, CultureInfo[] supportedCultures)
+            {
+                _serviceProvider = serviceProvider;
+                _host = serviceProvider.GetService(typeof(IDesignerHost)) as IDesignerHost;
+                _language = CultureInfo.InvariantCulture;
+
+                if (supportedCultures != null)
+                {
+                    _supportedCultures = new TypeConverter.StandardValuesCollection(supportedCultures);
+                }
+            }
+
+            /// <summary>
+            ///  A collection of custom supported cultures.  This can be null, indicating that the
+            ///  type converter should use the default set of supported cultures.
+            /// </summary>
+            internal TypeConverter.StandardValuesCollection SupportedCultures
+            {
+                get
+                {
+                    return _supportedCultures;
+                }
+            }
+
+            /// <summary>
+            ///  Returns the current default language for the thread.
+            /// </summary>
+            private CultureInfo ThreadDefaultLanguage
+            {
+                get
+                {
+                    if (_defaultLanguage == null)
+                    {
+                        _defaultLanguage = Application.CurrentCulture;
+                    }
+                    return _defaultLanguage;
+                }
+            }
+
+            /// <summary>
+            ///  Broadcasts a global change, indicating that all 
+            ///  objects on the designer have changed.
+            /// </summary>
+            private void BroadcastGlobalChange(IComponent comp)
+            {
+                ISite site = comp.Site;
+
+                if (site != null)
+                {
+                    IComponentChangeService cs = site.GetService(typeof(IComponentChangeService)) as IComponentChangeService;
+                    IContainer container = site.GetService(typeof(IContainer)) as IContainer;
+
+                    if (cs != null && container != null)
+                    {
+                        foreach (IComponent c in container.Components)
+                        {
+                            cs.OnComponentChanging(c, null);
+                            cs.OnComponentChanged(c, null, null, null);
+                        }
+                    }
+                }
+            }
+
+            /// <summary>
+            ///  This method compares the current root component
+            ///  with the last one we saw.  If they don't match,
+            ///  that means the designer has reloaded and we
+            ///  should set all of our properties back to their
+            ///  defaults.  This is more efficient than syncing
+            ///  an event.
+            /// </summary>
+            private void CheckRoot()
+            {
+                if (_host != null && _host.RootComponent != _lastRoot)
+                {
+                    _lastRoot = _host.RootComponent;
+                    _language = CultureInfo.InvariantCulture;
+                    _loadLanguage = null;
+                    _localizable = false;
+                }
+            }
+
+            /// <summary>
+            ///  Gets the language set for the specified object.
+            /// </summary>
+            [DesignOnly(true)]
+            [TypeConverter(typeof(LanguageCultureInfoConverter))]
+            [Category("Design")]
+            [SRDescriptionAttribute("LocalizationProviderLanguageDescr")]
+            public CultureInfo GetLanguage(IComponent o)
+            {
+                CheckRoot();
+
+                return _language;
+            }
+
+            /// <summary>
+            ///  Gets the language we'll use when re-loading the designer.
+            /// </summary>
+            [DesignOnly(true)]
+            [Browsable(false)]
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+            public CultureInfo GetLoadLanguage(IComponent o)
+            {
+                CheckRoot();
+
+                // If we never configured the load language, we're always invariant.
+                if (_loadLanguage == null)
+                {
+                    _loadLanguage = CultureInfo.InvariantCulture;
+                }
+
+                return _loadLanguage;
+            }
+
+            /// <summary>
+            ///  Gets a value indicating whether the specified object supports design-time localization 
+            ///  support.
+            /// </summary>
+            [DesignOnly(true)]
+            [Category("Design")]
+            [SRDescriptionAttribute("LocalizationProviderLocalizableDescr")]
+            public bool GetLocalizable(IComponent o)
+            {
+                CheckRoot();
+
+                return _localizable;
+            }
+
+            /// <summary>
+            ///  Sets the language to use.  When the language is set the designer will be
+            ///  reloaded.
+            /// </summary>
+            public void SetLanguage(IComponent o, CultureInfo language)
+            {
+                CheckRoot();
+
+                if (language == null)
+                {
+                    language = CultureInfo.InvariantCulture;
+                }
+
+                bool isInvariantCulture = (language.Equals(CultureInfo.InvariantCulture));
+
+                if (_language.Equals(language))
+                {
+                    return;
+                }
+
+                _language = language;
+
+                if (!isInvariantCulture)
+                {
+                    SetLocalizable(o, true);
+                }
+
+                if (_serviceProvider != null && _host != null)
+                {
+                    IDesignerLoaderService ls = _serviceProvider.GetService(typeof(IDesignerLoaderService)) as IDesignerLoaderService;
+
+                    // Only reload if we're not in the process of loading!
+                    if (_host.Loading)
+                    {
+                        _loadLanguage = language;
+                    }
+                    else
+                    {
+                        bool reloadSuccessful = false;
+
+                        if (ls != null)
+                        {
+                            reloadSuccessful = ls.Reload();
+                        }
+
+                        if (!reloadSuccessful)
+                        {
+                            IUIService uis = (IUIService)_serviceProvider.GetService(typeof(IUIService));
+
+                            if (uis != null)
+                            {
+                                uis.ShowMessage(SR.LocalizationProviderManualReload);
+                            }
+                        }
+                    }
+                }
+            }
+
+            /// <summary>
+            ///  Sets a value indicating whether or not the specified object has design-time 
+            ///  localization support.
+            /// </summary>
+            public void SetLocalizable(IComponent o, bool localizable)
+            {
+                CheckRoot();
+
+                if (localizable != _localizable)
+                {
+                    _localizable = localizable;
+
+                    if (!localizable)
+                    {
+                        SetLanguage(o, CultureInfo.InvariantCulture);
+                    }
+
+                    if (_host != null && !_host.Loading)
+                    {
+                        BroadcastGlobalChange(o);
+                    }
+                }
+            }
+
+            /// <summary>
+            ///  Gets a value indicating whether the specified object should have its design-time localization support persisted.
+            /// </summary>
+            private bool ShouldSerializeLanguage(IComponent o)
+            {
+                return (_language != null && _language != CultureInfo.InvariantCulture);
+            }
+
+            /// <summary>
+            ///  Gets a value indicating whether the specified object should have its design-time localization support persisted.
+            /// </summary>
+            private bool ShouldSerializeLocalizable(IComponent o)
+            {
+                return (_localizable);
+            }
+
+            /// <summary>
+            ///  Resets the localizable property to the 'defaultLocalizable' value.
+            /// </summary>
+            private void ResetLocalizable(IComponent o)
+            {
+                SetLocalizable(o, false);
+            }
+
+            /// <summary>
+            ///  Resets the language for the specified object.
+            /// </summary>
+            private void ResetLanguage(IComponent o)
+            {
+                SetLanguage(o, CultureInfo.InvariantCulture);
+            }
+
+            /// <summary>
+            ///  We only extend the root component.
+            /// </summary>
+            public bool CanExtend(object o)
+            {
+                CheckRoot();
+
+                return (_host != null && o == _host.RootComponent);
+            }
+        }
+
+        #region LanguageCultureInfoConverter 
+        /// <summary>
+        ///  This is a culture info converter that knows how to provide
+        ///  a restricted list of cultures based on the SupportedCultures
+        ///  property of the extender.  If the extender can't be found
+        ///  or the SupportedCultures property returns null, this 
+        ///  defaults to the stock implementation.
+        /// </summary>
+        internal sealed class LanguageCultureInfoConverter : CultureInfoConverter
+        {
+            /// <summary>
+            ///  Retrieves the Name for a input CultureInfo.
+            /// </summary>
+            protected override string GetCultureName(CultureInfo culture)
+            {
+                return culture.DisplayName;
+            }
+
+            /// <summary>
+            ///  Gets a collection of standard values collection for a System.Globalization.CultureInfo
+            ///  object using the specified context.
+            /// </summary>
+            public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+            {
+                StandardValuesCollection values = null;
+
+                if (context.PropertyDescriptor != null)
+                {
+                    ExtenderProvidedPropertyAttribute attr = context.PropertyDescriptor.Attributes[typeof(ExtenderProvidedPropertyAttribute)] as ExtenderProvidedPropertyAttribute;
+
+                    if (attr != null)
+                    {
+                        LanguageExtenders provider = attr.Provider as LanguageExtenders;
+
+                        if (provider != null)
+                        {
+                            values = provider.SupportedCultures;
+                        }
+                    }
+                }
+
+                if (values == null)
+                {
+                    values = base.GetStandardValues(context);
+                }
+
+                return values;
+            }
+        }
+        #endregion
+        #endregion
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ICodeDomDesignerReload.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ICodeDomDesignerReload.cs
@@ -1,0 +1,28 @@
+﻿
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CodeDom;
+
+namespace System.ComponentModel.Design.Serialization
+{
+    /// <summary>
+    ///  Implement this interface on a CodeDomProvider to optimize reloading in the designer.  When the designer
+    ///  goes to reparse a file, it will reparse the top level of the file, and then pass the new CodeCompileUnit to
+    ///  the ShouldReloadDesigner method, which returns true if the desinger should be reloaded.  Reloading generally occurs
+    ///  when the code inside the methods that the designer has generated, such as InitializeComponent have changed.  Otherwise,
+    ///  it is unnecessary to take the performance hit of reloading the designer.
+    /// </summary>
+    public interface ICodeDomDesignerReload
+    {
+        /// <summary>
+        ///  If ICodeDomDesignerReload is implemented on a CodeDomProvider that is in use by the designer, ShouldReloadDesigner will be called
+        ///  before a reload occurs.  Reloads generally occur when a user switches from design view to code view, modifies the code, and switches
+        ///  back to design view.  ShouldReloadDesigner allows the CodeDomProvider implementation to decide if code that is relevant to the designer
+        ///  has been modified -- ususally this is the code that the designer generated when the user saved or went to code view.
+        /// </summary>
+        bool ShouldReloadDesigner(CodeCompileUnit newTree);
+    }
+
+}

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/LocalizationCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/LocalizationCodeDomSerializer.cs
@@ -1,0 +1,177 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CodeDom;
+using System.Collections;
+using System.Diagnostics;
+using System.Resources;
+
+namespace System.ComponentModel.Design.Serialization
+{
+    /// <summary>
+    ///  Code model serializer for resource managers.  This is called
+    ///  in one of two ways.  On Deserialization, we are associated
+    ///  with a ResourceManager object.  Instead of creating a
+    ///  ResourceManager, however, we create an object called a
+    ///  SerializationResourceManager.  This class inherits
+    ///  from ResourceManager, but overrides all of the methods.
+    ///  Instead of letting resource manager maintain resource
+    ///  sets, it uses the designer host's IResourceService
+    ///  for this purpose.
+    ///  
+    ///  During serialization, this class will also create
+    ///  a SerializationResourceManager.  This will be added
+    ///  to the serialization manager as a service so other
+    ///  resource serializers can get at it.  SerializationResourceManager
+    ///  has additional methods on it to support writing data
+    ///  into the resource streams for various cultures.
+    /// </summary>
+    internal class LocalizationCodeDomSerializer : CodeDomSerializer
+    {
+        private readonly CodeDomLocalizationModel _model;
+        private readonly CodeDomSerializer _currentSerializer;
+
+        /// <summary>
+        ///  Only we can create an instance of this. Everyonen else accesses it though
+        ///  static properties.
+        /// </summary>
+        internal LocalizationCodeDomSerializer(CodeDomLocalizationModel model, object currentSerializer)
+        {
+            _model = model;
+            _currentSerializer = currentSerializer as CodeDomSerializer;
+        }
+
+        /// <summary>
+        ///  Returns true if we should emit an ApplyResources method for this object. We only emit
+        ///  this method once during serialization, and we track this by appending an object to
+        ///  the context stack.
+        /// </summary>
+        private bool EmitApplyMethod(IDesignerSerializationManager manager, object owner)
+        {
+            ApplyMethodTable table = (ApplyMethodTable)manager.Context[typeof(ApplyMethodTable)];
+
+            if (table == null)
+            {
+                table = new ApplyMethodTable();
+                manager.Context.Append(table);
+            }
+
+            if (!table.Contains(owner))
+            {
+                table.Add(owner);
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        ///  Serializes the given object into a CodeDom object.  This uses the stock
+        ///  resource serialization scheme and retains the expression it provides.
+        /// </summary>
+        public override object Serialize(IDesignerSerializationManager manager, object value)
+        {
+            PropertyDescriptor desc = (PropertyDescriptor)manager.Context[typeof(PropertyDescriptor)];
+            ExpressionContext tree = (ExpressionContext)manager.Context[typeof(ExpressionContext)];
+            bool isSerializable = (value != null) ? GetReflectionTypeHelper(manager, value).IsSerializable : true;
+
+            // If value is not serializable, we have no option but to call the original serializer,
+            // since we cannot push this into resources.
+            bool callExistingSerializer = !isSerializable;
+
+            // Compat: If we are serializing content, we need to skip property reflection to preserve compatibility, 
+            //         since tools like WinRes expect items in collections (like TreeNodes and ListViewItems) 
+            //         to be serialized as binary blobs.
+            bool serializingContent = (desc != null && desc.Attributes.Contains(DesignerSerializationVisibilityAttribute.Content));
+
+            // We also skip back to the original serializer if there is a preset value for this object.
+            if (!callExistingSerializer)
+            {
+                callExistingSerializer = tree != null && tree.PresetValue != null && tree.PresetValue == value;
+            }
+
+            if (_model == CodeDomLocalizationModel.PropertyReflection && !serializingContent && !callExistingSerializer)
+            {
+                // For a property reflecting model, we need to do more work.  Here we need to find
+                // the object we are serializing against and inject an "ApplyResources" method
+                // against the object and its name.  If any of this machinery fails we will
+                // just return the existing expression which will default to the original behavior.
+                CodeStatementCollection statements = (CodeStatementCollection)manager.Context[typeof(CodeStatementCollection)];
+
+                // In the case of extender properties, we don't want to serialize using the property
+                // reflecting model.  In this case we'll skip it and fall through to the
+                // property assignment model.
+                bool skipPropertyReflect = false;
+                ExtenderProvidedPropertyAttribute attr = null;
+
+                if (desc != null)
+                {
+                    attr = desc.Attributes[typeof(ExtenderProvidedPropertyAttribute)] as ExtenderProvidedPropertyAttribute;
+
+                    if (attr != null && attr.ExtenderProperty != null)
+                    {
+                        skipPropertyReflect = true;
+                    }
+                }
+
+                if (!skipPropertyReflect && tree != null && statements != null)
+                {
+                    string name = manager.GetName(tree.Owner);
+                    CodeExpression ownerExpression = SerializeToExpression(manager, tree.Owner);
+
+                    if (name != null && ownerExpression != null)
+                    {
+                        RootContext rootCxt = manager.Context[typeof(RootContext)] as RootContext;
+
+                        if (rootCxt != null && rootCxt.Value == tree.Owner)
+                        {
+                            name = "$this";
+                        }
+
+                        // Ok, if we got here it means we have enough data to emit
+                        // using the reflection model.
+                        SerializeToResourceExpression(manager, value, false);
+
+                        if (EmitApplyMethod(manager, tree.Owner))
+                        {
+                            ResourceManager rm = manager.Context[typeof(ResourceManager)] as ResourceManager;
+                            Debug.Assert(rm != null, "No resource manager available in context.");
+                            CodeExpression rmExpression = GetExpression(manager, rm);
+                            Debug.Assert(rmExpression != null, "No expression available for resource manager.");
+
+                            CodeMethodReferenceExpression methodRef = new CodeMethodReferenceExpression(rmExpression, "ApplyResources");
+                            CodeMethodInvokeExpression methodInvoke = new CodeMethodInvokeExpression();
+
+                            methodInvoke.Method = methodRef;
+                            methodInvoke.Parameters.Add(ownerExpression);
+                            methodInvoke.Parameters.Add(new CodePrimitiveExpression(name));
+                            statements.Add(methodInvoke);
+                        }
+
+                        return null;    // we have already worked our statements into the tree.
+                    }
+                }
+            }
+
+            if (callExistingSerializer)
+            {
+                return _currentSerializer.Serialize(manager, value);
+            }
+
+            return SerializeToResourceExpression(manager, value);
+        }
+
+        /// <summary>
+        ///  This class is used as a table to track which objects we've injected the "ApplyResources" method for.
+        /// </summary>
+        private class ApplyMethodTable
+        {
+            private readonly Hashtable _table = new Hashtable();
+
+            internal bool Contains(object value) => _table.ContainsKey(value);
+
+            internal void Add(object value) => _table.Add(value, value);
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourcePropertyMemberCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourcePropertyMemberCodeDomSerializer.cs
@@ -1,0 +1,146 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CodeDom;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace System.ComponentModel.Design.Serialization
+{
+    /// <summary>
+    ///  This serializer replaces the property serializer for properties when we're
+    ///  in localization mode.
+    /// </summary>
+	internal class ResourcePropertyMemberCodeDomSerializer : MemberCodeDomSerializer
+    {
+        private CodeDomLocalizationModel _model;
+        private MemberCodeDomSerializer _serializer;
+        private CodeDomLocalizationProvider.LanguageExtenders _extender;
+        private CultureInfo localizationLanguage = null;
+
+        internal ResourcePropertyMemberCodeDomSerializer(MemberCodeDomSerializer serializer, CodeDomLocalizationProvider.LanguageExtenders extender, CodeDomLocalizationModel model)
+        {
+            Debug.Assert(extender != null, "Extender should have been created by now.");
+
+            _serializer = serializer;
+            _extender = extender;
+            _model = model;
+        }
+
+        /// <summary>
+        ///  This method actually performs the serialization.  When the member is serialized
+        ///  the necessary statements will be added to the statements collection.
+        /// </summary>
+        public override void Serialize(IDesignerSerializationManager manager, object value, MemberDescriptor descriptor, CodeStatementCollection statements)
+        {
+            // We push the localization model to indicate that our serializer is in control.  Our
+            // serialization provider looks for this and decides what type of resource serializer
+            // to give us.
+            manager.Context.Push(_model);
+
+            try
+            {
+                _serializer.Serialize(manager, value, descriptor, statements);
+            }
+            finally
+            {
+                manager.Context.Pop();
+            }
+        }
+
+        private CultureInfo GetLocalizationLanguage(IDesignerSerializationManager manager)
+        {
+            if (localizationLanguage == null)
+            {
+                // Check to see if our base component's localizable prop is true
+                RootContext rootCxt = manager.Context[typeof(RootContext)] as RootContext;
+                
+                if (rootCxt != null)
+                {
+                    object comp = rootCxt.Value;
+                    PropertyDescriptor prop = TypeDescriptor.GetProperties(comp)["LoadLanguage"];
+                    
+                    if (prop != null && prop.PropertyType == typeof(CultureInfo))
+                    {
+                        localizationLanguage = (CultureInfo)prop.GetValue(comp);
+                    }
+                }
+            }
+
+            return localizationLanguage;
+        }
+
+        private void OnSerializationComplete(object sender, EventArgs e)
+        {
+            // we do the cleanup here and clear out the cache of the localizedlanguage
+            localizationLanguage = null;
+
+            //unhook the event
+            IDesignerSerializationManager manager = sender as IDesignerSerializationManager;
+            Debug.Assert(manager != null, "manager should not be null!");
+            
+            if (manager != null)
+            {
+                manager.SerializationComplete -= new EventHandler(OnSerializationComplete);
+            }
+        }
+
+        /// <summary>
+        ///  This method returns true if the given member descriptor should be serialized,
+        ///  or false if there is no need to serialize the member.
+        /// </summary>
+        public override bool ShouldSerialize(IDesignerSerializationManager manager, object value, MemberDescriptor descriptor)
+        {
+            bool shouldSerialize = _serializer.ShouldSerialize(manager, value, descriptor);
+
+            if (!shouldSerialize && !descriptor.Attributes.Contains(DesignOnlyAttribute.Yes))
+            {
+                switch (_model)
+                {
+                    case CodeDomLocalizationModel.PropertyReflection:
+                        if (!shouldSerialize)
+                        {
+                            // hook up the event the first time to clear out our cache at the end of the serialization
+                            if (localizationLanguage == null)
+                            {
+                                manager.SerializationComplete += new EventHandler(OnSerializationComplete);
+                            }
+                            if (GetLocalizationLanguage(manager) != CultureInfo.InvariantCulture)
+                            {
+                                shouldSerialize = true;
+                            }
+                        }
+                        break;
+
+                    case CodeDomLocalizationModel.PropertyAssignment:
+                        // If this property contains its default value, we still want to serialize it if we are in
+                        // localization mode if we are writing to the default culture, but only if the object
+                        // is not inherited.
+                        InheritanceAttribute inheritance = (InheritanceAttribute)manager.Context[typeof(InheritanceAttribute)];
+
+                        if (inheritance == null)
+                        {
+                            inheritance = (InheritanceAttribute)TypeDescriptor.GetAttributes(value)[typeof(InheritanceAttribute)];
+                            if (inheritance == null)
+                            {
+                                inheritance = InheritanceAttribute.NotInherited;
+                            }
+                        }
+
+                        if (inheritance.InheritanceLevel != InheritanceLevel.InheritedReadOnly)
+                        {
+                            shouldSerialize = true;
+                        }
+
+                        break;
+
+                    default:
+                        break;
+                }
+            }
+
+            return shouldSerialize;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/TypeCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/TypeCodeDomSerializer.cs
@@ -48,12 +48,12 @@ namespace System.ComponentModel.Design.Serialization
         {
             if (manager == null)
             {
-                throw new ArgumentNullException("manager");
+                throw new ArgumentNullException(nameof(manager));
             }
 
             if (declaration == null)
             {
-                throw new ArgumentNullException("declaration");
+                throw new ArgumentNullException(nameof(declaration));
             }
 
             object rootObject = null;
@@ -355,15 +355,15 @@ namespace System.ComponentModel.Design.Serialization
         {
             if (manager == null)
             {
-                throw new ArgumentNullException("manager");
+                throw new ArgumentNullException(nameof(manager));
             }
             if (declaration == null)
             {
-                throw new ArgumentNullException("declaration");
+                throw new ArgumentNullException(nameof(declaration));
             }
             if (value == null)
             {
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
             }
             if (!(declaration.UserData[s_initMethodKey] is CodeConstructor ctor))
             {
@@ -380,11 +380,11 @@ namespace System.ComponentModel.Design.Serialization
         {
             if (manager == null)
             {
-                throw new ArgumentNullException("manager");
+                throw new ArgumentNullException(nameof(manager));
             }
             if (declaration == null)
             {
-                throw new ArgumentNullException("declaration");
+                throw new ArgumentNullException(nameof(declaration));
             }
             foreach (CodeTypeMember member in declaration.Members)
             {
@@ -430,11 +430,11 @@ namespace System.ComponentModel.Design.Serialization
         {
             if (manager == null)
             {
-                throw new ArgumentNullException("manager");
+                throw new ArgumentNullException(nameof(manager));
             }
             if (root == null)
             {
-                throw new ArgumentNullException("root");
+                throw new ArgumentNullException(nameof(root));
             }
             Trace("TypeCodeDomSerializer::Serialize");
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCodeDomSerializer.cs
@@ -1,0 +1,465 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CodeDom;
+using System.Collections;
+using System.ComponentModel;
+using System.ComponentModel.Design;
+using System.ComponentModel.Design.Serialization;
+using System.Diagnostics;
+using System.Reflection;
+using System.Globalization;
+
+namespace System.Windows.Forms.Design
+{
+    /// <summary>
+    ///  Control's provide their own serializer so they can write out resource hierarchy
+    ///  information.  We delegate nearly everything to our base class's serializer.
+    /// </summary>
+    internal class ControlCodeDomSerializer : CodeDomSerializer
+    {
+        /// <summary>
+        ///  Deserilizes the given CodeDom object into a real object.  This
+        ///  will use the serialization manager to create objects and resolve
+        ///  data types.  The root of the object graph is returned.
+        /// </summary>
+        public override object Deserialize(IDesignerSerializationManager manager, object codeObject)
+        {
+            if (manager == null || codeObject == null)
+            {
+                throw new ArgumentNullException(manager == null ? "manager" : "codeObject");
+            }
+
+            //Attempt to suspend all components within the icontainer
+            IContainer container = (IContainer)manager.GetService(typeof(IContainer));
+            ArrayList suspendedComponents = null;
+
+            if (container != null)
+            {
+                suspendedComponents = new ArrayList(container.Components.Count);
+
+                foreach (IComponent comp in container.Components)
+                {
+                    Control control = comp as Control;
+
+                    if (control != null)
+                    {
+                        control.SuspendLayout();
+
+                        //Add this control to our suspended components list so we can resume later
+                        suspendedComponents.Add(control);
+                    }
+                }
+            }
+
+            object objectGraphData = null;
+
+            try
+            {
+                // Find our base class's serializer.  
+                CodeDomSerializer serializer = (CodeDomSerializer)manager.GetSerializer(typeof(Component), typeof(CodeDomSerializer));
+
+                if (serializer == null)
+                {
+                    Debug.Fail("Unable to find a CodeDom serializer for 'Component'. Has someone tampered with the serialization providers?");
+
+                    return null;
+                }
+
+                objectGraphData = serializer.Deserialize(manager, codeObject);
+            }
+            finally
+            {
+                //resume all suspended comps we found earlier
+                if (suspendedComponents != null)
+                {
+                    foreach (Control c in suspendedComponents)
+                    {
+                        // Dev10 Bug #462211: Controls in design time may change their size due to incorrectly
+                        // calculated anchor info.
+                        // UNDONE: c.ResumeLayout(false) because it regressed layouts with Dock property
+                        // see Dev11 bug 117530 DTS Winforms: Upgraded project -Control location and size are changed in the designer gen'd code
+                        c.ResumeLayout(true /*performLayout*/);
+                    }
+                }
+            }
+
+            return objectGraphData;
+        }
+
+        private bool HasAutoSizedChildren(Control parent)
+        {
+            foreach (Control child in parent.Controls)
+            {
+                if (child.AutoSize)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private bool HasMixedInheritedChildren(Control parent)
+        {
+            bool inheritedChildren = false;
+            bool nonInheritedChildren = false;
+
+            foreach (Control c in parent.Controls)
+            {
+                InheritanceAttribute ia = (InheritanceAttribute)TypeDescriptor.GetAttributes(c)[typeof(InheritanceAttribute)];
+
+                if (ia != null && ia.InheritanceLevel != InheritanceLevel.NotInherited)
+                {
+                    inheritedChildren = true;
+                }
+                else
+                {
+                    nonInheritedChildren = true;
+                }
+
+                if (inheritedChildren && nonInheritedChildren)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        protected virtual bool HasSitedNonReadonlyChildren(Control parent)
+        {
+            if (!parent.HasChildren)
+            {
+                return false;
+            }
+
+            foreach (Control c in parent.Controls)
+            {
+                if (c.Site != null && c.Site.DesignMode)
+                {
+                    // We only emit Size/Location information for controls that are sited and not inherrited readonly.
+                    InheritanceAttribute ia = (InheritanceAttribute)TypeDescriptor.GetAttributes(c)[typeof(InheritanceAttribute)];
+
+                    if (ia != null && ia.InheritanceLevel != InheritanceLevel.InheritedReadOnly)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        ///  Serializes the given object into a CodeDom object.
+        /// </summary>
+        public override object Serialize(IDesignerSerializationManager manager, object value)
+        {
+            if (manager == null || value == null)
+            {
+                throw new ArgumentNullException(manager == null ? "manager" : "value");
+            }
+
+            // Find our base class's serializer.  
+            CodeDomSerializer serializer = (CodeDomSerializer)manager.GetSerializer(typeof(Component), typeof(CodeDomSerializer));
+
+            if (serializer == null)
+            {
+                Debug.Fail("Unable to find a CodeDom serializer for 'Component'.  Has someone tampered with the serialization providers?");
+
+                return null;
+            }
+
+            // Now ask it to serializer
+            object retVal = serializer.Serialize(manager, value);
+            InheritanceAttribute inheritanceAttribute = (InheritanceAttribute)TypeDescriptor.GetAttributes(value)[typeof(InheritanceAttribute)];
+            InheritanceLevel inheritanceLevel = InheritanceLevel.NotInherited;
+
+            if (inheritanceAttribute != null)
+            {
+                inheritanceLevel = inheritanceAttribute.InheritanceLevel;
+            }
+
+            if (inheritanceLevel != InheritanceLevel.InheritedReadOnly)
+            {
+                // Next, see if we are in localization mode.  If we are, and if we can get
+                // to a ResourceManager through the service provider, then emit the hierarchy information for
+                // this object.  There is a small fragile assumption here:  The resource manager is demand
+                // created, so if all of the properties of this control had default values it is possible
+                // there will be no resource manager for us.  I'm letting that slip a bit, however, because
+                // for Control classes, we always emit at least the location / size information for the
+                // control.
+                IDesignerHost host = (IDesignerHost)manager.GetService(typeof(IDesignerHost));
+
+                if (host != null)
+                {
+                    PropertyDescriptor prop = TypeDescriptor.GetProperties(host.RootComponent)["Localizable"];
+
+                    if (prop != null && prop.PropertyType == typeof(bool) && ((bool)prop.GetValue(host.RootComponent)))
+                    {
+                        SerializeControlHierarchy(manager, host, value);
+                    }
+                }
+
+                CodeStatementCollection csCollection = retVal as CodeStatementCollection;
+                
+                if (csCollection != null)
+                {
+                    Control control = (Control)value;
+
+                    // Serialize a suspend / resume pair.  We always serialize this
+                    // for the root component
+                    if ((host != null && control == host.RootComponent) || HasSitedNonReadonlyChildren(control))
+                    {
+                        SerializeSuspendLayout(manager, csCollection, value);
+                        SerializeResumeLayout(manager, csCollection, value);
+                        ControlDesigner controlDesigner = host.GetDesigner(control) as ControlDesigner;
+                        
+                        if (HasAutoSizedChildren(control) || (controlDesigner != null && controlDesigner.SerializePerformLayout))
+                        {
+                            SerializePerformLayout(manager, csCollection, value);
+                        }
+                    }
+
+                    // And now serialize the correct z-order relationships for the controls.  We only need to 
+                    // do this if there are controls in the collection that are inherited.
+                    if (HasMixedInheritedChildren(control))
+                    {
+                        SerializeZOrder(manager, csCollection, control);
+                    }
+                }
+            }
+
+            return retVal;
+        }
+
+        /// <summary>
+        ///  This writes out our control hierarchy information if there is a resource manager available for us to write to.
+        /// </summary>
+        private void SerializeControlHierarchy(IDesignerSerializationManager manager, IDesignerHost host, object value)
+        {
+            Control control = value as Control;
+
+            if (control != null)
+            {
+                // Object name
+                string name;
+                IMultitargetHelperService mthelperSvc = host.GetService(typeof(IMultitargetHelperService)) as IMultitargetHelperService;
+
+                if (control == host.RootComponent)
+                {
+                    name = "$this";
+
+                    // For the root component, we also take this as
+                    // an opportunity to emit information for all non-visual components in the container too.
+                    foreach (IComponent component in host.Container.Components)
+                    {
+                        // Skip controls
+                        if (component is Control)
+                        {
+                            continue;
+                        }
+
+                        // Skip privately inherited components
+                        if (TypeDescriptor.GetAttributes(component).Contains(InheritanceAttribute.InheritedReadOnly))
+                        {
+                            continue;
+                        }
+
+                        // Now emit the data
+                        string componentName = manager.GetName(component);
+                        string componentTypeName = mthelperSvc == null ? component.GetType().AssemblyQualifiedName : mthelperSvc.GetAssemblyQualifiedName(component.GetType());
+
+                        if (componentName != null)
+                        {
+                            SerializeResourceInvariant(manager, ">>" + componentName + ".Name", componentName);
+                            SerializeResourceInvariant(manager, ">>" + componentName + ".Type", componentTypeName);
+                        }
+                    }
+                }
+                else
+                {
+                    name = manager.GetName(value);
+
+                    // if we get null back, this must be an unsited control
+                    if (name == null)
+                    {
+                        Debug.Assert(!(value is IComponent) || ((IComponent)value).Site == null, "Unnamed, sited control in hierarchy");
+                        return;
+                    }
+                }
+
+                SerializeResourceInvariant(manager, ">>" + name + ".Name", manager.GetName(value));
+
+                // Object type
+                SerializeResourceInvariant(manager, ">>" + name + ".Type", mthelperSvc == null ? control.GetType().AssemblyQualifiedName : mthelperSvc.GetAssemblyQualifiedName(control.GetType()));
+
+                // Parent
+                Control parent = control.Parent;
+                
+                if (parent != null && parent.Site != null)
+                {
+                    string parentName;
+
+                    if (parent == host.RootComponent)
+                    {
+                        parentName = "$this";
+                    }
+                    else
+                    {
+                        parentName = manager.GetName(parent);
+                    }
+
+                    if (parentName != null)
+                    {
+                        SerializeResourceInvariant(manager, ">>" + name + ".Parent", parentName);
+                    }
+
+                    // Z-Order
+                    for (int i = 0; i < parent.Controls.Count; i++)
+                    {
+                        if (parent.Controls[i] == control)
+                        {
+                            SerializeResourceInvariant(manager, ">>" + name + ".ZOrder", i.ToString(CultureInfo.InvariantCulture));
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        private enum StatementOrdering
+        {
+            Prepend,
+            Append
+        }
+
+        private static Type ToTargetType(object context, Type runtimeType)
+        {
+            return TypeDescriptor.GetProvider(context).GetReflectionType(runtimeType);
+        }
+
+        private static Type[] ToTargetTypes(object context, Type[] runtimeTypes)
+        {
+            Type[] types = new Type[runtimeTypes.Length];
+            
+            for (int i = 0; i < runtimeTypes.Length; i++)
+            {
+                types[i] = ToTargetType(context, runtimeTypes[i]);
+            
+            }
+
+            return types;
+        }
+
+        /// <summary>
+        ///  Serializes a method invocation on the control being serialized.  Used to serialize Suspend/ResumeLayout pairs, etc.
+        /// </summary>
+        private void SerializeMethodInvocation(IDesignerSerializationManager manager, CodeStatementCollection statements, object control, string methodName, CodeExpressionCollection parameters, Type[] paramTypes, StatementOrdering ordering)
+        {
+            using (TraceScope("ControlCodeDomSerializer::SerializeMethodInvocation(" + methodName + ")"))
+            {
+                string name = manager.GetName(control);
+                Trace(name + "." + methodName);
+
+                // Use IReflect to see if this method name exists on the control.  
+                paramTypes = ToTargetTypes(control, paramTypes);
+                MethodInfo mi = TypeDescriptor.GetReflectionType(control).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance, null, paramTypes, null);
+                
+                if (mi != null)
+                {
+                    CodeExpression field = SerializeToExpression(manager, control);
+                    CodeMethodReferenceExpression method = new CodeMethodReferenceExpression(field, methodName);
+                    CodeMethodInvokeExpression methodInvoke = new CodeMethodInvokeExpression();
+                    methodInvoke.Method = method;
+                    
+                    if (parameters != null)
+                    {
+                        methodInvoke.Parameters.AddRange(parameters);
+                    }
+
+                    CodeExpressionStatement statement = new CodeExpressionStatement(methodInvoke);
+                    
+                    switch (ordering)
+                    {
+                        case StatementOrdering.Prepend:
+                            statement.UserData["statement-ordering"] = "begin";
+                            break;
+                        case StatementOrdering.Append:
+                            statement.UserData["statement-ordering"] = "end";
+                            break;
+                        default:
+                            Debug.Fail("Unsupported statement ordering: " + ordering);
+                            break;
+                    }
+
+                    statements.Add(statement);
+                }
+            }
+        }
+
+        private void SerializePerformLayout(IDesignerSerializationManager manager, CodeStatementCollection statements, object control)
+        {
+            SerializeMethodInvocation(manager, statements, control, "PerformLayout", null, new Type[0], StatementOrdering.Append);
+        }
+
+        private void SerializeResumeLayout(IDesignerSerializationManager manager, CodeStatementCollection statements, object control)
+        {
+            CodeExpressionCollection parameters = new CodeExpressionCollection();
+            parameters.Add(new CodePrimitiveExpression(false));
+            Type[] paramTypes = { typeof(bool) };
+            SerializeMethodInvocation(manager, statements, control, "ResumeLayout", parameters, paramTypes, StatementOrdering.Append);
+        }
+
+        private void SerializeSuspendLayout(IDesignerSerializationManager manager, CodeStatementCollection statements, object control)
+        {
+            SerializeMethodInvocation(manager, statements, control, "SuspendLayout", null, new Type[0], StatementOrdering.Prepend);
+        }
+
+        /// <summary>
+        ///  Serializes a series of SetChildIndex() statements for each control iln a child control collection in
+        ///  reverse order.
+        /// </summary>
+        private void SerializeZOrder(IDesignerSerializationManager manager, CodeStatementCollection statements, Control control)
+        {
+            using (TraceScope("ControlCodeDomSerializer::SerializeZOrder()"))
+            {
+                // Push statements in reverse order so the first guy in the
+                // collection is the last one to be brought to the front.
+                for (int i = control.Controls.Count - 1; i >= 0; i--)
+                {
+                    // Only serialize this control if it is (a) sited and
+                    // (b) not being privately inherited
+                    Control child = control.Controls[i];
+
+                    if (child.Site == null || child.Site.Container != control.Site.Container)
+                    {
+                        continue;
+                    }
+
+                    InheritanceAttribute attr = (InheritanceAttribute)TypeDescriptor.GetAttributes(child)[typeof(InheritanceAttribute)];
+                    
+                    if (attr.InheritanceLevel == InheritanceLevel.InheritedReadOnly)
+                    {
+                        continue;
+                    }
+
+                    // Create the "control.Controls.SetChildIndex" call
+                    CodeExpression controlsCollection = new CodePropertyReferenceExpression(SerializeToExpression(manager, control), "Controls");
+                    CodeMethodReferenceExpression method = new CodeMethodReferenceExpression(controlsCollection, "SetChildIndex");
+                    CodeMethodInvokeExpression methodInvoke = new CodeMethodInvokeExpression();
+                    methodInvoke.Method = method;
+
+                    // Fill in parameters
+                    CodeExpression childControl = SerializeToExpression(manager, child);
+                    methodInvoke.Parameters.Add(childControl);
+                    methodInvoke.Parameters.Add(SerializeToExpression(manager, 0));
+                    CodeExpressionStatement statement = new CodeExpressionStatement(methodInvoke);
+                    statements.Add(statement);
+                }
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewRowCollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewRowCollectionCodeDomSerializer.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CodeDom;
+using System.Collections;
+using System.ComponentModel.Design.Serialization;
+using System.Diagnostics;
+
+namespace System.Windows.Forms.Design
+{
+    internal class DataGridViewRowCollectionCodeDomSerializer : CollectionCodeDomSerializer
+    {
+        private static DataGridViewRowCollectionCodeDomSerializer s_defaultSerializer;
+
+        // FxCop made me add this constructor
+        private DataGridViewRowCollectionCodeDomSerializer() { }
+
+        /// <summery>
+        ///  Retrieves a default static instance of this serializer.
+        /// </summery>
+        internal static DataGridViewRowCollectionCodeDomSerializer DefaultSerializer
+        {
+            get
+            {
+                if (s_defaultSerializer == null)
+                {
+                    s_defaultSerializer = new DataGridViewRowCollectionCodeDomSerializer();
+                }
+
+                return s_defaultSerializer;
+            }
+        }
+
+        /// <summery>
+        ///  Serializes the given collection.  targetExpression will refer to the expression used to rever to the 
+        ///  collection, but it can be null.
+        /// </summery>
+        protected override object SerializeCollection(IDesignerSerializationManager manager, CodeExpression targetExpression, Type targetType, ICollection originalCollection, ICollection valuesToSerialize)
+        {
+#if DEBUG
+            // some checks
+            DataGridViewRowCollection rowCollection = originalCollection as DataGridViewRowCollection;
+
+            if (rowCollection.Count > 0)
+            {
+                Debug.Assert(rowCollection.Count == 1, " we should have only the add new row");
+                DataGridView dataGridView = rowCollection[0].DataGridView;
+                Debug.Assert(dataGridView.AllowUserToAddRows, "we only have the add new row when the data grid view allows users to add rows");
+            }
+#endif // DEBUG
+
+            // with the new dataGridView designer we don't serialize any rows any more.
+            // the only purpose of this serializer is to block serialization of the DataGridView add new row.
+            // which is accomplished by returning an empty codeStatementCollection;
+
+            return new CodeStatementCollection();
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageCollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageCollectionCodeDomSerializer.cs
@@ -2,7 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.CodeDom;
+using System.Collections.Specialized;
+using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
+using System.Diagnostics;
 
 namespace System.Windows.Forms.Design
 {
@@ -17,7 +21,23 @@ namespace System.Windows.Forms.Design
         /// </summary>
         public override object Deserialize(IDesignerSerializationManager manager, object codeObject)
         {
-            throw new NotImplementedException(SR.NotImplementedByDesign);
+            // REVIEW: Please look at this carefully - This is just copied from ControlCodeDomSerializer
+            if (manager == null || codeObject == null)
+            {
+                throw new ArgumentNullException(manager == null ? "manager" : "codeObject");
+            }
+
+            // Find our base class's serializer.  
+            CodeDomSerializer serializer = (CodeDomSerializer)manager.GetSerializer(typeof(Component), typeof(CodeDomSerializer));
+            
+            if (serializer == null)
+            {
+                Debug.Fail("Unable to find a CodeDom serializer for 'Component'.  Has someone tampered with the serialization providers?");
+
+                return null;
+            }
+
+            return serializer.Deserialize(manager, codeObject);
         }
 
         /// <summary>
@@ -25,7 +45,43 @@ namespace System.Windows.Forms.Design
         /// </summary>
         public override object Serialize(IDesignerSerializationManager manager, object value)
         {
-            throw new NotImplementedException(SR.NotImplementedByDesign);
+            CodeDomSerializer baseSerializer = (CodeDomSerializer)manager.GetSerializer(typeof(ImageList).BaseType, typeof(CodeDomSerializer));
+            object codeObject = baseSerializer.Serialize(manager, value);
+            ImageList imageList = value as ImageList;
+            
+            if (imageList != null)
+            {
+                StringCollection imageKeys = imageList.Images.Keys;
+
+                if (codeObject is CodeStatementCollection)
+                {
+                    CodeExpression imageListObject = GetExpression(manager, value);
+                    
+                    if (imageListObject != null)
+                    {
+                        CodeExpression imageListImagesProperty = new CodePropertyReferenceExpression(imageListObject, "Images");
+
+                        if (imageListImagesProperty != null)
+                        {
+                            for (int i = 0; i < imageKeys.Count; i++)
+                            {
+                                if ((imageKeys[i] != null) || (imageKeys[i].Length != 0))
+                                {
+                                    CodeMethodInvokeExpression setNameMethodCall = new CodeMethodInvokeExpression(imageListImagesProperty, "SetKeyName",
+                                                                                   new CodeExpression[] {
+                                                                                            new CodePrimitiveExpression(i),         // SetKeyName(int,
+                                                                                            new CodePrimitiveExpression(imageKeys[i])        // string);
+                                                                                            });
+
+                                    ((CodeStatementCollection)codeObject).Add(setNameMethodCall);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            return codeObject;
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutControlCollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutControlCollectionCodeDomSerializer.cs
@@ -1,0 +1,101 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CodeDom;
+using System.Collections;
+using System.ComponentModel;
+using System.ComponentModel.Design.Serialization;
+
+namespace System.Windows.Forms.Design
+{
+    //This is the serializer for TableLayoutControlCollection. It uses the Add(control, col, row)
+    //syntax to add a control to the specific cell of the table whenever appropriate.
+    //most of the code is copied from CollectionCodeDomSerializer. 
+    internal class TableLayoutControlCollectionCodeDomSerializer : CollectionCodeDomSerializer
+    {
+        /// <summary>
+        ///  Serializes the given collection.  targetExpression will refer to the expression used to rever to the 
+        ///  collection, but it can be null.
+        /// </summary>
+        protected override object SerializeCollection(IDesignerSerializationManager manager, CodeExpression targetExpression, Type targetType, ICollection originalCollection, ICollection valuesToSerialize)
+        {
+            // Here we need to invoke Add once for each and every item in the collection. We can re-use the property
+            // reference and method reference, but we will need to recreate the invoke statement each time.
+            CodeStatementCollection statements = new CodeStatementCollection();
+            CodeMethodReferenceExpression methodRef = new CodeMethodReferenceExpression(targetExpression, "Add");
+            TableLayoutControlCollection tableCollection = (TableLayoutControlCollection)originalCollection;
+
+            if (valuesToSerialize.Count > 0)
+            {
+                bool isTargetInherited = false;
+                ExpressionContext cxt = manager.Context[typeof(ExpressionContext)] as ExpressionContext;
+
+                if (cxt != null && cxt.Expression == targetExpression)
+                {
+                    IComponent comp = cxt.Owner as IComponent;
+
+                    if (comp != null)
+                    {
+                        InheritanceAttribute ia = (InheritanceAttribute)TypeDescriptor.GetAttributes(comp)[typeof(InheritanceAttribute)];
+                        isTargetInherited = (ia != null && ia.InheritanceLevel == InheritanceLevel.Inherited);
+                    }
+                }
+
+                foreach (object o in valuesToSerialize)
+                {
+                    bool genCode = !(o is IComponent);
+
+                    if (!genCode)
+                    {
+                        InheritanceAttribute ia = (InheritanceAttribute)TypeDescriptor.GetAttributes(o)[typeof(InheritanceAttribute)];
+
+                        if (ia != null)
+                        {
+                            if (ia.InheritanceLevel == InheritanceLevel.InheritedReadOnly)
+                                genCode = false;
+                            else if (ia.InheritanceLevel == InheritanceLevel.Inherited && isTargetInherited)
+                                genCode = false;
+                            else
+                                genCode = true;
+                        }
+                        else
+                        {
+                            genCode = true;
+                        }
+                    }
+
+                    if (genCode)
+                    {
+                        CodeMethodInvokeExpression statement = new CodeMethodInvokeExpression();
+                        statement.Method = methodRef;
+                        CodeExpression serializedObj = SerializeToExpression(manager, o);
+
+                        if (serializedObj != null && !typeof(Control).IsAssignableFrom(o.GetType()))
+                        {
+                            serializedObj = new CodeCastExpression(typeof(Control), serializedObj);
+                        }
+
+                        if (serializedObj != null)
+                        {
+                            int col, row;
+                            col = tableCollection.Container.GetColumn((Control)o);
+                            row = tableCollection.Container.GetRow((Control)o);
+                            statement.Parameters.Add(serializedObj);
+
+                            if (col != -1 || row != -1)
+                            {
+                                statement.Parameters.Add(new CodePrimitiveExpression(col));
+                                statement.Parameters.Add(new CodePrimitiveExpression(row));
+                            }
+
+                            statements.Add(statement);
+                        }
+                    }
+                }
+            }
+
+            return statements;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutPanelCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutPanelCodeDomSerializer.cs
@@ -1,0 +1,86 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.ComponentModel.Design;
+using System.Diagnostics;
+using System.ComponentModel.Design.Serialization;
+
+namespace System.Windows.Forms.Design
+{
+    /// <summary>
+    ///  Custom serializer for the TableLayoutPanel. We need this so we can push the TableLayoutSettings object
+    ///  into the resx in localization mode. This is used by loc tools like WinRes to correctly setup the 
+    ///  TableLayoutPanel with all its settings. Note that we don't serialize code to access the settings.
+    /// </summary>
+    internal class TableLayoutPanelCodeDomSerializer : CodeDomSerializer
+    {
+        private static readonly string s_layoutSettingsPropName = "LayoutSettings";
+
+        public override object Deserialize(IDesignerSerializationManager manager, object codeObject)
+        {
+            return GetBaseSerializer(manager).Deserialize(manager, codeObject);
+        }
+
+        private CodeDomSerializer GetBaseSerializer(IDesignerSerializationManager manager)
+        {
+            return (CodeDomSerializer)manager.GetSerializer(typeof(TableLayoutPanel).BaseType, typeof(CodeDomSerializer));
+        }
+
+        /// <summary>
+        ///  We don't actually want to serialize any code here, so we just delegate that to the base type's
+        ///  serializer. All we want to do is if we are in a localizable form, we want to push a
+        ///  'LayoutSettings' entry into the resx.
+        /// </summary>
+        public override object Serialize(IDesignerSerializationManager manager, object value)
+        {
+            // First call the base serializer to serialize the object.
+            object codeObject = GetBaseSerializer(manager).Serialize(manager, value);
+
+            // Now push our layout settings stuff into the resx if we are not inherited read only and 
+            // are in a localizable Form.
+            TableLayoutPanel tlp = value as TableLayoutPanel;
+            Debug.Assert(tlp != null, "Huh? We were expecting to be serializing a TableLayoutPanel here.");
+
+            if (tlp != null)
+            {
+                InheritanceAttribute ia = (InheritanceAttribute)TypeDescriptor.GetAttributes(tlp)[typeof(InheritanceAttribute)];
+
+                if (ia == null || ia.InheritanceLevel != InheritanceLevel.InheritedReadOnly)
+                {
+                    IDesignerHost host = (IDesignerHost)manager.GetService(typeof(IDesignerHost));
+
+                    if (IsLocalizable(host))
+                    {
+                        PropertyDescriptor lsProp = TypeDescriptor.GetProperties(tlp)[s_layoutSettingsPropName];
+                        object val = (lsProp != null) ? lsProp.GetValue(tlp) : null;
+
+                        if (val != null)
+                        {
+                            string key = manager.GetName(tlp) + "." + s_layoutSettingsPropName;
+                            SerializeResourceInvariant(manager, key, val);
+                        }
+                    }
+                }
+            }
+
+            return codeObject;
+        }
+
+        private bool IsLocalizable(IDesignerHost host)
+        {
+            if (host != null)
+            {
+                PropertyDescriptor prop = TypeDescriptor.GetProperties(host.RootComponent)["Localizable"];
+
+                if (prop != null && prop.PropertyType == typeof(bool))
+                {
+                    return (bool)prop.GetValue(host.RootComponent);
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripCodeDomSerializer.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Diagnostics;
+
+namespace System.Windows.Forms.Design
+{
+    internal class ToolStripCodeDomSerializer : ControlCodeDomSerializer
+    {
+        protected override bool HasSitedNonReadonlyChildren(Control parent)
+        {
+            ToolStrip toolStrip = parent as ToolStrip;
+            
+            if (toolStrip == null)
+            {
+                Debug.Fail("why were we passed a non winbar?");
+                return false;
+            }
+
+            if (toolStrip.Items.Count == 0)
+            {
+                return false;
+            }
+
+            foreach (ToolStripItem item in toolStrip.Items)
+            {
+                if (item.Site != null && toolStrip.Site != null && item.Site.Container == toolStrip.Site.Container)
+                {
+                    // We only emit Size/Location information for controls that are sited and not inherrited readonly.
+                    InheritanceAttribute ia = (InheritanceAttribute)TypeDescriptor.GetAttributes(item)[typeof(InheritanceAttribute)];
+
+                    if (ia != null && ia.InheritanceLevel != InheritanceLevel.InheritedReadOnly)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemCodeDomSerializer.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.ComponentModel.Design.Serialization;
+
+namespace System.Windows.Forms.Design
+{
+    /// <summary>
+    ///  The Reason for having a CustomSerializer for ToolStripMenuItem is the existance of Dummy ToolStripMenuItem for ContextMenuStrips.
+    ///  We add this Dummy ToolStripMenuItem on the "Non Site" ToolStrip to Host the DropDown which facilitates the entry of New MenuItems.
+    ///  These items are then added to the ContextMenuStrip that we are designing. 
+    ///  But we dont want the Dummy ToolStripMenuItem to Serialize and hence the need for this Custom Serializer.
+    /// </summary>
+    internal class ToolStripMenuItemCodeDomSerializer : CodeDomSerializer
+    {
+        /// <summary>
+        /// We implement this for the abstract method on CodeDomSerializer.
+        /// </summary>
+        public override object Deserialize(IDesignerSerializationManager manager, object codeObject)
+        {
+            return GetBaseSerializer(manager).Deserialize(manager, codeObject);
+        }
+
+        /// <summary>
+        /// This is a small helper method that returns the serializer for base Class
+        /// </summary>
+        private CodeDomSerializer GetBaseSerializer(IDesignerSerializationManager manager)
+        {
+            return (CodeDomSerializer)manager.GetSerializer(typeof(Component), typeof(CodeDomSerializer));
+        }
+
+        /// <summary>
+        /// We implement this for the abstract method on CodeDomSerializer.  This method
+        /// takes an object graph, and serializes the object into CodeDom elements.  
+        /// </summary>
+        public override object Serialize(IDesignerSerializationManager manager, object value)
+        {
+            ToolStripMenuItem item = value as ToolStripMenuItem;
+            ToolStrip parent = item.GetCurrentParent() as ToolStrip;
+            
+            //Dont Serialize if we are Dummy Item ...
+            if ((item != null) && !(item.IsOnDropDown) && (parent != null) && (parent.Site == null))
+            {
+                //dont serialize anything...
+                return null;
+            }
+            else
+            {
+                CodeDomSerializer baseSerializer = (CodeDomSerializer)manager.GetSerializer(typeof(ImageList).BaseType, typeof(CodeDomSerializer));
+                
+                return baseSerializer.Serialize(manager, value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #2185


## Proposed changes

- Port missing code DOM serializers from #2185 description list and related types
- Make code refactoring
- Minimal clean up using Roslyn analyzers in VS

> Checked controls that have `DesignerSerializerAttribute`. 
> The list of ported types:
> - Control – ControlCodeDomSerializer
> - DataGridViewRowCollection – DataGridViewRowCollectionCodeDomSerializer
> - TableLayoutPanel – TableLayoutPanelCodeDomSerializer
> - TableLayoutControlCollection – TableLayoutControlCollectionCodeDomSerializer
> - ToolStrip – ToolStripCodeDomSerializer
> - ToolStripMenuItem - ToolStripMenuItemCodeDomSerializer

> Also implemented this type:
> - ImageList – ImageListCodeDomSerializer

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Minimal, if any. API compat database has no recorded public usage for these types, these types are required for the VS designer

## Regression? 

- Yes

## Risk

- Minimal, if any

## Test environment(s)
- .Net Core version: 3.1.0-preview1.19458.7
- Microsoft Windows [Version 10.0.18362.418]


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2194)