### PR TITLE
Improve performance of Enum*Windows() interop functions

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnumChildWindows.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnumChildWindows.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public delegate BOOL EnumChildWindowsCallback(IntPtr hWnd);
+
+        private delegate BOOL EnumChildWindowsNativeCallback(IntPtr hWnd, IntPtr lParam);
+
+        private static readonly EnumChildWindowsNativeCallback s_enumChildWindowsNativeCallback = HandleEnumChildWindowsNativeCallback;
+
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        private static extern BOOL EnumChildWindows(IntPtr hwndParent, EnumChildWindowsNativeCallback lpEnumFunc, IntPtr lParam);
+
+        public static BOOL EnumChildWindows(IntPtr hwndParent, EnumChildWindowsCallback lpEnumFunc)
+        {
+            // We pass a static delegate to the native function and supply the callback as
+            // reference data, so that the CLR doesn't need to generate a native code block for
+            // each callback delegate instance (for storing the closure pointer).
+            var gcHandle = GCHandle.Alloc(lpEnumFunc);
+            try
+            {
+                return EnumChildWindows(hwndParent, s_enumChildWindowsNativeCallback, GCHandle.ToIntPtr(gcHandle));
+            }
+            finally
+            {
+                gcHandle.Free();
+            }
+        }
+
+        public static BOOL EnumChildWindows(IHandle hwndParent, EnumChildWindowsCallback lpEnumFunc)
+        {
+            BOOL result = EnumChildWindows(hwndParent.Handle, lpEnumFunc);
+            GC.KeepAlive(hwndParent);
+            return result;
+        }
+
+        public static BOOL EnumChildWindows(HandleRef hwndParent, EnumChildWindowsCallback lpEnumFunc)
+        {
+            BOOL result = EnumChildWindows(hwndParent.Handle, lpEnumFunc);
+            GC.KeepAlive(hwndParent.Wrapper);
+            return result;
+        }
+
+        private static BOOL HandleEnumChildWindowsNativeCallback(IntPtr hWnd, IntPtr lParam)
+        {
+            return ((EnumChildWindowsCallback)GCHandle.FromIntPtr(lParam).Target)(hWnd);
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnumThreadWindows.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnumThreadWindows.cs
@@ -9,16 +9,34 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        public delegate bool EnumThreadWindowsCallback(IntPtr hWnd, IntPtr lParam);
+        public delegate BOOL EnumThreadWindowsCallback(IntPtr hWnd);
+
+        private delegate BOOL EnumThreadWindowsNativeCallback(IntPtr hWnd, IntPtr lParam);
+
+        private static readonly EnumThreadWindowsNativeCallback s_enumThreadWindowsNativeCallback = HandleEnumThreadWindowsNativeCallback;
 
         [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL EnumThreadWindows(uint dwThreadId, EnumThreadWindowsCallback lpfn, IntPtr lParam);
+        private static extern BOOL EnumThreadWindows(uint dwThreadId, EnumThreadWindowsNativeCallback lpfn, IntPtr lParam);
 
-        public static BOOL EnumThreadWindows(uint dwThreadId, EnumThreadWindowsCallback lpfn, IHandle lParam)
+        public static BOOL EnumThreadWindows(uint dwThreadId, EnumThreadWindowsCallback lpfn)
         {
-            BOOL result = EnumThreadWindows(dwThreadId, lpfn, lParam.Handle);
-            GC.KeepAlive(lParam);
-            return result;
+            // We pass a static delegate to the native function and supply the callback as
+            // reference data, so that the CLR doesn't need to generate a native code block for
+            // each callback delegate instance (for storing the closure pointer).
+            var gcHandle = GCHandle.Alloc(lpfn);
+            try
+            {
+                return EnumThreadWindows(dwThreadId, s_enumThreadWindowsNativeCallback, GCHandle.ToIntPtr(gcHandle));
+            }
+            finally
+            {
+                gcHandle.Free();
+            }
+        }
+
+        private static BOOL HandleEnumThreadWindowsNativeCallback(IntPtr hWnd, IntPtr lParam)
+        {
+            return ((EnumThreadWindowsCallback)GCHandle.FromIntPtr(lParam).Target)(hWnd);
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -351,8 +351,6 @@ namespace System.Windows.Forms
             public int dwFlags;
         }
 
-        public delegate bool EnumChildrenCallback(IntPtr hwnd, IntPtr lParam);
-
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
         public class HH_AKLINK
         {

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -85,9 +85,6 @@ namespace System.Windows.Forms
             }
         }
 
-        [DllImport(ExternDll.User32, ExactSpelling = true)]
-        public static extern bool EnumChildWindows(HandleRef hwndParent, NativeMethods.EnumChildrenCallback lpEnumFunc, HandleRef lParam);
-
         [DllImport(ExternDll.Shell32, CharSet = CharSet.Auto)]
         public static extern int Shell_NotifyIcon(int message, NativeMethods.NOTIFYICONDATA pnid);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadWindows.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadWindows.cs
@@ -30,15 +30,12 @@ namespace System.Windows.Forms
             {
                 _windows = new IntPtr[16];
                 _onlyWinForms = onlyWinForms;
-                var callback = new User32.EnumThreadWindowsCallback(Callback);
                 User32.EnumThreadWindows(
                     Kernel32.GetCurrentThreadId(),
-                    callback,
-                    IntPtr.Zero);
-                GC.KeepAlive(callback);
+                    Callback);
             }
 
-            private bool Callback(IntPtr hWnd, IntPtr lparam)
+            private BOOL Callback(IntPtr hWnd)
             {
                 // We only do visible and enabled windows.  Also, we only do top level windows.
                 // Finally, we only include windows that are DNA windows, since other MSO components
@@ -68,7 +65,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                return true;
+                return BOOL.TRUE;
             }
 
             // Disposes all top-level Controls on this thread

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -6078,7 +6078,7 @@ namespace System.Windows.Forms
                 Debug.Assert(!ACWindows.ContainsKey(acHandle));
                 AssignHandle(acHandle);
                 ACWindows.Add(acHandle, this);
-                EnumChildWindows(new HandleRef(this, acHandle), 
+                EnumChildWindows(new HandleRef(this, acHandle),
                     ACNativeWindow.RegisterACWindowRecursive);
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -6078,18 +6078,17 @@ namespace System.Windows.Forms
                 Debug.Assert(!ACWindows.ContainsKey(acHandle));
                 AssignHandle(acHandle);
                 ACWindows.Add(acHandle, this);
-                UnsafeNativeMethods.EnumChildWindows(new HandleRef(this, acHandle),
-                    new NativeMethods.EnumChildrenCallback(ACNativeWindow.RegisterACWindowRecursive),
-                    NativeMethods.NullHandleRef);
+                EnumChildWindows(new HandleRef(this, acHandle), 
+                    ACNativeWindow.RegisterACWindowRecursive);
             }
 
-            private static bool RegisterACWindowRecursive(IntPtr handle, IntPtr lparam)
+            private static BOOL RegisterACWindowRecursive(IntPtr handle)
             {
                 if (!ACWindows.ContainsKey(handle))
                 {
                     ACNativeWindow newAC = new ACNativeWindow(handle);
                 }
-                return true;
+                return BOOL.TRUE;
             }
 
             internal bool Visible => IsWindowVisible(this).IsTrue();
@@ -6200,15 +6199,12 @@ namespace System.Windows.Forms
 
                 // Look for a popped up dropdown
                 shouldSubClass = subclass;
-                var callback = new EnumThreadWindowsCallback(Callback);
                 EnumThreadWindows(
                     Kernel32.GetCurrentThreadId(),
-                    callback,
-                    IntPtr.Zero);
-                GC.KeepAlive(callback);
+                    Callback);
             }
 
-            private bool Callback(IntPtr hWnd, IntPtr lParam)
+            private BOOL Callback(IntPtr hWnd)
             {
                 HandleRef hRef = new HandleRef(null, hWnd);
 
@@ -6218,7 +6214,7 @@ namespace System.Windows.Forms
                     ACNativeWindow.RegisterACWindow(hRef.Handle, shouldSubClass);
                 }
 
-                return true;
+                return BOOL.TRUE;
             }
 
             static string GetClassName(HandleRef hRef)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
@@ -1562,8 +1562,7 @@ namespace System.Windows.Forms
             if (ShowUpDown)
             {
                 EnumChildren c = new EnumChildren();
-                NativeMethods.EnumChildrenCallback cb = new NativeMethods.EnumChildrenCallback(c.enumChildren);
-                UnsafeNativeMethods.EnumChildWindows(new HandleRef(this, Handle), cb, NativeMethods.NullHandleRef);
+                User32.EnumChildWindows(this, c.enumChildren);
                 if (c.hwndFound != IntPtr.Zero)
                 {
                     User32.InvalidateRect(new HandleRef(c, c.hwndFound), null, BOOL.TRUE);
@@ -1738,10 +1737,10 @@ namespace System.Windows.Forms
         {
             public IntPtr hwndFound = IntPtr.Zero;
 
-            public bool enumChildren(IntPtr hwnd, IntPtr lparam)
+            public BOOL enumChildren(IntPtr hwnd)
             {
                 hwndFound = hwnd;
-                return true;
+                return BOOL.TRUE;
             }
         }
 


### PR DESCRIPTION
## Proposed changes

In `EnumWindows`, `EnumChildWindows`, and `EnumThreadWindows`, instead of passing the supplied callback delegate to the native function, use a (fixed) static delegate, and specify a handle pointer of the supplied callback in the `lParam` parameter (that is available for storing application-provided data).

That way, the CLR no longer needs to allocate memory for each delegate instance in order to store a native code block (that contains the closure pointer), thus improving performance in many cases (see comparison below). (On the other hand, the invoked callback delegate now has a little bit more work to do, by dereferencing a `GCHandle` and calling another method.)

This can especially improve speed when running x86 applications on **ARM64** systems, as it avoids the need for the emulation layer to generate new ARM64 code from the x86 code every time the method is invoked with a new delegate instance.

Note: In `Form.RecreateHandleCore` there was a call to `EnumThreadWindows` where the form handle was passed as `lParam` data, but I think it makes more sense to store it in the callback closure since a new instance of the delegate is created anyway.

Note: I'm not sure about the naming/placement of the delegate types. In the native declarations, all functions use `WNDENUMPROC` as callback type.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Better performance and reduced memory footprint in many cases when using code that calls `EnumWindows`, `EnumChildWindows` or `EnumThreadWindows`.
In specific cases (when the callback is called very often), performance might be slower due to the additional work the callback has to do.

## Regression? 

- No

## Risk

-

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

### Performance
- Manual testing using a code like this (for `EnumChildWindows`):
```c#
    class Program
    {
        [STAThread]
        private static void Main()
        {
            var f = new Form();
            f.Controls.Add(new Button());
            f.Controls.Add(new CheckBox());
            f.Controls.Add(new RadioButton());

            var handle = f.Handle;

            f.Show();

            var sw = new Stopwatch();
            for (int i = -5; i < 100000; i++)
            {
                if (i == 0)
                    sw.Start();

                Interop.User32.EnumChildWindows(
                    handle, new EnumChildWindowsTest().HandleCallback);
            }
            sw.Stop();
            f.Close();
            f.Dispose();
            Console.WriteLine("Elapsed: " + sw.ElapsedMilliseconds);            
        }

        private class EnumChildWindowsTest
        {
            private int count;

            public Interop.BOOL HandleCallback(IntPtr hWnd)
            {
                count++;
                return Interop.BOOL.TRUE;
            }
        }
    }
```

**Average time** before/after this PR:
- **x86** app on a **x64** system (Windows 10 Version 1909)
  - Before: ~660 ms
  - After: ~370 ms
  - Factor: 1.8x
- **x64** app:
  - Before: ~400 ms
  - After: ~280 ms
  - Factor: 1.4x
- **x86** app on a (slow) **ARM64** machine (Windows 10 on ARM on Raspberry Pi 3 B+):
  - Before: ~27.0s
  - After: ~5.4s
  - Factor: **5.0x**

Note: When the callback is called more often (e.g. about 200 times when calling `EnumWindows`), the timing improvement vanishes with a x64 app, probably because the callback delegate has now a bit more work to do.


## Test environment(s) <!-- Remove any that don't apply -->

.NET Core SDK (reflecting any global.json):
 Version:   5.0.100-alpha1-016073
 Commit:    bd7bf8c6d2

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.18363
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\5.0.100-alpha1-016073\

Host (useful for support):
  Version: 5.0.0-alpha.1.19564.1
  Commit:  c77948d92a

.NET Core SDKs installed:
  3.1.100 [C:\Program Files\dotnet\sdk]
  5.0.100-alpha1-016073 [C:\Program Files\dotnet\sdk]

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2639)