### PR TITLE
Add tests for Control.AssignParent

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Properties.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Properties.cs
@@ -9606,6 +9606,7 @@ namespace System.Windows.Forms.Tests
         {
             yield return new object[] { null };
             yield return new object[] { new Control() };
+            yield return new object[] { new Form() };
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.Windows.Forms.Tests
@@ -14,6 +15,144 @@ namespace System.Windows.Forms.Tests
             var dataGridView = new DataGridView();
             Assert.NotNull(dataGridView.RowTemplate);
             Assert.Same(dataGridView.RowTemplate, dataGridView.RowTemplate);
+        }
+
+        public static IEnumerable<object[]> Parent_Set_TestData()
+        {
+            yield return new object[] { null };
+            yield return new object[] { new Control() };
+            yield return new object[] { new DataGridView() };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(Parent_Set_TestData))]
+        public void DataGridView_Parent_Set_GetReturnsExpected(Control value)
+        {
+            using var control = new DataGridView
+            {
+                Parent = value
+            };
+            Assert.Same(value, control.Parent);
+            Assert.False(control.IsHandleCreated);
+
+            // Set same.
+            control.Parent = value;
+            Assert.Same(value, control.Parent);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(Parent_Set_TestData))]
+        public void DataGridView_Parent_SetWithNonNullOldParent_GetReturnsExpected(Control value)
+        {
+            using var oldParent = new Control();
+            using var control = new DataGridView
+            {
+                Parent = oldParent
+            };
+
+            control.Parent = value;
+            Assert.Same(value, control.Parent);
+            Assert.Empty(oldParent.Controls);
+            Assert.False(control.IsHandleCreated);
+
+            // Set same.
+            control.Parent = value;
+            Assert.Same(value, control.Parent);
+            Assert.Empty(oldParent.Controls);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridView_Parent_SetNonNull_AddsToControls()
+        {
+            using var parent = new Control();
+            using var control = new DataGridView
+            {
+                Parent = parent
+            };
+            Assert.Same(parent, control.Parent);
+            Assert.Same(control, Assert.Single(parent.Controls));
+            Assert.False(control.IsHandleCreated);
+
+            // Set same.
+            control.Parent = parent;
+            Assert.Same(parent, control.Parent);
+            Assert.Same(control, Assert.Single(parent.Controls));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(Parent_Set_TestData))]
+        public void DataGridView_Parent_SetWithHandle_GetReturnsExpected(Control value)
+        {
+            using var control = new DataGridView();
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            int invalidatedCallCount = 0;
+            control.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            control.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            control.HandleCreated += (sender, e) => createdCallCount++;
+
+            control.Parent = value;
+            Assert.Same(value, control.Parent);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+
+            // Set same.
+            control.Parent = value;
+            Assert.Same(value, control.Parent);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+        }
+
+        [WinFormsFact]
+        public void DataGridView_Parent_SetWithHandler_CallsParentChanged()
+        {
+            using var parent = new Control();
+            using var control = new DataGridView();
+            int callCount = 0;
+            EventHandler handler = (sender, e) =>
+            {
+                Assert.Same(control, sender);
+                Assert.Same(EventArgs.Empty, e);
+                callCount++;
+            };
+            control.ParentChanged += handler;
+
+            // Set different.
+            control.Parent = parent;
+            Assert.Same(parent, control.Parent);
+            Assert.Equal(1, callCount);
+
+            // Set same.
+            control.Parent = parent;
+            Assert.Same(parent, control.Parent);
+            Assert.Equal(1, callCount);
+
+            // Set null.
+            control.Parent = null;
+            Assert.Null(control.Parent);
+            Assert.Equal(2, callCount);
+
+            // Remove handler.
+            control.ParentChanged -= handler;
+            control.Parent = parent;
+            Assert.Same(parent, control.Parent);
+            Assert.Equal(2, callCount);
+        }
+
+        [WinFormsFact]
+        public void DataGridView_Parent_SetSame_ThrowsArgumentException()
+        {
+            using var control = new DataGridView();
+            Assert.Throws<ArgumentException>(null, () => control.Parent = control);
+            Assert.Null(control.Parent);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
@@ -746,6 +746,220 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, createdCallCount);
         }
 
+        public static IEnumerable<object[]> Parent_Set_TestData()
+        {
+            yield return new object[] { null };
+            yield return new object[] { new Control() };
+            yield return new object[] { new Form() };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(Parent_Set_TestData))]
+        public void Form_Parent_Set_GetReturnsExpected(Control value)
+        {
+            using var control = new Form
+            {
+                TopLevel = false,
+                Parent = value
+            };
+            Assert.Same(value, control.Parent);
+            Assert.Null(control.MdiParent);
+            Assert.False(control.IsHandleCreated);
+
+            // Set same.
+            control.Parent = value;
+            Assert.Same(value, control.Parent);
+            Assert.Null(control.MdiParent);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(Parent_Set_TestData))]
+        public void Form_Parent_SetWithNonNullOldParent_GetReturnsExpected(Control value)
+        {
+            using var oldParent = new Control();
+            using var control = new Form
+            {
+                TopLevel = false,
+                Parent = oldParent
+            };
+
+            control.Parent = value;
+            Assert.Same(value, control.Parent);
+            Assert.Null(control.MdiParent);
+            Assert.Empty(oldParent.Controls);
+            Assert.False(control.IsHandleCreated);
+
+            // Set same.
+            control.Parent = value;
+            Assert.Same(value, control.Parent);
+            Assert.Null(control.MdiParent);
+            Assert.Empty(oldParent.Controls);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> Parent_SetMdiChild_TestData()
+        {
+            yield return new object[] { null };
+            yield return new object[] { new Control() };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(Parent_SetMdiChild_TestData))]
+        public void Form_Parent_SetMdiChild_GetReturnsExpected(Control value)
+        {
+            using var oldParent = new Form
+            {
+                IsMdiContainer = true
+            };
+            using var control = new Form
+            {
+                MdiParent = oldParent,
+                Parent = value
+            };
+
+            control.Parent = value;
+            Assert.Same(value, control.Parent);
+            Assert.Null(control.MdiParent);
+            Assert.False(control.IsHandleCreated);
+
+            // Set same.
+            control.Parent = value;
+            Assert.Same(value, control.Parent);
+            Assert.Null(control.MdiParent);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void Form_Parent_SetNonNull_AddsToControls()
+        {
+            using var parent = new Control();
+            using var control = new Form
+            {
+                TopLevel = false,
+                Parent = parent
+            };
+            Assert.Same(parent, control.Parent);
+            Assert.Same(control, Assert.Single(parent.Controls));
+            Assert.False(control.IsHandleCreated);
+
+            // Set same.
+            control.Parent = parent;
+            Assert.Same(parent, control.Parent);
+            Assert.Same(control, Assert.Single(parent.Controls));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(Parent_Set_TestData))]
+        public void Form_Parent_SetWithHandle_GetReturnsExpected(Control value)
+        {
+            using var control = new Form
+            {
+                TopLevel = false
+            };
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            int invalidatedCallCount = 0;
+            control.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            control.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            control.HandleCreated += (sender, e) => createdCallCount++;
+
+            control.Parent = value;
+            Assert.Same(value, control.Parent);
+            Assert.Null(control.MdiParent);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+
+            // Set same.
+            control.Parent = value;
+            Assert.Same(value, control.Parent);
+            Assert.Null(control.MdiParent);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+        }
+
+        [WinFormsFact]
+        public void Form_Parent_SetWithHandler_CallsParentChanged()
+        {
+            using var parent = new Control();
+            using var control = new Form
+            {
+                TopLevel = false
+            };
+            int callCount = 0;
+            EventHandler handler = (sender, e) =>
+            {
+                Assert.Same(control, sender);
+                Assert.Same(EventArgs.Empty, e);
+                callCount++;
+            };
+            control.ParentChanged += handler;
+
+            // Set different.
+            control.Parent = parent;
+            Assert.Same(parent, control.Parent);
+            Assert.Equal(1, callCount);
+
+            // Set same.
+            control.Parent = parent;
+            Assert.Same(parent, control.Parent);
+            Assert.Equal(1, callCount);
+
+            // Set null.
+            control.Parent = null;
+            Assert.Null(control.Parent);
+            Assert.Equal(2, callCount);
+
+            // Remove handler.
+            control.ParentChanged -= handler;
+            control.Parent = parent;
+            Assert.Same(parent, control.Parent);
+            Assert.Equal(2, callCount);
+        }
+
+        [WinFormsFact]
+        public void Form_Parent_SetSame_ThrowsArgumentException()
+        {
+            using var control = new Form
+            {
+                TopLevel = false
+            };
+            Assert.Throws<ArgumentException>(null, () => control.Parent = control);
+            Assert.Null(control.Parent);
+        }
+
+        [WinFormsFact]
+        public void Form_Parent_SetTopLevel_ThrowsArgumentException()
+        {
+            using var control = new Form();
+            using var parent = new Control();
+            Assert.Throws<ArgumentException>(null, () => control.Parent = parent);
+            Assert.Null(control.Parent);
+        }
+
+        [WinFormsFact]
+        public void Form_Parent_SetFormWithMdiParent_ThrowsArgumentException()
+        {
+            using var oldParent = new Form
+            {
+                IsMdiContainer = true
+            };
+            using var control = new Form
+            {
+                MdiParent = oldParent
+            };
+            using var parent = new Form();
+            Assert.Throws<ArgumentException>("value", () => control.Parent = parent);
+            Assert.NotNull(control.Parent);
+            Assert.Same(oldParent, control.MdiParent);
+        }
+
         public static IEnumerable<object[]> TransparencyKey_Set_TestData()
         {
             foreach (bool allowTransparency in new bool[] { true, false })

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PictureBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PictureBoxTests.cs
@@ -1105,13 +1105,14 @@ namespace System.Windows.Forms.Tests
         {
             yield return new object[] { null };
             yield return new object[] { new Control() };
+            yield return new object[] { new Form() };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(Parent_Set_TestData))]
         public void PictureBox_Parent_Set_GetReturnsExpected(Control value)
         {
-            var control = new PictureBox
+            using var control = new PictureBox
             {
                 Parent = value
             };
@@ -1122,12 +1123,12 @@ namespace System.Windows.Forms.Tests
             Assert.Same(value, control.Parent);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(Parent_Set_TestData))]
         public void PictureBox_Parent_SetWithNonNullOldParent_GetReturnsExpected(Control value)
         {
-            var oldParent = new Control();
-            var control = new PictureBox
+            using var oldParent = new Control();
+            using var control = new PictureBox
             {
                 Parent = oldParent
             };
@@ -1142,11 +1143,11 @@ namespace System.Windows.Forms.Tests
             Assert.Empty(oldParent.Controls);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void PictureBox_Parent_SetNonNull_AddsToControls()
         {
-            var parent = new Control();
-            var control = new PictureBox
+            using var parent = new Control();
+            using var control = new PictureBox
             {
                 Parent = parent
             };
@@ -1159,11 +1160,11 @@ namespace System.Windows.Forms.Tests
             Assert.Same(control, Assert.Single(parent.Controls));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void PictureBox_Parent_SetWithHandler_CallsParentChanged()
         {
-            var parent = new Control();
-            var control = new PictureBox();
+            using var parent = new Control();
+            using var control = new PictureBox();
             int callCount = 0;
             EventHandler handler = (sender, e) =>
             {
@@ -1195,10 +1196,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(2, callCount);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void PictureBox_Parent_SetSame_ThrowsArgumentException()
         {
-            var control = new PictureBox();
+            using var control = new PictureBox();
             Assert.Throws<ArgumentException>(null, () => control.Parent = control);
             Assert.Null(control.Parent);
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/SplitterPanelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/SplitterPanelTests.cs
@@ -709,6 +709,7 @@ namespace System.Windows.Forms.Tests
         {
             yield return new object[] { null };
             yield return new object[] { new Control() };
+            yield return new object[] { new Form() };
         }
 
         [WinFormsTheory]
@@ -726,6 +727,42 @@ namespace System.Windows.Forms.Tests
             control.Parent = value;
             Assert.Same(value, control.Parent);
             Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void SplitterPanel_Parent_SetWithHandler_CallsParentChanged()
+        {
+            using var parent = new Control();
+            using var control = new SplitterPanel(null);
+            int callCount = 0;
+            EventHandler handler = (sender, e) =>
+            {
+                Assert.Same(control, sender);
+                Assert.Same(EventArgs.Empty, e);
+                callCount++;
+            };
+            control.ParentChanged += handler;
+
+            // Set different.
+            control.Parent = parent;
+            Assert.Same(parent, control.Parent);
+            Assert.Equal(1, callCount);
+
+            // Set same.
+            control.Parent = parent;
+            Assert.Same(parent, control.Parent);
+            Assert.Equal(1, callCount);
+
+            // Set null.
+            control.Parent = null;
+            Assert.Null(control.Parent);
+            Assert.Equal(2, callCount);
+
+            // Remove handler.
+            control.ParentChanged -= handler;
+            control.Parent = parent;
+            Assert.Same(parent, control.Parent);
+            Assert.Equal(2, callCount);
         }
 
         public static IEnumerable<object[]> Size_Set_TestData()


### PR DESCRIPTION
## Proposed Changes
- Make Control.AssignParent private protected
- Remove related test - our tests for `Control.Parent` already cover this, so no need for new tests

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2612)