### PR TITLE
Add Microsoft.DotNet.RemoteExecutor package reference to tests

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -79,6 +79,10 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>d2d025c1de37b1258f147851cb3e7373ad5ff09d</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="5.0.0-beta.19617.1">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>d2d025c1de37b1258f147851cb3e7373ad5ff09d</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="5.0.0-beta.19627.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>d2d025c1de37b1258f147851cb3e7373ad5ff09d</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,6 +33,7 @@
   <!-- Arcade -->
   <PropertyGroup>
     <MicrosoftDotNetGenFacadesPackageVersion>5.0.0-beta.19627.1</MicrosoftDotNetGenFacadesPackageVersion>
+    <MicrosoftDotNetRemoteExecutorVersion>5.0.0-beta.19627.1</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetXUnitExtensionsPackageVersion>5.0.0-beta.19627.1</MicrosoftDotNetXUnitExtensionsPackageVersion>
   </PropertyGroup>
   <!-- Below have no corresponding entries in Versions.Details.XML because they are not updated via Maestro -->

--- a/src/Common/tests/InternalUtilitiesForTests/InternalUtilitiesForTests.csproj
+++ b/src/Common/tests/InternalUtilitiesForTests/InternalUtilitiesForTests.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
     <PackageReference Include="xunit.stafact" Version="$(XUnitStaFactPackageVersion)" />
     <PackageReference Include="xunit.assert" Version="$(XUnitAssertVersion)" />
+    <PackageReference Include="Microsoft.DotNet.RemoteExecutor" Version="$(MicrosoftDotNetRemoteExecutorVersion)" />
     <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsPackageVersion)" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryPackageVersion)" />
   </ItemGroup>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationTests.cs
@@ -3,18 +3,23 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Windows.Forms.VisualStyles;
-using Xunit;
+using Microsoft.DotNet.RemoteExecutor;
 using WinForms.Common.Tests;
+using Xunit;
 
 namespace System.Windows.Forms.Tests
 {
     public class ApplicationTests
     {
-        [Fact]
-        public void Application_EnableVisualStyles_GetUseVisualStyles_ReturnsTrue()
+        [WinFormsFact]
+        public void Application_EnableVisualStyles_InvokeBeforeGettingRenderWithVisualStyles_Success()
         {
-            Application.EnableVisualStyles();
-            Assert.True(Application.UseVisualStyles, "New Visual Styles will not be applied on Winforms app. This is a high priority bug and must be looked into");
+            RemoteExecutor.Invoke(() =>
+            {
+                Application.EnableVisualStyles();
+                Assert.True(Application.UseVisualStyles);
+                Assert.True(Application.RenderWithVisualStyles);
+            }).Dispose();
         }
 
         [Fact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CommonDialogTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CommonDialogTests.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Reflection;
+using Microsoft.DotNet.RemoteExecutor;
 using Moq;
 using WinForms.Common.Tests;
 using Xunit;
@@ -124,19 +125,26 @@ namespace System.Windows.Forms.Tests
         [WinFormsTheory]
         [InlineData(true, DialogResult.OK)]
         [InlineData(false, DialogResult.Cancel)]
-        public void ShowDialog_NonControlOwnerWithVisualStyles_ReturnsExpected(bool runDialogResult, DialogResult expectedDialogResult)
+        public void ShowDialog_NonControlOwnerWithVisualStyles_ReturnsExpected(bool runDialogResultParam, DialogResult expectedDialogResultParam)
         {
-            Application.EnableVisualStyles();
-
-            using var dialog = new SubCommonDialog
+            // Run this from another thread as we call Application.EnableVisualStyles.
+            RemoteExecutor.Invoke((runDialogResultString, expectedDialogResultString) =>
             {
-                RunDialogResult = runDialogResult
-            };
-            var owner = new Mock<IWin32Window>(MockBehavior.Strict);
-            owner
-                .Setup(o => o.Handle)
-                .Returns(IntPtr.Zero);
-            Assert.Equal(expectedDialogResult, dialog.ShowDialog(owner.Object));
+                bool runDialogResult = bool.Parse(runDialogResultString);
+                DialogResult expectedDialogResult = (DialogResult)Enum.Parse(typeof(DialogResult), expectedDialogResultString);
+                
+                Application.EnableVisualStyles();
+
+                using var dialog = new SubCommonDialog
+                {
+                    RunDialogResult = runDialogResult
+                };
+                var owner = new Mock<IWin32Window>(MockBehavior.Strict);
+                owner
+                    .Setup(o => o.Handle)
+                    .Returns(IntPtr.Zero);
+                Assert.Equal(expectedDialogResult, dialog.ShowDialog(owner.Object));
+            }, runDialogResultParam.ToString(), expectedDialogResultParam.ToString()).Dispose();
         }
 
         [WinFormsTheory]
@@ -155,16 +163,23 @@ namespace System.Windows.Forms.Tests
         [WinFormsTheory]
         [InlineData(true, DialogResult.OK)]
         [InlineData(false, DialogResult.Cancel)]
-        public void ShowDialog_ControlOwnerWithVisualStyles_ReturnsExpected(bool runDialogResult, DialogResult expectedDialogResult)
+        public void ShowDialog_ControlOwnerWithVisualStyles_ReturnsExpected(bool runDialogResultParam, DialogResult expectedDialogResultParam)
         {
-            Application.EnableVisualStyles();
-
-            using var dialog = new SubCommonDialog
+            // Run this from another thread as we call Application.EnableVisualStyles.
+            RemoteExecutor.Invoke((runDialogResultString, expectedDialogResultString) =>
             {
-                RunDialogResult = runDialogResult
-            };
-            using var owner = new Control();
-            Assert.Equal(expectedDialogResult, dialog.ShowDialog(owner));
+                bool runDialogResult = bool.Parse(runDialogResultString);
+                DialogResult expectedDialogResult = (DialogResult)Enum.Parse(typeof(DialogResult), expectedDialogResultString);
+
+                Application.EnableVisualStyles();
+
+                using var dialog = new SubCommonDialog
+                {
+                    RunDialogResult = runDialogResult
+                };
+                using var owner = new Control();
+                Assert.Equal(expectedDialogResult, dialog.ShowDialog(owner));
+            }, runDialogResultParam.ToString(), expectedDialogResultParam.ToString()).Dispose();
         }
 
         [WinFormsTheory]
@@ -184,17 +199,24 @@ namespace System.Windows.Forms.Tests
         [WinFormsTheory]
         [InlineData(true, DialogResult.OK)]
         [InlineData(false, DialogResult.Cancel)]
-        public void ShowDialog_ControlOwnerWithHandleWithVisualStyles_ReturnsExpected(bool runDialogResult, DialogResult expectedDialogResult)
+        public void ShowDialog_ControlOwnerWithHandleWithVisualStyles_ReturnsExpected(bool runDialogResultParam, DialogResult expectedDialogResultParam)
         {
-            Application.EnableVisualStyles();
-
-            using var dialog = new SubCommonDialog
+            // Run this from another thread as we call Application.EnableVisualStyles.
+            RemoteExecutor.Invoke((runDialogResultString, expectedDialogResultString) =>
             {
-                RunDialogResult = runDialogResult
-            };
-            using var owner = new Control();
-            Assert.NotEqual(IntPtr.Zero, owner.Handle);
-            Assert.Equal(expectedDialogResult, dialog.ShowDialog(owner));
+                bool runDialogResult = bool.Parse(runDialogResultString);
+                DialogResult expectedDialogResult = (DialogResult)Enum.Parse(typeof(DialogResult), expectedDialogResultString);
+
+                Application.EnableVisualStyles();
+
+                using var dialog = new SubCommonDialog
+                {
+                    RunDialogResult = runDialogResult
+                };
+                using var owner = new Control();
+                Assert.NotEqual(IntPtr.Zero, owner.Handle);
+                Assert.Equal(expectedDialogResult, dialog.ShowDialog(owner));
+            }, runDialogResultParam.ToString(), expectedDialogResultParam.ToString()).Dispose();
         }
 
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/GroupBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/GroupBoxTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms.Layout;
+using Microsoft.DotNet.RemoteExecutor;
 using WinForms.Common.Tests;
 using Xunit;
 using static Interop;
@@ -669,7 +670,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(FlatStyle.Flat, true, true, true, 1, 0)]
         [InlineData(FlatStyle.Popup, true, true, true, 1, 0)]
         [InlineData(FlatStyle.Standard, false, true, false, 0, 0)]
-        [InlineData(FlatStyle.System, true, false, false, 1, 1)]
+        [InlineData(FlatStyle.System, true, false, false, 0, 1)]
         public void GroupBox_FlatStyle_SetWithHandle_GetReturnsExpected(FlatStyle value, bool containerControl, bool ownerDraw, bool userMouse, int expectedInvalidatedCallCount, int expectedCreatedCallCount)
         {
             using var control = new SubGroupBox();
@@ -709,18 +710,76 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
+        [InlineData(FlatStyle.Flat, true, true, true, 1, 0)]
+        [InlineData(FlatStyle.Popup, true, true, true, 1, 0)]
+        [InlineData(FlatStyle.Standard, false, true, false, 0, 0)]
+        [InlineData(FlatStyle.System, true, false, false, 1, 1)]
+        public void GroupBox_FlatStyle_SetWithHandleWithVisualStyles_GetReturnsExpected(FlatStyle valueParam, bool containerControlParam, bool ownerDrawParam, bool userMouseParam, int expectedInvalidatedCallCountParam, int expectedCreatedCallCountParam)
+        {
+            // Run this from another thread as we call Application.EnableVisualStyles.
+            RemoteExecutor.Invoke((valueString, boolStrings, intStrings) =>
+            {
+                FlatStyle value = (FlatStyle)Enum.Parse(typeof(FlatStyle), valueString);
+                string[] bools = boolStrings.Split(',');
+                bool containerControl = bool.Parse(bools[0]);
+                bool ownerDraw = bool.Parse(bools[1]);
+                bool userMouse = bool.Parse(bools[2]);
+                string[] ints = intStrings.Split(',');
+                int expectedInvalidatedCallCount = int.Parse(ints[0]);
+                int expectedCreatedCallCount = int.Parse(ints[1]);
+
+                Application.EnableVisualStyles();
+
+                using var control = new SubGroupBox();
+                Assert.NotEqual(IntPtr.Zero, control.Handle);
+                int invalidatedCallCount = 0;
+                control.Invalidated += (sender, e) => invalidatedCallCount++;
+                int styleChangedCallCount = 0;
+                control.StyleChanged += (sender, e) => styleChangedCallCount++;
+                int createdCallCount = 0;
+                control.HandleCreated += (sender, e) => createdCallCount++;
+                control.SetStyle(ControlStyles.ContainerControl, false);
+
+                control.FlatStyle = value;
+                Assert.Equal(value, control.FlatStyle);
+                Assert.Equal(containerControl, control.GetStyle(ControlStyles.ContainerControl));
+                Assert.Equal(ownerDraw, control.GetStyle(ControlStyles.SupportsTransparentBackColor));
+                Assert.Equal(ownerDraw, control.GetStyle(ControlStyles.UserPaint));
+                Assert.Equal(ownerDraw, control.GetStyle(ControlStyles.ResizeRedraw));
+                Assert.Equal(containerControl && ownerDraw, control.GetStyle(ControlStyles.UserMouse));
+                Assert.True(control.IsHandleCreated);
+                Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
+                Assert.Equal(0, styleChangedCallCount);
+                Assert.Equal(expectedCreatedCallCount, createdCallCount);
+                
+                // Set same.
+                control.FlatStyle = value;
+                Assert.Equal(value, control.FlatStyle);
+                Assert.Equal(containerControl, control.GetStyle(ControlStyles.ContainerControl));
+                Assert.Equal(ownerDraw, control.GetStyle(ControlStyles.SupportsTransparentBackColor));
+                Assert.Equal(ownerDraw, control.GetStyle(ControlStyles.UserPaint));
+                Assert.Equal(ownerDraw, control.GetStyle(ControlStyles.ResizeRedraw));
+                Assert.Equal(containerControl && ownerDraw, control.GetStyle(ControlStyles.UserMouse));
+                Assert.True(control.IsHandleCreated);
+                Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
+                Assert.Equal(0, styleChangedCallCount);
+                Assert.Equal(expectedCreatedCallCount, createdCallCount);
+            }, valueParam.ToString(), $"{containerControlParam},{ownerDrawParam},{userMouseParam}", $"{expectedInvalidatedCallCountParam},{expectedCreatedCallCountParam}").Dispose();
+        }
+
+        [WinFormsTheory]
         [InlineData(FlatStyle.Flat, FlatStyle.Flat, false, true, true, 0, 0)]
         [InlineData(FlatStyle.Flat, FlatStyle.Popup, true, true, true, 1, 0)]
         [InlineData(FlatStyle.Flat, FlatStyle.Standard, true, true, true, 1, 0)]
-        [InlineData(FlatStyle.Flat, FlatStyle.System, true, false, false, 1, 1)]
+        [InlineData(FlatStyle.Flat, FlatStyle.System, true, false, false, 0, 1)]
         [InlineData(FlatStyle.Popup, FlatStyle.Flat, true, true, true, 1, 0)]
         [InlineData(FlatStyle.Popup, FlatStyle.Popup, false, true, true, 0, 0)]
         [InlineData(FlatStyle.Popup, FlatStyle.Standard, true, true, true, 1, 0)]
-        [InlineData(FlatStyle.Popup, FlatStyle.System, true, false, false, 1, 1)]
+        [InlineData(FlatStyle.Popup, FlatStyle.System, true, false, false, 0, 1)]
         [InlineData(FlatStyle.Standard, FlatStyle.Flat, true, true, true, 1, 0)]
         [InlineData(FlatStyle.Standard, FlatStyle.Popup, true, true, true, 1, 0)]
         [InlineData(FlatStyle.Standard, FlatStyle.Standard, false, true, false, 0, 0)]
-        [InlineData(FlatStyle.Standard, FlatStyle.System, true, false, false, 1, 1)]
+        [InlineData(FlatStyle.Standard, FlatStyle.System, true, false, false, 0, 1)]
         [InlineData(FlatStyle.System, FlatStyle.Flat, true, true, true, 0, 1)]
         [InlineData(FlatStyle.System, FlatStyle.Popup, true, true, true, 0, 1)]
         [InlineData(FlatStyle.System, FlatStyle.Standard, true, true, true, 0, 1)]
@@ -764,6 +823,80 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(expectedCreatedCallCount, createdCallCount);
+        }
+
+        [WinFormsTheory]
+        [InlineData(FlatStyle.Flat, FlatStyle.Flat, false, true, true, 0, 0)]
+        [InlineData(FlatStyle.Flat, FlatStyle.Popup, true, true, true, 1, 0)]
+        [InlineData(FlatStyle.Flat, FlatStyle.Standard, true, true, true, 1, 0)]
+        [InlineData(FlatStyle.Flat, FlatStyle.System, true, false, false, 1, 1)]
+        [InlineData(FlatStyle.Popup, FlatStyle.Flat, true, true, true, 1, 0)]
+        [InlineData(FlatStyle.Popup, FlatStyle.Popup, false, true, true, 0, 0)]
+        [InlineData(FlatStyle.Popup, FlatStyle.Standard, true, true, true, 1, 0)]
+        [InlineData(FlatStyle.Popup, FlatStyle.System, true, false, false, 1, 1)]
+        [InlineData(FlatStyle.Standard, FlatStyle.Flat, true, true, true, 1, 0)]
+        [InlineData(FlatStyle.Standard, FlatStyle.Popup, true, true, true, 1, 0)]
+        [InlineData(FlatStyle.Standard, FlatStyle.Standard, false, true, false, 0, 0)]
+        [InlineData(FlatStyle.Standard, FlatStyle.System, true, false, false, 1, 1)]
+        [InlineData(FlatStyle.System, FlatStyle.Flat, true, true, true, 0, 1)]
+        [InlineData(FlatStyle.System, FlatStyle.Popup, true, true, true, 0, 1)]
+        [InlineData(FlatStyle.System, FlatStyle.Standard, true, true, true, 0, 1)]
+        [InlineData(FlatStyle.System, FlatStyle.System, false, false, false, 0, 0)]
+        public void GroupBox_FlatStyle_SetWithCustomOldValueWithHandleWithVisualStyles_GetReturnsExpected(FlatStyle oldValueParam, FlatStyle valueParam, bool containerControlParam, bool ownerDrawParam, bool userMouseParam, int expectedInvalidatedCallCountParam, int expectedCreatedCallCountParam)
+        {
+            // Run this from another thread as we call Application.EnableVisualStyles.
+            RemoteExecutor.Invoke((oldValueString, valueString, boolStrings, intStrings) =>
+            {
+                FlatStyle oldValue = (FlatStyle)Enum.Parse(typeof(FlatStyle), oldValueString);
+                FlatStyle value = (FlatStyle)Enum.Parse(typeof(FlatStyle), valueString);
+                string[] bools = boolStrings.Split(',');
+                bool containerControl = bool.Parse(bools[0]);
+                bool ownerDraw = bool.Parse(bools[1]);
+                bool userMouse = bool.Parse(bools[2]);
+                string[] ints = intStrings.Split(',');
+                int expectedInvalidatedCallCount = int.Parse(ints[0]);
+                int expectedCreatedCallCount = int.Parse(ints[1]);
+
+                Application.EnableVisualStyles();
+
+                using var control = new SubGroupBox
+                {
+                    FlatStyle = oldValue
+                };
+                Assert.NotEqual(IntPtr.Zero, control.Handle);
+                int invalidatedCallCount = 0;
+                control.Invalidated += (sender, e) => invalidatedCallCount++;
+                int styleChangedCallCount = 0;
+                control.StyleChanged += (sender, e) => styleChangedCallCount++;
+                int createdCallCount = 0;
+                control.HandleCreated += (sender, e) => createdCallCount++;
+                control.SetStyle(ControlStyles.ContainerControl, false);
+
+                control.FlatStyle = value;
+                Assert.Equal(value, control.FlatStyle);
+                Assert.Equal(containerControl, control.GetStyle(ControlStyles.ContainerControl));
+                Assert.Equal(ownerDraw, control.GetStyle(ControlStyles.SupportsTransparentBackColor));
+                Assert.Equal(ownerDraw, control.GetStyle(ControlStyles.UserPaint));
+                Assert.Equal(ownerDraw, control.GetStyle(ControlStyles.ResizeRedraw));
+                Assert.Equal(userMouse, control.GetStyle(ControlStyles.UserMouse));
+                Assert.True(control.IsHandleCreated);
+                Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
+                Assert.Equal(0, styleChangedCallCount);
+                Assert.Equal(expectedCreatedCallCount, createdCallCount);
+
+                // Set same.
+                control.FlatStyle = value;
+                Assert.Equal(value, control.FlatStyle);
+                Assert.Equal(containerControl, control.GetStyle(ControlStyles.ContainerControl));
+                Assert.Equal(ownerDraw, control.GetStyle(ControlStyles.SupportsTransparentBackColor));
+                Assert.Equal(ownerDraw, control.GetStyle(ControlStyles.UserPaint));
+                Assert.Equal(ownerDraw, control.GetStyle(ControlStyles.ResizeRedraw));
+                Assert.Equal(userMouse, control.GetStyle(ControlStyles.UserMouse));
+                Assert.True(control.IsHandleCreated);
+                Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
+                Assert.Equal(0, styleChangedCallCount);
+                Assert.Equal(expectedCreatedCallCount, createdCallCount);
+            }, oldValueParam.ToString(), valueParam.ToString(), $"{containerControlParam},{ownerDrawParam},{userMouseParam}", $"{expectedInvalidatedCallCountParam},{expectedCreatedCallCountParam}").Dispose();
         }
 
         [WinFormsFact]


### PR DESCRIPTION
This is needed for various tests that test Application.RenderWithVisualStyles, because calling `Application.UseVisualStyles` poisons the whole test process, meaning that all subsequent tests will be run in visual style enabled mode. Since we want to avoid one test affecting any others, these sorts of tests should be run in their own process.

I'm submitting this on its own since PRs using this could take some time and arcade package updates makes it an absolute nightmare to add new package references as there will be an almost daily merge conflict!

See #2564


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2565)