### PR TITLE
Remove HRESULT constants from NativeMethods.cs

### DIFF
--- a/src/Common/src/Interop/Interop.HRESULT.cs
+++ b/src/Common/src/Interop/Interop.HRESULT.cs
@@ -35,6 +35,7 @@ internal static partial class Interop
         STG_E_ACCESSDENIED = unchecked((int)0x80030005),
         STG_E_INVALIDPARAMETER = unchecked((int)0x80030057),
         STG_E_INVALIDFLAG = unchecked((int)0x800300FF),
+        E_OUTOFMEMORY = unchecked((int)0x8007000E),
         E_ACCESSDENIED = unchecked((int)0x80070005L),
         E_INVALIDARG = unchecked((int)0x80070057),
         ERROR_CANCELLED = unchecked((int)0x800704C7),

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -144,15 +144,7 @@ namespace System.Windows.Forms
         DTN_DROPDOWN = ((0 - 760) + 6),
         DTN_CLOSEUP = ((0 - 760) + 7);
 
-        public const int E_NOTIMPL = unchecked((int)0x80004001),
-        E_OUTOFMEMORY = unchecked((int)0x8007000E),
-        E_INVALIDARG = unchecked((int)0x80070057),
-        E_NOINTERFACE = unchecked((int)0x80004002),
-        E_POINTER = unchecked((int)0x80004003),
-        E_FAIL = unchecked((int)0x80004005),
-        E_UNEXPECTED = unchecked((int)0x8000FFFF),
-        INET_E_DEFAULT_ACTION = unchecked((int)0x800C0011),
-        EMR_POLYTEXTOUT = 97,
+        public const int EMR_POLYTEXTOUT = 97,
         ES_LEFT = 0x0000,
         ES_CENTER = 0x0001,
         ES_RIGHT = 0x0002,
@@ -543,9 +535,6 @@ namespace System.Windows.Forms
         SBT_NOBORDERS = 0x0100,
         SBT_POPOUT = 0x0200,
         SBT_RTLREADING = 0x0400;
-
-        public const int S_OK = 0x00000000;
-        public const int S_FALSE = 0x00000001;
 
         public static bool Succeeded(int hr)
         {

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -512,7 +512,7 @@ namespace System.Windows.Forms
         {
             [return: MarshalAs(UnmanagedType.I4)]
             [PreserveSig]
-            int ShowContextMenu(
+            HRESULT ShowContextMenu(
                 uint dwID,
                 ref Point pt,
                 [In, MarshalAs(UnmanagedType.Interface)]
@@ -522,7 +522,7 @@ namespace System.Windows.Forms
 
             [return: MarshalAs(UnmanagedType.I4)]
             [PreserveSig]
-            int GetHostInfo(
+            HRESULT GetHostInfo(
                 [In, Out]
                 NativeMethods.DOCHOSTUIINFO info);
 
@@ -536,15 +536,15 @@ namespace System.Windows.Forms
 
             [return: MarshalAs(UnmanagedType.I4)]
             [PreserveSig]
-            int HideUI();
+            HRESULT HideUI();
 
             [return: MarshalAs(UnmanagedType.I4)]
             [PreserveSig]
-            int UpdateUI();
+            HRESULT UpdateUI();
 
             [return: MarshalAs(UnmanagedType.I4)]
             [PreserveSig]
-            int EnableModeless(
+            HRESULT EnableModeless(
                 [In, MarshalAs(UnmanagedType.Bool)]
                 bool fEnable);
 
@@ -554,7 +554,7 @@ namespace System.Windows.Forms
 
             [return: MarshalAs(UnmanagedType.I4)]
             [PreserveSig]
-            int OnFrameWindowActivate(
+            HRESULT OnFrameWindowActivate(
                 [In, MarshalAs(UnmanagedType.Bool)]
                 bool fActivate);
 
@@ -572,7 +572,7 @@ namespace System.Windows.Forms
 
             [return: MarshalAs(UnmanagedType.I4)]
             [PreserveSig]
-            int GetOptionKeyPath(
+            HRESULT GetOptionKeyPath(
                 [Out, MarshalAs(UnmanagedType.LPArray)]
                 string[] pbstrKey,
                 [In, MarshalAs(UnmanagedType.U4)]
@@ -585,13 +585,13 @@ namespace System.Windows.Forms
 
             [return: MarshalAs(UnmanagedType.I4)]
             [PreserveSig]
-            int GetExternal(
+            HRESULT GetExternal(
                 [Out, MarshalAs(UnmanagedType.Interface)]
                 out object ppDispatch);
 
             [return: MarshalAs(UnmanagedType.I4)]
             [PreserveSig]
-            int TranslateUrl(
+            HRESULT TranslateUrl(
                 [In, MarshalAs(UnmanagedType.U4)]
                 int dwTranslate,
                 [In, MarshalAs(UnmanagedType.LPWStr)]
@@ -601,7 +601,7 @@ namespace System.Windows.Forms
 
             [return: MarshalAs(UnmanagedType.I4)]
             [PreserveSig]
-            int FilterDataObject(
+            HRESULT FilterDataObject(
                 IComDataObject pDO,
                 out IComDataObject ppDORet);
         }
@@ -620,7 +620,7 @@ namespace System.Windows.Forms
                 out Ole32.IOleClientSite ppClientSite);
 
             [PreserveSig]
-            int SetHostNames(
+            HRESULT SetHostNames(
                    [In, MarshalAs(UnmanagedType.LPWStr)]
                       string szContainerApp,
                    [In, MarshalAs(UnmanagedType.LPWStr)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.OleInterfaces.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.OleInterfaces.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -385,7 +385,7 @@ namespace System.Windows.Forms
                 if (host.GetAxState(AxHost.fOwnWindow))
                 {
                     Debug.Fail("we can't be in showobject if we own our window...");
-                    return NativeMethods.S_OK;
+                    return HRESULT.S_OK;
                 }
                 if (host.GetAxState(AxHost.fFakingWindow))
                 {
@@ -402,7 +402,7 @@ namespace System.Windows.Forms
                 }
                 if (host.GetOcState() < OC_INPLACE)
                 {
-                    return NativeMethods.S_OK;
+                    return HRESULT.S_OK;
                 }
 
                 IntPtr hwnd = IntPtr.Zero;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IPerPropertyBrowsingHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IPerPropertyBrowsingHandler.cs
@@ -342,12 +342,13 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                             }
 
                             var.Clear();
-                            if (hr == NativeMethods.S_OK)
+                            if (hr == HRESULT.S_OK)
                             {
                                 itemCount++;
                                 continue;
                             }
-                            else if (itemCount > 0)
+                            
+                            if (itemCount > 0)
                             {
                                 // shorten the arrays to ignore the failed ones.  this isn't terribly
                                 // efficient but shouldn't happen very often.  It's rare for these to fail.
@@ -362,7 +363,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                         string[] strings = new string[itemCount];
                         Array.Copy(nameItems, 0, strings, 0, itemCount);
                         base.PopulateArrays(strings, valueItems);
-
                     }
                 }
                 catch (Exception ex)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -2313,7 +2313,7 @@ namespace System.Windows.Forms
                                 lpmsg->message = (User32.WindowMessage)msg.Msg;
                                 lpmsg->wParam = msg.WParam;
                                 lpmsg->lParam = msg.LParam;
-                                return NativeMethods.S_OK;
+                                return HRESULT.S_OK;
                             case PreProcessControlState.MessageNeeded:
                                 // Here we need to dispatch the message ourselves
                                 // otherwise the host may never send the key to our wndproc.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -13679,12 +13679,12 @@ namespace System.Windows.Forms
             return HRESULT.S_OK;
         }
 
-        int UnsafeNativeMethods.IOleObject.SetHostNames(string szContainerApp, string szContainerObj)
+        HRESULT UnsafeNativeMethods.IOleObject.SetHostNames(string szContainerApp, string szContainerObj)
         {
             Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:SetHostNames");
             // Since ActiveX controls never "open" for editing, we shouldn't need
             // to store these.
-            return NativeMethods.S_OK;
+            return HRESULT.S_OK;
         }
 
         HRESULT UnsafeNativeMethods.IOleObject.Close(Ole32.OLECLOSE dwSaveOption)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog_Vista.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog_Vista.cs
@@ -186,12 +186,12 @@ namespace System.Windows.Forms
 
             public int OnFileOk(FileDialogNative.IFileDialog pfd)
             {
-                return _dialog.HandleVistaFileOk(pfd) ? NativeMethods.S_OK : NativeMethods.S_FALSE;
+                return _dialog.HandleVistaFileOk(pfd) ? (int)HRESULT.S_OK : (int)HRESULT.S_FALSE;
             }
 
             public int OnFolderChanging(FileDialogNative.IFileDialog pfd, FileDialogNative.IShellItem psiFolder)
             {
-                return NativeMethods.S_OK;
+                return (int)HRESULT.S_OK;
             }
 
             public void OnFolderChange(FileDialogNative.IFileDialog pfd)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StringSource.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StringSource.cs
@@ -106,7 +106,7 @@ namespace System.Windows.Forms
         {
             if (celt < 0)
             {
-                return NativeMethods.E_INVALIDARG;
+                return (int)HRESULT.E_INVALIDARG;
             }
             int fetched = 0;
 
@@ -122,7 +122,7 @@ namespace System.Windows.Forms
             {
                 Marshal.WriteInt32(pceltFetched, fetched);
             }
-            return celt == 0 ? NativeMethods.S_OK : NativeMethods.S_FALSE;
+            return celt == 0 ? (int)HRESULT.S_OK : (int)HRESULT.S_FALSE;
         }
 
         void IEnumString.Reset()
@@ -135,9 +135,9 @@ namespace System.Windows.Forms
             current += celt;
             if (current >= size)
             {
-                return (NativeMethods.S_FALSE);
+                return (int)HRESULT.S_FALSE;
             }
-            return NativeMethods.S_OK;
+            return (int)HRESULT.S_OK;
         }
 
         #endregion

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1466,31 +1466,29 @@ namespace System.Windows.Forms
             //
             // IDocHostUIHandler Implementation
             //
-            int UnsafeNativeMethods.IDocHostUIHandler.ShowContextMenu(uint dwID, ref Point pt, object pcmdtReserved, object pdispReserved)
+            HRESULT UnsafeNativeMethods.IDocHostUIHandler.ShowContextMenu(uint dwID, ref Point pt, object pcmdtReserved, object pdispReserved)
             {
                 WebBrowser wb = (WebBrowser)Host;
 
                 if (wb.IsWebBrowserContextMenuEnabled)
                 {
                     // let MSHTML display its UI
-                    return NativeMethods.S_FALSE;
+                    return HRESULT.S_FALSE;
                 }
-                else
+                
+                if (pt.X == 0 && pt.Y == 0)
                 {
-                    if (pt.X == 0 && pt.Y == 0)
-                    {
-                        // IDocHostUIHandler::ShowContextMenu sends (0,0) when the context menu is invoked via the keyboard
-                        // make it (-1, -1) for the WebBrowser::ShowContextMenu method
-                        pt.X = -1;
-                        pt.Y = -1;
-                    }
-                    wb.ShowContextMenu(pt.X, pt.Y);
-                    // MSHTML should not display its context menu because we displayed ours
-                    return NativeMethods.S_OK;
+                    // IDocHostUIHandler::ShowContextMenu sends (0,0) when the context menu is invoked via the keyboard
+                    // make it (-1, -1) for the WebBrowser::ShowContextMenu method
+                    pt.X = -1;
+                    pt.Y = -1;
                 }
+                wb.ShowContextMenu(pt.X, pt.Y);
+                // MSHTML should not display its context menu because we displayed ours
+                return HRESULT.S_OK;
             }
 
-            int UnsafeNativeMethods.IDocHostUIHandler.GetHostInfo(NativeMethods.DOCHOSTUIINFO info)
+            HRESULT UnsafeNativeMethods.IDocHostUIHandler.GetHostInfo(NativeMethods.DOCHOSTUIINFO info)
             {
                 WebBrowser wb = (WebBrowser)Host;
 
@@ -1516,12 +1514,12 @@ namespace System.Windows.Forms
                     info.dwFlags |= DOCHOSTUIFLAG.NOTHEME;
                 }
 
-                return NativeMethods.S_OK;
+                return HRESULT.S_OK;
             }
 
-            int UnsafeNativeMethods.IDocHostUIHandler.EnableModeless(bool fEnable)
+            HRESULT UnsafeNativeMethods.IDocHostUIHandler.EnableModeless(bool fEnable)
             {
-                return NativeMethods.E_NOTIMPL;
+                return HRESULT.E_NOTIMPL;
             }
 
             HRESULT UnsafeNativeMethods.IDocHostUIHandler.ShowUI(
@@ -1534,14 +1532,14 @@ namespace System.Windows.Forms
                 return HRESULT.S_FALSE;
             }
 
-            int UnsafeNativeMethods.IDocHostUIHandler.HideUI()
+            HRESULT UnsafeNativeMethods.IDocHostUIHandler.HideUI()
             {
-                return NativeMethods.E_NOTIMPL;
+                return HRESULT.E_NOTIMPL;
             }
 
-            int UnsafeNativeMethods.IDocHostUIHandler.UpdateUI()
+            HRESULT UnsafeNativeMethods.IDocHostUIHandler.UpdateUI()
             {
-                return NativeMethods.E_NOTIMPL;
+                return HRESULT.E_NOTIMPL;
             }
 
             HRESULT UnsafeNativeMethods.IDocHostUIHandler.OnDocWindowActivate(BOOL fActivate)
@@ -1549,9 +1547,9 @@ namespace System.Windows.Forms
                 return HRESULT.E_NOTIMPL;
             }
 
-            int UnsafeNativeMethods.IDocHostUIHandler.OnFrameWindowActivate(bool fActivate)
+            HRESULT UnsafeNativeMethods.IDocHostUIHandler.OnFrameWindowActivate(bool fActivate)
             {
-                return NativeMethods.E_NOTIMPL;
+                return HRESULT.E_NOTIMPL;
             }
 
             unsafe HRESULT UnsafeNativeMethods.IDocHostUIHandler.ResizeBorder(RECT* rect, Ole32.IOleInPlaceUIWindow doc, BOOL fFrameWindow)
@@ -1559,9 +1557,9 @@ namespace System.Windows.Forms
                 return HRESULT.E_NOTIMPL;
             }
 
-            int UnsafeNativeMethods.IDocHostUIHandler.GetOptionKeyPath(string[] pbstrKey, int dw)
+            HRESULT UnsafeNativeMethods.IDocHostUIHandler.GetOptionKeyPath(string[] pbstrKey, int dw)
             {
-                return NativeMethods.E_NOTIMPL;
+                return HRESULT.E_NOTIMPL;
             }
 
             HRESULT UnsafeNativeMethods.IDocHostUIHandler.GetDropTarget(Ole32.IDropTarget pDropTarget, out Ole32.IDropTarget ppDropTarget)
@@ -1572,11 +1570,11 @@ namespace System.Windows.Forms
                 return HRESULT.E_NOTIMPL;
             }
 
-            int UnsafeNativeMethods.IDocHostUIHandler.GetExternal(out object ppDispatch)
+            HRESULT UnsafeNativeMethods.IDocHostUIHandler.GetExternal(out object ppDispatch)
             {
                 WebBrowser wb = (WebBrowser)Host;
                 ppDispatch = wb.ObjectForScripting;
-                return NativeMethods.S_OK;
+                return HRESULT.S_OK;
             }
 
             unsafe HRESULT UnsafeNativeMethods.IDocHostUIHandler.TranslateAccelerator(User32.MSG* lpMsg, Guid* pguidCmdGroup, uint nCmdID)
@@ -1601,22 +1599,22 @@ namespace System.Windows.Forms
                 return HRESULT.S_FALSE;
             }
 
-            int UnsafeNativeMethods.IDocHostUIHandler.TranslateUrl(int dwTranslate, string strUrlIn, out string pstrUrlOut)
+            HRESULT UnsafeNativeMethods.IDocHostUIHandler.TranslateUrl(int dwTranslate, string strUrlIn, out string pstrUrlOut)
             {
                 //
                 // Set to null no matter what we return, to prevent the marshaller
                 // from having issues if the pointer points to random stuff.
                 pstrUrlOut = null;
-                return NativeMethods.S_FALSE;
+                return HRESULT.S_FALSE;
             }
 
-            int UnsafeNativeMethods.IDocHostUIHandler.FilterDataObject(IComDataObject pDO, out IComDataObject ppDORet)
+            HRESULT UnsafeNativeMethods.IDocHostUIHandler.FilterDataObject(IComDataObject pDO, out IComDataObject ppDORet)
             {
                 //
                 // Set to null no matter what we return, to prevent the marshaller
                 // from having issues if the pointer points to random stuff.
                 ppDORet = null;
-                return NativeMethods.S_FALSE;
+                return HRESULT.S_FALSE;
             }
 
             //


### PR DESCRIPTION
## Proposed changes

- Remove HRESULT constants from NativeMethods.cs.
- Add E_OUTOFMEMORY in HRESULT enum.
- Replace the usages of the constants with the enum values.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2535)