### PR TITLE
Add more ColumnHeader tests

### DIFF
--- a/src/Common/src/Interop/ComCtl32/Interop.LVCF.cs
+++ b/src/Common/src/Interop/ComCtl32/Interop.LVCF.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        [Flags]
+        public enum LVCF : uint
+        {
+            /// <summary>
+            /// The <c>fmt</c> member is valid.
+            /// </summary>
+            FMT = 0x0001,
+
+            /// <summary>
+            /// The <c>cx</c> member is valid.
+            /// </summary>
+            WIDTH = 0x0002,
+
+            /// <summary>
+            /// The <c>pszText</c> member is valid.
+            /// </summary>
+            TEXT = 0x0004,
+
+            /// <summary>
+            /// The <c>iSubItem</c> member is valid.
+            /// </summary>
+            SUBITEM = 0x0008,
+
+            /// <summary>
+            /// The <c>iImage</c> member is valid.
+            /// </summary>
+            IMAGE = 0x0010,
+
+            /// <summary>
+            /// The <c>iOrder </c> member is valid.
+            /// </summary>
+            ORDER = 0x0020,
+
+            /// <summary>
+            /// The <c>cxMin</c> member is valid.
+            /// </summary>
+            MINWIDTH = 0x0040,
+
+            /// <summary>
+            /// The <c>cxDefault</c> member is valid.
+            /// </summary>
+            DEFAULTWIDTH = 0x0080,
+
+            /// <summary>
+            /// The <c>cxIdeal</c> member is valid.
+            /// </summary>
+            IDEALWIDTH = 0x0100,
+        }
+    }
+}

--- a/src/Common/src/Interop/ComCtl32/Interop.LVCFMT.cs
+++ b/src/Common/src/Interop/ComCtl32/Interop.LVCFMT.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        [Flags]
+        public enum LVCFMT : int
+        {
+            // Same as HDF_LEFT
+            LEFT = 0x0000,
+
+            // Same as HDF_RIGHT
+            RIGHT = 0x0001,
+
+            // Same as HDF_CENTER
+            CENTER = 0x0002,
+
+            // Same as HDF_JUSTIFYMASK
+            JUSTIFYMASK = 0x0003,
+
+            // Same as HDF_IMAGE
+            IMAGE = 0x0800,
+
+            // Same as HDF_BITMAP_ON_RIGHT
+            BITMAP_ON_RIGHT = 0x1000,
+
+            // Same as HDF_OWNERDRAW
+            COL_HAS_IMAGES = 0x8000,
+
+            /// <summary>
+            /// Can't resize the column
+            /// </summary>
+            // same as HDF_FIXEDWIDTH
+            FIXED_WIDTH = 0x00100,
+
+            /// <summary>
+            /// If not set, CCM_DPISCALE will govern scaling up fixed width
+            /// </summary>
+            NO_DPI_SCALE = 0x40000,
+
+            /// <summary>
+            /// Width will augment with the row height
+            /// </summary>
+            FIXED_RATIO = 0x80000,
+
+            //
+            // ListView specific flags
+            //
+
+            /// <summary>
+            /// Forces the column to wrap to the top of the next list of columns.
+            /// This flag is <c>ListView</c> specific.
+            /// </summary>
+            LINE_BREAK = 0x100000,
+
+            /// <summary>
+            /// Fills the remainder of the tile area. Might have a title.
+            /// This flag is <c>ListView</c> specific.
+            /// </summary>
+            FILL = 0x200000,
+
+            /// <summary>
+            /// Allows the column to wrap within the remaining space in its list of columns.
+            /// This flag is <c>ListView</c> specific.
+            /// </summary>
+            WRAP = 0x400000,
+
+            /// <summary>
+            /// Removes the title from the subitem.
+            /// This flag is <c>ListView</c> specific.
+            /// </summary>
+            NO_TITLE = 0x800000,
+
+            /// <summary>
+            /// Equivalent to a combination of LVCFMT_LINE_BREAK and LVCFMT_FILL.
+            /// This flag is <c>ListView</c> specific.
+            /// </summary>
+            TILE_PLACEMENTMASK = (LINE_BREAK | FILL),
+
+            /// <summary>
+            /// Column is a split button; same as HDF_SPLITBUTTON
+            /// This flag is <c>ListView</c> specific.
+            /// </summary>
+            SPLITBUTTON = 0x1000000
+        }
+    }
+}

--- a/src/Common/src/Interop/ComCtl32/Interop.LVCOLUMNW.cs
+++ b/src/Common/src/Interop/ComCtl32/Interop.LVCOLUMNW.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public unsafe struct LVCOLUMNW
+        {
+            public LVCF mask;
+            public LVCFMT fmt;
+            public int cx;
+            public char* /* LPWSTR */ pszText;
+            public int cchTextMax;
+            public int iSubItem;
+            public int iImage;
+            public int iOrder;
+            public int cxMin;
+            public int cxDefault;
+            public int cxIdeal;
+        }
+    }
+}

--- a/src/Common/tests/ThreadExceptionFixture.cs
+++ b/src/Common/tests/ThreadExceptionFixture.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Windows.Forms;
+
+namespace System
+{
+    public class ThreadExceptionFixture : IDisposable
+    {
+        public ThreadExceptionFixture()
+        {
+            Application.ThreadException += OnThreadException;
+        }
+
+        public void Dispose()
+        {
+            Application.ThreadException -= OnThreadException;
+        }
+
+        private void OnThreadException(object sender, ThreadExceptionEventArgs e)
+        {
+            ExceptionDispatchInfo.Capture(e.Exception).Throw();
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
+++ b/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
@@ -19,8 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\..\Common\tests\CommonTestHelper.cs" Link="Common\CommonTestHelper.cs" />
     <Compile Include="..\..\..\Common\tests\CommonMemberDataAttribute.cs" Link="Common\CommonMemberDataAttribute.cs" />
+    <Compile Include="..\..\..\Common\tests\CommonTestHelper.cs" Link="Common\CommonTestHelper.cs" />
+    <Compile Include="..\..\..\Common\tests\ThreadExceptionFixture.cs" Link="Common\ThreadExceptionFixture.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeaderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeaderTests.cs
@@ -2,86 +2,107 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Drawing;
 using Moq;
 using WinForms.Common.Tests;
 using Xunit;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
-    public class ColumnHeaderTests
+    public class ColumnHeaderTests : IClassFixture<ThreadExceptionFixture>
     {
-        [Fact]
+        [WinFormsFact]
         public void ColumnHeader_Ctor_Default()
         {
-            var header = new ColumnHeader();
+            using var header = new SubColumnHeader();
+            Assert.True(header.CanRaiseEvents);
+            Assert.Null(header.Container);
+            Assert.False(header.DesignMode);
             Assert.Equal(-1, header.DisplayIndex);
+            Assert.NotNull(header.Events);
+            Assert.Same(header.Events, header.Events);
             Assert.Equal(-1, header.ImageIndex);
             Assert.Equal(string.Empty, header.ImageKey);
             Assert.Null(header.ImageList);
             Assert.Equal(-1, header.Index);
             Assert.Null(header.ListView);
             Assert.Empty(header.Name);
+            Assert.Null(header.Site);
             Assert.Null(header.Tag);
             Assert.Equal("ColumnHeader", header.Text);
             Assert.Equal(HorizontalAlignment.Left, header.TextAlign);
             Assert.Equal(60, header.Width);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [InlineData(-1)]
         [InlineData(0)]
         [InlineData(1)]
         public void ColumnHeader_Ctor_Int(int imageIndex)
         {
-            var header = new ColumnHeader(imageIndex);
+            using var header = new SubColumnHeader(imageIndex);
+            Assert.True(header.CanRaiseEvents);
+            Assert.Null(header.Container);
+            Assert.False(header.DesignMode);
             Assert.Equal(-1, header.DisplayIndex);
+            Assert.NotNull(header.Events);
+            Assert.Same(header.Events, header.Events);
             Assert.Equal(imageIndex, header.ImageIndex);
             Assert.Equal(string.Empty, header.ImageKey);
             Assert.Null(header.ImageList);
             Assert.Equal(-1, header.Index);
             Assert.Null(header.ListView);
             Assert.Empty(header.Name);
+            Assert.Null(header.Site);
             Assert.Null(header.Tag);
             Assert.Equal("ColumnHeader", header.Text);
             Assert.Equal(HorizontalAlignment.Left, header.TextAlign);
             Assert.Equal(60, header.Width);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
         public void ColumnHeader_Ctor_String(string imageKey, string expectedImageKey)
         {
-            var header = new ColumnHeader(imageKey);
+            using var header = new SubColumnHeader(imageKey);
+            Assert.True(header.CanRaiseEvents);
+            Assert.Null(header.Container);
+            Assert.False(header.DesignMode);
             Assert.Equal(-1, header.DisplayIndex);
+            Assert.NotNull(header.Events);
+            Assert.Same(header.Events, header.Events);
             Assert.Equal(-1, header.ImageIndex);
             Assert.Equal(expectedImageKey, header.ImageKey);
             Assert.Null(header.ImageList);
             Assert.Equal(-1, header.Index);
             Assert.Null(header.ListView);
             Assert.Empty(header.Name);
+            Assert.Null(header.Site);
             Assert.Null(header.Tag);
             Assert.Equal("ColumnHeader", header.Text);
             Assert.Equal(HorizontalAlignment.Left, header.TextAlign);
             Assert.Equal(60, header.Width);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void ColumnHeader_DisplayIndex_GetWithListView_ReturnsExpected()
         {
-            var listView = new ListView();
-            var header = new ColumnHeader();
+            using var listView = new ListView();
+            using var header = new ColumnHeader();
             listView.Columns.Add(header);
             Assert.Equal(0, header.DisplayIndex);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [InlineData(-1)]
         [InlineData(0)]
         [InlineData(1)]
         public void ColumnHeader_DisplayIndex_SetWithoutListView_GetReturnsExpected(int value)
         {
-            var header = new ColumnHeader
+            using var header = new ColumnHeader
             {
                 DisplayIndex = value
             };
@@ -92,292 +113,653 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(value, header.DisplayIndex);
         }
 
-        [Theory]
-        [InlineData(0)]
-        public void ColumnHeader_DisplayIndex_SetWithListView_GetReturnsExpected(int value)
+        public static IEnumerable<object[]> DisplayIndex_Set_TestData()
         {
-            var listView = new ListView();
-            var header = new ColumnHeader();
-            listView.Columns.Add(header);
-
-            header.DisplayIndex = value;
-            Assert.Equal(value, header.DisplayIndex);
-
-            // Set same.
-            header.DisplayIndex = value;
-            Assert.Equal(value, header.DisplayIndex);
+            yield return new object[] { 0, 0, new int[] { 0, 1, 2 } };
+            yield return new object[] { 0, 1, new int[] { 1, 0, 2 } };
+            yield return new object[] { 0, 2, new int[] { 2, 0, 1 } };
+            
+            yield return new object[] { 1, 0, new int[] { 1, 0, 2 } };
+            yield return new object[] { 1, 1, new int[] { 0, 1, 2 } };
+            yield return new object[] { 1, 2, new int[] { 0, 2, 1 } };
+            
+            yield return new object[] { 2, 0, new int[] { 1, 2, 0 } };
+            yield return new object[] { 2, 1, new int[] { 0, 2, 1 } };
+            yield return new object[] { 2, 2, new int[] { 0, 1, 2 } };
         }
 
-        [Theory]
-        [InlineData(0)]
-        public void ColumnHeader_DisplayIndex_SetWithListViewWithHandle_GetReturnsExpected(int value)
+        [WinFormsTheory]
+        [MemberData(nameof(DisplayIndex_Set_TestData))]
+        public void ColumnHeader_DisplayIndex_SetWithListView_GetReturnsExpected(int columnIndex, int value, int[] expectedDisplayIndices)
         {
-            var listView = new ListView();
-            var header = new ColumnHeader();
-            listView.Columns.Add(header);
+            using var listView = new ListView();
+            using var header1 = new ColumnHeader();
+            using var header2 = new ColumnHeader();
+            using var header3 = new ColumnHeader();
+            listView.Columns.Add(header1);
+            listView.Columns.Add(header2);
+            listView.Columns.Add(header3);
+
+            listView.Columns[columnIndex].DisplayIndex = value;
+            Assert.Equal(expectedDisplayIndices[0], header1.DisplayIndex);
+            Assert.Equal(expectedDisplayIndices[1], header2.DisplayIndex);
+            Assert.Equal(expectedDisplayIndices[2], header3.DisplayIndex);
+            Assert.False(listView.IsHandleCreated);
+
+            // Set same.
+            listView.Columns[columnIndex].DisplayIndex = value;
+            Assert.Equal(expectedDisplayIndices[0], header1.DisplayIndex);
+            Assert.Equal(expectedDisplayIndices[1], header2.DisplayIndex);
+            Assert.Equal(expectedDisplayIndices[2], header3.DisplayIndex);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(DisplayIndex_Set_TestData))]
+        public void ColumnHeader_DisplayIndex_SetWithListViewWithHandle_GetReturnsExpected(int columnIndex, int value, int[] expectedDisplayIndices)
+{
+            using var listView = new ListView();
+            using var header1 = new ColumnHeader();
+            using var header2 = new ColumnHeader();
+            using var header3 = new ColumnHeader();
+            listView.Columns.Add(header1);
+            listView.Columns.Add(header2);
+            listView.Columns.Add(header3);
             Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            int invalidatedCallCount = 0;
+            listView.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            listView.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            listView.HandleCreated += (sender, e) => createdCallCount++;
 
-            header.DisplayIndex = value;
-            Assert.Equal(value, header.DisplayIndex);
+            listView.Columns[columnIndex].DisplayIndex = value;
+            Assert.Equal(expectedDisplayIndices[0], header1.DisplayIndex);
+            Assert.Equal(expectedDisplayIndices[1], header2.DisplayIndex);
+            Assert.Equal(expectedDisplayIndices[2], header3.DisplayIndex);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
 
             // Set same.
-            header.DisplayIndex = value;
-            Assert.Equal(value, header.DisplayIndex);
+            listView.Columns[columnIndex].DisplayIndex = value;
+            Assert.Equal(expectedDisplayIndices[0], header1.DisplayIndex);
+            Assert.Equal(expectedDisplayIndices[1], header2.DisplayIndex);
+            Assert.Equal(expectedDisplayIndices[2], header3.DisplayIndex);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
         }
 
-        [Theory]
-        [InlineData(0, 1, 2)]
-        [InlineData(1, 0, 2)]
-        [InlineData(2, 0, 1)]
-        public void ColumnHeader_DisplayIndex_SetFirstOfMultipleColumns_GetReturnsExpected(int value, int expectedHeader2, int expectedHeader3)
+        public static IEnumerable<object[]> DisplayIndex_SetGetColOrderArray_TestData()
         {
-            var listView = new ListView();
-            var header1 = new ColumnHeader();
-            var header2 = new ColumnHeader();
-            var header3 = new ColumnHeader();
+            yield return new object[] { 0, 0, new int[] { 0, 1, 2 } };
+            yield return new object[] { 0, 1, new int[] { 1, 0, 2 } };
+            yield return new object[] { 0, 2, new int[] { 1, 2, 0 } };
+            
+            yield return new object[] { 1, 0, new int[] { 1, 0, 2 } };
+            yield return new object[] { 1, 1, new int[] { 0, 1, 2 } };
+            yield return new object[] { 1, 2, new int[] { 0, 2, 1 } };
+            
+            yield return new object[] { 2, 0, new int[] { 2, 0, 1 } };
+            yield return new object[] { 2, 1, new int[] { 0, 2, 1 } };
+            yield return new object[] { 2, 2, new int[] { 0, 1, 2 } };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(DisplayIndex_SetGetColOrderArray_TestData))]
+        public void ColumnHeader_DisplayIndex_GetColumnOrderArray_Success(int columnIndex, int value, int[] expectedDisplayIndices)
+        {
+            using var listView = new ListView();
+            using var header1 = new ColumnHeader();
+            using var header2 = new ColumnHeader();
+            using var header3 = new ColumnHeader();
             listView.Columns.Add(header1);
             listView.Columns.Add(header2);
             listView.Columns.Add(header3);
 
-            header1.DisplayIndex = value;
-            Assert.Equal(value, header1.DisplayIndex);
-            Assert.Equal(expectedHeader2, header2.DisplayIndex);
-            Assert.Equal(expectedHeader3, header3.DisplayIndex);
-
-            // Set same.
-            header1.DisplayIndex = value;
-            Assert.Equal(value, header1.DisplayIndex);
-            Assert.Equal(expectedHeader2, header2.DisplayIndex);
-            Assert.Equal(expectedHeader3, header3.DisplayIndex);
+            Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            listView.Columns[columnIndex].DisplayIndex = value;
+            var result = new int[3];
+            Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WindowMessage)LVM.GETCOLUMNORDERARRAY, (IntPtr)3, ref result[0]));
+            Assert.Equal(expectedDisplayIndices, result);
         }
 
-        [Theory]
-        [InlineData(0, 1, 2)]
-        [InlineData(1, 0, 2)]
-        [InlineData(2, 0, 1)]
-        public void ColumnHeader_DisplayIndex_SetSecondOfMultipleColumns_GetReturnsExpected(int value, int expectedHeader1, int expectedHeader3)
-        {
-            var listView = new ListView();
-            var header1 = new ColumnHeader();
-            var header2 = new ColumnHeader();
-            var header3 = new ColumnHeader();
-            listView.Columns.Add(header1);
-            listView.Columns.Add(header2);
-            listView.Columns.Add(header3);
-
-            header2.DisplayIndex = value;
-            Assert.Equal(value, header2.DisplayIndex);
-            Assert.Equal(expectedHeader1, header1.DisplayIndex);
-            Assert.Equal(expectedHeader3, header3.DisplayIndex);
-
-            // Set same.
-            header2.DisplayIndex = value;
-            Assert.Equal(value, header2.DisplayIndex);
-            Assert.Equal(expectedHeader1, header1.DisplayIndex);
-            Assert.Equal(expectedHeader3, header3.DisplayIndex);
-        }
-
-        [Theory]
-        [InlineData(0, 1, 2)]
-        [InlineData(1, 0, 2)]
-        [InlineData(2, 0, 1)]
-        public void ColumnHeader_DisplayIndex_SetLastOfMultipleColumns_GetReturnsExpected(int value, int expectedHeader1, int expectedHeader2)
-        {
-            var listView = new ListView();
-            var header1 = new ColumnHeader();
-            var header2 = new ColumnHeader();
-            var header3 = new ColumnHeader();
-            listView.Columns.Add(header1);
-            listView.Columns.Add(header2);
-            listView.Columns.Add(header3);
-
-            header3.DisplayIndex = value;
-            Assert.Equal(value, header3.DisplayIndex);
-            Assert.Equal(expectedHeader1, header1.DisplayIndex);
-            Assert.Equal(expectedHeader2, header2.DisplayIndex);
-
-            // Set same.
-            header3.DisplayIndex = value;
-            Assert.Equal(value, header3.DisplayIndex);
-            Assert.Equal(expectedHeader1, header1.DisplayIndex);
-            Assert.Equal(expectedHeader2, header2.DisplayIndex);
-        }
-
-        [Theory]
+        [WinFormsTheory]
         [InlineData(-1)]
         [InlineData(1)]
         public void ColumnHeader_DisplayIndex_SetInvalidWithListView_ThrowsArgumentOutOfRangeException(int value)
         {
-            var listView = new ListView();
-            var header = new ColumnHeader();
+            using var listView = new ListView();
+            using var header = new ColumnHeader();
             listView.Columns.Add(header);
             Assert.Throws<ArgumentOutOfRangeException>("DisplayIndex", () => header.DisplayIndex = value);
         }
 
-        [Theory]
+
+        [WinFormsFact]
+        public void ColumnHeader_DisplayIndex_ShouldSerializeValue_Success()
+        {
+            PropertyDescriptor property = TypeDescriptor.GetProperties(typeof(ColumnHeader))[nameof(ColumnHeader.DisplayIndex)];
+            using var item = new ColumnHeader();
+            Assert.False(property.ShouldSerializeValue(item));
+
+            item.DisplayIndex = -1;
+            Assert.Equal(-1, item.DisplayIndex);
+            Assert.False(property.ShouldSerializeValue(item));
+
+            // Set custom
+            item.DisplayIndex = 0;
+            Assert.Equal(0, item.DisplayIndex);
+            Assert.True(property.ShouldSerializeValue(item));
+
+            property.ResetValue(item);
+            Assert.Equal(0, item.DisplayIndex);
+            Assert.True(property.ShouldSerializeValue(item));
+        }
+
+        [WinFormsFact]
+        public void ColumnHeader_DisplayIndex_ResetValue_Success()
+        {
+            PropertyDescriptor property = TypeDescriptor.GetProperties(typeof(ColumnHeader))[nameof(ColumnHeader.DisplayIndex)];
+            using var item = new ColumnHeader();
+            Assert.False(property.CanResetValue(item));
+
+            item.DisplayIndex = -1;
+            Assert.Equal(-1, item.DisplayIndex);
+            Assert.False(property.CanResetValue(item));
+
+            // Set custom
+            item.DisplayIndex = 0;
+            Assert.Equal(0, item.DisplayIndex);
+            Assert.False(property.CanResetValue(item));
+
+            property.ResetValue(item);
+            Assert.Equal(0, item.DisplayIndex);
+            Assert.False(property.CanResetValue(item));
+        }
+
+        [WinFormsTheory]
         [InlineData(-1)]
         [InlineData(0)]
         [InlineData(1)]
         public void ColumnHeader_ImageIndex_SetWithoutListView_GetReturnsExpected(int value)
         {
-            var header = new ColumnHeader
+            using var header = new ColumnHeader
             {
                 ImageIndex = value
             };
             Assert.Equal(value, header.ImageIndex);
+            Assert.Empty(header.ImageKey);
 
             // Set same.
             header.ImageIndex = value;
             Assert.Equal(value, header.ImageIndex);
+            Assert.Empty(header.ImageKey);
         }
 
-        [Theory]
+        [WinFormsTheory]
+        [InlineData(-1, "ImageKey")]
+        [InlineData(0, "")]
+        [InlineData(1, "")]
+        public void ColumnHeader_ImageIndex_SetWithImageKey_GetReturnsExpected(int value, string expectedImageKey)
+        {
+            using var header = new ColumnHeader
+            {
+                ImageKey = "ImageKey",
+                ImageIndex = value
+            };
+            Assert.Equal(value, header.ImageIndex);
+            Assert.Equal(expectedImageKey, header.ImageKey);
+
+            // Set same.
+            header.ImageIndex = value;
+            Assert.Equal(value, header.ImageIndex);
+            Assert.Equal(expectedImageKey, header.ImageKey);
+        }
+
+        [WinFormsTheory]
         [InlineData(-1)]
         [InlineData(0)]
         [InlineData(1)]
         public void ColumnHeader_ImageIndex_SetWithListView_GetReturnsExpected(int value)
         {
-            var listView = new ListView();
-            var header = new ColumnHeader();
+            using var listView = new ListView();
+            using var header = new ColumnHeader();
             listView.Columns.Add(header);
 
             header.ImageIndex = value;
             Assert.Equal(value, header.ImageIndex);
+            Assert.Empty(header.ImageKey);
+            Assert.False(listView.IsHandleCreated);
 
             // Set same.
             header.ImageIndex = value;
             Assert.Equal(value, header.ImageIndex);
+            Assert.Empty(header.ImageKey);
+            Assert.False(listView.IsHandleCreated);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [InlineData(-1)]
         [InlineData(0)]
         [InlineData(1)]
-        public void ColumnHeader_ImageIndex_SetWithListViewWithList_GetReturnsExpected(int value)
+        public void ColumnHeader_ImageIndex_SetWithListViewWithEmptyList_GetReturnsExpected(int value)
         {
-            var listView = new ListView
+            using var imageList = new ImageList();
+            using var listView = new ListView
             {
-                SmallImageList = new ImageList()
+                SmallImageList = imageList
             };
-            var header = new ColumnHeader();
+            using var header = new ColumnHeader();
             listView.Columns.Add(header);
 
             header.ImageIndex = value;
             Assert.Equal(-1, header.ImageIndex);
+            Assert.Empty(header.ImageKey);
+            Assert.False(listView.IsHandleCreated);
 
             // Set same.
             header.ImageIndex = value;
             Assert.Equal(-1, header.ImageIndex);
+            Assert.Empty(header.ImageKey);
+            Assert.False(listView.IsHandleCreated);
         }
 
-        [Theory]
+        [WinFormsTheory]
+        [InlineData(-1, -1)]
+        [InlineData(0, 0)]
+        [InlineData(1, 1)]
+        [InlineData(2, 1)]
+        public void ColumnHeader_ImageIndex_SetWithListViewWithNotEmptyList_GetReturnsExpected(int value, int expected)
+        {
+            using var image1 = new Bitmap(10, 10);
+            using var image2 = new Bitmap(10, 10);
+            using var imageList = new ImageList();
+            imageList.Images.Add(image1);
+            imageList.Images.Add(image2);
+            using var listView = new ListView
+            {
+                SmallImageList = imageList
+            };
+            using var header = new ColumnHeader();
+            listView.Columns.Add(header);
+
+            header.ImageIndex = value;
+            Assert.Equal(expected, header.ImageIndex);
+            Assert.Empty(header.ImageKey);
+            Assert.False(listView.IsHandleCreated);
+
+            // Set same.
+            header.ImageIndex = value;
+            Assert.Equal(expected, header.ImageIndex);
+            Assert.Empty(header.ImageKey);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
         [InlineData(-1)]
         [InlineData(0)]
         [InlineData(1)]
         public void ColumnHeader_ImageIndex_SetWithListViewWithHandle_GetReturnsExpected(int value)
         {
-            var listView = new ListView();
-            var header = new ColumnHeader();
+            using var listView = new ListView();
+            using var header = new ColumnHeader();
             listView.Columns.Add(header);
             Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            int invalidatedCallCount = 0;
+            listView.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            listView.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            listView.HandleCreated += (sender, e) => createdCallCount++;
 
             header.ImageIndex = value;
             Assert.Equal(value, header.ImageIndex);
+            Assert.Empty(header.ImageKey);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
 
             // Set same.
             header.ImageIndex = value;
             Assert.Equal(value, header.ImageIndex);
+            Assert.Empty(header.ImageKey);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
         }
 
-        [Theory]
+        [WinFormsTheory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void ColumnHeader_ImageIndex_GetColumnWithoutImageList_Success(int value)
+        {
+            using var listView = new ListView();
+            using var header = new ColumnHeader();
+            listView.Columns.Add(header);
+
+            Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            header.ImageIndex = value;
+            var column = new ComCtl32.LVCOLUMNW
+            {
+                mask = ComCtl32.LVCF.IMAGE
+            };
+            Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WindowMessage)LVM.GETCOLUMN, (IntPtr)0, ref column));
+            Assert.Equal(0, column.iImage);
+        }
+
+        [WinFormsTheory]
+        [InlineData(-1, 0)]
+        [InlineData(0, 0)]
+        [InlineData(1, 1)]
+        [InlineData(2, 0)]
+        public void ColumnHeader_ImageIndex_GetColumnWithImageList_Success(int value, int expected)
+        {
+            using var image1 = new Bitmap(10, 10);
+            using var image2 = new Bitmap(10, 10);
+            using var imageList = new ImageList();
+            imageList.Images.Add(image1);
+            imageList.Images.Add(image2);
+            using var listView = new ListView
+            {
+                SmallImageList = imageList
+            };
+            using var header = new ColumnHeader();
+            listView.Columns.Add(header);
+
+            Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            header.ImageIndex = value;
+            var column = new ComCtl32.LVCOLUMNW
+            {
+                mask = ComCtl32.LVCF.IMAGE | ComCtl32.LVCF.FMT,
+                fmt = ComCtl32.LVCFMT.IMAGE
+            };
+            Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WindowMessage)LVM.GETCOLUMN, (IntPtr)0, ref column));
+            Assert.Equal(expected, column.iImage);
+        }
+
+        [WinFormsTheory]
         [InlineData(-2)]
         public void ColumnHeader_ImageIndex_SetInvalid_ThrowsArgumentOutOfRangeException(int value)
         {
-            var header = new ColumnHeader();
+            using var header = new ColumnHeader();
             Assert.Throws<ArgumentOutOfRangeException>("value", () => header.ImageIndex = value);
         }
 
-        [Theory]
+        [WinFormsFact]
+        public void ColumnHeader_ImageIndex_SetInvalidSetColumn_ThrowsInvalidOperationException()
+        {
+            using var listView = new InvalidSetColumnListView();
+            using var header = new ColumnHeader();
+            listView.Columns.Add(header);
+            Assert.NotEqual(IntPtr.Zero, listView.Handle);
+
+            listView.MakeInvalid = true;
+            Assert.Throws<InvalidOperationException>(() => header.ImageIndex = 0);
+        }
+
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
         public void ColumnHeader_ImageKey_SetWithoutListView_GetReturnsExpected(string value, string expected)
         {
-            var header = new ColumnHeader
+            using var header = new ColumnHeader
             {
                 ImageKey = value
             };
             Assert.Equal(expected, header.ImageKey);
+            Assert.Equal(-1, header.ImageIndex);
 
             // Set same.
             header.ImageKey = value;
             Assert.Equal(expected, header.ImageKey);
+            Assert.Equal(-1, header.ImageIndex);
         }
 
-        [Theory]
+        [WinFormsTheory]
+        [InlineData(null, "", -1)]
+        [InlineData("", "", 0)]
+        [InlineData("ImageKey", "ImageKey", -1)]
+        public void ColumnHeader_ImageKey_SetWithImageIndex_GetReturnsExpected(string value, string expected, int expectedImageIndex)
+        {
+            using var header = new ColumnHeader
+            {
+                ImageIndex = 0,
+                ImageKey = value
+            };
+            Assert.Equal(expected, header.ImageKey);
+            Assert.Equal(expectedImageIndex, header.ImageIndex);
+
+            // Set same.
+            header.ImageKey = value;
+            Assert.Equal(expected, header.ImageKey);
+            Assert.Equal(expectedImageIndex, header.ImageIndex);
+        }
+
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
         public void ColumnHeader_ImageKey_SetWithListView_GetReturnsExpected(string value, string expected)
         {
-            var listView = new ListView();
-            var header = new ColumnHeader
-            {
-                ImageKey = value
-            };
+            using var listView = new ListView();
+            using var header = new ColumnHeader();
             listView.Columns.Add(header);
+
+            header.ImageKey = value;
             Assert.Equal(expected, header.ImageKey);
+            Assert.Equal(-1, header.ImageIndex);
+            Assert.False(listView.IsHandleCreated);
 
             // Set same.
             header.ImageKey = value;
             Assert.Equal(expected, header.ImageKey);
+            Assert.Equal(-1, header.ImageIndex);
+            Assert.False(listView.IsHandleCreated);
         }
 
-        [Theory]
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
+        public void ColumnHeader_ImageKey_SetWithListViewWithEmptyList_GetReturnsExpected(string value, string expected)
+        {
+            using var imageList = new ImageList();
+            using var listView = new ListView
+            {
+                SmallImageList = imageList
+            };
+            using var header = new ColumnHeader();
+            listView.Columns.Add(header);
+
+            header.ImageKey = value;
+            Assert.Equal(expected, header.ImageKey);
+            Assert.Equal(-1, header.ImageIndex);
+            Assert.False(listView.IsHandleCreated);
+
+            // Set same.
+            header.ImageKey = value;
+            Assert.Equal(expected, header.ImageKey);
+            Assert.Equal(-1, header.ImageIndex);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("Image1", "Image1")]
+        [InlineData("image1", "image1")]
+        [InlineData("Image2", "Image2")]
+        [InlineData("NoSuchImage", "NoSuchImage")]
+        public void ColumnHeader_ImageKey_SetWithListViewWithNotEmptyList_GetReturnsExpected(string value, string expected)
+        {
+            using var image1 = new Bitmap(10, 10);
+            using var image2 = new Bitmap(10, 10);
+            using var imageList = new ImageList();
+            imageList.Images.Add("Image1", image1);
+            imageList.Images.Add("Image2", image2);
+            using var listView = new ListView
+            {
+                SmallImageList = imageList
+            };
+            using var header = new ColumnHeader();
+            listView.Columns.Add(header);
+
+            header.ImageKey = value;
+            Assert.Equal(expected, header.ImageKey);
+            Assert.Equal(-1, header.ImageIndex);
+            Assert.False(listView.IsHandleCreated);
+
+            // Set same.
+            header.ImageKey = value;
+            Assert.Equal(expected, header.ImageKey);
+            Assert.Equal(-1, header.ImageIndex);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
         public void ColumnHeader_ImageKey_SetWithListViewWithHandle_GetReturnsExpected(string value, string expected)
         {
-            var listView = new ListView();
-            var header = new ColumnHeader
-            {
-                ImageKey = value
-            };
+            using var listView = new ListView();
+            using var header = new ColumnHeader();
             listView.Columns.Add(header);
             Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            int invalidatedCallCount = 0;
+            listView.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            listView.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            listView.HandleCreated += (sender, e) => createdCallCount++;
+
+            header.ImageKey = value;
             Assert.Equal(expected, header.ImageKey);
+            Assert.Equal(-1, header.ImageIndex);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
 
             // Set same.
             header.ImageKey = value;
             Assert.Equal(expected, header.ImageKey);
+            Assert.Equal(-1, header.ImageIndex);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
         }
 
-        [Fact]
-        public void ColumnHeader_ImageList_GetWithListView_ReturnsExpected()
+
+        [WinFormsTheory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("Image1")]
+        [InlineData("image1")]
+        [InlineData("Image2")]
+        [InlineData("NoSuchImage")]
+        public void ColumnHeader_ImageKey_GetColumnWithoutImageList_Success(string value)
         {
-            var listView = new ListView
+            using var listView = new ListView();
+            using var header = new ColumnHeader();
+            listView.Columns.Add(header);
+
+            Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            header.ImageKey = value;
+            var column = new ComCtl32.LVCOLUMNW
             {
-                SmallImageList = new ImageList()
+                mask = ComCtl32.LVCF.IMAGE
             };
-            var header = new ColumnHeader();
+            Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WindowMessage)LVM.GETCOLUMN, (IntPtr)0, ref column));
+            Assert.Equal(0, column.iImage);
+        }
+
+        [WinFormsTheory]
+        [InlineData(null, 0)]
+        [InlineData("", 0)]
+        [InlineData("Image1", 0)]
+        [InlineData("image1", 0)]
+        [InlineData("Image2", 1)]
+        [InlineData("NoSuchImage", 0)]
+        public void ColumnHeader_ImageKey_GetColumnWithImageList_Success(string value, int expected)
+        {
+            using var image1 = new Bitmap(10, 10);
+            using var image2 = new Bitmap(10, 10);
+            using var imageList = new ImageList();
+            imageList.Images.Add("Image1", image1);
+            imageList.Images.Add("Image2", image2);
+            using var listView = new ListView
+            {
+                SmallImageList = imageList
+            };
+            using var header = new ColumnHeader();
+            listView.Columns.Add(header);
+
+            Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            header.ImageKey = value;
+            var column = new ComCtl32.LVCOLUMNW
+            {
+                mask = ComCtl32.LVCF.IMAGE | ComCtl32.LVCF.FMT,
+                fmt = ComCtl32.LVCFMT.IMAGE
+            };
+            Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WindowMessage)LVM.GETCOLUMN, (IntPtr)0, ref column));
+            Assert.Equal(expected, column.iImage);
+        }
+
+        [WinFormsFact]
+        public void ColumnHeader_ImageKey_SetInvalidSetColumn_ThrowsInvalidOperationException()
+        {
+            using var listView = new InvalidSetColumnListView();
+            using var header = new ColumnHeader();
+            listView.Columns.Add(header);
+            Assert.NotEqual(IntPtr.Zero, listView.Handle);
+
+            listView.MakeInvalid = true;
+            Assert.Throws<InvalidOperationException>(() => header.ImageKey = "Key");
+        }
+
+        [WinFormsFact]
+        public void ColumnHeader_ImageList_GetWithListViewWithoutImageList_ReturnsExpected()
+        {
+            using var listView = new ListView();
+            using var header = new ColumnHeader();
+            listView.Columns.Add(header);
+            Assert.Null(header.ImageList);
+        }
+
+        [WinFormsFact]
+        public void ColumnHeader_ImageList_GetWithListViewWithImageList_ReturnsExpected()
+        {
+            using var imageList = new ImageList();
+            using var listView = new ListView
+            {
+                SmallImageList = imageList
+            };
+            using var header = new ColumnHeader();
             listView.Columns.Add(header);
             Assert.Same(listView.SmallImageList, header.ImageList);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void ColumnHeader_Index_GetWithListView_ReturnsExpected()
         {
-            var listView = new ListView();
-            var header = new ColumnHeader();
+            using var listView = new ListView();
+            using var header = new ColumnHeader();
             listView.Columns.Add(header);
             Assert.Equal(0, header.Index);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void ColumnHeader_ListView_GetWithListView_ReturnsExpected()
         {
-            var listView = new ListView();
-            var header = new ColumnHeader();
+            using var listView = new ListView();
+            using var header = new ColumnHeader();
             listView.Columns.Add(header);
             Assert.Same(listView, header.ListView);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
         public void ColumnHeader_Name_GetWithSite_ReturnsExpected(string name, string expected)
         {
@@ -385,19 +767,21 @@ namespace System.Windows.Forms.Tests
             mockSite
                 .Setup(x => x.Name)
                 .Returns(name);
-
-            var header = new ColumnHeader
+            mockSite
+                .Setup(x => x.Container)
+                .Returns((IContainer)null);
+            using var header = new ColumnHeader
             {
                 Site = mockSite.Object
             };
             Assert.Equal(expected, header.Name);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
         public void ColumnHeader_Name_SetWithoutListView_GetReturnsExpected(string value, string expected)
         {
-            var header = new ColumnHeader
+            using var header = new ColumnHeader
             {
                 Name = value
             };
@@ -408,44 +792,60 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, header.Name);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
         public void ColumnHeader_Name_SetWithListView_GetReturnsExpected(string value, string expected)
         {
-            var listView = new ListView();
-            var header = new ColumnHeader();
+            using var listView = new ListView();
+            using var header = new ColumnHeader();
             listView.Columns.Add(header);
 
             header.Name = value;
             Assert.Equal(expected, header.Name);
+            Assert.False(listView.IsHandleCreated);
 
             // Set same.
             header.Name = value;
             Assert.Equal(expected, header.Name);
+            Assert.False(listView.IsHandleCreated);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
         public void ColumnHeader_Name_SetWithListViewWithHandle_GetReturnsExpected(string value, string expected)
         {
-            var listView = new ListView();
-            var header = new ColumnHeader();
+            using var listView = new ListView();
+            using var header = new ColumnHeader();
             listView.Columns.Add(header);
             Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            int invalidatedCallCount = 0;
+            listView.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            listView.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            listView.HandleCreated += (sender, e) => createdCallCount++;
 
             header.Name = value;
             Assert.Equal(expected, header.Name);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
 
             // Set same.
             header.Name = value;
             Assert.Equal(expected, header.Name);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
         public void ColumnHeader_Name_SetWithSite_GetReturnsExpected(string value, string expected)
         {
-            var header = new ColumnHeader
+            using var header = new ColumnHeader
             {
                 Site = Mock.Of<ISite>(),
                 Name = value
@@ -459,11 +859,66 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(value, header.Site.Name);
         }
 
-        [Theory]
+
+        [WinFormsFact]
+        public void ColumnHeader_Name_ResetValue_Success()
+        {
+            PropertyDescriptor property = TypeDescriptor.GetProperties(typeof(ColumnHeader))[nameof(ColumnHeader.Name)];
+            using var header = new ColumnHeader();
+            Assert.False(property.CanResetValue(header));
+
+            // Set null.
+            header.Name = null;
+            Assert.Empty(header.Name);
+            Assert.False(property.CanResetValue(header));
+            
+            // Set empty.
+            header.Name = string.Empty;
+            Assert.Empty(header.Name);
+            Assert.False(property.CanResetValue(header));
+
+            // Set custom
+            header.Name = "name";
+            Assert.Equal("name", header.Name);
+            Assert.False(property.CanResetValue(header));
+
+            property.ResetValue(header);
+            Assert.Equal("name", header.Name);
+            Assert.False(property.CanResetValue(header));
+        }
+
+        [WinFormsFact]
+        public void ColumnHeader_Name_ShouldSerializeValue_Success()
+        {
+            PropertyDescriptor property = TypeDescriptor.GetProperties(typeof(ColumnHeader))[nameof(ColumnHeader.Name)];
+            using var header = new ColumnHeader();
+            Assert.False(property.ShouldSerializeValue(header));
+
+            // Set null.
+            header.Name = null;
+            Assert.Empty(header.Name);
+            Assert.False(property.ShouldSerializeValue(header));
+            
+            // Set empty.
+            header.Name = string.Empty;
+            Assert.Empty(header.Name);
+            Assert.False(property.ShouldSerializeValue(header));
+
+            // Set custom
+            header.Name = "name";
+            Assert.Equal("name", header.Name);
+            Assert.True(property.ShouldSerializeValue(header));
+
+            property.ResetValue(header);
+            Assert.Equal("name", header.Name);
+            Assert.True(property.ShouldSerializeValue(header));
+        }
+
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringWithNullTheoryData))]
         public void ColumnHeader_Tag_Set_GetReturnsExpected(object value)
         {
-            var header = new ColumnHeader
+            using var header = new ColumnHeader
             {
                 Tag = value
             };
@@ -474,11 +929,11 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(value, header.Tag);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
         public void ColumnHeader_Text_SetWithoutListView_GetReturnsExpected(string value, string expected)
         {
-            var header = new ColumnHeader
+            using var header = new ColumnHeader
             {
                 Text = value
             };
@@ -489,12 +944,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, header.Text);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
         public void ColumnHeader_Text_SetWithListView_GetReturnsExpected(string value, string expected)
         {
-            var listView = new ListView();
-            var header = new ColumnHeader();
+            using var listView = new ListView();
+            using var header = new ColumnHeader();
             listView.Columns.Add(header);
 
             header.Text = value;
@@ -505,12 +960,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, header.Text);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
         public void ColumnHeader_Text_SetWithListViewWithHandle_GetReturnsExpected(string value, string expected)
         {
-            var listView = new ListView();
-            var header = new ColumnHeader();
+            using var listView = new ListView();
+            using var header = new ColumnHeader();
             listView.Columns.Add(header);
             Assert.NotEqual(IntPtr.Zero, listView.Handle);
 
@@ -522,7 +977,28 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, header.Text);
         }
 
-        [Theory]
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
+        public unsafe void ColumnHeader_Text_GetColumn_Success(string value, string expected)
+        {
+            using var listView = new ListView();
+            using var header = new ColumnHeader();
+            listView.Columns.Add(header);
+
+            Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            header.Text = value;
+            char* buffer = stackalloc char[256];
+            var column = new ComCtl32.LVCOLUMNW
+            {
+                mask = ComCtl32.LVCF.TEXT,
+                pszText = buffer,
+                cchTextMax = 256
+            };
+            Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WindowMessage)LVM.GETCOLUMN, (IntPtr)0, ref column));
+            Assert.Equal(expected, new string(column.pszText));
+        }
+
+        [WinFormsTheory]
         [InlineData(RightToLeft.No, true, HorizontalAlignment.Left)]
         [InlineData(RightToLeft.Yes, true, HorizontalAlignment.Left)]
         [InlineData(RightToLeft.Inherit, true, HorizontalAlignment.Left)]
@@ -531,24 +1007,88 @@ namespace System.Windows.Forms.Tests
         [InlineData(RightToLeft.Inherit, false, HorizontalAlignment.Left)]
         public void ColumnHeader_TextAlign_GetWithListView_ReturnsExpected(RightToLeft rightToLeft, bool rightToLeftLayout, HorizontalAlignment expected)
         {
-            var listView = new ListView
+            using var listView = new ListView
             {
                 RightToLeft = rightToLeft,
                 RightToLeftLayout = rightToLeftLayout
             };
-            var header1 = new ColumnHeader();
-            var header2 = new ColumnHeader();
+            using var header1 = new ColumnHeader();
+            using var header2 = new ColumnHeader();
             listView.Columns.Add(header1);
             listView.Columns.Add(header2);
             Assert.Equal(HorizontalAlignment.Left, header1.TextAlign);
             Assert.Equal(expected, header2.TextAlign);
+
+            // Get again to test caching.
+            Assert.Equal(HorizontalAlignment.Left, header1.TextAlign);
+            Assert.Equal(expected, header2.TextAlign);
+
+            // Change listView.
+            listView.RightToLeft = RightToLeft.No;
+            listView.RightToLeftLayout = false;
+            Assert.Equal(HorizontalAlignment.Left, header1.TextAlign);
+            Assert.Equal(expected, header2.TextAlign);
         }
 
-        [Theory]
+        [WinFormsFact]
+        public void ColumnHeader_Text_ResetValue_Success()
+        {
+            PropertyDescriptor property = TypeDescriptor.GetProperties(typeof(ColumnHeader))[nameof(ColumnHeader.Text)];
+            using var header = new ColumnHeader();
+            Assert.False(property.CanResetValue(header));
+
+            // Set null.
+            header.Text = null;
+            Assert.Empty(header.Text);
+            Assert.True(property.CanResetValue(header));
+            
+            // Set empty.
+            header.Text = string.Empty;
+            Assert.Empty(header.Text);
+            Assert.True(property.CanResetValue(header));
+
+            // Set custom
+            header.Text = "text";
+            Assert.Equal("text", header.Text);
+            Assert.True(property.CanResetValue(header));
+
+            property.ResetValue(header);
+            Assert.Empty(header.Text);
+            Assert.True(property.CanResetValue(header));
+        }
+
+        [WinFormsFact]
+        public void ColumnHeader_Text_ShouldSerializeValue_Success()
+        {
+            PropertyDescriptor property = TypeDescriptor.GetProperties(typeof(ColumnHeader))[nameof(ColumnHeader.Text)];
+            using var header = new ColumnHeader();
+            Assert.False(property.ShouldSerializeValue(header));
+
+            // Set null.
+            header.Text = null;
+            Assert.Empty(header.Text);
+            Assert.True(property.ShouldSerializeValue(header));
+            
+            // Set empty.
+            header.Text = string.Empty;
+            Assert.Empty(header.Text);
+            Assert.True(property.ShouldSerializeValue(header));
+
+            // Set custom
+            header.Text = "text";
+            Assert.Equal("text", header.Text);
+            Assert.True(property.ShouldSerializeValue(header));
+
+            property.ResetValue(header);
+            Assert.Empty(header.Text);
+            Assert.True(property.ShouldSerializeValue(header));
+        }
+
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(HorizontalAlignment))]
         public void ColumnHeader_TextAlign_SetWithoutListView_GetReturnsExpected(HorizontalAlignment value)
         {
-            var header = new ColumnHeader
+            using var header = new ColumnHeader
             {
                 TextAlign = value
             };
@@ -559,122 +1099,173 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(value, header.TextAlign);
         }
 
-        [Theory]
-        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(HorizontalAlignment))]
-        public void ColumnHeader_TextAlign_SetWithListView_GetReturnsExpected(HorizontalAlignment value)
+        [WinFormsTheory]
+        [InlineData(0, HorizontalAlignment.Center, HorizontalAlignment.Left)]
+        [InlineData(0, HorizontalAlignment.Left, HorizontalAlignment.Left)]
+        [InlineData(0, HorizontalAlignment.Right, HorizontalAlignment.Left)]
+        [InlineData(1, HorizontalAlignment.Center, HorizontalAlignment.Center)]
+        [InlineData(1, HorizontalAlignment.Left, HorizontalAlignment.Left)]
+        [InlineData(1, HorizontalAlignment.Right, HorizontalAlignment.Right)]
+        public void ColumnHeader_TextAlign_SetWithListView_GetReturnsExpected(int columnIndex, HorizontalAlignment value, HorizontalAlignment expected)
         {
-            var listView = new ListView();
-            var header = new ColumnHeader();
-            listView.Columns.Add(header);
+            using var listView = new ListView();
+            using var header1 = new ColumnHeader();
+            using var header2 = new ColumnHeader();
+            listView.Columns.Add(header1);
+            listView.Columns.Add(header2);
 
-            header.TextAlign = value;
-            Assert.Equal(HorizontalAlignment.Left, header.TextAlign);
+            listView.Columns[columnIndex].TextAlign = value;
+            Assert.Equal(expected, listView.Columns[columnIndex].TextAlign);
+            Assert.False(listView.IsHandleCreated);
 
             // Set same.
-            header.TextAlign = value;
-            Assert.Equal(HorizontalAlignment.Left, header.TextAlign);
+            listView.Columns[columnIndex].TextAlign = value;
+            Assert.Equal(expected, listView.Columns[columnIndex].TextAlign);
+            Assert.False(listView.IsHandleCreated);
         }
-
-        [Theory]
-        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(HorizontalAlignment))]
-        public void ColumnHeader_TextAlign_SetWithListViewNonZeroIndex_GetReturnsExpected(HorizontalAlignment value)
+        
+        [WinFormsTheory]
+        [InlineData(0, HorizontalAlignment.Center, HorizontalAlignment.Left)]
+        [InlineData(0, HorizontalAlignment.Left, HorizontalAlignment.Left)]
+        [InlineData(0, HorizontalAlignment.Right, HorizontalAlignment.Left)]
+        [InlineData(1, HorizontalAlignment.Center, HorizontalAlignment.Center)]
+        [InlineData(1, HorizontalAlignment.Left, HorizontalAlignment.Left)]
+        [InlineData(1, HorizontalAlignment.Right, HorizontalAlignment.Right)]
+        public void ColumnHeader_TextAlign_SetWithListViewWithHandle_GetReturnsExpected(int columnIndex, HorizontalAlignment value, HorizontalAlignment expected)
         {
-            var listView = new ListView();
-            listView.Columns.Add(new ColumnHeader());
-            var header = new ColumnHeader();
-            listView.Columns.Add(header);
-
-            header.TextAlign = value;
-            Assert.Equal(value, header.TextAlign);
-
-            // Set same.
-            header.TextAlign = value;
-            Assert.Equal(value, header.TextAlign);
-        }
-
-        [Theory]
-        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(HorizontalAlignment))]
-        public void ColumnHeader_TextAlign_SetWithListViewWithHandle_GetReturnsExpected(HorizontalAlignment value)
-        {
-            var listView = new ListView();
-            var header = new ColumnHeader();
-            listView.Columns.Add(header);
+            using var listView = new ListView();
+            using var header1 = new ColumnHeader();
+            using var header2 = new ColumnHeader();
+            listView.Columns.Add(header1);
+            listView.Columns.Add(header2);
             Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            int invalidatedCallCount = 0;
+            listView.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            listView.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            listView.HandleCreated += (sender, e) => createdCallCount++;
 
-            header.TextAlign = value;
-            Assert.Equal(HorizontalAlignment.Left, header.TextAlign);
+            listView.Columns[columnIndex].TextAlign = value;
+            Assert.Equal(expected, listView.Columns[columnIndex].TextAlign);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(1, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
 
             // Set same.
-            header.TextAlign = value;
-            Assert.Equal(HorizontalAlignment.Left, header.TextAlign);
+            listView.Columns[columnIndex].TextAlign = value;
+            Assert.Equal(expected, listView.Columns[columnIndex].TextAlign);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(2, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
         }
 
-        [Theory]
-        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(HorizontalAlignment))]
-        public void ColumnHeader_TextAlign_SetWithListViewWithHandleNonZeroIndex_GetReturnsExpected(HorizontalAlignment value)
+        [WinFormsTheory]
+        [InlineData(0, HorizontalAlignment.Center, 0x4000)]
+        [InlineData(0, HorizontalAlignment.Left, 0x4000)]
+        [InlineData(0, HorizontalAlignment.Right, 0x4000)]
+        [InlineData(1, HorizontalAlignment.Center, 0x4002)]
+        [InlineData(1, HorizontalAlignment.Left, 0x4000)]
+        [InlineData(1, HorizontalAlignment.Right, 0x4001)]
+        public unsafe void ColumnHeader_TextAlign_GetColumn_Success(int columnIndex, HorizontalAlignment value, int expected)
         {
-            var listView = new ListView();
-            listView.Columns.Add(new ColumnHeader());
-            var header = new ColumnHeader();
-            listView.Columns.Add(header);
+            using var listView = new ListView();
+            using var header1 = new ColumnHeader();
+            using var header2 = new ColumnHeader();
+            listView.Columns.Add(header1);
+            listView.Columns.Add(header2);
+
             Assert.NotEqual(IntPtr.Zero, listView.Handle);
-
-            header.TextAlign = value;
-            Assert.Equal(value, header.TextAlign);
-
-            // Set same.
-            header.TextAlign = value;
-            Assert.Equal(value, header.TextAlign);
+            listView.Columns[columnIndex].TextAlign = value;
+            var column = new ComCtl32.LVCOLUMNW
+            {
+                mask = ComCtl32.LVCF.FMT
+            };
+            Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WindowMessage)LVM.GETCOLUMN, (IntPtr)columnIndex, ref column));
+            Assert.Equal(expected, (int)column.fmt);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryDataInvalid), typeof(HorizontalAlignment))]
         public void ColumnHeader_TextAlign_SetInvalid_ThrowsInvalidEnumArgumentException(HorizontalAlignment value)
         {
-            var header = new ColumnHeader();
+            using var header = new ColumnHeader();
             Assert.Throws<InvalidEnumArgumentException>("value", () => header.TextAlign = value);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void ColumnHeader_Width_GetWithListView_GetReturnsExpected()
         {
-            var listView = new ListView();
-            var header = new ColumnHeader();
+            using var listView = new ListView();
+            using var header = new ColumnHeader();
             listView.Columns.Add(header);
 
             Assert.Equal(60, header.Width);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void ColumnHeader_Width_GetWithListViewWithHandle_GetReturnsExpected()
         {
-            var listView = new ListView();
-            var header = new ColumnHeader();
+            using var listView = new ListView();
+            using var header = new ColumnHeader();
             listView.Columns.Add(header);
             Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            int invalidatedCallCount = 0;
+            listView.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            listView.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            listView.HandleCreated += (sender, e) => createdCallCount++;
 
             Assert.Equal(60, header.Width);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);            
         }
 
-        [Fact]
+        [WinFormsFact]
         public void ColumnHeader_Width_GetWithListViewWithHandleWithDetails_GetReturnsExpected()
         {
-            var listView = new ListView
+            using var listView = new ListView
             {
                 View = View.Details
             };
-            var header = new ColumnHeader();
+            using var header = new ColumnHeader();
             listView.Columns.Add(header);
             Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            int invalidatedCallCount = 0;
+            listView.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            listView.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            listView.HandleCreated += (sender, e) => createdCallCount++;
 
             Assert.Equal(header.Width, header.Width);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount); 
         }
 
-        [Theory]
-        [CommonMemberData(nameof(CommonTestHelper.GetIntTheoryData))]
+        public static IEnumerable<object[]> Width_Set_TestData()
+        {
+            yield return new object[] { -3 };
+            yield return new object[] { -2 };
+            yield return new object[] { -1 };
+            yield return new object[] { 0 };
+            yield return new object[] { 1 };
+            yield return new object[] { 60 };
+            yield return new object[] { 75 };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(Width_Set_TestData))]
         public void ColumnHeader_Width_SetWithoutListView_GetReturnsExpected(int value)
         {
-            var header = new ColumnHeader
+            using var header = new ColumnHeader
             {
                 Width = value
             };
@@ -685,90 +1276,184 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(value, header.Width);
         }
 
-        [Theory]
-        [CommonMemberData(nameof(CommonTestHelper.GetIntTheoryData))]
+        [WinFormsTheory]
+        [MemberData(nameof(Width_Set_TestData))]
         public void ColumnHeader_Width_SetWithListView_GetReturnsExpected(int value)
         {
-            var listView = new ListView();
-            var header = new ColumnHeader();
+            using var listView = new ListView();
+            using var header = new ColumnHeader();
             listView.Columns.Add(header);
 
             header.Width = value;
             Assert.Equal(value, header.Width);
+            Assert.False(listView.IsHandleCreated);
 
             // Set same.
             header.Width = value;
             Assert.Equal(value, header.Width);
+            Assert.False(listView.IsHandleCreated);
         }
 
-        [Theory]
-        [CommonMemberData(nameof(CommonTestHelper.GetIntTheoryData))]
+        [WinFormsTheory]
+        [MemberData(nameof(Width_Set_TestData))]
         public void ColumnHeader_Width_SetWithListViewWithHandle_GetReturnsExpected(int value)
         {
-            var listView = new ListView();
-            var header = new ColumnHeader();
+            using var listView = new ListView();
+            using var header = new ColumnHeader();
             listView.Columns.Add(header);
             Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            int invalidatedCallCount = 0;
+            listView.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            listView.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            listView.HandleCreated += (sender, e) => createdCallCount++;
 
             header.Width = value;
             Assert.Equal(value, header.Width);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
 
             // Set same.
             header.Width = value;
             Assert.Equal(value, header.Width);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
         }
 
-        [Theory]
+        [WinFormsTheory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(60)]
+        [InlineData(75)]
+        public void ColumnHeader_Width_GetColumnWidth_ReturnsExpected(int value)
+        {
+            using var listView = new ListView
+            {
+                View = View.Details
+            };
+            using var header = new ColumnHeader();
+            listView.Columns.Add(header);
+
+            Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            header.Width = value;
+            Assert.Equal((IntPtr)value, User32.SendMessageW(listView.Handle, (User32.WindowMessage)LVM.GETCOLUMNWIDTH, IntPtr.Zero, IntPtr.Zero));
+        }
+
+        [WinFormsTheory]
+        [InlineData(-3)]
+        [InlineData(-2)]
+        [InlineData(-1)]
+        public void ColumnHeader_Width_GetColumnWidthCustom_ReturnsExpected(int value)
+        {
+            using var listView = new ListView
+            {
+                View = View.Details
+            };
+            using var header = new ColumnHeader();
+            listView.Columns.Add(header);
+
+            Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            header.Width = value;
+            Assert.True(User32.SendMessageW(listView.Handle, (User32.WindowMessage)LVM.GETCOLUMNWIDTH, IntPtr.Zero, IntPtr.Zero).ToInt32() > 0);
+        }
+
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(ColumnHeaderAutoResizeStyle))]
         public void ColumnHeader_AutoSize_WithoutListView_Nop(ColumnHeaderAutoResizeStyle headerAutoResize)
         {
-            var header = new ColumnHeader();
+            using var header = new ColumnHeader();
             header.AutoResize(headerAutoResize);
+            Assert.Equal(60, header.Width);
+            
+            // Call again.
+            header.AutoResize(headerAutoResize);
+            Assert.Equal(60, header.Width);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(ColumnHeaderAutoResizeStyle))]
         public void ColumnHeader_AutoSize_WithListView_Success(ColumnHeaderAutoResizeStyle headerAutoResize)
         {
-            var listView = new ListView();
-            var header = new ColumnHeader();
+            using var listView = new ListView();
+            using var header = new ColumnHeader();
             listView.Columns.Add(header);
+
             header.AutoResize(headerAutoResize);
+            Assert.Equal(60, header.Width);
+            Assert.True(listView.IsHandleCreated);
+
+            // Call again.
+            header.AutoResize(headerAutoResize);
+            Assert.Equal(60, header.Width);
+            Assert.True(listView.IsHandleCreated);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(ColumnHeaderAutoResizeStyle))]
         public void ColumnHeader_AutoSize_WithListViewWithHandle_Success(ColumnHeaderAutoResizeStyle headerAutoResize)
         {
-            var listView = new ListView();
-            var header = new ColumnHeader();
+            using var listView = new ListView();
+            using var header = new ColumnHeader();
             listView.Columns.Add(header);
             Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            int invalidatedCallCount = 0;
+            listView.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            listView.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            listView.HandleCreated += (sender, e) => createdCallCount++;
+
             header.AutoResize(headerAutoResize);
+            Assert.Equal(60, header.Width);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+            
+            // Call again.
+            header.AutoResize(headerAutoResize);
+            Assert.Equal(60, header.Width);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryDataInvalid), typeof(ColumnHeaderAutoResizeStyle))]
         public void ColumnHeader_AutoSize_InvalidHeaderAutoResize_ThrowsInvalidEnumArgumentException(ColumnHeaderAutoResizeStyle headerAutoResize)
         {
-            var header = new ColumnHeader();
+            using var header = new ColumnHeader();
             Assert.Throws<InvalidEnumArgumentException>("headerAutoResize", () => header.AutoResize(headerAutoResize));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void ColumnHeader_Clone_Invoke_ReturnsExpected()
         {
-            ColumnHeader source = new ColumnHeader
+            var mockSite = new Mock<ISite>(MockBehavior.Strict);
+            mockSite
+                .Setup(s => s.Container)
+                .Returns((IContainer)null);
+            using var source = new ColumnHeader
             {
+                DisplayIndex = 1,
                 ImageKey = "imageKey",
                 ImageIndex = 1,
                 Name = "name",
+                Site = mockSite.Object,
                 Tag = "tag",
                 Text = "text",
                 TextAlign = HorizontalAlignment.Center,
                 Width = 10
             };
-            ColumnHeader header = Assert.IsType<ColumnHeader>(source.Clone());
+            using ColumnHeader header = Assert.IsType<ColumnHeader>(source.Clone());
+            Assert.NotSame(header, source);
+            Assert.Null(header.Container);
             Assert.Equal(-1, header.DisplayIndex);
             Assert.Equal(-1, header.ImageIndex);
             Assert.Equal(string.Empty, header.ImageKey);
@@ -776,52 +1461,105 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, header.Index);
             Assert.Null(header.ListView);
             Assert.Empty(header.Name);
+            Assert.Null(header.Site);
             Assert.Null(header.Tag);
             Assert.Equal("text", header.Text);
             Assert.Equal(HorizontalAlignment.Center, header.TextAlign);
             Assert.Equal(10, header.Width);
         }
 
-        [Fact]
+        [WinFormsFact]
+        public void ColumnHeader_Clone_InvokeWithListView_ReturnsExpected()
+        {
+            using var listView = new ListView();
+            var mockSite = new Mock<ISite>(MockBehavior.Strict);
+            mockSite
+                .Setup(s => s.Container)
+                .Returns((IContainer)null);
+            using var source = new ColumnHeader
+            {
+                DisplayIndex = 1,
+                ImageKey = "imageKey",
+                ImageIndex = 1,
+                Name = "name",
+                Site = mockSite.Object,
+                Tag = "tag",
+                Text = "text",
+                TextAlign = HorizontalAlignment.Center,
+                Width = 10
+            };
+            listView.Columns.Add(source);
+
+            using ColumnHeader header = Assert.IsType<ColumnHeader>(source.Clone());
+            Assert.NotSame(header, source);
+            Assert.Null(header.Container);
+            Assert.Equal(-1, header.DisplayIndex);
+            Assert.Equal(-1, header.ImageIndex);
+            Assert.Equal(string.Empty, header.ImageKey);
+            Assert.Null(header.ImageList);
+            Assert.Equal(-1, header.Index);
+            Assert.Null(header.ListView);
+            Assert.Empty(header.Name);
+            Assert.Null(header.Site);
+            Assert.Null(header.Tag);
+            Assert.Equal("text", header.Text);
+            Assert.Equal(HorizontalAlignment.Center, header.TextAlign);
+            Assert.Equal(10, header.Width);
+        }
+
+        [WinFormsFact]
         public void ColumnHeader_Clone_InvokeSubClass_ReturnsExpected()
         {
-            CustomColumnHeader source = new CustomColumnHeader
+            var mockSite = new Mock<ISite>(MockBehavior.Strict);
+            mockSite
+                .Setup(s => s.Container)
+                .Returns((IContainer)null);
+            using var source = new SubColumnHeader
             {
+                DisplayIndex = 1,
                 ImageKey = "imageKey",
                 ImageIndex = 1,
                 Name = "name",
+                Site = mockSite.Object,
                 Tag = "tag",
                 Text = "text",
                 TextAlign = HorizontalAlignment.Center,
                 Width = 10
             };
-            CustomColumnHeader header = Assert.IsType<CustomColumnHeader>(source.Clone());
+            using SubColumnHeader header = Assert.IsType<SubColumnHeader>(source.Clone());
+            Assert.NotSame(header, source);
+            Assert.True(header.CanRaiseEvents);
+            Assert.Null(header.Container);
+            Assert.False(header.DesignMode);
             Assert.Equal(-1, header.DisplayIndex);
+            Assert.NotNull(header.Events);
+            Assert.Same(header.Events, header.Events);
             Assert.Equal(-1, header.ImageIndex);
             Assert.Equal(string.Empty, header.ImageKey);
             Assert.Null(header.ImageList);
             Assert.Equal(-1, header.Index);
             Assert.Null(header.ListView);
             Assert.Empty(header.Name);
+            Assert.Null(header.Site);
             Assert.Null(header.Tag);
             Assert.Equal("text", header.Text);
             Assert.Equal(HorizontalAlignment.Center, header.TextAlign);
             Assert.Equal(10, header.Width);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void ColumnHeader_Dispose_WithoutListView_Success()
         {
-            var header = new ColumnHeader();
+            using var header = new ColumnHeader();
             header.Dispose();
             header.Dispose();
         }
 
-        [Fact]
+        [WinFormsFact]
         public void ColumnHeader_Dispose_WithListView_Success()
         {
-            var listView = new ListView();
-            var header = new ColumnHeader();
+            using var listView = new ListView();
+            using var header = new ColumnHeader();
             listView.Columns.Add(header);
             header.Dispose();
             Assert.Empty(listView.Columns);
@@ -830,19 +1568,78 @@ namespace System.Windows.Forms.Tests
             Assert.Empty(listView.Columns);
         }
 
-        [Theory]
-        [CommonMemberData(nameof(CommonTestHelper.GetStringWithNullTheoryData))]
-        public void ColumnHeader_ToString_Invoke_ReturnsExpected(string value)
+        [WinFormsFact]
+        public void ColumnHeader_ToString_Invoke_ReturnsExpected()
         {
-            var header = new ColumnHeader
+            using var header = new ColumnHeader();
+            Assert.Equal($"ColumnHeader: Text: ColumnHeader", header.ToString());
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetStringWithNullTheoryData))]
+        public void ColumnHeader_ToString_InvokeWithText_ReturnsExpected(string value)
+        {
+            using var header = new ColumnHeader
             {
                 Text = value
             };
             Assert.Equal($"ColumnHeader: Text: {header.Text}", header.ToString());
         }
 
-        private class CustomColumnHeader : ColumnHeader
+        private class InvalidSetColumnListView : ListView
         {
+            public bool MakeInvalid { get; set; }
+
+            protected override void WndProc(ref Message m)
+            {
+                if (MakeInvalid && m.Msg == (int)LVM.SETCOLUMN)
+                {
+                    m.Result = IntPtr.Zero;
+                }
+                else
+                {
+                    base.WndProc(ref m);
+                }
+            }
+        }
+
+        [WinFormsFact]
+        public void ColumnHeader_ImageIndexer_SetImageList_Nop()
+        {
+            using (new NoAssertContext())
+            {
+                using var imageList = new ImageList();
+                using var listView = new ListView
+                {
+                    SmallImageList = imageList
+                };
+                using var header = new ColumnHeader();
+                listView.Columns.Add(header);
+                var indexer = new ColumnHeader.ColumnHeaderImageListIndexer(header);
+                indexer.ImageList = new ImageList();
+                Assert.Same(imageList, indexer.ImageList);
+            }
+        }
+
+        private class SubColumnHeader : ColumnHeader
+        {
+            public SubColumnHeader() : base()
+            {
+            }
+            
+            public SubColumnHeader(int imageIndex) : base(imageIndex)
+            {
+            }
+            
+            public SubColumnHeader(string imageKey) : base(imageKey)
+            {
+            }
+
+            public new bool CanRaiseEvents => base.CanRaiseEvents;
+
+            public new EventHandlerList Events => base.Events;
+
+            public new bool DesignMode => base.DesignMode;
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes
- Add ColumnHeader tests with an extra focus on making sure #1913 does not regress things

(Sort of) relies on #1913 and #2521 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2526)