### PR TITLE
Move SetLayeredWindowAttributes to Interop User32 and add LWA enum

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.LWA.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.LWA.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [Flags]
+        public enum LWA : uint
+        {
+            COLORKEY = 0x00000001,
+            ALPHA = 0x00000002
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetLayeredWindowAttributes.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetLayeredWindowAttributes.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
+        public static extern BOOL SetLayeredWindowAttributes(IntPtr hwnd, int crKey, byte bAlpha, LWA dwFlags);
+
+        public static BOOL SetLayeredWindowAttributes(IHandle hwnd, int crKey, byte bAlpha, LWA dwFlags)
+        {
+            BOOL result = SetLayeredWindowAttributes(hwnd.Handle, crKey, bAlpha, dwFlags);
+            GC.KeepAlive(hwnd);
+            return result;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -259,10 +259,7 @@ namespace System.Windows.Forms
         LVN_ODSTATECHANGED = ((0 - 100) - 15),
         LVN_SETDISPINFO = ((0 - 100) - 78),
         LVN_GETINFOTIP = ((0 - 100) - 58),
-        LVN_KEYDOWN = ((0 - 100) - 55),
-
-        LWA_COLORKEY = 0x00000001,
-        LWA_ALPHA = 0x00000002;
+        LVN_KEYDOWN = ((0 - 100) - 55);
 
         public const int LANG_NEUTRAL = 0x00,
                          LOCALE_IFIRSTDAYOFWEEK = 0x0000100C;   /* first day of week specifier */

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -371,9 +371,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
         public static extern IntPtr DefFrameProc(IntPtr hWnd, IntPtr hWndClient, int msg, IntPtr wParam, IntPtr lParam);
 
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto, SetLastError = true)]
-        public static extern bool SetLayeredWindowAttributes(HandleRef hwnd, int crKey, byte bAlpha, int dwFlags);
-
         [DllImport(ExternDll.Kernel32, CharSet = CharSet.Auto)]
         public static extern void GetStartupInfo([In, Out] NativeMethods.STARTUPINFO_I startupinfo_i);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -5703,27 +5703,26 @@ namespace System.Windows.Forms
         {
             if ((formState[FormStateLayered] != 0) && IsHandleCreated && TopLevel)
             {
-                bool result;
+                BOOL result;
 
                 Color transparencyKey = TransparencyKey;
 
                 if (transparencyKey.IsEmpty)
                 {
 
-                    result = UnsafeNativeMethods.SetLayeredWindowAttributes(new HandleRef(this, Handle), 0, OpacityAsByte, NativeMethods.LWA_ALPHA);
+                    result = User32.SetLayeredWindowAttributes(this, 0, OpacityAsByte, User32.LWA.ALPHA);
                 }
                 else if (OpacityAsByte == 255)
                 {
                     // Windows doesn't do so well setting colorkey and alpha, so avoid it if we can
-                    result = UnsafeNativeMethods.SetLayeredWindowAttributes(new HandleRef(this, Handle), ColorTranslator.ToWin32(transparencyKey), 0, NativeMethods.LWA_COLORKEY);
+                    result = User32.SetLayeredWindowAttributes(this, ColorTranslator.ToWin32(transparencyKey), 0, User32.LWA.COLORKEY);
                 }
                 else
                 {
-                    result = UnsafeNativeMethods.SetLayeredWindowAttributes(new HandleRef(this, Handle), ColorTranslator.ToWin32(transparencyKey),
-                                                                OpacityAsByte, NativeMethods.LWA_ALPHA | NativeMethods.LWA_COLORKEY);
+                    result = User32.SetLayeredWindowAttributes(this, ColorTranslator.ToWin32(transparencyKey), OpacityAsByte, User32.LWA.ALPHA | User32.LWA.COLORKEY);
                 }
 
-                if (!result)
+                if (result.IsFalse())
                 {
                     throw new Win32Exception();
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
@@ -2074,11 +2074,9 @@ namespace System.Windows.Forms
         {
             if (state[stateLayered] && IsHandleCreated && TopLevel)
             {
-                bool result;
+                BOOL result = User32.SetLayeredWindowAttributes(this, 0, OpacityAsByte, User32.LWA.ALPHA);
 
-                result = UnsafeNativeMethods.SetLayeredWindowAttributes(new HandleRef(this, Handle), 0, OpacityAsByte, NativeMethods.LWA_ALPHA);
-
-                if (!result)
+                if (result.IsFalse())
                 {
                     throw new Win32Exception();
                 }


### PR DESCRIPTION
## Proposed changes

- Move SetLayeredWindowAttributes to Interop User32.
- Add LWA enum.
- Remove LWA constants and replace their usages with the above enum values.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2618)