### PR TITLE
Fix wrong argument in Interop.Gdi32.BitBlt

### DIFF
--- a/src/Common/src/Interop/Gdi32/Interop.BitBlt.cs
+++ b/src/Common/src/Interop/Gdi32/Interop.BitBlt.cs
@@ -36,7 +36,7 @@ internal static partial class Interop
                 hdc.Handle,
                 x,
                 y,
-                cy,
+                cx,
                 cy,
                 hdcSrc.Handle,
                 x1,


### PR DESCRIPTION
Fixes #2525


## Proposed changes

- Fix wrong argument passed to the native `BitBlt` function, which was introduced with #2144.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- ToolStrip will be drawn correctly.

## Regression? 

- Yes

## Risk

-

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![grafik](https://user-images.githubusercontent.com/13289184/71323698-62f44b80-24d6-11ea-90d4-38ddebd26d27.png)


### After
![grafik](https://user-images.githubusercontent.com/13289184/71323685-39d3bb00-24d6-11ea-883e-71315b03a2f1.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual testing by using sample project from #2525

 

## Test environment(s) <!-- Remove any that don't apply -->

.NET Core SDK (reflecting any global.json):
 Version:   5.0.100-alpha1-015777
 Commit:    cea32db3f2

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.17134
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\5.0.100-alpha1-015777\

Host (useful for support):
  Version: 5.0.0-alpha.1.19564.1
  Commit:  c77948d92a

.NET Core SDKs installed:
  3.1.100 [C:\Program Files\dotnet\sdk]
  5.0.100-alpha1-015777 [C:\Program Files\dotnet\sdk]


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2551)