### PR TITLE
Remove assignment duplication

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Binding.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Binding.cs
@@ -83,7 +83,6 @@ namespace System.Windows.Forms
             _formatString = formatString;
             _nullValue = nullValue;
             _formatInfo = formatInfo;
-            _formattingEnabled = formattingEnabled;
             DataSourceUpdateMode = dataSourceUpdateMode;
 
             CheckBinding();


### PR DESCRIPTION

## Proposed changes

-  Removes second assignment to _formattingEnabled which duplicates [this one](https://github.com/dotnet/winforms/blob/master/src/System.Windows.Forms/src/System/Windows/Forms/Binding.cs#L82)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2255)