### PR TITLE
Porting System.Windows.Forms.Design.ListViewSubItemCollectionEditor

### DIFF
--- a/src/System.Design/src/System.Design.Forwards.cs
+++ b/src/System.Design/src/System.Design.Forwards.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ImageCollectionEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ImageIndexEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ListControlStringCollectionEditor))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ListViewSubItemCollectionEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.StringArrayEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.StringCollectionEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.TabPageCollectionEditor))]

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/SR.resx
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/SR.resx
@@ -181,6 +181,9 @@
   <data name="imageFileDescription" xml:space="preserve">
     <value>All image files</value>
   </data>
+  <data name="ListViewSubItemBaseName" xml:space="preserve">
+    <value>ListViewSubItem</value>
+  </data>
   <data name="metafileFileDescription" xml:space="preserve">
     <value>Metafiles</value>
   </data>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.cs.xlf
@@ -130,7 +130,7 @@
       <trans-unit id="ContentAlignmentEditorTopRightAccName">
         <source>Top Right</source>
         <target state="new">Top Right</target>
-      <note />
+        <note />
       </trans-unit>
       <trans-unit id="DataSourceLocksItems">
         <source>Items collection cannot be modified when the DataSource property is set.</source>
@@ -185,6 +185,11 @@
       <trans-unit id="ImageCollectionEditorFormText">
         <source>Images Collection Editor</source>
         <target state="translated">Editor kolekce Images</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListViewSubItemBaseName">
+        <source>ListViewSubItem</source>
+        <target state="new">ListViewSubItem</target>
         <note />
       </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.de.xlf
@@ -187,6 +187,11 @@
         <target state="translated">Bildsammlungs-Editor</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewSubItemBaseName">
+        <source>ListViewSubItem</source>
+        <target state="new">ListViewSubItem</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
         <source>Press Enter to begin a new line.
 Press Ctrl+Enter to accept Text.</source>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.es.xlf
@@ -187,6 +187,11 @@
         <target state="translated">Editor de la colección Imágenes</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewSubItemBaseName">
+        <source>ListViewSubItem</source>
+        <target state="new">ListViewSubItem</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
         <source>Press Enter to begin a new line.
 Press Ctrl+Enter to accept Text.</source>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.fr.xlf
@@ -187,6 +187,11 @@
         <target state="translated">Éditeur de collections Images</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewSubItemBaseName">
+        <source>ListViewSubItem</source>
+        <target state="new">ListViewSubItem</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
         <source>Press Enter to begin a new line.
 Press Ctrl+Enter to accept Text.</source>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.it.xlf
@@ -187,6 +187,11 @@
         <target state="translated">Editor della raccolta Images</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewSubItemBaseName">
+        <source>ListViewSubItem</source>
+        <target state="new">ListViewSubItem</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
         <source>Press Enter to begin a new line.
 Press Ctrl+Enter to accept Text.</source>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ja.xlf
@@ -187,6 +187,11 @@
         <target state="translated">イメージ コレクション エディター</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewSubItemBaseName">
+        <source>ListViewSubItem</source>
+        <target state="new">ListViewSubItem</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
         <source>Press Enter to begin a new line.
 Press Ctrl+Enter to accept Text.</source>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ko.xlf
@@ -187,6 +187,11 @@
         <target state="translated">이미지 컬렉션 편집기</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewSubItemBaseName">
+        <source>ListViewSubItem</source>
+        <target state="new">ListViewSubItem</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
         <source>Press Enter to begin a new line.
 Press Ctrl+Enter to accept Text.</source>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.pl.xlf
@@ -187,6 +187,11 @@
         <target state="translated">Edytor kolekcji obrazów</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewSubItemBaseName">
+        <source>ListViewSubItem</source>
+        <target state="new">ListViewSubItem</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
         <source>Press Enter to begin a new line.
 Press Ctrl+Enter to accept Text.</source>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.pt-BR.xlf
@@ -187,6 +187,11 @@
         <target state="translated">Editor de Coleção de Imagens</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewSubItemBaseName">
+        <source>ListViewSubItem</source>
+        <target state="new">ListViewSubItem</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
         <source>Press Enter to begin a new line.
 Press Ctrl+Enter to accept Text.</source>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ru.xlf
@@ -187,6 +187,11 @@
         <target state="translated">Редактор коллекции изображений</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewSubItemBaseName">
+        <source>ListViewSubItem</source>
+        <target state="new">ListViewSubItem</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
         <source>Press Enter to begin a new line.
 Press Ctrl+Enter to accept Text.</source>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.tr.xlf
@@ -187,6 +187,11 @@
         <target state="translated">Görüntüler Koleksiyonu Düzenleyicisi</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewSubItemBaseName">
+        <source>ListViewSubItem</source>
+        <target state="new">ListViewSubItem</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
         <source>Press Enter to begin a new line.
 Press Ctrl+Enter to accept Text.</source>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.zh-Hans.xlf
@@ -187,6 +187,11 @@
         <target state="translated">图像集合编辑器</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewSubItemBaseName">
+        <source>ListViewSubItem</source>
+        <target state="new">ListViewSubItem</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
         <source>Press Enter to begin a new line.
 Press Ctrl+Enter to accept Text.</source>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.zh-Hant.xlf
@@ -187,6 +187,11 @@
         <target state="translated">影像集合編輯器</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewSubItemBaseName">
+        <source>ListViewSubItem</source>
+        <target state="new">ListViewSubItem</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultilineStringEditorWatermark">
         <source>Press Enter to begin a new line.
 Press Ctrl+Enter to accept Text.</source>

--- a/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/ListViewSubItemCollectionEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/ListViewSubItemCollectionEditor.cs
@@ -1,0 +1,113 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.ComponentModel;
+using System.ComponentModel.Design;
+
+namespace System.Windows.Forms.Design
+{
+    /// <summary>
+    ///  Provides an editor for a ListView subitems collection.
+    /// </summary>
+    internal class ListViewSubItemCollectionEditor : CollectionEditor
+    {
+        private static int _count = 0;
+        private ListViewItem.ListViewSubItem _firstSubItem = null;
+
+        /// <summary>
+        ///  Initializes a new instance of the <see cref='System.Windows.Forms.Design.ListViewSubItemCollectionEditor'/> class.
+        /// </summary>
+        public ListViewSubItemCollectionEditor(Type type) : base(type)
+        { }
+
+        /// <summary>
+        ///  Creates an instance of the specified type in the collection.
+        /// </summary>
+        protected override object CreateInstance(Type type)
+        {
+            object instance = base.CreateInstance(type);
+
+            // slap in a default site-like name
+            if (instance is ListViewItem.ListViewSubItem)
+            {
+                ((ListViewItem.ListViewSubItem)instance).Name = SR.ListViewSubItemBaseName + _count++;
+            }
+
+            return instance;
+        }
+
+        /// <summary>
+        ///  Retrieves the display text for the given list sub item.
+        /// </summary>
+        protected override string GetDisplayText(object value)
+        {
+            if (value == null)
+            {
+                return string.Empty;
+            }
+
+            string text;
+
+            PropertyDescriptor prop = TypeDescriptor.GetDefaultProperty(CollectionType);
+
+            if (prop != null && prop.PropertyType == typeof(string))
+            {
+                text = (string)prop.GetValue(value);
+
+                if (text != null && text.Length > 0)
+                {
+                    return text;
+                }
+            }
+
+            text = TypeDescriptor.GetConverter(value).ConvertToString(value);
+
+            if (text == null || text.Length == 0)
+            {
+                text = value.GetType().Name;
+            }
+
+            return text;
+        }
+
+        protected override object[] GetItems(object editValue)
+        {
+            // take the fist sub item out of the collection
+            ListViewItem.ListViewSubItemCollection subItemsColl = (ListViewItem.ListViewSubItemCollection)editValue;
+
+            // add all the other sub items
+            object[] values = new object[subItemsColl.Count];
+            ((ICollection)subItemsColl).CopyTo(values, 0);
+
+            if (values.Length > 0)
+            {
+                // save the first sub item
+                _firstSubItem = subItemsColl[0];
+
+                // now return the rest.
+                object[] subValues = new object[values.Length - 1];
+                Array.Copy(values, 1, subValues, 0, subValues.Length);
+                values = subValues;
+            }
+
+            return values;
+        }
+
+        protected override object SetItems(object editValue, object[] value)
+        {
+            IList list = editValue as IList;
+            list.Clear();
+
+            list.Add(_firstSubItem);
+
+            for (int i = 0; i < value.Length; i++)
+            {
+                list.Add(value[i]);
+            }
+
+            return editValue;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design.Editors/tests/UnitTests/EnsureEditorsTests.cs
+++ b/src/System.Windows.Forms.Design.Editors/tests/UnitTests/EnsureEditorsTests.cs
@@ -94,7 +94,7 @@ namespace System.Windows.Forms.Design.Editors.Tests
         [InlineData(typeof(ListViewItem), "ImageIndex", typeof(ImageIndexEditor))]
         [InlineData(typeof(ListViewItem), "ImageKey", typeof(ImageIndexEditor))]
         [InlineData(typeof(ListViewItem), "StateImageIndex", typeof(ImageIndexEditor))]
-        //[InlineData(typeof(ListViewItem), "SubItems", typeof(ListViewSubItemCollectionEditor))]
+        [InlineData(typeof(ListViewItem), "SubItems", typeof(ListViewSubItemCollectionEditor))]
         //[InlineData(typeof(MaskedTextBox), "Mask", typeof(MaskPropertyEditor))]
         //[InlineData(typeof(MaskedTextBox), "Text", typeof(MaskedTextBoxTextEditor))]
         [InlineData(typeof(NotifyIcon), "BalloonTipText", typeof(MultilineStringEditor))]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1277
Related issue: #1115

## Proposed changes

- Add System.Windows.Forms.Design.ListViewSubItemCollectionEditor class
- Make code refactoring

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Changed ListViewItems SubItems editor to compliance with .Net 4.8.

## Regression? 

- Yes

## Risk

- Low

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->
- It made as in .Net 4.8:
![image](https://user-images.githubusercontent.com/49272759/67568216-4638d300-f734-11e9-99ba-39083ee3520b.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual UI testing


## Test environment(s) <!-- Remove any that don't apply -->

- .Net Core version: 3.1.100-preview2-014533
- Microsoft Windows [Version 10.0.18362.418]


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2198)