### PR TITLE
fix: Unable to pack Microsoft.VisualBasic.Forms

### DIFF
--- a/eng/packageContent.targets
+++ b/eng/packageContent.targets
@@ -19,6 +19,8 @@
 
   <PropertyGroup>
     <IntellisenseXmlFileSource>$(IntellisenseXmlDir)$(AssemblyName).xml</IntellisenseXmlFileSource>
+    <!-- TODO: remove when we get dotnet-api-docs_netcoreapp5.0 -->
+    <IntellisenseXmlFileSource Condition="!Exists('$(IntellisenseXmlFileSource)')">$([System.IO.Path]::ChangeExtension('$(TargetPath)', '.xml'))</IntellisenseXmlFileSource>
     
     <IntellisenseXml Condition="'$(ProduceReferenceAssembly)' == 'true' And '$(PackageAsRefAndLib)' != 'true'" >$([System.IO.Path]::ChangeExtension('$(TargetRefPath)', '.xml'))</IntellisenseXml>
     <IntellisenseXml Condition="'$(PackageAsRefAndLib)' == 'true'" >$([System.IO.Path]::ChangeExtension('$(TargetPath)', '.xml'))</IntellisenseXml>

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft.VisualBasic.Forms.vbproj
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft.VisualBasic.Forms.vbproj
@@ -6,6 +6,7 @@
     <RootNamespace></RootNamespace>
     <LangVersion>15.0</LangVersion>
     <VBRuntime>None</VBRuntime>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION

Closes #2395



## Proposed changes

- Copy the project's intellisense file to the ref folder as a temporary fix until the intellisense file will be added to the main docs bundle.
Without the file we were unable to pack.

- Once the intellisense file is added to the main docs bundle, the task will start breaking and remind us to revert the change.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2396)