### PR TITLE
Add IMN enum to Interop Imm32

### DIFF
--- a/src/Common/src/Interop/Imm32/Interop.IMN.cs
+++ b/src/Common/src/Interop/Imm32/Interop.IMN.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal partial class Interop
+{
+    internal partial class Imm32
+    {
+        public enum IMN
+        {
+            CLOSESTATUSWINDOW = 0x0001,
+            OPENSTATUSWINDOW = 0x0002,
+            CHANGECANDIDATE = 0x0003,
+            CLOSECANDIDATE = 0x0004,
+            OPENCANDIDATE = 0x0005,
+            SETCONVERSIONMODE = 0x0006,
+            SETSENTENCEMODE = 0x0007,
+            SETOPENSTATUS = 0x0008,
+            SETCANDIDATEPOS = 0x0009,
+            SETCOMPOSITIONFONT = 0x000A,
+            SETCOMPOSITIONWINDOW = 0x000B,
+            SETSTATUSWINDOWPOS = 0x000C,
+            GUIDELINE = 0x000D,
+            PRIVATE = 0x000E
+        }
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -761,23 +761,6 @@ namespace System.Windows.Forms
 
         public const int WHEEL_DELTA = 120;
 
-        // wParam of report message WM_IME_NOTIFY (public\sdk\imm.h)
-        public const int
-        //IMN_CLOSESTATUSWINDOW = 0x0001,
-        IMN_OPENSTATUSWINDOW = 0x0002,
-        //IMN_CHANGECANDIDATE   = 0x0003,
-        //IMN_CLOSECANDIDATE    = 0x0004,
-        //IMN_OPENCANDIDATE     = 0x0005,
-        IMN_SETCONVERSIONMODE = 0x0006,
-        //IMN_SETSENTENCEMODE   = 0x0007,
-        IMN_SETOPENSTATUS = 0x0008;
-        //IMN_SETCANDIDATEPOS    = 0x0009,
-        //IMN_SETCOMPOSITIONFONT = 0x000A,
-        //IMN_SETCOMPOSITIONWINDOW = 0x000B,
-        //IMN_SETSTATUSWINDOWPOS   = 0x000C,
-        //IMN_GUIDELINE            = 0x000D,
-        //IMN_PRIVATE              = 0x000E;
-
         public static int START_PAGE_GENERAL = unchecked((int)0xffffffff);
 
         //  Result action ids for PrintDlgEx.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.Ime.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.Ime.cs
@@ -778,7 +778,7 @@ namespace System.Windows.Forms
                 // We guard against re-entrancy since the ImeModeChanged event can be raised and any changes from the handler could
                 // lead to another WM_IME_NOTIFY loop.
 
-                if (wparam == NativeMethods.IMN_SETCONVERSIONMODE || wparam == NativeMethods.IMN_SETOPENSTATUS)
+                if (wparam == (int)Imm32.IMN.SETCONVERSIONMODE || wparam == (int)Imm32.IMN.SETOPENSTATUS)
                 {
                     Debug.WriteLineIf(CompModSwitches.ImeMode.Level >= TraceLevel.Info, string.Format(CultureInfo.CurrentCulture, "Inside WmImeNotify(m.wparam=[{0}]), this={1}", m.WParam, this));
                     Debug.Indent();


### PR DESCRIPTION
## Proposed changes

- Add IMN enum to Interop Imm32
- Remove corresponding constants from NativeMethods.cs and replace their usages with the above enum.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2486)