### PR TITLE
Structify NMCUSTOMDRAW and dependencies

### DIFF
--- a/src/Common/src/Interop/ComCtl32/Interop.CDDS.cs
+++ b/src/Common/src/Interop/ComCtl32/Interop.CDDS.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        [Flags]
+        public enum CDDS : uint
+        {
+            PREPAINT = 0x00000001,
+            POSTPAINT = 0x00000002,
+            PREERASE = 0x00000003,
+            POSTERASE = 0x00000004,
+            ITEM = 0x00010000,
+            ITEMPREPAINT = ITEM | PREPAINT,
+            ITEMPOSTPAINT = ITEM | POSTPAINT,
+            ITEMPREERASE = ITEM | PREERASE,
+            ITEMPOSTERASE = ITEM | POSTERASE,
+            SUBITEM = 0x00020000,
+        }
+    }
+}

--- a/src/Common/src/Interop/ComCtl32/Interop.CDIS.cs
+++ b/src/Common/src/Interop/ComCtl32/Interop.CDIS.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        [Flags]
+        public enum CDIS : uint
+        {
+            SELECTED = 0x0001,
+            GRAYED = 0x0002,
+            DISABLED = 0x0004,
+            CHECKED = 0x0008,
+            FOCUS = 0x0010,
+            DEFAULT = 0x0020,
+            HOT = 0x0040,
+            MARKED = 0x0080,
+            INDETERMINATE = 0x0100,
+            SHOWKEYBOARDCUES = 0x0200,
+            NEARHOT = 0x0400,
+            OTHERSIDEHOT = 0x0800,
+            DROPHILITED = 0x1000,
+        }
+    }
+}

--- a/src/Common/src/Interop/ComCtl32/Interop.CDRF.cs
+++ b/src/Common/src/Interop/ComCtl32/Interop.CDRF.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        [Flags]
+        public enum CDRF : uint
+        {
+            DODEFAULT = 0x00000000,
+            NEWFONT = 0x00000002,
+            SKIPDEFAULT = 0x00000004,
+            DOERASE = 0x00000008,
+            SKIPPOSTPAINT = 0x00000100,
+            NOTIFYPOSTPAINT = 0x00000010,
+            NOTIFYITEMDRAW = 0x00000020,
+            NOTIFYSUBITEMDRAW = 0x00000020,
+            NOTIFYPOSTERASE = 0x00000040,
+        }
+    }
+}

--- a/src/Common/src/Interop/ComCtl32/Interop.LVCDI.cs
+++ b/src/Common/src/Interop/ComCtl32/Interop.LVCDI.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        [Flags]
+        public enum LVCDI : uint
+        {
+            ITEM = 0x00000000,
+            GROUP = 0x00000001,
+            ITEMSLIST = 0x00000002,
+        }
+    }
+}

--- a/src/Common/src/Interop/ComCtl32/Interop.LVGA.cs
+++ b/src/Common/src/Interop/ComCtl32/Interop.LVGA.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        [Flags]
+        public enum LVGA : uint
+        {
+            HEADER_LEFT = 0x00000001,
+            HEADER_CENTER = 0x00000002,
+            HEADER_RIGHT = 0x00000004,
+            FOOTER_LEFT = 0x00000008,
+            FOOTER_CENTER = 0x00000010,
+            FOOTER_RIGHT = 0x00000020,
+        }
+    }
+}

--- a/src/Common/src/Interop/ComCtl32/Interop.LVGF.cs
+++ b/src/Common/src/Interop/ComCtl32/Interop.LVGF.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        [Flags]
+        public enum LVGF : uint
+        {
+            NONE = 0x00000000,
+            HEADER = 0x00000001,
+            FOOTER = 0x00000002,
+            STATE = 0x00000004,
+            ALIGN = 0x00000008,
+            GROUPID = 0x00000010,
+            SUBTITLE = 0x00000100,
+            TASK = 0x00000200,
+            DESCRIPTIONTOP = 0x00000400,
+            DESCRIPTIONBOTTOM = 0x00000800,
+            TITLEIMAGE = 0x00001000,
+            EXTENDEDIMAGE = 0x00002000,
+            ITEMS = 0x00004000,
+            SUBSET = 0x00008000,
+            SUBSETITEMS = 0x00010000,
+        }
+    }
+}

--- a/src/Common/src/Interop/ComCtl32/Interop.LVGROUP.cs
+++ b/src/Common/src/Interop/ComCtl32/Interop.LVGROUP.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        public struct LVGROUP
+        {
+            public uint cbSize;
+            public LVGF mask;
+            public IntPtr pszHeader;
+            public int cchHeader;
+            public IntPtr pszFooter;
+            public int cchFooter;
+            public int iGroupId;
+            public uint stateMask;
+            public LVGS state;
+            public LVGA uAlign;
+        }
+    }
+}

--- a/src/Common/src/Interop/ComCtl32/Interop.LVGS.cs
+++ b/src/Common/src/Interop/ComCtl32/Interop.LVGS.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        [Flags]
+        public enum LVGS : uint
+        {
+            NORMAL = 0x00000000,
+            COLLAPSED = 0x00000001,
+            HIDDEN = 0x00000002,
+            NOHEADER = 0x00000004,
+            COLLAPSIBLE = 0x00000008,
+            FOCUSED = 0x00000010,
+            SELECTED = 0x00000020,
+            SUBSETED = 0x00000040,
+            SUBSETLINKFOCUSED = 0x00000080,
+        }
+    }
+}

--- a/src/Common/src/Interop/ComCtl32/Interop.NMCUSTOMDRAW.cs
+++ b/src/Common/src/Interop/ComCtl32/Interop.NMCUSTOMDRAW.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        public struct NMCUSTOMDRAW
+        {
+            public User32.NMHDR nmcd;
+            public CDDS dwDrawStage;
+            public IntPtr hdc;
+            public RECT rc;
+            public IntPtr dwItemSpec;
+            public CDIS uItemState;
+            public IntPtr lItemlParam;
+        }
+    }
+}

--- a/src/Common/src/Interop/ComCtl32/Interop.NMLVCUSTOMDRAW.cs
+++ b/src/Common/src/Interop/ComCtl32/Interop.NMLVCUSTOMDRAW.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Drawing;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        public struct NMLVCUSTOMDRAW
+        {
+            public NMCUSTOMDRAW nmcd;
+            public int clrText;
+            public int clrTextBk;
+            public int iSubItem;
+            public ComCtl32.LVCDI dwItemType;
+            public int clrFace;
+            public int iIconEffect;
+            public int iIconPhase;
+            public int iPartId;
+            public int iStateId;
+            public RECT rcText;
+            public uint uAlign;
+        }
+    }
+}

--- a/src/Common/src/Interop/ComCtl32/Interop.NMTVCUSTOMDRAW.cs
+++ b/src/Common/src/Interop/ComCtl32/Interop.NMTVCUSTOMDRAW.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        public struct NMTVCUSTOMDRAW
+        {
+            public NMCUSTOMDRAW nmcd;
+            public int clrText;
+            public int clrTextBk;
+            public int iLevel;
+        }
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -434,8 +434,6 @@ namespace System.Windows.Forms
         LVA_ALIGNLEFT = 0x0001,
         LVA_ALIGNTOP = 0x0002,
         LVA_SNAPTOGRID = 0x0005,
-        LVCDI_ITEM = 0x0000,
-        LVCDI_GROUP = 0x00000001,
         LVCF_FMT = 0x0001,
         LVCF_WIDTH = 0x0002,
         LVCF_TEXT = 0x0004,
@@ -443,12 +441,6 @@ namespace System.Windows.Forms
         LVCF_IMAGE = 0x0010,
         LVCF_ORDER = 0x0020,
         LVCFMT_IMAGE = 0x0800,
-        LVGA_HEADER_LEFT = 0x00000001,
-        LVGA_HEADER_CENTER = 0x00000002,
-        LVGA_HEADER_RIGHT = 0x00000004,
-        LVGA_FOOTER_LEFT = 0x00000008,
-        LVGA_FOOTER_CENTER = 0x00000010,
-        LVGA_FOOTER_RIGHT = 0x00000020,
         LVGF_NONE = 0x00000000,
         LVGF_HEADER = 0x00000001,
         LVGF_FOOTER = 0x00000002,
@@ -1829,25 +1821,6 @@ namespace System.Windows.Forms
             public short st_wMilliseconds = 0;
         }
 
-        [StructLayout(LayoutKind.Sequential)]
-        public struct NMLVCUSTOMDRAW
-        {
-            public ComCtl32.NMCUSTOMDRAW nmcd;
-            public int clrText;
-            public int clrTextBk;
-            public int iSubItem;
-            public int dwItemType;
-            // Item Custom Draw
-            public int clrFace;
-            public int iIconEffect;
-            public int iIconPhase;
-            public int iPartId;
-            public int iStateId;
-            // Group Custom Draw
-            public RECT rcText;
-            public uint uAlign;
-        }
-
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
         public class NMLVGETINFOTIP
         {
@@ -1987,7 +1960,7 @@ namespace System.Windows.Forms
             public int iGroupId;
             public uint stateMask = 0;
             public uint state = 0;
-            public uint uAlign;
+            public ComCtl32.LVGA uAlign;
 
             public override string ToString()
             {

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -441,15 +441,6 @@ namespace System.Windows.Forms
         LVCF_IMAGE = 0x0010,
         LVCF_ORDER = 0x0020,
         LVCFMT_IMAGE = 0x0800,
-        LVGF_NONE = 0x00000000,
-        LVGF_HEADER = 0x00000001,
-        LVGF_FOOTER = 0x00000002,
-        LVGF_STATE = 0x00000004,
-        LVGF_ALIGN = 0x00000008,
-        LVGF_GROUPID = 0x00000010,
-        LVGS_NORMAL = 0x00000000,
-        LVGS_COLLAPSED = 0x00000001,
-        LVGS_HIDDEN = 0x00000002,
         LVIM_AFTER = 0x00000001,
         LVTVIF_FIXEDSIZE = 0x00000003,
         LVTVIM_TILESIZE = 0x00000001,
@@ -1937,26 +1928,6 @@ namespace System.Windows.Forms
             public int iSubItem = 0;
             public int iImage;
             public int iOrder = 0;
-        }
-
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-        public class LVGROUP
-        {
-            public uint cbSize = (uint)Marshal.SizeOf<LVGROUP>();
-            public uint mask;
-            public IntPtr pszHeader;
-            public int cchHeader;
-            public IntPtr pszFooter = IntPtr.Zero;
-            public int cchFooter = 0;
-            public int iGroupId;
-            public uint stateMask = 0;
-            public uint state = 0;
-            public ComCtl32.LVGA uAlign;
-
-            public override string ToString()
-            {
-                return "LVGROUP: header = " + pszHeader.ToString() + ", iGroupId = " + iGroupId.ToString(CultureInfo.InvariantCulture);
-            }
         }
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -121,28 +121,6 @@ namespace System.Windows.Forms
         CB_FINDSTRINGEXACT = 0x0158,
         CB_GETDROPPEDWIDTH = 0x015F,
         CB_SETDROPPEDWIDTH = 0x0160,
-        CDRF_DODEFAULT = 0x00000000,
-        CDRF_NEWFONT = 0x00000002,
-        CDRF_SKIPDEFAULT = 0x00000004,
-        CDRF_NOTIFYPOSTPAINT = 0x00000010,
-        CDRF_NOTIFYITEMDRAW = 0x00000020,
-        CDRF_NOTIFYSUBITEMDRAW = CDRF_NOTIFYITEMDRAW,
-        CDDS_PREPAINT = 0x00000001,
-        CDDS_POSTPAINT = 0x00000002,
-        CDDS_ITEM = 0x00010000,
-        CDDS_SUBITEM = 0x00020000,
-        CDDS_ITEMPREPAINT = (0x00010000 | 0x00000001),
-        CDDS_ITEMPOSTPAINT = (0x00010000 | 0x00000002),
-        CDIS_SELECTED = 0x0001,
-        CDIS_GRAYED = 0x0002,
-        CDIS_DISABLED = 0x0004,
-        CDIS_CHECKED = 0x0008,
-        CDIS_FOCUS = 0x0010,
-        CDIS_DEFAULT = 0x0020,
-        CDIS_HOT = 0x0040,
-        CDIS_MARKED = 0x0080,
-        CDIS_INDETERMINATE = 0x0100,
-        CDIS_SHOWKEYBOARDCUES = 0x0200,
         CCM_SETVERSION = (0x2000 + 0x7),
         CCM_GETVERSION = (0x2000 + 0x8),
         CCS_NORESIZE = 0x00000004,
@@ -1828,22 +1806,10 @@ namespace System.Windows.Forms
         [StructLayout(LayoutKind.Sequential)]
         public class NMTVCUSTOMDRAW
         {
-            public NMCUSTOMDRAW nmcd;
+            public ComCtl32.NMCUSTOMDRAW nmcd;
             public int clrText;
             public int clrTextBk;
             public int iLevel = 0;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public struct NMCUSTOMDRAW
-        {
-            public User32.NMHDR nmcd;
-            public int dwDrawStage;
-            public IntPtr hdc;
-            public RECT rc;
-            public IntPtr dwItemSpec;
-            public int uItemState;
-            public IntPtr lItemlParam;
         }
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
@@ -1866,7 +1832,7 @@ namespace System.Windows.Forms
         [StructLayout(LayoutKind.Sequential)]
         public struct NMLVCUSTOMDRAW
         {
-            public NMCUSTOMDRAW nmcd;
+            public ComCtl32.NMCUSTOMDRAW nmcd;
             public int clrText;
             public int clrTextBk;
             public int iSubItem;

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -1795,15 +1795,6 @@ namespace System.Windows.Forms
             public IntPtr hItem = IntPtr.Zero;
         }
 
-        [StructLayout(LayoutKind.Sequential)]
-        public class NMTVCUSTOMDRAW
-        {
-            public ComCtl32.NMCUSTOMDRAW nmcd;
-            public int clrText;
-            public int clrTextBk;
-            public int iLevel = 0;
-        }
-
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
         public class MCHITTESTINFO
         {

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -359,9 +359,6 @@ namespace System.Windows.Forms
         public static extern IntPtr SendMessage(HandleRef hWnd, int msg, int wParam, NativeMethods.LVCOLUMN lParam);
 
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-        public static extern IntPtr SendMessage(HandleRef hWnd, int msg, int wParam, NativeMethods.LVGROUP lParam);
-
-        [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
         public static extern IntPtr SendMessage(HandleRef hWnd, int msg, ref Point wParam, [In, Out] NativeMethods.LVINSERTMARK lParam);
 
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.cs
@@ -807,22 +807,21 @@ namespace System.Windows.Forms.Design
                 }
             }
 
-            private void OnCustomDraw(ref Message m)
+            private unsafe void OnCustomDraw(ref Message m)
             {
-                NativeMethods.NMTVCUSTOMDRAW nmtvcd = (NativeMethods.NMTVCUSTOMDRAW)m.GetLParam(typeof(NativeMethods.NMTVCUSTOMDRAW));
-
-                switch (nmtvcd.nmcd.dwDrawStage)
+                ComCtl32.NMTVCUSTOMDRAW* nmtvcd = (ComCtl32.NMTVCUSTOMDRAW*)m.LParam;
+                switch (nmtvcd->nmcd.dwDrawStage)
                 {
                     case ComCtl32.CDDS.PREPAINT:
                         m.Result = (IntPtr)(ComCtl32.CDRF.NOTIFYITEMDRAW | ComCtl32.CDRF.NOTIFYPOSTPAINT);
                         break;
                     case ComCtl32.CDDS.ITEMPREPAINT:
                         {
-                            TreeNode itemNode = TreeNode.FromHandle(this, (IntPtr)nmtvcd.nmcd.dwItemSpec);
+                            TreeNode itemNode = TreeNode.FromHandle(this, (IntPtr)nmtvcd->nmcd.dwItemSpec);
                             if (itemNode != null)
                             {
                                 int state = STATE_NORMAL;
-                                ComCtl32.CDIS itemState = nmtvcd.nmcd.uItemState;
+                                ComCtl32.CDIS itemState = nmtvcd->nmcd.uItemState;
                                 if (((itemState & ComCtl32.CDIS.HOT) != 0) || ((itemState & ComCtl32.CDIS.FOCUS) != 0))
                                 {
                                     state |= STATE_HOT;
@@ -834,7 +833,7 @@ namespace System.Windows.Forms.Design
                                 }
 
                                 DrawTreeItem(itemNode.Text, itemNode.ImageIndex,
-                                         nmtvcd.nmcd.hdc, nmtvcd.nmcd.rc,
+                                         nmtvcd->nmcd.hdc, nmtvcd->nmcd.rc,
                                          state, ColorTranslator.ToWin32(SystemColors.Control), ColorTranslator.ToWin32(SystemColors.ControlText));
                             }
                             m.Result = (IntPtr)ComCtl32.CDRF.SKIPDEFAULT;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.cs
@@ -813,24 +813,22 @@ namespace System.Windows.Forms.Design
 
                 switch (nmtvcd.nmcd.dwDrawStage)
                 {
-                    case NativeMethods.CDDS_PREPAINT:
-                        m.Result = (IntPtr)(NativeMethods.CDRF_NOTIFYITEMDRAW | NativeMethods.CDRF_NOTIFYPOSTPAINT);
+                    case ComCtl32.CDDS.PREPAINT:
+                        m.Result = (IntPtr)(ComCtl32.CDRF.NOTIFYITEMDRAW | ComCtl32.CDRF.NOTIFYPOSTPAINT);
                         break;
-                    case NativeMethods.CDDS_ITEMPREPAINT:
+                    case ComCtl32.CDDS.ITEMPREPAINT:
                         {
                             TreeNode itemNode = TreeNode.FromHandle(this, (IntPtr)nmtvcd.nmcd.dwItemSpec);
                             if (itemNode != null)
                             {
                                 int state = STATE_NORMAL;
-                                int itemState = nmtvcd.nmcd.uItemState;
-
-                                if (((itemState & NativeMethods.CDIS_HOT) != 0) ||
-                                   ((itemState & NativeMethods.CDIS_FOCUS) != 0))
+                                ComCtl32.CDIS itemState = nmtvcd.nmcd.uItemState;
+                                if (((itemState & ComCtl32.CDIS.HOT) != 0) || ((itemState & ComCtl32.CDIS.FOCUS) != 0))
                                 {
                                     state |= STATE_HOT;
                                 }
 
-                                if ((itemState & NativeMethods.CDIS_SELECTED) != 0)
+                                if ((itemState & ComCtl32.CDIS.SELECTED) != 0)
                                 {
                                     state |= STATE_SELECTED;
                                 }
@@ -839,15 +837,15 @@ namespace System.Windows.Forms.Design
                                          nmtvcd.nmcd.hdc, nmtvcd.nmcd.rc,
                                          state, ColorTranslator.ToWin32(SystemColors.Control), ColorTranslator.ToWin32(SystemColors.ControlText));
                             }
-                            m.Result = (IntPtr)NativeMethods.CDRF_SKIPDEFAULT;
+                            m.Result = (IntPtr)ComCtl32.CDRF.SKIPDEFAULT;
 
                         }
                         break;
-                    case NativeMethods.CDDS_POSTPAINT:
-                        m.Result = (IntPtr)NativeMethods.CDRF_SKIPDEFAULT;
+                    case ComCtl32.CDDS.POSTPAINT:
+                        m.Result = (IntPtr)ComCtl32.CDRF.SKIPDEFAULT;
                         break;
                     default:
-                        m.Result = (IntPtr)NativeMethods.CDRF_DODEFAULT;
+                        m.Result = (IntPtr)ComCtl32.CDRF.DODEFAULT;
                         break;
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -2593,14 +2593,14 @@ namespace System.Windows.Forms
                 // Find out which stage we're drawing
                 switch (nmcd->nmcd.dwDrawStage)
                 {
-                    case NativeMethods.CDDS_PREPAINT:
+                    case ComCtl32.CDDS.PREPAINT:
                         if (OwnerDraw)
                         {
-                            m.Result = (IntPtr)(NativeMethods.CDRF_NOTIFYITEMDRAW);
+                            m.Result = (IntPtr)(ComCtl32.CDRF.NOTIFYITEMDRAW);
                             return;
                         }
                         // We want custom draw for this paint cycle
-                        m.Result = (IntPtr)(NativeMethods.CDRF_NOTIFYSUBITEMDRAW | NativeMethods.CDRF_NEWFONT);
+                        m.Result = (IntPtr)(ComCtl32.CDRF.NOTIFYSUBITEMDRAW | ComCtl32.CDRF.NEWFONT);
                         // refresh the cache of the current color & font settings for this paint cycle
                         odCacheBackColor = BackColor;
                         odCacheForeColor = ForeColor;
@@ -2618,7 +2618,7 @@ namespace System.Windows.Forms
                             odCacheFontHandleWrapper = new FontHandleWrapper(odCacheFont);
                             odCacheFontHandle = odCacheFontHandleWrapper.Handle;
                             Gdi32.SelectObject(new HandleRef(nmcd->nmcd, nmcd->nmcd.hdc), new HandleRef(odCacheFontHandleWrapper, odCacheFontHandleWrapper.Handle));
-                            m.Result = (IntPtr)NativeMethods.CDRF_NEWFONT;
+                            m.Result = (IntPtr)ComCtl32.CDRF.NEWFONT;
                         }
                         return;
 
@@ -2627,7 +2627,7 @@ namespace System.Windows.Forms
 
                     //HOWEVER... we only want to do this for report styles...
 
-                    case NativeMethods.CDDS_ITEMPREPAINT:
+                    case ComCtl32.CDDS.ITEMPREPAINT:
 
                         int itemIndex = (int)nmcd->nmcd.dwItemSpec;
                         // The following call silently returns Rectangle.Empty if no corresponding
@@ -2676,13 +2676,13 @@ namespace System.Windows.Forms
                             // For other view styles, we do it here.
                             if (viewStyle == View.Details)
                             {
-                                m.Result = (IntPtr)(NativeMethods.CDRF_NOTIFYSUBITEMDRAW);
+                                m.Result = (IntPtr)(ComCtl32.CDRF.NOTIFYSUBITEMDRAW);
                             }
                             else
                             {
                                 if (!e.DrawDefault)
                                 {
-                                    m.Result = (IntPtr)(NativeMethods.CDRF_SKIPDEFAULT);
+                                    m.Result = (IntPtr)(ComCtl32.CDRF.SKIPDEFAULT);
                                 }
                             }
 
@@ -2694,7 +2694,7 @@ namespace System.Windows.Forms
 
                         if (viewStyle == View.Details || viewStyle == View.Tile)
                         {
-                            m.Result = (IntPtr)(NativeMethods.CDRF_NOTIFYSUBITEMDRAW | NativeMethods.CDRF_NEWFONT);
+                            m.Result = (IntPtr)(ComCtl32.CDRF.NOTIFYSUBITEMDRAW | ComCtl32.CDRF.NEWFONT);
                             dontmess = true; // don't mess with our return value!
 
                             //ITEMPREPAINT is used to work out the rect for the first column!!! GAH!!!
@@ -2706,9 +2706,9 @@ namespace System.Windows.Forms
 
                         //If it's not a report, we fall through and change the main item's styles
 
-                        goto case (NativeMethods.CDDS_SUBITEM | NativeMethods.CDDS_ITEMPREPAINT);
+                        goto case (ComCtl32.CDDS.SUBITEM | ComCtl32.CDDS.ITEMPREPAINT);
 
-                    case (NativeMethods.CDDS_SUBITEM | NativeMethods.CDDS_ITEMPREPAINT):
+                    case (ComCtl32.CDDS.SUBITEM | ComCtl32.CDDS.ITEMPREPAINT):
 
                         itemIndex = (int)nmcd->nmcd.dwItemSpec;
                         // The following call silently returns Rectangle.Empty if no corresponding
@@ -2774,7 +2774,7 @@ namespace System.Windows.Forms
 
                             if (skipCustomDrawCode)
                             {
-                                m.Result = (IntPtr)(NativeMethods.CDRF_SKIPDEFAULT);
+                                m.Result = (IntPtr)(ComCtl32.CDRF.SKIPDEFAULT);
                                 return; // skip our custom draw code
                             }
                         }
@@ -2784,11 +2784,11 @@ namespace System.Windows.Forms
                         // if we're doing the whole row in one style, change our result!
                         if (dontmess && item.UseItemStyleForSubItems)
                         {
-                            m.Result = (IntPtr)NativeMethods.CDRF_NEWFONT;
+                            m.Result = (IntPtr)ComCtl32.CDRF.NEWFONT;
                         }
                         Debug.Assert(item != null, "Item was null in ITEMPREPAINT");
 
-                        int state = nmcd->nmcd.uItemState;
+                        ComCtl32.CDIS state = nmcd->nmcd.uItemState;
                         // There is a known and documented problem in the ListView winctl control -
                         // if the LVS_SHOWSELALWAYS style is set, then the item state will have
                         // the CDIS_SELECTED bit set for all items. So we need to verify with the
@@ -2798,7 +2798,7 @@ namespace System.Windows.Forms
                             ComCtl32.LVIS realState = GetItemState((int)(nmcd->nmcd.dwItemSpec));
                             if ((realState & ComCtl32.LVIS.SELECTED) == 0)
                             {
-                                state &= ~NativeMethods.CDIS_SELECTED;
+                                state &= ~ComCtl32.CDIS.SELECTED;
                             }
                         }
 
@@ -2806,7 +2806,7 @@ namespace System.Windows.Forms
                         // cases where subitems aren't visible (ie. non-Details modes), so if subitem
                         // is invalid, point it at the main item's render info
 
-                        int subitem = ((nmcd->nmcd.dwDrawStage & NativeMethods.CDDS_SUBITEM) != 0) ? nmcd->iSubItem : 0;
+                        int subitem = ((nmcd->nmcd.dwDrawStage & ComCtl32.CDDS.SUBITEM) != 0) ? nmcd->iSubItem : 0;
 
                         // Work out the style in which to render this item
                         //
@@ -2818,7 +2818,7 @@ namespace System.Windows.Forms
                         if (item != null && subitem < item.SubItems.Count)
                         {
                             haveRenderInfo = true;
-                            if (subitem == 0 && (state & NativeMethods.CDIS_HOT) != 0 && HotTracking)
+                            if (subitem == 0 && (state & ComCtl32.CDIS.HOT) != 0 && HotTracking)
                             {
                                 disposeSubItemFont = true;
                                 subItemFont = new Font(item.SubItems[0].Font, FontStyle.Underline);
@@ -2828,7 +2828,7 @@ namespace System.Windows.Forms
                                 subItemFont = item.SubItems[subitem].Font;
                             }
 
-                            if (subitem > 0 || (state & (NativeMethods.CDIS_SELECTED | NativeMethods.CDIS_GRAYED | NativeMethods.CDIS_HOT | NativeMethods.CDIS_DISABLED)) == 0)
+                            if (subitem > 0 || (state & (ComCtl32.CDIS.SELECTED | ComCtl32.CDIS.GRAYED | ComCtl32.CDIS.HOT | ComCtl32.CDIS.DISABLED)) == 0)
                             {
                                 // we only propogate colors if we're displaying things normally
                                 // the user can override this method to do all kinds of other bad things if they
@@ -2859,10 +2859,10 @@ namespace System.Windows.Forms
                         else if ((activation == ItemActivation.OneClick)
                               || (activation == ItemActivation.TwoClick))
                         {
-                            if ((state & (NativeMethods.CDIS_SELECTED
-                                        | NativeMethods.CDIS_GRAYED
-                                        | NativeMethods.CDIS_HOT
-                                        | NativeMethods.CDIS_DISABLED)) != 0)
+                            if ((state & (ComCtl32.CDIS.SELECTED
+                                        | ComCtl32.CDIS.GRAYED
+                                        | ComCtl32.CDIS.HOT
+                                        | ComCtl32.CDIS.DISABLED)) != 0)
                             {
                                 changeColor = false;
                             }
@@ -2953,7 +2953,7 @@ namespace System.Windows.Forms
 
                         if (!dontmess)
                         {
-                            m.Result = (IntPtr)NativeMethods.CDRF_NEWFONT;
+                            m.Result = (IntPtr)ComCtl32.CDRF.NEWFONT;
                         }
                         if (disposeSubItemFont)
                         {
@@ -2962,14 +2962,14 @@ namespace System.Windows.Forms
                         return;
 
                     default:
-                        m.Result = (IntPtr)NativeMethods.CDRF_DODEFAULT;
+                        m.Result = (IntPtr)ComCtl32.CDRF.DODEFAULT;
                         return;
                 }
             }
             catch (Exception e)
             {
                 Debug.Fail("Exception occurred attempting to setup custom draw. Disabling custom draw for this control", e.ToString());
-                m.Result = (IntPtr)NativeMethods.CDRF_DODEFAULT;
+                m.Result = (IntPtr)ComCtl32.CDRF.DODEFAULT;
             }
         }
 
@@ -5753,17 +5753,17 @@ namespace System.Windows.Forms
             {
                 try
                 {
-                    NativeMethods.NMCUSTOMDRAW* nmcd = (NativeMethods.NMCUSTOMDRAW*)m.LParam;
+                    ComCtl32.NMCUSTOMDRAW* nmcd = (ComCtl32.NMCUSTOMDRAW*)m.LParam;
                     // Find out which stage we're drawing
                     switch (nmcd->dwDrawStage)
                     {
-                        case NativeMethods.CDDS_PREPAINT:
+                        case ComCtl32.CDDS.PREPAINT:
                             {
-                                m.Result = (IntPtr)(NativeMethods.CDRF_NOTIFYITEMDRAW);
+                                m.Result = (IntPtr)(ComCtl32.CDRF.NOTIFYITEMDRAW);
                                 return true; // we are done - don't do default handling
 
                             }
-                        case NativeMethods.CDDS_ITEMPREPAINT:
+                        case ComCtl32.CDDS.ITEMPREPAINT:
                             {
                                 using (Graphics g = Graphics.FromHdcInternal(nmcd->hdc))
                                 {
@@ -5782,13 +5782,13 @@ namespace System.Windows.Forms
                                     OnDrawColumnHeader(e);
                                     if (e.DrawDefault)
                                     {
-                                        m.Result = (IntPtr)(NativeMethods.CDRF_DODEFAULT);
+                                        m.Result = (IntPtr)(ComCtl32.CDRF.DODEFAULT);
                                         return false;
                                     }
                                     else
                                     {
 
-                                        m.Result = (IntPtr)(NativeMethods.CDRF_SKIPDEFAULT);
+                                        m.Result = (IntPtr)(ComCtl32.CDRF.SKIPDEFAULT);
                                         return true; // we are done - don't do default handling
                                     }
                                 }
@@ -5801,7 +5801,7 @@ namespace System.Windows.Forms
                 catch (Exception e)
                 {
                     Debug.Fail("Exception occurred attempting to setup header custom draw. Disabling custom draw for the column header", e.ToString());
-                    m.Result = (IntPtr)NativeMethods.CDRF_DODEFAULT;
+                    m.Result = (IntPtr)ComCtl32.CDRF.DODEFAULT;
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -2589,7 +2589,7 @@ namespace System.Windows.Forms
 
             try
             {
-                NativeMethods.NMLVCUSTOMDRAW* nmcd = (NativeMethods.NMLVCUSTOMDRAW*)m.LParam;
+                ComCtl32.NMLVCUSTOMDRAW* nmcd = (ComCtl32.NMLVCUSTOMDRAW*)m.LParam;
                 // Find out which stage we're drawing
                 switch (nmcd->nmcd.dwDrawStage)
                 {
@@ -2608,7 +2608,7 @@ namespace System.Windows.Forms
                         odCacheFontHandle = FontHandle;
 
                         // If preparing to paint a group item, make sure its bolded.
-                        if (nmcd->dwItemType == NativeMethods.LVCDI_GROUP)
+                        if (nmcd->dwItemType == ComCtl32.LVCDI.GROUP)
                         {
                             if (odCacheFontHandleWrapper != null)
                             {
@@ -3645,27 +3645,24 @@ namespace System.Windows.Forms
             };
 
             // Header
-            //
             string header = group.Header;
             lvgroup.pszHeader = Marshal.StringToHGlobalAuto(header);
             lvgroup.cchHeader = header.Length;
 
             // Group ID
-            //
             lvgroup.iGroupId = group.ID;
 
             // Alignment
-            //
             switch (group.HeaderAlignment)
             {
                 case HorizontalAlignment.Left:
-                    lvgroup.uAlign = NativeMethods.LVGA_HEADER_LEFT;
+                    lvgroup.uAlign = ComCtl32.LVGA.HEADER_LEFT;
                     break;
                 case HorizontalAlignment.Right:
-                    lvgroup.uAlign = NativeMethods.LVGA_HEADER_RIGHT;
+                    lvgroup.uAlign = ComCtl32.LVGA.HEADER_RIGHT;
                     break;
                 case HorizontalAlignment.Center:
-                    lvgroup.uAlign = NativeMethods.LVGA_HEADER_CENTER;
+                    lvgroup.uAlign = ComCtl32.LVGA.HEADER_CENTER;
                     break;
             }
             return lvgroup;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -2995,7 +2995,7 @@ namespace System.Windows.Forms
             }
         }
 
-        private void DestroyLVGROUP(NativeMethods.LVGROUP lvgroup)
+        private void DestroyLVGROUP(ComCtl32.LVGROUP lvgroup)
         {
             if (lvgroup.pszHeader != IntPtr.Zero)
             {
@@ -3637,11 +3637,12 @@ namespace System.Windows.Forms
             return Rectangle.FromLTRB(itemrect.left, itemrect.top, itemrect.right, itemrect.bottom);
         }
 
-        private NativeMethods.LVGROUP GetLVGROUP(ListViewGroup group)
+        private ComCtl32.LVGROUP GetLVGROUP(ListViewGroup group)
         {
-            NativeMethods.LVGROUP lvgroup = new NativeMethods.LVGROUP
+            var lvgroup = new ComCtl32.LVGROUP
             {
-                mask = NativeMethods.LVGF_HEADER | NativeMethods.LVGF_GROUPID | NativeMethods.LVGF_ALIGN
+                cbSize = (uint)Marshal.SizeOf<ComCtl32.LVGROUP>(),
+                mask = ComCtl32.LVGF.HEADER | ComCtl32.LVGF.GROUPID | ComCtl32.LVGF.ALIGN
             };
 
             // Header
@@ -3973,11 +3974,11 @@ namespace System.Windows.Forms
             Debug.Assert(IsHandleCreated, "InsertGroupNative precondition: list-view handle must be created");
             Debug.Assert(group == DefaultGroup || Groups.Contains(group), "Make sure ListView.Groups contains this group before adding the native LVGROUP. Otherwise, custom-drawing may break.");
 
-            NativeMethods.LVGROUP lvgroup = new NativeMethods.LVGROUP();
+            var lvgroup = new ComCtl32.LVGROUP();
             try
             {
                 lvgroup = GetLVGROUP(group);
-                int retval = (int)UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), (int)LVM.INSERTGROUP, index, lvgroup);
+                int retval = (int)User32.SendMessageW(this, (User32.WindowMessage)LVM.INSERTGROUP, (IntPtr)index, ref lvgroup);
                 Debug.Assert(retval != -1, "Failed to insert group");
             }
             finally
@@ -5578,14 +5579,11 @@ namespace System.Windows.Forms
         {
             Debug.Assert(IsHandleCreated, "UpdateGroupNative precondition: list-view handle must be created");
 
-            NativeMethods.LVGROUP lvgroup = new NativeMethods.LVGROUP();
+            var lvgroup = new ComCtl32.LVGROUP();
             try
             {
                 lvgroup = GetLVGROUP(group);
-                int retval = (int)UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle),
-                                                                  (int)LVM.SETGROUPINFO,
-                                                                  group.ID,
-                                                                  lvgroup);
+                int retval = (int)User32.SendMessageW(this, (User32.WindowMessage)LVM.SETGROUPINFO, (IntPtr)group.ID, ref lvgroup);
             }
             finally
             {
@@ -5593,7 +5591,6 @@ namespace System.Windows.Forms
             }
 
             // The comctl32 ListView does not correctly invalidate itself, so we need to invalidate the entire ListView
-            //
             Invalidate();
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItemState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItemState.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using static Interop;
+
 namespace System.Windows.Forms
 {
     /// <summary>
@@ -10,14 +12,14 @@ namespace System.Windows.Forms
     [Flags]
     public enum ListViewItemStates
     {
-        Checked = NativeMethods.CDIS_CHECKED,
-        Default = NativeMethods.CDIS_DEFAULT,
-        Focused = NativeMethods.CDIS_FOCUS,
-        Grayed = NativeMethods.CDIS_GRAYED,
-        Hot = NativeMethods.CDIS_HOT,
-        Indeterminate = NativeMethods.CDIS_INDETERMINATE,
-        Marked = NativeMethods.CDIS_MARKED,
-        Selected = NativeMethods.CDIS_SELECTED,
-        ShowKeyboardCues = NativeMethods.CDIS_SHOWKEYBOARDCUES
+        Checked = (int)ComCtl32.CDIS.CHECKED,
+        Default = (int)ComCtl32.CDIS.DEFAULT,
+        Focused = (int)ComCtl32.CDIS.FOCUS,
+        Grayed = (int)ComCtl32.CDIS.GRAYED,
+        Hot = (int)ComCtl32.CDIS.HOT,
+        Indeterminate = (int)ComCtl32.CDIS.INDETERMINATE,
+        Marked = (int)ComCtl32.CDIS.MARKED,
+        Selected = (int)ComCtl32.CDIS.SELECTED,
+        ShowKeyboardCues = (int)ComCtl32.CDIS.SHOWKEYBOARDCUES
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeState.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using static Interop;
+
 namespace System.Windows.Forms
 {
     /// <summary>
@@ -10,14 +12,14 @@ namespace System.Windows.Forms
     [Flags]
     public enum TreeNodeStates
     {
-        Checked = NativeMethods.CDIS_CHECKED,
-        Default = NativeMethods.CDIS_DEFAULT,
-        Focused = NativeMethods.CDIS_FOCUS,
-        Grayed = NativeMethods.CDIS_GRAYED,
-        Hot = NativeMethods.CDIS_HOT,
-        Indeterminate = NativeMethods.CDIS_INDETERMINATE,
-        Marked = NativeMethods.CDIS_MARKED,
-        Selected = NativeMethods.CDIS_SELECTED,
-        ShowKeyboardCues = NativeMethods.CDIS_SHOWKEYBOARDCUES
+        Checked = (int)ComCtl32.CDIS.CHECKED,
+        Default = (int)ComCtl32.CDIS.DEFAULT,
+        Focused = (int)ComCtl32.CDIS.FOCUS,
+        Grayed = (int)ComCtl32.CDIS.GRAYED,
+        Hot = (int)ComCtl32.CDIS.HOT,
+        Indeterminate = (int)ComCtl32.CDIS.INDETERMINATE,
+        Marked = (int)ComCtl32.CDIS.MARKED,
+        Selected = (int)ComCtl32.CDIS.SELECTED,
+        ShowKeyboardCues = (int)ComCtl32.CDIS.SHOWKEYBOARDCUES
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -2748,12 +2748,12 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Performs custom draw handling
         /// </summary>
-        private void CustomDraw(ref Message m)
+        private unsafe void CustomDraw(ref Message m)
         {
-            NativeMethods.NMTVCUSTOMDRAW nmcd = (NativeMethods.NMTVCUSTOMDRAW)m.GetLParam(typeof(NativeMethods.NMTVCUSTOMDRAW));
+            ComCtl32.NMTVCUSTOMDRAW* nmtvcd = (ComCtl32.NMTVCUSTOMDRAW*)m.LParam;
 
             // Find out which stage we're drawing
-            switch (nmcd.nmcd.dwDrawStage)
+            switch (nmtvcd->nmcd.dwDrawStage)
             {
                 // Do we want OwnerDraw for this paint cycle?
                 case ComCtl32.CDDS.PREPAINT:
@@ -2762,8 +2762,8 @@ namespace System.Windows.Forms
                 // We've got opt-in on owner draw for items - so handle each one.
                 case ComCtl32.CDDS.ITEMPREPAINT:
                     // get the node
-                    Debug.Assert(nmcd.nmcd.dwItemSpec != IntPtr.Zero, "Invalid node handle in ITEMPREPAINT");
-                    TreeNode node = NodeFromHandle((IntPtr)nmcd.nmcd.dwItemSpec);
+                    Debug.Assert(nmtvcd->nmcd.dwItemSpec != IntPtr.Zero, "Invalid node handle in ITEMPREPAINT");
+                    TreeNode node = NodeFromHandle((IntPtr)nmtvcd->nmcd.dwItemSpec);
 
                     if (node == null)
                     {
@@ -2773,7 +2773,7 @@ namespace System.Windows.Forms
                         return;
                     }
 
-                    ComCtl32.CDIS state = nmcd.nmcd.uItemState;
+                    ComCtl32.CDIS state = nmtvcd->nmcd.uItemState;
 
                     // The commctrl TreeView allows you to draw the whole row of a node
                     // or nothing at all. The way we provide OwnerDrawText is by asking it
@@ -2781,14 +2781,13 @@ namespace System.Windows.Forms
                     // as background color.
                     if (drawMode == TreeViewDrawMode.OwnerDrawText)
                     {
-                        nmcd.clrText = nmcd.clrTextBk;
-                        Marshal.StructureToPtr(nmcd, m.LParam, false);
+                        nmtvcd->clrText = nmtvcd->clrTextBk;
                         m.Result = (IntPtr)(ComCtl32.CDRF.NEWFONT | ComCtl32.CDRF.NOTIFYPOSTPAINT);
                         return;
                     }
                     else if (drawMode == TreeViewDrawMode.OwnerDrawAll)
                     {
-                        Graphics g = Graphics.FromHdcInternal(nmcd.nmcd.hdc);
+                        Graphics g = Graphics.FromHdcInternal(nmtvcd->nmcd.hdc);
 
                         DrawTreeNodeEventArgs e;
 
@@ -2847,28 +2846,21 @@ namespace System.Windows.Forms
                     // TreeView has problems with drawing items at times; it gets confused
                     // as to which colors apply to which items (see focus rectangle shifting;
                     // when one item is selected, click and hold on another). This needs to be fixed.
-
-                    bool colordelta = false;
                     Color riFore = renderinfo.ForeColor;
                     Color riBack = renderinfo.BackColor;
                     if (renderinfo != null && !riFore.IsEmpty)
                     {
-                        nmcd.clrText = ColorTranslator.ToWin32(riFore);
-                        colordelta = true;
+                        nmtvcd->clrText = ColorTranslator.ToWin32(riFore);
                     }
                     if (renderinfo != null && !riBack.IsEmpty)
                     {
-                        nmcd.clrTextBk = ColorTranslator.ToWin32(riBack);
-                        colordelta = true;
+                        nmtvcd->clrTextBk = ColorTranslator.ToWin32(riBack);
                     }
-                    if (colordelta)
-                    {
-                        Marshal.StructureToPtr(nmcd, m.LParam, false);
-                    }
+
                     if (renderinfo != null && renderinfo.Font != null)
                     {
                         // Mess with the DC directly...
-                        Gdi32.SelectObject(new HandleRef(nmcd.nmcd, nmcd.nmcd.hdc), new HandleRef(renderinfo, renderinfo.FontHandle));
+                        Gdi32.SelectObject(new HandleRef(nmtvcd->nmcd, nmtvcd->nmcd.hdc), new HandleRef(renderinfo, renderinfo.FontHandle));
                         // There is a problem in winctl that clips node fonts if the fontsize
                         // is larger than the treeview font size. The behavior is much better in comctl 5 and above.
                         m.Result = (IntPtr)ComCtl32.CDRF.NEWFONT;
@@ -2882,10 +2874,10 @@ namespace System.Windows.Forms
                     //User draws only the text in OwnerDrawText mode, as explained in comments above
                     if (drawMode == TreeViewDrawMode.OwnerDrawText)
                     {
-                        Debug.Assert(nmcd.nmcd.dwItemSpec != IntPtr.Zero, "Invalid node handle in ITEMPOSTPAINT");
+                        Debug.Assert(nmtvcd->nmcd.dwItemSpec != IntPtr.Zero, "Invalid node handle in ITEMPOSTPAINT");
 
                         // Get the node
-                        node = NodeFromHandle((IntPtr)nmcd.nmcd.dwItemSpec);
+                        node = NodeFromHandle((IntPtr)nmtvcd->nmcd.dwItemSpec);
 
                         if (node == null)
                         {
@@ -2894,7 +2886,7 @@ namespace System.Windows.Forms
                             return;
                         }
 
-                        Graphics g = Graphics.FromHdcInternal(nmcd.nmcd.hdc);
+                        Graphics g = Graphics.FromHdcInternal(nmtvcd->nmcd.hdc);
 
                         DrawTreeNodeEventArgs e;
 
@@ -2905,7 +2897,7 @@ namespace System.Windows.Forms
                             Point textLoc = new Point(bounds.X - 1, bounds.Y); // required to center the text
                             bounds = new Rectangle(textLoc, new Size(textSize.Width, bounds.Height));
 
-                            e = new DrawTreeNodeEventArgs(g, node, bounds, (TreeNodeStates)(nmcd.nmcd.uItemState));
+                            e = new DrawTreeNodeEventArgs(g, node, bounds, (TreeNodeStates)(nmtvcd->nmcd.uItemState));
                             OnDrawNode(e);
 
                             if (e.DrawDefault)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -2756,11 +2756,11 @@ namespace System.Windows.Forms
             switch (nmcd.nmcd.dwDrawStage)
             {
                 // Do we want OwnerDraw for this paint cycle?
-                case NativeMethods.CDDS_PREPAINT:
-                    m.Result = (IntPtr)NativeMethods.CDRF_NOTIFYITEMDRAW; // yes, we do...
+                case ComCtl32.CDDS.PREPAINT:
+                    m.Result = (IntPtr)ComCtl32.CDRF.NOTIFYITEMDRAW; // yes, we do...
                     return;
                 // We've got opt-in on owner draw for items - so handle each one.
-                case NativeMethods.CDDS_ITEMPREPAINT:
+                case ComCtl32.CDDS.ITEMPREPAINT:
                     // get the node
                     Debug.Assert(nmcd.nmcd.dwItemSpec != IntPtr.Zero, "Invalid node handle in ITEMPREPAINT");
                     TreeNode node = NodeFromHandle((IntPtr)nmcd.nmcd.dwItemSpec);
@@ -2769,12 +2769,11 @@ namespace System.Windows.Forms
                     {
                         // this can happen if we are presently inserting the node - it hasn't yet
                         // been added to the handle table
-
-                        m.Result = (IntPtr)(NativeMethods.CDRF_SKIPDEFAULT);
+                        m.Result = (IntPtr)(ComCtl32.CDRF.SKIPDEFAULT);
                         return;
                     }
 
-                    int state = nmcd.nmcd.uItemState;
+                    ComCtl32.CDIS state = nmcd.nmcd.uItemState;
 
                     // The commctrl TreeView allows you to draw the whole row of a node
                     // or nothing at all. The way we provide OwnerDrawText is by asking it
@@ -2784,7 +2783,7 @@ namespace System.Windows.Forms
                     {
                         nmcd.clrText = nmcd.clrTextBk;
                         Marshal.StructureToPtr(nmcd, m.LParam, false);
-                        m.Result = (IntPtr)(NativeMethods.CDRF_NEWFONT | NativeMethods.CDRF_NOTIFYPOSTPAINT);
+                        m.Result = (IntPtr)(ComCtl32.CDRF.NEWFONT | ComCtl32.CDRF.NOTIFYPOSTPAINT);
                         return;
                     }
                     else if (drawMode == TreeViewDrawMode.OwnerDrawAll)
@@ -2823,7 +2822,7 @@ namespace System.Windows.Forms
 
                         if (!e.DrawDefault)
                         {
-                            m.Result = (IntPtr)(NativeMethods.CDRF_SKIPDEFAULT);
+                            m.Result = (IntPtr)(ComCtl32.CDRF.SKIPDEFAULT);
                             return;
                         }
                     }
@@ -2833,17 +2832,17 @@ namespace System.Windows.Forms
                     // Diagnostic output
                     Debug.WriteLine("Itemstate: "+state);
                     Debug.WriteLine("Itemstate: "+
-                                            "\nDISABLED" + (((state & NativeMethods.CDIS_DISABLED) != 0) ? "TRUE" : "FALSE") +
-                                            "\nHOT" + (((state & NativeMethods.CDIS_HOT) != 0) ? "TRUE" : "FALSE") +
-                                            "\nGRAYED" + (((state & NativeMethods.CDIS_GRAYED) != 0) ? "TRUE" : "FALSE") +
-                                            "\nSELECTED" + (((state & NativeMethods.CDIS_SELECTED) != 0) ? "TRUE" : "FALSE") +
-                                            "\nFOCUS" + (((state & NativeMethods.CDIS_FOCUS) != 0) ? "TRUE" : "FALSE") +
-                                            "\nDEFAULT" + (((state & NativeMethods.CDIS_DEFAULT) != 0) ? "TRUE" : "FALSE") +
-                                            "\nMARKED" + (((state & NativeMethods.CDIS_MARKED) != 0) ? "TRUE" : "FALSE") +
-                                            "\nINDETERMINATE" + (((state & NativeMethods.CDIS_INDETERMINATE) != 0) ? "TRUE" : "FALSE"));
+                                            "\nDISABLED" + (((state & ComCtl32.CDIS.DISABLED) != 0) ? "TRUE" : "FALSE") +
+                                            "\nHOT" + (((state & ComCtl32.CDIS.HOT) != 0) ? "TRUE" : "FALSE") +
+                                            "\nGRAYED" + (((state & ComCtl32.CDIS.GRAYED) != 0) ? "TRUE" : "FALSE") +
+                                            "\nSELECTED" + (((state & ComCtl32.CDIS.SELECTED) != 0) ? "TRUE" : "FALSE") +
+                                            "\nFOCUS" + (((state & ComCtl32.CDIS.FOCUS) != 0) ? "TRUE" : "FALSE") +
+                                            "\nDEFAULT" + (((state & ComCtl32.CDIS.DEFAULT) != 0) ? "TRUE" : "FALSE") +
+                                            "\nMARKED" + (((state & ComCtl32.CDIS.MARKED) != 0) ? "TRUE" : "FALSE") +
+                                            "\nINDETERMINATE" + (((state & ComCtl32.CDIS.INDETERMINATE) != 0) ? "TRUE" : "FALSE"));
 #endif
 
-                    OwnerDrawPropertyBag renderinfo = GetItemRenderStyles(node, state);
+                    OwnerDrawPropertyBag renderinfo = GetItemRenderStyles(node, (int)state);
 
                     // TreeView has problems with drawing items at times; it gets confused
                     // as to which colors apply to which items (see focus rectangle shifting;
@@ -2872,14 +2871,14 @@ namespace System.Windows.Forms
                         Gdi32.SelectObject(new HandleRef(nmcd.nmcd, nmcd.nmcd.hdc), new HandleRef(renderinfo, renderinfo.FontHandle));
                         // There is a problem in winctl that clips node fonts if the fontsize
                         // is larger than the treeview font size. The behavior is much better in comctl 5 and above.
-                        m.Result = (IntPtr)NativeMethods.CDRF_NEWFONT;
+                        m.Result = (IntPtr)ComCtl32.CDRF.NEWFONT;
                         return;
                     }
 
                     // fall through and do the default drawing work
                     goto default;
 
-                case (NativeMethods.CDDS_ITEMPOSTPAINT):
+                case (ComCtl32.CDDS.ITEMPOSTPAINT):
                     //User draws only the text in OwnerDrawText mode, as explained in comments above
                     if (drawMode == TreeViewDrawMode.OwnerDrawText)
                     {
@@ -2940,7 +2939,7 @@ namespace System.Windows.Forms
                             g.Dispose();
                         }
 
-                        m.Result = (IntPtr)NativeMethods.CDRF_NOTIFYSUBITEMDRAW;
+                        m.Result = (IntPtr)ComCtl32.CDRF.NOTIFYSUBITEMDRAW;
                         return;
                     }
 
@@ -2948,7 +2947,7 @@ namespace System.Windows.Forms
 
                 default:
                     // just in case we get a spurious message, tell it to do the right thing
-                    m.Result = (IntPtr)NativeMethods.CDRF_DODEFAULT;
+                    m.Result = (IntPtr)ComCtl32.CDRF.DODEFAULT;
                     return;
             }
         }
@@ -2966,7 +2965,7 @@ namespace System.Windows.Forms
             }
 
             // we only change colors if we're displaying things normally
-            if ((state & (NativeMethods.CDIS_SELECTED | NativeMethods.CDIS_GRAYED | NativeMethods.CDIS_HOT | NativeMethods.CDIS_DISABLED)) == 0)
+            if ((state & (int)(ComCtl32.CDIS.SELECTED | ComCtl32.CDIS.GRAYED | ComCtl32.CDIS.HOT | ComCtl32.CDIS.DISABLED)) == 0)
             {
                 retval.ForeColor = node.propBag.ForeColor;
                 retval.BackColor = node.propBag.BackColor;


### PR DESCRIPTION
## Proposed Changes
- Cleanup `NMCUSTOMDRAW` (including `CDDS_`, `CDIS_` and `CDRF_` constants)
- Cleanup `NMLVCUSTOMDRAW` (including `LVCDI_` and `LVGA_` constants)
- Structify `NMTVCUSTOMDRAW`
- Structify `LVGROUP` (including `LVGF_` and `LVGS_` constants)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2249)