### PR TITLE
Move DragAcceptFiles to Interop Shell32

### DIFF
--- a/src/Common/src/Interop/Shell32/Interop.DragAcceptFiles.cs
+++ b/src/Common/src/Interop/Shell32/Interop.DragAcceptFiles.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Shell32
+    {
+        [DllImport(Libraries.Shell32, ExactSpelling = true)]
+        public static extern void DragAcceptFiles(IntPtr hWnd, BOOL fAccept);
+
+        public static void DragAcceptFiles(IHandle hWnd, BOOL fAccept)
+        {
+            DragAcceptFiles(hWnd.Handle, fAccept);
+            GC.KeepAlive(hWnd);
+        }
+    }
+}

--- a/src/Common/src/Interop/Shell32/Interop.ShellExecuteW.cs
+++ b/src/Common/src/Interop/Shell32/Interop.ShellExecuteW.cs
@@ -17,6 +17,7 @@ internal static partial class Interop
             string lpParameters,
             string lpDirectory,
             User32.SW nShowCmd);
+
         public static IntPtr ShellExecuteW(
             HandleRef hwnd,
             string lpOperation,

--- a/src/Common/src/UnsafeNativeMethods.cs
+++ b/src/Common/src/UnsafeNativeMethods.cs
@@ -313,9 +313,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.User32, EntryPoint = "SendMessage", CharSet = CharSet.Auto)]
         public extern static IntPtr SendCallbackMessage(HandleRef hWnd, int Msg, IntPtr wParam, IntPtr lParam);
 
-        [DllImport(ExternDll.Shell32, ExactSpelling = true, CharSet = CharSet.Ansi)]
-        public static extern void DragAcceptFiles(HandleRef hWnd, bool fAccept);
-
         //GetWindowLong won't work correctly for 64-bit: we should use GetWindowLongPtr instead.  On
         //32-bit, GetWindowLongPtr is just #defined as GetWindowLong.  GetWindowLong really should
         //take/return int instead of IntPtr/HandleRef, but since we're running this only for 32-bit

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -3402,7 +3402,8 @@ namespace System.Windows.Forms
                         Marshal.Release(punk);
                     }
                 }
-                UnsafeNativeMethods.DragAcceptFiles(new HandleRef(this, Handle), false);
+
+                Shell32.DragAcceptFiles(this, BOOL.FALSE);
             }
         }
 


### PR DESCRIPTION
## Proposed changes

- Move DragAcceptFiles to Interop Shell32.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2589)