### PR TITLE
Don't recreate the handle twice in TabControl.Alignment setter

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -125,7 +125,7 @@ namespace System.Windows.Forms
                     _alignment = value;
                     if (_alignment == TabAlignment.Left || _alignment == TabAlignment.Right)
                     {
-                        Multiline = true;
+                        SetState(State.Multiline, true);
                     }
 
                     RecreateHandle();


### PR DESCRIPTION
## Proposed Changes
- The setter for `Multiline` calls `RecreateHandle`

```cs
public bool Multiline
{
    get => GetState(State.Multiline);
    set
    {
        if (Multiline != value)
        {
            SetState(State.Multiline, value);
            if (Multiline == false && (_alignment == TabAlignment.Left || _alignment == TabAlignment.Right))
            {
                _alignment = TabAlignment.Top;
            }

            RecreateHandle();
        }
    }
}
```

But the setter for `Alignment` does this too
```cs
[
SRCategory(nameof(SR.CatBehavior)),
Localizable(true),
DefaultValue(TabAlignment.Top),
RefreshProperties(RefreshProperties.All),
SRDescription(nameof(SR.TabBaseAlignmentDescr))
]
public TabAlignment Alignment
{
    get
    {
        return _alignment;
    }

    set
    {
        if (_alignment != value)
        {
            //valid values are 0x0 to 0x3
            if (!ClientUtils.IsEnumValid(value, (int)value, (int)TabAlignment.Top, (int)TabAlignment.Right))
            {
                throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(TabAlignment));
            }

            _alignment = value;
            if (_alignment == TabAlignment.Left || _alignment == TabAlignment.Right)
            {
                SetState(State.Multiline, true);
            }

            RecreateHandle();
        }
    }
}
```

Avoid recreating the handle twice

Fixes #2047


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2270)