### PR TITLE
fix: Incorrect invocation of `PeekMessageW`

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -1705,7 +1705,7 @@ namespace System.Windows.Forms
         ///  handle for this control.  If the control's handle hasn't been
         ///  created yet, this method will return the current thread's ID.
         /// </summary>
-        internal uint CreateThreadId => IsHandleCreated 
+        internal uint CreateThreadId => IsHandleCreated
             ? User32.GetWindowThreadProcessId(this, out _)
             : Kernel32.GetCurrentThreadId();
 
@@ -2212,7 +2212,7 @@ namespace System.Windows.Forms
         {
             Font local = (Font)Properties.GetObject(s_fontProperty);
             Font resolved = Font;
-            Font newFont = new Font(Font.FontFamily, Font.Size*  factor, Font.Style);
+            Font newFont = new Font(Font.FontFamily, Font.Size * factor, Font.Style);
 
             if ((local == null) || !local.Equals(newFont))
             {
@@ -7882,7 +7882,7 @@ namespace System.Windows.Forms
                     ListenToUserPreferenceChanged(GetTopLevel());
                 }
             }
-            
+
             ((EventHandler)Events[s_handleCreatedEvent])?.Invoke(this, e);
 
             if (IsHandleCreated)
@@ -8091,7 +8091,7 @@ namespace System.Windows.Forms
             {
                 _parent.ChildGotFocus(this);
             }
-            
+
             ((EventHandler)Events[s_gotFocusEvent])?.Invoke(this, e);
         }
 
@@ -8146,7 +8146,7 @@ namespace System.Windows.Forms
                     controls[i].OnParentInvalidated(e);
                 }
             }
-            
+
             ((InvalidateEventHandler)Events[s_invalidatedEvent])?.Invoke(this, e);
         }
 
@@ -8248,7 +8248,7 @@ namespace System.Windows.Forms
             {
                 ActiveXOnFocus(false);
             }
-            
+
             ((EventHandler)Events[s_lostFocusEvent])?.Invoke(this, e);
         }
 
@@ -8407,7 +8407,7 @@ namespace System.Windows.Forms
             {
                 Invalidate();
             }
-            
+
             ((EventHandler)Events[s_paddingChangedEvent])?.Invoke(this, e);
         }
 
@@ -9667,7 +9667,7 @@ namespace System.Windows.Forms
             if (!IsDisposed)
             {
                 var msg = new User32.MSG();
-                while (User32.PeekMessageW(ref msg, this, msgMin, msgMax).IsTrue())
+                while (User32.PeekMessageW(ref msg, this, msgMin, msgMax, User32.PM.REMOVE).IsTrue())
                 {
                     // No-op.
                 }
@@ -12286,7 +12286,7 @@ namespace System.Windows.Forms
                     if (local != null)
                     {
                         var factor = (float)_deviceDpi / deviceDpiOld;
-                        Font = new Font(local.FontFamily, local.Size*  factor, local.Style, local.Unit, local.GdiCharSet, local.GdiVerticalFont);
+                        Font = new Font(local.FontFamily, local.Size * factor, local.Style, local.Unit, local.GdiCharSet, local.GdiVerticalFont);
                     }
 
                     RescaleConstantsForDpi(deviceDpiOld, _deviceDpi);
@@ -12662,7 +12662,7 @@ namespace System.Windows.Forms
                         {
                             Gdi32.SelectPalette(dc, oldPal, BOOL.FALSE);
                         }
-                        
+
                         bufferedGraphics?.Dispose();
                     }
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -5778,7 +5778,8 @@ namespace System.Windows.Forms.PropertyGridInternal
             while (User32.PeekMessageW(ref mouseMsg,
                 IntPtr.Zero,
                 (User32.WindowMessage)WindowMessages.WM_MOUSEFIRST,
-                (User32.WindowMessage)WindowMessages.WM_MOUSELAST).IsTrue())
+                (User32.WindowMessage)WindowMessages.WM_MOUSELAST,
+                User32.PM.REMOVE).IsTrue())
             {
                 // No-op.
             }
@@ -5860,7 +5861,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             // which usually discards the message by returning 1 to GetMessage(). But this won't occur until after the
             // error dialog gets closed, which is much too late.
             var mouseMsg = new User32.MSG();
-            while (User32.PeekMessageW(ref mouseMsg, msgMin: User32.WM_MOUSEFIRST, msgMax: User32.WM_MOUSELAST).IsTrue())
+            while (User32.PeekMessageW(ref mouseMsg, IntPtr.Zero, User32.WM_MOUSEFIRST, User32.WM_MOUSELAST, User32.PM.REMOVE).IsTrue())
             {
                 // No-op.
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -549,10 +549,10 @@ namespace System.Windows.Forms
                         SetState(State.GetTabRectfromItemSize, true);
                         return GetTabRect(0).Size;
                     }
-                    
+
                     return DefaultItemSize;
                 }
-                
+
                 return _itemSize;
             }
             set
@@ -2109,7 +2109,7 @@ namespace System.Windows.Forms
 
             // Remove other TabBaseReLayout messages from the message queue
             var msg = new User32.MSG();
-            while (User32.PeekMessageW(ref msg, this, _tabBaseReLayoutMessage, _tabBaseReLayoutMessage).IsTrue())
+            while (User32.PeekMessageW(ref msg, this, _tabBaseReLayoutMessage, _tabBaseReLayoutMessage, User32.PM.REMOVE).IsTrue())
             {
                 // No-op.
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.cs
@@ -912,7 +912,7 @@ namespace System.Windows.Forms
                             try
                             {
                                 var msg = new User32.MSG();
-                                while (User32.PeekMessageW(ref msg, msgMin: User32.WindowMessage.WM_PAINT, msgMax: User32.WindowMessage.WM_PAINT).IsTrue())
+                                while (User32.PeekMessageW(ref msg, IntPtr.Zero, User32.WindowMessage.WM_PAINT, User32.WindowMessage.WM_PAINT, User32.PM.REMOVE).IsTrue())
                                 {
                                     User32.UpdateWindow(msg.hwnd);
 


### PR DESCRIPTION
Fixes #2462



## Proposed changes

- During the refactor in d52e526 a number of calls to `PeekMessageW` lost `PM.REMOVE` argument that led to situations where callers would get stuck in a infinite loop peeking for messages.
For example, a form with a `TabControl` with two `TabPage` controls added to it would dead lock and hang.

Fix affected calls by restoring the correct argument.


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- `TabControl` and other affected controls will work again

## Regression? 

- Yes 


<!-- end TELL-MODE -->



## Test methodology <!-- How did you ensure quality? -->

- manual creation of a test app as described in #2462 and checking that it works as expected

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2463)