### PR TITLE
Fix NullReferenceException serializing TableLayoutSettings for controls without name

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -5441,6 +5441,9 @@ Stack trace where the illegal operation occurred was:
   <data name="TableLayoutPanelSpanDesc" xml:space="preserve">
     <value>TableLayoutPanel cannot expand to contain the control, because the panel's GrowStyle property is set to 'FixedSize'.</value>
   </data>
+  <data name="TableLayoutSettingsConverterNoName" xml:space="preserve">
+    <value>Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</value>
+  </data>
   <data name="TableLayoutSettingSettingsIsNotSupported" xml:space="preserve">
     <value>Directly setting TableLayoutSettings is not supported.  Use individual properties instead.</value>
   </data>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -9121,6 +9121,11 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">Přímé nastavování vlastnosti TableLayoutSettings není podporováno. Místo toho použijte individuální vlastnosti.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TableLayoutSettingsConverterNoName">
+        <source>Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</source>
+        <target state="new">Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TableLayoutSettingsGetCellPositionDescr">
         <source>Indicates the row and column of the cell.</source>
         <target state="translated">Označuje řádek a sloupec buňky.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -9121,6 +9121,11 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">Das direkte Festlegen von TableLayoutSettings wird nicht unterstützt. Verwenden Sie einzelne Eigenschaften.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TableLayoutSettingsConverterNoName">
+        <source>Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</source>
+        <target state="new">Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TableLayoutSettingsGetCellPositionDescr">
         <source>Indicates the row and column of the cell.</source>
         <target state="translated">Gibt die Zeile und die Spalte der Zelle an.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -9121,6 +9121,11 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">No se permite establecer directamente TableLayoutSettings. En lugar de eso utilice propiedades individuales.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TableLayoutSettingsConverterNoName">
+        <source>Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</source>
+        <target state="new">Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TableLayoutSettingsGetCellPositionDescr">
         <source>Indicates the row and column of the cell.</source>
         <target state="translated">Indica la fila y la columna de la celda.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -9121,6 +9121,11 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">La définition directe de TableLayoutSettings n'est pas prise en charge. Utilisez des propriétés individuelles à la place.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TableLayoutSettingsConverterNoName">
+        <source>Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</source>
+        <target state="new">Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TableLayoutSettingsGetCellPositionDescr">
         <source>Indicates the row and column of the cell.</source>
         <target state="translated">Indique la ligne et la colonne de la cellule.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -9121,6 +9121,11 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">L'impostazione diretta di TableLayoutSettings non è supportata. Utilizzare le singole proprietà.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TableLayoutSettingsConverterNoName">
+        <source>Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</source>
+        <target state="new">Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TableLayoutSettingsGetCellPositionDescr">
         <source>Indicates the row and column of the cell.</source>
         <target state="translated">Indica la riga e la colonna della cella.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -9121,6 +9121,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">TableLayoutSettings を直接設定する操作はサポートされていません。  各プロパティを使用してください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="TableLayoutSettingsConverterNoName">
+        <source>Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</source>
+        <target state="new">Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TableLayoutSettingsGetCellPositionDescr">
         <source>Indicates the row and column of the cell.</source>
         <target state="translated">セルの行および列を示します。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -9121,6 +9121,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">TableLayoutSettings를 직접 설정할 수 없습니다. 대신 개별 속성을 사용하십시오.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TableLayoutSettingsConverterNoName">
+        <source>Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</source>
+        <target state="new">Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TableLayoutSettingsGetCellPositionDescr">
         <source>Indicates the row and column of the cell.</source>
         <target state="translated">셀의 행과 열을 나타냅니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -9121,6 +9121,11 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">Bezpośrednie ustawianie elementu TableLayoutSettings nie jest obsługiwane. Użyj zamiast tego indywidualnych właściwości.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TableLayoutSettingsConverterNoName">
+        <source>Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</source>
+        <target state="new">Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TableLayoutSettingsGetCellPositionDescr">
         <source>Indicates the row and column of the cell.</source>
         <target state="translated">Wskazuje wiersz i kolumnę komórki.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -9121,6 +9121,11 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">Não há suporte para a definição direta de TableLayoutSettings. Use propriedades individuais.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TableLayoutSettingsConverterNoName">
+        <source>Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</source>
+        <target state="new">Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TableLayoutSettingsGetCellPositionDescr">
         <source>Indicates the row and column of the cell.</source>
         <target state="translated">Indica a linha e a coluna da célula.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -9122,6 +9122,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">Задание TableLayoutSettings напрямую не поддерживается.  Вместо этого используйте отдельные свойства.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TableLayoutSettingsConverterNoName">
+        <source>Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</source>
+        <target state="new">Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TableLayoutSettingsGetCellPositionDescr">
         <source>Indicates the row and column of the cell.</source>
         <target state="translated">Указывает строку и столбец данной ячейки.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -9121,6 +9121,11 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">TableLayoutSettings'i doğrudan ayarlama desteklenmiyor. Yerine özellikleri ayrı ayrı kullanın.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TableLayoutSettingsConverterNoName">
+        <source>Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</source>
+        <target state="new">Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TableLayoutSettingsGetCellPositionDescr">
         <source>Indicates the row and column of the cell.</source>
         <target state="translated">Hücrenin satır ve sütununu gösterir.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -9121,6 +9121,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">不支持直接设置 TableLayoutSettings。  请改用单个属性。</target>
         <note />
       </trans-unit>
+      <trans-unit id="TableLayoutSettingsConverterNoName">
+        <source>Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</source>
+        <target state="new">Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TableLayoutSettingsGetCellPositionDescr">
         <source>Indicates the row and column of the cell.</source>
         <target state="translated">指示单元格的行和列。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -9121,6 +9121,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">不支援直接設定 TableLayoutSettings。請使用個別的屬性代替。</target>
         <note />
       </trans-unit>
+      <trans-unit id="TableLayoutSettingsConverterNoName">
+        <source>Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</source>
+        <target state="new">Cannot convert TableLayoutSettings to string: could not find a 'Name' string property on a control.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TableLayoutSettingsGetCellPositionDescr">
         <source>Indicates the row and column of the cell.</source>
         <target state="translated">表示儲存格的資料列和資料行。</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutSettingsTypeConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutSettingsTypeConverter.cs
@@ -75,6 +75,11 @@ namespace System.Windows.Forms.Layout
 
                 foreach (TableLayoutSettings.ControlInformation c in tableLayoutSettings.GetControlsInformation())
                 {
+                    if (c.Name == null)
+                    {
+                        throw new InvalidOperationException(SR.TableLayoutSettingsConverterNoName);
+                    }
+
                     xmlWriter.WriteStartElement("Control");
                     xmlWriter.WriteAttributeString("Name", c.Name.ToString());
                     xmlWriter.WriteAttributeString("Row", c.Row.ToString(CultureInfo.CurrentCulture));

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/TableLayoutSettingsTypeConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/TableLayoutSettingsTypeConverterTests.cs
@@ -233,15 +233,15 @@ namespace System.Windows.Forms.Layout.Tests
         }
 
         [Fact]
-        public void TableLayoutSettingsTypeConverter_ConvertTo_HasControlChildWithoutNameProperty_ThrowsNullReferenceException()
+        public void TableLayoutSettingsTypeConverter_ConvertTo_HasControlChildWithoutNameProperty_ThrowsInvalidOperationException()
         {
-            var panel = new TableLayoutPanel();
-            var control = new ScrollableControl();
-            TableLayoutSettings settings = Assert.IsType<TableLayoutSettings>(panel.LayoutSettings);
-            panel.Controls.Add(new ControlWithoutName());
+            using var control = new TableLayoutPanel();
+            var settings = Assert.IsType<TableLayoutSettings>(control.LayoutSettings);
 
+            using var child = new ControlWithNullName();
+            control.Controls.Add(child);
             var converter = new TableLayoutSettingsTypeConverter();
-            Assert.Throws<NullReferenceException>(() => converter.ConvertTo(settings, typeof(string)));
+            Assert.Throws<InvalidOperationException>(() => converter.ConvertTo(settings, typeof(string)));
         }
 
         [Fact]
@@ -302,7 +302,7 @@ namespace System.Windows.Forms.Layout.Tests
         }
 
         [TypeDescriptionProvider(typeof(CustomTypeDescriptionProvider))]
-        private class ControlWithoutName : Control
+        private class ControlWithNullName : Control
         {
         }
 


### PR DESCRIPTION
## Proposed Changes
- Fix NullReferenceException serializing TableLayoutSettings for controls without name

The problem is that we would not set the `ControlInformation.Name` property so throw NRE serializing it

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2563)