### PR TITLE
Move RGBQUAD struct to Gdi32

### DIFF
--- a/src/Common/src/Interop/Gdi32/Interop.RGBQUAD.cs
+++ b/src/Common/src/Interop/Gdi32/Interop.RGBQUAD.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class Gdi32
+    {
+        public struct RGBQUAD
+        {
+            public byte rgbBlue;
+            public byte rgbGreen;
+            public byte rgbRed;
+            public byte rgbReserved;
+        }
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -2564,14 +2564,6 @@ namespace System.Windows.Forms
             HRESULT GetClassInfo(out UnsafeNativeMethods.ITypeInfo ppTI);
         }
 
-        public struct RGBQUAD
-        {
-            public byte rgbBlue;
-            public byte rgbGreen;
-            public byte rgbRed;
-            public byte rgbReserved;
-        }
-
         [StructLayout(LayoutKind.Sequential)]
         public struct PALETTEENTRY
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.MetafileDCWrapper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.MetafileDCWrapper.cs
@@ -141,7 +141,7 @@ namespace System.Windows.Forms
                         {
                             fixed (byte* ppal = aj)
                             {
-                                NativeMethods.RGBQUAD* prgb = (NativeMethods.RGBQUAD*)pcolors;
+                                Gdi32.RGBQUAD* prgb = (Gdi32.RGBQUAD*)pcolors;
                                 NativeMethods.PALETTEENTRY* lppe = (NativeMethods.PALETTEENTRY*)ppal;
 
                                 // Convert the palette entries to RGB quad entries


### PR DESCRIPTION
## Proposed changes

- Move RGBQUAD from NativeMethods.cs to a separate file in Gdi32.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2215)