### PR TITLE
Remove dead code from TableLayoutSettings

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutSettings.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutSettings.cs
@@ -796,11 +796,6 @@ namespace System.Windows.Forms
 
             public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
             {
-                if (destinationType == null)
-                {
-                    throw new ArgumentNullException(nameof(destinationType));
-                }
-
                 if (destinationType == typeof(InstanceDescriptor) && value is TableLayoutStyle)
                 {
                     TableLayoutStyle style = (TableLayoutStyle)value;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutSettings.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutSettings.cs
@@ -595,7 +595,6 @@ namespace System.Windows.Forms
             private TableLayoutColumnStyleCollection columnStyles;
             private TableLayoutRowStyleCollection rowStyles;
             private Dictionary<object, ControlInformation> controlsInfo;
-            private bool isValid = true;
 
             public TableLayoutSettingsStub()
             {
@@ -659,10 +658,6 @@ namespace System.Windows.Forms
                 // since we've given over the styles to the other guy, null out.
                 columnStyles = null;
                 rowStyles = null;
-
-                // set a flag for assertion detection.
-                isValid = false;
-
             }
 
             public TableLayoutColumnStyleCollection ColumnStyles
@@ -675,11 +670,6 @@ namespace System.Windows.Forms
                     }
                     return columnStyles;
                 }
-            }
-
-            public bool IsValid
-            {
-                get { return isValid; }
             }
 
             public TableLayoutRowStyleCollection RowStyles

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutSettingsTypeConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutSettingsTypeConverter.cs
@@ -60,11 +60,6 @@ namespace System.Windows.Forms.Layout
 
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {
-            if (destinationType == null)
-            {
-                throw new ArgumentNullException(nameof(destinationType));
-            }
-
             if (value is TableLayoutSettings && (destinationType == typeof(string)))
             {
                 TableLayoutSettings tableLayoutSettings = value as TableLayoutSettings;


### PR DESCRIPTION
## Proposed Changes
- Remove TableLayoutSettings.IsValid
- Remove dead null check in StyleConverter.ConvertTo

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2560)