### PR TITLE
DataGridViewEditingControl: Adding null reference check for parent DataGridView control

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs
@@ -161,7 +161,10 @@ namespace System.Windows.Forms
         {
             base.OnHandleCreated(e);
 
-            dataGridView.SetAccessibleObjectParent(this.AccessibilityObject);
+            if (dataGridView != null)
+            {
+                dataGridView.SetAccessibleObjectParent(this.AccessibilityObject);
+            }
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs
@@ -161,10 +161,7 @@ namespace System.Windows.Forms
         {
             base.OnHandleCreated(e);
 
-            if (dataGridView != null)
-            {
-                dataGridView.SetAccessibleObjectParent(this.AccessibilityObject);
-            }
+            dataGridView?.SetAccessibleObjectParent(this.AccessibilityObject);
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
@@ -301,7 +301,10 @@ namespace System.Windows.Forms
         {
             base.OnHandleCreated(e);
 
-            dataGridView.SetAccessibleObjectParent(this.AccessibilityObject);
+            if (dataGridView != null)
+            {
+                dataGridView.SetAccessibleObjectParent(this.AccessibilityObject);
+            }
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
@@ -301,10 +301,7 @@ namespace System.Windows.Forms
         {
             base.OnHandleCreated(e);
 
-            if (dataGridView != null)
-            {
-                dataGridView.SetAccessibleObjectParent(this.AccessibilityObject);
-            }
+            dataGridView?.SetAccessibleObjectParent(this.AccessibilityObject);
         }
     }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #2138 


## Proposed changes

- Adding null reference check to DataGridView editing controls (DataGridViewComboBoxEditingControl, DataGridViewTextBoxEditingControl) to their OnHandleCreated method to prevent throwing null reference exception when the controls are outside of DataGridView control (developers potentially may put these controls anywhere on the Form)

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Users will not experience the exception in case DataGridView editing controls are outside the DataGridView control.

## Regression? 

- No

## Risk

- No

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

```
System.NullReferenceException: Object reference not set to an instance of an object.
  at System.Windows.Forms.DataGridViewComboBoxEditingControl.OnHandleCreated(EventArgs e) in /_/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs:line 164
   at System.Windows.Forms.Control.WmCreate(Message& m) in /_/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs:line 12452
   at System.Windows.Forms.Control.WndProc(Message& m) in /_/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs:line 13486
   at System.Windows.Forms.ComboBox.WndProc(Message& m) in /_/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs:line 4051
   at System.Windows.Forms.Control.ControlNativeWindow.OnMessage(Message& m) in /_/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlNativeWindow.cs:line 65
   at System.Windows.Forms.Control.ControlNativeWindow.WndProc(Message& m) in /_/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlNativeWindow.cs:line 113
   at System.Windows.Forms.NativeWindow.DebuggableCallback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam) in /_/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs:line 626
```

### After

No exception


## Test methodology <!-- How did you ensure quality? -->

- Manual testing;
- Unit tests (to be implemented);
- UI Automation tests.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

<!-- use `dotnet --info` -->

Net Core version: 3.1.0-preview1.19458.7
Microsoft Windows [Version 10.0.18362.418]


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2247)