### PR TITLE
Fix incorrect call to GetTextColor in Interop.Gdi32.SetBkColor

### DIFF
--- a/src/Common/src/Interop/Gdi32/Interop.SetBkColor.cs
+++ b/src/Common/src/Interop/Gdi32/Interop.SetBkColor.cs
@@ -15,14 +15,14 @@ internal static partial class Interop
 
         public static int SetBkColor(IHandle hdc, int color)
         {
-            int result = GetTextColor(hdc.Handle);
+            int result = SetBkColor(hdc.Handle, color);
             GC.KeepAlive(hdc);
             return result;
         }
 
         public static int SetBkColor(HandleRef hdc, int color)
         {
-            int result = GetTextColor(hdc.Handle);
+            int result = SetBkColor(hdc.Handle, color);
             GC.KeepAlive(hdc.Wrapper);
             return result;
         }


### PR DESCRIPTION
Fixes #2523
Fixes #2524

//cc @hughbe 

## Proposed changes

- Fix `Interop.Gdi32.SetBkColor` to correctly call `SetBkColor` rather than `GetTextColor`, which has been broken with #1922.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Background Color will be applied correctly, e.g. in PropertyGrid.

## Regression? 

- Yes

## Risk

-


<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![bgcolor-before](https://user-images.githubusercontent.com/13289184/71322853-b19ce800-24cc-11ea-989a-f2a4f018a683.png)


### After
![bgcolor-after](https://user-images.githubusercontent.com/13289184/71322856-b82b5f80-24cc-11ea-80f1-0b3419bddec0.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual testing using sample code from #2523 and #2524


## Test environment(s) <!-- Remove any that don't apply -->

.NET Core SDK (reflecting any global.json):
 Version:   5.0.100-alpha1-015777
 Commit:    cea32db3f2

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.17134
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\5.0.100-alpha1-015777\

Host (useful for support):
  Version: 5.0.0-alpha.1.19564.1
  Commit:  c77948d92a

.NET Core SDKs installed:
  3.1.100 [C:\Program Files\dotnet\sdk]
  5.0.100-alpha1-015777 [C:\Program Files\dotnet\sdk]

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2550)