### PR TITLE
Fixing UI and accessibility regression in DataGridView editing cell

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -1341,10 +1341,8 @@ namespace System.Windows.Forms
                 Type editingControlType = DataGridView.EditingControl.GetType();
 
                 return
-                    (editingControlType == typeof(DataGridViewComboBoxEditingControl) &&
-                    !editingControlType.IsSubclassOf(typeof(DataGridViewComboBoxEditingControl))) ||
-                    (editingControlType == typeof(DataGridViewTextBoxEditingControl) &&
-                    !editingControlType.IsSubclassOf(typeof(DataGridViewTextBoxEditingControl)));
+                    (editingControlType == typeof(DataGridViewComboBoxEditingControl) && !editingControlType.IsSubclassOf(typeof(DataGridViewComboBoxEditingControl))) ||
+                    (editingControlType == typeof(DataGridViewTextBoxEditingControl) && !editingControlType.IsSubclassOf(typeof(DataGridViewTextBoxEditingControl)));
             }
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #2036 


## Proposed changes

- Prevented accessible restructuring for the editing controls with custom accessible hierarchy (like masked editing control or IP editing control which may have several children under the cell) - in this case control WM processing can be broken on recreating handle.
- Added check for known editing controls (ComboBox and TextBox) - these controls' and DataGridView cell hierarchy should be updated in case there are multiple columns of the same type in the DataGridView.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- User will experience correct accessibility hierarchy of DataGridView cell and will not experience issues with incorrect handling of Window messages related to incorrect accessibility restructuring.

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

- Incorrect accessibility hierarchy and broken visual representation of some custom editing controls.

### After

- Correct hierarchy and no UI issues.


## Test methodology <!-- How did you ensure quality? -->

- Manual testing;
- Unit tests (to be implemented);
- UI automation tests.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

<!-- use `dotnet --info` -->
Net Core version: 3.1.0-preview1.19458.7
Microsoft Windows [Version 10.0.18362.418]


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2248)