### PR TITLE
Add SB and SBT enums in Interop ComCtl32 and SBS and SS enums in User32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.SB.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.SB.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using static Interop.User32;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        [Flags]
+        public enum SB : uint
+        {
+            SETPARTS = WM_USER + 4,
+            GETPARTS = WM_USER + 6,
+            GETBORDERS = WM_USER + 7,
+            SETMINHEIGHT = WM_USER + 8,
+            SIMPLE = WM_USER + 9,
+            GETRECT = WM_USER + 10,
+            SETTEXT = WM_USER + 11,
+            GETTEXTLENGTH = WM_USER + 12,
+            GETTEXT = WM_USER + 13,
+            ISSIMPLE = WM_USER + 14,
+            SETICON = WM_USER + 15,
+            SETTIPTEXT = WM_USER + 17,
+            GETTIPTEXT = WM_USER + 19,
+            GETICON = WM_USER + 20
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.SBT.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.SBT.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        [Flags]
+        public enum SBT : uint
+        {
+            NOBORDERS = 0x0100,
+            POPOUT = 0x0200,
+            RTLREADING = 0x0400,
+            NOTABPARSING = 0x0800,
+            OWNERDRAW = 0x1000
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SBS.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SBS.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [Flags]
+        public enum SBS : uint
+        {
+            HORZ = 0x0000,
+            VERT = 0x0001,
+            TOPALIGN = 0x0002,
+            LEFTALIGN = 0x0002,
+            SIZEBOXTOPLEFTALIGN = 0x0002,
+            BOTTOMALIGN = 0x0004,
+            RIGHTALIGN = 0x0004,
+            SIZEBOXBOTTOMRIGHTALIGN = 0x0004,
+            SIZEBOX = 0x0008,
+            SIZEGRIP = 0x0010
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SS.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SS.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [Flags]
+        public enum SS : uint
+        {
+            LEFT = 0x00000000,
+            CENTER = 0x00000001,
+            RIGHT = 0x00000002,
+            ICON = 0x00000003,
+            BLACKRECT = 0x00000004,
+            GRAYRECT = 0x00000005,
+            WHITERECT = 0x00000006,
+            BLACKFRAME = 0x00000007,
+            GRAYFRAME = 0x00000008,
+            WHITEFRAME = 0x00000009,
+            USERITEM = 0x0000000A,
+            SIMPLE = 0x0000000B,
+            LEFTNOWORDWRAP = 0x0000000C,
+            OWNERDRAW = 0x0000000D,
+            BITMAP = 0x0000000E,
+            ENHMETAFILE = 0x0000000F,
+            ETCHEDHORZ = 0x00000010,
+            ETCHEDVERT = 0x00000011,
+            ETCHEDFRAME = 0x00000012,
+            TYPEMASK = 0x0000001F,
+            REALSIZECONTROL = 0x00000040,
+            NOPREFIX = 0x00000080,
+            NOTIFY = 0x00000100,
+            CENTERIMAGE = 0x00000200,
+            RIGHTJUST = 0x00000400,
+            REALSIZEIMAGE = 0x00000800,
+            SUNKEN = 0x00001000,
+            EDITCONTROL = 0x00002000,
+            ENDELLIPSIS = 0x00004000,
+            PATHELLIPSIS = 0x00008000,
+            WORDELLIPSIS = 0x0000C000,
+            ELLIPSISMASK = 0x0000C000
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -351,29 +351,7 @@ namespace System.Windows.Forms
         HLP_NAVIGATOR = 3,
         HLP_OBJECT = 4;
 
-        public const int
-        SS_LEFT = 0x00000000,
-        SS_CENTER = 0x00000001,
-        SS_RIGHT = 0x00000002,
-        SS_OWNERDRAW = 0x0000000D,
-        SS_NOPREFIX = 0x00000080,
-        SS_SUNKEN = 0x00001000,
-        SBS_HORZ = 0x0000,
-        SBS_VERT = 0x0001,
-        SBARS_SIZEGRIP = 0x0100,
-        SB_SETTEXT = (0x0400 + 11),
-        SB_GETTEXT = (0x0400 + 13),
-        SB_GETTEXTLENGTH = (0x0400 + 12),
-        SB_SETPARTS = (0x0400 + 4),
-        SB_SIMPLE = (0x0400 + 9),
-        SB_GETRECT = (0x0400 + 10),
-        SB_SETICON = (0x0400 + 15),
-        SB_SETTIPTEXT = (0x0400 + 17),
-        SB_GETTIPTEXT = (0x0400 + 19),
-        SBT_OWNERDRAW = 0x1000,
-        SBT_NOBORDERS = 0x0100,
-        SBT_POPOUT = 0x0200,
-        SBT_RTLREADING = 0x0400;
+        public const int SBARS_SIZEGRIP = 0x0100;
 
         public static bool Succeeded(int hr)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HScrollBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HScrollBar.cs
@@ -4,6 +4,7 @@
 
 using System.Drawing;
 using System.Runtime.InteropServices;
+using static Interop;
 
 namespace System.Windows.Forms
 {
@@ -20,7 +21,7 @@ namespace System.Windows.Forms
             get
             {
                 CreateParams cp = base.CreateParams;
-                cp.Style |= NativeMethods.SBS_HORZ;
+                cp.Style |= (int)User32.SBS.HORZ;
                 return cp;
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
@@ -296,11 +296,10 @@ namespace System.Windows.Forms
                     // An unfortunate side effect of this style is Windows sends us WM_DRAWITEM
                     // messages instead of WM_PAINT, but since Windows insists on repainting
                     // *without* a WM_PAINT after SetWindowText, I don't see much choice.
-                    cp.Style |= NativeMethods.SS_OWNERDRAW;
+                    cp.Style |= (int)User32.SS.OWNERDRAW;
 
                     // Since we're owner draw, I don't see any point in setting the
                     // SS_CENTER/SS_RIGHT styles.
-                    //
                     cp.ExStyle &= ~(int)User32.WS_EX.RIGHT;   // WS_EX_RIGHT overrides the SS_XXXX alignment styles
                 }
 
@@ -311,25 +310,23 @@ namespace System.Windows.Forms
                         case ContentAlignment.TopLeft:
                         case ContentAlignment.MiddleLeft:
                         case ContentAlignment.BottomLeft:
-                            cp.Style |= NativeMethods.SS_LEFT;
+                            cp.Style |= (int)User32.SS.LEFT;
                             break;
-
                         case ContentAlignment.TopRight:
                         case ContentAlignment.MiddleRight:
                         case ContentAlignment.BottomRight:
-                            cp.Style |= NativeMethods.SS_RIGHT;
+                            cp.Style |= (int)User32.SS.RIGHT;
                             break;
-
                         case ContentAlignment.TopCenter:
                         case ContentAlignment.MiddleCenter:
                         case ContentAlignment.BottomCenter:
-                            cp.Style |= NativeMethods.SS_CENTER;
+                            cp.Style |= (int)User32.SS.CENTER;
                             break;
                     }
                 }
                 else
                 {
-                    cp.Style |= NativeMethods.SS_LEFT;
+                    cp.Style |= (int)User32.SS.LEFT;
                 }
 
                 switch (BorderStyle)
@@ -338,13 +335,13 @@ namespace System.Windows.Forms
                         cp.Style |= (int)User32.WS.BORDER;
                         break;
                     case BorderStyle.Fixed3D:
-                        cp.Style |= NativeMethods.SS_SUNKEN;
+                        cp.Style |= (int)User32.SS.SUNKEN;
                         break;
                 }
 
                 if (!UseMnemonic)
                 {
-                    cp.Style |= NativeMethods.SS_NOPREFIX;
+                    cp.Style |= (int)User32.SS.NOPREFIX;
                 }
 
                 return cp;
@@ -983,11 +980,11 @@ namespace System.Windows.Forms
                         int style = WindowStyle;
                         if (!UseMnemonic)
                         {
-                            style |= NativeMethods.SS_NOPREFIX;
+                            style |= (int)User32.SS.NOPREFIX;
                         }
                         else
                         {
-                            style &= ~NativeMethods.SS_NOPREFIX;
+                            style &= ~(int)User32.SS.NOPREFIX;
                         }
                         WindowStyle = style;
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -5514,7 +5514,7 @@ namespace System.Windows.Forms
                     lvgroup.uAlign = LVGA.HEADER_CENTER;
                     break;
             }
-            
+
             fixed (char* pHeader = header)
             {
                 lvgroup.pszHeader = pHeader;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.cs
@@ -41,7 +41,7 @@ namespace System.Windows.Forms
 
             TabStop = false;
 
-            if ((CreateParams.Style & NativeMethods.SBS_VERT) != 0)
+            if ((CreateParams.Style & (int)User32.SBS.VERT) != 0)
             {
                 _scrollOrientation = ScrollOrientation.VerticalScroll;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
@@ -10,6 +10,7 @@ using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Windows.Forms.VisualStyles;
 using static Interop;
+using static Interop.ComCtl32;
 
 namespace System.Windows.Forms
 {
@@ -196,7 +197,7 @@ namespace System.Windows.Forms
             get
             {
                 CreateParams cp = base.CreateParams;
-                cp.ClassName = ComCtl32.WindowClasses.WC_STATUSBAR;
+                cp.ClassName = WindowClasses.WC_STATUSBAR;
 
                 if (sizeGrip)
                 {
@@ -204,7 +205,7 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    cp.Style &= (~NativeMethods.SBARS_SIZEGRIP);
+                    cp.Style &= ~NativeMethods.SBARS_SIZEGRIP;
                 }
                 cp.Style |= NativeMethods.CCS_NOPARENTALIGN | NativeMethods.CCS_NORESIZE;
 
@@ -410,7 +411,7 @@ namespace System.Windows.Forms
                     {
                         int bShowPanels = (!showPanels) ? 1 : 0;
 
-                        SendMessage(NativeMethods.SB_SIMPLE, bShowPanels, 0);
+                        SendMessage((int)SB.SIMPLE, bShowPanels, 0);
 
                         if (showPanels)
                         {
@@ -558,8 +559,8 @@ namespace System.Windows.Forms
                 {
                     offsets[0] -= SizeGripWidth;
                 }
-                UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.SB_SETPARTS, 1, offsets);
-                SendMessage(NativeMethods.SB_SETICON, 0, IntPtr.Zero);
+                UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), (int)SB.SETPARTS, 1, offsets);
+                SendMessage((int)SB.SETICON, 0, IntPtr.Zero);
 
                 return;
             }
@@ -573,7 +574,7 @@ namespace System.Windows.Forms
                 offsets2[i] = currentOffset;
                 panel.Right = offsets2[i];
             }
-            UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), NativeMethods.SB_SETPARTS, length, offsets2);
+            UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), (int)SB.SETPARTS, length, offsets2);
 
             // Tooltip setup...
             for (int i = 0; i < length; i++)
@@ -593,11 +594,11 @@ namespace System.Windows.Forms
 
                 try
                 {
-                    var icc = new ComCtl32.INITCOMMONCONTROLSEX
+                    var icc = new INITCOMMONCONTROLSEX
                     {
-                        dwICC = ComCtl32.ICC.BAR_CLASSES
+                        dwICC = ICC.BAR_CLASSES
                     };
-                    ComCtl32.InitCommonControlsEx(ref icc);
+                    InitCommonControlsEx(ref icc);
                 }
                 finally
                 {
@@ -658,7 +659,7 @@ namespace System.Windows.Forms
 
             if (!showPanels)
             {
-                SendMessage(NativeMethods.SB_SIMPLE, 1, 0);
+                SendMessage((int)SB.SIMPLE, 1, 0);
                 SetSimpleText(simpleText);
             }
             else
@@ -725,7 +726,7 @@ namespace System.Windows.Forms
 
             if (length == 0)
             {
-                SendMessage(NativeMethods.SB_SETTEXT, 0, "");
+                SendMessage((int)SB.SETTEXT, 0, string.Empty);
             }
 
             int i;
@@ -743,7 +744,7 @@ namespace System.Windows.Forms
             }
             for (; i < old; i++)
             {
-                SendMessage(NativeMethods.SB_SETTEXT, 0, null);
+                SendMessage((int)SB.SETTEXT, 0, null);
             }
         }
 
@@ -800,13 +801,13 @@ namespace System.Windows.Forms
         {
             if (!showPanels && IsHandleCreated)
             {
-                int wparam = SIMPLE_INDEX + NativeMethods.SBT_NOBORDERS;
+                int wparam = SIMPLE_INDEX + (int)SBT.NOBORDERS;
                 if (RightToLeft == RightToLeft.Yes)
                 {
-                    wparam |= NativeMethods.SBT_RTLREADING;
+                    wparam |= (int)SBT.RTLREADING;
                 }
 
-                SendMessage(NativeMethods.SB_SETTEXT, wparam, simpleText);
+                SendMessage((int)SB.SETTEXT, wparam, simpleText);
             }
         }
 
@@ -1022,21 +1023,21 @@ namespace System.Windows.Forms
             {
                 MouseButtons button = MouseButtons.Left;
                 int clicks = 0;
-                switch ((ComCtl32.NM)note->code)
+                switch ((NM)note->code)
                 {
-                    case ComCtl32.NM.CLICK:
+                    case NM.CLICK:
                         button = MouseButtons.Left;
                         clicks = 1;
                         break;
-                    case ComCtl32.NM.RCLICK:
+                    case NM.RCLICK:
                         button = MouseButtons.Right;
                         clicks = 1;
                         break;
-                    case ComCtl32.NM.DBLCLK:
+                    case NM.DBLCLK:
                         button = MouseButtons.Left;
                         clicks = 2;
                         break;
-                    case ComCtl32.NM.RDBLCLK:
+                    case NM.RDBLCLK:
                         button = MouseButtons.Right;
                         clicks = 2;
                         break;
@@ -1133,12 +1134,12 @@ namespace System.Windows.Forms
                 case WindowMessages.WM_NOTIFY:
                 case WindowMessages.WM_NOTIFY + WindowMessages.WM_REFLECT:
                     User32.NMHDR* note = (User32.NMHDR*)m.LParam;
-                    switch ((ComCtl32.NM)note->code)
+                    switch ((NM)note->code)
                     {
-                        case ComCtl32.NM.CLICK:
-                        case ComCtl32.NM.RCLICK:
-                        case ComCtl32.NM.DBLCLK:
-                        case ComCtl32.NM.RDBLCLK:
+                        case NM.CLICK:
+                        case NM.RCLICK:
+                        case NM.DBLCLK:
+                        case NM.RDBLCLK:
                             WmNotifyNMClick(note);
                             break;
                         default:
@@ -1642,16 +1643,16 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    var icc = new ComCtl32.INITCOMMONCONTROLSEX
+                    var icc = new INITCOMMONCONTROLSEX
                     {
-                        dwICC = ComCtl32.ICC.TAB_CLASSES
+                        dwICC = ICC.TAB_CLASSES
                     };
-                    ComCtl32.InitCommonControlsEx(ref icc);
+                    InitCommonControlsEx(ref icc);
 
                     var cp = new CreateParams
                     {
                         Parent = IntPtr.Zero,
-                        ClassName = ComCtl32.WindowClasses.TOOLTIPS_CLASS
+                        ClassName = WindowClasses.TOOLTIPS_CLASS
                     };
                     cp.Style |= NativeMethods.TTS_ALWAYSTIP;
                     cp.ExStyle = 0;
@@ -1761,7 +1762,7 @@ namespace System.Windows.Forms
                 {
                     StatusBar p = (StatusBar)parent;
 
-                    ComCtl32.ToolInfoWrapper<Control> info = GetTOOLINFO(tool);
+                    ToolInfoWrapper<Control> info = GetTOOLINFO(tool);
                     if (info.SendMessage(p.ToolTipSet ? (IHandle)p.mainToolTip : this, User32.WindowMessage.TTM_ADDTOOLW) == IntPtr.Zero)
                     {
                         throw new InvalidOperationException(SR.StatusBarAddFailed);
@@ -1773,7 +1774,7 @@ namespace System.Windows.Forms
             {
                 if (tool != null && tool.text != null && tool.text.Length > 0 && (int)tool.id >= 0)
                 {
-                    ComCtl32.ToolInfoWrapper<Control> info = GetMinTOOLINFO(tool);
+                    ToolInfoWrapper<Control> info = GetMinTOOLINFO(tool);
                     info.SendMessage(this, User32.WindowMessage.TTM_DELTOOLW);
                 }
             }
@@ -1782,7 +1783,7 @@ namespace System.Windows.Forms
             {
                 if (tool != null && tool.text != null && tool.text.Length > 0 && (int)tool.id >= 0)
                 {
-                    ComCtl32.ToolInfoWrapper<Control> info = GetTOOLINFO(tool);
+                    ToolInfoWrapper<Control> info = GetTOOLINFO(tool);
                     info.SendMessage(this, User32.WindowMessage.TTM_SETTOOLINFOW);
                 }
             }
@@ -1834,14 +1835,14 @@ namespace System.Windows.Forms
             ///  required data to uniquely identify a region. This is used primarily
             ///  for delete operations. NOTE: This cannot force the creation of a handle.
             /// </summary>
-            private ComCtl32.ToolInfoWrapper<Control> GetMinTOOLINFO(Tool tool)
+            private ToolInfoWrapper<Control> GetMinTOOLINFO(Tool tool)
             {
                 if ((int)tool.id < 0)
                 {
                     AssignId(tool);
                 }
 
-                return new ComCtl32.ToolInfoWrapper<Control>(
+                return new ToolInfoWrapper<Control>(
                     parent,
                     id: parent is StatusBar sb ? sb.Handle : tool.id);
             }
@@ -1850,16 +1851,16 @@ namespace System.Windows.Forms
             ///  Returns a detailed TOOLINFO_T structure that represents the specified
             ///  region. NOTE: This may force the creation of a handle.
             /// </summary>
-            private ComCtl32.ToolInfoWrapper<Control> GetTOOLINFO(Tool tool)
+            private ToolInfoWrapper<Control> GetTOOLINFO(Tool tool)
             {
-                ComCtl32.ToolInfoWrapper<Control> ti = GetMinTOOLINFO(tool);
-                ti.Info.uFlags |= ComCtl32.TTF.TRANSPARENT | ComCtl32.TTF.SUBCLASS;
+                ToolInfoWrapper<Control> ti = GetMinTOOLINFO(tool);
+                ti.Info.uFlags |= TTF.TRANSPARENT | TTF.SUBCLASS;
 
                 // RightToLeft reading order
                 Control richParent = parent;
                 if (richParent != null && richParent.RightToLeft == RightToLeft.Yes)
                 {
-                    ti.Info.uFlags |= ComCtl32.TTF.RTLREADING;
+                    ti.Info.uFlags |= TTF.RTLREADING;
                 }
 
                 ti.Text = tool.text;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusBarPanel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusBarPanel.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using static Interop;
+using static Interop.ComCtl32;
 
 namespace System.Windows.Forms
 {
@@ -187,7 +188,7 @@ namespace System.Windows.Forms
                 if (Created)
                 {
                     IntPtr handle = (icon == null) ? IntPtr.Zero : icon.Handle;
-                    parent.SendMessage(NativeMethods.SB_SETICON, (IntPtr)GetIndex(), handle);
+                    parent.SendMessage((int)SB.SETICON, (IntPtr)GetIndex(), handle);
                 }
                 UpdateSize();
                 if (Created)
@@ -571,18 +572,10 @@ namespace System.Windows.Forms
         {
             if (Created)
             {
-                string text;
                 string sendText;
-                int border = 0;
+                SBT border = 0;
 
-                if (this.text == null)
-                {
-                    text = string.Empty;
-                }
-                else
-                {
-                    text = this.text;
-                }
+                string text = this.text ?? string.Empty;
 
                 HorizontalAlignment align = alignment;
                 // Translate the alignment for Rtl apps
@@ -615,12 +608,12 @@ namespace System.Windows.Forms
                 switch (borderStyle)
                 {
                     case StatusBarPanelBorderStyle.None:
-                        border |= NativeMethods.SBT_NOBORDERS;
+                        border |= SBT.NOBORDERS;
                         break;
                     case StatusBarPanelBorderStyle.Sunken:
                         break;
                     case StatusBarPanelBorderStyle.Raised:
-                        border |= NativeMethods.SBT_POPOUT;
+                        border |= SBT.POPOUT;
                         break;
                 }
                 switch (style)
@@ -628,17 +621,17 @@ namespace System.Windows.Forms
                     case StatusBarPanelStyle.Text:
                         break;
                     case StatusBarPanelStyle.OwnerDraw:
-                        border |= NativeMethods.SBT_OWNERDRAW;
+                        border |= SBT.OWNERDRAW;
                         break;
                 }
 
-                int wparam = GetIndex() | border;
+                int wparam = GetIndex() | (int)border;
                 if (parent.RightToLeft == RightToLeft.Yes)
                 {
-                    wparam |= NativeMethods.SBT_RTLREADING;
+                    wparam |= (int)SBT.RTLREADING;
                 }
 
-                int result = (int)UnsafeNativeMethods.SendMessage(new HandleRef(parent, parent.Handle), NativeMethods.SB_SETTEXT, (IntPtr)wparam, sendText);
+                int result = (int)UnsafeNativeMethods.SendMessage(new HandleRef(parent, parent.Handle), (int)SB.SETTEXT, (IntPtr)wparam, sendText);
 
                 if (result == 0)
                 {
@@ -647,17 +640,17 @@ namespace System.Windows.Forms
 
                 if (icon != null && style != StatusBarPanelStyle.OwnerDraw)
                 {
-                    parent.SendMessage(NativeMethods.SB_SETICON, (IntPtr)GetIndex(), icon.Handle);
+                    parent.SendMessage((int)SB.SETICON, (IntPtr)GetIndex(), icon.Handle);
                 }
                 else
                 {
-                    parent.SendMessage(NativeMethods.SB_SETICON, (IntPtr)GetIndex(), IntPtr.Zero);
+                    parent.SendMessage((int)SB.SETICON, (IntPtr)GetIndex(), IntPtr.Zero);
                 }
 
                 if (style == StatusBarPanelStyle.OwnerDraw)
                 {
                     RECT rect = new RECT();
-                    result = (int)UnsafeNativeMethods.SendMessage(new HandleRef(parent, parent.Handle), NativeMethods.SB_GETRECT, (IntPtr)GetIndex(), ref rect);
+                    result = (int)UnsafeNativeMethods.SendMessage(new HandleRef(parent, parent.Handle), (int)SB.GETRECT, (IntPtr)GetIndex(), ref rect);
 
                     if (result != 0)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -5074,7 +5074,7 @@ namespace System.Windows.Forms
                 // be taken - but we'll handle that in WM_NCACTIVATE handler.
                 Point pt = PointToClient(WindowsFormsUtils.LastCursorPoint);
                 IntPtr hwndClicked = User32.ChildWindowFromPointEx(this, pt, User32.CWP.SKIPINVISIBLE | User32.CWP.SKIPDISABLED | User32.CWP.SKIPTRANSPARENT);
-                
+
                 // if we click on the toolstrip itself, eat the activation.
                 // if we click on a child control, allow the toolstrip to activate.
                 if (hwndClicked == Handle)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VScrollBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VScrollBar.cs
@@ -5,6 +5,7 @@
 using System.ComponentModel;
 using System.Drawing;
 using System.Runtime.InteropServices;
+using static Interop;
 
 namespace System.Windows.Forms
 {
@@ -23,7 +24,7 @@ namespace System.Windows.Forms
             get
             {
                 CreateParams cp = base.CreateParams;
-                cp.Style |= NativeMethods.SBS_VERT;
+                cp.Style |= (int)User32.SBS.VERT;
                 return cp;
             }
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupTests.cs
@@ -408,7 +408,7 @@ namespace System.Windows.Forms.Tests
             ISerializable iSerializable = group;
             var info = new SerializationInfo(typeof(ListViewGroup), new FormatterConverter());
             var context = new StreamingContext();
-            
+
             iSerializable.GetObjectData(info, context);
             Assert.Equal("ListViewGroup", info.GetString("Header"));
             Assert.Equal(HorizontalAlignment.Left, info.GetValue("HeaderAlignment", typeof(HorizontalAlignment)));
@@ -426,7 +426,7 @@ namespace System.Windows.Forms.Tests
             ISerializable iSerializable = group;
             var info = new SerializationInfo(typeof(ListViewGroup), new FormatterConverter());
             var context = new StreamingContext();
-            
+
             iSerializable.GetObjectData(info, context);
             Assert.Equal("ListViewGroup", info.GetString("Header"));
             Assert.Equal(HorizontalAlignment.Left, info.GetValue("HeaderAlignment", typeof(HorizontalAlignment)));

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -1484,15 +1484,15 @@ namespace System.Windows.Forms.Tests
                 yield return new object[] { showGroups, null, HorizontalAlignment.Left, string.Empty, 0x00000001 };
                 yield return new object[] { showGroups, null, HorizontalAlignment.Center, string.Empty, 0x00000002 };
                 yield return new object[] { showGroups, null, HorizontalAlignment.Right, string.Empty, 0x00000004 };
-                    
+
                 yield return new object[] { showGroups, string.Empty, HorizontalAlignment.Left, string.Empty, 0x00000001 };
                 yield return new object[] { showGroups, string.Empty, HorizontalAlignment.Center, string.Empty, 0x00000002 };
                 yield return new object[] { showGroups, string.Empty, HorizontalAlignment.Right, string.Empty, 0x00000004 };
-                    
+
                 yield return new object[] { showGroups, "text", HorizontalAlignment.Left, "text", 0x00000001 };
                 yield return new object[] { showGroups, "text", HorizontalAlignment.Center, "text", 0x00000002 };
                 yield return new object[] { showGroups, "text", HorizontalAlignment.Right, "text", 0x00000004 };
-                    
+
                 yield return new object[] { showGroups, "te\0xt", HorizontalAlignment.Left, "te", 0x00000001 };
                 yield return new object[] { showGroups, "te\0xt", HorizontalAlignment.Center, "te", 0x00000002 };
                 yield return new object[] { showGroups, "te\0xt", HorizontalAlignment.Right, "te", 0x00000004 };
@@ -1541,7 +1541,7 @@ namespace System.Windows.Forms.Tests
                     Assert.Equal("ListViewGroup", new string(lvgroup1.pszHeader));
                     Assert.True(lvgroup1.iGroupId >= 0);
                     Assert.Equal(0x00000001, (int)lvgroup1.uAlign);
-                    
+
                     var lvgroup2 = new ComCtl32.LVGROUPW
                     {
                         cbSize = (uint)Marshal.SizeOf<ComCtl32.LVGROUPW>(),


### PR DESCRIPTION
## Proposed changes

- Add SB and SBT enums in Interop ComCtl32 and SBS and SS enums in User32. 
- Remove SB, SBT, SBS and SS constants from NativeMethods.cs and replace their usages with the above enums.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2588)