### PR TITLE
Add CommDlgExtendedError method in Comdlg32 and FNERR enum and replac…

### DIFF
--- a/src/Common/src/Interop/Comdlg32/Interop.CommDlgExtendedError.cs
+++ b/src/Common/src/Interop/Comdlg32/Interop.CommDlgExtendedError.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Comdlg32
+    {
+        [DllImport(Libraries.Comdlg32, ExactSpelling = true)]
+        public static extern FNERR CommDlgExtendedError();
+    }
+}

--- a/src/Common/src/Interop/Comdlg32/Interop.FNERR.cs
+++ b/src/Common/src/Interop/Comdlg32/Interop.FNERR.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal partial class Interop
+{
+    internal partial class Comdlg32
+    {
+        public enum FNERR : uint
+        {
+            SUBCLASSFAILURE = 0x3001,
+            INVALIDFILENAME = 0x3002,
+            BUFFERTOOSMALL = 0x3003
+        }
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -195,9 +195,6 @@ namespace System.Windows.Forms
         public const int ERROR_INVALID_HANDLE = 6;
         public const int ERROR_CLASS_ALREADY_EXISTS = 1410;
 
-        public const int FNERR_SUBCLASSFAILURE = 0x3001;
-        public const int FNERR_INVALIDFILENAME = 0x3002;
-        public const int FNERR_BUFFERTOOSMALL = 0x3003;
         public const int FRERR_BUFFERLENGTHZERO = 0x4001;
         public const int FADF_BSTR = (0x100);
         public const int FADF_UNKNOWN = (0x200);

--- a/src/Common/src/SafeNativeMethods.cs
+++ b/src/Common/src/SafeNativeMethods.cs
@@ -28,9 +28,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern int GetBitmapBits(HandleRef hbmp, int cbBuffer, byte[] lpvBits);
 
-        [DllImport(ExternDll.Comdlg32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern int CommDlgExtendedError();
-
         [DllImport(ExternDll.Hhctrl, CharSet = CharSet.Auto)]
         public static extern int HtmlHelp(HandleRef hwndCaller, [MarshalAs(UnmanagedType.LPTStr)]string pszFile, int uCommand, int dwData);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
@@ -4,6 +4,7 @@
 
 using System.ComponentModel;
 using System.IO;
+using static Interop;
 
 namespace System.Windows.Forms
 {
@@ -130,17 +131,13 @@ namespace System.Windows.Forms
             if (!result)
             {
                 // Something may have gone wrong - check for error condition
-                //
-                int errorCode = SafeNativeMethods.CommDlgExtendedError();
-                switch (errorCode)
+                switch (Comdlg32.CommDlgExtendedError())
                 {
-                    case NativeMethods.FNERR_INVALIDFILENAME:
+                    case Comdlg32.FNERR.INVALIDFILENAME:
                         throw new InvalidOperationException(string.Format(SR.FileDialogInvalidFileName, FileName));
-
-                    case NativeMethods.FNERR_SUBCLASSFAILURE:
+                    case Comdlg32.FNERR.SUBCLASSFAILURE:
                         throw new InvalidOperationException(SR.FileDialogSubLassFailure);
-
-                    case NativeMethods.FNERR_BUFFERTOOSMALL:
+                    case Comdlg32.FNERR.BUFFERTOOSMALL:
                         throw new InvalidOperationException(SR.FileDialogBufferTooSmall);
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SaveFileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SaveFileDialog.cs
@@ -4,6 +4,7 @@
 
 using System.ComponentModel;
 using System.IO;
+using static Interop;
 
 namespace System.Windows.Forms
 {
@@ -146,11 +147,9 @@ namespace System.Windows.Forms
             if (!result)
             {
                 // Something may have gone wrong - check for error condition
-                //
-                int errorCode = SafeNativeMethods.CommDlgExtendedError();
-                switch (errorCode)
+                switch (Comdlg32.CommDlgExtendedError())
                 {
-                    case NativeMethods.FNERR_INVALIDFILENAME:
+                    case Comdlg32.FNERR.INVALIDFILENAME:
                         throw new InvalidOperationException(string.Format(SR.FileDialogInvalidFileName, FileName));
                 }
             }


### PR DESCRIPTION
…e corresponding NativeMethods and SafeNativeMethods items

## Proposed changes

- Add CommDlgExtendedError method in Comdlg32
- Add FNERR enum in Comdlg32
- Replace corresponding NativeMethods and SafeNativeMethods items

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2206)