### PR TITLE
Port SelectedPathEditor

### DIFF
--- a/src/System.Design/src/System.Design.Forwards.cs
+++ b/src/System.Design/src/System.Design.Forwards.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,6 +11,7 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ListViewGroupCollectionEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ListViewItemCollectionEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ListViewSubItemCollectionEditor))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.SelectedPathEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.StringArrayEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.StringCollectionEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.TabPageCollectionEditor))]

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/SR.resx
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/SR.resx
@@ -257,4 +257,7 @@ Press Ctrl+Enter to accept Text.</value>
   <data name="iconFileDescription" xml:space="preserve">
     <value>Icon files</value>
   </data>
+  <data name="SelectedPathEditorLabel" xml:space="preserve">
+    <value>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.cs.xlf
@@ -209,6 +209,11 @@ Stisknutím kombinace kláves Ctrl+Enter text přijměte.</target>
         <target state="translated">RTL_False</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelectedPathEditorLabel">
+        <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
+        <target state="new">Select the path to the folder that will initially be selected in the FolderBrowserDialog.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ShortcutKeys_InvalidKey">
         <source>(Unknown)</source>
         <target state="translated">(Neznámý)</target>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.de.xlf
@@ -209,6 +209,11 @@ Drücken Sie Strg+Eingabetaste, um Text zu übernehmen.</target>
         <target state="translated">RTL_False</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelectedPathEditorLabel">
+        <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
+        <target state="new">Select the path to the folder that will initially be selected in the FolderBrowserDialog.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ShortcutKeys_InvalidKey">
         <source>(Unknown)</source>
         <target state="translated">(Unbekannt)</target>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.es.xlf
@@ -209,6 +209,11 @@ Presione Ctrl+Entrar para aceptar el texto.</target>
         <target state="translated">RTL_False</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelectedPathEditorLabel">
+        <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
+        <target state="new">Select the path to the folder that will initially be selected in the FolderBrowserDialog.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ShortcutKeys_InvalidKey">
         <source>(Unknown)</source>
         <target state="translated">(Se desconoce)</target>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.fr.xlf
@@ -209,6 +209,11 @@ Appuyez sur Ctrl+Entrée pour valider le texte.</target>
         <target state="translated">RTL_False</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelectedPathEditorLabel">
+        <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
+        <target state="new">Select the path to the folder that will initially be selected in the FolderBrowserDialog.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ShortcutKeys_InvalidKey">
         <source>(Unknown)</source>
         <target state="translated">(Inconnu)</target>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.it.xlf
@@ -209,6 +209,11 @@ Per accettare testo premere CTRL+INVIO.</target>
         <target state="translated">RTL_False</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelectedPathEditorLabel">
+        <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
+        <target state="new">Select the path to the folder that will initially be selected in the FolderBrowserDialog.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ShortcutKeys_InvalidKey">
         <source>(Unknown)</source>
         <target state="translated">(Sconosciuto)</target>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ja.xlf
@@ -209,6 +209,11 @@ Press Ctrl+Enter to accept Text.</source>
         <target state="translated">RTL_False</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelectedPathEditorLabel">
+        <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
+        <target state="new">Select the path to the folder that will initially be selected in the FolderBrowserDialog.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ShortcutKeys_InvalidKey">
         <source>(Unknown)</source>
         <target state="translated">(不明)</target>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ko.xlf
@@ -209,6 +209,11 @@ Press Ctrl+Enter to accept Text.</source>
         <target state="translated">RTL_False</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelectedPathEditorLabel">
+        <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
+        <target state="new">Select the path to the folder that will initially be selected in the FolderBrowserDialog.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ShortcutKeys_InvalidKey">
         <source>(Unknown)</source>
         <target state="translated">(알 수 없음)</target>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.pl.xlf
@@ -209,6 +209,11 @@ Naciśnij klawisze Ctrl+Enter, aby zaakceptować tekst.</target>
         <target state="translated">RTL_False</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelectedPathEditorLabel">
+        <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
+        <target state="new">Select the path to the folder that will initially be selected in the FolderBrowserDialog.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ShortcutKeys_InvalidKey">
         <source>(Unknown)</source>
         <target state="translated">(Nieznany)</target>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.pt-BR.xlf
@@ -209,6 +209,11 @@ Pressione Ctrl+Enter para aceitar Texto.</target>
         <target state="translated">RTL_False</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelectedPathEditorLabel">
+        <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
+        <target state="new">Select the path to the folder that will initially be selected in the FolderBrowserDialog.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ShortcutKeys_InvalidKey">
         <source>(Unknown)</source>
         <target state="translated">(Desconhecido)</target>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.ru.xlf
@@ -209,6 +209,11 @@ Press Ctrl+Enter to accept Text.</source>
         <target state="translated">RTL_False</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelectedPathEditorLabel">
+        <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
+        <target state="new">Select the path to the folder that will initially be selected in the FolderBrowserDialog.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ShortcutKeys_InvalidKey">
         <source>(Unknown)</source>
         <target state="translated">(Неизвестный)</target>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.tr.xlf
@@ -209,6 +209,11 @@ Metni kabul etmek için Ctrl+Enter tuşlarına basın.</target>
         <target state="translated">RTL_False</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelectedPathEditorLabel">
+        <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
+        <target state="new">Select the path to the folder that will initially be selected in the FolderBrowserDialog.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ShortcutKeys_InvalidKey">
         <source>(Unknown)</source>
         <target state="translated">(Bilinmiyor)</target>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.zh-Hans.xlf
@@ -209,6 +209,11 @@ Press Ctrl+Enter to accept Text.</source>
         <target state="translated">RTL_False</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelectedPathEditorLabel">
+        <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
+        <target state="new">Select the path to the folder that will initially be selected in the FolderBrowserDialog.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ShortcutKeys_InvalidKey">
         <source>(Unknown)</source>
         <target state="translated">(未知)</target>

--- a/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms.Design.Editors/src/Resources/xlf/SR.zh-Hant.xlf
@@ -209,6 +209,11 @@ Press Ctrl+Enter to accept Text.</source>
         <target state="translated">RTL_False</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelectedPathEditorLabel">
+        <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
+        <target state="new">Select the path to the folder that will initially be selected in the FolderBrowserDialog.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ShortcutKeys_InvalidKey">
         <source>(Unknown)</source>
         <target state="translated">(未知)</target>

--- a/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/FolderNameEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/FolderNameEditor.cs
@@ -95,7 +95,7 @@ namespace System.Windows.Forms.Design
             public unsafe DialogResult ShowDialog(IWin32Window owner)
             {
                 // Get/find an owner HWND for this dialog
-                IntPtr hWndOwner = owner == null ? owner.Handle : UnsafeNativeMethods.GetActiveWindow();
+                IntPtr hWndOwner = owner != null ? owner.Handle : UnsafeNativeMethods.GetActiveWindow();
 
                 // Get the IDL for the specific startLocation
                 Shell32.SHGetSpecialFolderLocation(hWndOwner, (int)StartLocation, out CoTaskMemSafeHandle listHandle);

--- a/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/SelectedPathEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/SelectedPathEditor.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.Design
+{
+    /// <summary>
+    ///  Folder editor for choosing the initial folder of the folder browser dialog.
+    /// </summary>
+    internal class SelectedPathEditor : FolderNameEditor
+    {
+        protected override void InitializeDialog(FolderBrowser folderBrowser)
+        {
+            folderBrowser.Description = SR.SelectedPathEditorLabel;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design.Editors/tests/UnitTests/EnsureEditorsTests.cs
+++ b/src/System.Windows.Forms.Design.Editors/tests/UnitTests/EnsureEditorsTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -82,7 +82,7 @@ namespace System.Windows.Forms.Design.Editors.Tests
         [InlineData(typeof(DateTimePicker), "Value", typeof(DateTimeEditor))]
         [InlineData(typeof(DomainUpDown), "Items", typeof(StringCollectionEditor))]
         //[InlineData(typeof(ErrorProvider), "DataMember", typeof(DataMemberListEditor))]
-        //[InlineData(typeof(FolderBrowserDialog), "SelectedPath", typeof(SelectedPathEditor))]
+        [InlineData(typeof(FolderBrowserDialog), "SelectedPath", typeof(SelectedPathEditor))]
         //[InlineData(typeof(HelpProvider), "HelpNamespace", typeof(HelpNamespaceEditor))]
         [InlineData(typeof(Label), "ImageIndex", typeof(ImageIndexEditor))]
         [InlineData(typeof(Label), "ImageKey", typeof(ImageIndexEditor))]


### PR DESCRIPTION
Fixes issue #2282
Related issue #1115

## Proposed changes

- Port `SelectedPathEditor`
- Add **`TypeForwardedTo`** statement for `SelectedPathEditor`
- Make code refactoring
- Add a unit test case to check SelectedPathEditor

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Changed SelectedPath editor to compliance with .Net 4.8.

## Regression? 

- Yes 

## Risk

- Low

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://user-images.githubusercontent.com/49272759/68331673-6ed2ac80-00e6-11ea-8efa-acb6f1af164d.png)

<!-- TODO -->

### After
![image](https://user-images.githubusercontent.com/49272759/68331406-fcfa6300-00e5-11ea-811f-d2b26f1035cd.png)

![image](https://user-images.githubusercontent.com/49272759/68387878-6aeb6c80-0170-11ea-8a87-fc4481afdb77.png)


<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual UI testing
- CTI
- Unit testing


## Test environment(s) <!-- Remove any that don't apply -->

- .Net Core version: 3.1.0-preview3.19553.2
- Microsoft Windows [Version 10.0.18362.418]


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2305)