### PR TITLE
Fix nullability bug in BindingContext

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingContext.cs
@@ -70,7 +70,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Gets an object to use for synchronization (thread safety).
         /// </summary>
-        object ICollection.SyncRoot => null;
+        object ICollection.SyncRoot => this;
 
         /// <summary>
         ///  Gets the System.Windows.Forms.BindingManagerBase associated with the specified

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BindingContextTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BindingContextTests.cs
@@ -26,7 +26,7 @@ namespace System.Windows.Forms.Tests
         {
             ICollection context = new BindingContext();
             Assert.False(context.IsSynchronized);
-            Assert.Null(context.SyncRoot);
+            Assert.Same(context, context.SyncRoot);
             Assert.Empty(context);
         }
 


### PR DESCRIPTION
## Proposed Changes
- Make `ICollection.SyncRoot` return non-null value

## ~TODO~
~We have the following warnings~
> System/Windows/Forms/BindingContext.cs(377,38): warning CS8605: Unboxing a possibly null value. [/Users/hugh/Documents/GitHub/winforms/src/System.Windows.Forms/src/System.Windows.Forms.csproj]
System/Windows/Forms/BindingContext.cs(379,38): warning CS8600: Converting null literal or possible null value to non-nullable type. [/Users/hugh/Documents/GitHub/winforms/src/System.Windows.Forms/src/System.Windows.Forms.csproj]
System/Windows/Forms/BindingContext.cs(380,21): warning CS8602: Dereference of a possibly null reference. [/Users/hugh/Documents/GitHub/winforms/src/System.Windows.Forms/src/System.Windows.Forms.csproj]
    3 Warning(s)

Happens in cases like below in `foreach (DictionaryEntry de in _listManagers)`, how are we unboxing a possibly null value
```cs
private void ScrubWeakRefs()
{
    List<object>? cleanupList = null;
    foreach (DictionaryEntry de in _listManagers)
    {
        WeakReference wRef = (WeakReference)de.Value;
        if (wRef.Target == null)
        {
            cleanupList ??= new List<object>();
            cleanupList.Add(de.Key);
        }
    }

    ...
}
```
/cc @weltkante  

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2646)