### PR TITLE
Move SetWindowTheme to Interop UxTheme

### DIFF
--- a/src/Common/src/Interop/UxTheme/Interop.DrawThemeBackground.cs
+++ b/src/Common/src/Interop/UxTheme/Interop.DrawThemeBackground.cs
@@ -3,9 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Drawing;
 using System.Runtime.InteropServices;
-using System.Windows.Forms;
 
 internal static partial class Interop
 {

--- a/src/Common/src/Interop/UxTheme/Interop.DrawThemeEdge.cs
+++ b/src/Common/src/Interop/UxTheme/Interop.DrawThemeEdge.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Windows.Forms;
 
 internal static partial class Interop
 {

--- a/src/Common/src/Interop/UxTheme/Interop.DrawThemeParentBackground.cs
+++ b/src/Common/src/Interop/UxTheme/Interop.DrawThemeParentBackground.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Windows.Forms;
 
 internal static partial class Interop
 {

--- a/src/Common/src/Interop/UxTheme/Interop.DrawThemeText.cs
+++ b/src/Common/src/Interop/UxTheme/Interop.DrawThemeText.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Windows.Forms;
 
 internal static partial class Interop
 {

--- a/src/Common/src/Interop/UxTheme/Interop.GetCurrentThemeName.cs
+++ b/src/Common/src/Interop/UxTheme/Interop.GetCurrentThemeName.cs
@@ -9,6 +9,6 @@ internal static partial class Interop
     public static partial class UxTheme
     {
         [DllImport(Libraries.UxTheme, CharSet = CharSet.Unicode)]
-        public static unsafe extern int GetCurrentThemeName(char *pszThemeFileName, int dwMaxNameChars, char *pszColorBuff, int dwMaxColorChars, char *pszSizeBuff, int cchMaxSizeChars);
+        public static extern unsafe HRESULT GetCurrentThemeName(char *pszThemeFileName, int dwMaxNameChars, char *pszColorBuff, int dwMaxColorChars, char *pszSizeBuff, int cchMaxSizeChars);
     }
 }

--- a/src/Common/src/Interop/UxTheme/Interop.GetThemeSysBool.cs
+++ b/src/Common/src/Interop/UxTheme/Interop.GetThemeSysBool.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Windows.Forms;
 
 internal static partial class Interop
 {

--- a/src/Common/src/Interop/UxTheme/Interop.GetThemeSysInt.cs
+++ b/src/Common/src/Interop/UxTheme/Interop.GetThemeSysInt.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Windows.Forms;
 
 internal static partial class Interop
 {

--- a/src/Common/src/Interop/UxTheme/Interop.IsThemePartDefined.cs
+++ b/src/Common/src/Interop/UxTheme/Interop.IsThemePartDefined.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Windows.Forms;
 
 internal static partial class Interop
 {

--- a/src/Common/src/Interop/UxTheme/Interop.SetWindowTheme.cs
+++ b/src/Common/src/Interop/UxTheme/Interop.SetWindowTheme.cs
@@ -2,13 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
     public static partial class UxTheme
     {
-        [DllImport(Libraries.UxTheme, ExactSpelling = true)]
-        public static extern void SetThemeAppProperties(STAP dwFlags);
+        [DllImport(Libraries.UxTheme, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        public static extern HRESULT SetWindowTheme(IntPtr hWnd, string pszSubAppName, string pszSubIdList);
     }
 }

--- a/src/Common/src/SafeNativeMethods.cs
+++ b/src/Common/src/SafeNativeMethods.cs
@@ -129,9 +129,5 @@ namespace System.Windows.Forms
 
         [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
         public static extern bool IsThemeBackgroundPartiallyTransparent(HandleRef hTheme, int iPartId, int iStateId);
-
-        [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
-        public extern static int SetWindowTheme(IntPtr hWnd, string subAppName, string subIdList);
     }
 }
-

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -219,6 +219,7 @@
     <Compile Include="..\..\Common\src\Interop\User32\Interop.WS.cs" Link="Interop\User32\Interop.WS.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.WS_EX.cs" Link="Interop\User32\Interop.WS_EX.cs" />
     <Compile Include="..\..\Common\src\Interop\UxTheme\Interop.MARGINS.cs" Link="Interop\UxTheme\Interop.MARGINS.cs" />
+    <Compile Include="..\..\Common\src\Interop\UxTheme\Interop.SetWindowTheme.cs" Link="Interop\UxTheme\Interop.SetWindowTheme.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\System\ComponentModel\Design\Arrow.ico">

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerUtils.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerUtils.cs
@@ -951,7 +951,7 @@ namespace System.Windows.Forms.Design
             treeView.HotTracking = true;
             treeView.ShowLines = false;
             IntPtr hwnd = treeView.Handle;
-            SafeNativeMethods.SetWindowTheme(hwnd, "Explorer", null);
+            UxTheme.SetWindowTheme(hwnd, "Explorer", null);
             ComCtl32.TVS_EX exstyle = TreeView_GetExtendedStyle(hwnd);
             exstyle |= ComCtl32.TVS_EX.DOUBLEBUFFER | ComCtl32.TVS_EX.FADEINOUTEXPANDOS;
             TreeView_SetExtendedStyle(hwnd, exstyle, 0);
@@ -973,7 +973,7 @@ namespace System.Windows.Forms.Design
                 throw new ArgumentNullException(nameof(listView));
             }
             IntPtr hwnd = listView.Handle;
-            SafeNativeMethods.SetWindowTheme(hwnd, "Explorer", null);
+            UxTheme.SetWindowTheme(hwnd, "Explorer", null);
             ListView_SetExtendedListViewStyleEx(hwnd, NativeMethods.LVS_EX_DOUBLEBUFFER, NativeMethods.LVS_EX_DOUBLEBUFFER);
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -767,7 +767,7 @@ namespace System.Windows.Forms
 
                 if (SystemInformation.HighContrast)
                 {
-                    SafeNativeMethods.SetWindowTheme(Handle, "", "");
+                    UxTheme.SetWindowTheme(Handle, string.Empty, string.Empty);
                 }
             }
             finally


### PR DESCRIPTION
## Proposed changes

- Move SetWindowTheme to Interop UxTheme.
- Remove some unused namespaces.
- Fix GetCurrentThemeName return type.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2446)