### PR TITLE
Add ListViewInsertionMark ComCtl32 tests 

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewInsertionMarkTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewInsertionMarkTests.cs
@@ -4,6 +4,8 @@
 
 using System.Collections.Generic;
 using System.Drawing;
+using System.Runtime.InteropServices;
+using Microsoft.DotNet.RemoteExecutor;
 using WinForms.Common.Tests;
 using Xunit;
 using static Interop;
@@ -11,58 +13,178 @@ using static Interop.ComCtl32;
 
 namespace System.Windows.Forms.Tests
 {
+    using Point = System.Drawing.Point;
+
     public class ListViewInsertionMarkTests : IClassFixture<ThreadExceptionFixture>
     {
-        [Fact]
+        [WinFormsFact]
         public void ListViewInsertionMark_AppearsAfterItem_Get_ReturnsExpected()
         {
-            var listView = new ListView();
-            ListViewInsertionMark insertionMark = listView.InsertionMark;
+            using var control = new ListView();
+            ListViewInsertionMark insertionMark = control.InsertionMark;
             Assert.False(insertionMark.AppearsAfterItem);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Fact]
-        public void ListViewInsertionMark_AppearsAfterItem_SetWithHandle_ReturnsExpected()
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void ListViewInsertionMark_AppearsAfterItem_Set_GetReturnsExpected(bool value)
         {
-            var listView = new ListView();
-            Assert.NotEqual(IntPtr.Zero, listView.Handle);
-            ListViewInsertionMark insertionMark = listView.InsertionMark;
+            using var control = new ListView();
+            ListViewInsertionMark insertionMark = control.InsertionMark;
 
-            // Set true.
-            insertionMark.AppearsAfterItem = true;
-            Assert.True(insertionMark.AppearsAfterItem);
+            insertionMark.AppearsAfterItem = value;
+            Assert.Equal(value, insertionMark.AppearsAfterItem);
+            Assert.False(control.IsHandleCreated);
+            
+            // Set same.
+            insertionMark.AppearsAfterItem = value;
+            Assert.Equal(value, insertionMark.AppearsAfterItem);
+            Assert.False(control.IsHandleCreated);
+            
+            // Set different.
+            insertionMark.AppearsAfterItem = !value;
+            Assert.Equal(!value, insertionMark.AppearsAfterItem);
+            Assert.False(control.IsHandleCreated);
+        }
+        
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void ListViewInsertionMark_AppearsAfterItem_SetWithHandle_GetReturnsExpected(bool value)
+        {
+            using var control = new ListView();
+            ListViewInsertionMark insertionMark = control.InsertionMark;
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            int invalidatedCallCount = 0;
+            control.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            control.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            control.HandleCreated += (sender, e) => createdCallCount++;
 
-            // Set again to test caching behaviour.
-            insertionMark.AppearsAfterItem = true;
-            Assert.True(insertionMark.AppearsAfterItem);
-
-            // Set false.
-            insertionMark.AppearsAfterItem = false;
-            Assert.False(insertionMark.AppearsAfterItem);
-
-            // Set with color.
-            insertionMark.Color = Color.Blue;
-            insertionMark.AppearsAfterItem = true;
-            Assert.True(insertionMark.AppearsAfterItem);
+            insertionMark.AppearsAfterItem = value;
+            Assert.Equal(value, insertionMark.AppearsAfterItem);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+            
+            // Set same.
+            insertionMark.AppearsAfterItem = value;
+            Assert.Equal(value, insertionMark.AppearsAfterItem);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+            
+            // Set different.
+            insertionMark.AppearsAfterItem = !value;
+            Assert.Equal(!value, insertionMark.AppearsAfterItem);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
         }
 
-        [Fact]
-        public void ListViewInsertionMark_AppearsAfterItem_SetWithoutHandle_ReturnsExpected()
+        [WinFormsFact]
+        public unsafe void ListViewInsertionMark_AppearsAfterItem_GetInsertMark_Success()
         {
-            var listView = new ListView();
-            ListViewInsertionMark insertionMark = listView.InsertionMark;
+            // Run this from another thread as we call Application.EnableVisualStyles.
+            RemoteExecutor.Invoke(() =>
+            {
+                Application.EnableVisualStyles();
 
-            // Set true.
-            insertionMark.AppearsAfterItem = true;
-            Assert.True(insertionMark.AppearsAfterItem);
+                using var control = new ListView();
+                ListViewInsertionMark insertionMark = control.InsertionMark;
 
-            // Set again to test caching behaviour.
-            insertionMark.AppearsAfterItem = true;
-            Assert.True(insertionMark.AppearsAfterItem);
+                // Set same.
+                Assert.NotEqual(IntPtr.Zero, control.Handle);
+                control.InsertionMark.AppearsAfterItem = false;
+                var insertMark = new ComCtl32.LVINSERTMARK
+                {
+                    cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
+                };
+                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
+                Assert.Equal(-1, insertMark.iItem);
+                Assert.Equal(0u, insertMark.dwReserved);
+                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
 
-            // Set false.
-            insertionMark.AppearsAfterItem = false;
-            Assert.False(insertionMark.AppearsAfterItem);
+                // Set true.
+                control.InsertionMark.AppearsAfterItem = true;
+                insertMark = new ComCtl32.LVINSERTMARK
+                {
+                    cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
+                };
+                Assert.Equal((IntPtr)1, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(0x80000001, (uint)insertMark.dwFlags);
+                Assert.Equal(0, insertMark.iItem);
+                Assert.Equal(0u, insertMark.dwReserved);
+                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+
+                // Set false.
+                control.InsertionMark.AppearsAfterItem = false;
+                insertMark = new ComCtl32.LVINSERTMARK
+                {
+                    cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
+                };
+                Assert.Equal((IntPtr)1, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
+                Assert.Equal(0, insertMark.iItem);
+                Assert.Equal(0u, insertMark.dwReserved);
+                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+            }).Dispose();
+        }
+
+        [WinFormsFact]
+        public unsafe void ListViewInsertionMark_AppearsAfterItem_GetInsertMarkWithColor_Success()
+        {
+            // Run this from another thread as we call Application.EnableVisualStyles.
+            RemoteExecutor.Invoke(() =>
+            {
+                Application.EnableVisualStyles();
+
+                using var control = new ListView();
+                ListViewInsertionMark insertionMark = control.InsertionMark;
+                control.InsertionMark.Color = Color.FromArgb(0x12, 0x34, 0x56, 0x78);
+
+                // Set same.
+                Assert.NotEqual(IntPtr.Zero, control.Handle);
+                control.InsertionMark.AppearsAfterItem = false;
+                var insertMark = new ComCtl32.LVINSERTMARK
+                {
+                    cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
+                };
+                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
+                Assert.Equal(-1, insertMark.iItem);
+                Assert.Equal(0u, insertMark.dwReserved);
+                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+
+                // Set true.
+                control.InsertionMark.AppearsAfterItem = true;
+                insertMark = new ComCtl32.LVINSERTMARK
+                {
+                    cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
+                };
+                Assert.Equal((IntPtr)1, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(0x80000001, (uint)insertMark.dwFlags);
+                Assert.Equal(0, insertMark.iItem);
+                Assert.Equal(0u, insertMark.dwReserved);
+                Assert.Equal((IntPtr)0x785634, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+
+                // Set false.
+                control.InsertionMark.AppearsAfterItem = false;
+                insertMark = new ComCtl32.LVINSERTMARK
+                {
+                    cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
+                };
+                Assert.Equal((IntPtr)1, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
+                Assert.Equal(0, insertMark.iItem);
+                Assert.Equal(0u, insertMark.dwReserved);
+                Assert.Equal((IntPtr)0x785634, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+            }).Dispose();
         }
 
         [WinFormsFact]
@@ -112,7 +234,6 @@ namespace System.Windows.Forms.Tests
             };
             ListViewInsertionMark insertionMark = control.InsertionMark;
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-
             Assert.Equal(expected, insertionMark.Bounds);
         }
 
@@ -122,7 +243,7 @@ namespace System.Windows.Forms.Tests
 
             protected unsafe override void WndProc(ref Message m)
             {
-                if (m.Msg == (int)LVM.GETINSERTMARKRECT)
+                if (m.Msg == (int)ComCtl32.LVM.GETINSERTMARKRECT)
                 {
                     RECT* pRect = (RECT*)m.LParam;
                     *pRect = GetInsertMarkRectResult;
@@ -151,7 +272,7 @@ namespace System.Windows.Forms.Tests
 
             protected unsafe override void WndProc(ref Message m)
             {
-                if (MakeInvalid && m.Msg == (int)LVM.GETINSERTMARKRECT)
+                if (MakeInvalid && m.Msg == (int)ComCtl32.LVM.GETINSERTMARKRECT)
                 {
                     RECT* pRect = (RECT*)m.LParam;
                     *pRect = new RECT(1, 2, 3, 4);
@@ -163,88 +284,351 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [Fact]
-        public void ListViewInsertionMark_Color_Get_ReturnsExpected()
+        [WinFormsFact]
+        public void ListViewInsertionMark_Color_GetWithoutHandle_ReturnsExpected()
         {
-            var listView = new ListView();
-            ListViewInsertionMark insertionMark = listView.InsertionMark;
+            using var control = new ListView();
+            ListViewInsertionMark insertionMark = control.InsertionMark;
             Assert.NotEqual(Color.Empty, insertionMark.Color);
+            Assert.Equal(insertionMark.Color, insertionMark.Color);
+            Assert.True(control.IsHandleCreated);
         }
 
-        [Theory]
-        [CommonMemberData(nameof(CommonTestHelper.GetColorTheoryData))]
-        public void Color_SetWithHandle_ReturnsExpected(Color value)
+        [WinFormsFact]
+        public void ListViewInsertionMark_Color_GetWithHandle_ReturnsExpected()
         {
-            var listView = new ListView();
-            Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            using var control = new ListView();
+            ListViewInsertionMark insertionMark = control.InsertionMark;
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            int invalidatedCallCount = 0;
+            control.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            control.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            control.HandleCreated += (sender, e) => createdCallCount++;
 
-            ListViewInsertionMark insertionMark = listView.InsertionMark;
-            insertionMark.Color = value;
-            Assert.Equal(value, insertionMark.Color);
-
-            // Set again to test caching behaviour.
-            insertionMark.Color = value;
-            Assert.Equal(value, insertionMark.Color);
+            Assert.NotEqual(Color.Empty, insertionMark.Color);
+            Assert.Equal(insertionMark.Color, insertionMark.Color);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetColorTheoryData))]
         public void ListViewInsertionMark_Color_SetWithoutHandle_ReturnsExpected(Color value)
         {
-            var listView = new ListView();
-            ListViewInsertionMark insertionMark = listView.InsertionMark;
-            insertionMark.Color = value;
-            Assert.Equal(value, insertionMark.Color);
+            using var control = new ListView();
+            ListViewInsertionMark insertionMark = control.InsertionMark;
 
-            // Set again to test caching behaviour.
             insertionMark.Color = value;
             Assert.Equal(value, insertionMark.Color);
+            Assert.False(control.IsHandleCreated);
+
+            // Set again.
+            insertionMark.Color = value;
+            Assert.Equal(value, insertionMark.Color);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Fact]
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetColorTheoryData))]
+        public void ListViewInsertionMark_Color_SetWithHandle_ReturnsExpected(Color value)
+        {
+            using var control = new ListView();
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            int invalidatedCallCount = 0;
+            control.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            control.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            control.HandleCreated += (sender, e) => createdCallCount++;
+
+            ListViewInsertionMark insertionMark = control.InsertionMark;
+            insertionMark.Color = value;
+            Assert.Equal(value, insertionMark.Color);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+
+            // Set again.
+            insertionMark.Color = value;
+            Assert.Equal(value, insertionMark.Color);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+        }
+
+        [WinFormsFact]
+        public unsafe void ListViewInsertionMark_Color_GetInsertMarkColor_Success()
+        {
+            // Run this from another thread as we call Application.EnableVisualStyles.
+            RemoteExecutor.Invoke(() =>
+            {
+                Application.EnableVisualStyles();
+
+                using var control = new ListView();
+                ListViewInsertionMark insertionMark = control.InsertionMark;
+                Assert.NotEqual(IntPtr.Zero, control.Handle);
+
+                // Set same.
+                control.InsertionMark.Color = Color.Empty;
+                var insertMark = new ComCtl32.LVINSERTMARK
+                {
+                    cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
+                };
+                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
+                Assert.Equal(-1, insertMark.iItem);
+                Assert.Equal(0u, insertMark.dwReserved);
+                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+
+                // Set different.
+                control.InsertionMark.Color = Color.FromArgb(0x12, 0x34, 0x56, 0x78);
+                insertMark = new ComCtl32.LVINSERTMARK
+                {
+                    cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
+                };
+                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
+                Assert.Equal(-1, insertMark.iItem);
+                Assert.Equal(0u, insertMark.dwReserved);
+                Assert.Equal((IntPtr)0x785634, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+            }).Dispose();
+        }
+
+        [WinFormsFact]
         public void ListViewInsertionMark_Index_Get_ReturnsExpected()
         {
-            var listView = new ListView();
-            ListViewInsertionMark insertionMark = listView.InsertionMark;
+            using var control = new ListView();
+            ListViewInsertionMark insertionMark = control.InsertionMark;
             Assert.Equal(0, insertionMark.Index);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Theory]
-        [CommonMemberData(nameof(CommonTestHelper.GetIntTheoryData))]
-        public void ListViewInsertionMark_Index_SetWithHandle_GetReturnsExpected(int value)
-        {
-            var listView = new ListView();
-            Assert.NotEqual(IntPtr.Zero, listView.Handle);
-
-            ListViewInsertionMark insertionMark = listView.InsertionMark;
-            insertionMark.Index = value;
-            Assert.Equal(value, insertionMark.Index);
-
-            // Set again to test caching behaviour.
-            insertionMark.Index = value;
-            Assert.Equal(value, insertionMark.Index);
-        }
-
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetIntTheoryData))]
         public void ListViewInsertionMark_Index_SetWithoutHandle_GetReturnsExpected(int value)
         {
-            var listView = new ListView();
-            ListViewInsertionMark insertionMark = listView.InsertionMark;
+            using var control = new ListView();
+            ListViewInsertionMark insertionMark = control.InsertionMark;
+
             insertionMark.Index = value;
             Assert.Equal(value, insertionMark.Index);
+            Assert.False(control.IsHandleCreated);
 
-            // Set again to test caching behaviour.
+            // Set again.
             insertionMark.Index = value;
+            Assert.Equal(value, insertionMark.Index);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetIntTheoryData))]
+        public void ListViewInsertionMark_Index_SetWithHandle_GetReturnsExpected(int value)
+        {
+            using var control = new ListView();
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            int invalidatedCallCount = 0;
+            control.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            control.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            control.HandleCreated += (sender, e) => createdCallCount++;
+
+            ListViewInsertionMark insertionMark = control.InsertionMark;
+            insertionMark.Index = value;
+            Assert.Equal(value, insertionMark.Index);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+
+            // Set again.
+            insertionMark.Index = value;
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
             Assert.Equal(value, insertionMark.Index);
         }
 
-        [Fact]
-        public void ListViewInsertionMark_NearestIndex_NoSuchPoint_ReturnsInvalid()
+        [WinFormsTheory]
+        [InlineData(-2)]
+        [InlineData(1)]
+        public unsafe void ListViewInsertionMark_Index_GetInsertMark_Success(int indexParam)
         {
-            var listView = new ListView();
-            ListViewInsertionMark insertionMark = listView.InsertionMark;
+            // Run this from another thread as we call Application.EnableVisualStyles.
+            RemoteExecutor.Invoke((indexString) =>
+            {
+                int index = int.Parse(indexString);
+                Application.EnableVisualStyles();
+
+                using var control = new ListView();
+                ListViewInsertionMark insertionMark = control.InsertionMark;
+
+                // Set same.
+                Assert.NotEqual(IntPtr.Zero, control.Handle);
+                control.InsertionMark.Index = 0;
+                var insertMark = new ComCtl32.LVINSERTMARK
+                {
+                    cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
+                };
+                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
+                Assert.Equal(-1, insertMark.iItem);
+                Assert.Equal(0u, insertMark.dwReserved);
+                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+                
+                // Set negative one.
+                Assert.NotEqual(IntPtr.Zero, control.Handle);
+                control.InsertionMark.Index = -1;
+                insertMark = new ComCtl32.LVINSERTMARK
+                {
+                    cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
+                };
+                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
+                Assert.Equal(-1, insertMark.iItem);
+                Assert.Equal(0u, insertMark.dwReserved);
+                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+
+                // Set different.
+                control.InsertionMark.Index = index;
+                insertMark = new ComCtl32.LVINSERTMARK
+                {
+                    cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
+                };
+                Assert.Equal((IntPtr)1, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
+                Assert.Equal(index, insertMark.iItem);
+                Assert.Equal(0u, insertMark.dwReserved);
+                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+            }, indexParam.ToString()).Dispose();
+        }
+
+        [WinFormsTheory]
+        [InlineData(-2)]
+        [InlineData(1)]
+        public unsafe void ListViewInsertionMark_Index_GetInsertMarkWithColor_Success(int indexParam)
+        {
+            // Run this from another thread as we call Application.EnableVisualStyles.
+            RemoteExecutor.Invoke((indexString) =>
+            {
+                int index = int.Parse(indexString);
+                Application.EnableVisualStyles();
+
+                using var control = new ListView();
+                ListViewInsertionMark insertionMark = control.InsertionMark;
+                insertionMark.Color = Color.FromArgb(0x12, 0x34, 0x56, 0x78);
+
+                // Set same.
+                Assert.NotEqual(IntPtr.Zero, control.Handle);
+                control.InsertionMark.Index = 0;
+                var insertMark = new ComCtl32.LVINSERTMARK
+                {
+                    cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
+                };
+                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
+                Assert.Equal(-1, insertMark.iItem);
+                Assert.Equal(0u, insertMark.dwReserved);
+                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+                
+                // Set negative one.
+                Assert.NotEqual(IntPtr.Zero, control.Handle);
+                control.InsertionMark.Index = -1;
+                insertMark = new ComCtl32.LVINSERTMARK
+                {
+                    cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
+                };
+                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
+                Assert.Equal(-1, insertMark.iItem);
+                Assert.Equal(0u, insertMark.dwReserved);
+                Assert.Equal((IntPtr)0x785634, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+
+                // Set different.
+                control.InsertionMark.Index = index;
+                insertMark = new ComCtl32.LVINSERTMARK
+                {
+                    cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
+                };
+                Assert.Equal((IntPtr)1, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
+                Assert.Equal(index, insertMark.iItem);
+                Assert.Equal(0u, insertMark.dwReserved);
+                Assert.Equal((IntPtr)0x785634, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+            }, indexParam.ToString()).Dispose();
+        }
+
+        [WinFormsFact]
+        public void ListViewInsertionMark_NearestIndex_NoSuchPointWithoutHandle_ReturnsInvalid()
+        {
+            using var control = new ListView();
+            ListViewInsertionMark insertionMark = control.InsertionMark;
             Assert.True(insertionMark.NearestIndex(new Point(-10, -11)) >= -1);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewInsertionMark_NearestIndex_NoSuchPointWithHandle_ReturnsInvalid()
+        {
+            using var control = new ListView();
+            ListViewInsertionMark insertionMark = control.InsertionMark;
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            int invalidatedCallCount = 0;
+            control.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            control.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            control.HandleCreated += (sender, e) => createdCallCount++;
+
+            Assert.True(insertionMark.NearestIndex(new Point(-10, -11)) >= -1);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+        }
+
+        [WinFormsTheory]
+        [InlineData(-2)]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void ListViewInsertionMark_NearestIndex_InvokeCustomInsertMarkHitTest_ReturnsExpected(int result)
+        {
+            using var control = new CustomInsertMarkHitTestListView
+            {
+                InsertMarkHitTestResult = result
+            };
+            ListViewInsertionMark insertionMark = control.InsertionMark;
+
+            Assert.Equal(result, insertionMark.NearestIndex(new Point(1, 2)));
+        }
+        
+        private class CustomInsertMarkHitTestListView : ListView
+        {
+            public int InsertMarkHitTestResult { get; set; }
+
+            protected unsafe override void WndProc(ref Message m)
+            {
+                if (m.Msg == (int)ComCtl32.LVM.INSERTMARKHITTEST)
+                {
+                    Point* pPt = (Point*)m.WParam;
+                    Assert.Equal(1, pPt->X);
+                    Assert.Equal(2, pPt->Y);
+                    ComCtl32.LVINSERTMARK* pInsertMark = (ComCtl32.LVINSERTMARK*)m.LParam;
+                    pInsertMark->iItem = InsertMarkHitTestResult;
+                    m.Result = (IntPtr)1;
+                    return;
+                }
+
+                base.WndProc(ref m);
+            }
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes
- Add ListViewInsertionMark ComCtl32 tests
- Cleanup ListViewInsertionMark interop (extracted from #2459 with cleanup)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2556)