### PR TITLE
Move GetThemeBool, GetThemeColor, GetThemeEnumValue and GetThemeInt t…

### DIFF
--- a/src/Common/src/Interop/UxTheme/Interop.GetThemeBool.cs
+++ b/src/Common/src/Interop/UxTheme/Interop.GetThemeBool.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    public static partial class UxTheme
+    {
+        [DllImport(Libraries.UxTheme, ExactSpelling = true)]
+        public static extern HRESULT GetThemeBool(IntPtr hTheme, int iPartId, int iStateId, int iPropId, ref BOOL pfVal);
+
+        public static HRESULT GetThemeBool(IHandle hTheme, int iPartId, int iStateId, int iPropId, ref BOOL pfVal)
+        {
+            HRESULT hr = GetThemeBool(hTheme.Handle, iPartId, iStateId, iPropId, ref pfVal);
+            GC.KeepAlive(hTheme);
+            return hr;
+        }
+    }
+}

--- a/src/Common/src/Interop/UxTheme/Interop.GetThemeColor.cs
+++ b/src/Common/src/Interop/UxTheme/Interop.GetThemeColor.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    public static partial class UxTheme
+    {
+        [DllImport(Libraries.UxTheme, ExactSpelling = true)]
+        public static extern HRESULT GetThemeColor(IntPtr hTheme, int iPartId, int iStateId, int iPropId, ref int pColor);
+
+        public static HRESULT GetThemeColor(IHandle hTheme, int iPartId, int iStateId, int iPropId, ref int pColor)
+        {
+            HRESULT hr = GetThemeColor(hTheme.Handle, iPartId, iStateId, iPropId, ref pColor);
+            GC.KeepAlive(hTheme);
+            return hr;
+        }
+    }
+}

--- a/src/Common/src/Interop/UxTheme/Interop.GetThemeEnumValue.cs
+++ b/src/Common/src/Interop/UxTheme/Interop.GetThemeEnumValue.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    public static partial class UxTheme
+    {
+        [DllImport(Libraries.UxTheme, ExactSpelling = true)]
+        public static extern HRESULT GetThemeEnumValue(IntPtr hTheme, int iPartId, int iStateId, int iPropId, ref int piVal);
+
+        public static HRESULT GetThemeEnumValue(IHandle hTheme, int iPartId, int iStateId, int iPropId, ref int piVal)
+        {
+            HRESULT hr = GetThemeEnumValue(hTheme.Handle, iPartId, iStateId, iPropId, ref piVal);
+            GC.KeepAlive(hTheme);
+            return hr;
+        }
+    }
+}

--- a/src/Common/src/Interop/UxTheme/Interop.GetThemeInt.cs
+++ b/src/Common/src/Interop/UxTheme/Interop.GetThemeInt.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    public static partial class UxTheme
+    {
+        [DllImport(Libraries.UxTheme, ExactSpelling = true)]
+        public static extern HRESULT GetThemeInt(IntPtr hTheme, int iPartId, int iStateId, int iPropId, ref int piVal);
+
+        public static HRESULT GetThemeInt(IHandle hTheme, int iPartId, int iStateId, int iPropId, ref int piVal)
+        {
+            HRESULT hr = GetThemeInt(hTheme.Handle, iPartId, iStateId, iPropId, ref piVal);
+            GC.KeepAlive(hTheme);
+            return hr;
+        }
+    }
+}

--- a/src/Common/src/SafeNativeMethods.cs
+++ b/src/Common/src/SafeNativeMethods.cs
@@ -6,7 +6,6 @@ using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Text;
 using static Interop;
-using static Interop.Ole32;
 using static Interop.UxTheme;
 
 namespace System.Windows.Forms
@@ -78,19 +77,7 @@ namespace System.Windows.Forms
         public static extern int GetThemeBackgroundRegion(HandleRef hTheme, HandleRef hdc, int iPartId, int iStateId, [In] NativeMethods.COMRECT pRect, ref IntPtr pRegion);
 
         [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
-        public static extern int GetThemeBool(HandleRef hTheme, int iPartId, int iStateId, int iPropId, ref bool pfVal);
-
-        [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
-        public static extern int GetThemeColor(HandleRef hTheme, int iPartId, int iStateId, int iPropId, ref int pColor);
-
-        [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
-        public static extern int GetThemeEnumValue(HandleRef hTheme, int iPartId, int iStateId, int iPropId, ref int piVal);
-
-        [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
         public static extern int GetThemeFilename(HandleRef hTheme, int iPartId, int iStateId, int iPropId, StringBuilder pszThemeFilename, int cchMaxBuffChars);
-
-        [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
-        public static extern int GetThemeInt(HandleRef hTheme, int iPartId, int iStateId, int iPropId, ref int piVal);
 
         [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
         public static extern int GetThemePartSize(HandleRef hTheme, HandleRef hdc, int iPartId, int iStateId, [In] NativeMethods.COMRECT prc, VisualStyles.ThemeSizeType eSize, out Size psz);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
@@ -614,9 +614,9 @@ namespace System.Windows.Forms.VisualStyles
                 throw new InvalidEnumArgumentException(nameof(prop), (int)prop, typeof(BooleanProperty));
             }
 
-            bool val = false;
-            lastHResult = SafeNativeMethods.GetThemeBool(new HandleRef(this, Handle), part, state, (int)prop, ref val);
-            return val;
+            BOOL val = BOOL.FALSE;
+            lastHResult = (int)UxTheme.GetThemeBool(this, part, state, (int)prop, ref val);
+            return val.IsTrue();
         }
 
         /// <summary>
@@ -631,7 +631,7 @@ namespace System.Windows.Forms.VisualStyles
             }
 
             int color = 0;
-            lastHResult = SafeNativeMethods.GetThemeColor(new HandleRef(this, Handle), part, state, (int)prop, ref color);
+            lastHResult = (int)UxTheme.GetThemeColor(this, part, state, (int)prop, ref color);
             return ColorTranslator.FromWin32(color);
         }
 
@@ -647,7 +647,7 @@ namespace System.Windows.Forms.VisualStyles
             }
 
             int val = 0;
-            lastHResult = SafeNativeMethods.GetThemeEnumValue(new HandleRef(this, Handle), part, state, (int)prop, ref val);
+            lastHResult = (int)UxTheme.GetThemeEnumValue(this, part, state, (int)prop, ref val);
             return val;
         }
 
@@ -728,7 +728,7 @@ namespace System.Windows.Forms.VisualStyles
             }
 
             int val = 0;
-            lastHResult = SafeNativeMethods.GetThemeInt(new HandleRef(this, Handle), part, state, (int)prop, ref val);
+            lastHResult = (int)UxTheme.GetThemeInt(this, part, state, (int)prop, ref val);
             return val;
         }
 


### PR DESCRIPTION
…o Interop UxTheme

## Proposed changes

- Move GetThemeBool, GetThemeColor, GetThemeEnumValue and GetThemeInt to Interop UxTheme.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2591)