### PR TITLE
Cleanup NativeMethods SendMessage overloads

### DIFF
--- a/src/Common/src/NativeMethods.cs
+++ b/src/Common/src/NativeMethods.cs
@@ -1366,15 +1366,6 @@ namespace System.Windows.Forms
         // Threading stuff
         public const uint STILL_ACTIVE = 259;
 
-        [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-        public static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
-
-        [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-        public static extern IntPtr SendMessage(IntPtr hWnd, int msg, int wParam, int lParam);
-
-        [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-        public static extern IntPtr SendMessage(IntPtr hWnd, int msg, int wParam, string lParam);
-
         [DllImport(ExternDll.User32, ExactSpelling = true)]
         public static extern bool GetUpdateRect(IntPtr hwnd, ref RECT rc, bool fErase);
     }

--- a/src/System.Windows.Forms.Design.Editors/src/Misc/NativeMethods.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/Misc/NativeMethods.cs
@@ -54,15 +54,6 @@ namespace System.Windows.Forms.Design
         public const int TVM_GETEXTENDEDSTYLE = TV_FIRST + 45;
         public const int SWP_HIDEWINDOW = 0x0080;
 
-        [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-        public static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
-
-        [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-        public static extern IntPtr SendMessage(IntPtr hWnd, int msg, int wParam, int lParam);
-
-        [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-        public static extern IntPtr SendMessage(IntPtr hWnd, int msg, int wParam, string lParam);
-
         public const int CHILDID_SELF = 0;
     }
 }

--- a/src/System.Windows.Forms.Design.Editors/src/System.Windows.Forms.Design.Editors.csproj
+++ b/src/System.Windows.Forms.Design.Editors/src/System.Windows.Forms.Design.Editors.csproj
@@ -124,6 +124,7 @@
     <Compile Include="..\..\Common\src\Interop\User32\Interop.RegisterWindowMessageW.cs" Link="Interop\User32\Interop.RegisterWindowMessageW.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.ReleaseDC.cs" Link="Interop\User32\Interop.ReleaseDC.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.ScreenToClient.cs" Link="Interop\User32\Interop.ScreenToClient.cs" />
+    <Compile Include="..\..\Common\src\Interop\User32\Interop.SendMessageW.cs" Link="Interop\User32\Interop.SendMessageW.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SetFocus.cs" Link="Interop\User32\Interop.SetFocus.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SetProcessDPIAware.cs" Link="Interop\User32\Interop.SetProcessDPIAware.cs" />
     <Compile Include="..\..\Common\src\Interop\User32\Interop.SetProcessDpiAwarenessContext.cs" Link="Interop\User32\Interop.SetProcessDpiAwarenessContext.cs" />

--- a/src/System.Windows.Forms.Design.Editors/src/System/ComponentModel/Design/CollectionEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/ComponentModel/Design/CollectionEditor.cs
@@ -2164,7 +2164,7 @@ namespace System.ComponentModel.Design
                             if (PropertyGrid.Focused || PropertyGrid.ContainsFocus)
                             {
                                 // recreate the keystroke to the newly activated window
-                                NativeMethods.SendMessage(User32.GetFocus(), WindowMessages.WM_KEYDOWN, _lastKeyDown.WParam, _lastKeyDown.LParam);
+                                User32.SendMessageW(User32.GetFocus(), User32.WindowMessage.WM_KEYDOWN, _lastKeyDown.WParam, _lastKeyDown.LParam);
                             }
                         }
                         break;
@@ -2191,8 +2191,8 @@ namespace System.ComponentModel.Design
                         if (PropertyGrid.Focused || PropertyGrid.ContainsFocus)
                         {
                             IntPtr hWnd = User32.GetFocus();
-                            NativeMethods.SendMessage(hWnd, WindowMessages.WM_KEYDOWN, _lastKeyDown.WParam, _lastKeyDown.LParam);
-                            NativeMethods.SendMessage(hWnd, WindowMessages.WM_CHAR, m.WParam, m.LParam);
+                            User32.SendMessageW(hWnd, User32.WindowMessage.WM_KEYDOWN, _lastKeyDown.WParam, _lastKeyDown.LParam);
+                            User32.SendMessageW(hWnd, User32.WindowMessage.WM_CHAR, m.WParam, m.LParam);
                             return;
                         }
                         break;

--- a/src/System.Windows.Forms.Design.Editors/src/System/ComponentModel/Design/ObjectSelectorEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/ComponentModel/Design/ObjectSelectorEditor.cs
@@ -92,12 +92,12 @@ namespace System.ComponentModel.Design
         }
         private static ComCtl32.TVS_EX TreeView_GetExtendedStyle(IntPtr handle)
         {
-            return (ComCtl32.TVS_EX)NativeMethods.SendMessage(handle, NativeMethods.TVM_GETEXTENDEDSTYLE, IntPtr.Zero, IntPtr.Zero);
+            return (ComCtl32.TVS_EX)User32.SendMessageW(handle, (User32.WindowMessage)NativeMethods.TVM_GETEXTENDEDSTYLE, IntPtr.Zero, IntPtr.Zero);
         }
 
         private static void TreeView_SetExtendedStyle(IntPtr handle, ComCtl32.TVS_EX extendedStyle, int mask)
         {
-            NativeMethods.SendMessage(handle, NativeMethods.TVM_SETEXTENDEDSTYLE, (IntPtr)mask, (IntPtr)extendedStyle);
+            User32.SendMessageW(handle, (User32.WindowMessage)NativeMethods.TVM_SETEXTENDEDSTYLE, (IntPtr)mask, (IntPtr)extendedStyle);
         }
 
         public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
@@ -545,7 +545,7 @@ namespace System.Windows.Forms.Design
                     IntPtr hwnd = User32.WindowFromPoint(p);
                     if (hwnd != IntPtr.Zero)
                     {
-                        NativeMethods.SendMessage(hwnd, WindowMessages.WM_SETCURSOR, hwnd, (IntPtr)NativeMethods.HTCLIENT);
+                        User32.SendMessageW(hwnd, User32.WindowMessage.WM_SETCURSOR, hwnd, (IntPtr)NativeMethods.HTCLIENT);
                     }
                     else
                     {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -1837,7 +1837,7 @@ namespace System.Windows.Forms.Design
                         button = MouseButtons.Left;
                     }
                     // We don't really want the focus, but we want to focus the designer. Below we handle WM_SETFOCUS and do the right thing.
-                    NativeMethods.SendMessage(Control.Handle, WindowMessages.WM_SETFOCUS, 0, 0);
+                    User32.SendMessageW(Control.Handle, User32.WindowMessage.WM_SETFOCUS, IntPtr.Zero, IntPtr.Zero);
                     // We simulate doubleclick for things that don't...
                     if (button == MouseButtons.Left && IsDoubleClick(x, y))
                     {
@@ -1873,7 +1873,7 @@ namespace System.Windows.Forms.Design
 
                         if (_toolPassThrough)
                         {
-                            NativeMethods.SendMessage(Control.Parent.Handle, m.Msg, m.WParam, (IntPtr)GetParentPointFromLparam(m.LParam));
+                            User32.SendMessageW(Control.Parent.Handle, (User32.WindowMessage)m.Msg, m.WParam, (IntPtr)GetParentPointFromLparam(m.LParam));
                             return;
                         }
 
@@ -1919,7 +1919,7 @@ namespace System.Windows.Forms.Design
                     {
                         if (_toolPassThrough)
                         {
-                            NativeMethods.SendMessage(Control.Parent.Handle, m.Msg, m.WParam, (IntPtr)GetParentPointFromLparam(m.LParam));
+                            User32.SendMessageW(Control.Parent.Handle, (User32.WindowMessage)m.Msg, m.WParam, (IntPtr)GetParentPointFromLparam(m.LParam));
                             return;
                         }
 
@@ -1964,7 +1964,7 @@ namespace System.Windows.Forms.Design
                     {
                         if (_toolPassThrough)
                         {
-                            NativeMethods.SendMessage(Control.Parent.Handle, m.Msg, m.WParam, (IntPtr)GetParentPointFromLparam(m.LParam));
+                            User32.SendMessageW(Control.Parent.Handle, (User32.WindowMessage)m.Msg, m.WParam, (IntPtr)GetParentPointFromLparam(m.LParam));
                             _toolPassThrough = false;
                             return;
                         }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerFrame.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerFrame.cs
@@ -101,7 +101,7 @@ namespace System.Windows.Forms.Design
         {
             if (_designer != null && _designer.IsHandleCreated)
             {
-                NativeMethods.SendMessage(_designer.Handle, WindowMessages.WM_NCACTIVATE, focus ? 1 : 0, 0);
+                User32.SendMessageW(_designer.Handle, User32.WindowMessage.WM_NCACTIVATE, PARAM.FromBool(focus), IntPtr.Zero);
                 User32.RedrawWindow(_designer.Handle, null, IntPtr.Zero, User32.RDW.FRAME);
             }
         }
@@ -202,7 +202,7 @@ namespace System.Windows.Forms.Design
                     if (!_designerRegion._messageMouseWheelProcessed)
                     {
                         _designerRegion._messageMouseWheelProcessed = true;
-                        NativeMethods.SendMessage(_designerRegion.Handle, WindowMessages.WM_MOUSEWHEEL, m.WParam, m.LParam);
+                        User32.SendMessageW(_designerRegion.Handle, User32.WindowMessage.WM_MOUSEWHEEL, m.WParam, m.LParam);
                         return;
                     }
                     break;
@@ -250,12 +250,12 @@ namespace System.Windows.Forms.Design
                         || (msg == WindowMessages.WM_HSCROLL))
                     {
                         // Send a message to ourselves to scroll
-                        NativeMethods.SendMessage(_designerRegion.Handle, msg, PARAM.ToInt((int)wScrollNotify, 0), 0);
+                        User32.SendMessageW(_designerRegion.Handle, (User32.WindowMessage)msg, (IntPtr)PARAM.ToInt((int)wScrollNotify, 0), IntPtr.Zero);
                         return;
                     }
                     break;
                 case WindowMessages.WM_CONTEXTMENU:
-                    NativeMethods.SendMessage(_designer.Handle, m.Msg, m.WParam, m.LParam);
+                    User32.SendMessageW(_designer.Handle, (User32.WindowMessage)m.Msg, m.WParam, m.LParam);
                     return;
             }
             base.WndProc(ref m);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerUtils.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerUtils.cs
@@ -515,7 +515,7 @@ namespace System.Windows.Forms.Design
             {
                 IntPtr hDc = g.GetHdc();
                 //send the actual wm_print message
-                NativeMethods.SendMessage(hWnd, WindowMessages.WM_PRINT, hDc, (IntPtr)(NativeMethods.PRF_CHILDREN | NativeMethods.PRF_CLIENT | NativeMethods.PRF_ERASEBKGND | NativeMethods.PRF_NONCLIENT));
+                User32.SendMessageW(hWnd, User32.WindowMessage.WM_PRINT, hDc, (IntPtr)(NativeMethods.PRF_CHILDREN | NativeMethods.PRF_CLIENT | NativeMethods.PRF_ERASEBKGND | NativeMethods.PRF_NONCLIENT));
                 g.ReleaseHdc(hDc);
             }
 
@@ -930,12 +930,12 @@ namespace System.Windows.Forms.Design
 
         private static ComCtl32.TVS_EX TreeView_GetExtendedStyle(IntPtr handle)
         {
-            return (ComCtl32.TVS_EX)NativeMethods.SendMessage(handle, NativeMethods.TVM_GETEXTENDEDSTYLE, IntPtr.Zero, IntPtr.Zero);
+            return (ComCtl32.TVS_EX)User32.SendMessageW(handle, (User32.WindowMessage)NativeMethods.TVM_GETEXTENDEDSTYLE, IntPtr.Zero, IntPtr.Zero);
         }
 
         private static void TreeView_SetExtendedStyle(IntPtr handle, ComCtl32.TVS_EX extendedStyle, int mask)
         {
-            NativeMethods.SendMessage(handle, NativeMethods.TVM_SETEXTENDEDSTYLE, (IntPtr)mask, (IntPtr)extendedStyle);
+            User32.SendMessageW(handle, (User32.WindowMessage)NativeMethods.TVM_SETEXTENDEDSTYLE, (IntPtr)mask, (IntPtr)extendedStyle);
         }
 
         /// <summary>
@@ -959,7 +959,7 @@ namespace System.Windows.Forms.Design
 
         private static void ListView_SetExtendedListViewStyleEx(IntPtr handle, int mask, int extendedStyle)
         {
-            NativeMethods.SendMessage(handle, (int)ComCtl32.LVM.SETEXTENDEDLISTVIEWSTYLE, new IntPtr(mask), new IntPtr(extendedStyle));
+            User32.SendMessageW(handle, (User32.WindowMessage)ComCtl32.LVM.SETEXTENDEDLISTVIEWSTYLE, (IntPtr)mask, (IntPtr)extendedStyle);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormDocumentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormDocumentDesigner.cs
@@ -368,7 +368,7 @@ namespace System.Windows.Forms.Design
             Control control = Control;
             if (control != null && control.IsHandleCreated)
             {
-                NativeMethods.SendMessage(control.Handle, WindowMessages.WM_NCACTIVATE, 1, 0);
+                User32.SendMessageW(control.Handle, User32.WindowMessage.WM_NCACTIVATE, (IntPtr)1, IntPtr.Zero);
                 User32.RedrawWindow(control.Handle, null, IntPtr.Zero, User32.RDW.FRAME);
             }
         }
@@ -381,7 +381,7 @@ namespace System.Windows.Forms.Design
             Control control = Control;
             if (control != null && control.IsHandleCreated)
             {
-                NativeMethods.SendMessage(control.Handle, WindowMessages.WM_NCACTIVATE, 0, 0);
+                User32.SendMessageW(control.Handle, User32.WindowMessage.WM_NCACTIVATE, IntPtr.Zero, IntPtr.Zero);
                 User32.RedrawWindow(control.Handle, null, IntPtr.Zero, User32.RDW.FRAME);
             }
         }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripTemplateNode.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripTemplateNode.cs
@@ -889,9 +889,9 @@ namespace System.Windows.Forms.Design
                     if (_designerHost != null)
                     {
                         baseComponent = (Control)_designerHost.RootComponent;
-                        NativeMethods.SendMessage(baseComponent.Handle, WindowMessages.WM_SETREDRAW, 0, 0);
+                        User32.SendMessageW(baseComponent.Handle, User32.WindowMessage.WM_SETREDRAW, IntPtr.Zero, IntPtr.Zero);
                         tb.Focus();
-                        NativeMethods.SendMessage(baseComponent.Handle, WindowMessages.WM_SETREDRAW, 1, 0);
+                        User32.SendMessageW(baseComponent.Handle, User32.WindowMessage.WM_SETREDRAW, (IntPtr)1, IntPtr.Zero);
                     }
                 }
                 finally
@@ -973,9 +973,9 @@ namespace System.Windows.Forms.Design
                 if (_designerHost != null)
                 {
                     Control baseComponent = (Control)_designerHost.RootComponent;
-                    NativeMethods.SendMessage(baseComponent.Handle, WindowMessages.WM_SETREDRAW, 0, 0);
+                    User32.SendMessageW(baseComponent.Handle, User32.WindowMessage.WM_SETREDRAW, IntPtr.Zero, IntPtr.Zero);
                     designerFrame.Focus();
-                    NativeMethods.SendMessage(baseComponent.Handle, WindowMessages.WM_SETREDRAW, 1, 0);
+                    User32.SendMessageW(baseComponent.Handle, User32.WindowMessage.WM_SETREDRAW, (IntPtr)1, IntPtr.Zero);
                 }
             }
         }


### PR DESCRIPTION
## Proposed Change
- Cleanup NativeMethods SendMessage overloads

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2606)