### PR TITLE
Remove WinFormsUtils.GetRootHWnd

### DIFF
--- a/src/Common/src/Interop/User32/Interop.IsZoomed.cs
+++ b/src/Common/src/Interop/User32/Interop.IsZoomed.cs
@@ -4,20 +4,12 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Windows.Forms;
 
 internal static partial class Interop
 {
     internal static partial class User32
     {
         [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr GetAncestor(IntPtr hwnd, GA flags);
-
-        public static IntPtr GetAncestor(IHandle hwnd, GA flags)
-        {
-            IntPtr result = GetAncestor(hwnd.Handle, flags);
-            GC.KeepAlive(hwnd);
-            return result;
-        }
+        public static extern BOOL IsZoomed(IntPtr hWnd);
     }
 }

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -203,9 +203,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.Kernel32, CharSet = CharSet.Auto)]
         public static extern void GetTempFileName(string tempDirName, string prefixName, int unique, StringBuilder sb);
 
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern bool IsZoomed(HandleRef hWnd);
-
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
         public static extern IntPtr FindWindow(string className, string windowName);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MenuStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MenuStrip.cs
@@ -235,7 +235,8 @@ namespace System.Windows.Forms
                         Debug.WriteLineIf(ToolStrip.SnapFocusDebug.TraceVerbose, "[MenuStrip.ProcessCmdKey] Rolling up the menu and invoking the system menu");
                         ToolStripManager.ModalMenuFilter.ExitMenuMode();
                         // send a WM_SYSCOMMAND SC_KEYMENU + Space to activate the system menu.
-                        User32.PostMessageW(WindowsFormsUtils.GetRootHWnd(this), User32.WindowMessage.WM_SYSCOMMAND, (IntPtr)User32.SC.KEYMENU, (IntPtr)Keys.Space);
+                        IntPtr ancestor = User32.GetAncestor(this, User32.GA.ROOT);
+                        User32.PostMessageW(ancestor, User32.WindowMessage.WM_SYSCOMMAND, (IntPtr)User32.SC.KEYMENU, (IntPtr)Keys.Space);
                         return true;
                     }
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusStrip.cs
@@ -206,18 +206,18 @@ namespace System.Windows.Forms
                     {
                         return true;  // we dont care about the state of VS.
                     }
-                    else
+
+                    IntPtr rootHwnd = User32.GetAncestor(this, User32.GA.ROOT);
+                    if (rootHwnd != IntPtr.Zero)
                     {
-                        HandleRef rootHwnd = WindowsFormsUtils.GetRootHWnd(this);
-                        if (rootHwnd.Handle != IntPtr.Zero)
-                        {
-                            return !UnsafeNativeMethods.IsZoomed(rootHwnd);
-                        }
+                        return !User32.IsZoomed(rootHwnd).IsTrue();
                     }
                 }
+
                 return false;
             }
         }
+
         [
         SRCategory(nameof(SR.CatAppearance)),
         DefaultValue(true),
@@ -623,11 +623,11 @@ namespace System.Windows.Forms
 
                 if (sizeGripBounds.Contains(PointToClient(new Point(x, y))))
                 {
-                    HandleRef rootHwnd = WindowsFormsUtils.GetRootHWnd(this);
+                    IntPtr rootHwnd = User32.GetAncestor(this, User32.GA.ROOT);
 
                     // if the main window isnt maximized - we should paint a resize grip.
                     // double check that we're at the bottom right hand corner of the window.
-                    if (rootHwnd.Handle != IntPtr.Zero && !UnsafeNativeMethods.IsZoomed(rootHwnd))
+                    if (rootHwnd != IntPtr.Zero && !User32.IsZoomed(rootHwnd).IsTrue())
                     {
                         // get the client area of the topmost window.  If we're next to the edge then
                         // the sizing grip is valid.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -4964,10 +4964,10 @@ namespace System.Windows.Forms
                     {
                         // make sure the root window of the otherHwnd is the same as
                         // the root window of thisHwnd.
-                        HandleRef thisHwndRoot = WindowsFormsUtils.GetRootHWnd(this);
-                        HandleRef otherHwndRoot = WindowsFormsUtils.GetRootHWnd(new HandleRef(null, otherHwnd));
+                        IntPtr thisHwndRoot = User32.GetAncestor(this, User32.GA.ROOT);
+                        IntPtr otherHwndRoot = User32.GetAncestor(otherHwnd, User32.GA.ROOT);
 
-                        if (thisHwndRoot.Handle == otherHwndRoot.Handle && (thisHwndRoot.Handle != IntPtr.Zero))
+                        if (thisHwndRoot == otherHwndRoot && (thisHwndRoot != IntPtr.Zero))
                         {
                             Debug.WriteLineIf(SnapFocusDebug.TraceVerbose, "[ToolStrip SnapFocus]: Caching for return focus:" + WindowsFormsUtils.GetControlInformation(otherHwnd));
                             // we know we're in the same window heirarchy.
@@ -5157,16 +5157,14 @@ namespace System.Windows.Forms
 
                     if (!IsDropDown && !IsInDesignMode)
                     {
-
                         // If our root HWND is not the active hwnd,
                         // eat the mouse message and bring the form to the front.
-                        HandleRef rootHwnd = WindowsFormsUtils.GetRootHWnd(this);
-                        if (rootHwnd.Handle != IntPtr.Zero)
+                        IntPtr rootHwnd = User32.GetAncestor(this, User32.GA.ROOT);
+                        if (rootHwnd != IntPtr.Zero)
                         {
-
                             // snap the active window and compare to our root window.
                             IntPtr hwndActive = User32.GetActiveWindow();
-                            if (hwndActive != rootHwnd.Handle)
+                            if (hwndActive != rootHwnd)
                             {
                                 // Activate the window, and discard the mouse message.
                                 // this appears to be the same behavior as office.
@@ -5661,8 +5659,8 @@ namespace System.Windows.Forms
                             // currently have focus, restore it.
                             if (!User32.IsChild(new HandleRef(ownerToolStrip, ownerToolStrip.Handle), m.HWnd).IsTrue())
                             {
-                                HandleRef rootHwnd = WindowsFormsUtils.GetRootHWnd(ownerToolStrip);
-                                if (rootHwnd.Handle == m.HWnd || User32.IsChild(rootHwnd, m.HWnd).IsTrue())
+                                IntPtr rootHwnd = User32.GetAncestor(ownerToolStrip, User32.GA.ROOT);
+                                if (rootHwnd == m.HWnd || User32.IsChild(rootHwnd, m.HWnd).IsTrue())
                                 {
                                     // Only RestoreFocus if the hwnd is a child of the root window and isnt on the toolstrip.
                                     RestoreFocusInternal();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.cs
@@ -286,7 +286,7 @@ namespace System.Windows.Forms
 
         private static bool IsOnSameWindow(Control control1, Control control2)
         {
-            return (WindowsFormsUtils.GetRootHWnd(control1).Handle == WindowsFormsUtils.GetRootHWnd(control2).Handle);
+            return User32.GetAncestor(control1, User32.GA.ROOT) == User32.GetAncestor(control2, User32.GA.ROOT);
         }
 
         internal static bool IsThreadUsingToolStrips()
@@ -1840,14 +1840,14 @@ namespace System.Windows.Forms
                             ToolStrip topMostToolStrip = toolStrip.GetToplevelOwnerToolStrip();
                             if (topMostToolStrip != null && activeControl != null)
                             {
-                                HandleRef rootWindowOfToolStrip = WindowsFormsUtils.GetRootHWnd(topMostToolStrip);
-                                HandleRef rootWindowOfControl = WindowsFormsUtils.GetRootHWnd(activeControl);
-                                rootWindowsMatch = (rootWindowOfToolStrip.Handle == rootWindowOfControl.Handle);
+                                IntPtr rootWindowOfToolStrip = User32.GetAncestor(topMostToolStrip, User32.GA.ROOT);
+                                IntPtr rootWindowOfControl = User32.GetAncestor(activeControl, User32.GA.ROOT);
+                                rootWindowsMatch = rootWindowOfToolStrip == rootWindowOfControl;
 
                                 if (rootWindowsMatch)
                                 {
                                     // Double check this is not an MDIContainer type situation...
-                                    if (Control.FromHandle(rootWindowOfControl.Handle) is Form mainForm && mainForm.IsMdiContainer)
+                                    if (Control.FromHandle(rootWindowOfControl) is Form mainForm && mainForm.IsMdiContainer)
                                     {
                                         Form toolStripForm = topMostToolStrip.FindForm();
                                         if (toolStripForm != mainForm && toolStripForm != null)
@@ -1958,10 +1958,10 @@ namespace System.Windows.Forms
                         Debug.WriteLineIf(ToolStrip.SnapFocusDebug.TraceVerbose, "[ProcessMenuKey] attempting to set focus to menustrip");
 
                         // if we've alt-tabbed away dont snap/restore focus.
-                        HandleRef topmostParentOfMenu = WindowsFormsUtils.GetRootHWnd(menuStripToActivate);
+                        IntPtr topmostParentOfMenu = User32.GetAncestor(menuStripToActivate, User32.GA.ROOT);
                         IntPtr foregroundWindow = UnsafeNativeMethods.GetForegroundWindow();
 
-                        if (topmostParentOfMenu.Handle == foregroundWindow)
+                        if (topmostParentOfMenu == foregroundWindow)
                         {
                             Debug.WriteLineIf(ToolStrip.SnapFocusDebug.TraceVerbose, "[ProcessMenuKey] ToolStripManager call MenuStrip.OnMenuKey");
                             return menuStripToActivate.OnMenuKey();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -304,7 +304,7 @@ namespace System.Windows.Forms
                 (windowControl.ShowParams & (User32.SW)0xF) != User32.SW.SHOWNOACTIVATE)
             {
                 IntPtr hWnd = User32.GetActiveWindow();
-                IntPtr rootHwnd = User32.GetAncestor(new HandleRef(window, window.Handle), User32.GA.ROOT);
+                IntPtr rootHwnd = User32.GetAncestor(windowControl, User32.GA.ROOT);
                 if (hWnd != rootHwnd)
                 {
                     TipInfo tt = (TipInfo)_tools[windowControl];

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WinFormsUtils.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WinFormsUtils.cs
@@ -250,23 +250,6 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Finds the top level handle for a given handle.
-        /// </summary>
-        public static HandleRef GetRootHWnd(HandleRef hwnd)
-        {
-            IntPtr rootHwnd = User32.GetAncestor(new HandleRef(hwnd, hwnd.Handle), User32.GA.ROOT);
-            return new HandleRef(hwnd.Wrapper, rootHwnd);
-        }
-
-        /// <summary>
-        ///  Finds the top level handle for a given handle.
-        /// </summary>
-        public static HandleRef GetRootHWnd(Control control)
-        {
-            return GetRootHWnd(new HandleRef(control, control.Handle));
-        }
-
-        /// <summary>
         ///  Strips all keyboard mnemonic prefixes from a given string, eg. turning "He&lp" into "Help".
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
## Proposed Changes
- Make `GetAncestor` `IHandle`
- Cleanup `IsZoomed`
- Replace `WinFormsUtils.GetRootHWnd` with `User32.GetAncestor(this, User32.GA.Root)` as this is cleaner

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2495)