### PR TITLE
Move ChildWindowFromPointEx to Interop User32 and add CWP enum

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CWP.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CWP.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [Flags]
+        public enum CWP : uint
+        {
+            ALL = 0x0000,
+            SKIPINVISIBLE = 0x0001,
+            SKIPDISABLED = 0x0002,
+            SKIPTRANSPARENT = 0x0004
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.ChildWindowFromPointEx.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.ChildWindowFromPointEx.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Drawing;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern IntPtr ChildWindowFromPointEx(IntPtr hwndParent, Point pt, CWP uFlags);
+
+        public static IntPtr ChildWindowFromPointEx(IHandle hwndParent, Point pt, CWP uFlags)
+        {
+            IntPtr result = ChildWindowFromPointEx(hwndParent.Handle, pt, uFlags);
+            GC.KeepAlive(hwndParent);
+            return result;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -34,7 +34,6 @@ namespace System.Windows.Forms
         public const int cmb4 = 0x0473;
 
         public const int CW_USEDEFAULT = (unchecked((int)0x80000000)),
-        CWP_SKIPINVISIBLE = 0x0001,
         COLOR_WINDOW = 5,
         CB_ERR = (-1),
         CBN_SELCHANGE = 1,

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -163,9 +163,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.Comdlg32, SetLastError = true, CharSet = CharSet.Auto)]
         public static extern bool GetSaveFileName([In, Out] NativeMethods.OPENFILENAME_I ofn);
 
-        [DllImport(ExternDll.User32, ExactSpelling = true)]
-        public static extern IntPtr ChildWindowFromPointEx(IntPtr hwndParent, Point pt, int uFlags);
-
         [DllImport(ExternDll.Kernel32, CharSet = CharSet.Auto)]
         public static extern uint GetShortPathName(string lpszLongPath, StringBuilder lpszShortPath, uint cchBuffer);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -5666,7 +5666,7 @@ namespace System.Windows.Forms
                 throw new InvalidEnumArgumentException(nameof(skipValue), value, typeof(GetChildAtPointSkip));
             }
 
-            IntPtr hwnd = UnsafeNativeMethods.ChildWindowFromPointEx(Handle, pt, value);
+            IntPtr hwnd = User32.ChildWindowFromPointEx(this, pt, (User32.CWP)value);
             Control ctl = FromChildHandle(hwnd);
 
             return (ctl == this) ? null : ctl;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GetChildAtPointSkip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GetChildAtPointSkip.cs
@@ -2,14 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using static Interop.User32;
+
 namespace System.Windows.Forms
 {
     [Flags]
     public enum GetChildAtPointSkip
     {
-        None = 0x0000,
-        Invisible = 0x0001,
-        Disabled = 0x0002,
-        Transparent = 0x0004
+        None = (int)CWP.ALL,
+        Invisible = (int)CWP.SKIPINVISIBLE,
+        Disabled = (int)CWP.SKIPDISABLED,
+        Transparent = (int)CWP.SKIPTRANSPARENT
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -5139,7 +5139,8 @@ namespace System.Windows.Forms
                 // if someone clicks on a child control (combobox, textbox, etc) focus will
                 // be taken - but we'll handle that in WM_NCACTIVATE handler.
                 Point pt = PointToClient(WindowsFormsUtils.LastCursorPoint);
-                IntPtr hwndClicked = UnsafeNativeMethods.ChildWindowFromPointEx(Handle, pt, (int)(GetChildAtPointSkip.Invisible | GetChildAtPointSkip.Disabled | GetChildAtPointSkip.Transparent));
+                IntPtr hwndClicked = User32.ChildWindowFromPointEx(this, pt, User32.CWP.SKIPINVISIBLE | User32.CWP.SKIPDISABLED | User32.CWP.SKIPTRANSPARENT);
+                
                 // if we click on the toolstrip itself, eat the activation.
                 // if we click on a child control, allow the toolstrip to activate.
                 if (hwndClicked == Handle)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -1083,7 +1083,7 @@ namespace System.Windows.Forms
                     pt = baseVar.PointToClient(screenCoords);
                 }
 
-                IntPtr found = UnsafeNativeMethods.ChildWindowFromPointEx(baseHwnd, pt, NativeMethods.CWP_SKIPINVISIBLE);
+                IntPtr found = User32.ChildWindowFromPointEx(baseHwnd, pt, User32.CWP.SKIPINVISIBLE);
                 if (found == baseHwnd)
                 {
                     hwnd = found;


### PR DESCRIPTION
## Proposed changes

- Move ChildWindowFromPointEx to Interop User32 and add CWP enum
- Remove CWP_SKIPINVISIBLE and replace its usage with the above enum value.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2597)