### PR TITLE
Porting a VS fix to designer host site nested container

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
@@ -1744,6 +1744,10 @@ namespace System.ComponentModel.Design
                     if (_nestedContainer == null)
                     {
                         _nestedContainer = new SiteNestedContainer(_component, null, _host);
+                        
+                        // Initialize IServiceContainer in the nested container as soon as INestedContainer is created, 
+                        // otherwise site has no access to the DesignerHost's services.
+                        _ = _nestedContainer.GetServiceInternal(typeof(IServiceContainer));
                     }
                     return _nestedContainer;
                 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerHostTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerHostTests.cs
@@ -1481,7 +1481,7 @@ namespace System.ComponentModel.Design.Tests
             var component = new RootDesignerComponent();
             host.Container.Add(component);
             INestedContainer nestedContainer = Assert.IsAssignableFrom<INestedContainer>(component.Site.GetService(typeof(INestedContainer)));
-            Assert.Null(component.Site.GetService(typeof(int)));
+            Assert.Same(service, component.Site.GetService(typeof(int)));
             Assert.Same(component.Site, component.Site.GetService(typeof(IDictionaryService)));
             Assert.Same(nestedContainer, component.Site.GetService(typeof(INestedContainer)));
         }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #2325

## Proposed changes
Initialize IServiceContainer in the nested container as soon as INestedContainer is created, otherwise site has no access to the DesignerHost's services. Initialize IServiceContainer in the nested container as soon as INestedContainer is created, otherwise site has no access to the DesignerHost's services.

## Regression? 

- No

## Risk
low

## Test methodology <!-- How did you ensure quality? -->
unit test


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2326)