### PR TITLE
Remove References from Directory.Build.props

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/Directory.Build.props
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/Directory.Build.props
@@ -2,23 +2,4 @@
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
-  <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonPackageVersion)" />
-  </ItemGroup>
-
-  <!-- Note that all relative paths in this file are relative to the CSPROJ that is being built, NOT relative to this file -->
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\System.Windows.Forms.csproj" />
-    <ProjectReference Include="..\..\System.Windows.Forms.IntegrationTests.Common\System.Windows.Forms.IntegrationTests.Common.csproj" />
-  </ItemGroup>
-    
-  <ItemGroup>
-    <Reference Include="GenStrings">
-      <HintPath>..\lib\GenStrings.dll</HintPath>
-    </Reference>
-    <Reference Include="WinformsTestLib">
-      <HintPath>..\lib\WinformsTestLib.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
 </Project>

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiButtonTests/MauiButtonTests.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiButtonTests/MauiButtonTests.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\References.targets"/>
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiComboBoxTests/MauiComboBoxTests.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiComboBoxTests/MauiComboBoxTests.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
+  <Import Project="..\References.targets"/>
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/References.targets
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/References.targets
@@ -1,0 +1,22 @@
+<Project>
+
+  <ItemGroup>
+    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonPackageVersion)" />
+  </ItemGroup>
+
+  <!-- Note that all relative paths in this file are relative to the CSPROJ that is being built, NOT relative to this file -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\System.Windows.Forms.csproj" />
+    <ProjectReference Include="..\..\System.Windows.Forms.IntegrationTests.Common\System.Windows.Forms.IntegrationTests.Common.csproj" />
+  </ItemGroup>
+    
+  <ItemGroup>
+    <Reference Include="GenStrings">
+      <HintPath>..\lib\GenStrings.dll</HintPath>
+    </Reference>
+    <Reference Include="WinformsTestLib">
+      <HintPath>..\lib\WinformsTestLib.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Investigate CI build failures - see #2107

## Proposed changes

Avoid References in Directory.Build.props.

## Customer Impact

None

## Risk

Low

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2241)