### PR TITLE
Cleanup Control.SendMessage ref rect overload

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
@@ -496,7 +496,7 @@ namespace System.Windows.Forms
             if (IsHandleCreated)
             {
                 var rect = new RECT();
-                SendMessage((int)User32.LB.GETITEMRECT, index, ref rect);
+                User32.SendMessageW(this, (User32.WindowMessage)User32.LB.GETITEMRECT, (IntPtr)index, ref rect);
                 User32.InvalidateRect(new HandleRef(this, Handle), &rect, BOOL.FALSE);
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -10655,15 +10655,6 @@ namespace System.Windows.Forms
         ///  Sends a Win32 message to this control.  If the control does not yet
         ///  have a handle, it will be created.
         /// </summary>
-        internal IntPtr SendMessage(int msg, int wparam, ref RECT lparam)
-        {
-            return UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), msg, wparam, ref lparam);
-        }
-
-        /// <summary>
-        ///  Sends a Win32 message to this control.  If the control does not yet
-        ///  have a handle, it will be created.
-        /// </summary>
         internal IntPtr SendMessage(int msg, bool wparam, int lparam)
         {
             Debug.Assert(IsHandleCreated, "Performance alert!  Calling Control::SendMessage and forcing handle creation.  Re-work control so handle creation is not required to set properties.  If there is no work around, wrap the call in an IsHandleCreated check.");

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -1556,10 +1556,8 @@ namespace System.Windows.Forms
         public Rectangle GetItemRectangle(int index)
         {
             CheckIndex(index);
-            RECT rect = new RECT();
-            int result = SendMessage((int)User32.LB.GETITEMRECT, index, ref rect).ToInt32();
-
-            if (result == 0)
+            var rect = new RECT();
+            if (User32.SendMessageW(this, (User32.WindowMessage)User32.LB.GETITEMRECT, (IntPtr)index, ref rect) == IntPtr.Zero)
             {
                 return Rectangle.Empty;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -3595,11 +3595,11 @@ namespace System.Windows.Forms
                 return Rectangle.Empty;
             }
 
-            RECT itemrect = new RECT
+            var itemrect = new RECT
             {
                 left = (int)portion
             };
-            if (unchecked((int)(long)SendMessage((int)LVM.GETITEMRECT, index, ref itemrect)) == 0)
+            if (User32.SendMessageW(this, (User32.WindowMessage)LVM.GETITEMRECT, (IntPtr)index, ref itemrect) == IntPtr.Zero)
             {
                 throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
             }
@@ -3623,11 +3623,11 @@ namespace System.Windows.Forms
                 return Rectangle.Empty;
             }
 
-            RECT itemrect = new RECT
+            var itemrect = new RECT
             {
                 left = 0
             };
-            if (unchecked((int)(long)SendMessage((int)LVM.GETITEMRECT, index, ref itemrect)) == 0)
+            if (User32.SendMessageW(this, (User32.WindowMessage)LVM.GETITEMRECT, (IntPtr)index, ref itemrect) == IntPtr.Zero)
             {
                 return Rectangle.Empty;
             }
@@ -3703,12 +3703,12 @@ namespace System.Windows.Forms
                 return Rectangle.Empty;
             }
 
-            RECT itemrect = new RECT
+            var itemrect = new RECT
             {
                 left = (int)portion,
                 top = subItemIndex
             };
-            if (unchecked((int)(long)SendMessage((int)LVM.GETSUBITEMRECT, itemIndex, ref itemrect)) == 0)
+            if (User32.SendMessageW(this, (User32.WindowMessage)LVM.GETSUBITEMRECT, (IntPtr)itemIndex, ref itemrect) == IntPtr.Zero)
             {
                 throw new ArgumentOutOfRangeException(nameof(itemIndex), itemIndex, string.Format(SR.InvalidArgument, nameof(itemIndex), itemIndex));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewInsertionMark.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewInsertionMark.cs
@@ -59,8 +59,8 @@ namespace System.Windows.Forms
         {
             get
             {
-                RECT rect = new RECT();
-                listView.SendMessage((int)LVM.GETINSERTMARKRECT, 0, ref rect);
+                var rect = new RECT();
+                User32.SendMessageW(listView, (User32.WindowMessage)LVM.GETINSERTMARKRECT, IntPtr.Zero, ref rect);
                 return Rectangle.FromLTRB(rect.left, rect.top, rect.right, rect.bottom);
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -982,8 +982,7 @@ namespace System.Windows.Forms
 
                 if (IsHandleCreated)
                 {
-
-                    if (unchecked((int)(long)SendMessage((int)ComCtl32.MCM.GETMINREQRECT, 0, ref rect)) == 0)
+                    if (User32.SendMessageW(this, (User32.WindowMessage)ComCtl32.MCM.GETMINREQRECT, IntPtr.Zero, ref rect) == IntPtr.Zero)
                     {
                         throw new InvalidOperationException(SR.InvalidSingleMonthSize);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -4551,7 +4551,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             RECT rect = itemRect;
 
-            ToolTip.SendMessage((int)User32.WindowMessage.TTM_ADJUSTRECT, 1, ref rect);
+            User32.SendMessageW(ToolTip, User32.WindowMessage.TTM_ADJUSTRECT, (IntPtr)1, ref rect);
 
             // now offset it back to screen coords
             Point locPoint = parent.PointToScreen(new Point(rect.left, rect.top));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -407,7 +407,7 @@ namespace System.Windows.Forms
                     }
                     if (IsHandleCreated)
                     {
-                        SendMessage((int)ComCtl32.TCM.ADJUSTRECT, 0, ref rect);
+                        User32.SendMessageW(this, (User32.WindowMessage)ComCtl32.TCM.ADJUSTRECT, IntPtr.Zero, ref rect);
                     }
                 }
 
@@ -1228,7 +1228,7 @@ namespace System.Windows.Forms
                 CreateHandle();
             }
 
-            SendMessage((int)ComCtl32.TCM.GETITEMRECT, index, ref rect);
+            User32.SendMessageW(this, (User32.WindowMessage)ComCtl32.TCM.GETITEMRECT, (IntPtr)index, ref rect);
             return Rectangle.FromLTRB(rect.left, rect.top, rect.right, rect.bottom);
         }
 


### PR DESCRIPTION
## Proposed Changes
- Cleanup Control.SendMessage ref rect overload

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2482)