### PR TITLE
Move EnumChildWindows to Interop User32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnumChildWindows.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnumChildWindows.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public delegate BOOL EnumChildWindowsCallback(IntPtr hwnd, IntPtr lParam);
+
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern BOOL EnumChildWindows(IntPtr hwndParent, EnumChildWindowsCallback lpEnumFunc, IntPtr lParam);
+
+        public static BOOL EnumChildWindows(IHandle hwndParent, EnumChildWindowsCallback lpEnumFunc, IntPtr lParam)
+        {
+            BOOL result = EnumChildWindows(hwndParent.Handle, lpEnumFunc, lParam);
+            GC.KeepAlive(hwndParent);
+            return result;
+        }
+
+        public static BOOL EnumChildWindows(HandleRef hwndParent, EnumChildWindowsCallback lpEnumFunc, IntPtr lParam)
+        {
+            BOOL result = EnumChildWindows(hwndParent.Handle, lpEnumFunc, lParam);
+            GC.KeepAlive(hwndParent.Wrapper);
+            return result;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnumThreadWindows.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnumThreadWindows.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        public delegate bool EnumThreadWindowsCallback(IntPtr hWnd, IntPtr lParam);
+        public delegate BOOL EnumThreadWindowsCallback(IntPtr hWnd, IntPtr lParam);
 
         [DllImport(Libraries.User32, ExactSpelling = true)]
         public static extern BOOL EnumThreadWindows(uint dwThreadId, EnumThreadWindowsCallback lpfn, IntPtr lParam);

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnumWindows.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnumWindows.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        public delegate bool EnumWindowsCallback(IntPtr hWnd, IntPtr lParam);
+        public delegate BOOL EnumWindowsCallback(IntPtr hWnd, IntPtr lParam);
 
         [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
         public static extern BOOL EnumWindows(EnumWindowsCallback callback, IntPtr extraData);

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -384,8 +384,6 @@ namespace System.Windows.Forms
             public int dwFlags;
         }
 
-        public delegate bool EnumChildrenCallback(IntPtr hwnd, IntPtr lParam);
-
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
         public class HH_AKLINK
         {

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -85,9 +85,6 @@ namespace System.Windows.Forms
             }
         }
 
-        [DllImport(ExternDll.User32, ExactSpelling = true)]
-        public static extern bool EnumChildWindows(HandleRef hwndParent, NativeMethods.EnumChildrenCallback lpEnumFunc, HandleRef lParam);
-
         [DllImport(ExternDll.Shell32, CharSet = CharSet.Auto)]
         public static extern int Shell_NotifyIcon(int message, NativeMethods.NOTIFYICONDATA pnid);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadWindows.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadWindows.cs
@@ -38,7 +38,7 @@ namespace System.Windows.Forms
                 GC.KeepAlive(callback);
             }
 
-            private bool Callback(IntPtr hWnd, IntPtr lparam)
+            private BOOL Callback(IntPtr hWnd, IntPtr lparam)
             {
                 // We only do visible and enabled windows.  Also, we only do top level windows.
                 // Finally, we only include windows that are DNA windows, since other MSO components
@@ -68,7 +68,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                return true;
+                return BOOL.TRUE;
             }
 
             // Disposes all top-level Controls on this thread

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -616,7 +616,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  This helper broadcasts out a WM_THEMECHANGED to appropriate top level windows of this app.
         /// </summary>
-        private unsafe static bool SendThemeChanged(IntPtr handle, IntPtr extraParameter)
+        private unsafe static BOOL SendThemeChanged(IntPtr handle, IntPtr extraParameter)
         {
             uint thisPID = Kernel32.GetCurrentProcessId();
             User32.GetWindowThreadProcessId(handle, out uint processId);
@@ -629,7 +629,7 @@ namespace System.Windows.Forms
                     IntPtr.Zero,
                     User32.RDW.INVALIDATE | User32.RDW.FRAME | User32.RDW.ERASE | User32.RDW.ALLCHILDREN);
             }
-            return true;
+            return BOOL.TRUE;
         }
 
         /// <summary>
@@ -637,17 +637,18 @@ namespace System.Windows.Forms
         ///  It is assumed at this point that the handle belongs to the current process
         ///  and has a visible top level window.
         /// </summary>
-        private static bool SendThemeChangedRecursive(IntPtr handle, IntPtr lparam)
+        private static BOOL SendThemeChangedRecursive(IntPtr handle, IntPtr lparam)
         {
             // First send to all children...
-            UnsafeNativeMethods.EnumChildWindows(new HandleRef(null, handle),
-                new NativeMethods.EnumChildrenCallback(Application.SendThemeChangedRecursive),
-                NativeMethods.NullHandleRef);
+            User32.EnumChildWindows(
+                handle,
+                new User32.EnumChildWindowsCallback(SendThemeChangedRecursive),
+                IntPtr.Zero);
 
             // Then do myself.
             UnsafeNativeMethods.SendMessage(new HandleRef(null, handle), Interop.WindowMessages.WM_THEMECHANGED, 0, 0);
 
-            return true;
+            return BOOL.TRUE;
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -6078,18 +6078,19 @@ namespace System.Windows.Forms
                 Debug.Assert(!ACWindows.ContainsKey(acHandle));
                 AssignHandle(acHandle);
                 ACWindows.Add(acHandle, this);
-                UnsafeNativeMethods.EnumChildWindows(new HandleRef(this, acHandle),
-                    new NativeMethods.EnumChildrenCallback(ACNativeWindow.RegisterACWindowRecursive),
-                    NativeMethods.NullHandleRef);
+                User32.EnumChildWindows(
+                    new HandleRef(this, acHandle),
+                    new User32.EnumChildWindowsCallback(RegisterACWindowRecursive),
+                    IntPtr.Zero);
             }
 
-            private static bool RegisterACWindowRecursive(IntPtr handle, IntPtr lparam)
+            private static BOOL RegisterACWindowRecursive(IntPtr handle, IntPtr lparam)
             {
                 if (!ACWindows.ContainsKey(handle))
                 {
                     ACNativeWindow newAC = new ACNativeWindow(handle);
                 }
-                return true;
+                return BOOL.TRUE;
             }
 
             internal bool Visible => User32.IsWindowVisible(this).IsTrue();
@@ -6208,7 +6209,7 @@ namespace System.Windows.Forms
                 GC.KeepAlive(callback);
             }
 
-            private bool Callback(IntPtr hWnd, IntPtr lParam)
+            private BOOL Callback(IntPtr hWnd, IntPtr lParam)
             {
                 HandleRef hRef = new HandleRef(null, hWnd);
 
@@ -6218,7 +6219,7 @@ namespace System.Windows.Forms
                     ACNativeWindow.RegisterACWindow(hRef.Handle, shouldSubClass);
                 }
 
-                return true;
+                return BOOL.TRUE;
             }
 
             static string GetClassName(HandleRef hRef)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
@@ -1562,8 +1562,10 @@ namespace System.Windows.Forms
             if (ShowUpDown)
             {
                 EnumChildren c = new EnumChildren();
-                NativeMethods.EnumChildrenCallback cb = new NativeMethods.EnumChildrenCallback(c.enumChildren);
-                UnsafeNativeMethods.EnumChildWindows(new HandleRef(this, Handle), cb, NativeMethods.NullHandleRef);
+                User32.EnumChildWindows(
+                    this,
+                    new User32.EnumChildWindowsCallback(c.enumChildren),
+                    IntPtr.Zero);
                 if (c.hwndFound != IntPtr.Zero)
                 {
                     User32.InvalidateRect(new HandleRef(c, c.hwndFound), null, BOOL.TRUE);
@@ -1738,10 +1740,10 @@ namespace System.Windows.Forms
         {
             public IntPtr hwndFound = IntPtr.Zero;
 
-            public bool enumChildren(IntPtr hwnd, IntPtr lparam)
+            public BOOL enumChildren(IntPtr hwnd, IntPtr lparam)
             {
                 hwndFound = hwnd;
-                return true;
+                return BOOL.TRUE;
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -6807,7 +6807,7 @@ namespace System.Windows.Forms
             {
             }
 
-            internal bool Callback(IntPtr hWnd, IntPtr lParam)
+            internal BOOL Callback(IntPtr hWnd, IntPtr lParam)
             {
                 Debug.Assert(lParam != IntPtr.Zero);
                 HandleRef hRef = new HandleRef(null, hWnd);
@@ -6822,7 +6822,7 @@ namespace System.Windows.Forms
                     }
                     ownedWindows.Add(hRef);
                 }
-                return true;
+                return BOOL.TRUE;
             }
 
             // Resets the owner of all the windows owned by this Form before handle recreation.


### PR DESCRIPTION
## Proposed changes

- Move EnumChildWindows to Interop User32.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2595)