### PR TITLE
Add WindowsFormsSynchronizationContext tests and remove some dead code

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/WindowsFormsSynchronizationContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WindowsFormsSynchronizationContext.cs
@@ -29,12 +29,7 @@ namespace System.Windows.Forms
         public WindowsFormsSynchronizationContext()
         {
             DestinationThread = Thread.CurrentThread;   //store the current thread to ensure its still alive during an invoke.
-            Application.ThreadContext context = Application.ThreadContext.FromCurrent();
-            Debug.Assert(context != null);
-            if (context != null)
-            {
-                controlToSendTo = context.MarshalingControl;
-            }
+            controlToSendTo = Application.ThreadContext.FromCurrent().MarshalingControl;
             Debug.Assert(controlToSendTo.IsHandleCreated, "Marshaling control should have created its handle in its ctor.");
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WindowsFormsSynchronizationContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WindowsFormsSynchronizationContext.cs
@@ -80,22 +80,12 @@ namespace System.Windows.Forms
                 throw new InvalidAsynchronousStateException(SR.ThreadNoLongerValid);
             }
 
-            Debug.Assert(controlToSendTo != null, "Should always have the marshaling control by this point");
-
-            if (controlToSendTo != null)
-            {
-                controlToSendTo.Invoke(d, new object[] { state });
-            }
+            controlToSendTo?.Invoke(d, new object[] { state });
         }
 
         public override void Post(SendOrPostCallback d, object state)
         {
-            Debug.Assert(controlToSendTo != null, "Should always have the marshaling control by this point");
-
-            if (controlToSendTo != null)
-            {
-                controlToSendTo.BeginInvoke(d, new object[] { state });
-            }
+            controlToSendTo?.BeginInvoke(d, new object[] { state });
         }
 
         public override SynchronizationContext CreateCopy()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WindowsFormsSynchronizationContextTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WindowsFormsSynchronizationContextTests.cs
@@ -1,0 +1,158 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Threading;
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    public partial class WindowsFormsSynchronizationContextTests
+    {
+        public WindowsFormsSynchronizationContextTests()
+        {
+            Application.ThreadException += (sender, e) => throw new Exception(e.Exception.StackTrace.ToString());
+        }
+
+        [WinFormsFact]
+        public void WindowsFormsSynchronizationContext_CreateCopy_Invoke_Success()
+        {
+            var context = new WindowsFormsSynchronizationContext();
+            WindowsFormsSynchronizationContext copy = Assert.IsType<WindowsFormsSynchronizationContext>(context.CreateCopy());
+            Assert.NotSame(context, copy);
+
+            // Send something.
+            object state = new object();
+            int callCount = 0;
+            SendOrPostCallback callback = (actualState) =>
+            {
+                Assert.Same(state, actualState);
+                callCount++;
+            };
+            copy.Send(callback, state);
+            Assert.Equal(1, callCount);
+            
+            // Call again.
+            copy.Send(callback, state);
+            Assert.Equal(2, callCount);
+        }
+
+        [WinFormsFact]
+        public void WindowsFormsSynchronizationContext_Dispose_MultipleTimes_Success()
+        {
+            var context = new WindowsFormsSynchronizationContext();
+            int callCount = 0;
+            SendOrPostCallback callback = (state) => callCount++;
+            context.Dispose();
+            context.Send(callback, new object());
+            Assert.Equal(0, callCount);
+            
+            // Call again.
+            context.Dispose();
+            context.Send(callback, new object());
+            Assert.Equal(0, callCount);
+        }
+
+        public static IEnumerable<object[]> Send_TestData()
+        {
+            yield return new object[] { null };
+            yield return new object[] { new object() };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(Send_TestData))]
+        public void WindowsFormsSynchronizationContext_Send_InvokeSameThread_Success(object state)
+        {
+            int callCount = 0;
+            SendOrPostCallback callback = (actualState) =>
+            {
+                Assert.Same(state, actualState);
+                callCount++;
+            };
+            var context = new WindowsFormsSynchronizationContext();
+            context.Send(callback, state);
+            Assert.Equal(1, callCount);
+            
+            // Call again.
+            context.Send(callback, state);
+            Assert.Equal(2, callCount);
+        }
+
+        [WinFormsFact]
+        public void WindowsFormsSynchronizationContext_Send_InvokeDeletedThread_ThrowsInvalidAsynchronousStateException()
+        {
+            int callCount = 0;
+            SendOrPostCallback callback = (actualState) => callCount++;
+            WindowsFormsSynchronizationContext context = null;
+            Thread thread = new Thread(() =>
+            {
+                context = new WindowsFormsSynchronizationContext();
+            });
+            thread.Start();
+            thread.Join();
+            Assert.Throws<InvalidAsynchronousStateException>(() => context.Send(callback, new object()));
+            Assert.Equal(0, callCount);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(Send_TestData))]
+        public void WindowsFormsSynchronizationContext_Send_InvokeDisposed_Nop(object state)
+        {
+            int callCount = 0;
+            SendOrPostCallback callback = (actualState) => callCount++;
+            var context = new WindowsFormsSynchronizationContext();
+            context.Dispose();
+
+            context.Send(callback, state);
+            Assert.Equal(0, callCount);
+            
+            // Call again.
+            context.Send(callback, state);
+            Assert.Equal(0, callCount);
+        }
+
+        public static IEnumerable<object[]> Post_TestData()
+        {
+            yield return new object[] { null };
+            yield return new object[] { new object() };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(Post_TestData))]
+        public void WindowsFormsSynchronizationContext_Post_InvokeSameThread_Success(object state)
+        {
+            int callCount = 0;
+            SendOrPostCallback callback = (actualState) =>
+            {
+                Assert.Same(state, actualState);
+                callCount++;
+            };
+            var context = new WindowsFormsSynchronizationContext();
+            context.Post(callback, state);
+            Assert.Equal(0, callCount);
+            
+            // Call again.
+            context.Post(callback, state);
+            Assert.Equal(0, callCount);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(Send_TestData))]
+        public void WindowsFormsSynchronizationContext_Post_InvokeDisposed_Nop(object state)
+        {
+            int callCount = 0;
+            SendOrPostCallback callback = (actualState) => callCount++;
+            var context = new WindowsFormsSynchronizationContext();
+            context.Dispose();
+
+            context.Post(callback, state);
+            Assert.Equal(0, callCount);
+            
+            // Call again.
+            context.Post(callback, state);
+            Assert.Equal(0, callCount);
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes
- Add WindowsFormsSynchronizationContext tests
- Remove WindowsFormsSynchronizationContext dead code
- Remove invalid debug asserts that are already handle


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2422)