### PR TITLE
Porting System.Windows.Forms.Design.ListViewItemCollectionEditor

### DIFF
--- a/src/System.Design/src/System.Design.Forwards.cs
+++ b/src/System.Design/src/System.Design.Forwards.cs
@@ -10,6 +10,7 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ImageIndexEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ListControlStringCollectionEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ListViewGroupCollectionEditor))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ListViewItemCollectionEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ListViewSubItemCollectionEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.StringArrayEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.StringCollectionEditor))]

--- a/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/ListViewItemCollectionEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/ListViewItemCollectionEditor.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.ComponentModel.Design;
+
+namespace System.Windows.Forms.Design
+{
+    /// <summary>
+    ///  Provides an editor for a ListView items collection.
+    /// </summary>
+    internal class ListViewItemCollectionEditor : CollectionEditor
+    {
+        /// <summary>
+        ///  Initializes a new instance of the <see cref='System.Windows.Forms.Design.ListViewItemCollectionEditor'/> class.
+        /// </summary>
+        public ListViewItemCollectionEditor(Type type) : base(type)
+        { }
+
+        /// <summary>
+        ///  Retrieves the display text for the given list item.
+        /// </summary>
+        protected override string GetDisplayText(object value)
+        {
+            if (value == null)
+            {
+                return string.Empty;
+            }
+
+            string text;
+
+            PropertyDescriptor prop = TypeDescriptor.GetDefaultProperty(CollectionType);
+            if (prop != null && prop.PropertyType == typeof(string))
+            {
+                text = (string)prop.GetValue(value);
+
+                if (text != null && text.Length > 0)
+                {
+                    return text;
+                }
+            }
+
+            text = TypeDescriptor.GetConverter(value).ConvertToString(value);
+
+            if (text == null || text.Length == 0)
+            {
+                text = value.GetType().Name;
+            }
+
+            return text;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design.Editors/tests/UnitTests/EnsureEditorsTests.cs
+++ b/src/System.Windows.Forms.Design.Editors/tests/UnitTests/EnsureEditorsTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -90,7 +90,7 @@ namespace System.Windows.Forms.Design.Editors.Tests
         //[InlineData(typeof(ListControl), "ValueMember", typeof(DataMemberFieldEditor))]
         //[InlineData(typeof(ListView), "Columns", typeof(ColumnHeaderCollectionEditor))]
         [InlineData(typeof(ListView), "Groups", typeof(ListViewGroupCollectionEditor))]
-        //[InlineData(typeof(ListView), "Items", typeof(ListViewItemCollectionEditor))]
+        [InlineData(typeof(ListView), "Items", typeof(ListViewItemCollectionEditor))]
         [InlineData(typeof(ListViewItem), "ImageIndex", typeof(ImageIndexEditor))]
         [InlineData(typeof(ListViewItem), "ImageKey", typeof(ImageIndexEditor))]
         [InlineData(typeof(ListViewItem), "StateImageIndex", typeof(ImageIndexEditor))]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1276
Related issue: #1115

## Proposed changes

- Add System.Windows.Forms.Design.ListViewItemCollectionEditor class
- Make code refactoring

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Changed ListViewItems editor to compliance with .Net 4.8.


## Regression? 

- Yes 

## Risk

- Low

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->
- It made as in .Net 4.8:
![image](https://user-images.githubusercontent.com/49272759/67566124-ada05400-f72f-11e9-862c-df256c798664.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual UI testing
- The unit testing

## Test environment(s) <!-- Remove any that don't apply -->

- .Net Core version: 3.1.100-preview2-014533
- Microsoft Windows [Version 10.0.18362.418]


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2197)