### PR TITLE
Cleanup ListControl tests

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListControlTests.cs
@@ -142,11 +142,11 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { new BindingContext() };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(BindingContext_Set_TestData))]
-        public void BindingContext_Set_GetReturnsExpected(BindingContext value)
+        public void ListControl_BindingContext_Set_GetReturnsExpected(BindingContext value)
         {
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 BindingContext = value
             };
@@ -154,6 +154,7 @@ namespace System.Windows.Forms.Tests
             Assert.Null(control.DataSource);
             Assert.Empty(control.DisplayMember);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.BindingContext = value;
@@ -161,13 +162,14 @@ namespace System.Windows.Forms.Tests
             Assert.Null(control.DataSource);
             Assert.Empty(control.DisplayMember);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(BindingContext_Set_TestData))]
-        public void BindingContext_SetWithNonNullBindingContext_GetReturnsExpected(BindingContext value)
+        public void ListControl_BindingContext_SetWithNonNullBindingContext_GetReturnsExpected(BindingContext value)
         {
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 BindingContext = new BindingContext()
             };
@@ -177,6 +179,7 @@ namespace System.Windows.Forms.Tests
             Assert.Null(control.DataSource);
             Assert.Empty(control.DisplayMember);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.BindingContext = value;
@@ -184,14 +187,15 @@ namespace System.Windows.Forms.Tests
             Assert.Null(control.DataSource);
             Assert.Empty(control.DisplayMember);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Fact]
-        public void BindingContext_SetWithDataSource_GetReturnsExpected()
+        [WinFormsFact]
+        public void ListControl_BindingContext_SetWithDataSource_GetReturnsExpected()
         {
             var value = new BindingContext();
             var dataSource = new List<DataClass>();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 DataSource = dataSource
             };
@@ -201,20 +205,23 @@ namespace System.Windows.Forms.Tests
             Assert.Same(dataSource, control.DataSource);
             Assert.Empty(control.DisplayMember);
             Assert.Same(value[dataSource], control.DataManager);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.BindingContext = value;
+            Assert.Same(value, control.BindingContext);
             Assert.Same(dataSource, control.DataSource);
             Assert.Empty(control.DisplayMember);
             Assert.Same(value[dataSource], control.DataManager);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Fact]
-        public void BindingContext_SetWithDataSourceAndDisplayMember_GetReturnsExpected()
+        [WinFormsFact]
+        public void ListControl_BindingContext_SetWithDataSourceAndDisplayMember_GetReturnsExpected()
         {
             var value = new BindingContext();
             var dataSource = new List<DataClass>();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 DataSource = dataSource,
                 DisplayMember = "Value"
@@ -225,21 +232,24 @@ namespace System.Windows.Forms.Tests
             Assert.Same(dataSource, control.DataSource);
             Assert.Equal("Value", control.DisplayMember);
             Assert.Same(value[dataSource], control.DataManager);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.BindingContext = value;
+            Assert.Same(value, control.BindingContext);
             Assert.Same(dataSource, control.DataSource);
             Assert.Equal("Value", control.DisplayMember);
             Assert.Same(value[dataSource], control.DataManager);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Fact]
-        public void BindingContext_SetWithDataSourceWithBindingContext_GetReturnsExpected()
+        [WinFormsFact]
+        public void ListControl_BindingContext_SetWithDataSourceWithBindingContext_GetReturnsExpected()
         {
             var originalValue = new BindingContext();
             var value = new BindingContext();
             var dataSource = new List<DataClass>();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 BindingContext = originalValue,
                 DataSource = dataSource
@@ -250,21 +260,24 @@ namespace System.Windows.Forms.Tests
             Assert.Same(dataSource, control.DataSource);
             Assert.Empty(control.DisplayMember);
             Assert.Same(value[dataSource], control.DataManager);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.BindingContext = value;
+            Assert.Same(value, control.BindingContext);
             Assert.Same(dataSource, control.DataSource);
             Assert.Empty(control.DisplayMember);
             Assert.Same(value[dataSource], control.DataManager);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Fact]
-        public void BindingContext_SetWithDataSourceAndDisplayMemberWithBindingContext_GetReturnsExpected()
+        [WinFormsFact]
+        public void ListControl_BindingContext_SetWithDataSourceAndDisplayMemberWithBindingContext_GetReturnsExpected()
         {
             var originalValue = new BindingContext();
             var value = new BindingContext();
             var dataSource = new List<DataClass>();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 BindingContext = originalValue,
                 DataSource = dataSource,
@@ -276,18 +289,20 @@ namespace System.Windows.Forms.Tests
             Assert.Same(dataSource, control.DataSource);
             Assert.Equal("Value", control.DisplayMember);
             Assert.Same(value[dataSource], control.DataManager);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.BindingContext = value;
             Assert.Same(dataSource, control.DataSource);
             Assert.Equal("Value", control.DisplayMember);
             Assert.Same(value[dataSource], control.DataManager);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Fact]
-        public void BindingContext_SetWithHandler_CallsBindingContextChanged()
+        [WinFormsFact]
+        public void ListControl_BindingContext_SetWithHandler_CallsBindingContextChanged()
         {
-            var control = new SubListControl();
+            using var control = new SubListControl();
             int callCount = 0;
             EventHandler handler = (sender, e) =>
             {
@@ -326,12 +341,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(3, callCount);
         }
 
-        [Fact]
-        public void DataManager_ChangePosition_UpdatesSelectionIndex()
+        [WinFormsFact]
+        public void ListControl_DataManager_ChangePosition_UpdatesSelectionIndex()
         {
             var context = new BindingContext();
             var dataSource = new List<DataClass> { new DataClass(), new DataClass() };
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 BindingContext = context,
                 DataSource = dataSource
@@ -341,12 +356,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, control.SelectedIndex);
         }
 
-        [Fact]
-        public void DataManager_ChangePositionDoesNotAllowSelection_DoesNotUpdateSelectionIndex()
+        [WinFormsFact]
+        public void ListControl_DataManager_ChangePositionDoesNotAllowSelection_DoesNotUpdateSelectionIndex()
         {
             var context = new BindingContext();
             var dataSource = new List<DataClass> { new DataClass(), new DataClass() };
-            var control = new AllowSelectionFalseListControl
+            using var control = new AllowSelectionFalseListControl
             {
                 SelectedIndex = -2,
                 BindingContext = context,
@@ -357,12 +372,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-2, control.SelectedIndex);
         }
 
-        [Fact]
-        public void DataManager_SuspendResumeBinding_CallsSetItemsCore()
+        [WinFormsFact]
+        public void ListControl_DataManager_SuspendResumeBinding_CallsSetItemsCore()
         {
             var context = new BindingContext();
             var dataSource = new List<DataClass> { new DataClass(), new DataClass() };
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 SelectedIndex = -1,
                 BindingContext = context,
@@ -402,12 +417,12 @@ namespace System.Windows.Forms.Tests
             control.DataSource = new List<DataClass>();
         }
 
-        [Fact]
-        public void DataManager_SuspendResumeBindingAfterDataManagerChanged_DoesNotCallSetItemsCore()
+        [WinFormsFact]
+        public void ListControl_DataManager_SuspendResumeBindingAfterDataManagerChanged_DoesNotCallSetItemsCore()
         {
             var context = new BindingContext();
             var dataSource = new List<DataClass> { new DataClass(), new DataClass() };
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 SelectedIndex = -1,
                 BindingContext = context,
@@ -433,12 +448,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, callCount);
         }
 
-        [Fact]
-        public void DataManager_SuspendResumeBindingDoesNotAllowSelection_CallsSetItemsCore()
+        [WinFormsFact]
+        public void ListControl_DataManager_SuspendResumeBindingDoesNotAllowSelection_CallsSetItemsCore()
         {
             var context = new BindingContext();
             var dataSource = new List<DataClass> { new DataClass(), new DataClass() };
-            var control = new AllowSelectionFalseListControl
+            using var control = new AllowSelectionFalseListControl
             {
                 SelectedIndex = -1,
                 BindingContext = context,
@@ -475,12 +490,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(2, callCount);
         }
 
-        [Fact]
-        public void DataManager_CancelCurrentEdit_CallsSetItemCore()
+        [WinFormsFact]
+        public void ListControl_DataManager_CancelCurrentEdit_CallsSetItemCore()
         {
             var context = new BindingContext();
             var dataSource = new List<DataClass> { new DataClass(), new DataClass() };
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 SelectedIndex = -1,
                 BindingContext = context,
@@ -502,12 +517,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, callCount);
         }
 
-        [Fact]
-        public void DataManager_CancelCurrentEditAfterDataManagerChanged_DoesNotCallSetItemCore()
+        [WinFormsFact]
+        public void ListControl_DataManager_CancelCurrentEditAfterDataManagerChanged_DoesNotCallSetItemCore()
         {
             var context = new BindingContext();
             var dataSource = new List<DataClass> { new DataClass(), new DataClass() };
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 SelectedIndex = -1,
                 BindingContext = context,
@@ -547,30 +562,32 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { mockSource.Object };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(DataSource_Set_TestData))]
-        public void DataSource_Set_GetReturnsExpected(object value)
+        public void ListControl_DataSource_Set_GetReturnsExpected(object value)
         {
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 DataSource = value
             };
             Assert.Same(value, control.DataSource);
             Assert.Empty(control.DisplayMember);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.DataSource = value;
             Assert.Same(value, control.DataSource);
             Assert.Empty(control.DisplayMember);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(DataSource_Set_TestData))]
-        public void DataSource_SetWithDataSourceNoDisplayMember_GetReturnsExpected(object value)
+        public void ListControl_DataSource_SetWithDataSourceNoDisplayMember_GetReturnsExpected(object value)
         {
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 DataSource = new List<int>()
             };
@@ -579,19 +596,21 @@ namespace System.Windows.Forms.Tests
             Assert.Same(value, control.DataSource);
             Assert.Empty(control.DisplayMember);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.DataSource = value;
             Assert.Same(value, control.DataSource);
             Assert.Empty(control.DisplayMember);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(DataSource_Set_TestData))]
-        public void DataSource_SetWithDisplayMember_GetReturnsExpected(object value)
+        public void ListControl_DataSource_SetWithDisplayMember_GetReturnsExpected(object value)
         {
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 DisplayMember = "Capacity"
             };
@@ -600,20 +619,22 @@ namespace System.Windows.Forms.Tests
             Assert.Same(value, control.DataSource);
             Assert.Equal("Capacity", control.DisplayMember);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.DataSource = value;
             Assert.Same(value, control.DataSource);
             Assert.Equal("Capacity", control.DisplayMember);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(DataSource_Set_TestData))]
-        public void DataSource_SetWithDataSourceNoSuchDisplayMemberAnymore_GetReturnsExpected(object value)
+        public void ListControl_DataSource_SetWithDataSourceNoSuchDisplayMemberAnymore_GetReturnsExpected(object value)
         {
             var originalValue = new List<int>();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 DataSource = originalValue,
                 DisplayMember = "Capacity"
@@ -623,19 +644,21 @@ namespace System.Windows.Forms.Tests
             Assert.Same(value, control.DataSource);
             Assert.Equal(value == null ? string.Empty : "Capacity", control.DisplayMember);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.DataSource = value;
             Assert.Same(value, control.DataSource);
             Assert.Equal(value == null ? string.Empty : "Capacity", control.DisplayMember);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Fact]
-        public void DataSource_SetComponent_DisposeValue_Removes()
+        [WinFormsFact]
+        public void ListControl_DataSource_SetComponent_DisposeValue_Removes()
         {
             var value = new ComponentList();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 DataSource = value,
                 DisplayMember = "Count"
@@ -650,11 +673,11 @@ namespace System.Windows.Forms.Tests
             Assert.Null(control.DataManager);
         }
 
-        [Fact]
-        public void DataSource_SetComponent_DisposeValueDifferentSender_Removes()
+        [WinFormsFact]
+        public void ListControl_DataSource_SetComponent_DisposeValueDifferentSender_Removes()
         {
             var value = new ComponentList();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 DataSource = value,
                 DisplayMember = "Count"
@@ -669,11 +692,11 @@ namespace System.Windows.Forms.Tests
             Assert.Null(control.DataManager);
         }
 
-        [Fact]
-        public void DataSource_SetComponent_DisposeValueNullSender_Removes()
+        [WinFormsFact]
+        public void ListControl_DataSource_SetComponent_DisposeValueNullSender_Removes()
         {
             var value = new ComponentList();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 DataSource = value,
                 DisplayMember = "Count"
@@ -688,12 +711,12 @@ namespace System.Windows.Forms.Tests
             Assert.Null(control.DataManager);
         }
 
-        [Fact]
-        public void DataSource_SetOverridenComponent_DisposeValue_DoesNotRemove()
+        [WinFormsFact]
+        public void ListControl_DataSource_SetOverridenComponent_DisposeValue_DoesNotRemove()
         {
             var originalValue = new ComponentList();
             var value = new List<int>();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 DataSource = originalValue,
                 DisplayMember = "Count"
@@ -709,8 +732,8 @@ namespace System.Windows.Forms.Tests
             Assert.Null(control.DataManager);
         }
 
-        [Fact]
-        public void DataSource_SetSupportInitializeNotification_InitializeValueNotInitializedSetsInitialized_Success()
+        [WinFormsFact]
+        public void ListControl_DataSource_SetSupportInitializeNotification_InitializeValueNotInitializedSetsInitialized_Success()
         {
             var value = new SupportInitializeNotificationList();
             value.Initialized += (sender, e) =>
@@ -718,7 +741,7 @@ namespace System.Windows.Forms.Tests
                 value.IsInitialized = true;
             };
 
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 DataSource = value,
                 DisplayMember = "Count"
@@ -733,11 +756,11 @@ namespace System.Windows.Forms.Tests
             Assert.Null(control.DataManager);
         }
 
-        [Fact]
-        public void DataSource_SetSupportInitializeNotification_InitializeValueNotInitialized_Success()
+        [WinFormsFact]
+        public void ListControl_DataSource_SetSupportInitializeNotification_InitializeValueNotInitialized_Success()
         {
             var value = new SupportInitializeNotificationList();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 DataSource = value,
                 DisplayMember = "Count"
@@ -752,11 +775,11 @@ namespace System.Windows.Forms.Tests
             Assert.Null(control.DataManager);
         }
 
-        [Fact]
-        public void DataSource_SetSupportInitializeNotification_InitializeValueInitialized_Success()
+        [WinFormsFact]
+        public void ListControl_DataSource_SetSupportInitializeNotification_InitializeValueInitialized_Success()
         {
             var value = new SupportInitializeNotificationList();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 DataSource = value,
                 DisplayMember = "Count"
@@ -771,11 +794,11 @@ namespace System.Windows.Forms.Tests
             Assert.Null(control.DataManager);
         }
 
-        [Fact]
-        public void DataSource_SetSupportInitializeNotification_InitializeValueDifferentSender_Success()
+        [WinFormsFact]
+        public void ListControl_DataSource_SetSupportInitializeNotification_InitializeValueDifferentSender_Success()
         {
             var value = new SupportInitializeNotificationList();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 DataSource = value,
                 DisplayMember = "Count"
@@ -790,11 +813,11 @@ namespace System.Windows.Forms.Tests
             Assert.Null(control.DataManager);
         }
 
-        [Fact]
-        public void DataSource_SetSupportInitializeNotification_InitializeValueNullSender_Succes()
+        [WinFormsFact]
+        public void ListControl_DataSource_SetSupportInitializeNotification_InitializeValueNullSender_Succes()
         {
             var value = new SupportInitializeNotificationList();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 DataSource = value,
                 DisplayMember = "Count"
@@ -809,13 +832,13 @@ namespace System.Windows.Forms.Tests
             Assert.Null(control.DataManager);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
-        public void DataSource_SetOverridenSupportInitializeNotification_InitializeValue_Success(bool isInitialized)
+        public void ListControl_DataSource_SetOverridenSupportInitializeNotification_InitializeValue_Success(bool isInitialized)
         {
             var originalValue = new SupportInitializeNotificationList();
             var value = new List<int>();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 DataSource = originalValue,
                 DisplayMember = "Count"
@@ -832,12 +855,12 @@ namespace System.Windows.Forms.Tests
             Assert.Null(control.DataManager);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(DataSource_Set_TestData))]
-        public void DataSource_SetWithBindingContext_GetReturnsExpected(object value)
+        public void ListControl_DataSource_SetWithBindingContext_GetReturnsExpected(object value)
         {
             var context = new BindingContext();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 BindingContext = context
             };
@@ -868,12 +891,12 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(DataSource_Set_TestData))]
-        public void DataSource_SetWithBindingContextWithDataSource_GetReturnsExpected(object value)
+        public void ListControl_DataSource_SetWithBindingContextWithDataSource_GetReturnsExpected(object value)
         {
             var context = new BindingContext();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 BindingContext = context,
                 DataSource = new List<int>()
@@ -905,12 +928,12 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [Fact]
-        public void DataSource_SetWithBindingContextWithDisplayMemberCanCreate_GetReturnsExpected()
+        [WinFormsFact]
+        public void ListControl_DataSource_SetWithBindingContextWithDisplayMemberCanCreate_GetReturnsExpected()
         {
             var context = new BindingContext();
             var value = new List<DataClass>();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 BindingContext = context,
                 DisplayMember = "Value"
@@ -928,12 +951,12 @@ namespace System.Windows.Forms.Tests
             Assert.Same(context[value], control.DataManager);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(DataSource_Set_TestData))]
-        public void DataSource_SetWithBindingContextWithDisplayMemberCantCreate_GetReturnsExpected(object value)
+        public void ListControl_DataSource_SetWithBindingContextWithDisplayMemberCantCreate_GetReturnsExpected(object value)
         {
             var context = new BindingContext();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 BindingContext = context,
                 DisplayMember = "NoSuchDisplayMember"
@@ -965,10 +988,10 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [Fact]
-        public void DataSource_SetWithHandler_CallsDataSourceChanged()
+        [WinFormsFact]
+        public void ListControl_DataSource_SetWithHandler_CallsDataSourceChanged()
         {
-            var control = new SubListControl();
+            using var control = new SubListControl();
             int dataSourceCallCount = 0;
             int displayMemberCallCount = 0;
             EventHandler dataSourceHandler = (sender, e) =>
@@ -1021,10 +1044,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, displayMemberCallCount);
         }
 
-        [Fact]
-        public void DataSource_SetInsideDataSourceChanged_Nop()
+        [WinFormsFact]
+        public void ListControl_DataSource_SetInsideDataSourceChanged_Nop()
         {
-            var control = new SubListControl();
+            using var control = new SubListControl();
             int callCount = 0;
             EventHandler handler = (sender, e) =>
             {
@@ -1040,37 +1063,39 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, callCount);
         }
 
-        [Fact]
-        public void DataSource_SetInvalid_ThrowsArgumentException()
+        [WinFormsFact]
+        public void ListControl_DataSource_SetInvalid_ThrowsArgumentException()
         {
-            var control = new SubListControl();
+            using var control = new SubListControl();
             Assert.Throws<ArgumentException>("value", () => control.DataSource = new object());
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
-        public void DisplayMember_Set_GetReturnsExpected(string value, string expected)
+        public void ListControl_DisplayMember_Set_GetReturnsExpected(string value, string expected)
         {
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 DisplayMember = value
             };
             Assert.Null(control.DataSource);
             Assert.Equal(expected, control.DisplayMember);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.DisplayMember = value;
             Assert.Null(control.DataSource);
             Assert.Equal(expected, control.DisplayMember);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
-        public void DataMember_SetWithDisplayMember_GetReturnsExpected(string value, string expected)
+        public void ListControl_DataMember_SetWithDisplayMember_GetReturnsExpected(string value, string expected)
         {
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 DisplayMember = "DataMember"
             };
@@ -1079,20 +1104,22 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, control.DisplayMember);
             Assert.Null(control.DataSource);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.DisplayMember = value;
             Assert.Equal(expected, control.DisplayMember);
             Assert.Null(control.DataSource);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringTheoryData))]
-        public void DisplayMember_SetWithDataSource_GetReturnsExpected(string value)
+        public void ListControl_DisplayMember_SetWithDataSource_GetReturnsExpected(string value)
         {
             var dataSource = new List<int>();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 DataSource = dataSource
             };
@@ -1101,20 +1128,22 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(value, control.DisplayMember);
             Assert.Same(dataSource, control.DataSource);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.DisplayMember = value;
             Assert.Equal(value, control.DisplayMember);
             Assert.Same(dataSource, control.DataSource);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
-        public void DisplayMember_SetWithBindingContext_GetReturnsExpected(string value, string expected)
+        public void ListControl_DisplayMember_SetWithBindingContext_GetReturnsExpected(string value, string expected)
         {
             var context = new BindingContext();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 BindingContext = context
             };
@@ -1123,21 +1152,23 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, control.DisplayMember);
             Assert.Null(control.DataSource);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.DisplayMember = value;
             Assert.Equal(expected, control.DisplayMember);
             Assert.Null(control.DataSource);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringTheoryData))]
-        public void DisplayMember_SetWithBindingContextWithDataSource_GetReturnsExpected(string value)
+        public void ListControl_DisplayMember_SetWithBindingContextWithDataSource_GetReturnsExpected(string value)
         {
             var context = new BindingContext();
             var dataSource = new List<int>();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 BindingContext = context,
                 DataSource = dataSource
@@ -1147,24 +1178,26 @@ namespace System.Windows.Forms.Tests
             Assert.Empty(control.DisplayMember);
             Assert.Same(dataSource, control.DataSource);
             Assert.Same(context[dataSource], control.DataManager);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.DisplayMember = value;
             Assert.Empty(control.DisplayMember);
             Assert.Same(dataSource, control.DataSource);
             Assert.Same(context[dataSource], control.DataManager);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [InlineData(null, "")]
         [InlineData("", "")]
         [InlineData("Value", "Value")]
         [InlineData("value", "value")]
-        public void DisplayMember_SetWithBindingContextWithDataSourceCanCreate_GetReturnsExpected(string value, string expected)
+        public void ListControl_DisplayMember_SetWithBindingContextWithDataSourceCanCreate_GetReturnsExpected(string value, string expected)
         {
             var context = new BindingContext();
             var dataSource = new List<DataClass>();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 BindingContext = context,
                 DataSource = dataSource
@@ -1174,22 +1207,24 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, control.DisplayMember);
             Assert.Equal(dataSource, control.DataSource);
             Assert.Same(context[dataSource], control.DataManager);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.DisplayMember = value;
             Assert.Equal(expected, control.DisplayMember);
             Assert.Equal(dataSource, control.DataSource);
             Assert.Same(context[dataSource], control.DataManager);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringTheoryData))]
         [InlineData("ListValue")]
-        public void DisplayMember_SetWithBindingContextWithDataSourceCantCreate_GetReturnsExpected(string value)
+        public void ListControl_DisplayMember_SetWithBindingContextWithDataSourceCantCreate_GetReturnsExpected(string value)
         {
             var context = new BindingContext();
             var dataSource = new List<DataClass>();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 BindingContext = context,
                 DataSource = dataSource
@@ -1206,6 +1241,7 @@ namespace System.Windows.Forms.Tests
             {
                 Assert.Same(context[dataSource], control.DataManager);
             }
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.DisplayMember = value;
@@ -1219,12 +1255,13 @@ namespace System.Windows.Forms.Tests
             {
                 Assert.Same(context[dataSource], control.DataManager);
             }
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Fact]
-        public void DisplayMember_SetWithHandler_CallsDisplayMemberChanged()
+        [WinFormsFact]
+        public void ListControl_DisplayMember_SetWithHandler_CallsDisplayMemberChanged()
         {
-            var control = new SubListControl();
+            using var control = new SubListControl();
             int displayMemberCallCount = 0;
             int dataSourceCallCount = 0;
             EventHandler displayMemberHandler = (sender, e) =>
@@ -1281,10 +1318,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, dataSourceCallCount);
         }
 
-        [Fact]
-        public void DisplayMember_SetInsideDisplayMemberChanged_Nop()
+        [WinFormsFact]
+        public void ListControl_DisplayMember_SetInsideDisplayMemberChanged_Nop()
         {
-            var control = new SubListControl();
+            using var control = new SubListControl();
             int callCount = 0;
             EventHandler handler = (sender, e) =>
             {
@@ -1298,10 +1335,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, callCount);
         }
 
-        [Fact]
-        public void Format_AddRemove_CallsRefreshItems()
+        [WinFormsFact]
+        public void ListControl_Format_AddRemove_CallsRefreshItems()
         {
-            var control = new SubListControl();
+            using var control = new SubListControl();
             int callCount = 0;
             control.RefreshItemsHandler = () => callCount++;
             ListControlConvertEventHandler handler = (sender, e) => { };
@@ -1321,42 +1358,46 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { CultureInfo.CurrentCulture };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(FormatInfo_Set_TestData))]
-        public void FormatInfo_Set_GetReturnsExpected(IFormatProvider value)
+        public void ListControl_FormatInfo_Set_GetReturnsExpected(IFormatProvider value)
         {
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 FormatInfo = value
             };
             Assert.Same(value, control.FormatInfo);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.FormatInfo = value;
             Assert.Same(value, control.FormatInfo);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(FormatInfo_Set_TestData))]
-        public void FormatInfo_SetWithFormatInfo_GetReturnsExpected(IFormatProvider value)
+        public void ListControl_FormatInfo_SetWithCustomOldValue_GetReturnsExpected(IFormatProvider value)
         {
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 FormatInfo = CultureInfo.InvariantCulture
             };
 
             control.FormatInfo = value;
             Assert.Same(value, control.FormatInfo);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.FormatInfo = value;
             Assert.Same(value, control.FormatInfo);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Fact]
-        public void FormatInfo_Set_CallsRefreshItems()
+        [WinFormsFact]
+        public void ListControl_FormatInfo_Set_CallsRefreshItems()
         {
-            var control = new SubListControl();
+            using var control = new SubListControl();
             int callCount = 0;
             control.RefreshItemsHandler = () => callCount++;
 
@@ -1381,10 +1422,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(3, callCount);
         }
 
-        [Fact]
-        public void FormatInfo_SetWithHandler_CallsOnFormatInfoChanged()
+        [WinFormsFact]
+        public void ListControl_FormatInfo_SetWithHandler_CallsOnFormatInfoChanged()
         {
-            var control = new SubListControl();
+            using var control = new SubListControl();
             int callCount = 0;
             EventHandler handler = (sender, e) =>
             {
@@ -1421,42 +1462,46 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(3, callCount);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
-        public void FormatString_Set_GetReturnsExpected(string value, string expected)
+        public void ListControl_FormatString_Set_GetReturnsExpected(string value, string expected)
         {
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 FormatString = value
             };
             Assert.Equal(expected, control.FormatString);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.FormatString = value;
             Assert.Equal(expected, control.FormatString);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
-        public void FormatString_SetWithFormatString_GetReturnsExpected(string value, string expected)
+        public void ListControl_FormatString_SetWithCustomOldValue_GetReturnsExpected(string value, string expected)
         {
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 FormatString = "FormatString"
             };
 
             control.FormatString = value;
             Assert.Equal(expected, control.FormatString);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.FormatString = value;
             Assert.Equal(expected, control.FormatString);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Fact]
-        public void FormatString_Set_CallsRefreshItems()
+        [WinFormsFact]
+        public void ListControl_FormatString_Set_CallsRefreshItems()
         {
-            var control = new SubListControl();
+            using var control = new SubListControl();
             int callCount = 0;
             control.RefreshItemsHandler = () => callCount++;
 
@@ -1486,10 +1531,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(3, callCount);
         }
 
-        [Fact]
-        public void FormatStringSetWithHandler_CallsOnFormatStringChanged()
+        [WinFormsFact]
+        public void ListControl_FormatString_SetWithHandler_CallsOnFormatStringChanged()
         {
-            var control = new SubListControl();
+            using var control = new SubListControl();
             int callCount = 0;
             EventHandler handler = (sender, e) =>
             {
@@ -1531,42 +1576,56 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(3, callCount);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
-        public void FormattingEnabled_Set_GetReturnsExpected(bool value)
+        public void ListControl_FormattingEnabled_Set_GetReturnsExpected(bool value)
         {
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 FormattingEnabled = value
             };
             Assert.Equal(value, control.FormattingEnabled);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.FormattingEnabled = value;
             Assert.Equal(value, control.FormattingEnabled);
+            Assert.False(control.IsHandleCreated);
+
+            // Set different.
+            control.FormattingEnabled = !value;
+            Assert.Equal(!value, control.FormattingEnabled);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
-        public void FormattingEnabled_SetWithFormattingEnabled_GetReturnsExpected(bool value)
+        public void ListControl_FormattingEnabled_SetWithFormattingEnabled_GetReturnsExpected(bool value)
         {
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 FormattingEnabled = true
             };
 
             control.FormattingEnabled = value;
             Assert.Equal(value, control.FormattingEnabled);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.FormattingEnabled = value;
             Assert.Equal(value, control.FormattingEnabled);
+            Assert.False(control.IsHandleCreated);
+
+            // Set different.
+            control.FormattingEnabled = !value;
+            Assert.Equal(!value, control.FormattingEnabled);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Fact]
-        public void FormattingEnabled_Set_CallsRefreshItems()
+        [WinFormsFact]
+        public void ListControl_FormattingEnabled_Set_CallsRefreshItems()
         {
-            var control = new SubListControl();
+            using var control = new SubListControl();
             int callCount = 0;
             control.RefreshItemsHandler = () => callCount++;
 
@@ -1586,10 +1645,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(2, callCount);
         }
 
-        [Fact]
-        public void FormattingEnabledSetWithHandler_CallsOnFormattingEnabledChanged()
+        [WinFormsFact]
+        public void ListControl_FormattingEnabled_SetWithHandler_CallsOnFormattingEnabledChanged()
         {
-            var control = new SubListControl();
+            using var control = new SubListControl();
             int callCount = 0;
             EventHandler handler = (sender, e) =>
             {
@@ -1621,11 +1680,11 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(2, callCount);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
-        public void ValueMember_Set_GetReturnsExpected(string value, string expected)
+        public void ListControl_ValueMember_Set_GetReturnsExpected(string value, string expected)
         {
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 ValueMember = value
             };
@@ -1633,6 +1692,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, control.DisplayMember);
             Assert.Equal(expected, control.ValueMember);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.ValueMember = value;
@@ -1640,13 +1700,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, control.DisplayMember);
             Assert.Equal(expected, control.ValueMember);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
-        public void ValueMember_SetWithDisplayMember_GetReturnsExpected(string value, string expected)
+        public void ListControl_ValueMember_SetWithDisplayMember_GetReturnsExpected(string value, string expected)
         {
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 DisplayMember = "DisplayMember"
             };
@@ -1656,6 +1717,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal("DisplayMember", control.DisplayMember);
             Assert.Equal(expected, control.ValueMember);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.ValueMember = value;
@@ -1663,14 +1725,15 @@ namespace System.Windows.Forms.Tests
             Assert.Equal("DisplayMember", control.DisplayMember);
             Assert.Equal(expected, control.ValueMember);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
-        public void ValueMember_SetWithBindingContext_GetReturnsExpected(string value, string expected)
+        public void ListControl_ValueMember_SetWithBindingContext_GetReturnsExpected(string value, string expected)
         {
             var context = new BindingContext();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 BindingContext = context
             };
@@ -1680,6 +1743,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, control.DisplayMember);
             Assert.Equal(expected, control.ValueMember);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.ValueMember = value;
@@ -1687,18 +1751,19 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, control.DisplayMember);
             Assert.Equal(expected, control.ValueMember);
             Assert.Null(control.DataManager);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [InlineData(null, "")]
         [InlineData("", "")]
         [InlineData("Value", "Value")]
         [InlineData("value", "value")]
-        public void ValueMember_SetWithBindingContextWithDataSourceCanCreate_GetReturnsExpected(string value, string expected)
+        public void ListControl_ValueMember_SetWithBindingContextWithDataSourceCanCreate_GetReturnsExpected(string value, string expected)
         {
             var context = new BindingContext();
             var dataSource = new List<DataClass>();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 BindingContext = context,
                 DataSource = dataSource
@@ -1709,6 +1774,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, control.DisplayMember);
             Assert.Equal(expected, control.ValueMember);
             Assert.Same(context[dataSource], control.DataManager);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.ValueMember = value;
@@ -1716,14 +1782,15 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, control.DisplayMember);
             Assert.Equal(expected, control.ValueMember);
             Assert.Same(context[dataSource], control.DataManager);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Fact]
-        public void ValueMember_SetWithBindingContextWithDataSourceCantCreate_ThrowsArgumentException()
+        [WinFormsFact]
+        public void ListControl_ValueMember_SetWithBindingContextWithDataSourceCantCreate_ThrowsArgumentException()
         {
             var context = new BindingContext();
             var dataSource = new List<DataClass>();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 BindingContext = context,
                 DataSource = dataSource
@@ -1734,16 +1801,16 @@ namespace System.Windows.Forms.Tests
             Assert.Empty(control.ValueMember);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [InlineData(null, "")]
         [InlineData("", "")]
         [InlineData("Value", "Value")]
         [InlineData("value", "value")]
-        public void ValueMember_SetWithBindingContextWithDataSourceWithDisplayMemberCanCreate_GetReturnsExpected(string value, string expected)
+        public void ListControl_ValueMember_SetWithBindingContextWithDataSourceWithDisplayMemberCanCreate_GetReturnsExpected(string value, string expected)
         {
             var context = new BindingContext();
             var dataSource = new List<DataClass>();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 BindingContext = context,
                 DataSource = dataSource,
@@ -1755,6 +1822,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal("OtherValue", control.DisplayMember);
             Assert.Equal(expected, control.ValueMember);
             Assert.Same(context[dataSource], control.DataManager);
+            Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.ValueMember = value;
@@ -1762,14 +1830,15 @@ namespace System.Windows.Forms.Tests
             Assert.Equal("OtherValue", control.DisplayMember);
             Assert.Equal(expected, control.ValueMember);
             Assert.Same(context[dataSource], control.DataManager);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Fact]
-        public void ValueMember_SetWithBindingContextWithDataSourceWithDisplayMemberCantCreate_ThrowsArgumentException()
+        [WinFormsFact]
+        public void ListControl_ValueMember_SetWithBindingContextWithDataSourceWithDisplayMemberCantCreate_ThrowsArgumentException()
         {
             var context = new BindingContext();
             var dataSource = new List<DataClass>();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 BindingContext = context,
                 DataSource = dataSource,
@@ -1781,10 +1850,10 @@ namespace System.Windows.Forms.Tests
             Assert.Empty(control.ValueMember);
         }
 
-        [Fact]
-        public void ValueMember_SetWithHandler_CallsValueMemberChanged()
+        [WinFormsFact]
+        public void ListControl_ValueMember_SetWithHandler_CallsValueMemberChanged()
         {
-            var control = new SubListControl();
+            using var control = new SubListControl();
             int valueMemberCallCount = 0;
             int selectedValueCallCount = 0;
             EventHandler valueMemberHandler = (sender, e) =>
@@ -1842,14 +1911,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(3, selectedValueCallCount);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [InlineData("Value")]
         [InlineData("value")]
-        public void SelectedValue_SetWithMatchingValue_Success(string valueMember)
+        public void ListControl_SelectedValue_SetWithMatchingValue_Success(string valueMember)
         {
             var context = new BindingContext();
             var dataSource = new List<DataClass> { new DataClass { Value = "StringValue" } };
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 SelectedIndex = 0,
                 ValueMember = valueMember,
@@ -1860,6 +1929,13 @@ namespace System.Windows.Forms.Tests
             control.SelectedValue = "StringValue";
             Assert.Equal(0, control.SelectedIndex);
             Assert.Equal("StringValue", control.SelectedValue);
+            Assert.False(control.IsHandleCreated);
+
+            // Set same.
+            control.SelectedValue = "StringValue";
+            Assert.Equal(0, control.SelectedIndex);
+            Assert.Equal("StringValue", control.SelectedValue);
+            Assert.False(control.IsHandleCreated);
         }
 
         public static IEnumerable<object[]> SelectedValue_NoMatchingValue_TestData()
@@ -1870,12 +1946,12 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { new List<DataClass> { new DataClass { Value = "NoSuchValue" } }, "nosuchvalue" };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(SelectedValue_NoMatchingValue_TestData))]
-        public void SelectedValue_SetWithNoMatchingValue_Success(object dataSource, string value)
+        public void ListControl_SelectedValue_SetWithNoMatchingValue_Success(object dataSource, string value)
         {
             var context = new BindingContext();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 SelectedIndex = 0,
                 ValueMember = "Value",
@@ -1886,14 +1962,21 @@ namespace System.Windows.Forms.Tests
             control.SelectedValue = value;
             Assert.Equal(-1, control.SelectedIndex);
             Assert.Null(control.SelectedValue);
+            Assert.False(control.IsHandleCreated);
+
+            // Set same.
+            control.SelectedValue = value;
+            Assert.Equal(-1, control.SelectedIndex);
+            Assert.Null(control.SelectedValue);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Fact]
-        public void SelectedValue_SetWithChangedDataManager_Success()
+        [WinFormsFact]
+        public void ListControl_SelectedValue_SetWithChangedDataManager_Success()
         {
             var context = new BindingContext();
             var dataSource = new List<DataClass>();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 SelectedIndex = 0,
                 ValueMember = "ValueMember",
@@ -1904,14 +1987,21 @@ namespace System.Windows.Forms.Tests
             control.SelectedValue = "selected";
             Assert.Equal(-1, control.SelectedIndex);
             Assert.Null(control.SelectedValue);
+            Assert.False(control.IsHandleCreated);
+
+            // Set same.
+            control.SelectedValue = "selected";
+            Assert.Equal(-1, control.SelectedIndex);
+            Assert.Null(control.SelectedValue);
+            Assert.False(control.IsHandleCreated);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [InlineData(null)]
         [InlineData(1)]
-        public void SelectedValue_SetWithoutDataManager_GetReturnsNull(object value)
+        public void ListControl_SelectedValue_SetWithoutDataManager_GetReturnsNull(object value)
         {
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 SelectedIndex = 0,
                 SelectedValue = value
@@ -1926,12 +2016,12 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<IndexOutOfRangeException>(() => control.SelectedValue);
         }
 
-        [Fact]
-        public void SelectedValue_SetWithHandler_DoesNotCallSelectedValueChanged()
+        [WinFormsFact]
+        public void ListControl_SelectedValue_SetWithHandler_DoesNotCallSelectedValueChanged()
         {
             var context = new BindingContext();
             var dataSource = new List<DataClass> { new DataClass { Value = "StringValue" } };
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 SelectedIndex = 0,
                 ValueMember = "Value",
@@ -1965,12 +2055,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, callCount);
         }
 
-        [Fact]
-        public void SelectedValue_SetNull_ThrowsArgumentNullException()
+        [WinFormsFact]
+        public void ListControl_SelectedValue_SetNull_ThrowsArgumentNullException()
         {
             var context = new BindingContext();
             var dataSource = new List<DataClass>();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 SelectedIndex = 0,
                 BindingContext = context,
@@ -1982,14 +2072,14 @@ namespace System.Windows.Forms.Tests
             Assert.Null(control.SelectedValue);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [InlineData(null)]
         [InlineData(1)]
-        public void SelectedValue_SetWithoutValueMember_ThrowsInvalidOperationException(object value)
+        public void ListControl_SelectedValue_SetWithoutValueMember_ThrowsInvalidOperationException(object value)
         {
             var context = new BindingContext();
             var dataSource = new List<DataClass>();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 SelectedIndex = 0,
                 BindingContext = context,
@@ -2000,7 +2090,7 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<IndexOutOfRangeException>(() => control.SelectedValue);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [InlineData(Keys.Alt, false)]
         [InlineData(Keys.Alt | Keys.PageUp, false)]
         [InlineData(Keys.PageUp, true)]
@@ -2010,7 +2100,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(Keys.A, false)]
         public void IsInputKey_Invoke_ReturnsExpected(Keys keyData, bool expected)
         {
-            var control = new SubListControl();
+            using var control = new SubListControl();
             Assert.Equal(expected, control.IsInputKey(keyData));
         }
 
@@ -2124,9 +2214,9 @@ namespace System.Windows.Forms.Tests
             };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(FilterItemOnProperty_TestData))]
-        public void FilterItemOnProperty_Invoke_ReturnsExpected(SubListControl control, object item, object expected)
+        public void ListControl_FilterItemOnProperty_Invoke_ReturnsExpected(SubListControl control, object item, object expected)
         {
             Assert.Equal(expected, control.FilterItemOnProperty(item));
         }
@@ -2238,9 +2328,9 @@ namespace System.Windows.Forms.Tests
             };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(FilterItemOnProperty_String_TestData))]
-        public void FilterItemOnProperty_InvokeString_ReturnsExpected(SubListControl control, object item, string field, object expected)
+        public void ListControl_FilterItemOnProperty_InvokeString_ReturnsExpected(SubListControl control, object item, string field, object expected)
         {
             Assert.Equal(expected, control.FilterItemOnProperty(item, field));
         }
@@ -2286,9 +2376,9 @@ namespace System.Windows.Forms.Tests
             };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(GetItemText_TestData))]
-        public void GetItemText_Invoke_ReturnsExpected(ListControl control, object item, string expected)
+        public void ListControl_GetItemText_Invoke_ReturnsExpected(ListControl control, object item, string expected)
         {
             Assert.Equal(expected, control.GetItemText(item));
 
@@ -2305,11 +2395,11 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { item, "custom", "custom" };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(GetItemText_HasHandler_TestData))]
-        public void GetItemText_HasHandler_CallsFormat(object item, object value, object expected)
+        public void ListControl_GetItemText_HasHandler_CallsFormat(object item, object value, object expected)
         {
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 FormattingEnabled = true,
                 DisplayMember = "Value"
@@ -2347,11 +2437,11 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { item, "custom" };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(GetItemText_HasHandlerFormattingDisabled_TestData))]
-        public void GetItemText_HasHandlerFormattingDisabled_DoesNotCallFormat(object item, object value)
+        public void ListControl_GetItemText_HasHandlerFormattingDisabled_DoesNotCallFormat(object item, object value)
         {
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 FormattingEnabled = false,
                 DisplayMember = "Value"
@@ -2380,11 +2470,11 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, callCount);
         }
 
-        [Fact]
-        public void GetItemText_CustomConverter_ReturnsExpected()
+        [WinFormsFact]
+        public void ListControl_GetItemText_CustomConverter_ReturnsExpected()
         {
             var item = new CustomTypeConverterDataClass { Value = 10 };
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 FormattingEnabled = true,
                 BindingContext = new BindingContext(),
@@ -2397,11 +2487,11 @@ namespace System.Windows.Forms.Tests
             Assert.Equal("custom", control.GetItemText(item));
         }
 
-        [Fact]
-        public void GetItemText_CustomConverterFormattingDisabled_ReturnsExpected()
+        [WinFormsFact]
+        public void ListControl_GetItemText_CustomConverterFormattingDisabled_ReturnsExpected()
         {
             var item = new CustomTypeConverterDataClass { Value = 10 };
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 FormattingEnabled = false,
                 BindingContext = new BindingContext(),
@@ -2414,11 +2504,11 @@ namespace System.Windows.Forms.Tests
             Assert.Equal("10", control.GetItemText(item));
         }
 
-        [Fact]
-        public void GetItemText_CustomConverterNoContext_ReturnsExpected()
+        [WinFormsFact]
+        public void ListControl_GetItemText_CustomConverterNoContext_ReturnsExpected()
         {
             var item = new CustomTypeConverterDataClass { Value = 10 };
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 FormattingEnabled = true,
                 DataSource = new List<CustomTypeConverterDataClass> { item },
@@ -2430,11 +2520,11 @@ namespace System.Windows.Forms.Tests
             Assert.Equal("10", control.GetItemText(item));
         }
 
-        [Fact]
-        public void GetItemText_NonCriticalThrowingExceptionType_ReturnsExpected()
+        [WinFormsFact]
+        public void ListControl_GetItemText_NonCriticalThrowingExceptionType_ReturnsExpected()
         {
             var item = new NonCriticalThrowingTypeConverterDataClass();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 FormattingEnabled = true,
                 BindingContext = new BindingContext(),
@@ -2447,11 +2537,11 @@ namespace System.Windows.Forms.Tests
             Assert.Equal("NonCriticalThrowingTypeConverterDataClassToString", control.GetItemText(item));
         }
 
-        [Fact]
-        public void GetItemText_CriticalThrowingExceptionType_RethrowsException()
+        [WinFormsFact]
+        public void ListControl_GetItemText_CriticalThrowingExceptionType_RethrowsException()
         {
             var item = new CriticalThrowingTypeConverterDataClass();
-            var control = new SubListControl
+            using var control = new SubListControl
             {
                 FormattingEnabled = true,
                 BindingContext = new BindingContext(),
@@ -2463,7 +2553,7 @@ namespace System.Windows.Forms.Tests
             // Test caching behaviour.
             Assert.Throws<StackOverflowException>(() => control.GetItemText(item));
         }
-        
+
         [WinFormsFact]
         public void ListControl_GetAutoSizeMode_Invoke_ReturnsExpected()
         {
@@ -2501,299 +2591,266 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, control.GetStyle(flag));
         }
 
-        [Fact]
-        public void OnBindingContextChanged_Invoke_CallsBindingContextChanged()
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
+        public void ListControl_OnBindingContextChanged_Invoke_CallsBindingContextChanged(EventArgs eventArgs)
         {
-            var control = new SubListControl();
-            var eventArgs = new EventArgs();
-
-            // No handler.
-            control.OnBindingContextChanged(eventArgs);
-
-            // Handler.
+            using var control = new SubListControl();
             int callCount = 0;
             EventHandler handler = (sender, e) =>
             {
-                Assert.Equal(control, sender);
+                Assert.Same(control, sender);
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
 
+            // Call with handler.
             control.BindingContextChanged += handler;
             control.OnBindingContextChanged(eventArgs);
             Assert.Equal(1, callCount);
 
-            // Should not call if the handler is removed.
+            // Remove handler.
             control.BindingContextChanged -= handler;
             control.OnBindingContextChanged(eventArgs);
             Assert.Equal(1, callCount);
         }
 
-        [Fact]
-        public void OnDataSourceChanged_Invoke_CallsDataSourceChanged()
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
+        public void ListControl_OnDataSourceChanged_Invoke_CallsDataSourceChanged(EventArgs eventArgs)
         {
-            var control = new SubListControl();
-            var eventArgs = new EventArgs();
-
-            // No handler.
-            control.OnDataSourceChanged(eventArgs);
-
-            // Handler.
+            using var control = new SubListControl();
             int callCount = 0;
             EventHandler handler = (sender, e) =>
             {
-                Assert.Equal(control, sender);
+                Assert.Same(control, sender);
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
 
+            // Call with handler.
             control.DataSourceChanged += handler;
             control.OnDataSourceChanged(eventArgs);
             Assert.Equal(1, callCount);
 
-            // Should not call if the handler is removed.
+            // Remove handler.
             control.DataSourceChanged -= handler;
             control.OnDataSourceChanged(eventArgs);
             Assert.Equal(1, callCount);
         }
 
-        [Fact]
-        public void OnDisplayMemberChanged_Invoke_CallsDisplayMemberChanged()
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
+        public void ListControl_OnDisplayMemberChanged_Invoke_CallsDisplayMemberChanged(EventArgs eventArgs)
         {
-            var control = new SubListControl();
-            var eventArgs = new EventArgs();
-
-            // No handler.
-            control.OnDisplayMemberChanged(eventArgs);
-
-            // Handler.
+            using var control = new SubListControl();
             int callCount = 0;
             EventHandler handler = (sender, e) =>
             {
-                Assert.Equal(control, sender);
+                Assert.Same(control, sender);
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
 
+            // Call with handler.
             control.DisplayMemberChanged += handler;
             control.OnDisplayMemberChanged(eventArgs);
             Assert.Equal(1, callCount);
 
-            // Should not call if the handler is removed.
+            // Remove handler.
             control.DisplayMemberChanged -= handler;
             control.OnDisplayMemberChanged(eventArgs);
             Assert.Equal(1, callCount);
         }
 
-        [Fact]
-        public void OnFormat_Invoke_CallsFormat()
+        public static IEnumerable<object[]> OnFormat_TestData()
         {
-            var control = new SubListControl();
-            var eventArgs = new ListControlConvertEventArgs(new object(), typeof(int), new object());
+            yield return new object[] { null };
+            yield return new object[] { new ListControlConvertEventArgs(null, null, null) };
+            yield return new object[] { new ListControlConvertEventArgs(new object(), typeof(int), new object()) };
+        }
 
-            // No handler.
-            control.OnFormat(eventArgs);
-
-            // Handler.
+        [WinFormsTheory]
+        [MemberData(nameof(OnFormat_TestData))]
+        public void ListControl_OnFormat_Invoke_CallsFormat(ListControlConvertEventArgs eventArgs)
+        {
+            using var control = new SubListControl();
             int callCount = 0;
             ListControlConvertEventHandler handler = (sender, e) =>
             {
-                Assert.Equal(control, sender);
+                Assert.Same(control, sender);
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
 
+            // Call with handler.
             control.Format += handler;
             control.OnFormat(eventArgs);
             Assert.Equal(1, callCount);
 
-            // Should not call if the handler is removed.
+            // Remove handler.
             control.Format -= handler;
             control.OnFormat(eventArgs);
             Assert.Equal(1, callCount);
         }
 
-        [Fact]
-        public void OnFormatInfoChanged_Invoke_CallsFormatInfoChanged()
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
+        public void ListControl_OnFormatInfoChanged_Invoke_CallsFormatInfoChanged(EventArgs eventArgs)
         {
-            var control = new SubListControl();
-            var eventArgs = new EventArgs();
-
-            // No handler.
-            control.OnFormatInfoChanged(eventArgs);
-
-            // Handler.
+            using var control = new SubListControl();
             int callCount = 0;
             EventHandler handler = (sender, e) =>
             {
-                Assert.Equal(control, sender);
+                Assert.Same(control, sender);
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
 
+            // Call with handler.
             control.FormatInfoChanged += handler;
             control.OnFormatInfoChanged(eventArgs);
             Assert.Equal(1, callCount);
 
-            // Should not call if the handler is removed.
+            // Remove handler.
             control.FormatInfoChanged -= handler;
             control.OnFormatInfoChanged(eventArgs);
             Assert.Equal(1, callCount);
         }
 
-        [Fact]
-        public void OnFormatStringChanged_Invoke_CallsFormatStringChanged()
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
+        public void ListControl_OnFormatStringChanged_Invoke_CallsFormatStringChanged(EventArgs eventArgs)
         {
-            var control = new SubListControl();
-            var eventArgs = new EventArgs();
-
-            // No handler.
-            control.OnFormatStringChanged(eventArgs);
-
-            // Handler.
+            using var control = new SubListControl();
             int callCount = 0;
             EventHandler handler = (sender, e) =>
             {
-                Assert.Equal(control, sender);
+                Assert.Same(control, sender);
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
 
+            // Call with handler.
             control.FormatStringChanged += handler;
             control.OnFormatStringChanged(eventArgs);
             Assert.Equal(1, callCount);
 
-            // Should not call if the handler is removed.
+            // Remove handler.
             control.FormatStringChanged -= handler;
             control.OnFormatStringChanged(eventArgs);
             Assert.Equal(1, callCount);
         }
 
-        [Fact]
-        public void OnFormattingEnabledChanged_Invoke_CallsFormattingEnabledChanged()
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
+        public void ListControl_OnFormattingEnabledChanged_Invoke_CallsFormattingEnabledChanged(EventArgs eventArgs)
         {
-            var control = new SubListControl();
-            var eventArgs = new EventArgs();
-
-            // No handler.
-            control.OnFormattingEnabledChanged(eventArgs);
-
-            // Handler.
+            using var control = new SubListControl();
             int callCount = 0;
             EventHandler handler = (sender, e) =>
             {
-                Assert.Equal(control, sender);
+                Assert.Same(control, sender);
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
 
+            // Call with handler.
             control.FormattingEnabledChanged += handler;
             control.OnFormattingEnabledChanged(eventArgs);
             Assert.Equal(1, callCount);
 
-            // Should not call if the handler is removed.
+            // Remove handler.
             control.FormattingEnabledChanged -= handler;
             control.OnFormattingEnabledChanged(eventArgs);
             Assert.Equal(1, callCount);
         }
 
-        [Fact]
-        public void OnSelectedIndexChanged_Invoke_CallsSelectedValueChanged()
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
+        public void ListControl_OnSelectedIndexChanged_Invoke_CallsSelectedValueChanged(EventArgs eventArgs)
         {
-            var control = new SubListControl();
-            var eventArgs = new EventArgs();
-
-            // No handler.
-            control.OnSelectedIndexChanged(eventArgs);
-
-            // Handler.
+            using var control = new SubListControl();
             int callCount = 0;
             EventHandler handler = (sender, e) =>
             {
-                Assert.Equal(control, sender);
+                Assert.Same(control, sender);
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
 
+            // Call with handler.
             control.SelectedValueChanged += handler;
             control.OnSelectedIndexChanged(eventArgs);
             Assert.Equal(1, callCount);
 
-            // Should not call if the handler is removed.
+            // Remove handler.
             control.SelectedValueChanged -= handler;
             control.OnSelectedIndexChanged(eventArgs);
             Assert.Equal(1, callCount);
         }
 
-        [Fact]
-        public void OnSelectedValueChanged_Invoke_CallsSelectedValueChanged()
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
+        public void ListControl_OnSelectedValueChanged_Invoke_CallsSelectedValueChanged(EventArgs eventArgs)
         {
-            var control = new SubListControl();
-            var eventArgs = new EventArgs();
-
-            // No handler.
-            control.OnSelectedValueChanged(eventArgs);
-
-            // Handler.
+            using var control = new SubListControl();
             int callCount = 0;
             EventHandler handler = (sender, e) =>
             {
-                Assert.Equal(control, sender);
+                Assert.Same(control, sender);
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
 
+            // Call with handler.
             control.SelectedValueChanged += handler;
             control.OnSelectedValueChanged(eventArgs);
             Assert.Equal(1, callCount);
 
-            // Should not call if the handler is removed.
+            // Remove handler.
             control.SelectedValueChanged -= handler;
             control.OnSelectedValueChanged(eventArgs);
             Assert.Equal(1, callCount);
         }
 
-        [Fact]
-        public void OnValueMemberChanged_Invoke_CallsValueMemberChanged()
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
+        public void ListControl_OnValueMemberChanged_Invoke_CallsValueMemberChanged(EventArgs eventArgs)
         {
-            var control = new SubListControl();
-            var eventArgs = new EventArgs();
-
-            // No handler.
-            control.OnValueMemberChanged(eventArgs);
-
-            // Handler.
+            using var control = new SubListControl();
             int callCount = 0;
             EventHandler handler = (sender, e) =>
             {
-                Assert.Equal(control, sender);
+                Assert.Same(control, sender);
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
 
+            // Call with handler.
             control.ValueMemberChanged += handler;
             control.OnValueMemberChanged(eventArgs);
             Assert.Equal(1, callCount);
 
-            // Should not call if the handler is removed.
+            // Remove handler.
             control.ValueMemberChanged -= handler;
             control.OnValueMemberChanged(eventArgs);
             Assert.Equal(1, callCount);
         }
 
-        [Fact]
-        public void RefreshItems_Invoke_Nop()
+        [WinFormsFact]
+        public void ListControl_RefreshItems_Invoke_Nop()
         {
-            var control = new SubListControl();
+            using var control = new SubListControl();
             control.RefreshItemsEntry();
         }
 
-        [Theory]
+        [WinFormsTheory]
         [InlineData(0, null)]
         [InlineData(-1, 1)]
-        public void SetItemCore_Invoke_Nop(int index, object value)
+        public void ListControl_SetItemCore_Invoke_Nop(int index, object value)
         {
-            var control = new SubListControl();
+            using var control = new SubListControl();
             control.SetItemCoreEntry(index, value);
         }
 


### PR DESCRIPTION
## Proposed Changes
Was going to write some test for subclasses of `ListControl` but noticed the tests were a bit messy - not disposing/using `WinFormsFact` etc. so went through and cleaned up the test class

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2566)