### PR TITLE
Add EC, EN and ES enums in Interop User32

### DIFF
--- a/src/System.Windows.Forms.Design.Editors/src/System/Drawing/Design/ColorEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/Drawing/Design/ColorEditor.cs
@@ -1111,12 +1111,12 @@ namespace System.Drawing.Design
                 switch (msg)
                 {
                     case WindowMessages.WM_INITDIALOG:
-                        UnsafeNativeMethods.SendDlgItemMessage(hwnd, COLOR_HUE, EditMessages.EM_SETMARGINS, (IntPtr)(NativeMethods.EC_LEFTMARGIN | NativeMethods.EC_RIGHTMARGIN), IntPtr.Zero);
-                        UnsafeNativeMethods.SendDlgItemMessage(hwnd, COLOR_SAT, EditMessages.EM_SETMARGINS, (IntPtr)(NativeMethods.EC_LEFTMARGIN | NativeMethods.EC_RIGHTMARGIN), IntPtr.Zero);
-                        UnsafeNativeMethods.SendDlgItemMessage(hwnd, COLOR_LUM, EditMessages.EM_SETMARGINS, (IntPtr)(NativeMethods.EC_LEFTMARGIN | NativeMethods.EC_RIGHTMARGIN), IntPtr.Zero);
-                        UnsafeNativeMethods.SendDlgItemMessage(hwnd, COLOR_RED, EditMessages.EM_SETMARGINS, (IntPtr)(NativeMethods.EC_LEFTMARGIN | NativeMethods.EC_RIGHTMARGIN), IntPtr.Zero);
-                        UnsafeNativeMethods.SendDlgItemMessage(hwnd, COLOR_GREEN, EditMessages.EM_SETMARGINS, (IntPtr)(NativeMethods.EC_LEFTMARGIN | NativeMethods.EC_RIGHTMARGIN), IntPtr.Zero);
-                        UnsafeNativeMethods.SendDlgItemMessage(hwnd, COLOR_BLUE, EditMessages.EM_SETMARGINS, (IntPtr)(NativeMethods.EC_LEFTMARGIN | NativeMethods.EC_RIGHTMARGIN), IntPtr.Zero);
+                        UnsafeNativeMethods.SendDlgItemMessage(hwnd, COLOR_HUE, EditMessages.EM_SETMARGINS, (IntPtr)(User32.EC.LEFTMARGIN | User32.EC.RIGHTMARGIN), IntPtr.Zero);
+                        UnsafeNativeMethods.SendDlgItemMessage(hwnd, COLOR_SAT, EditMessages.EM_SETMARGINS, (IntPtr)(User32.EC.LEFTMARGIN | User32.EC.RIGHTMARGIN), IntPtr.Zero);
+                        UnsafeNativeMethods.SendDlgItemMessage(hwnd, COLOR_LUM, EditMessages.EM_SETMARGINS, (IntPtr)(User32.EC.LEFTMARGIN | User32.EC.RIGHTMARGIN), IntPtr.Zero);
+                        UnsafeNativeMethods.SendDlgItemMessage(hwnd, COLOR_RED, EditMessages.EM_SETMARGINS, (IntPtr)(User32.EC.LEFTMARGIN | User32.EC.RIGHTMARGIN), IntPtr.Zero);
+                        UnsafeNativeMethods.SendDlgItemMessage(hwnd, COLOR_GREEN, EditMessages.EM_SETMARGINS, (IntPtr)(User32.EC.LEFTMARGIN | User32.EC.RIGHTMARGIN), IntPtr.Zero);
+                        UnsafeNativeMethods.SendDlgItemMessage(hwnd, COLOR_BLUE, EditMessages.EM_SETMARGINS, (IntPtr)(User32.EC.LEFTMARGIN | User32.EC.RIGHTMARGIN), IntPtr.Zero);
                         IntPtr hwndCtl = UnsafeNativeMethods.GetDlgItem(hwnd, COLOR_MIX);
                         User32.EnableWindow(hwndCtl, BOOL.FALSE);
                         User32.SetWindowPos(

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EC.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EC.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [Flags]
+        public enum EC : uint
+        {
+            LEFTMARGIN = 0x0001,
+            RIGHTMARGIN = 0x0002,
+            USEFONTINFO = 0xffff
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EN.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EN.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [Flags]
+        public enum EN : uint
+        {
+            SETFOCUS = 0x0100,
+            KILLFOCUS = 0x0200,
+            CHANGE = 0x0300,
+            UPDATE = 0x0400,
+            ERRSPACE = 0x0500,
+            MAXTEXT = 0x0501,
+            HSCROLL = 0x0601,
+            VSCROLL = 0x0602,
+            ALIGN_LTR_EC = 0x0700,
+            ALIGN_RTL_EC = 0x0701,
+            BEFORE_PASTE = 0x0800,
+            AFTER_PASTE = 0x0801
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.ES.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.ES.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [Flags]
+        public enum ES : uint
+        {
+            LEFT = 0x0000,
+            CENTER = 0x0001,
+            RIGHT = 0x0002,
+            MULTILINE = 0x0004,
+            UPPERCASE = 0x0008,
+            LOWERCASE = 0x0010,
+            PASSWORD = 0x0020,
+            AUTOVSCROLL = 0x0040,
+            AUTOHSCROLL = 0x0080,
+            NOHIDESEL = 0x0100,
+            OEMCONVERT = 0x0400,
+            READONLY = 0x0800,
+            WANTRETURN = 0x1000,
+            NUMBER = 0x2000
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -113,27 +113,6 @@ namespace System.Windows.Forms
         DTN_DROPDOWN = ((0 - 760) + 6),
         DTN_CLOSEUP = ((0 - 760) + 7);
 
-        public const int EMR_POLYTEXTOUT = 97,
-        ES_LEFT = 0x0000,
-        ES_CENTER = 0x0001,
-        ES_RIGHT = 0x0002,
-        ES_MULTILINE = 0x0004,
-        ES_UPPERCASE = 0x0008,
-        ES_LOWERCASE = 0x0010,
-        ES_AUTOVSCROLL = 0x0040,
-        ES_AUTOHSCROLL = 0x0080,
-        ES_NOHIDESEL = 0x0100,
-        ES_READONLY = 0x0800,
-        ES_PASSWORD = 0x0020,
-        EN_CHANGE = 0x0300,
-        EN_UPDATE = 0x0400,
-        EN_HSCROLL = 0x0601,
-        EN_VSCROLL = 0x0602,
-        EN_ALIGN_LTR_EC = 0x0700,
-        EN_ALIGN_RTL_EC = 0x0701,
-        EC_LEFTMARGIN = 0x0001,
-        EC_RIGHTMARGIN = 0x0002;
-
         public const int FRERR_BUFFERLENGTHZERO = 0x4001;
         public const int FADF_BSTR = (0x100);
         public const int FADF_UNKNOWN = (0x200);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -1848,7 +1848,7 @@ namespace System.Windows.Forms
                         UnsafeNativeMethods.SendMessage(
                             new HandleRef(this, childEdit.Handle),
                             EditMessages.EM_SETMARGINS,
-                            NativeMethods.EC_LEFTMARGIN | NativeMethods.EC_RIGHTMARGIN,
+                            (int)(User32.EC.LEFTMARGIN | User32.EC.RIGHTMARGIN),
                             0);
                     }
                     break;
@@ -2556,7 +2556,7 @@ namespace System.Windows.Forms
                     // set the initial margin for combobox to be zero (this is also done whenever the font is changed).
                     //
                     UnsafeNativeMethods.SendMessage(new HandleRef(this, childEdit.Handle), EditMessages.EM_SETMARGINS,
-                                              NativeMethods.EC_LEFTMARGIN | NativeMethods.EC_RIGHTMARGIN, 0);
+                        (int)(User32.EC.LEFTMARGIN | User32.EC.RIGHTMARGIN), 0);
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MaskedTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MaskedTextBox.cs
@@ -342,13 +342,13 @@ namespace System.Windows.Forms
                 switch (align)
                 {
                     case HorizontalAlignment.Left:
-                        cp.Style |= NativeMethods.ES_LEFT;
+                        cp.Style |= (int)User32.ES.LEFT;
                         break;
                     case HorizontalAlignment.Center:
-                        cp.Style |= NativeMethods.ES_CENTER;
+                        cp.Style |= (int)User32.ES.CENTER;
                         break;
                     case HorizontalAlignment.Right:
-                        cp.Style |= NativeMethods.ES_RIGHT;
+                        cp.Style |= (int)User32.ES.RIGHT;
                         break;
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -3529,17 +3529,14 @@ namespace System.Windows.Forms
             //
             if (m.LParam == Handle && !GetState(States.CreatingHandle))
             {
-                switch (PARAM.HIWORD(m.WParam))
+                switch ((User32.EN)PARAM.HIWORD(m.WParam))
                 {
-
-                    case NativeMethods.EN_HSCROLL:
+                    case User32.EN.HSCROLL:
                         OnHScroll(EventArgs.Empty);
                         break;
-
-                    case NativeMethods.EN_VSCROLL:
+                    case User32.EN.VSCROLL:
                         OnVScroll(EventArgs.Empty);
                         break;
-
                     default:
                         base.WndProc(ref m);
                         break;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
@@ -302,10 +302,10 @@ namespace System.Windows.Forms
                 switch (characterCasing)
                 {
                     case CharacterCasing.Lower:
-                        cp.Style |= NativeMethods.ES_LOWERCASE;
+                        cp.Style |= (int)User32.ES.LOWERCASE;
                         break;
                     case CharacterCasing.Upper:
-                        cp.Style |= NativeMethods.ES_UPPERCASE;
+                        cp.Style |= (int)User32.ES.UPPERCASE;
                         break;
                 }
 
@@ -316,13 +316,13 @@ namespace System.Windows.Forms
                 switch (align)
                 {
                     case HorizontalAlignment.Left:
-                        cp.Style |= NativeMethods.ES_LEFT;
+                        cp.Style |= (int)User32.ES.LEFT;
                         break;
                     case HorizontalAlignment.Center:
-                        cp.Style |= NativeMethods.ES_CENTER;
+                        cp.Style |= (int)User32.ES.CENTER;
                         break;
                     case HorizontalAlignment.Right:
-                        cp.Style |= NativeMethods.ES_RIGHT;
+                        cp.Style |= (int)User32.ES.RIGHT;
                         break;
                 }
 
@@ -343,7 +343,7 @@ namespace System.Windows.Forms
 
                 if (useSystemPasswordChar)
                 {
-                    cp.Style |= NativeMethods.ES_PASSWORD;
+                    cp.Style |= (int)User32.ES.PASSWORD;
                 }
 
                 return cp;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -458,15 +458,15 @@ namespace System.Windows.Forms
             {
                 CreateParams cp = base.CreateParams;
                 cp.ClassName = ComCtl32.WindowClasses.WC_EDIT;
-                cp.Style |= NativeMethods.ES_AUTOHSCROLL | NativeMethods.ES_AUTOVSCROLL;
+                cp.Style |= (int)(User32.ES.AUTOHSCROLL | User32.ES.AUTOVSCROLL);
                 if (!textBoxFlags[hideSelection])
                 {
-                    cp.Style |= NativeMethods.ES_NOHIDESEL;
+                    cp.Style |= (int)User32.ES.NOHIDESEL;
                 }
 
                 if (textBoxFlags[readOnly])
                 {
-                    cp.Style |= NativeMethods.ES_READONLY;
+                    cp.Style |= (int)User32.ES.READONLY;
                 }
 
                 cp.Style &= ~(int)User32.WS.BORDER;
@@ -483,10 +483,10 @@ namespace System.Windows.Forms
                 }
                 if (textBoxFlags[multiline])
                 {
-                    cp.Style |= NativeMethods.ES_MULTILINE;
+                    cp.Style |= (int)User32.ES.MULTILINE;
                     if (textBoxFlags[wordWrap])
                     {
-                        cp.Style &= ~NativeMethods.ES_AUTOHSCROLL;
+                        cp.Style &= ~(int)User32.ES.AUTOHSCROLL;
                     }
                 }
 
@@ -2168,11 +2168,12 @@ namespace System.Windows.Forms
         {
             if (!textBoxFlags[codeUpdateText] && !textBoxFlags[creatingHandle])
             {
-                if (PARAM.HIWORD(m.WParam) == NativeMethods.EN_CHANGE && CanRaiseTextChangedEvent)
+                User32.EN wParamAsEN = (User32.EN)PARAM.HIWORD(m.WParam);
+                if (wParamAsEN == User32.EN.CHANGE && CanRaiseTextChangedEvent)
                 {
                     OnTextChanged(EventArgs.Empty);
                 }
-                else if (PARAM.HIWORD(m.WParam) == NativeMethods.EN_UPDATE)
+                else if (wParamAsEN == User32.EN.UPDATE)
                 {
                     // Force update to the Modified property, which will trigger
                     // ModifiedChanged event handlers
@@ -2186,7 +2187,7 @@ namespace System.Windows.Forms
             base.WndProc(ref m);
             if (!textBoxFlags[multiline])
             {
-                SendMessage(EditMessages.EM_SETMARGINS, NativeMethods.EC_LEFTMARGIN | NativeMethods.EC_RIGHTMARGIN, 0);
+                SendMessage(EditMessages.EM_SETMARGINS, (int)(User32.EC.LEFTMARGIN | User32.EC.RIGHTMARGIN), 0);
             }
         }
 


### PR DESCRIPTION
## Proposed changes

- Add EC, EN and ES enums in Interop User32.
- Remove EC, EN and ES constants and replace their usages with the above enum values.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2620)