### PR TITLE
Move DPI_AWARENESS, GetAwarenessFromDpiAwarenessContext and GetWindow…

### DIFF
--- a/src/Common/src/CommonUnsafeNativeMethods.cs
+++ b/src/Common/src/CommonUnsafeNativeMethods.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
+using static Interop;
 
 namespace System.Windows.Forms
 {
@@ -16,12 +17,6 @@ namespace System.Windows.Forms
 
         [DllImport(ExternDll.User32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
         internal static extern DpiAwarenessContext SetThreadDpiAwarenessContext(DpiAwarenessContext dpiContext);
-
-        [DllImport(ExternDll.User32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
-        internal static extern IntPtr GetWindowDpiAwarenessContext(IntPtr hWnd);
-
-        [DllImport(ExternDll.User32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
-        internal static extern DPI_AWARENESS GetAwarenessFromDpiAwarenessContext(IntPtr dpiAwarenessContext);
 
         [DllImport(ExternDll.User32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
         internal static extern bool AreDpiAwarenessContextsEqual(DpiAwarenessContext dpiContextA, DpiAwarenessContext dpiContextB);
@@ -56,11 +51,9 @@ namespace System.Windows.Forms
             {
                 return GetThreadDpiAwarenessContext();
             }
-            else
-            {
-                // legacy OS that does not have this API available.
-                return DpiAwarenessContext.DPI_AWARENESS_CONTEXT_UNSPECIFIED;
-            }
+
+            // legacy OS that does not have this API available.
+            return DpiAwarenessContext.DPI_AWARENESS_CONTEXT_UNSPECIFIED;
         }
 
         /// <summary>
@@ -75,13 +68,12 @@ namespace System.Windows.Forms
                 {
                     throw new ArgumentException(nameof(dpiContext), dpiContext.ToString());
                 }
+
                 return SetThreadDpiAwarenessContext(dpiContext);
             }
-            else
-            {
-                // legacy OS that does not have this API available.
-                return DpiAwarenessContext.DPI_AWARENESS_CONTEXT_UNSPECIFIED;
-            }
+
+            // legacy OS that does not have this API available.
+            return DpiAwarenessContext.DPI_AWARENESS_CONTEXT_UNSPECIFIED;
         }
         /*
                 // Dpi awareness context values. Matching windows values.
@@ -98,8 +90,8 @@ namespace System.Windows.Forms
             if (OsVersion.IsWindows10_1607OrGreater)
             {
                 // Works only >= Windows 10/1607
-                IntPtr awarenessContext = GetWindowDpiAwarenessContext(hWnd);
-                DPI_AWARENESS awareness = GetAwarenessFromDpiAwarenessContext(awarenessContext);
+                IntPtr awarenessContext = User32.GetWindowDpiAwarenessContext(hWnd);
+                User32.DPI_AWARENESS awareness = User32.GetAwarenessFromDpiAwarenessContext(awarenessContext);
                 dpiAwarenessContext = ConvertToDpiAwarenessContext(awareness);
             }
 
@@ -110,34 +102,21 @@ namespace System.Windows.Forms
 
         #region Private Methods
 
-        private static DpiAwarenessContext ConvertToDpiAwarenessContext(DPI_AWARENESS dpiAwareness)
+        private static DpiAwarenessContext ConvertToDpiAwarenessContext(User32.DPI_AWARENESS dpiAwareness)
         {
             switch (dpiAwareness)
             {
-                case DPI_AWARENESS.DPI_AWARENESS_UNAWARE:
+                case User32.DPI_AWARENESS.UNAWARE:
                     return DpiAwarenessContext.DPI_AWARENESS_CONTEXT_UNAWARE;
-
-                case DPI_AWARENESS.DPI_AWARENESS_SYSTEM_AWARE:
+                case User32.DPI_AWARENESS.SYSTEM_AWARE:
                     return DpiAwarenessContext.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE;
-
-                case DPI_AWARENESS.DPI_AWARENESS_PER_MONITOR_AWARE:
+                case User32.DPI_AWARENESS.PER_MONITOR_AWARE:
                     return DpiAwarenessContext.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2;
-
                 default:
                     return DpiAwarenessContext.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE;
             }
         }
 
         #endregion
-
-#pragma warning disable CA1712 // Do not prefix enum values with type name
-        internal enum DPI_AWARENESS
-        {
-            DPI_AWARENESS_INVALID = -1,
-            DPI_AWARENESS_UNAWARE = 0,
-            DPI_AWARENESS_SYSTEM_AWARE = 1,
-            DPI_AWARENESS_PER_MONITOR_AWARE = 2
-        }
-#pragma warning restore CA1712 // Do not prefix enum values with type name
     }
 }

--- a/src/Common/src/Interop/User32/Interop.DPI_AWARENESS.cs
+++ b/src/Common/src/Interop/User32/Interop.DPI_AWARENESS.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public enum DPI_AWARENESS
+        {
+            INVALID = -1,
+            UNAWARE = 0,
+            SYSTEM_AWARE = 1,
+            PER_MONITOR_AWARE = 2
+        }
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.GetAwarenessFromDpiAwarenessContext.cs
+++ b/src/Common/src/Interop/User32/Interop.GetAwarenessFromDpiAwarenessContext.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, SetLastError = true, ExactSpelling = true)]
+        public static extern DPI_AWARENESS GetAwarenessFromDpiAwarenessContext(IntPtr dpiAwarenessContext);
+    }
+}

--- a/src/Common/src/Interop/User32/Interop.GetWindowDpiAwarenessContext.cs
+++ b/src/Common/src/Interop/User32/Interop.GetWindowDpiAwarenessContext.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, SetLastError = true, ExactSpelling = true)]
+        public static extern IntPtr GetWindowDpiAwarenessContext(IntPtr hWnd);
+    }
+}

--- a/src/System.Windows.Forms.Design.Editors/src/System.Windows.Forms.Design.Editors.csproj
+++ b/src/System.Windows.Forms.Design.Editors/src/System.Windows.Forms.Design.Editors.csproj
@@ -105,13 +105,16 @@
     <Compile Include="..\..\Common\src\Interop\Shell32\Interop.SHGetPathFromIDListLongPath.cs" Link="Interop\Shell32\Interop.SHGetPathFromIDListLongPath.cs" />
     <Compile Include="..\..\Common\src\Interop\Shell32\Interop.SHGetSpecialFolderLocation.cs" Link="Interop\Shell32\Interop.SHGetSpecialFolderLocation.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.ClientToScreen.cs" Link="Interop\User32\Interop.ClientToScreen.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.DPI_AWARENESS.cs" Link="Interop\User32\Interop.DPI_AWARENESS.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.DPI_AWARENESS_CONTEXT.cs" Link="Interop\User32\Interop.DPI_AWARENESS_CONTEXT.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.DrawText.cs" Link="Interop\User32\Interop.DrawText.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.DT.cs" Link="Interop\User32\Interop.DT.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.EnableWindow.cs" Link="Interop\User32\Interop.EnableWindow.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetActiveWindow.cs" Link="Interop\User32\Interop.GetActiveWindow.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.GetAwarenessFromDpiAwarenessContext.cs" Link="Interop\User32\Interop.GetAwarenessFromDpiAwarenessContext.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetDC.cs" Link="Interop\User32\Interop.GetDC.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetFocus.cs" Link="Interop\User32\Interop.GetFocus.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.GetWindowDpiAwarenessContext.cs" Link="Interop\User32\Interop.GetWindowDpiAwarenessContext.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetWindowText.cs" Link="Interop\User32\Interop.GetWindowText.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.IsProcessDPIAware.cs" Link="Interop\User32\Interop.IsProcessDPIAware.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.IsValidDpiAwarenessContext.cs" Link="Interop\User32\Interop.IsValidDpiAwarenessContext.cs" />

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -178,9 +178,11 @@
     <Compile Include="..\..\Common\src\Interop\User32\Interop.ClientToScreen.cs" Link="Interop\User32\Interop.ClientToScreen.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.CS.cs" Link="Interop\User32\Interop.CS.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.DefWindowProcW.cs" Link="Interop\User32\Interop.DefWindowProcW.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.DPI_AWARENESS.cs" Link="Interop\User32\Interop.DPI_AWARENESS.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.DPI_AWARENESS_CONTEXT.cs" Link="Interop\User32\Interop.DPI_AWARENESS_CONTEXT.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.EndPaint.cs" Link="Interop\User32\Interop.EndPaint.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetActiveWindow.cs" Link="Interop\User32\Interop.GetActiveWindow.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.GetAwarenessFromDpiAwarenessContext.cs" Link="Interop\User32\Interop.GetAwarenessFromDpiAwarenessContext.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetCapture.cs" Link="Interop\User32\Interop.GetCapture.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetCursor.cs" Link="Interop\User32\Interop.GetCursor.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetCursorPos.cs" Link="Interop\User32\Interop.GetCursorPos.cs" />
@@ -191,6 +193,7 @@
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetMessageTime.cs" Link="Interop\User32\Interop.GetMessageTime.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetUpdateRgn.cs" Link="Interop\User32\Interop.GetUpdateRgn.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetWindow.cs" Link="Interop\User32\Interop.GetWindow.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.GetWindowDpiAwarenessContext.cs" Link="Interop\User32\Interop.GetWindowDpiAwarenessContext.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetWindowLong.cs" Link="Interop\User32\Interop.GetWindowLong.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetWindowText.cs" Link="Interop\User32\Interop.GetWindowText.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.GetWindowThreadProcessId.cs" Link="Interop\User32\Interop.GetWindowThreadProcessId.cs" />


### PR DESCRIPTION
…DpiAwarenessContext to Interop User32

## Proposed changes

- Move DPI_AWARENESS, GetAwarenessFromDpiAwarenessContext and GetWindowDpiAwarenessContext to Interop User32.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2590)