### PR TITLE
Move DOCHOSTUIDBLCLK and DOCHOSTUIFLAG enums to separate files

### DIFF
--- a/src/Common/src/Interop/Mshtml/Interop.DOCHOSTUIDBLCLK.cs
+++ b/src/Common/src/Interop/Mshtml/Interop.DOCHOSTUIDBLCLK.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class Mshtml
+    {
+        public enum DOCHOSTUIDBLCLK
+        {
+            DEFAULT = 0,
+            SHOWPROPERTIES = 1,
+            SHOWCODE = 2
+        }
+    }
+}

--- a/src/Common/src/Interop/Mshtml/Interop.DOCHOSTUIFLAG.cs
+++ b/src/Common/src/Interop/Mshtml/Interop.DOCHOSTUIFLAG.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class Mshtml
+    {
+        [Flags]
+        public enum DOCHOSTUIFLAG
+        {
+            DIALOG = 0x00000001,
+            DISABLE_HELP_MENU = 0x00000002,
+            NO3DBORDER = 0x00000004,
+            SCROLL_NO = 0x00000008,
+            DISABLE_SCRIPT_INACTIVE = 0x00000010,
+            OPENNEWWIN = 0x00000020,
+            DISABLE_OFFSCREEN = 0x00000040,
+            FLAT_SCROLLBAR = 0x00000080,
+            DIV_BLOCKDEFAULT = 0x00000100,
+            ACTIVATE_CLIENTHIT_ONLY = 0x00000200,
+            OVERRIDEBEHAVIORFACTORY = 0x00000400,
+            CODEPAGELINKEDFONTS = 0x00000800,
+            URL_ENCODING_DISABLE_UTF8 = 0x00001000,
+            URL_ENCODING_ENABLE_UTF8 = 0x00002000,
+            ENABLE_FORMS_AUTOCOMPLETE = 0x00004000,
+            ENABLE_INPLACE_NAVIGATION = 0x00010000,
+            IME_ENABLE_RECONVERSION = 0x00020000,
+            THEME = 0x00040000,
+            NOTHEME = 0x00080000,
+            NOPICS = 0x00100000,
+            NO3DOUTERBORDER = 0x00200000,
+            DISABLE_EDIT_NS_FIXUP = 0x00400000,
+            LOCAL_MACHINE_ACCESS_CHECK = 0x00800000,
+            DISABLE_UNTRUSTEDPROTOCOL = 0x01000000,
+            HOST_NAVIGATES = 0x02000000,
+            ENABLE_REDIRECT_NOTIFICATION = 0x04000000,
+            USE_WINDOWLESS_SELECTCONTROL = 0x08000000,
+            USE_WINDOWED_SELECTCONTROL = 0x10000000,
+            ENABLE_ACTIVEX_INACTIVATE_MODE = 0x20000000,
+            DPI_AWARE = 0x40000000
+        }
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -2153,38 +2153,13 @@ namespace System.Windows.Forms
             [MarshalAs(UnmanagedType.U4)]
             public int cbSize = Marshal.SizeOf<DOCHOSTUIINFO>();
             [MarshalAs(UnmanagedType.I4)]
-            public int dwFlags;
+            public Mshtml.DOCHOSTUIFLAG dwFlags;
             [MarshalAs(UnmanagedType.I4)]
-            public int dwDoubleClick;
+            public Mshtml.DOCHOSTUIDBLCLK dwDoubleClick;
             [MarshalAs(UnmanagedType.I4)]
             public int dwReserved1 = 0;
             [MarshalAs(UnmanagedType.I4)]
             public int dwReserved2 = 0;
-        }
-
-        public enum DOCHOSTUIFLAG
-        {
-            DIALOG = 0x1,
-            DISABLE_HELP_MENU = 0x2,
-            NO3DBORDER = 0x4,
-            SCROLL_NO = 0x8,
-            DISABLE_SCRIPT_INACTIVE = 0x10,
-            OPENNEWWIN = 0x20,
-            DISABLE_OFFSCREEN = 0x40,
-            FLAT_SCROLLBAR = 0x80,
-            DIV_BLOCKDEFAULT = 0x100,
-            ACTIVATE_CLIENTHIT_ONLY = 0x200,
-            NO3DOUTERBORDER = 0x00200000,
-            THEME = 0x00040000,
-            NOTHEME = 0x80000,
-            DISABLE_COOKIE = 0x400
-        }
-
-        public enum DOCHOSTUIDBLCLICK
-        {
-            DEFAULT = 0x0,
-            SHOWPROPERTIES = 0x1,
-            SHOWCODE = 0x2
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -77,6 +77,8 @@
     <Compile Include="..\..\Common\src\Interop\Kernel32\Interop.MAX_UNICODESTRING_LEN.cs" Link="Interop\Kernel32\Interop.MAX_UNICODESTRING_LEN.cs" />
     <Compile Include="..\..\Common\src\Interop\Kernel32\Interop.OpenProcess.cs" Link="Interop\Kernel32\Interop.OpenProcess.cs" />
     <Compile Include="..\..\Common\src\Interop\Kernel32\Interop.ProcessAccessOptions.cs" Link="Interop\Kernel32\Interop.ProcessAccessOptions.cs" />
+    <Compile Include="..\..\Common\src\Interop\Mshtml\Interop.DOCHOSTUIDBLCLK.cs" Link="Interop\Mshtml\Interop.DOCHOSTUIDBLCLK.cs" />
+    <Compile Include="..\..\Common\src\Interop\Mshtml\Interop.DOCHOSTUIFLAG.cs" Link="Interop\Mshtml\Interop.DOCHOSTUIFLAG.cs" />
     <Compile Include="..\..\Common\src\Interop\NtDll\Interop.RTL_OSVERSIONINFOEX.cs" Link="Interop\NtDll\Interop.RTL_OSVERSIONINFOEX.cs" />
     <Compile Include="..\..\Common\src\Interop\NtDll\Interop.RtlGetVersion.cs" Link="Interop\NtDll\Interop.RtlGetVersion.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.ADVF.cs" Link="Interop\Ole32\Interop.ADVF.cs" />

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.cs
@@ -1505,26 +1505,26 @@ namespace System.Windows.Forms
             {
                 WebBrowser wb = (WebBrowser)Host;
 
-                info.dwDoubleClick = (int)NativeMethods.DOCHOSTUIDBLCLICK.DEFAULT;
-                info.dwFlags = (int)NativeMethods.DOCHOSTUIFLAG.NO3DOUTERBORDER |
-                                (int)NativeMethods.DOCHOSTUIFLAG.DISABLE_SCRIPT_INACTIVE;
+                info.dwDoubleClick = DOCHOSTUIDBLCLK.DEFAULT;
+                info.dwFlags = DOCHOSTUIFLAG.NO3DOUTERBORDER |
+                               DOCHOSTUIFLAG.DISABLE_SCRIPT_INACTIVE;
 
                 if (wb.ScrollBarsEnabled)
                 {
-                    info.dwFlags |= (int)NativeMethods.DOCHOSTUIFLAG.FLAT_SCROLLBAR;
+                    info.dwFlags |= DOCHOSTUIFLAG.FLAT_SCROLLBAR;
                 }
                 else
                 {
-                    info.dwFlags |= (int)NativeMethods.DOCHOSTUIFLAG.SCROLL_NO;
+                    info.dwFlags |= DOCHOSTUIFLAG.SCROLL_NO;
                 }
 
                 if (Application.RenderWithVisualStyles)
                 {
-                    info.dwFlags |= (int)NativeMethods.DOCHOSTUIFLAG.THEME;
+                    info.dwFlags |= DOCHOSTUIFLAG.THEME;
                 }
                 else
                 {
-                    info.dwFlags |= (int)NativeMethods.DOCHOSTUIFLAG.NOTHEME;
+                    info.dwFlags |= DOCHOSTUIFLAG.NOTHEME;
                 }
 
                 return NativeMethods.S_OK;


### PR DESCRIPTION
##  Proposed changes

- Create files for DOCHOSTUIDBLCLK and DOCHOSTUIFLAG enums.
- Remove corresponding enums from NativeMethods.cs and replace their usages with the above enums.
- Update DOCHOSTUIINFO definition.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2242)