### PR TITLE
Add PD and PD_RESULT enums in Interop Comdlg32

### DIFF
--- a/src/Common/src/Interop/Comdlg32/Interop.PD.cs
+++ b/src/Common/src/Interop/Comdlg32/Interop.PD.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal partial class Interop
+{
+    internal partial class Comdlg32
+    {
+        [Flags]
+        public enum PD : uint
+        {
+            ALLPAGES = 0x00000000,
+            SELECTION = 0x00000001,
+            PAGENUMS = 0x00000002,
+            NOSELECTION = 0x00000004,
+            NOPAGENUMS = 0x00000008,
+            COLLATE = 0x00000010,
+            PRINTTOFILE = 0x00000020,
+            PRINTSETUP = 0x00000040,
+            NOWARNING = 0x00000080,
+            RETURNDC = 0x00000100,
+            RETURNIC = 0x00000200,
+            RETURNDEFAULT = 0x00000400,
+            SHOWHELP = 0x00000800,
+            ENABLEPRINTHOOK = 0x00001000,
+            ENABLESETUPHOOK = 0x00002000,
+            ENABLEPRINTTEMPLATE = 0x00004000,
+            ENABLESETUPTEMPLATE = 0x00008000,
+            ENABLEPRINTTEMPLATEHANDLE = 0x00010000,
+            ENABLESETUPTEMPLATEHANDLE = 0x00020000,
+            USEDEVMODECOPIES = 0x00040000,
+            USEDEVMODECOPIESANDCOLLATE = 0x00040000,
+            DISABLEPRINTTOFILE = 0x00080000,
+            HIDEPRINTTOFILE = 0x00100000,
+            NONETWORKBUTTON = 0x00200000,
+            CURRENTPAGE = 0x00400000,
+            NOCURRENTPAGE = 0x00800000,
+            EXCLUSIONFLAGS = 0x01000000,
+            USELARGETEMPLATE = 0x10000000
+        }
+    }
+}

--- a/src/Common/src/Interop/Comdlg32/Interop.PD_RESULT.cs
+++ b/src/Common/src/Interop/Comdlg32/Interop.PD_RESULT.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal partial class Interop
+{
+    internal partial class Comdlg32
+    {
+        public enum PD_RESULT
+        {
+            CANCEL = 0,
+            PRINT = 1,
+            APPLY = 2
+        }
+    }
+}

--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -374,35 +374,7 @@ namespace System.Windows.Forms
         NM_CUSTOMDRAW = ((0 - 0) - 12),
         NM_RELEASEDCAPTURE = ((0 - 0) - 16);
 
-        public const int PD_ALLPAGES = 0x00000000,
-        PD_SELECTION = 0x00000001,
-        PD_PAGENUMS = 0x00000002,
-        PD_NOSELECTION = 0x00000004,
-        PD_NOPAGENUMS = 0x00000008,
-        PD_COLLATE = 0x00000010,
-        PD_PRINTTOFILE = 0x00000020,
-        PD_PRINTSETUP = 0x00000040,
-        PD_NOWARNING = 0x00000080,
-        PD_RETURNDC = 0x00000100,
-        PD_RETURNIC = 0x00000200,
-        PD_RETURNDEFAULT = 0x00000400,
-        PD_SHOWHELP = 0x00000800,
-        PD_ENABLEPRINTHOOK = 0x00001000,
-        PD_ENABLESETUPHOOK = 0x00002000,
-        PD_ENABLEPRINTTEMPLATE = 0x00004000,
-        PD_ENABLESETUPTEMPLATE = 0x00008000,
-        PD_ENABLEPRINTTEMPLATEHANDLE = 0x00010000,
-        PD_ENABLESETUPTEMPLATEHANDLE = 0x00020000,
-        PD_USEDEVMODECOPIES = 0x00040000,
-        PD_USEDEVMODECOPIESANDCOLLATE = 0x00040000,
-        PD_DISABLEPRINTTOFILE = 0x00080000,
-        PD_HIDEPRINTTOFILE = 0x00100000,
-        PD_NONETWORKBUTTON = 0x00200000,
-        PD_CURRENTPAGE = 0x00400000,
-        PD_NOCURRENTPAGE = 0x00800000,
-        PD_EXCLUSIONFLAGS = 0x01000000,
-        PD_USELARGETEMPLATE = 0x10000000,
-        PRF_CHECKVISIBLE = 0x00000001,
+        public const int PRF_CHECKVISIBLE = 0x00000001,
         PRF_NONCLIENT = 0x00000002,
         PRF_CLIENT = 0x00000004,
         PRF_ERASEBKGND = 0x00000008,
@@ -565,11 +537,6 @@ namespace System.Windows.Forms
 
         public static int START_PAGE_GENERAL = unchecked((int)0xffffffff);
 
-        //  Result action ids for PrintDlgEx.
-        public const int PD_RESULT_CANCEL = 0;
-        public const int PD_RESULT_PRINT = 1;
-        public const int PD_RESULT_APPLY = 2;
-
         private static uint wmMouseEnterMessage = uint.MaxValue;
 
         public static User32.WindowMessage WM_MOUSEENTER
@@ -724,7 +691,7 @@ namespace System.Windows.Forms
             IntPtr hDevNames { get; set; }
             IntPtr hDC { get; set; }
 
-            int Flags { get; set; }
+            Comdlg32.PD Flags { get; set; }
 
             short nFromPage { get; set; }
             short nToPage { get; set; }
@@ -757,8 +724,6 @@ namespace System.Windows.Forms
             IntPtr m_hDevNames;
             IntPtr m_hDC;
 
-            int m_Flags;
-
             short m_nFromPage;
             short m_nToPage;
             short m_nMinPage;
@@ -784,7 +749,7 @@ namespace System.Windows.Forms
             public IntPtr hDevNames { get { return m_hDevNames; } set { m_hDevNames = value; } }
             public IntPtr hDC { get { return m_hDC; } set { m_hDC = value; } }
 
-            public int Flags { get { return m_Flags; } set { m_Flags = value; } }
+            public Comdlg32.PD Flags { get; set; }
 
             public short nFromPage { get { return m_nFromPage; } set { m_nFromPage = value; } }
             public short nToPage { get { return m_nToPage; } set { m_nToPage = value; } }
@@ -817,8 +782,6 @@ namespace System.Windows.Forms
             IntPtr m_hDevNames;
             IntPtr m_hDC;
 
-            int m_Flags;
-
             short m_nFromPage;
             short m_nToPage;
             short m_nMinPage;
@@ -844,7 +807,7 @@ namespace System.Windows.Forms
             public IntPtr hDevNames { get { return m_hDevNames; } set { m_hDevNames = value; } }
             public IntPtr hDC { get { return m_hDC; } set { m_hDC = value; } }
 
-            public int Flags { get { return m_Flags; } set { m_Flags = value; } }
+            public Comdlg32.PD Flags { get; set; }
 
             public short nFromPage { get { return m_nFromPage; } set { m_nFromPage = value; } }
             public short nToPage { get { return m_nToPage; } set { m_nToPage = value; } }
@@ -875,7 +838,7 @@ namespace System.Windows.Forms
             public IntPtr hDevNames;
             public IntPtr hDC;
 
-            public int Flags;
+            public Comdlg32.PD Flags;
             public int Flags2;
 
             public int ExclusionFlags;
@@ -900,8 +863,7 @@ namespace System.Windows.Forms
             public IntPtr lphPropertyPages;
 
             public int nStartPage;
-            public int dwResultAction;
-
+            public Comdlg32.PD_RESULT dwResultAction;
         }
 
         // x86 requires EXPLICIT packing of 1.

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -74,13 +74,15 @@
     <Compile Include="..\..\Common\src\Interop\ComCtl32\Interop.TVHT.cs" Link="Interop\ComCtl32\Interop.TVHT.cs" />
     <Compile Include="..\..\Common\src\Interop\ComCtl32\Interop.TVIS.cs" Link="Interop\ComCtl32\Interop.TVIS.cs" />
     <Compile Include="..\..\Common\src\Interop\ComCtl32\Interop.TVS_EX.cs" Link="Interop\ComCtl32\Interop.TVS_EX.cs" />
-    <Compile Include="..\..\Common\src\Interop\Comdlg32\Interop.CF.cs" Link="Interop\Comdlg32\Interop.CF.cs" />
-    <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.BitBlt.cs" Link="Interop\Gdi32\Interop.BitBlt.cs" />
-    <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.CreatePen.cs" Link="Interop\Gdi32\Interop.CreatePen.cs" />
     <Compile Include="..\..\Common\src\Interop\ComCtl32\Interop.MCGIF.cs" Link="Interop\ComCtl32\Interop.MCGIF.cs" />
     <Compile Include="..\..\Common\src\Interop\ComCtl32\Interop.MCGIP.cs" Link="Interop\ComCtl32\Interop.MCGIP.cs" />
     <Compile Include="..\..\Common\src\Interop\ComCtl32\Interop.MCGRIDINFO.cs" Link="Interop\ComCtl32\Interop.MCGRIDINFO.cs" />
     <Compile Include="..\..\Common\src\Interop\ComCtl32\Interop.MCHITTESTINFO.cs" Link="Interop\ComCtl32\Interop.MCHITTESTINFO.cs" />
+    <Compile Include="..\..\Common\src\Interop\Comdlg32\Interop.CF.cs" Link="Interop\Comdlg32\Interop.CF.cs" />
+    <Compile Include="..\..\Common\src\Interop\Comdlg32\Interop.PD.cs" Link="Interop\Comdlg32\Interop.PD.cs" />
+    <Compile Include="..\..\Common\src\Interop\Comdlg32\Interop.PD_RESULT.cs" Link="Interop\Comdlg32\Interop.PD_RESULT.cs" />
+    <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.BitBlt.cs" Link="Interop\Gdi32\Interop.BitBlt.cs" />
+    <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.CreatePen.cs" Link="Interop\Gdi32\Interop.CreatePen.cs" />
     <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.CreateRectRgn.cs" Link="Interop\Gdi32\Interop.CreateRectRgn.cs" />
     <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.CreateSolidBrush.cs" Link="Interop\Gdi32\Interop.CreateSolidBrush.cs" />
     <Compile Include="..\..\Common\src\Interop\Gdi32\Interop.DeleteObject.cs" Link="Interop\Gdi32\Interop.DeleteObject.cs" />


### PR DESCRIPTION
## Proposed changes

- Add PD and PD_RESULT enums in Interop Comdlg32.
- Replace PD and PD_RESULT constants with the above enums.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2594)