### PR TITLE
[release/3.1] Remove stabilize package versions block

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,10 +5,6 @@
     <!-- where #####. come from the date and .## is the build-per-day -->
     <VersionPrefix>4.8.1</VersionPrefix>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
-    <!--
-        When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
-    -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <!-- Set to true to produce shipping version strings in non-official builds, instead of fixed values like 42.42.42.42 for AssemblyVersion -->
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <!-- Use the compiler in the CLI instead of in the sdk, since the sdk one doesn't work with netcoreapp3.0 yet -->


### PR DESCRIPTION
winforms does not stabilize so there is no need to add confusion.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2439)