### PR TITLE
Cleanup MonthCalendar interop definitions

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.MCGRIDINFO.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.MCGRIDINFO.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using static System.Windows.Forms.NativeMethods;
 
 internal static partial class Interop
 {
@@ -14,7 +13,7 @@ internal static partial class Interop
         /// MonthCalendar grid info structure.
         /// Copied form CommCtrl.h
         /// </summary>
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
         public unsafe struct MCGRIDINFO
         {
             public uint cbSize;
@@ -27,11 +26,8 @@ internal static partial class Interop
             public Kernel32.SYSTEMTIME stStart;
             public Kernel32.SYSTEMTIME stEnd;
             public RECT rc;
-            public string pszName;
+            public char* pszName;
             public uint cchName;
         }
-
-        [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-        public extern static IntPtr SendMessage(HandleRef hWnd, int Msg, int wParam, [In, Out] ref MCGRIDINFO gridInfo);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.MCHITTESTINFO.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.MCHITTESTINFO.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop
@@ -11,11 +12,10 @@ internal static partial class Interop
         /// <summary>
         /// <see href="https://docs.microsoft.com/en-us/windows/win32/api/commctrl/ns-commctrl-mchittestinfo">MCHITTESTINFO structure (Microsoft Docs)</see>
         /// </summary>
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
         public struct MCHITTESTINFO
         {
-            public int cbSize;
-            public POINT pt;
+            public uint cbSize;
+            public Point pt;
             public int uHit;
             public Kernel32.SYSTEMTIME st;
             public RECT rc;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -213,11 +213,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
         public static extern IntPtr SendMessage(HandleRef hWnd, int msg, int wParam, ref Size lParam);
 
-        // For MonthCalendar
-        //
-        [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-        public static extern IntPtr SendMessage(HandleRef hWnd, int msg, int wParam, ref ComCtl32.MCHITTESTINFO lParam);
-
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
         public static extern IntPtr SendMessage(HandleRef hWnd, int msg, int wParam, int lParam);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarBodyAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarBodyAccessibleObject.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using static Interop;
+using static Interop.ComCtl32;
 
 namespace System.Windows.Forms
 {
@@ -24,7 +25,7 @@ namespace System.Windows.Forms
 
             protected override RECT CalculateBoundingRectangle()
             {
-                _calendarAccessibleObject.GetCalendarPartRectangle(_calendarIndex, ComCtl32.MCGIP.CALENDARBODY, 0, 0, out RECT calendarPartRectangle);
+                _calendarAccessibleObject.GetCalendarPartRectangle(_calendarIndex, MCGIP.CALENDARBODY, 0, 0, out RECT calendarPartRectangle);
                 return calendarPartRectangle;
             }
 
@@ -45,13 +46,13 @@ namespace System.Windows.Forms
 
                 };
 
-            public CalendarChildAccessibleObject GetFromPoint(ComCtl32.MCHITTESTINFO hitTestInfo)
+            public CalendarChildAccessibleObject GetFromPoint(MCHITTESTINFO hitTestInfo)
             {
-                switch ((ComCtl32.MCHT)hitTestInfo.uHit)
+                switch ((MCHT)hitTestInfo.uHit)
                 {
-                    case ComCtl32.MCHT.CALENDARDAY:
-                    case ComCtl32.MCHT.CALENDARWEEKNUM:
-                    case ComCtl32.MCHT.CALENDARDATE:
+                    case MCHT.CALENDARDAY:
+                    case MCHT.CALENDARWEEKNUM:
+                    case MCHT.CALENDARDATE:
                         AccessibleObject rowAccessibleObject = _calendarAccessibleObject.GetCalendarChildAccessibleObject(_calendarIndex, CalendarChildType.CalendarRow, this, hitTestInfo.iRow);
                         return _calendarAccessibleObject.GetCalendarChildAccessibleObject(_calendarIndex, CalendarChildType.CalendarCell, rowAccessibleObject, hitTestInfo.iCol);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using static Interop;
+using static Interop.ComCtl32;
 
 namespace System.Windows.Forms
 {
@@ -38,7 +39,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    bool result = GetCalendarGridInfoText(ComCtl32.MCGIP.CALENDARCELL, _calendarIndex, -1, 0, out string text);
+                    bool result = GetCalendarGridInfoText(MCGIP.CALENDARCELL, _calendarIndex, -1, 0, out string text);
                     if (!result || string.IsNullOrEmpty(text))
                     {
                         return false;
@@ -87,7 +88,7 @@ namespace System.Windows.Forms
                         return name;
                     }
 
-                    if (_owner._mcCurView == ComCtl32.MCMV.MONTH)
+                    if (_owner._mcCurView == MCMV.MONTH)
                     {
                         if (DateTime.Equals(_owner.SelectionStart.Date, _owner.SelectionEnd.Date))
                         {
@@ -98,7 +99,7 @@ namespace System.Windows.Forms
                             return string.Format(SR.MonthCalendarRangeSelected, _owner.SelectionStart.ToLongDateString(), _owner.SelectionEnd.ToLongDateString());
                         }
                     }
-                    else if (_owner._mcCurView == ComCtl32.MCMV.YEAR)
+                    else if (_owner._mcCurView == MCMV.YEAR)
                     {
                         if (DateTime.Equals(_owner.SelectionStart.Month, _owner.SelectionEnd.Month))
                         {
@@ -109,7 +110,7 @@ namespace System.Windows.Forms
                             return string.Format(SR.MonthCalendarRangeSelected, _owner.SelectionStart.ToString("y"), _owner.SelectionEnd.ToString("y"));
                         }
                     }
-                    else if (_owner._mcCurView == ComCtl32.MCMV.DECADE)
+                    else if (_owner._mcCurView == MCMV.DECADE)
                     {
                         if (DateTime.Equals(_owner.SelectionStart.Year, _owner.SelectionEnd.Year))
                         {
@@ -120,7 +121,7 @@ namespace System.Windows.Forms
                             return string.Format(SR.MonthCalendarYearRangeSelected, _owner.SelectionStart.ToString("yyyy"), _owner.SelectionEnd.ToString("yyyy"));
                         }
                     }
-                    else if (_owner._mcCurView == ComCtl32.MCMV.CENTURY)
+                    else if (_owner._mcCurView == MCMV.CENTURY)
                     {
                         return string.Format(SR.MonthCalendarSingleDecadeSelected, _owner.SelectionStart.ToString("yyyy"));
                     }
@@ -141,7 +142,7 @@ namespace System.Windows.Forms
 
                     try
                     {
-                        if (_owner._mcCurView == ComCtl32.MCMV.MONTH)
+                        if (_owner._mcCurView == MCMV.MONTH)
                         {
                             if (System.DateTime.Equals(_owner.SelectionStart.Date, _owner.SelectionEnd.Date))
                             {
@@ -152,7 +153,7 @@ namespace System.Windows.Forms
                                 value = string.Format("{0} - {1}", _owner.SelectionStart.ToLongDateString(), _owner.SelectionEnd.ToLongDateString());
                             }
                         }
-                        else if (_owner._mcCurView == ComCtl32.MCMV.YEAR)
+                        else if (_owner._mcCurView == MCMV.YEAR)
                         {
                             if (System.DateTime.Equals(_owner.SelectionStart.Month, _owner.SelectionEnd.Month))
                             {
@@ -186,8 +187,8 @@ namespace System.Windows.Forms
                 get
                 {
                     GetCalendarGridInfo(
-                        ComCtl32.MCGIF.RECT,
-                        ComCtl32.MCGIP.CALENDARBODY,
+                        MCGIF.RECT,
+                        MCGIP.CALENDARBODY,
                         _calendarIndex,
                         -1,
                         -1,
@@ -200,8 +201,8 @@ namespace System.Windows.Forms
                     while (success)
                     {
                         success = GetCalendarGridInfo(
-                            ComCtl32.MCGIF.RECT,
-                            ComCtl32.MCGIP.CALENDARCELL,
+                            MCGIF.RECT,
+                            MCGIP.CALENDARCELL,
                             _calendarIndex,
                             0,
                             columnCount,
@@ -227,8 +228,8 @@ namespace System.Windows.Forms
                 get
                 {
                     GetCalendarGridInfo(
-                        ComCtl32.MCGIF.RECT,
-                        ComCtl32.MCGIP.CALENDARBODY,
+                        MCGIF.RECT,
+                        MCGIP.CALENDARBODY,
                         _calendarIndex,
                         -1,
                         -1,
@@ -241,8 +242,8 @@ namespace System.Windows.Forms
                     while (success)
                     {
                         success = GetCalendarGridInfo(
-                            ComCtl32.MCGIF.RECT,
-                            ComCtl32.MCGIP.CALENDARCELL,
+                            MCGIF.RECT,
+                            MCGIP.CALENDARCELL,
                             _calendarIndex,
                             rowCount,
                             0,
@@ -272,28 +273,28 @@ namespace System.Windows.Forms
                 int innerX = (int)x;
                 int innerY = (int)y;
 
-                ComCtl32.MCHITTESTINFO hitTestInfo = GetHitTestInfo(innerX, innerY);
-                switch ((ComCtl32.MCHT)hitTestInfo.uHit)
+                MCHITTESTINFO hitTestInfo = GetHitTestInfo(innerX, innerY);
+                switch ((MCHT)hitTestInfo.uHit)
                 {
-                    case ComCtl32.MCHT.TITLEBTNPREV:
+                    case MCHT.TITLEBTNPREV:
                         return GetCalendarChildAccessibleObject(_calendarIndex, CalendarChildType.PreviousButton);
 
-                    case ComCtl32.MCHT.TITLEBTNNEXT:
+                    case MCHT.TITLEBTNNEXT:
                         return GetCalendarChildAccessibleObject(_calendarIndex, CalendarChildType.NextButton);
 
-                    case ComCtl32.MCHT.TITLE:
-                    case ComCtl32.MCHT.TITLEMONTH:
-                    case ComCtl32.MCHT.TITLEYEAR:
+                    case MCHT.TITLE:
+                    case MCHT.TITLEMONTH:
+                    case MCHT.TITLEYEAR:
                         return GetCalendarChildAccessibleObject(_calendarIndex, CalendarChildType.CalendarHeader);
 
-                    case ComCtl32.MCHT.CALENDARDAY:
-                    case ComCtl32.MCHT.CALENDARWEEKNUM:
-                    case ComCtl32.MCHT.CALENDARDATE:
+                    case MCHT.CALENDARDAY:
+                    case MCHT.CALENDARWEEKNUM:
+                    case MCHT.CALENDARDATE:
                         // Get calendar body's child.
                         CalendarBodyAccessibleObject calendarBodyAccessibleObject = (CalendarBodyAccessibleObject)GetCalendarChildAccessibleObject(_calendarIndex, CalendarChildType.CalendarBody);
                         return calendarBodyAccessibleObject.GetFromPoint(hitTestInfo);
 
-                    case ComCtl32.MCHT.TODAYLINK:
+                    case MCHT.TODAYLINK:
                         return GetCalendarChildAccessibleObject(_calendarIndex, CalendarChildType.TodayLink);
                 }
 
@@ -319,9 +320,9 @@ namespace System.Windows.Forms
 
             public override AccessibleObject GetFocused() => _focused;
 
-            public ComCtl32.MCHITTESTINFO GetHitTestInfo(int xScreen, int yScreen)
+            public MCHITTESTINFO GetHitTestInfo(int xScreen, int yScreen)
             {
-                ComCtl32.MCHITTESTINFO hitTestInfo = new ComCtl32.MCHITTESTINFO();
+                MCHITTESTINFO hitTestInfo = new MCHITTESTINFO();
                 hitTestInfo.cbSize = (int)Marshal.SizeOf(hitTestInfo);
                 hitTestInfo.pt = new POINT();
                 hitTestInfo.st = new Kernel32.SYSTEMTIME();
@@ -331,7 +332,7 @@ namespace System.Windows.Forms
                 hitTestInfo.pt.x = point.X;
                 hitTestInfo.pt.y = point.Y;
 
-                UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), (int)ComCtl32.MCM.HITTEST, 0, ref hitTestInfo);
+                UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), (int)MCM.HITTEST, 0, ref hitTestInfo);
 
                 return hitTestInfo;
             }
@@ -354,7 +355,7 @@ namespace System.Windows.Forms
                 switch (calendarChildType)
                 {
                     case CalendarChildType.CalendarHeader:
-                        GetCalendarGridInfoText(ComCtl32.MCGIP.CALENDARHEADER, calendarIndex, 0, 0, out string text);
+                        GetCalendarGridInfoText(MCGIP.CALENDARHEADER, calendarIndex, 0, 0, out string text);
                         return text;
                     case CalendarChildType.TodayLink:
                         return string.Format(SR.MonthCalendarTodayButtonAccessibleName, _owner.TodayDate.ToShortDateString());
@@ -374,8 +375,8 @@ namespace System.Windows.Forms
 
                 CalendarRowAccessibleObject parentRowAccessibleObject = (CalendarRowAccessibleObject)parentAccessibleObject;
                 int rowIndex = parentRowAccessibleObject.RowIndex;
-                bool getNameResult = GetCalendarGridInfoText(ComCtl32.MCGIP.CALENDARCELL, calendarIndex, rowIndex, columnIndex, out string text);
-                bool getDateResult = GetCalendarGridInfo(ComCtl32.MCGIF.DATE, ComCtl32.MCGIP.CALENDARCELL,
+                bool getNameResult = GetCalendarGridInfoText(MCGIP.CALENDARCELL, calendarIndex, rowIndex, columnIndex, out string text);
+                bool getDateResult = GetCalendarGridInfo(MCGIF.DATE, MCGIP.CALENDARCELL,
                     calendarIndex,
                     rowIndex,
                     columnIndex,
@@ -399,7 +400,7 @@ namespace System.Windows.Forms
 
             private string GetCalendarCellName(DateTime endDate, DateTime startDate, string defaultName, bool headerCell)
             {
-                if (_owner._mcCurView == ComCtl32.MCMV.MONTH)
+                if (_owner._mcCurView == MCMV.MONTH)
                 {
                     if (headerCell)
                     {
@@ -408,7 +409,7 @@ namespace System.Windows.Forms
 
                     return startDate.ToString("dddd, MMMM dd, yyyy");
                 }
-                else if (_owner._mcCurView == ComCtl32.MCMV.YEAR)
+                else if (_owner._mcCurView == MCMV.YEAR)
                 {
                     return startDate.ToString("MMMM yyyy");
                 }
@@ -426,8 +427,8 @@ namespace System.Windows.Forms
 
                 // Search name for the first cell in the row.
                 bool success = GetCalendarGridInfo(
-                    ComCtl32.MCGIF.DATE,
-                    ComCtl32.MCGIP.CALENDARCELL,
+                    MCGIF.DATE,
+                    MCGIP.CALENDARCELL,
                     calendarIndex,
                     rowIndex,
                     0,
@@ -452,9 +453,9 @@ namespace System.Windows.Forms
                 return new CalendarRowAccessibleObject(this, calendarIndex, (CalendarBodyAccessibleObject)parentAccessibleObject, rowIndex);
             }
 
-            private bool GetCalendarGridInfo(
-                ComCtl32.MCGIF dwFlags,
-                ComCtl32.MCGIP dwPart,
+            private unsafe bool GetCalendarGridInfo(
+                MCGIF dwFlags,
+                MCGIP dwPart,
                 int calendarIndex,
                 int row,
                 int column,
@@ -463,85 +464,81 @@ namespace System.Windows.Forms
                 out Kernel32.SYSTEMTIME startDate)
             {
                 Debug.Assert(
-                    (dwFlags & ~(ComCtl32.MCGIF.DATE | ComCtl32.MCGIF.RECT)) == 0,
+                    (dwFlags & ~(MCGIF.DATE | MCGIF.RECT)) == 0,
                     "GetCalendarGridInfo() should be used only to obtain Date and Rect,"
                     + "dwFlags has flag bits other that MCGIF_DATE and MCGIF_RECT");
 
-                ComCtl32.MCGRIDINFO gridInfo = new ComCtl32.MCGRIDINFO();
-                gridInfo.dwFlags = dwFlags;
-                gridInfo.cbSize = (uint)Marshal.SizeOf(gridInfo);
-                gridInfo.dwPart = dwPart;
-                gridInfo.iCalendar = calendarIndex;
-                gridInfo.iCol = column;
-                gridInfo.iRow = row;
-                bool result;
+                var gridInfo = new MCGRIDINFO
+                {
+                    cbSize = (uint)sizeof(MCGRIDINFO),
+                    dwFlags = dwFlags,
+                    dwPart = dwPart,
+                    iCalendar = calendarIndex,
+                    iCol = column,
+                    iRow = row
+                };
 
                 try
                 {
-                    result = GetCalendarGridInfo(ref gridInfo);
+                    bool result = GetCalendarGridInfo(ref gridInfo);
                     rectangle = gridInfo.rc;
                     endDate = gridInfo.stEnd;
                     startDate = gridInfo.stStart;
+                    return result;
                 }
                 catch
                 {
                     rectangle = new RECT();
                     endDate = new Kernel32.SYSTEMTIME();
                     startDate = new Kernel32.SYSTEMTIME();
-                    result = false;
+                    return false;
                 }
-
-                return result;
             }
 
-            private bool GetCalendarGridInfo(ref ComCtl32.MCGRIDINFO gridInfo)
+            private bool GetCalendarGridInfo(ref MCGRIDINFO gridInfo)
             {
                 // Do not use this if gridInfo.dwFlags contains MCGIF_NAME;
                 // use GetCalendarGridInfoText() instead.
                 Debug.Assert(
-                    (gridInfo.dwFlags & ComCtl32.MCGIF.NAME) == 0,
+                    (gridInfo.dwFlags & MCGIF.NAME) == 0,
                     "Param dwFlags contains MCGIF_NAME, use GetCalendarGridInfoText() to retrieve the text of a calendar part.");
 
-                gridInfo.dwFlags &= ~ComCtl32.MCGIF.NAME;
+                gridInfo.dwFlags &= ~MCGIF.NAME;
 
-                return _owner.SendMessage((int)ComCtl32.MCM.GETCALENDARGRIDINFO, 0, ref gridInfo) != IntPtr.Zero;
+                return User32.SendMessageW(_owner, (User32.WindowMessage)MCM.GETCALENDARGRIDINFO, IntPtr.Zero, ref gridInfo) != IntPtr.Zero;
             }
 
-            private bool GetCalendarGridInfoText(ComCtl32.MCGIP dwPart, int calendarIndex, int row, int column, out string text)
+            private unsafe bool GetCalendarGridInfoText(MCGIP dwPart, int calendarIndex, int row, int column, out string text)
             {
                 const int nameLength = 128;
+                Span<char> name = stackalloc char[nameLength + 2];
 
-                ComCtl32.MCGRIDINFO gridInfo = new ComCtl32.MCGRIDINFO();
-                gridInfo.cbSize = (uint)Marshal.SizeOf(gridInfo);
-                gridInfo.dwPart = dwPart;
-                gridInfo.iCalendar = calendarIndex;
-                gridInfo.iCol = column;
-                gridInfo.iRow = row;
-                gridInfo.pszName = new string('\0', nameLength + 2);
-                gridInfo.cchName = (uint)gridInfo.pszName.Length - 1;
+                bool result;
+                fixed (char* pName = name)
+                {
+                    var gridInfo = new MCGRIDINFO
+                    {
+                        cbSize = (uint)sizeof(MCGRIDINFO),
+                        dwFlags = MCGIF.NAME,
+                        dwPart = dwPart,
+                        iCalendar = calendarIndex,
+                        iCol = column,
+                        iRow = row,
+                        pszName = pName,
+                        cchName = (uint)name.Length - 1
+                    };
 
-                bool result = GetCalendarGridInfoText(ref gridInfo);
-                text = gridInfo.pszName;
+                    result = User32.SendMessageW(_owner, (User32.WindowMessage)MCM.GETCALENDARGRIDINFO, IntPtr.Zero, ref gridInfo) != IntPtr.Zero;
+                }
 
+                text = name.SliceAtFirstNull().ToString();
                 return result;
             }
 
-            // Use to retrieve MCGIF_NAME only.
-            private bool GetCalendarGridInfoText(ref ComCtl32.MCGRIDINFO gridInfo)
-            {
-                Debug.Assert(
-                    gridInfo.dwFlags == 0,
-                    "gridInfo.dwFlags should be 0 when calling GetCalendarGridInfoText");
-
-                gridInfo.dwFlags = ComCtl32.MCGIF.NAME;
-
-                return _owner.SendMessage((int)ComCtl32.MCM.GETCALENDARGRIDINFO, 0, ref gridInfo) != IntPtr.Zero;
-            }
-
-            public bool GetCalendarPartRectangle(int calendarIndex, ComCtl32.MCGIP dwPart, int row, int column, out RECT calendarPartRectangle)
+            public bool GetCalendarPartRectangle(int calendarIndex, MCGIP dwPart, int row, int column, out RECT calendarPartRectangle)
             {
                 bool success = GetCalendarGridInfo(
-                    ComCtl32.MCGIF.RECT,
+                    MCGIF.RECT,
                     dwPart,
                     calendarIndex,
                     row,
@@ -678,8 +675,8 @@ namespace System.Windows.Forms
                     for (int column = 0; column < columnCount; column++)
                     {
                         bool success = GetCalendarGridInfo(
-                            ComCtl32.MCGIF.DATE,
-                            ComCtl32.MCGIP.CALENDARCELL,
+                            MCGIF.DATE,
+                            MCGIP.CALENDARCELL,
                             _calendarIndex,
                             row,
                             column,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -14,6 +14,7 @@ using System.Windows.Forms.Layout;
 using Microsoft.Win32;
 
 using static Interop;
+using static Interop.ComCtl32;
 using ArrayList = System.Collections.ArrayList;
 
 namespace System.Windows.Forms
@@ -122,8 +123,8 @@ namespace System.Windows.Forms
         private DateTime selectionStart;
         private DateTime selectionEnd;
         private Day firstDayOfWeek = DEFAULT_FIRST_DAY_OF_WEEK;
-        private ComCtl32.MCMV _mcCurView = ComCtl32.MCMV.MONTH;
-        private ComCtl32.MCMV _mcOldView = ComCtl32.MCMV.MONTH;
+        private MCMV _mcCurView = MCMV.MONTH;
+        private MCMV _mcOldView = MCMV.MONTH;
 
         /// <summary>
         ///  Bitmask for the annually bolded dates.  Months start on January.
@@ -363,21 +364,21 @@ namespace System.Windows.Forms
             get
             {
                 CreateParams cp = base.CreateParams;
-                cp.ClassName = ComCtl32.WindowClasses.WC_MONTHCAL;
-                cp.Style |= (int)ComCtl32.MCS.MULTISELECT | (int)ComCtl32.MCS.DAYSTATE;
+                cp.ClassName = WindowClasses.WC_MONTHCAL;
+                cp.Style |= (int)MCS.MULTISELECT | (int)MCS.DAYSTATE;
                 if (!showToday)
                 {
-                    cp.Style |= (int)ComCtl32.MCS.NOTODAY;
+                    cp.Style |= (int)MCS.NOTODAY;
                 }
 
                 if (!showTodayCircle)
                 {
-                    cp.Style |= (int)ComCtl32.MCS.NOTODAYCIRCLE;
+                    cp.Style |= (int)MCS.NOTODAYCIRCLE;
                 }
 
                 if (showWeekNumbers)
                 {
-                    cp.Style |= (int)ComCtl32.MCS.WEEKNUMBERS;
+                    cp.Style |= (int)MCS.WEEKNUMBERS;
                 }
 
                 if (RightToLeft == RightToLeft.Yes && RightToLeftLayout)
@@ -973,7 +974,7 @@ namespace System.Windows.Forms
 
                 if (IsHandleCreated)
                 {
-                    if (User32.SendMessageW(this, (User32.WM)ComCtl32.MCM.GETMINREQRECT, IntPtr.Zero, ref rect) == IntPtr.Zero)
+                    if (User32.SendMessageW(this, (User32.WM)MCM.GETMINREQRECT, IntPtr.Zero, ref rect) == IntPtr.Zero)
                     {
                         throw new InvalidOperationException(SR.InvalidSingleMonthSize);
                     }
@@ -1123,7 +1124,7 @@ namespace System.Windows.Forms
                                                               "value"));
                 }
                 titleBackColor = value;
-                SetControlColor(ComCtl32.MCSC.TITLEBK, value);
+                SetControlColor(MCSC.TITLEBK, value);
             }
         }
 
@@ -1149,7 +1150,7 @@ namespace System.Windows.Forms
                                                               "value"));
                 }
                 titleForeColor = value;
-                SetControlColor(ComCtl32.MCSC.TITLETEXT, value);
+                SetControlColor(MCSC.TITLETEXT, value);
             }
         }
 
@@ -1175,7 +1176,7 @@ namespace System.Windows.Forms
                                                               "value"));
                 }
                 trailingForeColor = value;
-                SetControlColor(ComCtl32.MCSC.TRAILINGTEXT, value);
+                SetControlColor(MCSC.TRAILINGTEXT, value);
             }
         }
 
@@ -1331,11 +1332,11 @@ namespace System.Windows.Forms
                 IntPtr userCookie = ThemingScope.Activate(Application.UseVisualStyles);
                 try
                 {
-                    var icc = new ComCtl32.INITCOMMONCONTROLSEX
+                    var icc = new INITCOMMONCONTROLSEX
                     {
-                        dwICC = ComCtl32.ICC.DATE_CLASSES
+                        dwICC = ICC.DATE_CLASSES
                     };
-                    ComCtl32.InitCommonControlsEx(ref icc);
+                    InitCommonControlsEx(ref icc);
                 }
                 finally
                 {
@@ -1390,31 +1391,31 @@ namespace System.Windows.Forms
         /// </summary>
         private HitArea GetHitArea(int hit)
         {
-            switch ((ComCtl32.MCHT)hit)
+            switch ((MCHT)hit)
             {
-                case ComCtl32.MCHT.TITLEBK:
+                case MCHT.TITLEBK:
                     return HitArea.TitleBackground;
-                case ComCtl32.MCHT.TITLEMONTH:
+                case MCHT.TITLEMONTH:
                     return HitArea.TitleMonth;
-                case ComCtl32.MCHT.TITLEYEAR:
+                case MCHT.TITLEYEAR:
                     return HitArea.TitleYear;
-                case ComCtl32.MCHT.TITLEBTNNEXT:
+                case MCHT.TITLEBTNNEXT:
                     return HitArea.NextMonthButton;
-                case ComCtl32.MCHT.TITLEBTNPREV:
+                case MCHT.TITLEBTNPREV:
                     return HitArea.PrevMonthButton;
-                case ComCtl32.MCHT.CALENDARBK:
+                case MCHT.CALENDARBK:
                     return HitArea.CalendarBackground;
-                case ComCtl32.MCHT.CALENDARDATE:
+                case MCHT.CALENDARDATE:
                     return HitArea.Date;
-                case ComCtl32.MCHT.CALENDARDATENEXT:
+                case MCHT.CALENDARDATENEXT:
                     return HitArea.NextMonthDate;
-                case ComCtl32.MCHT.CALENDARDATEPREV:
+                case MCHT.CALENDARDATEPREV:
                     return HitArea.PrevMonthDate;
-                case ComCtl32.MCHT.CALENDARDAY:
+                case MCHT.CALENDARDAY:
                     return HitArea.DayOfWeek;
-                case ComCtl32.MCHT.CALENDARWEEKNUM:
+                case MCHT.CALENDARWEEKNUM:
                     return HitArea.WeekNumbers;
-                case ComCtl32.MCHT.TODAYLINK:
+                case MCHT.TODAYLINK:
                     return HitArea.TodayLink;
                 default:
                     return HitArea.Nowhere;
@@ -1432,7 +1433,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Used internally to get the minimum size needed to display the
         ///  MonthCalendar. This is needed because
-        ///  ComCtl32.MCM.GETMINREQRECT
+        ///  MCM.GETMINREQRECT
         ///  returns an incorrect value if showToday
         ///  is set to false. If updateRows is true, then the
         ///  number of rows will be updated according to height.
@@ -1509,7 +1510,7 @@ namespace System.Windows.Forms
         private SelectionRange GetMonthRange(int flag)
         {
             Span<Kernel32.SYSTEMTIME> sa = stackalloc Kernel32.SYSTEMTIME[2];
-            User32.SendMessageW(this, (User32.WM)ComCtl32.MCM.GETMONTHRANGE, (IntPtr)flag, ref sa[0]);
+            User32.SendMessageW(this, (User32.WM)MCM.GETMONTHRANGE, (IntPtr)flag, ref sa[0]);
             return new SelectionRange
             {
                 Start = DateTimePicker.SysTimeToDateTime(sa[0]),
@@ -1541,22 +1542,17 @@ namespace System.Windows.Forms
         ///  Determines which portion of a month calendar control is at
         ///  at a given point on the screen.
         /// </summary>
-        public HitTestInfo HitTest(int x, int y)
+        public unsafe HitTestInfo HitTest(int x, int y)
         {
-            ComCtl32.MCHITTESTINFO mchi = new ComCtl32.MCHITTESTINFO
+            var mchi = new MCHITTESTINFO
             {
-                pt = new POINT
-                {
-                    x = x,
-                    y = y
-                },
-                st = new Kernel32.SYSTEMTIME(),
-                cbSize = Marshal.SizeOf<ComCtl32.MCHITTESTINFO>()
+                cbSize = (uint)sizeof(MCHITTESTINFO),
+                pt = new Point(x, y),
+                st = new Kernel32.SYSTEMTIME()
             };
-            UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), (int)ComCtl32.MCM.HITTEST, 0, ref mchi);
+            User32.SendMessageW(this, (User32.WM)MCM.HITTEST, IntPtr.Zero, ref mchi);
 
             // If the hit area has an associated valid date, get it
-            //
             HitArea hitArea = GetHitArea(mchi.uHit);
             if (HitTestInfo.HitAreaHasValidDateTime(hitArea))
             {
@@ -1571,11 +1567,11 @@ namespace System.Windows.Forms
                     wSecond = mchi.st.wSecond,
                     wMilliseconds = mchi.st.wMilliseconds
                 };
-                return new HitTestInfo(new Point(mchi.pt.x, mchi.pt.y), hitArea, DateTimePicker.SysTimeToDateTime(sys));
+                return new HitTestInfo(mchi.pt, hitArea, DateTimePicker.SysTimeToDateTime(sys));
             }
             else
             {
-                return new HitTestInfo(new Point(mchi.pt.x, mchi.pt.y), hitArea);
+                return new HitTestInfo(mchi.pt, hitArea);
             }
         }
 
@@ -1634,11 +1630,11 @@ namespace System.Windows.Forms
                 User32.SendMessageW(this, (User32.WM)User32.MCM.SETTODAY, IntPtr.Zero, ref st);
             }
 
-            SetControlColor(ComCtl32.MCSC.TEXT, ForeColor);
-            SetControlColor(ComCtl32.MCSC.MONTHBK, BackColor);
-            SetControlColor(ComCtl32.MCSC.TITLEBK, titleBackColor);
-            SetControlColor(ComCtl32.MCSC.TITLETEXT, titleForeColor);
-            SetControlColor(ComCtl32.MCSC.TRAILINGTEXT, trailingForeColor);
+            SetControlColor(MCSC.TEXT, ForeColor);
+            SetControlColor(MCSC.MONTHBK, BackColor);
+            SetControlColor(MCSC.TITLEBK, titleBackColor);
+            SetControlColor(MCSC.TITLETEXT, titleForeColor);
+            SetControlColor(MCSC.TRAILINGTEXT, trailingForeColor);
 
             int firstDay;
             if (firstDayOfWeek == Day.Default)
@@ -1703,13 +1699,13 @@ namespace System.Windows.Forms
         protected override void OnForeColorChanged(EventArgs e)
         {
             base.OnForeColorChanged(e);
-            SetControlColor(ComCtl32.MCSC.TEXT, ForeColor);
+            SetControlColor(MCSC.TEXT, ForeColor);
         }
 
         protected override void OnBackColorChanged(EventArgs e)
         {
             base.OnBackColorChanged(e);
-            SetControlColor(ComCtl32.MCSC.MONTHBK, BackColor);
+            SetControlColor(MCSC.MONTHBK, BackColor);
         }
 
         [EditorBrowsable(EditorBrowsableState.Advanced)]
@@ -1984,7 +1980,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  If the handle has been created, this applies the color to the control
         /// </summary>
-        private void SetControlColor(ComCtl32.MCSC colorIndex, Color value)
+        private void SetControlColor(MCSC colorIndex, Color value)
         {
             if (IsHandleCreated)
             {
@@ -2029,7 +2025,7 @@ namespace System.Windows.Forms
                 sa[0] = DateTimePicker.DateTimeToSysTime(minDate);
                 sa[1] = DateTimePicker.DateTimeToSysTime(maxDate);
                 int flag = NativeMethods.GDTR_MIN | NativeMethods.GDTR_MAX;
-                if ((int)User32.SendMessageW(this, (User32.WM)ComCtl32.MCM.SETRANGE, (IntPtr)flag, ref sa[0]) == 0)
+                if ((int)User32.SendMessageW(this, (User32.WM)MCM.SETRANGE, (IntPtr)flag, ref sa[0]) == 0)
                 {
                     throw new InvalidOperationException(string.Format(SR.MonthCalendarRange, minDate.ToShortDateString(), maxDate.ToShortDateString()));
                 }
@@ -2310,7 +2306,7 @@ namespace System.Windows.Forms
         /// </summary>
         private unsafe void WmDateChanged(ref Message m)
         {
-            ComCtl32.NMSELCHANGE* nmmcsc = (ComCtl32.NMSELCHANGE*)m.LParam;
+            NMSELCHANGE* nmmcsc = (NMSELCHANGE*)m.LParam;
             DateTime start = selectionStart = DateTimePicker.SysTimeToDateTime(nmmcsc->stSelStart);
             DateTime end = selectionEnd = DateTimePicker.SysTimeToDateTime(nmmcsc->stSelEnd);
 
@@ -2338,7 +2334,7 @@ namespace System.Windows.Forms
         /// </summary>
         private unsafe void WmDateBold(ref Message m)
         {
-            ComCtl32.NMDAYSTATE* nmmcds = (ComCtl32.NMDAYSTATE*)m.LParam;
+            NMDAYSTATE* nmmcds = (NMDAYSTATE*)m.LParam;
             DateTime start = DateTimePicker.SysTimeToDateTime(nmmcds->stStart);
             DateBoldEventArgs boldEvent = new DateBoldEventArgs(start, nmmcds->cDayState);
             BoldDates(boldEvent);
@@ -2354,7 +2350,7 @@ namespace System.Windows.Forms
         /// </summary>
         private unsafe void WmCalViewChanged(ref Message m)
         {
-            ComCtl32.NMVIEWCHANGE* nmmcvm = (ComCtl32.NMVIEWCHANGE*)m.LParam;
+            NMVIEWCHANGE* nmmcvm = (NMVIEWCHANGE*)m.LParam;
             Debug.Assert(_mcCurView == nmmcvm->uOldView, "Calendar view mode is out of sync with native control");
             if (_mcCurView != nmmcvm->uNewView)
             {
@@ -2370,7 +2366,7 @@ namespace System.Windows.Forms
         /// </summary>
         private unsafe void WmDateSelected(ref Message m)
         {
-            ComCtl32.NMSELCHANGE* nmmcsc = (ComCtl32.NMSELCHANGE*)m.LParam;
+            NMSELCHANGE* nmmcsc = (NMSELCHANGE*)m.LParam;
             DateTime start = selectionStart = DateTimePicker.SysTimeToDateTime(nmmcsc->stSelStart);
             DateTime end = selectionEnd = DateTimePicker.SysTimeToDateTime(nmmcsc->stSelEnd);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -1949,13 +1949,6 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Sends a Win32 message to this control.  If the control does not yet
-        ///  have a handle, it will be created.
-        /// </summary>
-        private IntPtr SendMessage(int msg, int wparam, ref ComCtl32.MCGRIDINFO lparam) =>
-            ComCtl32.SendMessage(new HandleRef(this, Handle), msg, wparam, ref lparam);
-
-        /// <summary>
         ///  Overrides Control.SetBoundsCore to enforce auto-sizing.
         /// </summary>
         protected override void SetBoundsCore(int x, int y, int width, int height, BoundsSpecified specified)

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/MonthCalendar.CalendarHeaderAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/MonthCalendar.CalendarHeaderAccessibleObjectTests.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.Tests.AccessibleObjects
+{
+    public class MonthCalendarCalendarHeaderAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsFact]
+        public void CalendarHeaderAccessibleObject_Name_Get_ReturnsExpected()
+        {
+            using var calendar = new MonthCalendar();
+            MonthCalendar.MonthCalendarAccessibleObject accessibleObject = Assert.IsType<MonthCalendar.MonthCalendarAccessibleObject>(calendar.AccessibilityObject);
+            var headerAccessibleObject = new MonthCalendar.CalendarHeaderAccessibleObject(accessibleObject, 0);
+            Assert.Empty(headerAccessibleObject.Name);
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes
- Make `MCGRIDINFO` blittable by using `Span`
- Cleanup `MCHITTESTINFO` interop

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2630)