### PR TITLE
Cleanup and fix Timer interop

### DIFF
--- a/src/Common/src/Interop/User32/Interop.KillTimer.cs
+++ b/src/Common/src/Interop/User32/Interop.KillTimer.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern BOOL KillTimer(IntPtr hWnd, IntPtr uIDEvent);
+
+        public static BOOL KillTimer(HandleRef hWnd, IntPtr uIDEvent)
+        {
+            BOOL result = KillTimer(hWnd.Handle, uIDEvent);
+            GC.KeepAlive(hWnd.Wrapper);
+            return result;
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.SetTimer.cs
+++ b/src/Common/src/Interop/User32/Interop.SetTimer.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern IntPtr SetTimer(IntPtr hWnd, IntPtr nIDEvent, uint uElapse, IntPtr lpTimerFunc);
+
+        public static IntPtr SetTimer(IHandle hWnd, IntPtr nIDEvent, uint uElapse, IntPtr lpTimerFunc)
+        {
+            IntPtr result = SetTimer(hWnd.Handle, nIDEvent, uElapse, lpTimerFunc);
+            GC.KeepAlive(hWnd);
+            return result;
+        }
+    }
+}

--- a/src/Common/src/SafeNativeMethods.cs
+++ b/src/Common/src/SafeNativeMethods.cs
@@ -114,12 +114,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern bool DrawMenuBar(HandleRef hWnd);
 
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern IntPtr SetTimer(HandleRef hWnd, int nIDEvent, int uElapse, IntPtr lpTimerFunc);
-
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern bool KillTimer(HandleRef hwnd, int idEvent);
-
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
         public static extern int MessageBox(HandleRef hWnd, string text, string caption, int type);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Timer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Timer.cs
@@ -183,17 +183,17 @@ namespace System.Windows.Forms
 
         public override string ToString() => $"{base.ToString()}, Interval: {Interval}";
 
-        private class TimerNativeWindow : NativeWindow
+        private class TimerNativeWindow : NativeWindow, IHandle
         {
             // The timer that owns the window
             private readonly Timer _owner;
 
             // The current id -- this is usally the same as TimerID but we also
             // use it as a flag of when our timer is running.
-            private int _timerID;
+            private IntPtr _timerID;
 
             // An arbitrary timer ID.
-            private static int s_timerID = 1;
+            private static IntPtr s_timerID = (IntPtr)1;
 
             // Setting this when we are stopping the timer so someone can't restart it in the process.
             private bool _stoppingTimer;
@@ -209,7 +209,7 @@ namespace System.Windows.Forms
                 StopTimer();
             }
 
-            public bool IsTimerRunning => _timerID != 0 && Handle != IntPtr.Zero;
+            public bool IsTimerRunning => _timerID != IntPtr.Zero && Handle != IntPtr.Zero;
 
             private bool EnsureHandle()
             {
@@ -259,11 +259,12 @@ namespace System.Windows.Forms
 
             public void StartTimer(int interval)
             {
-                if (_timerID == 0 && !_stoppingTimer)
+                if (_timerID == IntPtr.Zero && !_stoppingTimer)
                 {
                     if (EnsureHandle())
                     {
-                        _timerID = (int)SafeNativeMethods.SetTimer(new HandleRef(this, Handle), s_timerID++, interval, IntPtr.Zero);
+                        _timerID = User32.SetTimer(this, s_timerID, (uint)interval, IntPtr.Zero);
+                        s_timerID = s_timerID + 1;
                     }
                 }
             }
@@ -295,16 +296,16 @@ namespace System.Windows.Forms
                         return;
                     }
 
-                    if (_timerID != 0)
+                    if (_timerID != IntPtr.Zero)
                     {
                         try
                         {
                             _stoppingTimer = true;
-                            SafeNativeMethods.KillTimer(new HandleRef(this, hWnd), _timerID);
+                            User32.KillTimer(new HandleRef(this, hWnd), _timerID);
                         }
                         finally
                         {
-                            _timerID = 0;
+                            _timerID = IntPtr.Zero;
                             _stoppingTimer = false;
                         }
                     }
@@ -323,7 +324,7 @@ namespace System.Windows.Forms
             {
                 // Avoid recursing.
                 StopTimer(IntPtr.Zero, destroyHwnd: false);
-                Debug.Assert(_timerID == 0, "Destroying handle with timerID still set.");
+                Debug.Assert(_timerID == IntPtr.Zero, "Destroying handle with timerID still set.");
                 base.DestroyHandle();
             }
 
@@ -336,7 +337,7 @@ namespace System.Windows.Forms
             {
                 // Avoid recursing.
                 StopTimer(IntPtr.Zero, destroyHwnd: false);
-                Debug.Assert(_timerID == 0, "Destroying handle with timerID still set.");
+                Debug.Assert(_timerID == IntPtr.Zero, "Destroying handle with timerID still set.");
                 base.ReleaseHandle();
             }
 
@@ -347,7 +348,7 @@ namespace System.Windows.Forms
                 // For timer messages call the timer event.
                 if (m.Msg == WindowMessages.WM_TIMER)
                 {
-                    if (unchecked((int)(long)m.WParam) == _timerID)
+                    if (m.WParam == _timerID)
                     {
                         _owner.OnTick(EventArgs.Empty);
                         return;


### PR DESCRIPTION
## Proposed Changes
- Cleanup `Timer` interop
- Make the timer ID an `IntPtr` to match https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-settimer

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2322)