### PR TITLE
Update readme to refer to v3.1 and link to breaking changes

### DIFF
--- a/Documentation/contributing.md
+++ b/Documentation/contributing.md
@@ -2,6 +2,8 @@
 
 The primary focus of .NET Core 3.0 release for Windows Forms is to achieve parity with .NET Framework. Priority will be given to changes that align with that goal. See the [roadmap](../roadmap.md) to understand project goals.
 
+In .NET 5.0 and beyond we are aiming to optimize our implementations, reduce our memory footprints, increase performance, and update implementations to deliver all aspects of modern Windows UI, including missings properties or actions, and new UI controls.
+
 We need the most help with the following types of changes:
 
 * Test fixes, test improvements, and new tests increasing code coverage.

--- a/Documentation/debugging.md
+++ b/Documentation/debugging.md
@@ -8,7 +8,7 @@ Once you are ready to debug your changes on an existing Windows Forms applicatio
 
 If you do not want to modify your local SDK, you may with to perform technique 2, while if you do not want to add an additional reference to your project, technique 1 may be better for you.
 
-## (1) Copy your changes into the SDK
+## 1. Copy your changes into the SDK
 
 copy the resulting assembly(-ies) from the base of the repository  
 
@@ -22,7 +22,7 @@ where **[Drive]** is your OS drive (for example, C:)  and **[path-to-repo]** is 
 
 **NOTE** that this will modify your SDK; to revert back, you will have to repair the install or reinstall. See the [dotnet Core repository][dotnet-core-repos] for more information.
 
-## (2) Point your project to your experimental binary(-ies)
+## 2. Point your project to your experimental binary(-ies)
 
 Add references to the binary(-ies) to your project ported to Core. For example, for System.Windows.Forms, you should add the following reference:
 

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -6,9 +6,9 @@ This document describes the experience of using WinForms on .NET Core. The [Deve
 
 Choose one of these options:
 
-1. [.NET Core 3.0 SDK (recommended)][.net-core-3.0-sdk]
+1. [.NET Core 3.1 SDK (recommended)][.net-core-3.1-sdk]
 
-1. [.NET Core 3.1/.NET 5.0 daily build (latest changes, could be less stable)][.net-core-daily]
+1. [.NET 5.0 daily build (latest changes, could be less stable)][.net-core-daily]
 
 ## Creating new applications
 
@@ -26,15 +26,15 @@ You can try the WinForms Core Designer Visual Studio extension preview, see [Win
 
 ## Samples
 
-Check out the [.NET Core 3.0 WinForms samples][.net-core-3.0-samples] for both basic and advanced scenarios. Additionally, there is a collection of[ WinForms sample applications on MSDN][MSDN-winforms-samples].
+Check out the [.NET Core WinForms samples][.net-core-samples] for both basic and advanced scenarios. Additionally, there is a collection of[ WinForms sample applications on MSDN][MSDN-winforms-samples].
 
 ## Porting existing applications
 
-To port your existing WinForms application from .NET Framework to .NET Core 3.0, refer to our [porting guidelines](porting-guidelines.md).
+To port your existing WinForms application from .NET Framework to .NET Core 3.1, refer to our [porting guidelines](porting-guidelines.md).
 
 [comment]: <> (URI Links)
 
-[.net-core-3.0-sdk]: https://dotnet.microsoft.com/download/dotnet-core/3.0
+[.net-core-3.1-sdk]: https://dotnet.microsoft.com/download/dotnet-core/3.1
 [.net-core-daily]: https://github.com/dotnet/core-sdk/blob/master/README.md#installers-and-binaries
-[.net-core-3.0-samples]: https://github.com/dotnet/samples/tree/master/windowsforms
+[.net-core-samples]: https://github.com/dotnet/samples/tree/master/windowsforms
 [MSDN-winforms-samples]: https://code.msdn.microsoft.com/site/search?f%5B0%5D.Type=Platform&f%5B0%5D.Value=Desktop&f%5B0%5D.Text=Desktop&f%5B1%5D.Type=Contributors&f%5B1%5D.Value=Microsoft&f%5B1%5D.Text=Microsoft&f%5B2%5D.Type=Technology&f%5B2%5D.Value=Windows%20Forms

--- a/Documentation/issue-guide.md
+++ b/Documentation/issue-guide.md
@@ -12,9 +12,9 @@ You can help us streamline our response time to your feedback and ideas by filin
 
 ## Known Issues
 
-If you encounter an issue using the latest .NET Core 3.0 SDK, please:
+If you encounter an issue using the latest .NET Core 3.1 SDK, please:
 
-1. Check out the [Centralized 3.0 Preview Known Issues document][.net-core-3.0-known-issues],
+1. Check out the [Centralized 3.1 Preview Known Issues document][.net-core-3.1-known-issues],
 1. Explore [this repositories issues][winforms-issues], and then
 1. [Open a new issue][new-issue] if there is none.
 
@@ -39,23 +39,12 @@ We use GitHub [labels][labels] on our issues in order to classify them. We have 
 
 * **Issue Types**: These labels classify the type of issue. We use the following types:
   * [api-suggestion]: Issues which would add new APIs (see [API Review process][corefx-api-review-process] for details).
-    * Note: WinForms API process is not finalized yet. We may need to add additional UI-specific steps to it (e.g. accessibility review). Expect finalized API review version post-3.0 when we will be ready to take new APIs.
   * [bug][bug], [enhancement][enhancement], [test-bug][test-bug], [test-enhancement][test-enhancement], [question][question], [documentation][documentation]: See [label description][label-description] for details.
 * **Other**:
   * [up-for-grabs][up-for-grabs]: Smaller sections of work which we believe are well scoped. These sorts of issues are a good place to start if you are new. Anyone is free to work on these issues.
   * [needs-more-info][needs-more-info]: Issues which need more information to be actionable. Usually this will be because we can't reproduce a reported bug. We'll close these issues after a little bit if we haven't gotten actionable information, but we welcome folks who have acquired more information to reopen the issue.
   * [tenet-compatibility][tenet-compatibility]: Incompatibility between released versions or with WinForms for .NET Framework.
 
-## Milestones
-
-We use [milestones][milestones] to prioritize work for each upcoming release.
-
-* **3.0** milestone work is focused on parity with WinForms for .NET Framework. We do not plan to take contributions or address issues that are not unique to WinForms on .NET Core in 3.0 release. For example:
-  * The following will be put into **Future** milestone and will be reviewed and prioritized after 3.0 final release:
-    * Bugs which are present on both WinForms platforms (for .NET Core and .NET Framework)
-    * Requests for new APIs and features
-* **Future** milestone tracks all potential future work (which may or may not happen). When we are done with 3.0 release, we will move some of these issues into the next immediate milestone.
-  * Please do not start discussions about next post-3.0 milestone until we are close to final 3.0 release. If you want to express your opinion on prioritization, please [up-vote first post of the issue] instead.
 
 ## Assignee
 
@@ -91,8 +80,8 @@ Feel free to use other labels if it helps your triage efforts (for example, **ne
 1. Issue has no **Assignee**, unless someone is working on the issue at the moment.
     * Motivation: Observation is that contributors are less likely to grab assigned issues, no matter what the repository rules say.
 
-1. Use **up-for-grabs** as much as possible, ideally with a quick note about next steps / complexity of the issue.
-    * Note: Per [http://up-for-grabs.net][up-for-grabs-net], such issues should be no longer than few nights' worth of work. They should be actionable (i.e. no mysterious CI failures that can't be tested in the open).
+1. Use **up-for-grabs** as much as possible, ideally with a quick note about next steps / complexity of the issue.<br />
+    NB: Per [http://up-for-grabs.net][up-for-grabs-net], such issues should be no longer than few nights' worth of work. They should be actionable (i.e. no mysterious CI failures that can't be tested in the open).
 
 1. Set milestone to **Future**, unless you can 95%-commit you can fund the issue in specific milestone.
     * Motivation: Helps communicate desire/timeline to community. Can spark further priority/impact discussion.

--- a/Documentation/issue-guide.md
+++ b/Documentation/issue-guide.md
@@ -81,7 +81,7 @@ Feel free to use other labels if it helps your triage efforts (for example, **ne
     * Motivation: Observation is that contributors are less likely to grab assigned issues, no matter what the repository rules say.
 
 1. Use **up-for-grabs** as much as possible, ideally with a quick note about next steps / complexity of the issue.<br />
-    NB: Per [http://up-for-grabs.net][up-for-grabs-net], such issues should be no longer than few nights' worth of work. They should be actionable (i.e. no mysterious CI failures that can't be tested in the open).
+    NB: Per [http://up-for-grabs.net][up-for-grabs-net], such issues should be no longer than few nights' worth of work. They should be actionable (that is, no mysterious CI failures that can't be tested in the open).
 
 1. Set milestone to **Future**, unless you can 95%-commit you can fund the issue in specific milestone.
     * Motivation: Helps communicate desire/timeline to community. Can spark further priority/impact discussion.

--- a/Documentation/porting-guidelines.md
+++ b/Documentation/porting-guidelines.md
@@ -15,7 +15,7 @@ For additional information and assistance, we recommend checking out [this artic
 Review the following resources that describe breaking changes between Windows Forms on .NET Framework and .NET Core:
 
 * The [Breaking changes in Windows Forms (.NET Framework to .NET Core)](https://docs.microsoft.com/dotnet/core/porting/winforms-breaking-changes) describes breaking changes you need to be aware of when migrating your applications from .NET Framework
-* The [Breaking changes in Windows Forms (.NET Core to .NET Core)](https://docs.microsoft.com/en-us/dotnet/core/compatibility/winforms) describes breaking changes you need to be aware of when migrating your applications from one version of .NET Core to another.
+* The [Breaking changes in Windows Forms (.NET Core to .NET Core)](https://docs.microsoft.com/dotnet/core/compatibility/winforms) describes breaking changes you need to be aware of when migrating your applications from one version of .NET Core to another.
 
 ## Prepare your project for porting
 

--- a/Documentation/porting-guidelines.md
+++ b/Documentation/porting-guidelines.md
@@ -1,4 +1,4 @@
-# Porting existing applications to .NET Core 3.1
+# Port existing applications to .NET Core 3.1
 
 >We suggest doing migration in a separate branch or, if you're not using version
 >control, creating a copy of your project so you have a clean state to go back

--- a/Documentation/porting-guidelines.md
+++ b/Documentation/porting-guidelines.md
@@ -14,7 +14,7 @@ For additional information and assistance, we recommend checking out [this artic
 
 Review the following resources that describe breaking changes between Windows Forms on .NET Framework and .NET Core:
 
-* The [Breaking changes in Windows Forms (.NET Framework to .NET Core)](https://docs.microsoft.com/en-us/dotnet/core/porting/winforms-breaking-changes) describes breaking changes you need to be aware of when migrating your applications from .NET Framework
+* The [Breaking changes in Windows Forms (.NET Framework to .NET Core)](https://docs.microsoft.com/dotnet/core/porting/winforms-breaking-changes) describes breaking changes you need to be aware of when migrating your applications from .NET Framework
 * The [Breaking changes in Windows Forms (.NET Core to .NET Core)](https://docs.microsoft.com/en-us/dotnet/core/compatibility/winforms) describes breaking changes you need to be aware of when migrating your applications from one version of .NET Core to another.
 
 ## Prepare your project for porting

--- a/Documentation/porting-guidelines.md
+++ b/Documentation/porting-guidelines.md
@@ -12,7 +12,7 @@ For additional information and assistance, we recommend checking out [this artic
 
 ## Breaking changes
 
-Please review the following resources that describe breaking changes between Windows Forms on .NET Framework and .NET Core:
+Review the following resources that describe breaking changes between Windows Forms on .NET Framework and .NET Core:
 
 * The [Breaking changes in Windows Forms (.NET Framework to .NET Core)](https://docs.microsoft.com/en-us/dotnet/core/porting/winforms-breaking-changes) describes breaking changes you need to be aware of when migrating your applications from .NET Framework
 * The [Breaking changes in Windows Forms (.NET Core to .NET Core)](https://docs.microsoft.com/en-us/dotnet/core/compatibility/winforms) describes breaking changes you need to be aware of when migrating your applications from one version of .NET Core to another.

--- a/Documentation/porting-guidelines.md
+++ b/Documentation/porting-guidelines.md
@@ -1,4 +1,4 @@
-# Porting existing applications to .NET Core 3.0
+# Porting existing applications to .NET Core 3.1
 
 >We suggest doing migration in a separate branch or, if you're not using version
 >control, creating a copy of your project so you have a clean state to go back
@@ -8,6 +8,14 @@ The migration process includes two steps: **preparing your project for porting**
 .NET Core and **porting** itself.
 
 For additional information and assistance, we recommend checking out [this article on the dotnet blog][dotnet-blog-port-guide] as well as the [accompanying video tutorial][dotnet-blog-port-video].
+
+
+## Breaking changes
+
+Please review the following resources that describe breaking changes between Windows Forms on .NET Framework and .NET Core:
+
+* The [Breaking changes in Windows Forms (.NET Framework to .NET Core)](https://docs.microsoft.com/en-us/dotnet/core/porting/winforms-breaking-changes) describes breaking changes you need to be aware of when migrating your applications from .NET Framework
+* The [Breaking changes in Windows Forms (.NET Core to .NET Core)](https://docs.microsoft.com/en-us/dotnet/core/compatibility/winforms) describes breaking changes you need to be aware of when migrating your applications from one version of .NET Core to another.
 
 ## Prepare your project for porting
 
@@ -53,15 +61,25 @@ For additional information and assistance, we recommend checking out [this artic
 
     Build and run to make sure you did not introduce any issues while preparing your project. Now it is time to port it.
 
+
+
 ## Port your project
 
-1. **Add .NET Core Windows Forms project**. Add a new .NET Core 3.0 Windows Forms project to the solution.
+### Automated porting
 
-1. **Add `<ProjectReference>`**. Copy the `<ProjectReference>` elements from the `.csproj` file of the original project to the new project's `.csproj` file. Note: The new project format does not use the `Name` and `ProjectGuid` elements, so you can safely delete those.
+1. Try porting your project using [`try-convert` tool](https://github.com/dotnet/try-convert), which we built to help migrations. <br />
+NB: The tool may not for all possible projects, in that case please read on.
+
+### Manual porting
+
+1. **Add .NET Core Windows Forms project**. Add a new .NET Core 3.1 Windows Forms project to the solution.
+
+1. **Add `<ProjectReference>`**. Copy the `<ProjectReference>` elements from the `.csproj` file of the original project to the new project's `.csproj` file.<br />
+Note: The new project format does not use the `Name` and `ProjectGuid` elements, so you can safely delete those.
 
 1. **Restore/Build**. At this point, it's a good idea to restore/build to make sure all dependencies are properly configured.
 
-1. **Link files**. Link all files from your existing .NET Framework WinForms project to the .NET Core 3.0 WinForms project by adding following to the `.csproj` file.
+1. **Link files**. Link all files from your existing .NET Framework WinForms project to the .NET Core 3.1 WinForms project by adding following to the `.csproj` file.
 
     ```xml
     <ItemGroup>
@@ -81,7 +99,7 @@ For additional information and assistance, we recommend checking out [this artic
 
 1. **Run new project**. Set your new .NET Core project as StartUp Project and run it. Make sure everything works.
 
-1. **Copy or leave linked**. Now instead of linking the files, you can actually copy them from the old .NET Framework WinForms project to the new .NET Core 3.0 WinForms project. After that you can get rid of the old project. However, if you would like to use the Windows Forms' designer, it is not available in Visual Studio just yet. So you can stop at the step 6 and perform step 7 once designer support is available.
+1. **Copy or leave linked**. Now instead of linking the files, you can actually copy them from the old .NET Framework WinForms project to the new .NET Core 3.1 WinForms project. After that you can get rid of the old project. However, if you would like to use the Windows Forms' designer, it is not available in Visual Studio just yet. So you can stop at the step 6 and perform step 7 once designer support is available.
 
 ## Migration tips
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ For more information about the designer, please see the [Windows Forms Designer 
 
 To learn about project priorities as well as status and ship dates see the [Windows Forms Roadmap](roadmap.md).
 
-This repository contains WinForms for .NET Core. It does not contain the .NET Framework variant of WinForms.
+:warning: This repository contains WinForms for .NET Core. It does not contain the .NET Framework variant of WinForms.
 
-[Windows Presentation Foundation][wpf] (WPF) is another UI framework used to build Windows desktop applications which is supported on .NET Core. WPF and Windows Forms applications  run only on Windows operating systems. They are part of the `Microsoft.NET.Sdk.WindowsDesktop` SDK. You are recommended to use Visual Studio 2019 Preview 1 to use WPF and Windows Forms with .NET Core.
+[Windows Presentation Foundation](https://github.com/dotnet/wpf) (WPF) is another UI framework used to build Windows desktop applications which is supported on .NET Core. WPF and Windows Forms applications  run only on Windows operating systems. They are part of the `Microsoft.NET.Sdk.WindowsDesktop` SDK. You are recommended to use Visual Studio 2019 Preview 1 to use WPF and Windows Forms with .NET Core.
 
 ## Getting started
 
-* [.NET Core 3.0 SDK Preview][.net-core-3.0-sdk-preview]
+* [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1)
 * [Getting started instructions][getting-started]
 * [Contributing guide][contributing]
 * [Porting guide][porting-guidelines]
@@ -27,61 +27,44 @@ This repository contains WinForms for .NET Core. It does not contain the .NET Fr
 |               | Public CI                                  :arrow_right:  | Internal CI                                    :arrow_right:  | Core Setup CI                                     :arrow_right:  | Core SDK CI                                                   |
 |-------------  |---------------------------------------------------------  |-------------------------------------------------------------  |----------------------------------------------------------------  |-------------------------------------------------------------  |
 | master        | [![Build Status][master-public-build]][public-build]      | [![Build Status][master-internal-build]][internal-build]      | [![Build Status][master-core-setup-build]][core-setup-build]     | [![Build Status][master-core-sdk-build]][core-sdk-build]      |
-| release/3.0   | [![Build Status][release3-public-build]][public-build]    | [![Build Status][release3-internal-build]][internal-build]    | [![Build Status][release3-core-setup-build]][core-setup-build]   | [![Build Status][release3-core-sdk-build]][core-sdk-build]    |
 | release/3.1   | [![Build Status][release31-public-build]][public-build]   | [![Build Status][release31-internal-build]][internal-build]   | [![Build Status][release31-core-setup-build]][core-setup-build]  | [![Build Status][release31-core-sdk-build]][core-sdk-build]   |
+| release/3.0   | [![Build Status][release3-public-build]][public-build]    | [![Build Status][release3-internal-build]][internal-build]    | [![Build Status][release3-core-setup-build]][core-setup-build]   | [![Build Status][release3-core-sdk-build]][core-sdk-build]    |
 
 ### Code Coverage
 
 |               | Production Code                                   | 
 |-------------  |-------------------------------------------------  |
 | master        | [![codecov][master-coverage-prod]][coverage]      |
-| release/3.0   | [![codecov][release3-coverage-prod]][coverage]    |
 | release/3.1   | [![codecov][release31-coverage-prod]][coverage]   |
+| release/3.0   | [![codecov][release3-coverage-prod]][coverage]    |
 
-## Status
-
-We are in the process of doing four projects with Windows Forms:
-
-1. Port Windows Forms to .NET Core.
-
-1. Publish source to GitHub.
-
-1. Publish (and in some cases write) tests to GitHub and enable automated testing infrastructure.
-
-1. Enable the Visual Studio WinForms designer to work with WinForms running on .NET Core.
-
-The first two tasks are well underway. Most of the source has been published to GitHub although we are still bringing the codebase up to functional and performance parity with .NET Framework.
-
-We have published very few tests and have very limited coverage for PRs at this time as a result. We will be slow in merging PRs as a result. We will add more tests in 2019, however, it will be an incremental process. We welcome test contributions to increase coverage and help us validate PRs more easily.
-
-The Visual Studio WinForms designer is not yet available and will be part of a Visual Studio 2019 update. In short, we need to move to an out-of-proc model (relative to Visual Studio) for the designer.
 
 ## How to Engage, Contribute, and Provide Feedback
 
 Some of the best ways to contribute are to try things out, file bugs, join in design conversations, and fix issues.
 
-* The [contributing guidelines][contributing] and the more general [.NET Core contributing guide][corefx-contributing] define contributing rules.
-* The [Developer Guide][developing] defines the setup and workflow for working on this repository.
-* If you have a question or have found a bug, [file an issue][issue-new].
+* The [contributing guidelines][contributing] and the more general [.NET Core contributing guide](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/contributing.md) define contributing rules.
+* The [Developer Guide](Documentation/developer-guide.md) defines the setup and workflow for working on this repository.
+* If you have a question or have found a bug, [file an issue](https://github.com/dotnet/winforms/issues/new?template=bug_report.md).
 * Use [daily builds][getting-started] if you want to contribute and stay up to date with the team.
 
 ### .NET Framework issues
 
-Issues with .NET Framework, including WinForms, should be filed on [VS developer community][developer-community], or [Product Support][product-support]. They should not be filed on this repository.
+Issues with .NET Framework, including Windows Forms, should be filed on [VS developer community](https://developercommunity.visualstudio.com/spaces/61/index.html) or [Product Support](https://support.microsoft.com/en-us/contactus?ws=support). They should not be filed on this repository.
 
 ### Reporting security issues
 
-Security issues and bugs should be reported privately via email to the Microsoft Security Response Center (MSRC) <secure@microsoft.com>. You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Further information, including the MSRC PGP key, can be found in the [Security TechCenter][faqs-report-an-issue]. Also see info about related [Microsoft .NET Core and ASP.NET Core Bug Bounty Program][bounty-dot-net-core].
+Security issues and bugs should be reported privately via email to the Microsoft Security Response Center (MSRC) <secure@microsoft.com>. You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Further information, including the MSRC PGP key, can be found in the [Security TechCenter](https://www.microsoft.com/msrc/faqs-report-an-issue). Also see info about related [Microsoft .NET Core and ASP.NET Core Bug Bounty Program](https://www.microsoft.com/msrc/bounty-dot-net-core).
 
 ## Relationship to .NET Framework
 
-This code base is a fork of the Windows Forms code in the .NET Framework. We intend to release .NET Core 3.0 with Windows Forms having parity with the .NET Framework version. Over time, the two implementations may diverge.
+This codebase is a fork of the Windows Forms code in the .NET Framework 4.8. In Windows Forms .NET Core 3.0 we have strived to bring the two runtimes to a parity, however since then we have done a number of [changes, including breaking](https://docs.microsoft.com/en-us/dotnet/core/compatibility/winforms), which diverged the two.
 
-The [Update on .NET Core 3.0 and .NET Framework 4.8][update-on-net-core-3-0-and-net-framework-4-8] provides a good description of the forward-looking differences between .NET Core and .NET Framework.
+Please refer to [Porting guide][porting-guidelines] to learn more about breaking changes.
 
 ## Code of Conduct
 
-This project uses the [.NET Foundation Code of Conduct][dotnet-code-of-conduct] to define expected conduct in our community. Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a project maintainer at conduct@dotnetfoundation.org.
+This project uses the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct) to define expected conduct in our community. Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a project maintainer at conduct@dotnetfoundation.org.
 
 ## License
 
@@ -89,27 +72,12 @@ This project uses the [.NET Foundation Code of Conduct][dotnet-code-of-conduct] 
 
 ## .NET Foundation
 
-.NET Core WinForms is a [.NET Foundation][.net-foundation] project.
-
-See the [.NET home repository][dotnet-home] to find other .NET-related projects.
+.NET Core WinForms is a [.NET Foundation](https://www.dotnetfoundation.org/projects) project.<br />
+See the [.NET home repository](https://github.com/Microsoft/dotnet) to find other .NET-related projects.
 
 [getting-started]: Documentation/getting-started.md
 [contributing]: Documentation/contributing.md
 [porting-guidelines]: Documentation/porting-guidelines.md
-[developing]: Documentation/developer-guide.md
-
-[wpf]: https://github.com/dotnet/wpf
-[.net-core-3.0-sdk-preview]: https://dotnet.microsoft.com/download/dotnet-core/3.0
-[corefx-contributing]: https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/contributing.md
-[issue-new]: https://github.com/dotnet/winforms/issues/new
-[developer-community]: https://developercommunity.visualstudio.com/spaces/61/index.html
-[product-support]: https://support.microsoft.com/en-us/contactus?ws=support
-[faqs-report-an-issue]: https://www.microsoft.com/msrc/faqs-report-an-issue
-[bounty-dot-net-core]: https://www.microsoft.com/msrc/bounty-dot-net-core
-[update-on-net-core-3-0-and-net-framework-4-8]: https://blogs.msdn.microsoft.com/dotnet/2018/10/04/update-on-net-core-3-0-and-net-framework-4-8/
-[dotnet-code-of-conduct]: https://dotnetfoundation.org/code-of-conduct
-[.net-foundation]: https://www.dotnetfoundation.org/projects
-[dotnet-home]: https://github.com/Microsoft/dotnet
 
 [master-public-build]: https://dev.azure.com/dnceng/public/_apis/build/status/267?branchName=master
 [release3-public-build]: https://dev.azure.com/dnceng/public/_apis/build/status/267?branchName=release%2f3.0

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Some of the best ways to contribute are to try things out, file bugs, join in de
 
 ### .NET Framework issues
 
-Issues with .NET Framework, including Windows Forms, should be filed on [VS developer community](https://developercommunity.visualstudio.com/spaces/61/index.html) or [Product Support](https://support.microsoft.com/en-us/contactus?ws=support). They should not be filed on this repository.
+Issues with .NET Framework, including Windows Forms, should be filed on the [Developer Community](https://developercommunity.visualstudio.com/spaces/61/index.html) or [Product Support](https://support.microsoft.com/en-us/contactus?ws=support) websites. They should not be filed on this repository.
 
 ### Reporting security issues
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Security issues and bugs should be reported privately via email to the Microsoft
 
 This codebase is a fork of the Windows Forms code in the .NET Framework 4.8. In Windows Forms .NET Core 3.0 we have strived to bring the two runtimes to a parity, however since then we have done a number of [changes, including breaking](https://docs.microsoft.com/en-us/dotnet/core/compatibility/winforms), which diverged the two.
 
-Please refer to [Porting guide][porting-guidelines] to learn more about breaking changes.
+For more information about breaking changes, see the [Porting guide][porting-guidelines].
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Security issues and bugs should be reported privately via email to the Microsoft
 
 ## Relationship to .NET Framework
 
-This codebase is a fork of the Windows Forms code in the .NET Framework 4.8. In Windows Forms .NET Core 3.0 we have strived to bring the two runtimes to a parity, however since then we have done a number of [changes, including breaking](https://docs.microsoft.com/en-us/dotnet/core/compatibility/winforms), which diverged the two.
+This codebase is a fork of the Windows Forms code in the .NET Framework 4.8. In Windows Forms .NET Core 3.0, we've strived to bring the two runtimes to a parity. However, since then, we've done a number of changes, including [breaking changes](https://docs.microsoft.com/dotnet/core/compatibility/winforms), which diverged the two.
 
 For more information about breaking changes, see the [Porting guide][porting-guidelines].
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Resolves #2501


## Proposed changes

- Update readmes to include links to breaking changes between .NET Framework and .NET Core versions
- Remove out-dated sections
- Update readmes to refer to v3.1 instead of 3.0


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2529)