### PR TITLE
Add TVHT enum in Interop ComCtl32 and remove corresponding constants …

### DIFF
--- a/src/Common/src/Interop/ComCtl32/Interop.TVHT.cs
+++ b/src/Common/src/Interop/ComCtl32/Interop.TVHT.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        [Flags]
+        public enum TVHT : uint
+        {
+            NOWHERE = 0x0001,
+            ONITEMICON = 0x0002,
+            ONITEMLABEL = 0x0004,
+            ONITEM = ONITEMICON | ONITEMLABEL | ONITEMSTATEICON,
+            ONITEMINDENT = 0x0008,
+            ONITEMBUTTON = 0x0010,
+            ONITEMRIGHT = 0x0020,
+            ONITEMSTATEICON = 0x0040,
+            ABOVE = 0x0100,
+            BELOW = 0x0200,
+            TORIGHT = 0x0400,
+            TOLEFT = 0x0800
+        }
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -868,19 +868,6 @@ namespace System.Windows.Forms
         TVSIL_STATE = 2,
         TVM_SORTCHILDRENCB = (TV_FIRST + 21);
 
-        public const int TVHT_NOWHERE = 0x0001,
-        TVHT_ONITEMICON = 0x0002,
-        TVHT_ONITEMLABEL = 0x0004,
-        TVHT_ONITEM = (TVHT_ONITEMICON | TVHT_ONITEMLABEL | TVHT_ONITEMSTATEICON),
-        TVHT_ONITEMINDENT = 0x0008,
-        TVHT_ONITEMBUTTON = 0x0010,
-        TVHT_ONITEMRIGHT = 0x0020,
-        TVHT_ONITEMSTATEICON = 0x0040,
-        TVHT_ABOVE = 0x0100,
-        TVHT_BELOW = 0x0200,
-        TVHT_TORIGHT = 0x0400,
-        TVHT_TOLEFT = 0x0800;
-
         public const int UIS_SET = 1,
         UIS_CLEAR = 2,
         UIS_INITIALIZE = 3,
@@ -1742,7 +1729,7 @@ namespace System.Windows.Forms
         {
             public int pt_x;
             public int pt_y;
-            public int flags = 0;
+            public ComCtl32.TVHT flags = 0;
             public IntPtr hItem = IntPtr.Zero;
         }
 

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -53,6 +53,7 @@
     <Compile Include="..\..\Common\src\Interop\ComCtl32\Interop.TVITEMW.cs" Link="Interop\ComCtl32\Interop.TVITEMW.cs" />
     <Compile Include="..\..\Common\src\Interop\ComCtl32\Interop.TVIF.cs" Link="Interop\ComCtl32\Interop.TVIF.cs" />
     <Compile Include="..\..\Common\src\Interop\ComCtl32\Interop.TVC.cs" Link="Interop\ComCtl32\Interop.TVC.cs" />
+    <Compile Include="..\..\Common\src\Interop\ComCtl32\Interop.TVHT.cs" Link="Interop\ComCtl32\Interop.TVHT.cs" />
     <Compile Include="..\..\Common\src\Interop\ComCtl32\Interop.TVIS.cs" Link="Interop\ComCtl32\Interop.TVIS.cs" />
     <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.BitBlt.cs" Link="Interop\Gdi32\Interop.BitBlt.cs" />
     <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.CreatePen.cs" Link="Interop\Gdi32\Interop.CreatePen.cs" />

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -2203,7 +2203,7 @@ namespace System.Windows.Forms
             tvhip.pt_y = pos.Y;
             IntPtr hnode = UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TVM_HITTEST, 0, tvhip);
 
-            if (hnode != IntPtr.Zero && ((tvhip.flags & NativeMethods.TVHT_ONITEM) != 0))
+            if (hnode != IntPtr.Zero && ((tvhip.flags & ComCtl32.TVHT.ONITEM) != 0))
             {
                 TreeNode tn = NodeFromHandle(hnode);
                 if (tn != prevHoveredNode && tn != null)
@@ -2978,7 +2978,7 @@ namespace System.Windows.Forms
             tvhip.pt_y = pos.Y;
             IntPtr hnode = UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TVM_HITTEST, 0, tvhip);
 
-            if (hnode != IntPtr.Zero && ((tvhip.flags & NativeMethods.TVHT_ONITEM) != 0))
+            if (hnode != IntPtr.Zero && ((tvhip.flags & ComCtl32.TVHT.ONITEM) != 0))
             {
                 TreeNode tn = NodeFromHandle(hnode);
                 if (tn != null)
@@ -3013,7 +3013,7 @@ namespace System.Windows.Forms
             tvhip.pt_x = pos.X;
             tvhip.pt_y = pos.Y;
             IntPtr hnode = UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TVM_HITTEST, 0, tvhip);
-            if (hnode != IntPtr.Zero && ((tvhip.flags & NativeMethods.TVHT_ONITEM) != 0))
+            if (hnode != IntPtr.Zero && ((tvhip.flags & ComCtl32.TVHT.ONITEM) != 0))
             {
                 TreeNode tn = NodeFromHandle(hnode);
                 if (ShowNodeToolTips && tn != null && (!string.IsNullOrEmpty(tn.ToolTipText)))
@@ -3090,7 +3090,7 @@ namespace System.Windows.Forms
                         tvhip.pt_y = pos.Y;
                         IntPtr hnode = UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.TVM_HITTEST, 0, tvhip);
                         if (nmtv->nmhdr.code != NativeMethods.NM_CLICK
-                                    || (tvhip.flags & NativeMethods.TVHT_ONITEM) != 0)
+                                    || (tvhip.flags & ComCtl32.TVHT.ONITEM) != 0)
                         {
                             button = nmtv->nmhdr.code == NativeMethods.NM_CLICK
                                 ? MouseButtons.Left : MouseButtons.Right;
@@ -3100,7 +3100,7 @@ namespace System.Windows.Forms
                         // LBUTTONUP happens on TVHT_ONITEM. This is a comctl quirk.
                         // We work around that by calling OnMouseUp here.
                         if (nmtv->nmhdr.code != NativeMethods.NM_CLICK
-                            || (tvhip.flags & NativeMethods.TVHT_ONITEM) != 0 || FullRowSelect)
+                            || (tvhip.flags & ComCtl32.TVHT.ONITEM) != 0 || FullRowSelect)
                         {
                             if (hnode != IntPtr.Zero && !ValidationCancelled)
                             {
@@ -3129,7 +3129,7 @@ namespace System.Windows.Forms
                         if (!treeViewState[TREEVIEWSTATE_mouseUpFired])
                         {
                             if (nmtv->nmhdr.code != NativeMethods.NM_CLICK
-                            || (tvhip.flags & NativeMethods.TVHT_ONITEM) != 0)
+                            || (tvhip.flags & ComCtl32.TVHT.ONITEM) != 0)
                             {
                                 // The treeview's WndProc doesn't get the WM_LBUTTONUP messages when
                                 // LBUTTONUP happens on TVHT_ONITEM. This is a comctl quirk.
@@ -3327,7 +3327,7 @@ namespace System.Windows.Forms
 
                     // This gets around the TreeView behavior of temporarily moving the selection
                     // highlight to a node when the user clicks on its checkbox.
-                    if ((tvhip.flags & NativeMethods.TVHT_ONITEMSTATEICON) != 0)
+                    if ((tvhip.flags & ComCtl32.TVHT.ONITEMSTATEICON) != 0)
                     {
                         //We donot pass the Message to the Control .. so fire MouseDowm ...
                         OnMouseDown(new MouseEventArgs(MouseButtons.Left, 1, NativeMethods.Util.SignedLOWORD(m.LParam), NativeMethods.Util.SignedHIWORD(m.LParam), 0));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewHitTestLocation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewHitTestLocation.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
+using static Interop;
 
 namespace System.Windows.Forms
 {
@@ -16,56 +17,56 @@ namespace System.Windows.Forms
         /// <summary>
         ///  No Information.
         /// </summary>
-        None = NativeMethods.TVHT_NOWHERE,
+        None = (int)ComCtl32.TVHT.NOWHERE,
 
         /// <summary>
         ///  On Image.
         /// </summary>
-        Image = NativeMethods.TVHT_ONITEMICON,
+        Image = (int)ComCtl32.TVHT.ONITEMICON,
 
         /// <summary>
         ///  On Label.
         /// </summary>
-        Label = NativeMethods.TVHT_ONITEMLABEL,
+        Label = (int)ComCtl32.TVHT.ONITEMLABEL,
 
         /// <summary>
         ///  Indent.
         /// </summary>
-        Indent = NativeMethods.TVHT_ONITEMINDENT,
+        Indent = (int)ComCtl32.TVHT.ONITEMINDENT,
 
         /// <summary>
         ///  AboveClientArea.
         /// </summary>
-        AboveClientArea = NativeMethods.TVHT_ABOVE,
+        AboveClientArea = (int)ComCtl32.TVHT.ABOVE,
 
         /// <summary>
         ///  BelowClientArea.
         /// </summary>
-        BelowClientArea = NativeMethods.TVHT_BELOW,
+        BelowClientArea = (int)ComCtl32.TVHT.BELOW,
 
         /// <summary>
         ///  LeftOfClientArea.
         /// </summary>
-        LeftOfClientArea = NativeMethods.TVHT_TOLEFT,
+        LeftOfClientArea = (int)ComCtl32.TVHT.TOLEFT,
 
         /// <summary>
         ///  RightOfClientArea.
         /// </summary>
-        RightOfClientArea = NativeMethods.TVHT_TORIGHT,
+        RightOfClientArea = (int)ComCtl32.TVHT.TORIGHT,
 
         /// <summary>
         ///  RightOfNode.
         /// </summary>
-        RightOfLabel = NativeMethods.TVHT_ONITEMRIGHT,
+        RightOfLabel = (int)ComCtl32.TVHT.ONITEMRIGHT,
 
         /// <summary>
         ///  StateImage.
         /// </summary>
-        StateImage = NativeMethods.TVHT_ONITEMSTATEICON,
+        StateImage = (int)ComCtl32.TVHT.ONITEMSTATEICON,
 
         /// <summary>
         ///  PlusMinus.
         /// </summary>
-        PlusMinus = NativeMethods.TVHT_ONITEMBUTTON,
+        PlusMinus = (int)ComCtl32.TVHT.ONITEMBUTTON,
     }
 }


### PR DESCRIPTION
…from NativeMethods.cs

## Proposed changes

- Add TVHT enum.
- Remove TVHT constants and replaces their usages with the above enum.
- Update TV_HITTESTINFO definition.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2268)