### PR TITLE
Add HBMMENU enum to Interop User32

### DIFF
--- a/src/Common/src/Interop/User32/Interop.HBMMENU.cs
+++ b/src/Common/src/Interop/User32/Interop.HBMMENU.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public enum HBMMENU
+        {
+            CALLBACK = -1,
+            SYSTEM = 1,
+            MBAR_RESTORE = 2,
+            MBAR_MINIMIZE = 3,
+            MBAR_CLOSE = 5,
+            MBAR_CLOSE_D = 6,
+            MBAR_MINIMIZE_D = 7,
+            POPUP_CLOSE = 8,
+            POPUP_RESTORE = 9,
+            POPUP_MAXIMIZE = 10,
+            POPUP_MINIMIZE = 11
+        }
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -226,19 +226,6 @@ namespace System.Windows.Forms
 
         public const int HDS_FULLDRAG = 0x0080;
 
-        // Corresponds to bitmaps in MENUITEMINFO
-        public const int HBMMENU_CALLBACK = -1,
-        HBMMENU_SYSTEM = 1,
-        HBMMENU_MBAR_RESTORE = 2,
-        HBMMENU_MBAR_MINIMIZE = 3,
-        HBMMENU_MBAR_CLOSE = 5,
-        HBMMENU_MBAR_CLOSE_D = 6,
-        HBMMENU_MBAR_MINIMIZE_D = 7,
-        HBMMENU_POPUP_CLOSE = 8,
-        HBMMENU_POPUP_RESTORE = 9,
-        HBMMENU_POPUP_MAXIMIZE = 10,
-        HBMMENU_POPUP_MINIMIZE = 11;
-
         public const int
         ICON_SMALL = 0,
         ICON_BIG = 1,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.cs
@@ -829,61 +829,56 @@ namespace System.Windows.Forms
             };
             UnsafeNativeMethods.GetMenuItemInfo(new HandleRef(this, nativeMenuHandle), nativeMenuCommandID, /*fByPosition instead of ID=*/ false, info);
 
-            if (info.hbmpItem != IntPtr.Zero && info.hbmpItem.ToInt32() > NativeMethods.HBMMENU_POPUP_MINIMIZE)
+            if (info.hbmpItem != IntPtr.Zero && info.hbmpItem.ToInt32() > (int)User32.HBMMENU.POPUP_MINIMIZE)
             {
                 return Bitmap.FromHbitmap(info.hbmpItem);
             }
-            else
+
+            // its a system defined bitmap
+            int buttonToUse = -1;
+
+            switch (info.hbmpItem.ToInt32())
             {
-                // its a system defined bitmap
-                int buttonToUse = -1;
-
-                switch (info.hbmpItem.ToInt32())
-                {
-                    case NativeMethods.HBMMENU_MBAR_CLOSE:
-                    case NativeMethods.HBMMENU_MBAR_CLOSE_D:
-                    case NativeMethods.HBMMENU_POPUP_CLOSE:
-                        buttonToUse = (int)CaptionButton.Close;
-                        break;
-
-                    case NativeMethods.HBMMENU_MBAR_MINIMIZE:
-                    case NativeMethods.HBMMENU_MBAR_MINIMIZE_D:
-                    case NativeMethods.HBMMENU_POPUP_MINIMIZE:
-                        buttonToUse = (int)CaptionButton.Minimize;
-                        break;
-
-                    case NativeMethods.HBMMENU_MBAR_RESTORE:
-                    case NativeMethods.HBMMENU_POPUP_RESTORE:
-                        buttonToUse = (int)CaptionButton.Restore;
-                        break;
-
-                    case NativeMethods.HBMMENU_POPUP_MAXIMIZE:
-                        buttonToUse = (int)CaptionButton.Maximize;
-                        break;
-
-                    case NativeMethods.HBMMENU_SYSTEM:
-                    //
-                    case NativeMethods.HBMMENU_CALLBACK:
-                    // owner draw not supported
-                    default:
-                        break;
-                }
-                if (buttonToUse > -1)
-                {
-
-                    // we've mapped to a system defined bitmap we know how to draw
-                    Bitmap image = new Bitmap(16, 16);
-
-                    using (Graphics g = Graphics.FromImage(image))
-                    {
-                        ControlPaint.DrawCaptionButton(g, new Rectangle(Point.Empty, image.Size), (CaptionButton)buttonToUse, ButtonState.Flat);
-                        g.DrawRectangle(SystemPens.Control, 0, 0, image.Width - 1, image.Height - 1);
-                    }
-
-                    image.MakeTransparent(SystemColors.Control);
-                    return image;
-                }
+                case (int)User32.HBMMENU.MBAR_CLOSE:
+                case (int)User32.HBMMENU.MBAR_CLOSE_D:
+                case (int)User32.HBMMENU.POPUP_CLOSE:
+                    buttonToUse = (int)CaptionButton.Close;
+                    break;
+                case (int)User32.HBMMENU.MBAR_MINIMIZE:
+                case (int)User32.HBMMENU.MBAR_MINIMIZE_D:
+                case (int)User32.HBMMENU.POPUP_MINIMIZE:
+                    buttonToUse = (int)CaptionButton.Minimize;
+                    break;
+                case (int)User32.HBMMENU.MBAR_RESTORE:
+                case (int)User32.HBMMENU.POPUP_RESTORE:
+                    buttonToUse = (int)CaptionButton.Restore;
+                    break;
+                case (int)User32.HBMMENU.POPUP_MAXIMIZE:
+                    buttonToUse = (int)CaptionButton.Maximize;
+                    break;
+                case (int)User32.HBMMENU.SYSTEM:
+                //
+                case (int)User32.HBMMENU.CALLBACK:
+                // owner draw not supported
+                default:
+                    break;
             }
+
+            if (buttonToUse > -1)
+            {
+                // we've mapped to a system defined bitmap we know how to draw
+                Bitmap image = new Bitmap(16, 16);
+
+                using (Graphics g = Graphics.FromImage(image))
+                {
+                    ControlPaint.DrawCaptionButton(g, new Rectangle(Point.Empty, image.Size), (CaptionButton)buttonToUse, ButtonState.Flat);
+                    g.DrawRectangle(SystemPens.Control, 0, 0, image.Width - 1, image.Height - 1);
+                }
+
+                image.MakeTransparent(SystemColors.Control);
+                return image;
+            }
+            
             return null;
         }
 


### PR DESCRIPTION
## Proposed changes

- Add HBMMENU enum to Interop User32.
- Remove HBMMENU constants and replace their usages with the above enum.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2484)