### PR TITLE
Add IHandle and HandleRef overloads to GetWindow

### DIFF
--- a/src/Common/src/Interop/User32/Interop.GetWindow.cs
+++ b/src/Common/src/Interop/User32/Interop.GetWindow.cs
@@ -9,10 +9,21 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern IntPtr GetWindow(HandleRef hWnd, GW uCmd);
-
-        [DllImport(Libraries.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
+        [DllImport(Libraries.User32, ExactSpelling = true)]
         public static extern IntPtr GetWindow(IntPtr hWnd, GW uCmd);
+
+        public static IntPtr GetWindow(IHandle hWnd, GW uCmd)
+        {
+            IntPtr result = GetWindow(hWnd.Handle, uCmd);
+            GC.KeepAlive(hWnd);
+            return result;
+        }
+
+        public static IntPtr GetWindow(HandleRef hWnd, GW uCmd)
+        {
+            IntPtr result = GetWindow(hWnd.Handle, uCmd);
+            GC.KeepAlive(hWnd.Wrapper);
+            return result;
+        }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -34,6 +34,7 @@
     <Compile Include="..\..\Common\src\DpiHelper.cs" Link="misc\DpiHelper.cs" />
     <Compile Include="..\..\Common\src\ExternDll.cs" Link="misc\ExternDll.cs" />
     <Compile Include="..\..\Common\src\FileDialog_Vista_Interop.cs" Link="System\Windows\Forms\FileDialog_Vista_Interop.cs" />
+    <Compile Include="..\..\Common\src\Interop\IHandle.cs" Link="Interop\IHandle.cs" />
     <Compile Include="..\..\Common\src\Interop\Interop.ListViewMessages.cs" Link="Interop.ListViewMessages.cs" />
     <Compile Include="..\..\Common\src\NativeMethods.cs" Link="System\Windows\Forms\NativeMethods.cs" />
     <Compile Include="..\..\Common\src\OsVersion.cs" Link="Common\OsVersion.cs" />

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -2702,7 +2702,7 @@ namespace System.Windows.Forms
                     }
 
                     for (prev = start;
-                         (next = User32.GetWindow(new HandleRef(null, prev), User32.GW.HWNDPREV)) != IntPtr.Zero;
+                         (next = User32.GetWindow(prev, User32.GW.HWNDPREV)) != IntPtr.Zero;
                          prev = next)
                     {
 
@@ -6025,9 +6025,9 @@ namespace System.Windows.Forms
         {
             ArrayList windows = new ArrayList();
 
-            for (IntPtr hWndChild = User32.GetWindow(new HandleRef(null, hWndParent), User32.GW.CHILD);
+            for (IntPtr hWndChild = User32.GetWindow(hWndParent, User32.GW.CHILD);
                  hWndChild != IntPtr.Zero;
-                 hWndChild = User32.GetWindow(new HandleRef(null, hWndChild), User32.GW.HWNDNEXT))
+                 hWndChild = User32.GetWindow(hWndChild, User32.GW.HWNDNEXT))
             {
                 windows.Add(hWndChild);
             }
@@ -11671,7 +11671,7 @@ namespace System.Windows.Forms
             int newIndex = 0;
             int curIndex = Controls.GetChildIndex(ctl);
             IntPtr hWnd = ctl.InternalHandle;
-            while ((hWnd = User32.GetWindow(new HandleRef(null, hWnd), User32.GW.HWNDPREV)) != IntPtr.Zero)
+            while ((hWnd = User32.GetWindow(hWnd, User32.GW.HWNDPREV)) != IntPtr.Zero)
             {
                 Control c = FromHandle(hWnd);
                 if (c != null)


### PR DESCRIPTION
## Proposed changes

- Add IHandle/HandleRef overloads to GetWindow.
- Based on similar feedback on https://github.com/dotnet/winforms/pull/2277



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2291)