### PR TITLE
Fix message constants in Interop.ComCtl32.TB.

### DIFF
--- a/src/Common/src/Interop/ComCtl32/Interop.TB.cs
+++ b/src/Common/src/Interop/ComCtl32/Interop.TB.cs
@@ -8,10 +8,9 @@ internal static partial class Interop
     {
         public enum TB : int
         {
-            FIRST = 0x1000,
-            GETBUTTONINFOW = FIRST + 63,
-            SETBUTTONINFOW = FIRST + 64,
-            INSERTBUTTONW = FIRST + 67,
+            GETBUTTONINFOW = User32.WM_USER + 63,
+            SETBUTTONINFOW = User32.WM_USER + 64,
+            INSERTBUTTONW = User32.WM_USER + 67,
         }
     }
 }


### PR DESCRIPTION
Toolbar message constants are based on WM_USER, not LVM_FIRST.

Fixes this test case from Mono: https://github.com/mono/mono/blob/8683fa6db798298d576c120dd9e1443cd3c5b6de/mcs/class/System.Windows.Forms/Test/System.Windows.Forms/ToolBarTest.cs#L111

## Proposed changes

- Changes the constants in Interop.ComCtl32.TB to be based on 0x400 (WM_USER) instead of 0x1000 (LVM_FIRST), as the win32 api expects.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- I only know for sure that the test case is broken, but I expect that any modifications to a ToolBarButton after it's been displayed will not work without this change.

## Regression? 

- Yes

## Risk

- I consider it low risk since because it's a clear regression from baa5058c1a2a012ff912919f676975d21c3fd9b4 and we're going back to the old values for these constants.

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

- I ran only this one test on Wine in Wine Mono, using Wine Mono's fork of winforms.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2372)