### PR TITLE
Cleanup ADVF constants

### DIFF
--- a/src/Common/src/Interop/Ole32/Interop.ADVF.cs
+++ b/src/Common/src/Interop/Ole32/Interop.ADVF.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal partial class Interop
+{
+    internal static partial class Ole32
+    {
+        [Flags]
+        public enum ADVF : uint
+        {
+            NODATA = 0x01,
+            PRIMEFIRST = 0x02,
+            ONLYONCE = 0x04,
+            CACHE_NOHANDLER = 0x08,
+            CACHE_FORCEBUILTIN = 0x10,
+            CACHE_ONSAVE = 0x20,
+            DATAONSTOP = 0x40,
+        }
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -19,14 +19,8 @@ namespace System.Windows.Forms
 
         public const int STATUS_PENDING = 0x103; //259 = STILL_ALIVE
 
-        public const int ACM_OPENA = (0x0400 + 100),
-        ACM_OPENW = (0x0400 + 103),
-        ADVF_NODATA = 1,
-        ADVF_ONLYONCE = 4,
-        ADVF_PRIMEFIRST = 2;
-        // Note: ADVF_ONLYONCE and ADVF_PRIMEFIRST values now conform with objidl.dll but are backwards from
-        // Platform SDK documentation as of 07/21/2003.
-        // http://msdn.microsoft.com/library/default.asp?url=/library/en-us/com/htm/oen_a2z_8jxi.asp.
+        public const int ACM_OPENA = (0x0400 + 100);
+        public const int ACM_OPENW = (0x0400 + 103);
 
         public const int BCM_GETIDEALSIZE = 0x1601,
         BI_RGB = 0,

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -1308,8 +1308,10 @@ namespace System.Windows.Forms
                     int bFreeze);
         }
 
-        [ComImport(), Guid("0000010d-0000-0000-C000-000000000046"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        public interface IViewObject
+        [ComImport]
+        [Guid("0000010d-0000-0000-C000-000000000046")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        public unsafe interface IViewObject
         {
             [PreserveSig]
             int Draw(
@@ -1352,23 +1354,19 @@ namespace System.Windows.Forms
                 [In, MarshalAs(UnmanagedType.U4)]
                 int dwFreeze);
 
-            void SetAdvise(
+            [PreserveSig]
+            HRESULT SetAdvise(
                 Ole32.DVASPECT aspects,
-                [In, MarshalAs(UnmanagedType.U4)]
-                int advf,
-                [In, MarshalAs(UnmanagedType.Interface)]
+                Ole32.ADVF advf,
                 IAdviseSink pAdvSink);
 
-            void GetAdvise(
+            [PreserveSig]
+            HRESULT GetAdvise(
+                Ole32.DVASPECT* pAspects,
+                Ole32.ADVF* pAdvf,
                 // These can be NULL if caller doesn't want them
                 [In, Out, MarshalAs(UnmanagedType.LPArray)]
-                Ole32.DVASPECT[] paspects,
-                // These can be NULL if caller doesn't want them
-                [In, Out, MarshalAs(UnmanagedType.LPArray)]
-                int[] advf,
-                // These can be NULL if caller doesn't want them
-                [In, Out, MarshalAs(UnmanagedType.LPArray)]
-                IAdviseSink[] pAdvSink);
+                IAdviseSink[] ppAdvSink);
         }
 
         [ComImport]
@@ -1416,23 +1414,19 @@ namespace System.Windows.Forms
                 [In, MarshalAs(UnmanagedType.U4)]
                 int dwFreeze);
 
-            void SetAdvise(
+            [PreserveSig]
+            HRESULT SetAdvise(
                 Ole32.DVASPECT aspects,
-                [In, MarshalAs(UnmanagedType.U4)]
-                int advf,
-                [In, MarshalAs(UnmanagedType.Interface)]
+                Ole32.ADVF advf,
                 IAdviseSink pAdvSink);
 
-            void GetAdvise(
+            [PreserveSig]
+            HRESULT GetAdvise(
+                Ole32.DVASPECT* pAspects,
+                Ole32.ADVF* pAdvf,
                 // These can be NULL if caller doesn't want them
                 [In, Out, MarshalAs(UnmanagedType.LPArray)]
-                Ole32.DVASPECT[] paspects,
-                // These can be NULL if caller doesn't want them
-                [In, Out, MarshalAs(UnmanagedType.LPArray)]
-                int[] advf,
-                // These can be NULL if caller doesn't want them
-                [In, Out, MarshalAs(UnmanagedType.LPArray)]
-                IAdviseSink[] pAdvSink);
+                IAdviseSink[] ppAdvSink);
 
             [PreserveSig]
             HRESULT GetExtent(

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -79,6 +79,7 @@
     <Compile Include="..\..\Common\src\Interop\Kernel32\Interop.ProcessAccessOptions.cs" Link="Interop\Kernel32\Interop.ProcessAccessOptions.cs" />
     <Compile Include="..\..\Common\src\Interop\NtDll\Interop.RTL_OSVERSIONINFOEX.cs" Link="Interop\NtDll\Interop.RTL_OSVERSIONINFOEX.cs" />
     <Compile Include="..\..\Common\src\Interop\NtDll\Interop.RtlGetVersion.cs" Link="Interop\NtDll\Interop.RtlGetVersion.cs" />
+    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.ADVF.cs" Link="Interop\Ole32\Interop.ADVF.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.CALLCONV.cs" Link="Interop\Ole32\Interop.CALLCONV.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.DESCKIND.cs" Link="Interop\Ole32\Interop.DESCKIND.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.DispatchId.cs" Link="Interop\Ole32\Interop.DispatchId.cs" />

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -585,33 +585,33 @@ namespace System.Windows.Forms
             /// <summary>
             ///  Implements IViewObject2::GetAdvise.
             /// </summary>
-            internal void GetAdvise(Ole32.DVASPECT[] paspects, int[] padvf, IAdviseSink[] pAdvSink)
+            internal unsafe HRESULT GetAdvise(Ole32.DVASPECT* pAspects, Ole32.ADVF* pAdvf, IAdviseSink[] ppAdvSink)
             {
-                // if they want it, give it to them
-                if (paspects != null)
+                if (pAspects != null)
                 {
-                    paspects[0] = Ole32.DVASPECT.CONTENT;
+                    *pAspects = Ole32.DVASPECT.CONTENT;
                 }
 
-                if (padvf != null)
+                if (pAdvf != null)
                 {
-                    padvf[0] = 0;
+                    *pAdvf = 0;
 
                     if (_activeXState[s_viewAdviseOnlyOnce])
                     {
-                        padvf[0] |= NativeMethods.ADVF_ONLYONCE;
+                        *pAdvf |= Ole32.ADVF.ONLYONCE;
                     }
-
                     if (_activeXState[s_viewAdvisePrimeFirst])
                     {
-                        padvf[0] |= NativeMethods.ADVF_PRIMEFIRST;
+                        *pAdvf |= Ole32.ADVF.PRIMEFIRST;
                     }
                 }
 
-                if (pAdvSink != null)
+                if (ppAdvSink != null)
                 {
-                    pAdvSink[0] = _viewAdviseSink;
+                    ppAdvSink[0] = _viewAdviseSink;
                 }
+
+                return HRESULT.S_OK;
             }
 
             /// <summary>
@@ -1899,17 +1899,17 @@ namespace System.Windows.Forms
             /// <summary>
             ///  Implements IViewObject2::SetAdvise.
             /// </summary>
-            internal void SetAdvise(Ole32.DVASPECT aspects, int advf, IAdviseSink pAdvSink)
+            internal HRESULT SetAdvise(Ole32.DVASPECT aspects, Ole32.ADVF advf, IAdviseSink pAdvSink)
             {
                 // if it's not a content aspect, we don't support it.
                 if ((aspects & Ole32.DVASPECT.CONTENT) == 0)
                 {
-                    ThrowHr(HRESULT.DV_E_DVASPECT);
+                    return HRESULT.DV_E_DVASPECT;
                 }
 
-                // set up some flags  [we gotta stash for GetAdvise ...]
-                _activeXState[s_viewAdvisePrimeFirst] = (advf & NativeMethods.ADVF_PRIMEFIRST) != 0 ? true : false;
-                _activeXState[s_viewAdviseOnlyOnce] = (advf & NativeMethods.ADVF_ONLYONCE) != 0 ? true : false;
+                // Set up some flags to return from GetAdvise.
+                _activeXState[s_viewAdvisePrimeFirst] = (advf & Ole32.ADVF.PRIMEFIRST) != 0;
+                _activeXState[s_viewAdviseOnlyOnce] = (advf & Ole32.ADVF.ONLYONCE) != 0;
 
                 if (_viewAdviseSink != null && Marshal.IsComObject(_viewAdviseSink))
                 {
@@ -1923,6 +1923,8 @@ namespace System.Windows.Forms
                 {
                     ViewChanged();
                 }
+
+                return HRESULT.S_OK;
             }
 
             /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -14354,16 +14354,16 @@ namespace System.Windows.Forms
             return NativeMethods.E_NOTIMPL;
         }
 
-        void UnsafeNativeMethods.IViewObject.SetAdvise(Ole32.DVASPECT aspects, int advf, IAdviseSink pAdvSink)
+        HRESULT UnsafeNativeMethods.IViewObject.SetAdvise(Ole32.DVASPECT aspects, Ole32.ADVF advf, IAdviseSink pAdvSink)
         {
             Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:SetAdvise");
-            ActiveXInstance.SetAdvise(aspects, advf, pAdvSink);
+            return ActiveXInstance.SetAdvise(aspects, advf, pAdvSink);
         }
 
-        void UnsafeNativeMethods.IViewObject.GetAdvise(Ole32.DVASPECT[] paspects, int[] padvf, IAdviseSink[] pAdvSink)
+        unsafe HRESULT UnsafeNativeMethods.IViewObject.GetAdvise(Ole32.DVASPECT* pAspects, Ole32.ADVF* pAdvf, IAdviseSink[] ppAdvSink)
         {
             Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:GetAdvise");
-            ActiveXInstance.GetAdvise(paspects, padvf, pAdvSink);
+            return ActiveXInstance.GetAdvise(pAspects, pAdvf, ppAdvSink);
         }
 
         void UnsafeNativeMethods.IViewObject2.Draw(Ole32.DVASPECT dwDrawAspect, int lindex, IntPtr pvAspect, NativeMethods.tagDVTARGETDEVICE ptd,
@@ -14399,16 +14399,16 @@ namespace System.Windows.Forms
             return NativeMethods.E_NOTIMPL;
         }
 
-        void UnsafeNativeMethods.IViewObject2.SetAdvise(Ole32.DVASPECT aspects, int advf, IAdviseSink pAdvSink)
+        HRESULT UnsafeNativeMethods.IViewObject2.SetAdvise(Ole32.DVASPECT aspects, Ole32.ADVF advf, IAdviseSink pAdvSink)
         {
             Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:SetAdvise");
-            ActiveXInstance.SetAdvise(aspects, advf, pAdvSink);
+            return ActiveXInstance.SetAdvise(aspects, advf, pAdvSink);
         }
 
-        void UnsafeNativeMethods.IViewObject2.GetAdvise(Ole32.DVASPECT[] paspects, int[] padvf, IAdviseSink[] pAdvSink)
+        unsafe HRESULT UnsafeNativeMethods.IViewObject2.GetAdvise(Ole32.DVASPECT* pAspects, Ole32.ADVF* pAdvf, IAdviseSink[] ppAdvSink)
         {
             Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:GetAdvise");
-            ActiveXInstance.GetAdvise(paspects, padvf, pAdvSink);
+            return ActiveXInstance.GetAdvise(pAspects, pAdvf, ppAdvSink);
         }
 
         unsafe Interop.HRESULT UnsafeNativeMethods.IViewObject2.GetExtent(Ole32.DVASPECT dwDrawAspect, int lindex, NativeMethods.tagDVTARGETDEVICE ptd, Size *lpsizel)


### PR DESCRIPTION
## Proposed Changes
- Move ADVF to `Interop.Ole32`.
- Make `IViewObject.SetAdvise` and `IViewObject.GetAdvise` `PreserveSig`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2238)