### PR TITLE
WIP: Fixing ErrorProvider error text announcing by ScreenReader

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
@@ -867,6 +867,17 @@ namespace System.Windows.Forms
             }
 
             /// <summary>
+            ///  ScreenReader announces ToolTip text for an element
+            /// </summary>
+            private void AnnounceText(Control tool, string text)
+            {
+                tool?.AccessibilityObject?.RaiseAutomationNotification(
+                    Automation.AutomationNotificationKind.ActionCompleted,
+                    Automation.AutomationNotificationProcessing.All,
+                    text);
+            }
+
+            /// <summary>
             ///  Called to get rid of any resources the Object may have.
             /// </summary>
             public void Dispose() => EnsureDestroyed();
@@ -1065,6 +1076,11 @@ namespace System.Windows.Forms
                     if (((ControlItem)items[i]).Id == id)
                     {
                         ((ControlItem)items[i]).ToolTipShown = toolTipShown;
+
+                        if(toolTipShown)
+                        {
+                            AnnounceText(((ControlItem)items[i]).Control, ((ControlItem)items[i]).Error);
+                        }
                     }
                 }
 #if DEBUG
@@ -1320,6 +1336,8 @@ namespace System.Windows.Forms
                 _control.VisibleChanged += new EventHandler(OnParentVisibleChanged);
                 _control.ParentChanged += new EventHandler(OnParentVisibleChanged);
             }
+
+            internal Control Control => _control;
 
             public void Dispose()
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
@@ -867,17 +867,6 @@ namespace System.Windows.Forms
             }
 
             /// <summary>
-            ///  ScreenReader announces ToolTip text for an element
-            /// </summary>
-            private void AnnounceText(Control tool, string text)
-            {
-                tool?.AccessibilityObject?.RaiseAutomationNotification(
-                    Automation.AutomationNotificationKind.ActionCompleted,
-                    Automation.AutomationNotificationProcessing.All,
-                    text);
-            }
-
-            /// <summary>
             ///  Called to get rid of any resources the Object may have.
             /// </summary>
             public void Dispose() => EnsureDestroyed();
@@ -1079,7 +1068,7 @@ namespace System.Windows.Forms
 
                         if(toolTipShown)
                         {
-                            AnnounceText(((ControlItem)items[i]).Control, ((ControlItem)items[i]).Error);
+                            _provider.AnnounceErrorText(_items[i].Control, _items[i].Error);
                         }
                     }
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -92,6 +92,17 @@ namespace System.Windows.Forms
             }
 
             container.Add(this);
+        }
+
+        /// <summary>
+        ///  ScreenReader announces the error description string of the specified control
+        /// </summary>
+        private void AnnounceErrorText(Control control, string text)
+        {
+            control?.AccessibilityObject?.RaiseAutomationNotification(
+                Automation.AutomationNotificationKind.ActionCompleted,
+                Automation.AutomationNotificationProcessing.All,
+                text);
         }
 
         public override ISite Site
@@ -786,6 +797,7 @@ namespace System.Windows.Forms
         public void SetError(Control control, string value)
         {
             EnsureControlItem(control).Error = value;
+            AnnounceErrorText(control, value);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #2390
Original bug: [987891](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/987891)

## Proposed changes

- Raise automation notification when setting an error for a control

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- ScreenReader announces an error text

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
- Narrator doesn't announce an error text
![image](https://user-images.githubusercontent.com/49272759/69131010-9ea88980-0ac2-11ea-882f-037f16af43ad.png)


<!-- TODO -->

### After
- Narrator announces an error text when setting an error or hovering an error icon by mouse
![new](https://user-images.githubusercontent.com/49272759/69812917-2f3d4300-1202-11ea-9259-97c3d32067b6.gif)




## Test methodology <!-- How did you ensure quality? -->

- Manual UI testing
- CTI

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Using Narrator
 

## Test environment(s) <!-- Remove any that don't apply -->

- SDK Version: 5.0.100-alpha1-015730
- Microsoft Windows [Version 10.0.18363.418]


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2391)