### PR TITLE
fix: Type 'System.Windows.Forms.IWin32Window' is not defined

### DIFF
--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft.VisualBasic.Forms.vbproj
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft.VisualBasic.Forms.vbproj
@@ -1,5 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+<Project>
+  <!--
+    https://github.com/dotnet/winforms/issues/2107#issuecomment-559289716
+    https://github.com/microsoft/msbuild/issues/4923#issuecomment-554265394
+    -->
+  <Import Project="Sdk.Props" Sdk="Microsoft.NET.Sdk" />
+  
   <PropertyGroup>
     <AssemblyName>Microsoft.VisualBasic.Forms</AssemblyName>
     <Deterministic>true</Deterministic>
@@ -38,5 +43,11 @@
       <LogicalName>Microsoft.VisualBasic.CompilerServices.VBInputBox.resources</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
+
+  <Import Project="Sdk.Targets" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <GetCopyToOutputDirectoryItemsDependsOn>AssignProjectConfiguration;$(GetCopyToOutputDirectoryItemsDependsOn)</GetCopyToOutputDirectoryItemsDependsOn>
+  </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Builds randomly fail with "Type 'System.Windows.Forms.IWin32Window' is not defined" error, estimated about 10% of builds failed because of this.

Investigations suggest that there may be MSBuild bug that `GetCopyToOutputDirectoryItemsDependsOn` property stomps over previous property value without including itself, thus leading to incorrect behaviours later in a build.
More info: https://github.com/microsoft/msbuild/issues/4923#issuecomment-554265394

Closes #2107


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2442)