### PR TITLE
Move GetProcessWindowStation to Interop User32

### DIFF
--- a/src/Common/src/Interop/User32/Interop.GetProcessWindowStation.cs
+++ b/src/Common/src/Interop/User32/Interop.GetProcessWindowStation.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern IntPtr GetProcessWindowStation();
+    }
+}

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -322,9 +322,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
         public static extern IntPtr DefMDIChildProc(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
 
-        [DllImport(ExternDll.User32, ExactSpelling = true)]
-        public static extern IntPtr GetProcessWindowStation();
-
         [DllImport(ExternDll.User32, SetLastError = true)]
         public static extern bool GetUserObjectInformation(HandleRef hObj, int nIndex, ref NativeMethods.USEROBJECTFLAGS pvBuffer, int nLength, ref int lpnLengthNeeded);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SystemInformation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SystemInformation.cs
@@ -634,7 +634,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                IntPtr hwinsta = UnsafeNativeMethods.GetProcessWindowStation();
+                IntPtr hwinsta = User32.GetProcessWindowStation();
                 if (hwinsta != IntPtr.Zero && s_processWinStation != hwinsta)
                 {
                     s_isUserInteractive = true;


### PR DESCRIPTION
## Proposed changes

- Move GetProcessWindowStation to Interop User32.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2536)