### PR TITLE
Fall back to the legacy file/folder dialog on COMException

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
@@ -731,14 +731,14 @@ namespace System.Windows.Forms
                 throw new ThreadStateException(string.Format(SR.DebuggingExceptionOnly, SR.ThreadMustBeSTA));
             }
 
-            if (UseVistaDialogInternal)
+            // If running the Vista dialog fails (e.g. on Server Core), we fall back to the
+            // legacy dialog.
+            if (UseVistaDialogInternal && TryRunDialogVista(hWndOwner, out bool returnValue))
             {
-                return RunDialogVista(hWndOwner);
+                return returnValue;
             }
-            else
-            {
-                return RunDialogOld(hWndOwner);
-            }
+            
+            return RunDialogOld(hWndOwner);
         }
 
         private bool RunDialogOld(IntPtr hWndOwner)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog_Vista.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog_Vista.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace System.Windows.Forms
@@ -32,15 +33,28 @@ namespace System.Windows.Forms
 
         private protected abstract FileDialogNative.IFileDialog CreateVistaDialog();
 
-        private bool RunDialogVista(IntPtr hWndOwner)
+        private bool TryRunDialogVista(IntPtr hWndOwner, out bool returnValue)
         {
-            FileDialogNative.IFileDialog dialog = CreateVistaDialog();
+            FileDialogNative.IFileDialog dialog;
+            try
+            {
+                // Creating the Vista dialog can fail on Windows Server Core, even if the
+                // Server Core App Compatibility FOD is installed.
+                dialog = CreateVistaDialog();
+            }
+            catch (COMException)
+            {
+                returnValue = false;
+                return false;
+            }
+
             OnBeforeVistaDialog(dialog);
             var events = new VistaDialogEvents(this);
             dialog.Advise(events, out uint eventCookie);
             try
             {
-                return dialog.Show(hWndOwner) == 0;
+                returnValue = dialog.Show(hWndOwner) == 0;
+                return true;
             }
             finally
             {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #2506


## Proposed changes

- When creating an instance of the `NativeFileOpenDialog` or `NativeFileSaveDialog` fails with a `COMException`, fall back to the legacy file dialog instead of letting the exception bubble up to the caller.

Note: I'm not sure if there's another way to check if the COM object will be available without actually throwing (and catching) a `COMException`.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- When using the [`OpenFileDialog`](https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.openfiledialog?view=netcore-3.1), [`SaveFileDialog`](https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.savefiledialog?view=netcore-3.1), or [`FolderBrowserDialog`](https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.folderbrowserdialog?view=netcore-3.1) (with **`AutoUpgradeEnabled=true`**) on a Windows system lacking the necessary COM components (e.g. Windows Server Core), customers will experience the legacy file/folder dialog being shown when calling `ShowDialog()`, rather than a `COMException` being thrown preventing the dialog from working.

## Regression? 

- No

## Risk

-

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/13289184/71029761-58216b80-2110-11ea-8b27-0e4f1f38657a.png)


### After

![grafik](https://user-images.githubusercontent.com/13289184/71029872-99198000-2110-11ea-8ae7-de4783a9d5cf.png)

![grafik](https://user-images.githubusercontent.com/13289184/71029904-a6cf0580-2110-11ea-8807-607ddd2d6e10.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual testing on Windows Server 2019 (installed as Server Core) as described in #2506, as well as on Windows 10 to verify that the Vista dialogs are still shown

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

.NET Core SDK (reflecting any global.json):
 Version:   5.0.100-alpha1-015777
 Commit:    cea32db3f2

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.17134
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\5.0.100-alpha1-015777\

Host (useful for support):
  Version: 5.0.0-alpha.1.19564.1
  Commit:  c77948d92a

.NET Core SDKs installed:
  3.1.100 [C:\Program Files\dotnet\sdk]
  5.0.100-alpha1-015777 [C:\Program Files\dotnet\sdk]


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2515)