### PR TITLE
Remove WS_EX_TRANSPARENT from NativeMethods.cs

### DIFF
--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1993,9 +1993,6 @@ namespace System.Windows.Forms
             Uri uri = new Uri(fileName);
             return uri.LocalPath + uri.Fragment;
         }
-
-        // Theming/Visual Styles stuff
-        public const int WS_EX_TRANSPARENT = 0x00000020;
 
         // Threading stuff
         public const uint STILL_ACTIVE = 259;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
@@ -609,7 +609,7 @@ namespace System.Windows.Forms.Design.Behavior
                 {
                     CreateParams cp = base.CreateParams;
                     cp.Style &= ~(int)(User32.WS.CLIPCHILDREN | User32.WS.CLIPSIBLINGS);
-                    cp.ExStyle |= NativeMethods.WS_EX_TRANSPARENT;
+                    cp.ExStyle |= (int)User32.WS_EX.TRANSPARENT;
                     return cp;
                 }
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripAdornerWindowService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripAdornerWindowService.cs
@@ -196,7 +196,7 @@ namespace System.Windows.Forms.Design
                 {
                     CreateParams cp = base.CreateParams;
                     cp.Style &= ~(int)(User32.WS.CLIPCHILDREN | User32.WS.CLIPSIBLINGS);
-                    cp.ExStyle |= NativeMethods.WS_EX_TRANSPARENT;
+                    cp.ExStyle |= (int)User32.WS_EX.TRANSPARENT;
                     return cp;
                 }
             }


### PR DESCRIPTION
## Proposed changes

- Remove  WS_EX_TRANSPARENT from NativeMethods.cs and replace its usages with the appropriate enum value.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2425)