### PR TITLE
Move GetMessageTime to Interop User32

### DIFF
--- a/src/Common/src/Interop/User32/Interop.GetMessageTime.cs
+++ b/src/Common/src/Interop/User32/Interop.GetMessageTime.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern int GetMessageTime();
+    }
+}

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -17,9 +17,6 @@ namespace System.Windows.Forms
 {
     internal static class UnsafeNativeMethods
     {
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern int GetMessageTime();
-
         [DllImport(ExternDll.User32)]
         public static extern int GetClassName(HandleRef hwnd, StringBuilder lpClassName, int nMaxCount);
 

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -175,6 +175,7 @@
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetFocus.cs" Link="Interop\User32\Interop.GetFocus.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetKeyState.cs" Link="Interop\User32\Interop.GetKeyState.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetMessagePos.cs" Link="Interop\User32\Interop.GetMessagePos.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.GetMessageTime.cs" Link="Interop\User32\Interop.GetMessageTime.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetUpdateRgn.cs" Link="Interop\User32\Interop.GetUpdateRgn.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetWindow.cs" Link="Interop\User32\Interop.GetWindow.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetWindowText.cs" Link="Interop\User32\Interop.GetWindowText.cs" />

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
@@ -1185,11 +1185,11 @@ namespace System.Windows.Forms.Design.Behavior
                                 // No one knows why we get an extra click here from VS. As a workaround, we check the TimeStamp and discard it.
                                 if (m.Msg == WindowMessages.WM_LBUTTONDOWN)
                                 {
-                                    _lastLButtonDownTimeStamp = UnsafeNativeMethods.GetMessageTime();
+                                    _lastLButtonDownTimeStamp = User32.GetMessageTime();
                                 }
                                 else if (m.Msg == WindowMessages.WM_LBUTTONDBLCLK)
                                 {
-                                    int lButtonDoubleClickTimeStamp = UnsafeNativeMethods.GetMessageTime();
+                                    int lButtonDoubleClickTimeStamp = User32.GetMessageTime();
                                     if (lButtonDoubleClickTimeStamp == _lastLButtonDownTimeStamp)
                                     {
                                         return true;


### PR DESCRIPTION
## Proposed changes

- Move GetMessageTime to Interop User32


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2455)