### PR TITLE
Fix DivideByZeroException in MonthCalendar

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -1471,16 +1471,28 @@ namespace System.Windows.Forms
 
             if (updateRows)
             {
-                Debug.Assert(calendarHeight > INSERT_HEIGHT_SIZE, "Divide by 0");
-                int nRows = (newDimensionLength - todayHeight + INSERT_HEIGHT_SIZE) / (calendarHeight + INSERT_HEIGHT_SIZE);
-                dimensions.Height = (nRows < 1) ? 1 : nRows;
+                if (calendarHeight + INSERT_HEIGHT_SIZE == 0)
+                {
+                    dimensions.Height = 1;
+                }
+                else
+                {
+                    int nRows = (newDimensionLength - todayHeight + INSERT_HEIGHT_SIZE) / (calendarHeight + INSERT_HEIGHT_SIZE);
+                    dimensions.Height = (nRows < 1) ? 1 : nRows;
+                }
             }
 
             if (updateCols)
             {
-                Debug.Assert(minSize.Width > INSERT_WIDTH_SIZE, "Divide by 0");
-                int nCols = (newDimensionLength - scaledExtraPadding) / minSize.Width;
-                dimensions.Width = (nCols < 1) ? 1 : nCols;
+                if (minSize.Width == 0)
+                {
+                    dimensions.Width = 1;
+                }
+                else
+                {
+                    int nCols = (newDimensionLength - scaledExtraPadding) / minSize.Width;
+                    dimensions.Width = (nCols < 1) ? 1 : nCols;
+                }
             }
 
             minSize.Width = (minSize.Width + INSERT_WIDTH_SIZE) * dimensions.Width - INSERT_WIDTH_SIZE;


### PR DESCRIPTION
## Proposed Changes
- If `SingleMonthSize` is a certain size, (e.g. `new Size(6, 6)`) then a `DivideByZeroException` is thrown.
- Fix this by avoiding the `DivideByZeroException` by not checking for this case and not dividing by zero

Extracted from https://github.com/dotnet/winforms/pull/2482

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2499)