### PR TITLE
Cleanup LVGROUPW interop and fix HeaderAlignment refresh bugList view group tests

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.LVGROUPW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.LVGROUPW.cs
@@ -3,21 +3,23 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
     internal static partial class ComCtl32
     {
-        public struct LVGROUP
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public unsafe struct LVGROUPW
         {
             public uint cbSize;
             public LVGF mask;
-            public IntPtr pszHeader;
+            public char* pszHeader;
             public int cchHeader;
-            public IntPtr pszFooter;
+            public char* pszFooter;
             public int cchFooter;
             public int iGroupId;
-            public uint stateMask;
+            public LVGS stateMask;
             public LVGS state;
             public LVGA uAlign;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -2994,14 +2994,6 @@ namespace System.Windows.Forms
             }
         }
 
-        private void DestroyLVGROUP(LVGROUP lvgroup)
-        {
-            if (lvgroup.pszHeader != IntPtr.Zero)
-            {
-                Marshal.FreeHGlobal(lvgroup.pszHeader);
-            }
-        }
-
         /// <summary>
         ///  Resets the imageList to null.  We wire this method up to the imageList's
         ///  Dispose event, so that we don't hang onto an imageList that's gone away.
@@ -3633,38 +3625,6 @@ namespace System.Windows.Forms
             return Rectangle.FromLTRB(itemrect.left, itemrect.top, itemrect.right, itemrect.bottom);
         }
 
-        private unsafe LVGROUP GetLVGROUP(ListViewGroup group)
-        {
-            var lvgroup = new LVGROUP
-            {
-                cbSize = (uint)sizeof(LVGROUP),
-                mask = LVGF.HEADER | LVGF.GROUPID | LVGF.ALIGN
-            };
-
-            // Header
-            string header = group.Header;
-            lvgroup.pszHeader = Marshal.StringToHGlobalAuto(header);
-            lvgroup.cchHeader = header.Length;
-
-            // Group ID
-            lvgroup.iGroupId = group.ID;
-
-            // Alignment
-            switch (group.HeaderAlignment)
-            {
-                case HorizontalAlignment.Left:
-                    lvgroup.uAlign = LVGA.HEADER_LEFT;
-                    break;
-                case HorizontalAlignment.Right:
-                    lvgroup.uAlign = LVGA.HEADER_RIGHT;
-                    break;
-                case HorizontalAlignment.Center:
-                    lvgroup.uAlign = LVGA.HEADER_CENTER;
-                    break;
-            }
-            return lvgroup;
-        }
-
         /// <summary>
         ///  Returns a listview sub-item's bounding rectangle.
         /// </summary>
@@ -3962,22 +3922,13 @@ namespace System.Windows.Forms
         }
 
         // does the Win32 part of the job of inserting the group
-        private void InsertGroupNative(int index, ListViewGroup group)
+        private unsafe void InsertGroupNative(int index, ListViewGroup group)
         {
             Debug.Assert(IsHandleCreated, "InsertGroupNative precondition: list-view handle must be created");
             Debug.Assert(group == DefaultGroup || Groups.Contains(group), "Make sure ListView.Groups contains this group before adding the native LVGROUP. Otherwise, custom-drawing may break.");
 
-            var lvgroup = new LVGROUP();
-            try
-            {
-                lvgroup = GetLVGROUP(group);
-                int retval = (int)User32.SendMessageW(this, (User32.WindowMessage)LVM.INSERTGROUP, (IntPtr)index, ref lvgroup);
-                Debug.Assert(retval != -1, "Failed to insert group");
-            }
-            finally
-            {
-                DestroyLVGROUP(lvgroup);
-            }
+            IntPtr result = SendGroupMessage(group, LVM.INSERTGROUP, (IntPtr)index, LVGF.GROUPID);
+            Debug.Assert(result != (IntPtr)(-1), "Failed to insert group");
         }
 
         /// <summary>
@@ -5563,19 +5514,39 @@ namespace System.Windows.Forms
         {
             Debug.Assert(IsHandleCreated, "UpdateGroupNative precondition: list-view handle must be created");
 
-            var lvgroup = new LVGROUP();
-            try
-            {
-                lvgroup = GetLVGROUP(group);
-                int retval = (int)User32.SendMessageW(this, (User32.WindowMessage)LVM.SETGROUPINFO, (IntPtr)group.ID, ref lvgroup);
-            }
-            finally
-            {
-                DestroyLVGROUP(lvgroup);
-            }
+            IntPtr result = SendGroupMessage(group, LVM.SETGROUPINFO, (IntPtr)group.ID, (LVGF)0);
+            Debug.Assert(result != (IntPtr)(-1));
+        }
 
-            // The comctl32 ListView does not correctly invalidate itself, so we need to invalidate the entire ListView
-            Invalidate();
+        private unsafe IntPtr SendGroupMessage(ListViewGroup group, LVM msg, IntPtr lParam, LVGF additionalMask)
+        {
+            string header = group.Header;
+            var lvgroup = new LVGROUPW
+            {
+                cbSize = (uint)sizeof(LVGROUPW),
+                mask = LVGF.HEADER | LVGF.ALIGN | additionalMask,
+                cchHeader = header.Length,
+                iGroupId = group.ID
+            };
+
+            switch (group.HeaderAlignment)
+            {
+                case HorizontalAlignment.Left:
+                    lvgroup.uAlign = LVGA.HEADER_LEFT;
+                    break;
+                case HorizontalAlignment.Right:
+                    lvgroup.uAlign = LVGA.HEADER_RIGHT;
+                    break;
+                case HorizontalAlignment.Center:
+                    lvgroup.uAlign = LVGA.HEADER_CENTER;
+                    break;
+            }
+            
+            fixed (char* pHeader = header)
+            {
+                lvgroup.pszHeader = pHeader;
+                return User32.SendMessageW(this, (User32.WindowMessage)msg, lParam, ref lvgroup);
+            }
         }
 
         // ListViewGroupCollection::Clear needs to remove the items from the Default group

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
@@ -80,7 +80,7 @@ namespace System.Windows.Forms
                 if (_header != value)
                 {
                     _header = value;
-                    ListView?.RecreateHandleInternal();
+                    UpdateListView();
                 }
             }
         }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.cs
@@ -135,6 +135,10 @@ namespace WinformsControlsTest
             // Add the ListView to the control collection.
             Controls.Add(listView2);
             listView2.Dock = DockStyle.Bottom;
+
+            // Change a ListViewGroup's header.
+            listView2.Groups[0].HeaderAlignment = HorizontalAlignment.Center;
+            listView2.Groups[0].Header = "NewText";
         }
 
         private void listView2_Click(object sender, System.EventArgs e)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupTests.cs
@@ -6,16 +6,19 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
+using Microsoft.DotNet.RemoteExecutor;
 using WinForms.Common.Tests;
 using Xunit;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
-    public class ListViewGroupTests
+    public class ListViewGroupTests : IClassFixture<ThreadExceptionFixture>
     {
-        [Fact]
+        [WinFormsFact]
         public void ListViewGroup_Ctor_Default()
         {
             var group = new ListViewGroup();
@@ -28,7 +31,7 @@ namespace System.Windows.Forms.Tests
             Assert.Null(group.Tag);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
         public void ListViewGroup_Ctor_String(string header, string expectedHeader)
         {
@@ -51,7 +54,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { "reasonable", (HorizontalAlignment)(HorizontalAlignment.Center + 1), "reasonable" };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(Ctor_String_HorizontalAlignment_TestData))]
         public void ListViewGroup_Ctor_String_HorizontalAlignment(string header, HorizontalAlignment headerAlignment, string expectedHeader)
         {
@@ -72,7 +75,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { "key", "header", "header" };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(Ctor_String_String_TestData))]
         public void ListViewGroup_Ctor_String_String(string key, string header, string expectedHeader)
         {
@@ -86,25 +89,10 @@ namespace System.Windows.Forms.Tests
             Assert.Null(group.Tag);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
-        public void ListViewGroup_Header_SetWithListView_GetReturnsExpected(string value, string expected)
-        {
-            var listView = new ListView();
-            var group = new ListViewGroup();
-            listView.Groups.Add(group);
-
-            group.Header = value;
-            Assert.Equal(expected, group.Header);
-
-            // Set same.
-            group.Header = value;
-            Assert.Equal(expected, group.Header);
-        }
-
-        [Theory]
-        [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
-        public void ListViewGroup_Header_SetWithoutListView_GetReturnsExpected(string value, string expected)
+        [InlineData("te\0xt", "te\0xt")]
+        public void ListViewGroup_Header_SetWithoutListViewGroup_GetReturnsExpected(string value, string expected)
         {
             var group = new ListViewGroup
             {
@@ -117,42 +105,108 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, group.Header);
         }
 
-        [Theory]
-        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(HorizontalAlignment))]
-        public void ListViewGroup_HeaderAlignment_SetWithListView_GetReturnsExpected(HorizontalAlignment value)
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
+        [InlineData("te\0xt", "te\0xt")]
+        public void ListViewGroup_Header_SetWithListViewGroup_GetReturnsExpected(string value, string expected)
         {
-            var listView = new ListView();
+            using var listView = new ListView();
             var group = new ListViewGroup();
             listView.Groups.Add(group);
 
-            group.HeaderAlignment = value;
-            Assert.Equal(value, group.HeaderAlignment);
+            group.Header = value;
+            Assert.Equal(expected, group.Header);
+            Assert.False(listView.IsHandleCreated);
 
             // Set same.
-            group.HeaderAlignment = value;
-            Assert.Equal(value, group.HeaderAlignment);
+            group.Header = value;
+            Assert.Equal(expected, group.Header);
+            Assert.False(listView.IsHandleCreated);
         }
 
-        [Theory]
-        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(HorizontalAlignment))]
-        public void ListViewGroup_HeaderAlignment_SetWithListViewWithHandle_GetReturnsExpected(HorizontalAlignment value)
+        [WinFormsTheory]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("header", "header")]
+        [InlineData("te\0xt", "te\0xt")]
+        [InlineData("ListViewGroup", "ListViewGroup")]
+        public void ListViewGroup_Header_SetWithListViewWithHandle_GetReturnsExpected(string value, string expected)
         {
-            var listView = new ListView();
+            using var listView = new ListView();
+            var group = new ListViewGroup();
+            listView.Groups.Add(group);
             Assert.NotEqual(IntPtr.Zero, listView.Handle);
-            var group = new ListViewGroup();
-            listView.Groups.Add(group);
+            int invalidatedCallCount = 0;
+            listView.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            listView.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            listView.HandleCreated += (sender, e) => createdCallCount++;
 
-            group.HeaderAlignment = value;
-            Assert.Equal(value, group.HeaderAlignment);
+            group.Header = value;
+            Assert.Equal(expected, group.Header);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
 
             // Set same.
-            group.HeaderAlignment = value;
-            Assert.Equal(value, group.HeaderAlignment);
+            group.Header = value;
+            Assert.Equal(expected, group.Header);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
         }
 
-        [Theory]
+        public static IEnumerable<object[]> Header_GetGroupInfo_TestData()
+        {
+            yield return new object[] { null, string.Empty };
+            yield return new object[] { string.Empty, string.Empty };
+            yield return new object[] { "text", "text" };
+            yield return new object[] { "te\0t", "te" };
+        }
+
+        [WinFormsFact]
+        public unsafe void ListViewGroup_Header_GetGroupInfo_Success()
+        {
+            // Run this from another thread as we call Application.EnableVisualStyles.
+            RemoteExecutor.Invoke(() =>
+            {
+                foreach (object[] data in Header_GetGroupInfo_TestData())
+                {
+                    string value = (string)data[0];
+                    string expected = (string)data[1];
+
+                    Application.EnableVisualStyles();
+
+                    using var listView = new ListView();
+                    var group = new ListViewGroup();
+                    listView.Groups.Add(group);
+
+                    Assert.NotEqual(IntPtr.Zero, listView.Handle);
+                    group.Header = value;
+
+                    Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WindowMessage)ComCtl32.LVM.GETGROUPCOUNT, IntPtr.Zero, IntPtr.Zero));
+                    char* buffer = stackalloc char[256];
+                    var lvgroup = new ComCtl32.LVGROUPW
+                    {
+                        cbSize = (uint)sizeof(ComCtl32.LVGROUPW),
+                        mask = ComCtl32.LVGF.HEADER | ComCtl32.LVGF.GROUPID | ComCtl32.LVGF.ALIGN,
+                        pszHeader = buffer,
+                        cchHeader = 256
+                    };
+                    Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WindowMessage)ComCtl32.LVM.GETGROUPINFOBYINDEX, (IntPtr)0, ref lvgroup));
+                    Assert.Equal(expected, new string(lvgroup.pszHeader));
+                    Assert.True(lvgroup.iGroupId >= 0);
+                    Assert.Equal(ComCtl32.LVGA.HEADER_LEFT, lvgroup.uAlign);
+                }
+            }).Dispose();
+        }
+
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(HorizontalAlignment))]
-        public void ListViewGroup_HeaderAlignment_SetWithoutListView_GetReturnsExpected(HorizontalAlignment value)
+        public void ListViewGroup_HeaderAlignment_SetWithoutListViewGroup_GetReturnsExpected(HorizontalAlignment value)
         {
             var group = new ListViewGroup
             {
@@ -165,7 +219,92 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(value, group.HeaderAlignment);
         }
 
-        [Theory]
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(HorizontalAlignment))]
+        public void ListViewGroup_HeaderAlignment_SetWithListViewGroup_GetReturnsExpected(HorizontalAlignment value)
+        {
+            using var listView = new ListView();
+            var group = new ListViewGroup();
+            listView.Groups.Add(group);
+
+            group.HeaderAlignment = value;
+            Assert.Equal(value, group.HeaderAlignment);
+            Assert.False(listView.IsHandleCreated);
+
+            // Set same.
+            group.HeaderAlignment = value;
+            Assert.Equal(value, group.HeaderAlignment);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(HorizontalAlignment))]
+        public void ListViewGroup_HeaderAlignment_SetWithListViewWithHandle_GetReturnsExpected(HorizontalAlignment value)
+        {
+            using var listView = new ListView();
+            var group = new ListViewGroup();
+            listView.Groups.Add(group);
+            Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            int invalidatedCallCount = 0;
+            listView.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            listView.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            listView.HandleCreated += (sender, e) => createdCallCount++;
+
+            group.HeaderAlignment = value;
+            Assert.Equal(value, group.HeaderAlignment);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+
+            // Set same.
+            group.HeaderAlignment = value;
+            Assert.Equal(value, group.HeaderAlignment);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+        }
+
+        [WinFormsTheory]
+        [InlineData(HorizontalAlignment.Left, 0x00000001)]
+        [InlineData(HorizontalAlignment.Center, 0x00000002)]
+        [InlineData(HorizontalAlignment.Right, 0x00000004)]
+        public unsafe void ListView_HeaderAlignment_GetGroupInfo_Success(HorizontalAlignment valueParam, int expectedAlignParam)
+        {
+            // Run this from another thread as we call Application.EnableVisualStyles.
+            RemoteExecutor.Invoke((valueString, expectedAlignString) =>
+            {
+                HorizontalAlignment value = (HorizontalAlignment)Enum.Parse(typeof(HorizontalAlignment), valueString);
+                int expectedAlign = int.Parse(expectedAlignString);
+
+                Application.EnableVisualStyles();
+                using var listView = new ListView();
+                var group1 = new ListViewGroup();
+                listView.Groups.Add(group1);
+
+                Assert.NotEqual(IntPtr.Zero, listView.Handle);
+                group1.HeaderAlignment = value;
+
+                Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WindowMessage)ComCtl32.LVM.GETGROUPCOUNT, IntPtr.Zero, IntPtr.Zero));
+                char* buffer = stackalloc char[256];
+                var lvgroup = new ComCtl32.LVGROUPW
+                {
+                    cbSize = (uint)sizeof(ComCtl32.LVGROUPW),
+                    mask = ComCtl32.LVGF.HEADER | ComCtl32.LVGF.GROUPID | ComCtl32.LVGF.ALIGN,
+                    pszHeader = buffer,
+                    cchHeader = 256
+                };
+                Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WindowMessage)ComCtl32.LVM.GETGROUPINFOBYINDEX, (IntPtr)0, ref lvgroup));
+                Assert.Equal("ListViewGroup", new string(lvgroup.pszHeader));
+                Assert.True(lvgroup.iGroupId >= 0);
+                Assert.Equal(expectedAlign, (int)lvgroup.uAlign);
+            }, valueParam.ToString(), expectedAlignParam.ToString()).Dispose();
+        }
+
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryDataInvalid), typeof(HorizontalAlignment))]
         public void ListViewGroup_HeaderAlignment_SetInvalid_ThrowsInvalidEnumArgumentException(HorizontalAlignment value)
         {
@@ -173,7 +312,7 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<InvalidEnumArgumentException>("value", () => group.HeaderAlignment = value);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringWithNullTheoryData))]
         public void ListViewGroup_Name_Set_GetReturnsExpected(string value)
         {
@@ -188,7 +327,7 @@ namespace System.Windows.Forms.Tests
             Assert.Same(value, group.Name);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringWithNullTheoryData))]
         public void ListViewGroup_Tag_Set_GetReturnsExpected(string value)
         {
@@ -208,12 +347,16 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { new ListViewGroup() };
             yield return new object[] { new ListViewGroup("header", HorizontalAlignment.Center) { Name = "name", Tag = "tag" } };
 
+            var groupWithEmptyItems = new ListViewGroup();
+            Assert.Empty(groupWithEmptyItems.Items);
+            yield return new object[] { groupWithEmptyItems };
+
             var groupWithItems = new ListViewGroup();
             groupWithItems.Items.Add(new ListViewItem("text"));
             yield return new object[] { groupWithItems };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(Serialize_Deserialize_TestData))]
         public void ListViewGroup_Serialize_Deserialize_Success(ListViewGroup group)
         {
@@ -232,12 +375,74 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
         public void ListViewGroup_ToString_Invoke_ReturnsExpected(string header, string expected)
         {
             var group = new ListViewGroup(header);
             Assert.Equal(expected, group.ToString());
+        }
+
+        [WinFormsFact]
+        public void ListViewGroup_ISerializableGetObjectData_InvokeSimple_Success()
+        {
+            var group = new ListViewGroup();
+            ISerializable iSerializable = group;
+            var info = new SerializationInfo(typeof(ListViewGroup), new FormatterConverter());
+            var context = new StreamingContext();
+
+            iSerializable.GetObjectData(info, context);
+            Assert.Equal("ListViewGroup", info.GetString("Header"));
+            Assert.Equal(HorizontalAlignment.Left, info.GetValue("HeaderAlignment", typeof(HorizontalAlignment)));
+            Assert.Throws<SerializationException>(() => info.GetString("Name"));
+            Assert.Null(info.GetValue("Tag", typeof(object)));
+            Assert.Throws<SerializationException>(() => info.GetInt32("ItemsCount"));
+        }
+
+        [WinFormsFact]
+        public void ListViewGroup_ISerializableGetObjectData_InvokeWithEmptyItems_Success()
+        {
+            var group = new ListViewGroup();
+            Assert.Empty(group.Items);
+
+            ISerializable iSerializable = group;
+            var info = new SerializationInfo(typeof(ListViewGroup), new FormatterConverter());
+            var context = new StreamingContext();
+            
+            iSerializable.GetObjectData(info, context);
+            Assert.Equal("ListViewGroup", info.GetString("Header"));
+            Assert.Equal(HorizontalAlignment.Left, info.GetValue("HeaderAlignment", typeof(HorizontalAlignment)));
+            Assert.Throws<SerializationException>(() => info.GetString("Name"));
+            Assert.Null(info.GetValue("Tag", typeof(object)));
+            Assert.Throws<SerializationException>(() => info.GetInt32("ItemsCount"));
+        }
+
+        [WinFormsFact]
+        public void ListViewGroup_ISerializableGetObjectData_InvokeWithItems_Success()
+        {
+            var group = new ListViewGroup();
+            group.Items.Add(new ListViewItem("text"));
+
+            ISerializable iSerializable = group;
+            var info = new SerializationInfo(typeof(ListViewGroup), new FormatterConverter());
+            var context = new StreamingContext();
+            
+            iSerializable.GetObjectData(info, context);
+            Assert.Equal("ListViewGroup", info.GetString("Header"));
+            Assert.Equal(HorizontalAlignment.Left, info.GetValue("HeaderAlignment", typeof(HorizontalAlignment)));
+            Assert.Throws<SerializationException>(() => info.GetString("Name"));
+            Assert.Null(info.GetValue("Tag", typeof(object)));
+            Assert.Equal(1, info.GetInt32("ItemsCount"));
+            Assert.Equal("text", ((ListViewItem)info.GetValue("Item0", typeof(ListViewItem))).Text);
+        }
+
+        [WinFormsFact]
+        public void ListViewGroup_ISerializableGetObjectData_NullInfo_ThrowsNullReferenceException()
+        {
+            var group = new ListViewGroup();
+            ISerializable iSerializable = group;
+            var context = new StreamingContext();
+            Assert.Throws<NullReferenceException>(() => iSerializable.GetObjectData(null, context));
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes
- Fix setting ListViewGroup.HeaderAlignment if the handle is already created
- Avoid marshalling using `Marshal.PtrToStringAuto` and instead pin a `string`
- Add tests to make sure we are calling into comctl32 correctly

Fixes https://github.com/dotnet/winforms/issues/2554

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2555)