### PR TITLE
Move KillTimer and SetTimer methods to Interop User32

### DIFF
--- a/src/Common/src/Interop/User32/Interop.KillTimer.cs
+++ b/src/Common/src/Interop/User32/Interop.KillTimer.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern BOOL KillTimer(IntPtr hwnd, int idEvent);
+
+        public static BOOL KillTimer(IHandle hWnd, int idEvent)
+        {
+            BOOL result = KillTimer(hWnd.Handle, idEvent);
+            GC.KeepAlive(hWnd);
+            return result;
+        }
+
+        public static BOOL KillTimer(HandleRef hWnd, int idEvent)
+        {
+            BOOL result = KillTimer(hWnd.Handle, idEvent);
+            GC.KeepAlive(hWnd.Wrapper);
+            return result;
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.SetTimer.cs
+++ b/src/Common/src/Interop/User32/Interop.SetTimer.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern IntPtr SetTimer(IntPtr hWnd, int nIDEvent, int uElapse, IntPtr lpTimerFunc);
+
+        public static IntPtr SetTimer(IHandle hWnd, int nIDEvent, int uElapse, IntPtr lpTimerFunc)
+        {
+            IntPtr result = SetTimer(hWnd.Handle, nIDEvent, uElapse, lpTimerFunc);
+            GC.KeepAlive(hWnd);
+            return result;
+        }
+
+        public static IntPtr SetTimer(HandleRef hWnd, int nIDEvent, int uElapse, IntPtr lpTimerFunc)
+        {
+            IntPtr result = SetTimer(hWnd.Handle, nIDEvent, uElapse, lpTimerFunc);
+            GC.KeepAlive(hWnd.Wrapper);
+            return result;
+        }
+    }
+}

--- a/src/Common/src/SafeNativeMethods.cs
+++ b/src/Common/src/SafeNativeMethods.cs
@@ -114,12 +114,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern bool DrawMenuBar(HandleRef hWnd);
 
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern IntPtr SetTimer(HandleRef hWnd, int nIDEvent, int uElapse, IntPtr lpTimerFunc);
-
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern bool KillTimer(HandleRef hwnd, int idEvent);
-
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
         public static extern int MessageBox(HandleRef hWnd, string text, string caption, int type);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Timer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Timer.cs
@@ -263,7 +263,7 @@ namespace System.Windows.Forms
                 {
                     if (EnsureHandle())
                     {
-                        _timerID = (int)SafeNativeMethods.SetTimer(new HandleRef(this, Handle), s_timerID++, interval, IntPtr.Zero);
+                        _timerID = (int)User32.SetTimer(new HandleRef(this, Handle), s_timerID++, interval, IntPtr.Zero);
                     }
                 }
             }
@@ -300,7 +300,7 @@ namespace System.Windows.Forms
                         try
                         {
                             _stoppingTimer = true;
-                            SafeNativeMethods.KillTimer(new HandleRef(this, hWnd), _timerID);
+                            User32.KillTimer(new HandleRef(this, hWnd), _timerID);
                         }
                         finally
                         {


### PR DESCRIPTION
## Proposed changes

- Move KillTimer and SetTimer methods to Interop User32.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2276)