### PR TITLE
Remove UnsafeNativeMethods class from DesignerActionPanel.cs

### DIFF
--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -141,8 +141,10 @@
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetFocus.cs" Link="Interop\User32\Interop.GetFocus.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetKeyState.cs" Link="Interop\User32\Interop.GetKeyState.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetUpdateRgn.cs" Link="Interop\User32\Interop.GetUpdateRgn.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.GetWindowLong.cs" Link="Interop\User32\Interop.GetWindowLong.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetWindowText.cs" Link="Interop\User32\Interop.GetWindowText.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetWindowThreadProcessId.cs" Link="Interop\User32\Interop.GetWindowThreadProcessId.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.GWL.cs" Link="Interop\User32\Interop.GWL.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.HC.cs" Link="Interop\User32\Interop.HC.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.HOOKPROC.cs" Link="Interop\User32\Interop.HOOKPROC.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.MK.cs" Link="Interop\User32\Interop.MK.cs" />
@@ -159,8 +161,10 @@
     <Compile Include="..\..\Common\src\Interop\User32\Interop.ReleaseCapture.cs" Link="Interop\User32\Interop.ReleaseCapture.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.ReleaseDC.cs" Link="Interop\User32\Interop.ReleaseDC.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SBV.cs" Link="Interop\User32\Interop.SBV.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.SendMessageW.cs" Link="Interop\User32\Interop.SendMessageW.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SetActiveWindow.cs" Link="Interop\User32\Interop.SetActiveWindow.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SetParent.cs" Link="Interop\User32\Interop.SetParent.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.SetWindowLong.cs" Link="Interop\User32\Interop.SetWindowLong.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SetWindowPos.cs" Link="Interop\User32\Interop.SetWindowPos.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SetWindowsHookExW.cs" Link="Interop\User32\Interop.SetWindowsHookExW.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SWP.cs" Link="Interop\User32\Interop.SWP.cs" />

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.cs
@@ -2419,7 +2419,7 @@ namespace System.ComponentModel.Design
                 {
                     while (hWnd != IntPtr.Zero)
                     {
-                        hWnd = UnsafeNativeMethods.GetWindowLong(new HandleRef(null, hWnd), NativeMethods.GWL_HWNDPARENT);
+                        hWnd = User32.GetWindowLong(hWnd, User32.GWL.HWNDPARENT);
                         if (hWnd == IntPtr.Zero)
                         {
                             return false;
@@ -2449,12 +2449,12 @@ namespace System.ComponentModel.Design
                 {
                     try
                     {
-                        UnsafeNativeMethods.SetWindowLong(new HandleRef(this, Handle), NativeMethods.GWL_HWNDPARENT, new HandleRef(parent, parent.Handle));
+                        User32.SetWindowLong(Handle, User32.GWL.HWNDPARENT, parent.Handle);
                         // Lifted directly from Form.ShowDialog()...
                         IntPtr hWndCapture = User32.GetCapture();
                         if (hWndCapture != IntPtr.Zero)
                         {
-                            UnsafeNativeMethods.SendMessage(new HandleRef(null, hWndCapture), WindowMessages.WM_CANCELMODE, 0, 0);
+                            User32.SendMessageW(hWndCapture, User32.WindowMessage.WM_CANCELMODE, IntPtr.Zero, IntPtr.Zero);
                             User32.ReleaseCapture();
                         }
                         Visible = true; // NOTE: Do this AFTER creating handle and setting parent
@@ -2464,7 +2464,7 @@ namespace System.ComponentModel.Design
                     finally
                     {
 
-                        UnsafeNativeMethods.SetWindowLong(new HandleRef(this, Handle), NativeMethods.GWL_HWNDPARENT, new HandleRef(null, IntPtr.Zero));
+                        User32.SetWindowLong(Handle, User32.GWL.HWNDPARENT, IntPtr.Zero);
                         // sometimes activation goes to LALA land - if our parent control is still  around, remind it to take focus.
                         if (parent != null && parent.Visible)
                         {
@@ -2510,7 +2510,7 @@ namespace System.ComponentModel.Design
                 public const int WA_ACTIVE = 1;
                 public const int WS_POPUP = unchecked((int)0x80000000);
                 public const int WS_BORDER = 0x00800000;
-                public const int GWL_HWNDPARENT = (-8);
+
 
                 internal static class Util
                 {
@@ -2524,17 +2524,6 @@ namespace System.ComponentModel.Design
                 public static extern IntPtr SelectObject(HandleRef hDC, HandleRef hObject);
             }
 
-            private static class UnsafeNativeMethods
-            {
-                [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-                public static extern IntPtr GetWindowLong(HandleRef hWnd, int nIndex);
-
-                [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-                public static extern IntPtr SetWindowLong(HandleRef hWnd, int nIndex, HandleRef dwNewLong);
-
-                [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-                public static extern IntPtr SendMessage(HandleRef hWnd, int msg, int wParam, int lParam);
-            }
             #endregion
 
             // Class that renders either the ellipsis or dropdown button


### PR DESCRIPTION
## Proposed changes

- Remove UnsafeNativeMethods class from DesignerActionPanel.cs
- Use existing Interop methods and enum instead.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2223)