### PR TITLE
Move GetAncestor to Interop User32 and add GA enum

### DIFF
--- a/src/Common/src/Interop/User32/Interop.GA.cs
+++ b/src/Common/src/Interop/User32/Interop.GA.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public enum GA : uint
+        {
+            PARENT = 1,
+            ROOT = 2,
+            ROOTOWNER = 3
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.GetAncestor.cs
+++ b/src/Common/src/Interop/User32/Interop.GetAncestor.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern IntPtr GetAncestor(IntPtr hWnd, GA flags);
+
+        public static IntPtr GetAncestor(HandleRef hWnd, GA flags)
+        {
+            IntPtr result = GetAncestor(hWnd.Handle, flags);
+            GC.KeepAlive(hWnd.Wrapper);
+            return result;
+        }
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -197,9 +197,7 @@ namespace System.Windows.Forms
         GMR_DAYSTATE = 1,
         GDI_ERROR = (unchecked((int)0xFFFFFFFF)),
         GDTR_MIN = 0x0001,
-        GDTR_MAX = 0x0002,
-        GA_PARENT = 1,
-        GA_ROOT = 2;
+        GDTR_MAX = 0x0002;
 
         // attribute for COMPOSITIONSTRING Structure
         public const int

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -205,9 +205,6 @@ namespace System.Windows.Forms
 
         [DllImport(ExternDll.Kernel32, CharSet = CharSet.Auto)]
         public static extern void GetTempFileName(string tempDirName, string prefixName, int unique, StringBuilder sb);
-
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern IntPtr GetAncestor(HandleRef hWnd, int flags);
 
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern bool IsZoomed(HandleRef hWnd);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
@@ -1379,7 +1379,7 @@ namespace System.Windows.Forms
                         // winforms code.  This can happen with ActiveX controls that launch dialogs specificially
 
                         // First, get the first top-level window in the hierarchy.
-                        IntPtr hwndRoot = UnsafeNativeMethods.GetAncestor(new HandleRef(null, msg.hwnd), NativeMethods.GA_ROOT);
+                        IntPtr hwndRoot = User32.GetAncestor(msg.hwnd, User32.GA.ROOT);
 
                         // If we got a valid HWND, then call IsDialogMessage on it.  If that returns true, it's been processed
                         // so we should return true to prevent Translate/Dispatch from being called.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.Ime.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.Ime.cs
@@ -403,7 +403,7 @@ namespace System.Windows.Forms
                         // this is the case of a disabled winforms control hosted in a non-Form shell.
                         if (imeMode == ImeMode.Disable)
                         {
-                            focusHandle = UnsafeNativeMethods.GetAncestor(new HandleRef(null, focusHandle), NativeMethods.GA_ROOT);
+                            focusHandle = User32.GetAncestor(focusHandle, User32.GA.ROOT);
 
                             if (focusHandle != IntPtr.Zero)
                             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -5587,7 +5587,7 @@ namespace System.Windows.Forms
                     return ctl;
                 }
 
-                handle = UnsafeNativeMethods.GetAncestor(new HandleRef(null, handle), NativeMethods.GA_PARENT);
+                handle = User32.GetAncestor(handle, User32.GA.PARENT);
             }
             return null;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -304,7 +304,7 @@ namespace System.Windows.Forms
                 (windowControl.ShowParams & (User32.SW)0xF) != User32.SW.SHOWNOACTIVATE)
             {
                 IntPtr hWnd = User32.GetActiveWindow();
-                IntPtr rootHwnd = UnsafeNativeMethods.GetAncestor(new HandleRef(window, window.Handle), NativeMethods.GA_ROOT);
+                IntPtr rootHwnd = User32.GetAncestor(new HandleRef(window, window.Handle), User32.GA.ROOT);
                 if (hWnd != rootHwnd)
                 {
                     TipInfo tt = (TipInfo)_tools[windowControl];

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WinFormsUtils.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WinFormsUtils.cs
@@ -254,7 +254,7 @@ namespace System.Windows.Forms
         /// </summary>
         public static HandleRef GetRootHWnd(HandleRef hwnd)
         {
-            IntPtr rootHwnd = UnsafeNativeMethods.GetAncestor(new HandleRef(hwnd, hwnd.Handle), NativeMethods.GA_ROOT);
+            IntPtr rootHwnd = User32.GetAncestor(new HandleRef(hwnd, hwnd.Handle), User32.GA.ROOT);
             return new HandleRef(hwnd.Wrapper, rootHwnd);
         }
 


### PR DESCRIPTION
## Proposed changes

- Move GetAncestor to Interop User32.
- Add GA enum.
- Remove GA constants and replace their usages with the above enum.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2452)