### PR TITLE
Fixing LinkLabel text color setting

### DIFF
--- a/src/Common/src/Interop/Gdi32/Interop.SetTextColor.cs
+++ b/src/Common/src/Interop/Gdi32/Interop.SetTextColor.cs
@@ -15,14 +15,14 @@ internal static partial class Interop
 
         public static int SetTextColor(IHandle hdc, int color)
         {
-            int result = GetTextColor(hdc.Handle);
+            int result = SetTextColor(hdc.Handle, color);
             GC.KeepAlive(hdc);
             return result;
         }
 
         public static int SetTextColor(HandleRef hdc, int color)
         {
-            int result = GetTextColor(hdc.Handle);
+            int result = SetTextColor(hdc.Handle, color);
             GC.KeepAlive(hdc.Wrapper);
             return result;
         }


### PR DESCRIPTION
Fixes #2052

## Proposed changes

- Change the incorrect implementation of SetTextColor methods

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A user sees correct LinkLabel colors

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://user-images.githubusercontent.com/49272759/69036464-fe396300-09f6-11ea-98e6-ba8f948ae926.png)

<!-- TODO -->

### After
![image](https://user-images.githubusercontent.com/49272759/69036398-d8ac5980-09f6-11ea-87fd-f63807eed869.png)
![image](https://user-images.githubusercontent.com/49272759/69036406-dea23a80-09f6-11ea-98fd-aa9345f44922.png)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual UI testing
- CTI
- Unit testing



## Test environment(s) <!-- Remove any that don't apply -->
- SDK Version: 5.0.100-alpha1-015730
- Microsoft Windows [Version 10.0.18363.418]


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2379)