### PR TITLE
Remove always false Control.HasMenu

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -2527,8 +2527,6 @@ namespace System.Windows.Forms
             }
         }
 
-        internal virtual bool HasMenu => false;
-
         /// <summary>
         ///  The height of this control
         /// </summary>
@@ -5745,7 +5743,7 @@ namespace System.Windows.Forms
             // because windows scales them for us.
             RECT adornments = new RECT(0, 0, 0, 0);
             CreateParams cp = CreateParams;
-            AdjustWindowRectEx(ref adornments, cp.Style, HasMenu, cp.ExStyle);
+            AdjustWindowRectEx(ref adornments, cp.Style, false, cp.ExStyle);
 
             float dx = factor.Width;
             float dy = factor.Height;
@@ -10357,7 +10355,7 @@ namespace System.Windows.Forms
         {
             CreateParams cp = CreateParams;
             RECT adornments = new RECT(0, 0, 0, 0);
-            AdjustWindowRectEx(ref adornments, cp.Style, HasMenu, cp.ExStyle);
+            AdjustWindowRectEx(ref adornments, cp.Style, false, cp.ExStyle);
             Size minSize = MinimumSize;
             Size maxSize = MaximumSize;
 
@@ -10900,7 +10898,7 @@ namespace System.Windows.Forms
         {
             RECT rect = new RECT(0, 0, width, height);
             CreateParams cp = CreateParams;
-            AdjustWindowRectEx(ref rect, cp.Style, HasMenu, cp.ExStyle);
+            AdjustWindowRectEx(ref rect, cp.Style, false, cp.ExStyle);
             return rect.Size;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -1065,11 +1065,6 @@ namespace System.Windows.Forms
             }
         }
 
-        internal override bool HasMenu
-        {
-            get => false;
-        }
-
         /// <summary>
         ///  Gets or sets a value indicating whether a
         ///  help button should be displayed in the caption box of the form.
@@ -3167,7 +3162,7 @@ namespace System.Windows.Forms
         private Size ComputeWindowSize(Size clientSize, int style, int exStyle)
         {
             RECT result = new RECT(0, 0, clientSize.Width, clientSize.Height);
-            AdjustWindowRectEx(ref result, style, HasMenu, exStyle);
+            AdjustWindowRectEx(ref result, style, false, exStyle);
             return new Size(result.right - result.left, result.bottom - result.top);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.cs
@@ -562,7 +562,7 @@ namespace System.Windows.Forms
                     RECT rect = new RECT();
                     CreateParams cp = CreateParams;
 
-                    AdjustWindowRectEx(ref rect, cp.Style, HasMenu, cp.ExStyle);
+                    AdjustWindowRectEx(ref rect, cp.Style, false, cp.ExStyle);
 
                     // the coordinates we get back are negative, we need to translate this back to positive.
                     int offsetX = -rect.left; // one to get back to 0,0, another to translate


### PR DESCRIPTION
## Proposed Changes
- Remove always false Control.HasMenu

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2483)