### PR TITLE
Add MenuCommandService

### DIFF
--- a/src/System.Design/src/ApiCompatBaseline.netcoreapp.txt
+++ b/src/System.Design/src/ApiCompatBaseline.netcoreapp.txt
@@ -7,14 +7,7 @@ TypesMustExist : Type 'System.ComponentModel.Design.ByteViewer' does not exist i
 TypesMustExist : Type 'System.ComponentModel.Design.ComponentActionsType' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.ComponentModel.Design.DateTimeEditor' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.ComponentModel.Design.DesignerActionListsChangedEventArgs' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.ComponentModel.Design.DesignerActionListsChangedEventHandler' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.ComponentModel.Design.DesignerActionListsChangedType' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.ComponentModel.Design.DesignerActionService' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.ComponentModel.Design.DesignerActionUIService' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.ComponentModel.Design.DesignerActionUIStateChangeEventArgs' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.ComponentModel.Design.DesignerActionUIStateChangeEventHandler' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.ComponentModel.Design.DesignerActionUIStateChangeType' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.ComponentModel.Design.DesignerCommandSet' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.ComponentModel.Design.DesignSurface' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.ComponentModel.Design.DesignSurfaceCollection' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.ComponentModel.Design.DesignSurfaceEventArgs' does not exist in the implementation but it does exist in the contract.
@@ -31,10 +24,6 @@ TypesMustExist : Type 'System.ComponentModel.Design.InheritanceService' does not
 TypesMustExist : Type 'System.ComponentModel.Design.LoadedEventArgs' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.ComponentModel.Design.LoadedEventHandler' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.ComponentModel.Design.LocalizationExtenderProvider' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.ComponentModel.Design.MenuCommandsChangedEventArgs' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.ComponentModel.Design.MenuCommandsChangedEventHandler' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.ComponentModel.Design.MenuCommandsChangedType' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.ComponentModel.Design.MenuCommandService' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.ComponentModel.Design.MultilineStringEditor' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.ComponentModel.Design.ProjectTargetFrameworkAttribute' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.ComponentModel.Design.UndoEngine' does not exist in the implementation but it does exist in the contract.

--- a/src/System.Windows.Forms.Design/src/Resources/SR.resx
+++ b/src/System.Windows.Forms.Design/src/Resources/SR.resx
@@ -907,4 +907,7 @@
   <data name="MaskedTextBoxHintInvalidInput" xml:space="preserve">
     <value>Invalid input character</value>
   </data>
+  <data name="MenuCommandService_DuplicateCommand" xml:space="preserve">
+    <value>There is already a command handler for the menu command '{0}'.</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.cs.xlf
@@ -770,6 +770,11 @@
         <target state="new">Error at position {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MenuCommandService_DuplicateCommand">
+        <source>There is already a command handler for the menu command '{0}'.</source>
+        <target state="new">There is already a command handler for the menu command '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="None">
         <source>(None)</source>
         <target state="translated">(Žádné)</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.de.xlf
@@ -770,6 +770,11 @@
         <target state="new">Error at position {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MenuCommandService_DuplicateCommand">
+        <source>There is already a command handler for the menu command '{0}'.</source>
+        <target state="new">There is already a command handler for the menu command '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="None">
         <source>(None)</source>
         <target state="translated">(Keine)</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.es.xlf
@@ -770,6 +770,11 @@
         <target state="new">Error at position {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MenuCommandService_DuplicateCommand">
+        <source>There is already a command handler for the menu command '{0}'.</source>
+        <target state="new">There is already a command handler for the menu command '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="None">
         <source>(None)</source>
         <target state="translated">(Ninguno)</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.fr.xlf
@@ -770,6 +770,11 @@
         <target state="new">Error at position {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MenuCommandService_DuplicateCommand">
+        <source>There is already a command handler for the menu command '{0}'.</source>
+        <target state="new">There is already a command handler for the menu command '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="None">
         <source>(None)</source>
         <target state="translated">(Aucun)</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.it.xlf
@@ -770,6 +770,11 @@
         <target state="new">Error at position {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MenuCommandService_DuplicateCommand">
+        <source>There is already a command handler for the menu command '{0}'.</source>
+        <target state="new">There is already a command handler for the menu command '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="None">
         <source>(None)</source>
         <target state="translated">(Nessuno)</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ja.xlf
@@ -770,6 +770,11 @@
         <target state="new">Error at position {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MenuCommandService_DuplicateCommand">
+        <source>There is already a command handler for the menu command '{0}'.</source>
+        <target state="new">There is already a command handler for the menu command '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="None">
         <source>(None)</source>
         <target state="translated">(なし)</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ko.xlf
@@ -770,6 +770,11 @@
         <target state="new">Error at position {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MenuCommandService_DuplicateCommand">
+        <source>There is already a command handler for the menu command '{0}'.</source>
+        <target state="new">There is already a command handler for the menu command '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="None">
         <source>(None)</source>
         <target state="translated">(없음)</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pl.xlf
@@ -770,6 +770,11 @@
         <target state="new">Error at position {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MenuCommandService_DuplicateCommand">
+        <source>There is already a command handler for the menu command '{0}'.</source>
+        <target state="new">There is already a command handler for the menu command '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="None">
         <source>(None)</source>
         <target state="translated">(Brak)</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pt-BR.xlf
@@ -770,6 +770,11 @@
         <target state="new">Error at position {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MenuCommandService_DuplicateCommand">
+        <source>There is already a command handler for the menu command '{0}'.</source>
+        <target state="new">There is already a command handler for the menu command '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="None">
         <source>(None)</source>
         <target state="translated">(Nenhum)</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ru.xlf
@@ -770,6 +770,11 @@
         <target state="new">Error at position {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MenuCommandService_DuplicateCommand">
+        <source>There is already a command handler for the menu command '{0}'.</source>
+        <target state="new">There is already a command handler for the menu command '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="None">
         <source>(None)</source>
         <target state="translated">(Нет)</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.tr.xlf
@@ -770,6 +770,11 @@
         <target state="new">Error at position {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MenuCommandService_DuplicateCommand">
+        <source>There is already a command handler for the menu command '{0}'.</source>
+        <target state="new">There is already a command handler for the menu command '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="None">
         <source>(None)</source>
         <target state="translated">(Yok)</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hans.xlf
@@ -770,6 +770,11 @@
         <target state="new">Error at position {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MenuCommandService_DuplicateCommand">
+        <source>There is already a command handler for the menu command '{0}'.</source>
+        <target state="new">There is already a command handler for the menu command '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="None">
         <source>(None)</source>
         <target state="translated">(无)</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hant.xlf
@@ -770,6 +770,11 @@
         <target state="new">Error at position {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MenuCommandService_DuplicateCommand">
+        <source>There is already a command handler for the menu command '{0}'.</source>
+        <target state="new">There is already a command handler for the menu command '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="None">
         <source>(None)</source>
         <target state="translated">(無)</target>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionMethodItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionMethodItem.cs
@@ -59,5 +59,13 @@ namespace System.ComponentModel.Design
 
             _methodInfo.Invoke(_actionList, null);
         }
+
+        // this is only use for verbs so that a designer action method item can
+        // be converted to a verb. Verbs use an EventHandler to call their invoke
+        // so we need a way to translate the EventHandler Invoke into ou own Invoke
+        internal void Invoke(object sender, EventArgs args)
+        {
+            Invoke();
+        }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MenuCommandService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MenuCommandService.cs
@@ -1,0 +1,598 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace System.ComponentModel.Design
+{
+    /// <summary>
+    ///     The menu command service allows designers to add and respond to
+    ///     menu and toolbar items.  It is based on two interfaces.  Designers
+    ///     request IMenuCommandService to add menu command handlers, while
+    ///     the document or tool window forwards IOleCommandTarget requests
+    ///     to this object.
+    /// </summary>
+    public class MenuCommandService : IMenuCommandService, IDisposable
+    {
+        private IServiceProvider _serviceProvider;
+        private Dictionary<Guid, ArrayList> _commandGroups;
+        private object _commandGroupsLock;
+        private EventHandler _commandChangedHandler;
+        private MenuCommandsChangedEventHandler _commandsChangedHandler;
+        private ArrayList _globalVerbs;
+        private ISelectionService _selectionService;
+
+        internal static TraceSwitch MENUSERVICE = new TraceSwitch("MENUSERVICE", "MenuCommandService: Track menu command routing");
+
+        // This is the set of verbs we offer through the Verbs property.
+        // It consists of the global verbs + any verbs that the currently
+        // selected designer wants to offer.  This collection changes with the
+        // current selection.
+        //
+        private DesignerVerbCollection _currentVerbs;
+
+        // this is the type that we last picked up verbs from
+        // so we know when we need to refresh
+        //
+        private Type _verbSourceType;
+
+        /// <summary>
+        ///     Creates a new menu command service.
+        /// </summary>
+        public MenuCommandService(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+            _commandGroupsLock = new Object();
+            _commandGroups = new Dictionary<Guid, ArrayList>();
+            _commandChangedHandler = new EventHandler(this.OnCommandChanged);
+            TypeDescriptor.Refreshed += new RefreshEventHandler(this.OnTypeRefreshed);
+        }
+
+        /// <summary>
+        ///     This event is thrown whenever a MenuCommand is removed
+        ///     or added
+        /// </summary>
+        public event MenuCommandsChangedEventHandler MenuCommandsChanged
+        {
+            add
+            {
+                _commandsChangedHandler += value;
+            }
+            remove
+            {
+                _commandsChangedHandler -= value;
+            }
+        }
+
+        /// <summary>
+        ///      Retrieves a set of verbs that are global to all objects on the design
+        ///      surface.  This set of verbs will be merged with individual component verbs.
+        ///      In the case of a name conflict, the component verb will NativeMethods.
+        /// </summary>
+        public virtual DesignerVerbCollection Verbs
+        {
+            get
+            {
+                EnsureVerbs();
+                return _currentVerbs;
+            }
+        }
+
+        /// <summary>
+        ///     Adds a menu command to the document.  The menu command must already exist
+        ///     on a menu; this merely adds a handler for it.
+        /// </summary>
+        public virtual void AddCommand(MenuCommand command)
+        {
+            if (command == null)
+            {
+                throw new ArgumentNullException("command");
+            }
+
+            // If the command already exists, it is an error to add
+            // a duplicate.
+            //
+            if (((IMenuCommandService)this).FindCommand(command.CommandID) != null)
+            {
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.MenuCommandService_DuplicateCommand, command.CommandID.ToString()));
+            }
+
+            ArrayList commandsList;
+            lock (_commandGroupsLock)
+            {
+                if (!_commandGroups.TryGetValue(command.CommandID.Guid, out commandsList))
+                {
+                    commandsList = new ArrayList();
+                    commandsList.Add(command);
+                    _commandGroups.Add(command.CommandID.Guid, commandsList);
+                }
+                else
+                {
+                    commandsList.Add(command);
+                }
+            }
+
+            command.CommandChanged += _commandChangedHandler;
+            Debug.WriteLineIf(MENUSERVICE.TraceVerbose, "Command added: " + command.ToString());
+
+            // raise event
+            OnCommandsChanged(new MenuCommandsChangedEventArgs(MenuCommandsChangedType.CommandAdded, command));
+        }
+
+        /// <summary>
+        ///      Adds a verb to the set of global verbs.  Individual components should
+        ///      use the Verbs property of their designer, rather than call this method.
+        ///      This method is intended for objects that want to offer a verb that is
+        ///      available regardless of what components are selected.
+        /// </summary>
+        public virtual void AddVerb(DesignerVerb verb)
+        {
+            if (verb == null)
+            {
+                throw new ArgumentNullException("verb");
+            }
+
+            if (_globalVerbs == null)
+            {
+                _globalVerbs = new ArrayList();
+            }
+
+            _globalVerbs.Add(verb);
+            OnCommandsChanged(new MenuCommandsChangedEventArgs(MenuCommandsChangedType.CommandAdded, verb));
+            EnsureVerbs();
+            if (!((IMenuCommandService)this).Verbs.Contains(verb))
+            {
+                ((IMenuCommandService)this).Verbs.Add(verb);
+            }
+        }
+
+        /// <summary>
+        ///     Disposes of this service.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        /// <summary>
+        ///     Disposes of this service.
+        /// </summary>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (_selectionService != null)
+                {
+                    _selectionService.SelectionChanging -= new EventHandler(this.OnSelectionChanging);
+                    _selectionService = null;
+                }
+
+                if (_serviceProvider != null)
+                {
+                    _serviceProvider = null;
+                    TypeDescriptor.Refreshed -= new RefreshEventHandler(this.OnTypeRefreshed);
+                }
+                lock (_commandGroupsLock)
+                {
+                    foreach (KeyValuePair<Guid, ArrayList> group in _commandGroups)
+                    {
+                        ArrayList commands = group.Value;
+                        foreach (MenuCommand command in commands)
+                        {
+                            command.CommandChanged -= _commandChangedHandler;
+                        }
+                        commands.Clear();
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///      Ensures that the verb list has been created.
+        /// </summary>
+        protected void EnsureVerbs()
+        {
+            // We apply global verbs only if the base component is the
+            // currently selected object.
+            //
+            bool useGlobalVerbs = false;
+
+            if (_currentVerbs == null && _serviceProvider != null)
+            {
+                Hashtable buildVerbs = null;
+                ArrayList verbsOrder;
+
+                if (_selectionService == null)
+                {
+                    _selectionService = GetService(typeof(ISelectionService)) as ISelectionService;
+
+                    if (_selectionService != null)
+                    {
+                        _selectionService.SelectionChanging += new EventHandler(this.OnSelectionChanging);
+                    }
+                }
+
+                int verbCount = 0;
+                DesignerVerbCollection localVerbs = null;
+                DesignerVerbCollection designerActionVerbs = new DesignerVerbCollection(); // we instanciate this one here...
+                IDesignerHost designerHost = GetService(typeof(IDesignerHost)) as IDesignerHost;
+
+                if (_selectionService != null && designerHost != null && _selectionService.SelectionCount == 1)
+                {
+                    object selectedComponent = _selectionService.PrimarySelection;
+                    if (selectedComponent is IComponent &&
+                        !TypeDescriptor.GetAttributes(selectedComponent).Contains(InheritanceAttribute.InheritedReadOnly))
+                    {
+                        useGlobalVerbs = (selectedComponent == designerHost.RootComponent);
+
+                        // LOCAL VERBS
+                        IDesigner designer = designerHost.GetDesigner((IComponent)selectedComponent);
+                        if (designer != null)
+                        {
+                            localVerbs = designer.Verbs;
+                            if (localVerbs != null)
+                            {
+                                verbCount += localVerbs.Count;
+                                _verbSourceType = selectedComponent.GetType();
+                            }
+                            else
+                            {
+                                _verbSourceType = null;
+                            }
+                        }
+
+                        // DesignerAction Verbs
+                        DesignerActionService daSvc = GetService(typeof(DesignerActionService)) as DesignerActionService;
+                        if (daSvc != null)
+                        {
+                            DesignerActionListCollection actionLists = daSvc.GetComponentActions(selectedComponent as IComponent);
+                            if (actionLists != null)
+                            {
+                                foreach (DesignerActionList list in actionLists)
+                                {
+                                    DesignerActionItemCollection dai = list.GetSortedActionItems();
+                                    if (dai != null)
+                                    {
+                                        for (int i = 0; i < dai.Count; i++)
+                                        {
+                                            DesignerActionMethodItem dami = dai[i] as DesignerActionMethodItem;
+                                            if (dami != null && dami.IncludeAsDesignerVerb)
+                                            {
+                                                EventHandler handler = new EventHandler(dami.Invoke);
+                                                DesignerVerb verb = new DesignerVerb(dami.DisplayName, handler);
+                                                designerActionVerbs.Add(verb);
+                                                verbCount++;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // GLOBAL VERBS
+                if (useGlobalVerbs && _globalVerbs == null)
+                {
+                    useGlobalVerbs = false;
+                }
+
+                if (useGlobalVerbs)
+                {
+                    verbCount += _globalVerbs.Count;
+                }
+
+                // merge all
+                buildVerbs = new Hashtable(verbCount, StringComparer.OrdinalIgnoreCase);
+                verbsOrder = new ArrayList(verbCount);
+
+                // PRIORITY ORDER FROM HIGH TO LOW: LOCAL VERBS - DESIGNERACTION VERBS - GLOBAL VERBS
+                if (useGlobalVerbs)
+                {
+                    for (int i = 0; i < _globalVerbs.Count; i++)
+                    {
+                        string key = ((DesignerVerb)_globalVerbs[i]).Text;
+                        buildVerbs[key] = verbsOrder.Add(_globalVerbs[i]);
+                    }
+                }
+                if (designerActionVerbs.Count > 0)
+                {
+                    for (int i = 0; i < designerActionVerbs.Count; i++)
+                    {
+                        string key = designerActionVerbs[i].Text;
+                        buildVerbs[key] = verbsOrder.Add(designerActionVerbs[i]);
+                    }
+                }
+                if (localVerbs != null && localVerbs.Count > 0)
+                {
+                    for (int i = 0; i < localVerbs.Count; i++)
+                    {
+                        string key = localVerbs[i].Text;
+                        buildVerbs[key] = verbsOrder.Add(localVerbs[i]);
+                    }
+                }
+
+                // look for duplicate, prepare the result table
+                DesignerVerb[] result = new DesignerVerb[buildVerbs.Count];
+                int j = 0;
+                for (int i = 0; i < verbsOrder.Count; i++)
+                {
+                    DesignerVerb value = (DesignerVerb)verbsOrder[i];
+                    string key = value.Text;
+                    if ((int)buildVerbs[key] == i)
+                    { // there's not been a duplicate for this entry
+                        result[j] = value;
+                        j++;
+                    }
+                }
+
+                _currentVerbs = new DesignerVerbCollection(result);
+            }
+        }
+
+        /// <summary>
+        ///     Searches for the given command ID and returns the MenuCommand
+        ///     associated with it.
+        /// </summary>
+        public MenuCommand FindCommand(CommandID commandID)
+        {
+            return FindCommand(commandID.Guid, commandID.ID);
+        }
+
+        /// <summary>
+        ///     Locates the requested command. This will throw an appropriate
+        ///     ComFailException if the command couldn't be found.
+        /// </summary>
+        protected MenuCommand FindCommand(Guid guid, int id)
+        {
+            Debug.WriteLineIf(MENUSERVICE.TraceVerbose, "MCS Searching for command: " + guid.ToString() + " : " + id.ToString(CultureInfo.CurrentCulture));
+
+            // Search in the list of commands only if the command group is known
+            ArrayList commands;
+            lock (_commandGroupsLock)
+            {
+                _commandGroups.TryGetValue(guid, out commands);
+            }
+            if (commands != null)
+            {
+                Debug.WriteLineIf(MENUSERVICE.TraceVerbose, "\t...MCS Found group");
+                foreach (MenuCommand command in commands)
+                {
+                    if (command.CommandID.ID == id)
+                    {
+                        Debug.WriteLineIf(MENUSERVICE.TraceVerbose, "\t... MCS Found Command");
+                        return command;
+                    }
+                }
+            }
+
+            // Next, search the verb list as well.
+            //
+            EnsureVerbs();
+            if (_currentVerbs != null)
+            {
+                int currentID = StandardCommands.VerbFirst.ID;
+                foreach (DesignerVerb verb in _currentVerbs)
+                {
+                    CommandID cid = verb.CommandID;
+
+                    if (cid.ID == id)
+                    {
+                        Debug.WriteLineIf(MENUSERVICE.TraceVerbose, "\t...MCS Found verb");
+
+                        if (cid.Guid.Equals(guid))
+                        {
+                            Debug.WriteLineIf(MENUSERVICE.TraceVerbose, "\t...MCS Found group");
+                            return verb;
+                        }
+                    }
+
+                    // We assign virtual sequential IDs to verbs we get from the component. This allows users
+                    // to not worry about assigning these IDs themselves.
+                    //
+                    if (currentID == id)
+                    {
+                        Debug.WriteLineIf(MENUSERVICE.TraceVerbose, "\t...MCS Found verb");
+
+                        if (cid.Guid.Equals(guid))
+                        {
+                            Debug.WriteLineIf(MENUSERVICE.TraceVerbose, "\t...MCS Found group");
+                            return verb;
+                        }
+                    }
+
+                    if (cid.Equals(StandardCommands.VerbFirst))
+                        currentID++;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     Get the command list for a given GUID
+        /// </summary>
+        protected ICollection GetCommandList(Guid guid)
+        {
+            ArrayList commands = null;
+            lock (_commandGroupsLock)
+            {
+                _commandGroups.TryGetValue(guid, out commands);
+            }
+            return commands;
+        }
+
+        /// <summary>
+        /// </summary>
+        protected object GetService(Type serviceType)
+        {
+            if (serviceType == null)
+            {
+                throw new ArgumentNullException("serviceType");
+            }
+            if (_serviceProvider != null)
+            {
+                return _serviceProvider.GetService(serviceType);
+            }
+            return null;
+        }
+
+        /// <summary>
+        ///     Invokes a command on the local form or in the global environment.
+        ///     The local form is first searched for the given command ID.  If it is
+        ///     found, it is invoked.  Otherwise the the command ID is passed to the
+        ///     global environment command handler, if one is available.
+        /// </summary>
+        public virtual bool GlobalInvoke(CommandID commandID)
+        {
+            // try to find it locally
+            MenuCommand cmd = ((IMenuCommandService)this).FindCommand(commandID);
+            if (cmd != null)
+            {
+                cmd.Invoke();
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        ///     Invokes a command on the local form or in the global environment.
+        ///     The local form is first searched for the given command ID.  If it is
+        ///     found, it is invoked.  Otherwise the the command ID is passed to the
+        ///     global environment command handler, if one is available.
+        /// </summary>
+        public virtual bool GlobalInvoke(CommandID commandId, object arg)
+        {
+            // try to find it locally
+            MenuCommand cmd = ((IMenuCommandService)this).FindCommand(commandId);
+            if (cmd != null)
+            {
+                cmd.Invoke(arg);
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        ///     This is called by a menu command when it's status has changed.
+        /// </summary>
+        private void OnCommandChanged(object sender, EventArgs e)
+        {
+            Debug.WriteLineIf(MENUSERVICE.TraceVerbose, "Command dirty: " + ((sender != null) ? sender.ToString() : "(null sender)"));
+            OnCommandsChanged(new MenuCommandsChangedEventArgs(MenuCommandsChangedType.CommandChanged, (MenuCommand)sender));
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        protected virtual void OnCommandsChanged(MenuCommandsChangedEventArgs e)
+        {
+            if (_commandsChangedHandler != null)
+            {
+                _commandsChangedHandler(this, e);
+            }
+        }
+
+        /// <summary>
+        ///     Called by TypeDescriptor when a type changes.  If this type is currently holding
+        ///     our verb, invalidate the list.
+        /// </summary>
+        private void OnTypeRefreshed(RefreshEventArgs e)
+        {
+            if (_verbSourceType != null && _verbSourceType.IsAssignableFrom(e.TypeChanged))
+            {
+                _currentVerbs = null;
+            }
+        }
+
+        /// <summary>
+        ///      This is called by the selection service when the selection has changed.  Here
+        ///      we invalidate our verb list.
+        /// </summary>
+        private void OnSelectionChanging(object sender, EventArgs e)
+        {
+            if (_currentVerbs != null)
+            {
+                _currentVerbs = null;
+                OnCommandsChanged(new MenuCommandsChangedEventArgs(MenuCommandsChangedType.CommandChanged, null));
+            }
+        }
+
+        /// <summary>
+        ///     Removes the given menu command from the document.
+        /// </summary>
+        public virtual void RemoveCommand(MenuCommand command)
+        {
+            if (command == null)
+            {
+                throw new ArgumentNullException("command");
+            }
+            ArrayList commands;
+            lock (_commandGroupsLock)
+            {
+                if (_commandGroups.TryGetValue(command.CommandID.Guid, out commands))
+                {
+                    int index = commands.IndexOf(command);
+                    if (-1 != index)
+                    {
+                        commands.RemoveAt(index);
+                        // If there are no more commands in this command group, remove the group
+                        if (commands.Count == 0)
+                        {
+                            _commandGroups.Remove(command.CommandID.Guid);
+                        }
+
+                        command.CommandChanged -= _commandChangedHandler;
+
+                        Debug.WriteLineIf(MENUSERVICE.TraceVerbose, "Command removed: " + command.ToString());
+
+                        // raise event
+                        OnCommandsChanged(new MenuCommandsChangedEventArgs(MenuCommandsChangedType.CommandRemoved, command));
+                    }
+                    return;
+                }
+            }
+            Debug.WriteLineIf(MENUSERVICE.TraceVerbose, "Unable to remove command: " + command.ToString());
+        }
+
+        /// <summary>
+        ///     Removes the given verb from the document.
+        /// </summary>
+        public virtual void RemoveVerb(DesignerVerb verb)
+        {
+            if (verb == null)
+            {
+                throw new ArgumentNullException("verb");
+            }
+
+            if (_globalVerbs != null)
+            {
+                int index = _globalVerbs.IndexOf(verb);
+                if (index != -1)
+                {
+                    _globalVerbs.RemoveAt(index);
+                    EnsureVerbs();
+                    if (((IMenuCommandService)this).Verbs.Contains(verb))
+                    {
+                        ((IMenuCommandService)this).Verbs.Remove(verb);
+                    }
+                    OnCommandsChanged(new MenuCommandsChangedEventArgs(MenuCommandsChangedType.CommandRemoved, verb));
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Shows the context menu with the given command ID at the given
+        ///     location.
+        /// </summary>
+        public virtual void ShowContextMenu(CommandID menuID, int x, int y)
+        {
+        }
+    }
+}
+
+

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MenuCommandsChangedEventArgs.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MenuCommandsChangedEventArgs.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ComponentModel.Design
+{
+    /// <summary>
+    ///     This EventArgs class is used by the MenuCommandService to signify
+    ///     that there has been a change in MenuCommands (added or removed)
+    ///     on the related object.
+    /// </summary>
+    [System.Runtime.InteropServices.ComVisible(true)]
+    public class MenuCommandsChangedEventArgs : EventArgs
+    {
+        /// <summary>
+        ///     Constructor that requires the object in question, the type of change
+        ///     and the remaining commands left for the object.  "command" can be null
+        ///     to signify multiple commands changed at once.
+        /// </summary>
+        public MenuCommandsChangedEventArgs(MenuCommandsChangedType changeType, MenuCommand command)
+        {
+            ChangeType = changeType;
+            Command = command;
+        }
+
+        /// <summary>
+        ///     The type of changed that caused the related event
+        ///     to be thrown.
+        /// </summary>
+        public MenuCommandsChangedType ChangeType { get; }
+
+        /// <summary>
+        ///     The command that was added/removed/changed.  This can be null if more than one command changed at once.
+        /// </summary>
+        public MenuCommand Command { get; }
+    }
+}
+

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MenuCommandsChangedEventHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MenuCommandsChangedEventHandler.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ComponentModel.Design
+{
+    /// <summary>
+    ///     This event is thown by the MenuCommandService when a shortcut
+    ///     is either added or removed to/from the related object.
+    /// </summary>
+    [System.Runtime.InteropServices.ComVisible(true)]
+    public delegate void MenuCommandsChangedEventHandler(object sender, MenuCommandsChangedEventArgs e);
+}
+

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MenuCommandsChangedType.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MenuCommandsChangedType.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ComponentModel.Design
+{
+    /// <summary>
+    ///     An enum that defines what time of action happend to the
+    ///     related object's MenuCommands collection.
+    /// </summary>
+    [System.Runtime.InteropServices.ComVisible(true)]
+    public enum MenuCommandsChangedType
+    {
+        /// <summary>
+        ///     Signifies that one or more DesignerShortcut was added.
+        /// </summary>
+        CommandAdded,
+
+        /// <summary>
+        ///     Signifies that one or more DesignerShortcut was removed.
+        /// </summary>
+        CommandRemoved,
+
+        /// <summary>
+        ///     Signifies that one or more commands have changed their status.
+        /// </summary>
+        CommandChanged,
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2TypeInfoProcessor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2TypeInfoProcessor.cs
@@ -763,7 +763,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                         hr = enumTypeInfo.GetVarDesc(i, ref pVarDesc);
                         if (!hr.Succeeded() || pVarDesc == IntPtr.Zero)
                         {
-                            Debug.WriteLineIf(DbgTypeInfoProcessorSwitch.TraceVerbose, string.Format(CultureInfo.CurrentCulture, "ProcessTypeInfoEnum: ignoring item 0x{0:X} because ITypeInfo::GetVarDesc returned hr=0x{1:X} or NULL", hr));
+                            Debug.WriteLineIf(DbgTypeInfoProcessorSwitch.TraceVerbose, string.Format(CultureInfo.CurrentCulture, "ProcessTypeInfoEnum: ignoring item 0x{0:X} because ITypeInfo::GetVarDesc returned hr=0x{1:X} or NULL", i, hr));
                             continue;
                         }
 
@@ -782,7 +782,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                             hr = enumTypeInfo.GetDocumentation(varDesc.memid, ref name, ref helpstr, null, null);
                             if (!hr.Succeeded())
                             {
-                                Debug.WriteLineIf(DbgTypeInfoProcessorSwitch.TraceVerbose, string.Format(CultureInfo.CurrentCulture, "ProcessTypeInfoEnum: ignoring item 0x{0:X} because ITypeInfo::GetDocumentation returned hr=0x{1:X} or NULL", hr));
+                                Debug.WriteLineIf(DbgTypeInfoProcessorSwitch.TraceVerbose, string.Format(CultureInfo.CurrentCulture, "ProcessTypeInfoEnum: ignoring item 0x{0:X} because ITypeInfo::GetDocumentation returned hr=0x{1:X} or NULL", i, hr));
                                 continue;
                             }
 
@@ -901,7 +901,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                     hr = typeInfo.GetVarDesc(i, ref pVarDesc);
                     if (!hr.Succeeded() || pVarDesc == IntPtr.Zero)
                     {
-                        Debug.WriteLineIf(DbgTypeInfoProcessorSwitch.TraceVerbose, string.Format(CultureInfo.CurrentCulture, "ProcessTypeInfoEnum: ignoring variable item 0x{0:X} because ITypeInfo::GetFuncDesc returned hr=0x{1:X} or NULL", hr));
+                        Debug.WriteLineIf(DbgTypeInfoProcessorSwitch.TraceVerbose, string.Format(CultureInfo.CurrentCulture, "ProcessTypeInfoEnum: ignoring variable item 0x{0:X} because ITypeInfo::GetFuncDesc returned hr=0x{1:X} or NULL", i, hr));
                         continue;
                     }
 


### PR DESCRIPTION
## Proposed changes

- Add `MenuCommandService` and a few dependency types that are already identified as missing yet required for .NET 5.

## Test methodology 

- No tests have been ported (yet)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2650)