### PR TITLE
Move IErrorLog and IPropertyBag interfaces to interop

### DIFF
--- a/src/Common/src/Interop/Ole32/Interop.IErrorLog.cs
+++ b/src/Common/src/Interop/Ole32/Interop.IErrorLog.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal static partial class Ole32
+    {
+        [ComImport]
+        [Guid("3127CA40-446E-11CE-8135-00AA004BB851")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        public unsafe interface IErrorLog
+        {
+            [PreserveSig]
+            HRESULT AddError(
+                [MarshalAs(UnmanagedType.LPWStr)] string pszPropName,
+                EXCEPINFO* pExcepInfo);
+        }
+    }
+}

--- a/src/Common/src/Interop/Ole32/Interop.IPropertyBag.cs
+++ b/src/Common/src/Interop/Ole32/Interop.IPropertyBag.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal static partial class Ole32
+    {
+        [ComImport]
+        [Guid("55272A00-42CB-11CE-8135-00AA004BB851")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        public interface IPropertyBag
+        {
+            [PreserveSig]
+            HRESULT Read(
+                [MarshalAs(UnmanagedType.LPWStr)] string pszPropName,
+                ref object pVar,
+                IErrorLog pErrorLog);
+
+            [PreserveSig]
+            HRESULT Write(
+                [MarshalAs(UnmanagedType.LPWStr)]
+                string pszPropName,
+                ref object pVar);
+        }
+    }
+}

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -1191,9 +1191,14 @@ namespace System.Windows.Forms
 
             void InitNew();
 
-            void Load(IPropertyBag pPropBag, IErrorLog pErrorLog);
+            void Load(
+                Ole32.IPropertyBag pPropBag,
+                Ole32.IErrorLog pErrorLog);
 
-            void Save(IPropertyBag pPropBag, BOOL fClearDirty, BOOL fSaveAllProperties);
+            void Save(
+                Ole32.IPropertyBag pPropBag,
+                BOOL fClearDirty,
+                BOOL fSaveAllProperties);
         }
 
         [ComImport]
@@ -1213,36 +1218,6 @@ namespace System.Windows.Forms
             [PreserveSig]
             HRESULT GetContentExtent(
                 Size* pSizel);
-        }
-
-        [ComImport]
-        [Guid("55272A00-42CB-11CE-8135-00AA004BB851")]
-        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        public interface IPropertyBag
-        {
-            [PreserveSig]
-            HRESULT Read(
-                [MarshalAs(UnmanagedType.LPWStr)]
-                string pszPropName,
-                ref object pVar,
-                IErrorLog pErrorLog);
-
-            [PreserveSig]
-            HRESULT Write(
-                [MarshalAs(UnmanagedType.LPWStr)]
-                string pszPropName,
-                ref object pVar);
-        }
-
-        [ComImport]
-        [Guid("3127CA40-446E-11CE-8135-00AA004BB851")]
-        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        public unsafe interface IErrorLog
-        {
-            [PreserveSig]
-            HRESULT AddError(
-                [MarshalAs(UnmanagedType.LPWStr)] string pszPropName,
-                Ole32.EXCEPINFO* pExcepInfo);
         }
 
         [ComImport]

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -112,6 +112,7 @@
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IDLFLAG.cs" Link="Interop\Ole32\Interop.IDLFLAG.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IDropTarget.cs" Link="Interop\Ole32\Interop.IDropTarget.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IEnumUnknown.cs" Link="Interop\Ole32\Interop.IEnumUnknown.cs" />
+    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IErrorLog.cs" Link="Interop\Ole32\Interop.IErrorLog.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IFont.cs" Link="Interop\Ole32\Interop.IFont.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.ILockBytes.cs" Link="Interop\Ole32\Interop.ILockBytes.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IMPLTYPEFLAG.cs" Link="Interop\Ole32\Interop.IMPLTYPEFLAG.cs" />
@@ -122,6 +123,7 @@
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IOleInPlaceActiveObject.cs" Link="Interop\Ole32\Interop.IOleInPlaceActiveObject.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IOleInPlaceFrame.cs" Link="Interop\Ole32\Interop.IOleInPlaceFrame.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IOleInPlaceUIWindow.cs" Link="Interop\Ole32\Interop.IOleInPlaceUIWindow.cs" />
+    <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IPropertyBag.cs" Link="Interop\Ole32\Interop.IPropertyBag.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IPropertyNotifySink.cs" Link="Interop\Ole32\Interop.IPropertyNotifySink.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IServiceProvider.cs" Link="Interop\Ole32\Interop.IServiceProvider.cs" />
     <Compile Include="..\..\Common\src\Interop\Ole32\Interop.IStorage.cs" Link="Interop\Ole32\Interop.IStorage.cs" />

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.PropertyBagStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.PropertyBagStream.cs
@@ -12,7 +12,7 @@ namespace System.Windows.Forms
 {
     public abstract partial class AxHost
     {
-        internal class PropertyBagStream : UnsafeNativeMethods.IPropertyBag
+        internal class PropertyBagStream : Ole32.IPropertyBag
         {
             private Hashtable bag = new Hashtable();
 
@@ -30,7 +30,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            HRESULT UnsafeNativeMethods.IPropertyBag.Read(string pszPropName, ref object pVar, UnsafeNativeMethods.IErrorLog pErrorLog)
+            HRESULT Ole32.IPropertyBag.Read(string pszPropName, ref object pVar, Ole32.IErrorLog pErrorLog)
             {
                 Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "Reading property " + pszPropName + " from OCXState propertybag.");
 
@@ -50,7 +50,7 @@ namespace System.Windows.Forms
                 return (pVar == null) ? HRESULT.E_INVALIDARG : HRESULT.S_OK;
             }
 
-            HRESULT UnsafeNativeMethods.IPropertyBag.Write(string pszPropName, ref object pVar)
+            HRESULT Ole32.IPropertyBag.Write(string pszPropName, ref object pVar)
             {
                 Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "Writing property " + pszPropName + " [" + pVar + "] into OCXState propertybag.");
                 if (pVar != null && !pVar.GetType().IsSerializable)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
@@ -207,7 +207,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            internal UnsafeNativeMethods.IPropertyBag GetPropBag()
+            internal Ole32.IPropertyBag GetPropBag()
             {
                 return PropertyBagBinary;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -2978,7 +2978,7 @@ namespace System.Windows.Forms
             SetOcState(OC_RUNNING);
         }
 
-        private void DepersistFromIPropertyBag(UnsafeNativeMethods.IPropertyBag propBag)
+        private void DepersistFromIPropertyBag(Ole32.IPropertyBag propBag)
         {
             iPersistPropBag.Load(propBag, null);
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -1121,7 +1121,7 @@ namespace System.Windows.Forms
             /// <summary>
             ///  Implements IPersistPropertyBag::Load
             /// </summary>
-            internal unsafe void Load(UnsafeNativeMethods.IPropertyBag pPropBag, UnsafeNativeMethods.IErrorLog pErrorLog)
+            internal unsafe void Load(Ole32.IPropertyBag pPropBag, Ole32.IErrorLog pErrorLog)
             {
                 PropertyDescriptorCollection props = TypeDescriptor.GetProperties(_control,
                     new Attribute[] { DesignerSerializationVisibilityAttribute.Visible });
@@ -1831,7 +1831,7 @@ namespace System.Windows.Forms
             /// <summary>
             ///  Implements IPersistPropertyBag::Save
             /// </summary>
-            internal void Save(UnsafeNativeMethods.IPropertyBag pPropBag, BOOL fClearDirty, BOOL fSaveAllProperties)
+            internal void Save(Ole32.IPropertyBag pPropBag, BOOL fClearDirty, BOOL fSaveAllProperties)
             {
                 PropertyDescriptorCollection props = TypeDescriptor.GetProperties(_control,
                     new Attribute[] { DesignerSerializationVisibilityAttribute.Visible });
@@ -2550,7 +2550,7 @@ namespace System.Windows.Forms
             ///  This is a property bag implementation that sits on a stream.  It can
             ///  read and write the bag to the stream.
             /// </summary>
-            private class PropertyBagStream : UnsafeNativeMethods.IPropertyBag
+            private class PropertyBagStream : Ole32.IPropertyBag
             {
                 private Hashtable _bag = new Hashtable();
 
@@ -2597,7 +2597,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                HRESULT UnsafeNativeMethods.IPropertyBag.Read(string pszPropName, ref object pVar, UnsafeNativeMethods.IErrorLog pErrorLog)
+                HRESULT Ole32.IPropertyBag.Read(string pszPropName, ref object pVar, Ole32.IErrorLog pErrorLog)
                 {
                     if (!_bag.Contains(pszPropName))
                     {
@@ -2608,7 +2608,7 @@ namespace System.Windows.Forms
                     return HRESULT.S_OK;
                 }
 
-                HRESULT UnsafeNativeMethods.IPropertyBag.Write(string pszPropName, ref object pVar)
+                HRESULT Ole32.IPropertyBag.Write(string pszPropName, ref object pVar)
                 {
                     _bag[pszPropName] = pVar;
                     return HRESULT.S_OK;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -13881,7 +13881,7 @@ namespace System.Windows.Forms
             Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:IPersistPropertyBag.GetClassID.  ClassID: " + pClassID.ToString());
         }
 
-        void UnsafeNativeMethods.IPersistPropertyBag.Load(UnsafeNativeMethods.IPropertyBag pPropBag, UnsafeNativeMethods.IErrorLog pErrorLog)
+        void UnsafeNativeMethods.IPersistPropertyBag.Load(Ole32.IPropertyBag pPropBag, Ole32.IErrorLog pErrorLog)
         {
             Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:Load (IPersistPropertyBag)");
             Debug.Indent();
@@ -13889,7 +13889,7 @@ namespace System.Windows.Forms
             Debug.Unindent();
         }
 
-        void UnsafeNativeMethods.IPersistPropertyBag.Save(UnsafeNativeMethods.IPropertyBag pPropBag, BOOL fClearDirty, BOOL fSaveAllProperties)
+        void UnsafeNativeMethods.IPersistPropertyBag.Save(Ole32.IPropertyBag pPropBag, BOOL fClearDirty, BOOL fSaveAllProperties)
         {
             Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:Save (IPersistPropertyBag)");
             Debug.Indent();


### PR DESCRIPTION
## Proposed Changes
- Move IErrorLog and IPropertyBag interfaces to interop

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2392)