### PR TITLE
Move EnumWindows to Interop User32

### DIFF
--- a/src/Common/src/Interop/User32/Interop.EnumThreadWindows.cs
+++ b/src/Common/src/Interop/User32/Interop.EnumThreadWindows.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Windows.Forms;
 
 internal static partial class Interop
 {
@@ -13,7 +12,7 @@ internal static partial class Interop
         public delegate bool EnumThreadWindowsCallback(IntPtr hWnd, IntPtr lParam);
 
         [DllImport(Libraries.User32, ExactSpelling = true)]
-        public extern static BOOL EnumThreadWindows(uint dwThreadId, EnumThreadWindowsCallback lpfn, IntPtr lParam);
+        public static extern BOOL EnumThreadWindows(uint dwThreadId, EnumThreadWindowsCallback lpfn, IntPtr lParam);
 
         public static BOOL EnumThreadWindows(uint dwThreadId, EnumThreadWindowsCallback lpfn, IHandle lParam)
         {

--- a/src/Common/src/Interop/User32/Interop.EnumWindows.cs
+++ b/src/Common/src/Interop/User32/Interop.EnumWindows.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public delegate bool EnumWindowsCallback(IntPtr hWnd, IntPtr lParam);
+
+        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
+        public static extern BOOL EnumWindows(EnumWindowsCallback callback, IntPtr extraData);
+    }
+}

--- a/src/Common/src/SafeNativeMethods.cs
+++ b/src/Common/src/SafeNativeMethods.cs
@@ -55,11 +55,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true)]
         public static extern IntPtr /*HBITMAP*/ CreateBitmap(int nWidth, int nHeight, int nPlanes, int nBitsPerPixel, byte[] lpvBits);
 
-        [DllImport(ExternDll.User32, CharSet = CharSet.Auto, SetLastError = true)]
-        public static extern bool EnumWindows(EnumThreadWindowsCallback callback, IntPtr extraData);
-
-        internal delegate bool EnumThreadWindowsCallback(IntPtr hWnd, IntPtr lParam);
-
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern bool InvalidateRgn(HandleRef hWnd, HandleRef hrgn, bool erase);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -605,8 +605,8 @@ namespace System.Windows.Forms
 
                     // 248887 we need to send a WM_THEMECHANGED to the top level windows of this application.
                     // We do it this way to ensure that we get all top level windows -- whether we created them or not.
-                    SafeNativeMethods.EnumThreadWindowsCallback callback = new SafeNativeMethods.EnumThreadWindowsCallback(Application.SendThemeChanged);
-                    SafeNativeMethods.EnumWindows(callback, IntPtr.Zero);
+                    User32.EnumWindowsCallback callback = SendThemeChanged;
+                    User32.EnumWindows(callback, IntPtr.Zero);
 
                     GC.KeepAlive(callback);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -4807,21 +4807,18 @@ namespace System.Windows.Forms
             }
 
             EnumThreadWindowsCallback etwcb = null;
-            SafeNativeMethods.EnumThreadWindowsCallback callback = null;
+            User32.EnumThreadWindowsCallback callback = null;
             if (IsHandleCreated)
             {
                 // First put all the owned windows into a list
                 etwcb = new EnumThreadWindowsCallback();
-                if (etwcb != null)
-                {
-                    callback = new SafeNativeMethods.EnumThreadWindowsCallback(etwcb.Callback);
-                    User32.EnumThreadWindows(
-                        Kernel32.GetCurrentThreadId(),
-                        new User32.EnumThreadWindowsCallback(callback),
-                        this);
-                    // Reset the owner of the windows in the list
-                    etwcb.ResetOwners();
-                }
+                callback = etwcb.Callback;
+                User32.EnumThreadWindows(
+                    Kernel32.GetCurrentThreadId(),
+                    callback,
+                    this);
+                // Reset the owner of the windows in the list
+                etwcb.ResetOwners();
             }
 
             base.RecreateHandleCore();


### PR DESCRIPTION
## Proposed changes

- Move EnumWindows to Interop User32.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2488)