### PR TITLE
Repalce `ToolStripImageIndexEditor` with `ImageIndexEditor`

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -1314,7 +1314,7 @@ namespace System.Windows.Forms
         SRCategory(nameof(SR.CatBehavior)),
         RefreshProperties(RefreshProperties.Repaint),
         TypeConverter(typeof(NoneExcludedImageIndexConverter)),
-        Editor("System.Windows.Forms.Design.ToolStripImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor)),
+        Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor)),
         Browsable(false),
         RelatedImageList("Owner.ImageList")
         ]


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Resolves #2122
Original https://github.com/dotnet/winforms/pull/2140

## Proposed changes

- `ToolStripImageIndexEditor` does not exist, replace it with `ImageIndexEditor`


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2222)