### PR TITLE
Use separate file for PALETTEENTRY in Gdi32

### DIFF
--- a/src/Common/src/Interop/Gdi32/Interop.GetPaletteEntries.cs
+++ b/src/Common/src/Interop/Gdi32/Interop.GetPaletteEntries.cs
@@ -19,13 +19,5 @@ internal static partial class Interop
                 return GetPaletteEntries(hpal, 0, (uint)entries.Length, entry);
             }
         }
-
-        public struct PALETTEENTRY
-        {
-            public byte peRed;
-            public byte peGreen;
-            public byte peBlue;
-            public byte peFlags;
-        }
     }
 }

--- a/src/Common/src/Interop/Gdi32/Interop.PALETTEENTRY.cs
+++ b/src/Common/src/Interop/Gdi32/Interop.PALETTEENTRY.cs
@@ -6,12 +6,12 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        public struct RGBQUAD
+        public struct PALETTEENTRY
         {
-            public byte rgbBlue;
-            public byte rgbGreen;
-            public byte rgbRed;
-            public byte rgbReserved;
+            public byte peRed;
+            public byte peGreen;
+            public byte peBlue;
+            public byte peFlags;
         }
     }
 }

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -2549,15 +2549,6 @@ namespace System.Windows.Forms
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        public struct PALETTEENTRY
-        {
-            public byte peRed;
-            public byte peGreen;
-            public byte peBlue;
-            public byte peFlags;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
         public struct BITMAPINFO_FLAT
         {
             public int bmiHeader_biSize;// = Marshal.SizeOf<BITMAPINFOHEADER>();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.MetafileDCWrapper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.MetafileDCWrapper.cs
@@ -134,7 +134,7 @@ namespace System.Windows.Forms
                     long iColors = 1 << (bmp.bmBitsPixel * bmp.bmPlanes);
                     if (iColors <= 256)
                     {
-                        byte[] aj = new byte[Marshal.SizeOf<NativeMethods.PALETTEENTRY>() * 256];
+                        byte[] aj = new byte[sizeof(Gdi32.PALETTEENTRY) * 256];
                         SafeNativeMethods.GetSystemPaletteEntries(hdcSrc, 0, (int)iColors, aj);
 
                         fixed (byte* pcolors = lpbmi.bmiColors)
@@ -142,7 +142,7 @@ namespace System.Windows.Forms
                             fixed (byte* ppal = aj)
                             {
                                 Gdi32.RGBQUAD* prgb = (Gdi32.RGBQUAD*)pcolors;
-                                NativeMethods.PALETTEENTRY* lppe = (NativeMethods.PALETTEENTRY*)ppal;
+                                Gdi32.PALETTEENTRY* lppe = (Gdi32.PALETTEENTRY*)ppal;
 
                                 // Convert the palette entries to RGB quad entries
                                 for (i = 0; i < (int)iColors; i++)


### PR DESCRIPTION
## Proposed changes

- Add Interop.PALETTEENTRY struct.
- Replace usages of PALETTEENTRY with the above struct.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2216)