### PR TITLE
Update PreReleaseVersionLabel to RTM

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,7 +4,7 @@
     <!-- version in our package name Ver.sion.Prefix-PreReleaseVersionLabel.#####.## -->
     <!-- where #####. come from the date and .## is the build-per-day -->
     <VersionPrefix>4.8.1</VersionPrefix>
-    <PreReleaseVersionLabel>preview1</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
     <!-- Set to true to produce shipping version strings in non-official builds, instead of fixed values like 42.42.42.42 for AssemblyVersion -->
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <!-- Use the compiler in the CLI instead of in the sdk, since the sdk one doesn't work with netcoreapp3.0 yet -->


### PR DESCRIPTION
Non-shipping packages should be labeled RTM for GA. We need to take this fix for 3.1 GA

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2374)