### PR TITLE
suppress nuget package generation warnings NU5131 and NU5128 (#2373)

### DIFF
--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/Microsoft.Dotnet.Winforms.ProjectTemplates.csproj
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/Microsoft.Dotnet.Winforms.ProjectTemplates.csproj
@@ -7,6 +7,9 @@
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     
+    <!-- Suppress some nuget warnings that are breaking our build until https://github.com/dotnet/arcade/issues/4337 is resolved -->
+    <NoWarn>$(NoWarn);NU5131;NU5128</NoWarn>
+
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
   </PropertyGroup>

--- a/pkg/Microsoft.Private.Winforms/Microsoft.Private.Winforms.csproj
+++ b/pkg/Microsoft.Private.Winforms/Microsoft.Private.Winforms.csproj
@@ -17,6 +17,10 @@
     <TargetFrameworkName>netcoreapp</TargetFrameworkName>
     <TargetFrameworkVersion>3.0</TargetFrameworkVersion>
     <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>
+
+    <!-- Suppress some nuget warnings that are breaking our build until https://github.com/dotnet/arcade/issues/4337 is resolved -->
+    <NoWarn>$(NoWarn);NU5131;NU5128</NoWarn>
+
   </PropertyGroup>
 
   <!-- This is a Packaging Project -->


### PR DESCRIPTION
Port supression to allow upgrade to 3.0.100 SDK

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2418)