### PR TITLE
Move KeyboardLayout methods to Interop User32

### DIFF
--- a/src/Common/src/Interop/User32/Interop.ActivateKeyboardLayout.cs
+++ b/src/Common/src/Interop/User32/Interop.ActivateKeyboardLayout.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern IntPtr ActivateKeyboardLayout(IntPtr hkl, int uFlags);
+
+        public static IntPtr ActivateKeyboardLayout(IHandle hkl, int uFlags)
+        {
+            IntPtr result = ActivateKeyboardLayout(hkl.Handle, uFlags);
+            GC.KeepAlive(hkl);
+            return result;
+        }
+
+        public static IntPtr ActivateKeyboardLayout(HandleRef hkl, int uFlags)
+        {
+            IntPtr result = ActivateKeyboardLayout(hkl.Handle, uFlags);
+            GC.KeepAlive(hkl.Wrapper);
+            return result;
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.GetKeyboardLayout.cs
+++ b/src/Common/src/Interop/User32/Interop.GetKeyboardLayout.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern unsafe int GetKeyboardLayoutList(int size, IntPtr* hkls);
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.GetKeyboardLayoutList.cs
+++ b/src/Common/src/Interop/User32/Interop.GetKeyboardLayoutList.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
+        public static extern IntPtr GetKeyboardLayout(int dwLayout);
+    }
+}

--- a/src/Common/src/SafeNativeMethods.cs
+++ b/src/Common/src/SafeNativeMethods.cs
@@ -49,15 +49,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern bool PatBlt(HandleRef hdc, int left, int top, int width, int height, int rop);
 
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern IntPtr GetKeyboardLayout(int dwLayout);
-
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern IntPtr ActivateKeyboardLayout(HandleRef hkl, int uFlags);
-
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern int GetKeyboardLayoutList(int size, [Out, MarshalAs(UnmanagedType.LPArray)] IntPtr[] hkls);
-
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
         public static extern bool GetMonitorInfo(HandleRef hmonitor, [In, Out]NativeMethods.MONITORINFOEX info);
 


### PR DESCRIPTION
## Proposed changes

- Move KeyboardLayout methods to Interop User32 and update their usages.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2266)