### PR TITLE
Porting System.Windows.Forms.Design.ListViewGroupCollectionEditor 

### DIFF
--- a/src/System.Design/src/System.Design.Forwards.cs
+++ b/src/System.Design/src/System.Design.Forwards.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ImageCollectionEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ImageIndexEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ListControlStringCollectionEditor))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ListViewGroupCollectionEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ListViewSubItemCollectionEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.StringArrayEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.StringCollectionEditor))]

--- a/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/ListViewGroupCollectionEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/ListViewGroupCollectionEditor.cs
@@ -1,0 +1,79 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.ComponentModel.Design;
+using System.ComponentModel.Design.Serialization;
+
+namespace System.Windows.Forms.Design
+{
+    /// <summary>
+    ///  Provides an editor for a ListView groups collection.
+    /// </summary>
+    internal class ListViewGroupCollectionEditor : CollectionEditor
+    {
+        private object _editValue;
+
+        public ListViewGroupCollectionEditor(Type type) : base(type)
+        { }
+
+        /// <summary>
+        ///  Creates a ListViewGroup instance.
+        /// </summary>
+        protected override object CreateInstance(Type itemType)
+        {
+            ListViewGroup lvg = (ListViewGroup)base.CreateInstance(itemType);
+
+            // Create an unique name for the list view group.
+            lvg.Name = CreateListViewGroupName((ListViewGroupCollection)_editValue);
+
+            return lvg;
+        }
+
+        private string CreateListViewGroupName(ListViewGroupCollection lvgCollection)
+        {
+            string lvgName = "ListViewGroup";
+            string resultName;
+            INameCreationService ncs = GetService(typeof(INameCreationService)) as INameCreationService;
+            IContainer container = GetService(typeof(IContainer)) as IContainer;
+
+            if (ncs != null && container != null)
+            {
+                lvgName = ncs.CreateName(container, typeof(ListViewGroup));
+            }
+
+            // strip the digits from the end.
+            while (char.IsDigit(lvgName[lvgName.Length - 1]))
+            {
+                lvgName = lvgName.Substring(0, lvgName.Length - 1);
+            }
+
+            int i = 1;
+            resultName = lvgName + i.ToString(System.Globalization.CultureInfo.CurrentCulture);
+
+            while (lvgCollection[resultName] != null)
+            {
+                i++;
+                resultName = lvgName + i.ToString(System.Globalization.CultureInfo.CurrentCulture);
+            }
+
+            return resultName;
+        }
+
+        public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+        {
+            _editValue = value;
+            object ret;
+
+            // This will block while the ListViewGroupCollectionDialog is running.
+            ret = base.EditValue(context, provider, value);
+
+            // The user is done w/ the ListViewGroupCollectionDialog.
+            // Don't need the edit value any longer
+            _editValue = null;
+
+            return ret;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design.Editors/tests/UnitTests/EnsureEditorsTests.cs
+++ b/src/System.Windows.Forms.Design.Editors/tests/UnitTests/EnsureEditorsTests.cs
@@ -89,7 +89,7 @@ namespace System.Windows.Forms.Design.Editors.Tests
         //[InlineData(typeof(ListControl), "FormatString", typeof(FormatStringEditor))]
         //[InlineData(typeof(ListControl), "ValueMember", typeof(DataMemberFieldEditor))]
         //[InlineData(typeof(ListView), "Columns", typeof(ColumnHeaderCollectionEditor))]
-        //[InlineData(typeof(ListView), "Groups", typeof(ListViewGroupCollectionEditor))]
+        [InlineData(typeof(ListView), "Groups", typeof(ListViewGroupCollectionEditor))]
         //[InlineData(typeof(ListView), "Items", typeof(ListViewItemCollectionEditor))]
         [InlineData(typeof(ListViewItem), "ImageIndex", typeof(ImageIndexEditor))]
         [InlineData(typeof(ListViewItem), "ImageKey", typeof(ImageIndexEditor))]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Issue: `ListViewGroupCollectionEditor` from `System.Design` is missing.
Related issue: #1115

## Proposed changes

- Add System.Windows.Forms.Design.ListViewGroupCollectionEditor class
- Make code refactoring

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Changed ListViewGroup editor to compliance with .Net 4.8.

## Regression? 

- Yes

## Risk

- Low

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->
- It made as in .Net 4.8:
![image](https://user-images.githubusercontent.com/49272759/67561173-03bbca00-f725-11e9-8c35-ac887aba4b76.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual UI testing


## Test environment(s) <!-- Remove any that don't apply -->

- .Net Core version: 3.1.100-preview2-014533
- Microsoft Windows [Version 10.0.18362.418]

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2196)