### PR TITLE
Add designer attribute tests

### DIFF
--- a/src/System.Design/src/System.Design.Forwards.cs
+++ b/src/System.Design/src/System.Design.Forwards.cs
@@ -26,3 +26,17 @@ using System.Runtime.CompilerServices;
 
 // internal serializers
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ControlCodeDomSerializer))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.DataGridViewRowCollectionCodeDomSerializer))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.TableLayoutControlCollectionCodeDomSerializer))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.TableLayoutPanelCodeDomSerializer))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ToolStripCodeDomSerializer))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ToolStripMenuItemCodeDomSerializer))]
+
+// internal designers
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.FormDocumentDesigner))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.MaskedTextBoxDesigner))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.TextBoxBaseDesigner))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ToolStripDesigner))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ToolStripDropDownDesigner))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ToolStripItemDesigner))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ToolStripMenuItemDesigner))]

--- a/src/System.Design/src/System.Design.Forwards.cs
+++ b/src/System.Design/src/System.Design.Forwards.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+
+// internal UITypeEditors
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ColumnHeaderCollectionEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.DataMemberFieldConverter))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.DataGridViewCellStyleEditor))]
@@ -21,3 +23,6 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.StringArrayEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.StringCollectionEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.TabPageCollectionEditor))]
+
+// internal serializers
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ControlCodeDomSerializer))]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/DesignerAttributeTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/DesignerAttributeTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
 using System.Reflection;
@@ -17,6 +18,70 @@ namespace System.Windows.Forms.Design.Tests
         private const string AssemblyRef_SystemWinformsDesign = "System.Windows.Forms.Design, Version=" + FXAssembly.Version + ", Culture=neutral, PublicKeyToken=" + AssemblyRef.MicrosoftPublicKey;
         private readonly ITestOutputHelper _output;
 
+        private static readonly ImmutableHashSet<string> SkipList = ImmutableHashSet.Create(new string[] {
+            // https://github.com/dotnet/winforms/issues/2413
+            "System.Drawing.Design.UITypeEditor, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+
+            // https://github.com/dotnet/winforms/issues/2412
+            "System.Windows.Forms.Design.ControlBindingsConverter, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+
+            // https://github.com/dotnet/winforms/issues/2411
+            "System.Windows.Forms.Design.AxDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.AxHostDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.BindingNavigatorDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.BindingSourceDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.ButtonBaseDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.ComboBoxDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.DataGridViewColumnDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.DataGridViewComboBoxColumnDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.DataGridViewDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.DateTimePickerDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.FlowLayoutPanelDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.FolderBrowserDialogDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.GroupBoxDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.ImageListDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.LabelDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.ListBoxDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.ListViewDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.MonthCalendarDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.NotifyIconDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.PanelDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.PictureBoxDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.PrintDialogDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.PropertyGridDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.RadioButtonDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.RichTextBoxDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.SaveFileDialogDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.SplitContainerDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.SplitterDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.SplitterPanelDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.StatusBarDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.TabControlDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.TabPageDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.TableLayoutPanelDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.TextBoxDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.ToolStripContainerDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.ToolStripContentPanelDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.ToolStripPanelDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.TrackBarDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.TreeViewDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.UpDownBaseDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.UserControlDocumentDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.WebBrowserDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+
+            // https://github.com/dotnet/winforms/issues/1115
+            "System.Windows.Forms.Design.DataGridViewCellStyleEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.DataGridViewColumnCollectionEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.DataGridViewColumnDataPropertyNameEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.DataGridViewComponentEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.DataMemberFieldEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.DataMemberListEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.StyleCollectionEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.ToolStripCollectionEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.ToolStripImageIndexEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Windows.Forms.Design.TreeNodeCollectionEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+        });
+
         public DesignerAttributeTests(ITestOutputHelper output)
         {
             _output = output;
@@ -26,7 +91,7 @@ namespace System.Windows.Forms.Design.Tests
         {
             foreach (var type in Assembly.Load(assembly).GetTypes())
                 foreach (var attribute in type.GetCustomAttributes(attributeType, false))
-                    yield return new[] { attribute };
+                    yield return new[] { type, attribute };
         }
 
         public static IEnumerable<object[]> GetAttributeOfTypeAndProperty_TestData(string assembly, Type attributeType)
@@ -34,11 +99,11 @@ namespace System.Windows.Forms.Design.Tests
             foreach (var type in Assembly.Load(assembly).GetTypes())
             {
                 foreach (var attribute in type.GetCustomAttributes(attributeType, false))
-                    yield return new[] { attribute };
+                    yield return new[] { type.FullName, attribute };
 
                 foreach (var property in type.GetProperties())
                     foreach (var attribute in property.GetCustomAttributes(attributeType, false))
-                        yield return new[] { attribute };
+                        yield return new[] { $"{type.FullName}, property {property.Name}", attribute };
             }
         }
 
@@ -59,10 +124,16 @@ namespace System.Windows.Forms.Design.Tests
 
         [Theory]
         [MemberData(nameof(GetAttributeOfType_TestData), AssemblyRef_SystemWinforms, typeof(DesignerAttribute))]
-        public void DesignerAttributes_DesignerAttribute_TypeExists(DesignerAttribute attribute)
+        public void DesignerAttributes_DesignerAttribute_TypeExists(Type annotatedType, DesignerAttribute attribute)
         {
             var type = Type.GetType(attribute.DesignerTypeName, false);
-            _output.WriteLine($"{attribute.DesignerTypeName} --> {type?.FullName}");
+            _output.WriteLine($"{annotatedType.FullName}: {attribute.DesignerTypeName} --> {type?.FullName}");
+
+            if (SkipList.Contains(attribute.DesignerTypeName))
+            {
+                Assert.Null(type);
+                return;
+            }
 
             Assert.NotNull(type);
         }
@@ -71,10 +142,16 @@ namespace System.Windows.Forms.Design.Tests
         [MemberData(nameof(GetAttributeOfType_TestData), AssemblyRef.SystemDrawing, typeof(DesignerSerializerAttribute))]
         [MemberData(nameof(GetAttributeOfType_TestData), AssemblyRef_SystemWinforms, typeof(DesignerSerializerAttribute))]
         [MemberData(nameof(GetAttributeOfType_TestData), AssemblyRef_SystemWinformsDesign, typeof(DesignerSerializerAttribute))]
-        public void DesignerAttributes_DesignerSerializerAttribute_TypeExists(DesignerSerializerAttribute attribute)
+        public void DesignerAttributes_DesignerSerializerAttribute_TypeExists(Type annotatedType, DesignerSerializerAttribute attribute)
         {
             var type = Type.GetType(attribute.SerializerTypeName, false);
-            _output.WriteLine($"{attribute.SerializerTypeName} --> {type?.FullName}");
+            _output.WriteLine($"{annotatedType.FullName}: {attribute.SerializerTypeName} --> {type?.FullName}");
+
+            if (SkipList.Contains(attribute.SerializerTypeName))
+            {
+                Assert.Null(type);
+                return;
+            }
 
             Assert.NotNull(type);
         }
@@ -84,7 +161,7 @@ namespace System.Windows.Forms.Design.Tests
         public void DesignerAttributes_DefaultPropertyAttribute_PropertyExists(Type type, DefaultPropertyAttribute attribute)
         {
             var propertyInfo = type.GetProperty(attribute.Name);
-            _output.WriteLine($"{attribute.Name} --> {propertyInfo?.Name}");
+            _output.WriteLine($"{type.FullName}: {attribute.Name} --> {propertyInfo?.Name}");
 
             Assert.NotNull(propertyInfo);
         }
@@ -94,7 +171,7 @@ namespace System.Windows.Forms.Design.Tests
         public void DesignerAttributes_DefaultBindingPropertyAttribute_PropertyExists(Type type, DefaultBindingPropertyAttribute attribute)
         {
             var propertyInfo = type.GetProperty(attribute.Name);
-            _output.WriteLine($"{attribute.Name} --> {propertyInfo?.Name}");
+            _output.WriteLine($"{type.FullName}: {attribute.Name} --> {propertyInfo?.Name}");
 
             Assert.NotNull(propertyInfo);
         }
@@ -104,7 +181,7 @@ namespace System.Windows.Forms.Design.Tests
         public void DesignerAttributes_DefaultEventAttribute_EventExists(Type type, DefaultEventAttribute attribute)
         {
             var eventInfo = type.GetEvent(attribute.Name);
-            _output.WriteLine($"{attribute.Name} --> {eventInfo?.Name}");
+            _output.WriteLine($"{type.FullName}: {attribute.Name} --> {eventInfo?.Name}");
 
             Assert.NotNull(eventInfo);
         }
@@ -112,10 +189,16 @@ namespace System.Windows.Forms.Design.Tests
         [Theory]
         [MemberData(nameof(GetAttributeOfTypeAndProperty_TestData), AssemblyRef.SystemDrawing, typeof(TypeConverterAttribute))]
         [MemberData(nameof(GetAttributeOfTypeAndProperty_TestData), AssemblyRef_SystemWinforms, typeof(TypeConverterAttribute))]
-        public void DesignerAttributes_TypeConverterAttribute_TypeExists(TypeConverterAttribute attribute)
+        public void DesignerAttributes_TypeConverterAttribute_TypeExists(string subject, TypeConverterAttribute attribute)
         {
             var type = Type.GetType(attribute.ConverterTypeName, false);
-            _output.WriteLine($"{attribute.ConverterTypeName} --> {type?.Name}");
+            _output.WriteLine($"{subject}: {attribute.ConverterTypeName} --> {type?.Name}");
+
+            if (SkipList.Contains(attribute.ConverterTypeName))
+            {
+                Assert.Null(type);
+                return;
+            }
 
             Assert.NotNull(type);
         }
@@ -123,10 +206,16 @@ namespace System.Windows.Forms.Design.Tests
         [Theory]
         [MemberData(nameof(GetAttributeOfTypeAndProperty_TestData), AssemblyRef.SystemDrawing, typeof(EditorAttribute))]
         [MemberData(nameof(GetAttributeOfTypeAndProperty_TestData), AssemblyRef_SystemWinforms, typeof(EditorAttribute))]
-        public void DesignerAttributes_EditorAttribute_TypeExists(EditorAttribute attribute)
+        public void DesignerAttributes_EditorAttribute_TypeExists(string subject, EditorAttribute attribute)
         {
             var type = Type.GetType(attribute.EditorTypeName, false);
-            _output.WriteLine($"{attribute.EditorTypeName} --> {type?.Name}");
+            _output.WriteLine($"{subject}: {attribute.EditorTypeName} --> {type?.Name}");
+
+            if (SkipList.Contains(attribute.EditorTypeName))
+            {
+                Assert.Null(type);
+                return;
+            }
 
             Assert.NotNull(type);
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/DesignerAttributeTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/DesignerAttributeTests.cs
@@ -1,0 +1,105 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.Design.Serialization;
+using System.Reflection;
+using Xunit;
+
+namespace System.Windows.Forms.Design.Tests
+{
+    public class DesignerAttributeTests
+    {
+        private const string AssemblyRef_SystemWinforms = "System.Windows.Forms, Version=" + FXAssembly.Version + ", Culture=neutral, PublicKeyToken=" + AssemblyRef.MicrosoftPublicKey;
+
+        public static IEnumerable<object[]> GetAttributeOfType_TestData(string assembly, Type attributeType)
+        {
+            foreach (var type in Assembly.Load(assembly).GetTypes())
+                foreach (var attribute in type.GetCustomAttributes(attributeType, false))
+                    yield return new[] { attribute };
+        }
+
+        public static IEnumerable<object[]> GetAttributeOfTypeAndProperty_TestData(string assembly, Type attributeType)
+        {
+            foreach (var type in Assembly.Load(assembly).GetTypes())
+            {
+                foreach (var attribute in type.GetCustomAttributes(attributeType, false))
+                    yield return new[] { attribute };
+
+                foreach (var property in type.GetProperties())
+                    foreach (var attribute in property.GetCustomAttributes(attributeType, false))
+                        yield return new[] { attribute };
+            }
+        }
+
+        public static IEnumerable<object[]> GetAttributeWithType_TestData(string assembly, Type attributeType)
+        {
+            foreach (var type in Assembly.Load(assembly).GetTypes())
+                foreach (var attribute in type.GetCustomAttributes(attributeType, false))
+                    yield return new[] { type, attribute };
+        }
+
+        public static IEnumerable<object[]> GetAttributeWithProperty_TestData(string assembly, Type attributeType)
+        {
+            foreach (var type in Assembly.Load(assembly).GetTypes())
+                foreach (var property in type.GetProperties())
+                    foreach (var attribute in property.GetCustomAttributes(attributeType, false))
+                        yield return new[] { property, attribute };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetAttributeOfType_TestData), AssemblyRef_SystemWinforms, typeof(DesignerAttribute))]
+        public void DesignerAttributes_DesignerAttribute_TypeExists(DesignerAttribute attribute)
+        {
+            Assert.NotNull(Type.GetType(attribute.DesignerTypeName, false));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetAttributeOfType_TestData), AssemblyRef.SystemDrawing, typeof(DesignerSerializerAttribute))]
+        [MemberData(nameof(GetAttributeOfType_TestData), AssemblyRef_SystemWinforms, typeof(DesignerSerializerAttribute))]
+        [MemberData(nameof(GetAttributeOfType_TestData), AssemblyRef.SystemWinformsDesign, typeof(DesignerSerializerAttribute))]
+        public void DesignerAttributes_DesignerSerializerAttribute_TypeExists(DesignerSerializerAttribute attribute)
+        {
+            Assert.NotNull(Type.GetType(attribute.SerializerTypeName, false));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetAttributeWithType_TestData), AssemblyRef_SystemWinforms, typeof(DefaultPropertyAttribute))]
+        public void DesignerAttributes_DefaultPropertyAttribute_PropertyExists(Type type, DefaultPropertyAttribute attribute)
+        {
+            Assert.NotNull(type.GetProperty(attribute.Name));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetAttributeWithType_TestData), AssemblyRef_SystemWinforms, typeof(DefaultBindingPropertyAttribute))]
+        public void DesignerAttributes_DefaultBindingPropertyAttribute_PropertyExists(Type type, DefaultBindingPropertyAttribute attribute)
+        {
+            Assert.NotNull(type.GetProperty(attribute.Name));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetAttributeWithType_TestData), AssemblyRef_SystemWinforms, typeof(DefaultEventAttribute))]
+        public void DesignerAttributes_DefaultEventAttribute_EventExists(Type type, DefaultEventAttribute attribute)
+        {
+            Assert.NotNull(type.GetEvent(attribute.Name));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetAttributeOfTypeAndProperty_TestData), AssemblyRef.SystemDrawing, typeof(TypeConverterAttribute))]
+        [MemberData(nameof(GetAttributeOfTypeAndProperty_TestData), AssemblyRef_SystemWinforms, typeof(TypeConverterAttribute))]
+        public void DesignerAttributes_TypeConverterAttribute_TypeExists(TypeConverterAttribute attribute)
+        {
+            Assert.NotNull(Type.GetType(attribute.ConverterTypeName, false));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetAttributeOfTypeAndProperty_TestData), AssemblyRef.SystemDrawing, typeof(EditorAttribute))]
+        [MemberData(nameof(GetAttributeOfTypeAndProperty_TestData), AssemblyRef_SystemWinforms, typeof(EditorAttribute))]
+        public void DesignerAttributes_EditorAttribute_TypeExists(EditorAttribute attribute)
+        {
+            Assert.NotNull(Type.GetType(attribute.EditorTypeName, false));
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/DesignerAttributeTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/DesignerAttributeTests.cs
@@ -70,7 +70,6 @@ namespace System.Windows.Forms.Design.Tests
             "System.Windows.Forms.Design.WebBrowserDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
 
             // https://github.com/dotnet/winforms/issues/1115
-            "System.Windows.Forms.Design.DataGridViewCellStyleEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
             "System.Windows.Forms.Design.DataGridViewColumnCollectionEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
             "System.Windows.Forms.Design.DataGridViewColumnDataPropertyNameEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
             "System.Windows.Forms.Design.DataGridViewComponentEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/DesignerAttributeTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/DesignerAttributeTests.cs
@@ -14,6 +14,7 @@ namespace System.Windows.Forms.Design.Tests
     public class DesignerAttributeTests
     {
         private const string AssemblyRef_SystemWinforms = "System.Windows.Forms, Version=" + FXAssembly.Version + ", Culture=neutral, PublicKeyToken=" + AssemblyRef.MicrosoftPublicKey;
+        private const string AssemblyRef_SystemWinformsDesign = "System.Windows.Forms.Design, Version=" + FXAssembly.Version + ", Culture=neutral, PublicKeyToken=" + AssemblyRef.MicrosoftPublicKey;
         private readonly ITestOutputHelper _output;
 
         public DesignerAttributeTests(ITestOutputHelper output)
@@ -69,7 +70,7 @@ namespace System.Windows.Forms.Design.Tests
         [Theory]
         [MemberData(nameof(GetAttributeOfType_TestData), AssemblyRef.SystemDrawing, typeof(DesignerSerializerAttribute))]
         [MemberData(nameof(GetAttributeOfType_TestData), AssemblyRef_SystemWinforms, typeof(DesignerSerializerAttribute))]
-        [MemberData(nameof(GetAttributeOfType_TestData), AssemblyRef.SystemWinformsDesign, typeof(DesignerSerializerAttribute))]
+        [MemberData(nameof(GetAttributeOfType_TestData), AssemblyRef_SystemWinformsDesign, typeof(DesignerSerializerAttribute))]
         public void DesignerAttributes_DesignerSerializerAttribute_TypeExists(DesignerSerializerAttribute attribute)
         {
             var type = Type.GetType(attribute.SerializerTypeName, false);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/DesignerAttributeTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/DesignerAttributeTests.cs
@@ -7,12 +7,19 @@ using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
 using System.Reflection;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace System.Windows.Forms.Design.Tests
 {
     public class DesignerAttributeTests
     {
         private const string AssemblyRef_SystemWinforms = "System.Windows.Forms, Version=" + FXAssembly.Version + ", Culture=neutral, PublicKeyToken=" + AssemblyRef.MicrosoftPublicKey;
+        private readonly ITestOutputHelper _output;
+
+        public DesignerAttributeTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
 
         public static IEnumerable<object[]> GetAttributeOfType_TestData(string assembly, Type attributeType)
         {
@@ -53,7 +60,10 @@ namespace System.Windows.Forms.Design.Tests
         [MemberData(nameof(GetAttributeOfType_TestData), AssemblyRef_SystemWinforms, typeof(DesignerAttribute))]
         public void DesignerAttributes_DesignerAttribute_TypeExists(DesignerAttribute attribute)
         {
-            Assert.NotNull(Type.GetType(attribute.DesignerTypeName, false));
+            var type = Type.GetType(attribute.DesignerTypeName, false);
+            _output.WriteLine($"{attribute.DesignerTypeName} --> {type?.FullName}");
+
+            Assert.NotNull(type);
         }
 
         [Theory]
@@ -62,28 +72,40 @@ namespace System.Windows.Forms.Design.Tests
         [MemberData(nameof(GetAttributeOfType_TestData), AssemblyRef.SystemWinformsDesign, typeof(DesignerSerializerAttribute))]
         public void DesignerAttributes_DesignerSerializerAttribute_TypeExists(DesignerSerializerAttribute attribute)
         {
-            Assert.NotNull(Type.GetType(attribute.SerializerTypeName, false));
+            var type = Type.GetType(attribute.SerializerTypeName, false);
+            _output.WriteLine($"{attribute.SerializerTypeName} --> {type?.FullName}");
+
+            Assert.NotNull(type);
         }
 
         [Theory]
         [MemberData(nameof(GetAttributeWithType_TestData), AssemblyRef_SystemWinforms, typeof(DefaultPropertyAttribute))]
         public void DesignerAttributes_DefaultPropertyAttribute_PropertyExists(Type type, DefaultPropertyAttribute attribute)
         {
-            Assert.NotNull(type.GetProperty(attribute.Name));
+            var propertyInfo = type.GetProperty(attribute.Name);
+            _output.WriteLine($"{attribute.Name} --> {propertyInfo?.Name}");
+
+            Assert.NotNull(propertyInfo);
         }
 
         [Theory]
         [MemberData(nameof(GetAttributeWithType_TestData), AssemblyRef_SystemWinforms, typeof(DefaultBindingPropertyAttribute))]
         public void DesignerAttributes_DefaultBindingPropertyAttribute_PropertyExists(Type type, DefaultBindingPropertyAttribute attribute)
         {
-            Assert.NotNull(type.GetProperty(attribute.Name));
+            var propertyInfo = type.GetProperty(attribute.Name);
+            _output.WriteLine($"{attribute.Name} --> {propertyInfo?.Name}");
+
+            Assert.NotNull(propertyInfo);
         }
 
         [Theory]
         [MemberData(nameof(GetAttributeWithType_TestData), AssemblyRef_SystemWinforms, typeof(DefaultEventAttribute))]
         public void DesignerAttributes_DefaultEventAttribute_EventExists(Type type, DefaultEventAttribute attribute)
         {
-            Assert.NotNull(type.GetEvent(attribute.Name));
+            var eventInfo = type.GetEvent(attribute.Name);
+            _output.WriteLine($"{attribute.Name} --> {eventInfo?.Name}");
+
+            Assert.NotNull(eventInfo);
         }
 
         [Theory]
@@ -91,7 +113,10 @@ namespace System.Windows.Forms.Design.Tests
         [MemberData(nameof(GetAttributeOfTypeAndProperty_TestData), AssemblyRef_SystemWinforms, typeof(TypeConverterAttribute))]
         public void DesignerAttributes_TypeConverterAttribute_TypeExists(TypeConverterAttribute attribute)
         {
-            Assert.NotNull(Type.GetType(attribute.ConverterTypeName, false));
+            var type = Type.GetType(attribute.ConverterTypeName, false);
+            _output.WriteLine($"{attribute.ConverterTypeName} --> {type?.Name}");
+
+            Assert.NotNull(type);
         }
 
         [Theory]
@@ -99,7 +124,10 @@ namespace System.Windows.Forms.Design.Tests
         [MemberData(nameof(GetAttributeOfTypeAndProperty_TestData), AssemblyRef_SystemWinforms, typeof(EditorAttribute))]
         public void DesignerAttributes_EditorAttribute_TypeExists(EditorAttribute attribute)
         {
-            Assert.NotNull(Type.GetType(attribute.EditorTypeName, false));
+            var type = Type.GetType(attribute.EditorTypeName, false);
+            _output.WriteLine($"{attribute.EditorTypeName} --> {type?.Name}");
+
+            Assert.NotNull(type);
         }
     }
 }


### PR DESCRIPTION
Add tests to ensure that strings specified in designer attributes correspond to existing metadata

Contributes to #2185, #2172, #1115 

## Proposed changes

- Attributes may specify strings to refer to types and other metadata (properties, events). Make sure these actually still exist in the product. These tests help preventing dead references when porting from Desktop to Core and also can detect regressions in future refactoring when renaming something which is technically internal but forgetting that it may have been referenced by attribute strings.

## Customer Impact

- Raise product quality by detecting dead metadata references in attributes

## Regression? 

- Yes (most of the references which are dead now did exist in Desktop Framework)

## Risk

- None, the change is test-only and exists only to detect regressions.

### Before

- Some types and properties carry attributes which refer to nonexisting metadata. These go by undetected until reported by someone.

### After

- Attributes referring to nonexistant metadata should be detected during testing.


## Test methodology <!-- How did you ensure quality? -->

- Manual lookup of attributes which may refer to other metadata by name. May have missed some but the list can be extended anytime.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2230)