### PR TITLE
Clear ComCtlSupportsVisualStyles initialization status when enabling visual styles

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -844,6 +844,8 @@ namespace System.Windows.Forms
                 // CSC embeds DLL manifests as resource ID 2
                 UseVisualStyles = ThemingScope.CreateActivationContext(assemblyLoc, nativeResourceManifestID: 2);
                 Debug.Assert(UseVisualStyles, "Enable Visual Styles failed");
+
+                s_comCtlSupportsVisualStylesInitialized = false;
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -79,8 +79,6 @@ namespace System.Windows.Forms
         private const int LISTVIEWSTATE_doubleclickFired = 0x00040000;
         private const int LISTVIEWSTATE_mouseUpFired = 0x00080000;
         private const int LISTVIEWSTATE_expectingMouseUp = 0x00100000;
-        private const int LISTVIEWSTATE_comctlSupportsVisualStyles = 0x00200000;
-        private const int LISTVIEWSTATE_comctlSupportsVisualStylesTested = 0x00400000;
         private const int LISTVIEWSTATE_showGroups = 0x00800000;
         private const int LISTVIEWSTATE_handleDestroyed = 0x01000000; // while we are recreating the handle we want to know if we can still get data from the handle
         private const int LISTVIEWSTATE_virtualMode = 0x02000000;
@@ -672,24 +670,6 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Actually we are using this to indicate whether ComCtl supports
-        ///  the new listview features. This is true for ComCtl 6 and above, same as
-        ///  the versions that support visual styles.
-        /// </summary>
-        private bool ComctlSupportsVisualStyles
-        {
-            get
-            {
-                if (!listViewState[LISTVIEWSTATE_comctlSupportsVisualStylesTested])
-                {
-                    listViewState[LISTVIEWSTATE_comctlSupportsVisualStylesTested] = true;
-                    listViewState[LISTVIEWSTATE_comctlSupportsVisualStyles] = Application.ComCtlSupportsVisualStyles;
-                }
-                return listViewState[LISTVIEWSTATE_comctlSupportsVisualStyles];
-            }
-        }
-
-        /// <summary>
         ///  Computes the handle creation parameters for the ListView control.
         /// </summary>
         protected override CreateParams CreateParams
@@ -913,7 +893,7 @@ namespace System.Windows.Forms
             {
                 // it never hurts to check that our house is in order
                 Debug.Assert(!listViewState[LISTVIEWSTATE_flipViewToLargeIconAndSmallIcon] || View == View.SmallIcon, "we need this bit only in SmallIcon view");
-                Debug.Assert(!listViewState[LISTVIEWSTATE_flipViewToLargeIconAndSmallIcon] || ComctlSupportsVisualStyles, "we need this bit only when loading ComCtl 6.0");
+                Debug.Assert(!listViewState[LISTVIEWSTATE_flipViewToLargeIconAndSmallIcon] || Application.ComCtlSupportsVisualStyles, "we need this bit only when loading ComCtl 6.0");
 
                 return listViewState[LISTVIEWSTATE_flipViewToLargeIconAndSmallIcon];
             }
@@ -921,7 +901,7 @@ namespace System.Windows.Forms
             {
                 // it never hurts to check that our house is in order
                 Debug.Assert(!value || View == View.SmallIcon, "we need this bit only in SmallIcon view");
-                Debug.Assert(!value || ComctlSupportsVisualStyles, "we need this bit only when loading ComCtl 6.0");
+                Debug.Assert(!value || Application.ComCtlSupportsVisualStyles, "we need this bit only when loading ComCtl 6.0");
 
                 listViewState[LISTVIEWSTATE_flipViewToLargeIconAndSmallIcon] = value;
             }
@@ -1008,7 +988,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                return ShowGroups && groups != null && groups.Count > 0 && ComctlSupportsVisualStyles && !VirtualMode;
+                return ShowGroups && groups != null && groups.Count > 0 && Application.ComCtlSupportsVisualStyles && !VirtualMode;
             }
         }
 
@@ -1952,7 +1932,7 @@ namespace System.Windows.Forms
                 if (viewStyle != value)
                 {
                     viewStyle = value;
-                    if (IsHandleCreated && ComctlSupportsVisualStyles)
+                    if (IsHandleCreated && Application.ComCtlSupportsVisualStyles)
                     {
                         SendMessage((int)LVM.SETVIEW, (int)viewStyle, 0);
                         UpdateGroupView();
@@ -2458,7 +2438,7 @@ namespace System.Windows.Forms
 
         private unsafe int CompensateColumnHeaderResize(Message m, bool columnResizeCancelled)
         {
-            if (ComctlSupportsVisualStyles &&
+            if (Application.ComCtlSupportsVisualStyles &&
                 View == View.Details &&
                 !columnResizeCancelled &&
                 Items.Count > 0)
@@ -2484,7 +2464,7 @@ namespace System.Windows.Forms
             //  2. Otherwise, we need to add 18 pixels.
             // If the list view does not have a small image list then we need to add 2 pixels.
 
-            if (ComctlSupportsVisualStyles &&
+            if (Application.ComCtlSupportsVisualStyles &&
                 View == View.Details &&
                 !columnResizeCancelled &&
                 Items.Count > 0)
@@ -3116,7 +3096,7 @@ namespace System.Windows.Forms
 
         private void EnsureDefaultGroup()
         {
-            if (IsHandleCreated && ComctlSupportsVisualStyles && GroupsEnabled)
+            if (IsHandleCreated && Application.ComCtlSupportsVisualStyles && GroupsEnabled)
             {
                 if (SendMessage((int)LVM.HASGROUP, DefaultGroup.ID, 0) == IntPtr.Zero)
                 {
@@ -3918,7 +3898,7 @@ namespace System.Windows.Forms
                 return;
             }
 
-            if (IsHandleCreated && Items.Count == 0 && View == View.SmallIcon && ComctlSupportsVisualStyles)
+            if (IsHandleCreated && Items.Count == 0 && View == View.SmallIcon && Application.ComCtlSupportsVisualStyles)
             {
                 FlipViewToLargeIconAndSmallIcon = true;
             }
@@ -4413,9 +4393,6 @@ namespace System.Windows.Forms
 
         protected override void OnHandleCreated(EventArgs e)
         {
-            // uncache the "ComctlSupportsVisualStyles" property on a handle creation
-            listViewState[LISTVIEWSTATE_comctlSupportsVisualStylesTested] = false;
-
             // don't persist flipViewToLargeIconAndSmallIcon accross handle recreations...
             FlipViewToLargeIconAndSmallIcon = false;
 
@@ -4456,7 +4433,7 @@ namespace System.Windows.Forms
                 UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), (int)LVM.SETCALLBACKMASK, (int)callbackMask, 0);
             }
 
-            if (ComctlSupportsVisualStyles)
+            if (Application.ComCtlSupportsVisualStyles)
             {
                 SendMessage((int)LVM.SETVIEW, (int)viewStyle, 0);
                 UpdateGroupView();
@@ -4527,7 +4504,7 @@ namespace System.Windows.Forms
             {
                 Sort();
             }
-            if (ComctlSupportsVisualStyles && (InsertionMark.Index > 0))
+            if (Application.ComCtlSupportsVisualStyles && (InsertionMark.Index > 0))
             {
                 InsertionMark.UpdateListView();
             }
@@ -5521,7 +5498,7 @@ namespace System.Windows.Forms
         //
         internal void UpdateGroupView()
         {
-            if (IsHandleCreated && ComctlSupportsVisualStyles && !VirtualMode)
+            if (IsHandleCreated && Application.ComCtlSupportsVisualStyles && !VirtualMode)
             {
                 int retval = unchecked((int)(long)SendMessage((int)LVM.ENABLEGROUPVIEW, GroupsEnabled ? 1 : 0, 0));
                 Debug.Assert(retval != -1, "Error enabling group view");
@@ -5531,7 +5508,7 @@ namespace System.Windows.Forms
         // updates the win32 list view w/ our tile info - columns + tile size
         private unsafe void UpdateTileView()
         {
-            Debug.Assert(ComctlSupportsVisualStyles, "this function works only when ComCtl 6.0 and higher is loaded");
+            Debug.Assert(Application.ComCtlSupportsVisualStyles, "this function works only when ComCtl 6.0 and higher is loaded");
             Debug.Assert(viewStyle == View.Tile, "this function should be called only in Tile view");
 
             var tileViewInfo = new LVTILEVIEWINFO
@@ -6584,7 +6561,7 @@ namespace System.Windows.Forms
                     WmPrint(ref m);
                     break;
                 case WindowMessages.WM_TIMER:
-                    if (unchecked((int)(long)m.WParam) != LVTOOLTIPTRACKING || !ComctlSupportsVisualStyles)
+                    if (unchecked((int)(long)m.WParam) != LVTOOLTIPTRACKING || !Application.ComCtlSupportsVisualStyles)
                     {
                         base.WndProc(ref m);
                     }
@@ -9327,7 +9304,7 @@ namespace System.Windows.Forms
                         //
                         if (owner.View == View.SmallIcon)
                         {
-                            if (owner.ComctlSupportsVisualStyles)
+                            if (Application.ComCtlSupportsVisualStyles)
                             {
                                 owner.FlipViewToLargeIconAndSmallIcon = true;
                             }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationTests.cs
@@ -22,6 +22,22 @@ namespace System.Windows.Forms.Tests
             }).Dispose();
         }
 
+        [WinFormsFact]
+        public void Application_EnableVisualStyles_InvokeAfterGettingRenderWithVisualStyles_Success()
+        {
+            // This is not a recommended scenario per https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.application.enablevisualstyles
+            // EnableVisualStyles should be executed before any control-related code is.
+            RemoteExecutor.Invoke(() =>
+            {
+                Assert.False(Application.UseVisualStyles);
+                Assert.False(Application.RenderWithVisualStyles);
+
+                Application.EnableVisualStyles();
+                Assert.True(Application.UseVisualStyles, "New Visual Styles will not be applied on Winforms app. This is a high priority bug and must be looked into");
+                Assert.True(Application.RenderWithVisualStyles);
+            }).Dispose();
+        }
+
         [Fact]
         public void Application_OpenForms_Get_ReturnsExpected()
         {


### PR DESCRIPTION
Depends on #2565 

The implementation of `Application.RenderWithVisualStyles` is the following:
```cs
public static bool RenderWithVisualStyles
    => ComCtlSupportsVisualStyles && VisualStyleRenderer.IsSupported;
```

The implementation of `Application.ComCtlSupportsVisualStyles` is the following:
```cs
/// <summary>
///  Typically, you shouldn't need to use this directly - use RenderWithVisualStyles instead.
/// </summary>
internal static bool ComCtlSupportsVisualStyles
{
    get
    {
        if (!s_comCtlSupportsVisualStylesInitialized)
        {
            s_comCtlSupportsVisualStyles = InitializeComCtlSupportsVisualStyles();
            s_comCtlSupportsVisualStylesInitialized = true;
        }
        return s_comCtlSupportsVisualStyles;
    }
}

private static bool InitializeComCtlSupportsVisualStyles()
{
    if (UseVisualStyles)
    {
        // At this point, we may not have loaded ComCtl6 yet, but it will eventually be loaded,
        // so we return true here. This works because UseVisualStyles, once set, cannot be
        // turned off.
        return true;
    }

    // To see if we are comctl6, we look for a function that is exposed only from comctl6
    // we do not call DllGetVersion or any direct p/invoke, because the binding will be
    // cached.
    //
    // GetModuleHandle  returns a handle to a mapped module without incrementing its
    // reference count.
    IntPtr hModule = Kernel32.GetModuleHandleW(Libraries.Comctl32);
    if (hModule != IntPtr.Zero)
    {
        return Kernel32.GetProcAddress(hModule, "ImageList_WriteEx") != IntPtr.Zero;
    }

    // Load comctl since GetModuleHandle failed to find it
    hModule = Kernel32.LoadLibraryFromSystemPathIfAvailable(Libraries.Comctl32);
    if (hModule == IntPtr.Zero)
    {
        return false;
    }

    return Kernel32.GetProcAddress(hModule, "ImageList_WriteEx") != IntPtr.Zero;
}
```

Notice that `Application.ComCtlSupportsVisualStyles` caches the result. This can cause problems when we call `Application.EnableVisualStyles()`.

Once `Application.EnableVisualStyles()` is enabled, we expect `Application.ComCtlSupportsVisualStyles` to be true (because we just enabled visual styles). `Application.RenderWithVisualStyles` would be true as a result.

However, in the following case this does not work, as the result of `Application.ComCtlSupportsVisualStyles` is cached to `false` even though we enabled visual styles.
```cs
Assert.False(Application.RenderWithVisualStyles); // Commenting this out makes the assertion work.
Application.UseVisualStyles();
Assert.True(Application.RenderWithVisualStyles);
```

We can fix this by resetting the variable indicating whether `Application.ComCtlSupportsVisualStyles` is initialised, namely `s_comCtlSupportsVisualStylesInitialized`

Related #2556 #2555 #2555
/cc @weltkante @sharwell 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2564)