### PR TITLE
Fix Interop.User32.PostMessageW return type

### DIFF
--- a/src/Common/src/Interop/User32/Interop.PostMessageW.cs
+++ b/src/Common/src/Interop/User32/Interop.PostMessageW.cs
@@ -11,19 +11,19 @@ internal static partial class Interop
     internal static partial class User32
     {
         [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr PostMessageW(
+        public static extern BOOL PostMessageW(
             IntPtr hWnd,
             WindowMessage Msg,
             IntPtr wParam = default,
             IntPtr lParam = default);
 
-        public static IntPtr PostMessageW(
+        public static BOOL PostMessageW(
             IHandle hWnd,
             WindowMessage Msg,
             IntPtr wParam = default,
             IntPtr lParam = default)
         {
-            IntPtr result = PostMessageW(hWnd.Handle, Msg, wParam, lParam);
+            BOOL result = PostMessageW(hWnd.Handle, Msg, wParam, lParam);
             GC.KeepAlive(hWnd);
             return result;
         }


### PR DESCRIPTION
Fixes #1981

## Proposed changes

- Change PostMessageW return type from IntPtr to Interop.BOOL. It seems the return value is not currently used in NativeWindow.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2204)