### PR TITLE
Fix issues in Interop.User32.GetWindowText

### DIFF
--- a/src/Common/src/Interop/User32/Interop.GetWindowText.cs
+++ b/src/Common/src/Interop/User32/Interop.GetWindowText.cs
@@ -25,21 +25,30 @@ internal static partial class Interop
 
         public static unsafe string GetWindowText(IntPtr hWnd)
         {
+            int textLength = 0;
+
             while (true)
             {
                 // GetWindowTextLengthW returns the length of the text not
                 // including the null terminator.
-                int textLengthWithNullTerminator = GetWindowTextLengthW(hWnd) + 1;
-                char[] windowTitleBuffer = ArrayPool<char>.Shared.Rent(textLengthWithNullTerminator);
+                textLength = Math.Max(textLength, GetWindowTextLengthW(hWnd));
+                
+                // Use a buffer that has room for at least two additional chars
+                // (one for the null terminator, and one to detect if the text length
+                // has increased).
+                char[] windowTitleBuffer = ArrayPool<char>.Shared.Rent(textLength + 2);
                 string windowTitle;
                 fixed (char* pWindowTitle = windowTitleBuffer)
                 {
-                    int actualTextLength = GetWindowTextW(hWnd, pWindowTitle, textLengthWithNullTerminator + 1);
+                    int actualTextLength = GetWindowTextW(hWnd, pWindowTitle, windowTitleBuffer.Length);
 
                     // The window text may have changed between calls.
                     // Keep looping until we get a buffer that can fit.
-                    if (actualTextLength > textLengthWithNullTerminator)
+                    if (actualTextLength > windowTitleBuffer.Length - 2)
                     {
+                        // We know the text is at last actualTextLength characters
+                        // long, so use this as minimum value for the next iteration.
+                        textLength = actualTextLength;
                         ArrayPool<char>.Shared.Return(windowTitleBuffer);
                         continue;
                     }

--- a/src/Common/src/Interop/User32/Interop.GetWindowText.cs
+++ b/src/Common/src/Interop/User32/Interop.GetWindowText.cs
@@ -46,7 +46,7 @@ internal static partial class Interop
                     // Keep looping until we get a buffer that can fit.
                     if (actualTextLength > windowTitleBuffer.Length - 2)
                     {
-                        // We know the text is at last actualTextLength characters
+                        // We know the text is at least actualTextLength characters
                         // long, so use this as minimum value for the next iteration.
                         textLength = actualTextLength;
                         ArrayPool<char>.Shared.Return(windowTitleBuffer);

--- a/src/System.Windows.Forms/tests/UnitTests/InteropTests/GetWindowTextTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/InteropTests/GetWindowTextTests.cs
@@ -1,0 +1,83 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.Tests.InteropTests
+{
+    public class GetWindowTextTests
+    {
+        [WinFormsFact]
+        public void GetWindowText_DoesNotTruncateText()
+        {
+            CallGetWindowText(useBeforeGetTextLengthCallback: false);
+        }
+
+        [WinFormsFact]
+        public void GetWindowText_DoesNotLoopInfinitely()
+        {
+            CallGetWindowText(useBeforeGetTextLengthCallback: true);
+        }
+
+        private void CallGetWindowText(bool useBeforeGetTextLengthCallback)
+        {
+            const string shortText = "A";
+
+            // Use a long string that exceeds the initial buffer size (16).
+            string longText = new string('X', 50);
+
+            using var form = new ChangeWindowTextForm()
+            {
+                Text = shortText
+            };
+
+            // Creating the handle causes GetWindowText to be called,
+            // so do it before setting the delegates.
+            IntPtr formHandle = form.Handle;
+
+            form.BeforeGetTextCallback = () => longText;
+            if (useBeforeGetTextLengthCallback)
+            {
+                form.BeforeGetTextLengthCallback = () => shortText;
+            }
+
+            string result = User32.GetWindowText(formHandle);
+            Assert.Equal(longText, result);
+        }
+
+        private class ChangeWindowTextForm : Form
+        {
+            public Func<string> BeforeGetTextLengthCallback
+            {
+                get;
+                set;
+            }
+
+            public Func<string> BeforeGetTextCallback
+            {
+                get;
+                set;
+            }
+
+            protected override void WndProc(ref Message m)
+            {
+                if (m.Msg == WindowMessages.WM_GETTEXTLENGTH)
+                {
+                    string text = BeforeGetTextLengthCallback?.Invoke();
+                    if (text != null)
+                        User32.SetWindowTextW(m.HWnd, text);
+                }
+                else if (m.Msg == WindowMessages.WM_GETTEXT)
+                {
+                    string text = BeforeGetTextCallback?.Invoke();
+                    if (text != null)
+                        User32.SetWindowTextW(m.HWnd, text);
+                }
+
+                base.WndProc(ref m);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2424


## Proposed changes
Fix the following issues that appear to have been overlooked in the review of #923:
- Ensure the buffer passed to `GetWindowTextW()` has at least the length specified in that call, to prevent an out-of-bounds write.
- Fix the condition to detect if the text length has increased, to ensure the returned text is not truncated.
- Avoid an infinite loop (if the control text changes back and forth between a small and long text) by keeping the `actualTextLength` value as minimum text length.

Additional improvements:
- Avoid unnecessary loops by specifying the full buffer length as maximum number of characters, rather than the initial text length value.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

Customers will not experience invalid memory access, an infinite loop, or truncated text being returned when the window/control text changes while the code in `GetWindowText` is executing, e.g. if the window/control is owned by a different thread or process, or if the `WndProc` alters the text between receiving a `WM_GETTEXTLENGTH` and a `WM_GETTEXT` message.

## Regression? 

Yes (The out-of-bounds write is a regression from #923; the other items are not regressions)

## Risk

-

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

- Manual testing as described in https://github.com/dotnet/winforms/issues/2424#issuecomment-559819764
- The text truncation and infinite loop are tested by unit tests.


## Test environment(s) <!-- Remove any that don't apply -->

.NET Core SDK (reflecting any global.json):
 Version:   5.0.100-alpha1-015759
 Commit:    28f22a7729

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.17134
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\5.0.100-alpha1-015759\

Host (useful for support):
  Version: 5.0.0-alpha.1.19564.1
  Commit:  c77948d92a

.NET Core SDKs installed:
  3.1.100-preview3-014645 [C:\Program Files\dotnet\sdk]
  5.0.100-alpha1-015759 [C:\Program Files\dotnet\sdk]


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2460)