### PR TITLE
Cleanup IViewObject.Draw interop

### DIFF
--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -1065,13 +1065,10 @@ namespace System.Windows.Forms
                 Ole32.DVTARGETDEVICE* ptd,
                 IntPtr hdcTargetDev,
                 IntPtr hdcDraw,
-                [In]
-                NativeMethods.COMRECT lprcBounds,
-                [In]
-                NativeMethods.COMRECT lprcWBounds,
+                RECT* lprcBounds,
+                RECT* lprcWBounds,
                 IntPtr pfnContinue,
-                [In]
-                int dwContinue);
+                uint dwContinue);
 
             [PreserveSig]
             HRESULT GetColorSet(
@@ -1115,20 +1112,18 @@ namespace System.Windows.Forms
         [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
         public unsafe interface IViewObject2 /* : IViewObject */
         {
-            void Draw(
+            [PreserveSig]
+            HRESULT Draw(
                 Ole32.DVASPECT dwDrawAspect,
                 int lindex,
                 IntPtr pvAspect,
                 Ole32.DVTARGETDEVICE* ptd,
                 IntPtr hdcTargetDev,
                 IntPtr hdcDraw,
-                [In]
-                NativeMethods.COMRECT lprcBounds,
-                [In]
-                NativeMethods.COMRECT lprcWBounds,
+                RECT* lprcBounds,
+                RECT* lprcWBounds,
                 IntPtr pfnContinue,
-                [In]
-                int dwContinue);
+                uint dwContinue);
 
             [PreserveSig]
             HRESULT GetColorSet(

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -418,21 +418,19 @@ namespace System.Windows.Forms
             /// <summary>
             ///  Implements IViewObject2::Draw.
             /// </summary>
-            internal unsafe void Draw(
+            internal unsafe HRESULT Draw(
                 Ole32.DVASPECT dwDrawAspect,
                 int lindex,
                 IntPtr pvAspect,
                 Ole32.DVTARGETDEVICE* ptd,
                 IntPtr hdcTargetDev,
                 IntPtr hdcDraw,
-                NativeMethods.COMRECT prcBounds,
-                NativeMethods.COMRECT lprcWBounds,
+                RECT* prcBounds,
+                RECT* lprcWBounds,
                 IntPtr pfnContinue,
-                int dwContinue)
+                uint dwContinue)
             {
-
                 // support the aspects required for multi-pass drawing
-                //
                 switch (dwDrawAspect)
                 {
                     case Ole32.DVASPECT.CONTENT:
@@ -440,8 +438,7 @@ namespace System.Windows.Forms
                     case Ole32.DVASPECT.TRANSPARENT:
                         break;
                     default:
-                        ThrowHr(HRESULT.DV_E_DVASPECT);
-                        break;
+                        return HRESULT.DV_E_DVASPECT;
                 }
 
                 // We can paint to an enhanced metafile, but not all GDI / GDI+ is
@@ -451,10 +448,9 @@ namespace System.Windows.Forms
                 Gdi32.ObjectType hdcType = Gdi32.GetObjectType(hdcDraw);
                 if (hdcType == Gdi32.ObjectType.OBJ_METADC)
                 {
-                    ThrowHr(HRESULT.VIEW_E_DRAW);
+                    return HRESULT.VIEW_E_DRAW;
                 }
 
-                RECT rc;
                 var pVp = new Point();
                 var pW = new Point();
                 var sWindowExt = new Size();
@@ -469,7 +465,7 @@ namespace System.Windows.Forms
                 // if they didn't give us a rectangle, just copy over ours
                 if (prcBounds != null)
                 {
-                    rc = new RECT(prcBounds.left, prcBounds.top, prcBounds.right, prcBounds.bottom);
+                    RECT rc = *prcBounds;
 
                     // To draw to a given rect, we scale the DC in such a way as to
                     // make the values it takes match our own happy MM_TEXT.  Then,
@@ -514,6 +510,8 @@ namespace System.Windows.Forms
                         Gdi32.SetMapMode(hdcDraw, iMode);
                     }
                 }
+
+                return HRESULT.S_OK;
             }
 
             /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -14023,28 +14023,26 @@ namespace System.Windows.Forms
             Ole32.DVTARGETDEVICE* ptd,
             IntPtr hdcTargetDev,
             IntPtr hdcDraw,
-            NativeMethods.COMRECT lprcBounds,
-            NativeMethods.COMRECT lprcWBounds,
+            RECT* lprcBounds,
+            RECT* lprcWBounds,
             IntPtr pfnContinue,
-            int dwContinue)
+            uint dwContinue)
         {
             Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:Draw");
 
             Debug.Indent();
-            try
-            {
-                ActiveXInstance.Draw(dwDrawAspect, lindex, pvAspect, ptd, hdcTargetDev,
-                                 hdcDraw, lprcBounds, lprcWBounds, pfnContinue, dwContinue);
-
-            }
-            catch (ExternalException ex)
-            {
-                return (HRESULT)ex.ErrorCode;
-            }
-            finally
-            {
-                Debug.Unindent();
-            }
+            HRESULT hr = ActiveXInstance.Draw(
+                dwDrawAspect,
+                lindex,
+                pvAspect,
+                ptd,
+                hdcTargetDev,
+                hdcDraw,
+                lprcBounds,
+                lprcWBounds,
+                pfnContinue,
+                dwContinue);
+            Debug.Unindent();
             return HRESULT.S_OK;
         }
 
@@ -14086,23 +14084,33 @@ namespace System.Windows.Forms
             return ActiveXInstance.GetAdvise(pAspects, pAdvf, ppAdvSink);
         }
 
-        unsafe void UnsafeNativeMethods.IViewObject2.Draw(
+        unsafe HRESULT UnsafeNativeMethods.IViewObject2.Draw(
             Ole32.DVASPECT dwDrawAspect,
             int lindex,
             IntPtr pvAspect,
             Ole32.DVTARGETDEVICE* ptd,
             IntPtr hdcTargetDev,
             IntPtr hdcDraw,
-            NativeMethods.COMRECT lprcBounds,
-            NativeMethods.COMRECT lprcWBounds,
+            RECT* lprcBounds,
+            RECT* lprcWBounds,
             IntPtr pfnContinue,
-            int dwContinue)
+            uint dwContinue)
         {
             Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:Draw");
             Debug.Indent();
-            ActiveXInstance.Draw(dwDrawAspect, lindex, pvAspect, ptd, hdcTargetDev,
-                                 hdcDraw, lprcBounds, lprcWBounds, pfnContinue, dwContinue);
+            HRESULT hr = ActiveXInstance.Draw(
+                dwDrawAspect,
+                lindex,
+                pvAspect,
+                ptd,
+                hdcTargetDev,
+                hdcDraw,
+                lprcBounds,
+                lprcWBounds,
+                pfnContinue,
+                dwContinue);
             Debug.Unindent();
+            return hr;
         }
 
         unsafe HRESULT UnsafeNativeMethods.IViewObject2.GetColorSet(

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserHelper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserHelper.cs
@@ -132,7 +132,9 @@ namespace System.Windows.Forms
             return null;
         }
 
-        // Returns a big COMRECT
+        /// <remarks>
+        ///  Returns a big clip RECT.
+        /// </remarks>
         internal static RECT GetClipRect()
         {
             return new Rectangle(0, 0, 32000, 32000);


### PR DESCRIPTION
## Proposed Changes
- Make `PreserveSig`
- Use `RECT*` instead of `COMRECT` for `prcBounds` and `lprcWBounds`
- Use `uint` for `dwContinue` parameter

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2330)