### PR TITLE
Remove NativeMethods, SafeNativeMethods and UnsafeNativeMethods classes from DesignerActionPanel.cs

### DIFF
--- a/src/Common/src/Interop/User32/Interop.SetWindowLong.cs
+++ b/src/Common/src/Interop/User32/Interop.SetWindowLong.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Windows.Forms;
 
 internal static partial class Interop
 {
@@ -30,6 +29,14 @@ internal static partial class Interop
         {
             IntPtr result = SetWindowLong(hWnd.Handle, nIndex, dwNewLong);
             GC.KeepAlive(hWnd);
+            return result;
+        }
+
+        public static IntPtr SetWindowLong(IHandle hWnd, GWL nIndex, IHandle dwNewLong)
+        {
+            IntPtr result = SetWindowLong(hWnd.Handle, nIndex, dwNewLong.Handle);
+            GC.KeepAlive(hWnd);
+            GC.KeepAlive(dwNewLong);
             return result;
         }
 

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -180,9 +180,11 @@
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetMessageTime.cs" Link="Interop\User32\Interop.GetMessageTime.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetUpdateRgn.cs" Link="Interop\User32\Interop.GetUpdateRgn.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetWindow.cs" Link="Interop\User32\Interop.GetWindow.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.GetWindowLong.cs" Link="Interop\User32\Interop.GetWindowLong.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetWindowText.cs" Link="Interop\User32\Interop.GetWindowText.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetWindowThreadProcessId.cs" Link="Interop\User32\Interop.GetWindowThreadProcessId.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GW.cs" Link="Interop\User32\Interop.GW.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.GWL.cs" Link="Interop\User32\Interop.GWL.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.HC.cs" Link="Interop\User32\Interop.HC.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.HOOKPROC.cs" Link="Interop\User32\Interop.HOOKPROC.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.IsChild.cs" Link="Interop\User32\Interop.IsChild.cs" />
@@ -204,10 +206,12 @@
     <Compile Include="..\..\Common\src\Interop\User32\Interop.ReleaseCapture.cs" Link="Interop\User32\Interop.ReleaseCapture.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.ReleaseDC.cs" Link="Interop\User32\Interop.ReleaseDC.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SBV.cs" Link="Interop\User32\Interop.SBV.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.SendMessageW.cs" Link="Interop\User32\Interop.SendMessageW.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SetActiveWindow.cs" Link="Interop\User32\Interop.SetActiveWindow.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SetParent.cs" Link="Interop\User32\Interop.SetParent.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SetProcessDPIAware.cs" Link="Interop\User32\Interop.SetProcessDPIAware.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SetProcessDpiAwarenessContext.cs" Link="Interop\User32\Interop.SetProcessDpiAwarenessContext.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.SetWindowLong.cs" Link="Interop\User32\Interop.SetWindowLong.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SetWindowPos.cs" Link="Interop\User32\Interop.SetWindowPos.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SetWindowsHookExW.cs" Link="Interop\User32\Interop.SetWindowsHookExW.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SWP.cs" Link="Interop\User32\Interop.SWP.cs" />
@@ -220,6 +224,7 @@
     <Compile Include="..\..\Common\src\Interop\User32\Interop.WindowFromPoint.cs" Link="Interop\User32\Interop.WindowFromPoint.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.WindowMessage.cs" Link="Interop\User32\Interop.WindowMessage.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.WINDOWPOS.cs" Link="Interop\User32\Interop.WINDOWPOS.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.WNDPROC.cs" Link="Interop\User32\Interop.WNDPROC.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.WS.cs" Link="Interop\User32\Interop.WS.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.WS_EX.cs" Link="Interop\User32\Interop.WS_EX.cs" />
     <Compile Include="..\..\Common\src\Interop\UxTheme\Interop.MARGINS.cs" Link="Interop\UxTheme\Interop.MARGINS.cs" />

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.cs
@@ -2334,7 +2334,7 @@ namespace System.ComponentModel.Design
                 }
             }
 
-            internal class FlyoutDialog : Form
+            internal class FlyoutDialog : Form, IHandle
             {
                 private readonly Control _hostedControl;
                 private readonly Control _parentControl;
@@ -2419,7 +2419,7 @@ namespace System.ComponentModel.Design
                 {
                     while (hWnd != IntPtr.Zero)
                     {
-                        hWnd = UnsafeNativeMethods.GetWindowLong(new HandleRef(null, hWnd), NativeMethods.GWL_HWNDPARENT);
+                        hWnd = User32.GetWindowLong(hWnd, User32.GWL.HWNDPARENT);
                         if (hWnd == IntPtr.Zero)
                         {
                             return false;
@@ -2449,12 +2449,13 @@ namespace System.ComponentModel.Design
                 {
                     try
                     {
-                        UnsafeNativeMethods.SetWindowLong(new HandleRef(this, Handle), NativeMethods.GWL_HWNDPARENT, new HandleRef(parent, parent.Handle));
+                        User32.SetWindowLong(this, User32.GWL.HWNDPARENT, parent.Handle);
+
                         // Lifted directly from Form.ShowDialog()...
                         IntPtr hWndCapture = User32.GetCapture();
                         if (hWndCapture != IntPtr.Zero)
                         {
-                            UnsafeNativeMethods.SendMessage(new HandleRef(null, hWndCapture), WindowMessages.WM_CANCELMODE, 0, 0);
+                            User32.SendMessageW(hWndCapture, User32.WindowMessage.WM_CANCELMODE, IntPtr.Zero, IntPtr.Zero);
                             User32.ReleaseCapture();
                         }
                         Visible = true; // NOTE: Do this AFTER creating handle and setting parent
@@ -2463,8 +2464,7 @@ namespace System.ComponentModel.Design
                     }
                     finally
                     {
-
-                        UnsafeNativeMethods.SetWindowLong(new HandleRef(this, Handle), NativeMethods.GWL_HWNDPARENT, new HandleRef(null, IntPtr.Zero));
+                        User32.SetWindowLong(this, User32.GWL.HWNDPARENT, IntPtr.Zero);
                         // sometimes activation goes to LALA land - if our parent control is still  around, remind it to take focus.
                         if (parent != null && parent.Visible)
                         {
@@ -2502,31 +2502,6 @@ namespace System.ComponentModel.Design
                     base.WndProc(ref m);
                 }
             }
-
-            #region Interop definitions
-            private static class NativeMethods
-            {
-                public const int GWL_HWNDPARENT = (-8);
-            }
-
-            private static class SafeNativeMethods
-            {
-                [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-                public static extern IntPtr SelectObject(HandleRef hDC, HandleRef hObject);
-            }
-
-            private static class UnsafeNativeMethods
-            {
-                [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-                public static extern IntPtr GetWindowLong(HandleRef hWnd, int nIndex);
-
-                [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-                public static extern IntPtr SetWindowLong(HandleRef hWnd, int nIndex, HandleRef dwNewLong);
-
-                [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-                public static extern IntPtr SendMessage(HandleRef hWnd, int msg, int wParam, int lParam);
-            }
-            #endregion
 
             // Class that renders either the ellipsis or dropdown button
             internal sealed class EditorButton : Button


### PR DESCRIPTION
## Proposed changes

- SafeNativeMethods class seems to be unused, so remove it.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2221)