### PR TITLE
Enable several whitespace StyleCop rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,6 +17,7 @@ indent_size = 2
 [*.cs]
 charset = utf-8-bom
 insert_final_newline = true
+trim_trailing_whitespace = true
 # New line preferences
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true

--- a/eng/CodeStyle.targets
+++ b/eng/CodeStyle.targets
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" Visible="false" />
   </ItemGroup>
 

--- a/eng/Shipping.ruleset
+++ b/eng/Shipping.ruleset
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="Common diagnostic rules to run during build for all shipping projects" Description="This file contains diagnostic settings used by all projects. Projects that need specific settings should have their own rule set files that Include this one, and then make the necessary adjustments." ToolsVersion="15.0">
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <!--
@@ -36,8 +36,8 @@
     <Rule Id="SA1024" Action="None" />
     <Rule Id="SA1025" Action="None" />
     <Rule Id="SA1026" Action="None" />
-    <Rule Id="SA1027" Action="None" />
-    <Rule Id="SA1028" Action="None" />
+    <Rule Id="SA1027" Action="Warning" />
+    <Rule Id="SA1028" Action="Warning" />
     <Rule Id="SA1100" Action="None" />
     <Rule Id="SA1101" Action="None" />
     <Rule Id="SA1102" Action="None" />
@@ -123,11 +123,11 @@
     <Rule Id="SA1502" Action="None" />
     <Rule Id="SA1503" Action="None" />
     <Rule Id="SA1504" Action="None" />
-    <Rule Id="SA1505" Action="None" />
+    <Rule Id="SA1505" Action="Warning" />
     <Rule Id="SA1506" Action="None" />
-    <Rule Id="SA1507" Action="None" />
-    <Rule Id="SA1508" Action="None" />
-    <Rule Id="SA1509" Action="None" />
+    <Rule Id="SA1507" Action="Warning" />
+    <Rule Id="SA1508" Action="Warning" />
+    <Rule Id="SA1509" Action="Warning" />
     <Rule Id="SA1510" Action="None" />
     <Rule Id="SA1511" Action="None" />
     <Rule Id="SA1512" Action="None" />
@@ -135,7 +135,7 @@
     <Rule Id="SA1514" Action="None" />
     <Rule Id="SA1515" Action="None" />
     <Rule Id="SA1516" Action="None" />
-    <Rule Id="SA1517" Action="None" />
+    <Rule Id="SA1517" Action="Warning" />
     <Rule Id="SA1518" Action="None" />
     <Rule Id="SA1519" Action="None" />
     <Rule Id="SA1520" Action="None" />

--- a/src/Common/tests/InternalUtilitiesForTests/src/AdminHelpers.cs
+++ b/src/Common/tests/InternalUtilitiesForTests/src/AdminHelpers.cs
@@ -28,6 +28,5 @@ namespace System
                 return process.ExitCode;
             }
         }
-
     }
 }

--- a/src/System.Windows.Forms.Design.Editors/src/System/ComponentModel/Design/CollectionEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/ComponentModel/Design/CollectionEditor.cs
@@ -987,7 +987,6 @@ namespace System.ComponentModel.Design
                     {
                         Items = Array.Empty<object>();
                     }
-
                 }
                 catch (Exception ex)
                 {
@@ -1486,7 +1485,6 @@ namespace System.ComponentModel.Design
 
                 AdjustListBoxItemHeight();
                 UpdateItemWidths(null);
-
             }
 
             protected override void OnFontChanged(EventArgs e)
@@ -1550,7 +1548,6 @@ namespace System.ComponentModel.Design
             /// </summary>
             private void PropertyGrid_propertyValueChanged(object sender, PropertyValueChangedEventArgs e)
             {
-
                 _dirty = true;
 
                 // Refresh selected listbox item so that it picks up any name change
@@ -1731,7 +1728,6 @@ namespace System.ComponentModel.Design
                 {
                     ResumeEnabledUpdates(true);
                 }
-
             }
 
             /// <summary>
@@ -1907,7 +1903,7 @@ namespace System.ComponentModel.Design
                 public override Type PropertyType { get; }
 
                 /// <summary>
-                ///  When overridden in a derived class, indicates whether resetting the <paramref name="component"/> 
+                ///  When overridden in a derived class, indicates whether resetting the <paramref name="component"/>
                 ///  will change the value of the <paramref name="component"/>.
                 /// </summary>
                 public override bool CanResetValue(object component) => false;
@@ -2132,7 +2128,6 @@ namespace System.ComponentModel.Design
 
                     return _grid;
                 }
-
             }
 
             /// <summary>
@@ -2196,11 +2191,9 @@ namespace System.ComponentModel.Design
                             return;
                         }
                         break;
-
                 }
                 base.WndProc(ref m);
             }
-
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design.Editors/src/System/ComponentModel/Design/DateTimeEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/ComponentModel/Design/DateTimeEditor.cs
@@ -147,7 +147,7 @@ namespace System.ComponentModel.Design
                         case Keys.Enter:
                             return true;
                     }
-                    
+
                     return base.IsInputKey(keyData);
                 }
             }

--- a/src/System.Windows.Forms.Design.Editors/src/System/Drawing/Design/ColorEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/Drawing/Design/ColorEditor.cs
@@ -132,7 +132,6 @@ namespace System.Drawing.Design
 
             public ColorPalette(ColorUI colorUI, Color[] customColors)
             {
-
                 if (!isScalingInitialized)
                 {
                     if (DpiHelper.IsScalingRequired)

--- a/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/DataGridViewCellStyleBuilder.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/DataGridViewCellStyleBuilder.cs
@@ -7,7 +7,6 @@ using System.ComponentModel.Design;
 using System.Diagnostics;
 
 namespace System.Windows.Forms.Design
-
 {
     internal class DataGridViewCellStyleBuilder : Form
     {

--- a/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/DataGridViewComponentPropertyGridSite.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/DataGridViewComponentPropertyGridSite.cs
@@ -8,7 +8,6 @@ namespace System.Windows.Forms.Design
 {
     internal class DataGridViewComponentPropertyGridSite : ISite
     {
-
         private readonly IServiceProvider _sp;
         private readonly IComponent _comp;
         private bool _inGetService = false;

--- a/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/FormatControl.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/FormatControl.cs
@@ -456,7 +456,6 @@ namespace System.Windows.Forms.Design
             {
                 fsd.FormatControlFinishedLoading();
             }
-
         }
 
         private class DateTimeFormatsListBoxItem
@@ -1273,7 +1272,6 @@ namespace System.Windows.Forms.Design
             {
                 return SR.BindingFormattingDialogFormatTypeCustom;
             }
-
         }
 
         private void nullValueTextBox_TextChanged(object sender, EventArgs e)

--- a/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/FormatStringDialog.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/FormatStringDialog.cs
@@ -145,7 +145,7 @@ namespace System.Windows.Forms.Design
             }
             else
             {
-                // make General format type the default 
+                // make General format type the default
                 _formatControl1.FormatType = SR.BindingFormattingDialogFormatTypeNoFormatting;
             }
 
@@ -195,9 +195,9 @@ namespace System.Windows.Forms.Design
             _okButton.Text = SR.DataGridView_OK;
             _okButton.DialogResult = System.Windows.Forms.DialogResult.OK;
             _okButton.Click += new EventHandler(okButton_Click);
-            // 
+            //
             // Form1
-            // 
+            //
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             AutoScaleDimensions = new Drawing.SizeF(6, 13);
             ClientSize = new Drawing.Size(396, 295);

--- a/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/ImageCollectionEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/ImageCollectionEditor.cs
@@ -83,7 +83,7 @@ namespace System.Windows.Forms.Design
         }
 
         /// <summary>
-        ///  Gets images from the given array. 
+        ///  Gets images from the given array.
         /// </summary>
         /// <param name="array">The input is an <see cref="ArrayList"/> as an object.</param>
         /// <returns>An <see cref="ArrayList"/> which contains individual images that need to be created.</returns>

--- a/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/ImageIndexEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/ImageIndexEditor.cs
@@ -68,7 +68,6 @@ namespace System.Windows.Forms.Design
                     instance != currentInstance ||
                     (currentImageListProp != null && (ImageList)currentImageListProp.GetValue(currentInstance) != currentImageList))
                 {
-
                     currentInstance = instance;
                     // first look for an attribute
                     PropertyDescriptor imageListProp = GetImageListProperty(context.PropertyDescriptor, ref instance);
@@ -89,8 +88,7 @@ namespace System.Windows.Forms.Design
 
                         if (imageListProp == null)
                         {
-
-                            // We didn't find the image list in this component.  See if the 
+                            // We didn't find the image list in this component.  See if the
                             // component has a "parent" property.  If so, walk the tree...
                             PropertyDescriptor parentProp = props[ParentImageListProperty];
                             if (parentProp != null)

--- a/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/ImageListImageEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/ImageListImageEditor.cs
@@ -116,7 +116,7 @@ namespace System.Windows.Forms.Design
         }
 
         /// <summary>
-        ///  Paints a representative value of the given object to the provided canvas. 
+        ///  Paints a representative value of the given object to the provided canvas.
         ///  Painting should be done within the boundaries of the provided rectangle.
         /// </summary>
         public override void PaintValue(PaintValueEventArgs e)

--- a/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/LinkAreaEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/Windows/Forms/Design/LinkAreaEditor.cs
@@ -132,37 +132,37 @@ namespace System.Windows.Forms.Design
                 _okCancelTableLayoutPanel.SuspendLayout();
                 SuspendLayout();
                 _okButton.Click += new EventHandler(okButton_click);
-                // 
+                //
                 // caption
-                // 
+                //
                 resources.ApplyResources(_caption, "caption");
                 _caption.Margin = new Padding(3, 1, 3, 0);
                 _caption.Name = "caption";
-                // 
+                //
                 // sampleEdit
-                // 
+                //
                 resources.ApplyResources(_sampleEdit, "sampleEdit");
                 _sampleEdit.Margin = new Padding(3, 2, 3, 3);
                 _sampleEdit.Name = "sampleEdit";
                 _sampleEdit.HideSelection = false;
                 _sampleEdit.ScrollBars = ScrollBars.Vertical;
-                // 
+                //
                 // okButton
-                // 
+                //
                 resources.ApplyResources(_okButton, "okButton");
                 _okButton.DialogResult = DialogResult.OK;
                 _okButton.Margin = new Padding(0, 0, 2, 0);
                 _okButton.Name = "okButton";
-                // 
+                //
                 // cancelButton
-                // 
+                //
                 resources.ApplyResources(_cancelButton, "cancelButton");
                 _cancelButton.DialogResult = DialogResult.Cancel;
                 _cancelButton.Margin = new Padding(3, 0, 0, 0);
                 _cancelButton.Name = "cancelButton";
-                // 
+                //
                 // okCancelTableLayoutPanel
-                // 
+                //
                 resources.ApplyResources(_okCancelTableLayoutPanel, "okCancelTableLayoutPanel");
                 _okCancelTableLayoutPanel.ColumnCount = 2;
                 _okCancelTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
@@ -174,9 +174,9 @@ namespace System.Windows.Forms.Design
                 _okCancelTableLayoutPanel.RowCount = 1;
                 _okCancelTableLayoutPanel.RowStyles.Add(new RowStyle());
                 _okCancelTableLayoutPanel.RowStyles.Add(new RowStyle());
-                // 
+                //
                 // LinkAreaEditor
-                // 
+                //
                 resources.ApplyResources(this, "$this");
                 AutoScaleMode = AutoScaleMode.Font;
                 CancelButton = _cancelButton;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/BinaryEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/BinaryEditor.cs
@@ -290,17 +290,17 @@ namespace System.ComponentModel.Design
                 _overarchingTableLayoutPanel.SuspendLayout();
                 SuspendLayout();
 
-                // 
+                //
                 // byteViewer
-                // 
+                //
                 resources.ApplyResources(_byteViewer, "byteViewer");
                 _byteViewer.SetDisplayMode(DisplayMode.Auto);
                 _byteViewer.Name = "byteViewer";
                 _byteViewer.Margin = Padding.Empty;
                 _byteViewer.Dock = DockStyle.Fill;
-                // 
+                //
                 // buttonOK
-                // 
+                //
                 resources.ApplyResources(_buttonOK, "buttonOK");
                 _buttonOK.AutoSizeMode = AutoSizeMode.GrowAndShrink;
                 _buttonOK.DialogResult = DialogResult.OK;
@@ -309,9 +309,9 @@ namespace System.ComponentModel.Design
                 _buttonOK.Name = "buttonOK";
                 _buttonOK.Padding = new Padding(10, 0, 10, 0);
                 _buttonOK.Click += new EventHandler(ButtonOK_click);
-                // 
+                //
                 // buttonSave
-                // 
+                //
                 resources.ApplyResources(_buttonSave, "buttonSave");
                 _buttonSave.AutoSizeMode = AutoSizeMode.GrowAndShrink;
                 _buttonSave.Margin = new Padding(3, 0, 0, 0);
@@ -319,9 +319,9 @@ namespace System.ComponentModel.Design
                 _buttonSave.Name = "buttonSave";
                 _buttonSave.Padding = new Padding(10, 0, 10, 0);
                 _buttonSave.Click += new EventHandler(ButtonSave_click);
-                // 
+                //
                 // groupBoxMode
-                // 
+                //
                 resources.ApplyResources(_groupBoxMode, "groupBoxMode");
                 _groupBoxMode.AutoSizeMode = AutoSizeMode.GrowAndShrink;
                 _groupBoxMode.Controls.Add(_radioButtonsTableLayoutPanel);
@@ -329,9 +329,9 @@ namespace System.ComponentModel.Design
                 _groupBoxMode.Name = "groupBoxMode";
                 _groupBoxMode.Padding = new Padding(0);
                 _groupBoxMode.TabStop = false;
-                // 
+                //
                 // radioButtonsTableLayoutPanel
-                // 
+                //
                 resources.ApplyResources(_radioButtonsTableLayoutPanel, "radioButtonsTableLayoutPanel");
                 _radioButtonsTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 25F));
                 _radioButtonsTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 25F));
@@ -344,38 +344,38 @@ namespace System.ComponentModel.Design
                 _radioButtonsTableLayoutPanel.Margin = new Padding(9);
                 _radioButtonsTableLayoutPanel.Name = "radioButtonsTableLayoutPanel";
                 _radioButtonsTableLayoutPanel.RowStyles.Add(new RowStyle());
-                // 
+                //
                 // radioUnicode
-                // 
+                //
                 resources.ApplyResources(_radioUnicode, "radioUnicode");
                 _radioUnicode.Margin = new Padding(3, 0, 0, 0);
                 _radioUnicode.Name = "radioUnicode";
                 _radioUnicode.CheckedChanged += new EventHandler(RadioUnicode_checkedChanged);
-                // 
+                //
                 // radioAuto
-                // 
+                //
                 resources.ApplyResources(_radioAuto, "radioAuto");
                 _radioAuto.Checked = true;
                 _radioAuto.Margin = new Padding(0, 0, 3, 0);
                 _radioAuto.Name = "radioAuto";
                 _radioAuto.CheckedChanged += new EventHandler(RadioAuto_checkedChanged);
-                // 
+                //
                 // radioAnsi
-                // 
+                //
                 resources.ApplyResources(_radioAnsi, "radioAnsi");
                 _radioAnsi.Margin = new Padding(3, 0, 3, 0);
                 _radioAnsi.Name = "radioAnsi";
                 _radioAnsi.CheckedChanged += new EventHandler(RadioAnsi_checkedChanged);
-                // 
+                //
                 // radioHex
-                // 
+                //
                 resources.ApplyResources(_radioHex, "radioHex");
                 _radioHex.Margin = new Padding(3, 0, 3, 0);
                 _radioHex.Name = "radioHex";
                 _radioHex.CheckedChanged += new EventHandler(RadioHex_checkedChanged);
-                // 
+                //
                 // okSaveTableLayoutPanel
-                // 
+                //
                 resources.ApplyResources(_okSaveTableLayoutPanel, "okSaveTableLayoutPanel");
                 _okSaveTableLayoutPanel.AutoSizeMode = AutoSizeMode.GrowAndShrink;
                 _okSaveTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
@@ -385,9 +385,9 @@ namespace System.ComponentModel.Design
                 _okSaveTableLayoutPanel.Margin = new Padding(0, 9, 0, 0);
                 _okSaveTableLayoutPanel.Name = "okSaveTableLayoutPanel";
                 _okSaveTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
-                // 
+                //
                 // overarchingTableLayoutPanel
-                // 
+                //
                 resources.ApplyResources(_overarchingTableLayoutPanel, "overarchingTableLayoutPanel");
                 _overarchingTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
                 _overarchingTableLayoutPanel.Controls.Add(_byteViewer, 0, 0);
@@ -398,9 +398,9 @@ namespace System.ComponentModel.Design
                 _overarchingTableLayoutPanel.RowStyles.Add(new RowStyle());
                 _overarchingTableLayoutPanel.RowStyles.Add(new RowStyle());
 
-                // 
+                //
                 // BinaryUI
-                // 
+                //
                 AcceptButton = _buttonOK;
                 resources.ApplyResources(this, "$this");
                 AutoScaleMode = AutoScaleMode.Font;
@@ -426,7 +426,6 @@ namespace System.ComponentModel.Design
                 _overarchingTableLayoutPanel.ResumeLayout(false);
                 _overarchingTableLayoutPanel.PerformLayout();
                 ResumeLayout(false);
-
             }
         }
     }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ByteViewer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ByteViewer.cs
@@ -77,7 +77,7 @@ namespace System.ComponentModel.Design
             SetStyle(ControlStyles.ResizeRedraw, true);
         }
 
-        // Stole this code from  XmlSanner       
+        // Stole this code from  XmlSanner
         private static int AnalizeByteOrderMark(byte[] buffer, int index)
         {
             int c1 = buffer[index + 0] << 8 | buffer[index + 1];
@@ -86,17 +86,17 @@ namespace System.ComponentModel.Design
 
             //Assign an index (label) value for first two bytes
             c4 = GetEncodingIndex(c1);
-            //Assign an index (label) value for 3rd and 4th byte            
+            //Assign an index (label) value for 3rd and 4th byte
             c5 = GetEncodingIndex(c2);
 
             //Bellow table is to identify Encoding type based on
-            //first four bytes, those we have converted in index 
+            //first four bytes, those we have converted in index
             //values for this look up table
             //values on column are first two bytes and
-            //values on rows are 3rd and 4th byte 
+            //values on rows are 3rd and 4th byte
 
             int[,] encodings = {
-                   //Unknown 0000 feff fffe efbb  3c00 003c 3f00 003f  3c3f 786d  4c6f  a794 
+                   //Unknown 0000 feff fffe efbb  3c00 003c 3f00 003f  3c3f 786d  4c6f  a794
            /*Unknown*/ {1   ,5   ,1   ,1    ,1   ,1   ,1   ,1   ,1    ,1    ,1    ,1    ,1   },
               /*0000*/ {1   ,1   ,1   ,11   ,1   ,10  ,4   ,1   ,1    ,1    ,1    ,1    ,1   },
               /*feff*/ {2   ,9   ,5   ,2    ,2   ,2   ,2   ,2   ,2    ,2    ,2    ,2    ,2   },
@@ -303,11 +303,11 @@ namespace System.ComponentModel.Design
                     return DisplayMode.Unicode;
                 case 4:
                 case 5:
-                    //_Encoding = Ucs4Encoding.UCS4_Bigendian; 
+                    //_Encoding = Ucs4Encoding.UCS4_Bigendian;
                     return DisplayMode.Hexdump;
                 case 6:
                 case 7:
-                    //_Encoding = Ucs4Encoding.UCS4_Littleendian; 
+                    //_Encoding = Ucs4Encoding.UCS4_Littleendian;
                     return DisplayMode.Hexdump;
                 case 8:
                 case 9:
@@ -320,7 +320,7 @@ namespace System.ComponentModel.Design
                 case 12:
                     //8 ebcdic
                     return DisplayMode.Hexdump;
-                case 13: //9                    
+                case 13: //9
                          //_Encoding = new UTF8Encoding(false);
                     return DisplayMode.Ansi;
                 case 14:
@@ -384,7 +384,7 @@ namespace System.ComponentModel.Design
             return _displayMode;
         }
 
-        // Stole this code from  XmlSanner       
+        // Stole this code from  XmlSanner
         private static int GetEncodingIndex(int c1)
         {
             switch (c1)
@@ -600,7 +600,6 @@ namespace System.ComponentModel.Design
             }
 
             _displayLinesCount = (_startLine + _rowCount < _linesCount) ? _rowCount : _linesCount - _startLine;
-
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.cs
@@ -648,7 +648,6 @@ namespace System.ComponentModel.Design
                 PropertyDescriptor pd = TypeDescriptor.GetDefaultProperty(component);
                 if (pd != null && pd.PropertyType.Equals(typeof(string)))
                 {
-
                     string current = (string)pd.GetValue(component);
                     if (current == null || current.Length == 0)
                     {
@@ -880,7 +879,6 @@ namespace System.ComponentModel.Design
             /// </summary>
             private PropertyDescriptor GetShadowedPropertyDescriptor(string propertyName)
             {
-
                 if (_descriptors == null)
                 {
                     _descriptors = new Hashtable();

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurfaceCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurfaceCollection.cs
@@ -67,7 +67,7 @@ namespace System.ComponentModel.Design
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         /// <summary>
-        ///  Enumerator that performs the conversion from designer host 
+        ///  Enumerator that performs the conversion from designer host
         ///  to design surface.
         /// </summary>
         private class DesignSurfaceEnumerator : IEnumerator

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurfaceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurfaceManager.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 namespace System.ComponentModel.Design
 {
     /// <summary>
-    ///  A service container that supports "fixed" services.  Fixed 
+    ///  A service container that supports "fixed" services.  Fixed
     ///  services cannot be removed.
     /// </summary>
     public class DesignSurfaceManager : IServiceProvider, IDisposable
@@ -68,9 +68,9 @@ namespace System.ComponentModel.Design
             }
             set
             {
-                // If we are providing IDesignerEventService, then we are responsible for 
-                // notifying it of new designers coming into place.  If we aren't 
-                // the ones providing the event service, then whoever is providing 
+                // If we are providing IDesignerEventService, then we are responsible for
+                // notifying it of new designers coming into place.  If we aren't
+                // the ones providing the event service, then whoever is providing
                 // it will be responsible for updating it when new designers
                 // are created.
                 if (EventService is DesignerEventService eventService)
@@ -104,8 +104,8 @@ namespace System.ComponentModel.Design
         private IDesignerEventService EventService => GetService(typeof(IDesignerEventService)) as IDesignerEventService;
 
         /// <summary>
-        ///  Provides access to the designer application's 
-        ///  ServiceContainer. This property allows 
+        ///  Provides access to the designer application's
+        ///  ServiceContainer. This property allows
         ///  inheritors to add their own services.
         /// </summary>
         protected ServiceContainer ServiceContainer
@@ -269,9 +269,9 @@ namespace System.ComponentModel.Design
         {
             DesignSurface surface = CreateDesignSurfaceCore(this);
 
-            // If we are providing IDesignerEventService, then we are responsible for 
-            // notifying it of new designers coming into place.  If we aren't 
-            // the ones providing the event service, then whoever is providing 
+            // If we are providing IDesignerEventService, then we are responsible for
+            // notifying it of new designers coming into place.  If we aren't
+            // the ones providing the event service, then whoever is providing
             // it will be responsible for updating it when new designers are created.
             if (GetService(typeof(IDesignerEventService)) is DesignerEventService eventService)
             {
@@ -283,8 +283,8 @@ namespace System.ComponentModel.Design
 
         /// <summary>
         ///  Public method to create a design surface.  This method
-        ///  takes an additional service provider.  This service 
-        ///  provider will be combined with the service provider 
+        ///  takes an additional service provider.  This service
+        ///  provider will be combined with the service provider
         ///  already contained within DesignSurfaceManager.  Service
         ///  requests will go to this provider first, and then bubble
         ///  up to the service provider owned by DesignSurfaceManager.
@@ -301,9 +301,9 @@ namespace System.ComponentModel.Design
 
             DesignSurface surface = CreateDesignSurfaceCore(mergedProvider);
 
-            // If we are providing IDesignerEventService, then we are responsible for 
-            // notifying it of new designers coming into place.  If we aren't 
-            // the ones providing the event service, then whoever is providing 
+            // If we are providing IDesignerEventService, then we are responsible for
+            // notifying it of new designers coming into place.  If we aren't
+            // the ones providing the event service, then whoever is providing
             // it will be responsible for updating it when new designers are created.
             DesignerEventService eventService = GetService(typeof(IDesignerEventService)) as DesignerEventService;
             if (eventService != null)
@@ -315,7 +315,7 @@ namespace System.ComponentModel.Design
         }
 
         /// <summary>
-        ///  Creates an instance of a design surface.  This can be 
+        ///  Creates an instance of a design surface.  This can be
         ///  overridden to provide a derived version of DesignSurface.
         /// </summary>
         protected virtual DesignSurface CreateDesignSurfaceCore(IServiceProvider parentProvider) => new DesignSurface(parentProvider);
@@ -363,7 +363,6 @@ namespace System.ComponentModel.Design
         /// </returns>
         private object OnCreateService(IServiceContainer container, Type serviceType)
         {
-
             if (serviceType == typeof(IDesignerEventService))
             {
                 return new DesignerEventService();
@@ -382,7 +381,6 @@ namespace System.ComponentModel.Design
             Debug.Assert(_activeDesignSurfaceChanged != null, "Should have detached this event handler.");
             if (_activeDesignSurfaceChanged != null)
             {
-
                 DesignSurface newSurface = null;
                 DesignSurface oldSurface = null;
 
@@ -447,7 +445,7 @@ namespace System.ComponentModel.Design
         }
 
         /// <summary>
-        ///  Simple service provider that merges two providers together.  
+        ///  Simple service provider that merges two providers together.
         /// </summary>
         private sealed class MergedServiceProvider : IServiceProvider
         {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionListsChangedEventArgs.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionListsChangedEventArgs.cs
@@ -14,7 +14,7 @@ namespace System.ComponentModel.Design
     public class DesignerActionListsChangedEventArgs : EventArgs
     {
         /// <summary>
-        ///  Initializes a new instance of the <see cref="DesignerActionListsChangedEventArgs" /> class with the specified related object, 
+        ///  Initializes a new instance of the <see cref="DesignerActionListsChangedEventArgs" /> class with the specified related object,
         ///  the type of change, and the remaining action lists for the related object.
         /// </summary>
         /// <param name="relatedObject">The related object.</param>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionService.cs
@@ -113,7 +113,6 @@ namespace System.ComponentModel.Design
             {
                 OnDesignerActionListsChanged(new DesignerActionListsChangedEventArgs(comp, DesignerActionListsChangedType.ActionListsRemoved, GetComponentActions(comp)));
             }
-
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUI.cs
@@ -919,7 +919,6 @@ namespace System.ComponentModel.Design
             {
                 CheckFocusIsRight();
             }
-
         }
 
         private void PanelResized(object sender, System.EventArgs e)

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerEventService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerEventService.cs
@@ -48,7 +48,7 @@ namespace System.ComponentModel.Design
                 Debug.Assert(host != null, "Design surface did not provide us with a designer host");
             }
 
-            // If the designer host is not in our collection, add it.  
+            // If the designer host is not in our collection, add it.
             if (host != null && (_designerList == null || !_designerList.Contains(host)))
             {
                 OnCreateDesigner(surface);
@@ -161,7 +161,7 @@ namespace System.ComponentModel.Design
         }
 
         /// <summary>
-        ///  Called by DesignSurface when it is about to be disposed.  
+        ///  Called by DesignSurface when it is about to be disposed.
         /// </summary>
         private void OnDesignerDisposed(object sender, EventArgs e)
         {
@@ -264,7 +264,7 @@ namespace System.ComponentModel.Design
         }
 
         /// <summary>
-        ///  Sinks or unsinks selection and component change events from the 
+        ///  Sinks or unsinks selection and component change events from the
         ///  provided service provider.  We need to raise global selection change
         ///  notifications.  A global selection change should be raised whenever
         ///  the selection of the active designer changes, whenever a component

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
@@ -1744,8 +1744,8 @@ namespace System.ComponentModel.Design
                     if (_nestedContainer == null)
                     {
                         _nestedContainer = new SiteNestedContainer(_component, null, _host);
-                        
-                        // Initialize IServiceContainer in the nested container as soon as INestedContainer is created, 
+
+                        // Initialize IServiceContainer in the nested container as soon as INestedContainer is created,
                         // otherwise site has no access to the DesignerHost's services.
                         _ = _nestedContainer.GetServiceInternal(typeof(IServiceContainer));
                     }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DisplayMode.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DisplayMode.cs
@@ -28,6 +28,5 @@ namespace System.ComponentModel.Design
         ///  Indicates using automatic format selection.
         /// </summary>
         Auto = 4,
-
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/EventBindingService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/EventBindingService.cs
@@ -66,7 +66,7 @@ namespace System.ComponentModel.Design
         /// <summary>
         ///  Shows the user code.  This method does not show any
         ///  particular code; generally it shows the last code the
-        ///  user typed.  This returns true if it was possible to 
+        ///  user typed.  This returns true if it was possible to
         ///  show the code, or false if not.
         /// </summary>
         protected abstract bool ShowCode();
@@ -264,7 +264,7 @@ namespace System.ComponentModel.Design
 
             PropertyDescriptor prop = ((IEventBindingService)this).GetEventProperty(e);
             string methodName = (string)prop.GetValue(component);
-            
+
             if (methodName == null)
             {
                 return false;   // the event is not bound to a method.

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ReferenceService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ReferenceService.cs
@@ -66,7 +66,6 @@ namespace System.ComponentModel.Design
             // If the references are null, create them for the first time and connect up our events to listen to changes to the container. Otherwise, check to see if the added or removed lists contain anything for us to sync up.
             if (_references == null)
             {
-
                 if (_provider == null)
                 {
                     throw new ObjectDisposedException("IReferenceService");

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/BasicDesignerLoader.ReloadOptions.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/BasicDesignerLoader.ReloadOptions.cs
@@ -7,7 +7,7 @@ namespace System.ComponentModel.Design.Serialization
     public abstract partial class BasicDesignerLoader
     {
         /// <summary>
-        ///  A list of flags that indicate rules to apply when requesting 
+        ///  A list of flags that indicate rules to apply when requesting
         ///  that the designer reload itself.
         /// </summary>
         [Flags]

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/BasicDesignerLoader.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/BasicDesignerLoader.cs
@@ -11,10 +11,10 @@ using System.Windows.Forms;
 namespace System.ComponentModel.Design.Serialization
 {
     /// <summary>
-    ///  This is a class that derives from DesignerLoader but provides some default functionality.  
-    ///  This class tracks changes from the loader host and sets its "Modified" bit to true when a 
-    ///  change occurs.  Also, this class implements IDesignerLoaderService to support multiple 
-    ///  load dependencies.  To use BaseDesignerLoader, you need to implement the PerformLoad 
+    ///  This is a class that derives from DesignerLoader but provides some default functionality.
+    ///  This class tracks changes from the loader host and sets its "Modified" bit to true when a
+    ///  change occurs.  Also, this class implements IDesignerLoaderService to support multiple
+    ///  load dependencies.  To use BaseDesignerLoader, you need to implement the PerformLoad
     ///  and PerformFlush methods.
     /// </summary>
     public abstract partial class BasicDesignerLoader : DesignerLoader, IDesignerLoaderService
@@ -58,10 +58,10 @@ namespace System.ComponentModel.Design.Serialization
 
         /// <summary>
         ///  This protected property indicates if there have been any
-        ///  changes made to the design surface.  The Flush method 
+        ///  changes made to the design surface.  The Flush method
         ///  gets the value of this property to determine if it needs
         ///  to generate a code dom tree.  This property is set by
-        ///  the designer loader when it detects a change to the 
+        ///  the designer loader when it detects a change to the
         ///  design surface.  You can override this to perform
         ///  additional work, such as checking out a file from source
         ///  code control.
@@ -95,8 +95,8 @@ namespace System.ComponentModel.Design.Serialization
         }
 
         /// <summary>
-        ///  Returns true when the designer is in the process of loading.  
-        ///  Clients that are sinking notifications from the designer often 
+        ///  Returns true when the designer is in the process of loading.
+        ///  Clients that are sinking notifications from the designer often
         ///  want to ignore them while the desingner is loading
         ///  and only respond to them if they result from user interatcions.
         /// </summary>
@@ -135,9 +135,9 @@ namespace System.ComponentModel.Design.Serialization
         protected bool ReloadPending => _state[s_stateReloadAtIdle];
 
         /// <summary>
-        ///  Called by the designer host to begin the loading process.  
-        ///  The designer host passes in an instance of a designer loader 
-        ///  host.  This loader host allows the designer loader to reload 
+        ///  Called by the designer host to begin the loading process.
+        ///  The designer host passes in an instance of a designer loader
+        ///  host.  This loader host allows the designer loader to reload
         ///  the design document and also allows the designer loader to indicate
         ///  that it has finished loading the design document.
         /// </summary>
@@ -198,7 +198,7 @@ namespace System.ComponentModel.Design.Serialization
                 host.Deactivated += new EventHandler(OnDesignerDeactivate);
             }
 
-            // Now that we're initialized, let's begin the load.  We assume 
+            // Now that we're initialized, let's begin the load.  We assume
             // we support reload until the codeLoader tells us we
             // can't.  That way, we will do the reload if we didn't get a
             // valid loader to start with.
@@ -246,11 +246,11 @@ namespace System.ComponentModel.Design.Serialization
         }
 
         /// <summary>
-        ///  Disposes this designer loader.  The designer host will call 
-        ///  this method when the design document itself is being destroyed.  
+        ///  Disposes this designer loader.  The designer host will call
+        ///  this method when the design document itself is being destroyed.
         ///  Once called, the designer loader will never be called again.
         ///  This implementation removes any previously added services.  It
-        ///  does not flush changes, which allows for fast teardown of a 
+        ///  does not flush changes, which allows for fast teardown of a
         ///  designer that wasn't saved.
         /// </summary>
         public override void Dispose()
@@ -289,7 +289,7 @@ namespace System.ComponentModel.Design.Serialization
         ///  have been saved by the designer loader.  This method allows
         ///  designer loaders to implement a lazy-write scheme to improve
         ///  performance.  This designer loader implements lazy writes by
-        ///  listening to component change events.  If a component has 
+        ///  listening to component change events.  If a component has
         ///  changed it sets a "modified" bit.  When Flush is called the
         ///  loader will write out a new code dom tree.
         /// </summary>
@@ -444,7 +444,7 @@ namespace System.ComponentModel.Design.Serialization
 
         /// <summary>
         ///  This method is called immediately before the document is unloaded.
-        ///  The document may be unloaded in preparation for reload, or 
+        ///  The document may be unloaded in preparation for reload, or
         ///  if the document failed the load.  If you added document-specific
         ///  services in OnBeginLoad or OnEndLoad, you should remove them
         ///  here.
@@ -641,7 +641,7 @@ namespace System.ComponentModel.Design.Serialization
                     successful = true;
                 }
 
-                // Inform the serialization manager that we are all done.  The serialization 
+                // Inform the serialization manager that we are all done.  The serialization
                 // manager clears state at this point to help enforce a stateless serialization
                 // mechanism.
                 if (errors != null)
@@ -771,7 +771,7 @@ namespace System.ComponentModel.Design.Serialization
         }
 
         /// <summary>
-        ///  This method is called when it is time to flush the 
+        ///  This method is called when it is time to flush the
         ///  contents of the loader.  You should save any state
         ///  at this time.
         /// </summary>
@@ -779,8 +779,8 @@ namespace System.ComponentModel.Design.Serialization
 
         /// <summary>
         ///  This method is called when it is time to load the
-        ///  design surface.  If you are loading asynchronously 
-        ///  you should ask for IDesignerLoaderService and call 
+        ///  design surface.  If you are loading asynchronously
+        ///  you should ask for IDesignerLoaderService and call
         ///  AddLoadDependency.  When loading asynchronously you
         ///  should at least create the root component during
         ///  PerformLoad.  The DesignSurface is only able to provide
@@ -799,7 +799,7 @@ namespace System.ComponentModel.Design.Serialization
         ///  If flush is true, the designer is flushed before performing
         ///  a reload.  If false, any designer changes are abandonded.
         ///  If ModifyOnError is true, the designer loader will be put
-        ///  in the modified state if any errors happened during the 
+        ///  in the modified state if any errors happened during the
         ///  load.
         /// </summary>
         protected void Reload(ReloadOptions flags)
@@ -808,9 +808,9 @@ namespace System.ComponentModel.Design.Serialization
             _state[s_stateFlushReload] = ((flags & ReloadOptions.NoFlush) == 0);
             _state[s_stateModifyIfErrors] = ((flags & ReloadOptions.ModifyOnError) != 0);
 
-            // Our implementation of Reload only reloads if we are the 
+            // Our implementation of Reload only reloads if we are the
             // active designer.  Otherwise, we wait until we become
-            // active and reload at that time.  We also never do a 
+            // active and reload at that time.  We also never do a
             // reload if we are flushing code.
             if (_state[s_stateFlushInProgress])
             {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationService.cs
@@ -221,7 +221,7 @@ namespace System.ComponentModel.Design.Serialization
         }
 
         /// <summary>
-        ///  The SerializationStore class is an implementation-specific class that stores serialization data for the component serialization service.  
+        ///  The SerializationStore class is an implementation-specific class that stores serialization data for the component serialization service.
         ///  The service adds state to this serialization store.  Once the store is closed it can be saved to a stream.  A serialization store can
         ///  be deserialized at a later date by the same type of serialization service. SerializationStore implements the IDisposable interface such
         ///  that Dispose  simply calls the Close method.  Dispose is implemented as a private interface to avoid confusion.
@@ -589,7 +589,6 @@ namespace System.ComponentModel.Design.Serialization
 #if DEBUG
             internal static void TraceCode(string name, object code)
             {
-
                 if (code == null || !s_trace.TraceVerbose)
                 {
                     return;
@@ -1496,7 +1495,6 @@ namespace System.ComponentModel.Design.Serialization
             /// </summary>
             private class LocalServices : IServiceProvider, IResourceService
             {
-
                 private readonly CodeDomSerializationStore _store;
                 private readonly IServiceProvider _provider;
 
@@ -1632,7 +1630,6 @@ namespace System.ComponentModel.Design.Serialization
                 {
                     return ((IDesignerSerializationManager)_manager).GetService(serviceType);
                 }
-
             }
 
             /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.ModifierConverter.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.ModifierConverter.cs
@@ -75,7 +75,7 @@ namespace System.ComponentModel.Design.Serialization
             }
 
             /// <summary>
-            ///  <para>Gets a value indicating whether changing a value on this object requires a 
+            ///  <para>Gets a value indicating whether changing a value on this object requires a
             ///  call to <see cref='System.ComponentModel.TypeConverter.CreateInstance'/> to create a new value,
             ///  using the specified context.</para>
             /// </summary>
@@ -141,7 +141,7 @@ namespace System.ComponentModel.Design.Serialization
 
             /// <summary>
             ///  <para>Gets a value indicating whether the collection of standard values returned from
-            ///  <see cref='System.ComponentModel.TypeConverter.GetStandardValues'/> is an exclusive 
+            ///  <see cref='System.ComponentModel.TypeConverter.GetStandardValues'/> is an exclusive
             ///  list of possible values, using the specified context.</para>
             /// </summary>
             public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.ModifiersExtenderProvider.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.ModifiersExtenderProvider.cs
@@ -59,7 +59,7 @@ namespace System.ComponentModel.Design.Serialization
                 if (_host == null)
                 {
                     ISite site = c.Site;
-                    
+
                     if (site != null)
                     {
                         _host = (IDesignerHost)site.GetService(typeof(IDesignerHost));
@@ -89,7 +89,6 @@ namespace System.ComponentModel.Design.Serialization
                 if (site == null)
                 {
                     return true;
-
                 }
 
                 IDictionaryService dictionary = (IDictionaryService)site.GetService(typeof(IDictionaryService));
@@ -212,7 +211,7 @@ namespace System.ComponentModel.Design.Serialization
                 }
 
                 IDictionaryService dictionary = (IDictionaryService)site.GetService(typeof(IDictionaryService));
-                
+
                 if (dictionary != null)
                 {
                     dictionary.SetValue("Modifiers", modifiers);

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.ModifiersInheritedExtenderProvider.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.ModifiersInheritedExtenderProvider.cs
@@ -105,7 +105,7 @@ namespace System.ComponentModel.Design.Serialization
                 }
 
                 FieldInfo field = TypeDescriptor.GetReflectionType(baseType).GetField(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
-                
+
                 if (field != null)
                 {
                     if (field.IsPrivate)
@@ -127,7 +127,7 @@ namespace System.ComponentModel.Design.Serialization
                         return MemberAttributes.FamilyAndAssembly;
                 }
 
-                // Visual Basic uses a property called Foo and generates a field called _Foo. We need to check the 
+                // Visual Basic uses a property called Foo and generates a field called _Foo. We need to check the
                 // visibility of this accessor to fix the modifiers up.
                 PropertyInfo prop = TypeDescriptor.GetReflectionType(baseType).GetProperty(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
                 MethodInfo[] accessors = prop?.GetAccessors(true);
@@ -137,7 +137,7 @@ namespace System.ComponentModel.Design.Serialization
                 }
 
                 MethodInfo mi = accessors[0];
-                
+
                 if (mi.IsPrivate)
                     return MemberAttributes.Private;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.cs
@@ -16,19 +16,19 @@ using System.Windows.Forms.Design;
 namespace System.ComponentModel.Design.Serialization
 {
     /// <summary>
-    ///  DesignerLoader.  This class is responsible for loading a designer document.  
+    ///  DesignerLoader.  This class is responsible for loading a designer document.
     ///  Where and how this load occurs is a private matter for the designer loader.
-    ///  The designer loader will be handed to an IDesignerHost instance.  This instance, 
+    ///  The designer loader will be handed to an IDesignerHost instance.  This instance,
     ///  when it is ready to load the document, will call BeginLoad, passing an instance
     ///  of IDesignerLoaderHost.  The designer loader will load up the design surface
     ///  using the host interface, and call EndLoad on the interface when it is done.
     ///  The error collection passed into EndLoad should be empty or null to indicate a
-    ///  successful load, or it should contain a collection of exceptions that 
+    ///  successful load, or it should contain a collection of exceptions that
     ///  describe the error.
     ///
     ///  Once a document is loaded, the designer loader is also responsible for
     ///  writing any changes made to the document back whatever storage the
-    ///  loader used when loading the document.  
+    ///  loader used when loading the document.
     /// </summary>
     public abstract partial class CodeDomDesignerLoader : BasicDesignerLoader, INameCreationService, IDesignerSerializationService
     {
@@ -60,10 +60,10 @@ namespace System.ComponentModel.Design.Serialization
         protected abstract CodeDomProvider CodeDomProvider { get; }
 
         /// <summary>
-        ///  The TypeResolutionService property returns a type resolution service that the code dom 
-        ///  serializers will use when resolving types.  The CodeDomDesignerLoader automatically 
+        ///  The TypeResolutionService property returns a type resolution service that the code dom
+        ///  serializers will use when resolving types.  The CodeDomDesignerLoader automatically
         ///  adds this type resolver as a service to the service container during Initialize if it
-        ///  is non-null.  While the type resolution service is optional in many scenarios, it is required for 
+        ///  is non-null.  While the type resolution service is optional in many scenarios, it is required for
         ///  code interpretation because source code contains type names, but no assembly references.
         /// </summary>
         protected abstract ITypeResolutionService TypeResolutionService { get; }
@@ -86,8 +86,8 @@ namespace System.ComponentModel.Design.Serialization
         }
 
         /// <summary>
-        ///  Disposes this designer loader.  The designer host will call 
-        ///  this method when the design document itself is being destroyed.  
+        ///  Disposes this designer loader.  The designer host will call
+        ///  this method when the design document itself is being destroyed.
         ///  Once called, the designer loader will never be called again.
         ///  This implementation flushes any changes and removes any
         ///  previously added services.
@@ -183,10 +183,10 @@ namespace System.ComponentModel.Design.Serialization
         /// <summary>
         ///  This ensures that we can load the code dom elements into a
         ///  document.  It ensures that there is a code dom provider, that
-        ///  the provider can parse the code, and that the returned 
+        ///  the provider can parse the code, and that the returned
         ///  code compile unit contains a class that can be deserialized
         ///  through a code dom serializer.  During all of this checking
-        ///  it establishes state in our member variables so that 
+        ///  it establishes state in our member variables so that
         ///  calls after it can assume that the variables are set.  This
         ///  will throw a human readable exception if any part of the
         ///  process fails.
@@ -357,7 +357,7 @@ namespace System.ComponentModel.Design.Serialization
                 // If we did not get a document type, throw, because we're unable to continue.
                 if (_documentType == null)
                 {
-                    // The entire compile unit needs to be thrown away so 
+                    // The entire compile unit needs to be thrown away so
                     // we can later reparse.
                     _documentCompileUnit = null;
 
@@ -751,7 +751,7 @@ namespace System.ComponentModel.Design.Serialization
 
         /// <summary>
         ///  This method is called immediately before the document is unloaded.
-        ///  The document may be unloaded in preparation for reload, or 
+        ///  The document may be unloaded in preparation for reload, or
         ///  if the document failed the load.  If you added document-specific
         ///  services in OnBeginLoad or OnEndLoad, you should remove them
         ///  here.
@@ -929,7 +929,7 @@ namespace System.ComponentModel.Design.Serialization
         }
 
         /// <summary>
-        ///  This virtual method gets override in the VsCodeDomDesignerLoader to call the RenameElement on the 
+        ///  This virtual method gets override in the VsCodeDomDesignerLoader to call the RenameElement on the
         ///  ChangeNotificationService to rename the component name through out the project scope.
         /// </summary>
         protected virtual void OnComponentRename(object component, string oldName, string newName)
@@ -1082,7 +1082,7 @@ namespace System.ComponentModel.Design.Serialization
         }
 
         /// <summary>
-        ///  Serializes the given collection of objects and 
+        ///  Serializes the given collection of objects and
         ///  stores them in an opaque serialization data object.
         ///  The returning object fully supports runtime serialization.
         /// </summary>
@@ -1186,7 +1186,6 @@ namespace System.ComponentModel.Design.Serialization
                     {
                         conflict = true;
                     }
-
                 } while (conflict);
             }
             else
@@ -1217,7 +1216,7 @@ namespace System.ComponentModel.Design.Serialization
         }
 
         /// <summary>
-        ///  Determines if the given name is valid.  A name 
+        ///  Determines if the given name is valid.  A name
         ///  creation service may have rules defining a valid
         ///  name, and this method allows the sevice to enforce
         ///  those rules.
@@ -1260,7 +1259,7 @@ namespace System.ComponentModel.Design.Serialization
             }
 
             // We don't validate against the type members if we're loading,
-            // because during load these members are being added by the 
+            // because during load these members are being added by the
             // parser, so of course there will be duplicates.
             if (!Loading)
             {
@@ -1291,7 +1290,7 @@ namespace System.ComponentModel.Design.Serialization
         }
 
         /// <summary>
-        ///  Determines if the given name is valid.  A name 
+        ///  Determines if the given name is valid.  A name
         ///  creation service may have rules defining a valid
         ///  name, and this method allows the sevice to enforce
         ///  those rules.  It is similar to IsValidName, except
@@ -1354,7 +1353,7 @@ namespace System.ComponentModel.Design.Serialization
             }
 
             // We don't validate against the type members if we're loading,
-            // because during load these members are being added by the 
+            // because during load these members are being added by the
             // parser, so of course there will be duplicates.
             bool dup = false;
             CodeTypeDeclaration type = _documentType;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomLocalizationModel.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomLocalizationModel.cs
@@ -15,7 +15,7 @@ namespace System.ComponentModel.Design.Serialization
         ///  serializable.
         /// </summary>
         None = 0,
-        
+
         /// <summary>
         ///  Indicates that the localization provider will write out localizaed properties by assigning a resource to
         ///  each property.  This model is fast when the number of properties is small, but scales poorly

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomLocalizationProvider.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomLocalizationProvider.cs
@@ -14,7 +14,7 @@ namespace System.ComponentModel.Design.Serialization
     ///  This is a serialization provider that provides a localization feature.  This provider
     ///  adds two properties to the root component:  Language and Localizable.  If Localizable
     ///  is set to true this provider will change the way that component properties are generated
-    ///  and will route their values to a resource file.  Two localization models are 
+    ///  and will route their values to a resource file.  Two localization models are
     ///  supported.
     /// </summary>
     public sealed class CodeDomLocalizationProvider : IDisposable, IDesignerSerializationProvider
@@ -27,11 +27,11 @@ namespace System.ComponentModel.Design.Serialization
         private Hashtable _nopMemberSerializers;
 
         /// <summary>
-        ///  Creates a new adapter and attaches it to the serialization manager.  This 
-        ///  will add itself as a serializer for resources into the serialization manager, and, 
-        ///  if not already added, will add itself as an extender provider to the roost component 
-        ///  and provide the Language and Localizable properties.  The latter piece is only 
-        ///  supplied if CodeDomLocalizationModel is not �none�.  
+        ///  Creates a new adapter and attaches it to the serialization manager.  This
+        ///  will add itself as a serializer for resources into the serialization manager, and,
+        ///  if not already added, will add itself as an extender provider to the roost component
+        ///  and provide the Language and Localizable properties.  The latter piece is only
+        ///  supplied if CodeDomLocalizationModel is not �none�.
         /// </summary>
         public CodeDomLocalizationProvider(IServiceProvider provider, CodeDomLocalizationModel model)
         {
@@ -45,11 +45,11 @@ namespace System.ComponentModel.Design.Serialization
         }
 
         /// <summary>
-        ///  Creates a new adapter and attaches it to the serialization manager.  This 
-        ///  will add itself as a serializer for resources into the serialization manager, and, 
-        ///  if not already added, will add itself as an extender provider to the roost component 
-        ///  and provide the Language and Localizable properties.  The latter piece is only 
-        ///  supplied if CodeDomLocalizationModel is not �none�.  
+        ///  Creates a new adapter and attaches it to the serialization manager.  This
+        ///  will add itself as a serializer for resources into the serialization manager, and,
+        ///  if not already added, will add itself as an extender provider to the roost component
+        ///  and provide the Language and Localizable properties.  The latter piece is only
+        ///  supplied if CodeDomLocalizationModel is not �none�.
         /// </summary>
         public CodeDomLocalizationProvider(IServiceProvider provider, CodeDomLocalizationModel model, CultureInfo[] supportedCultures)
         {
@@ -114,7 +114,7 @@ namespace System.ComponentModel.Design.Serialization
                 return null;
             }
 
-            // Here's how this works.  We have two different types of serializers to offer :  a 
+            // Here's how this works.  We have two different types of serializers to offer :  a
             // serializer that writes out code like this:
             //
             //      this.Button1.Text = rm.GetString("Button1_Text");
@@ -234,7 +234,7 @@ namespace System.ComponentModel.Design.Serialization
         }
 
         /// <summary>
-        ///  Returns an appropriate serializer for the object.  
+        ///  Returns an appropriate serializer for the object.
         /// </summary>
         object IDesignerSerializationProvider.GetSerializer(IDesignerSerializationManager manager, object currentSerializer, Type objectType, Type serializerType)
         {
@@ -309,7 +309,7 @@ namespace System.ComponentModel.Design.Serialization
             }
 
             /// <summary>
-            ///  Broadcasts a global change, indicating that all 
+            ///  Broadcasts a global change, indicating that all
             ///  objects on the designer have changed.
             /// </summary>
             private void BroadcastGlobalChange(IComponent comp)
@@ -385,7 +385,7 @@ namespace System.ComponentModel.Design.Serialization
             }
 
             /// <summary>
-            ///  Gets a value indicating whether the specified object supports design-time localization 
+            ///  Gets a value indicating whether the specified object supports design-time localization
             ///  support.
             /// </summary>
             [DesignOnly(true)]
@@ -457,7 +457,7 @@ namespace System.ComponentModel.Design.Serialization
             }
 
             /// <summary>
-            ///  Sets a value indicating whether or not the specified object has design-time 
+            ///  Sets a value indicating whether or not the specified object has design-time
             ///  localization support.
             /// </summary>
             public void SetLocalizable(IComponent o, bool localizable)
@@ -523,12 +523,12 @@ namespace System.ComponentModel.Design.Serialization
             }
         }
 
-        #region LanguageCultureInfoConverter 
+        #region LanguageCultureInfoConverter
         /// <summary>
         ///  This is a culture info converter that knows how to provide
         ///  a restricted list of cultures based on the SupportedCultures
         ///  property of the extender.  If the extender can't be found
-        ///  or the SupportedCultures property returns null, this 
+        ///  or the SupportedCultures property returns null, this
         ///  defaults to the stock implementation.
         /// </summary>
         internal sealed class LanguageCultureInfoConverter : CultureInfoConverter

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs
@@ -721,7 +721,7 @@ namespace System.ComponentModel.Design.Serialization
                                 if (rhs is IConvertible ic)
                                 {
                                     // f.FieldType is a type from the reflection (or project target) universe, while rhs is a runtime type (exists in the Visual Studio framework)
-                                    // they need to be converted to the same universe for comparison to work. 
+                                    // they need to be converted to the same universe for comparison to work.
                                     // If TargetFrameworkProvider is not available, then we are working with runtime types.
                                     Type fieldType = f.FieldType;
                                     TypeDescriptionProvider tdp = GetTargetFrameworkProviderForType(manager, fieldType);
@@ -2080,7 +2080,6 @@ namespace System.ComponentModel.Design.Serialization
             // Now check IReferenceService.
             if (expression == null)
             {
-
                 // perf: first try to retrieve objectName from DesignerSerializationManager
                 // only then involve reference service if needed
                 // this is done to avoid unnecessary ensuring\creating references
@@ -2291,7 +2290,6 @@ namespace System.ComponentModel.Design.Serialization
             }
             Trace("IsSerialized called for object {0} : {1}", value, hasExpression);
             return hasExpression;
-
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ComponentCache.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ComponentCache.cs
@@ -240,7 +240,6 @@ namespace System.ComponentModel.Design.Serialization
                         RemoveEntry(parent);
                     }
                 }
-
             }
         }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ComponentCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ComponentCodeDomSerializer.cs
@@ -60,7 +60,7 @@ namespace System.ComponentModel.Design.Serialization
         /// <summary>
         ///  Determines if we can cache the results of serializing a component.
         /// </summary>
-		private bool CanCacheComponent(IDesignerSerializationManager manager, object value, PropertyDescriptorCollection props)
+        private bool CanCacheComponent(IDesignerSerializationManager manager, object value, PropertyDescriptorCollection props)
         {
             if (value is IComponent comp)
             {
@@ -230,7 +230,6 @@ namespace System.ComponentModel.Design.Serialization
 
                     try
                     {
-
                         string name = manager.GetName(value);
 
                         string typeName = TypeDescriptor.GetClassName(value);
@@ -240,7 +239,6 @@ namespace System.ComponentModel.Design.Serialization
                         {
                             if (generateField)
                             {
-
                                 if (inheritanceLevel == InheritanceLevel.NotInherited)
                                 {
                                     // We need to generate the field declaration.  See if there is a modifiers property on
@@ -438,7 +436,6 @@ namespace System.ComponentModel.Design.Serialization
                                             entry.AddDependency(dependency);
                                         }
                                     }
-
                                 }
                                 entry.Component = value;
                                 // we need to link the cached entry with its corresponding component right away, before it's put in the context

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/DesignerSerializationManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/DesignerSerializationManager.cs
@@ -205,7 +205,6 @@ namespace System.ComponentModel.Design.Serialization
             // If we have been asked to recycle instances, look in our nametable and container first for an object matching this name and type.  If we find it, we will use it.
             if (RecycleInstances && name != null)
             {
-
                 if (instancesByName != null)
                 {
                     instance = instancesByName[name];
@@ -344,7 +343,6 @@ namespace System.ComponentModel.Design.Serialization
                         {
                             argTypes.Append("null");
                         }
-
                     }
                     Exception ex = new SerializationException(string.Format(SR.SerializationManagerNoMatchingCtor, type.FullName, argTypes.ToString()))
                     {
@@ -380,7 +378,7 @@ namespace System.ComponentModel.Design.Serialization
         }
 
         /// <summary>
-        ///  Creates a new serialization session.  Most data within the serialization manager is transient and only lives for the life of a serialization session.  When a session is disposed, serialization is considered to be complete and this transient state is cleared.  This allows a single instance of a serialization manager to be used to serialize multiple object trees.  Some state, including the service provider and any custom serialization providers that were added to the serialization manager, span sessions.	
+        ///  Creates a new serialization session.  Most data within the serialization manager is transient and only lives for the life of a serialization session.  When a session is disposed, serialization is considered to be complete and this transient state is cleared.  This allows a single instance of a serialization manager to be used to serialize multiple object trees.  Some state, including the service provider and any custom serialization providers that were added to the serialization manager, span sessions.
         /// </summary>
         public IDisposable CreateSession()
         {
@@ -656,7 +654,6 @@ namespace System.ComponentModel.Design.Serialization
                         {
                             propArray[i] = WrapProperty(props[i], propObject);
                         }
-
                     }
                     properties = new PropertyDescriptorCollection(propArray);
                 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ICodeDomDesignerReload.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ICodeDomDesignerReload.cs
@@ -1,5 +1,4 @@
-﻿
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -24,5 +23,4 @@ namespace System.ComponentModel.Design.Serialization
         /// </summary>
         bool ShouldReloadDesigner(CodeCompileUnit newTree);
     }
-
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/LocalizationCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/LocalizationCodeDomSerializer.cs
@@ -19,7 +19,7 @@ namespace System.ComponentModel.Design.Serialization
     ///  Instead of letting resource manager maintain resource
     ///  sets, it uses the designer host's IResourceService
     ///  for this purpose.
-    ///  
+    ///
     ///  During serialization, this class will also create
     ///  a SerializationResourceManager.  This will be added
     ///  to the serialization manager as a service so other
@@ -80,8 +80,8 @@ namespace System.ComponentModel.Design.Serialization
             // since we cannot push this into resources.
             bool callExistingSerializer = !isSerializable;
 
-            // Compat: If we are serializing content, we need to skip property reflection to preserve compatibility, 
-            //         since tools like WinRes expect items in collections (like TreeNodes and ListViewItems) 
+            // Compat: If we are serializing content, we need to skip property reflection to preserve compatibility,
+            //         since tools like WinRes expect items in collections (like TreeNodes and ListViewItems)
             //         to be serialized as binary blobs.
             bool serializingContent = (desc != null && desc.Attributes.Contains(DesignerSerializationVisibilityAttribute.Content));
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/PrimitiveCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/PrimitiveCodeDomSerializer.cs
@@ -49,19 +49,19 @@ namespace System.ComponentModel.Design.Serialization
 
             if (value == null)
             {
-				return expression;
-			}
-			
+                return expression;
+            }
+
             if (value is string stringValue)
             {
                 if (stringValue.Length > 200)
                 {
                     expression = SerializeToResourceExpression(manager, stringValue);
                 }
-				return expression;
+                return expression;
             }
 
-		    if (!(value is bool || value is char || value is int || value is float || value is double))
+            if (!(value is bool || value is char || value is int || value is float || value is double))
             {
                 // Generate a cast for all other types because we won't parse them properly otherwise
                 // because we won't know to convert them to the narrow form.

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/PropertyMemberCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/PropertyMemberCodeDomSerializer.cs
@@ -95,7 +95,6 @@ namespace System.ComponentModel.Design.Serialization
             }
 
             return propertyValue;
-
         }
 
         /// <summary>
@@ -452,7 +451,6 @@ namespace System.ComponentModel.Design.Serialization
 
                 if (absolute != null && absolute.ShouldSerialize(propertyToSerialize))
                 {
-
                     // For ReadOnly properties, we only want to override the value returned from
                     // ShouldSerializeValue() if the property is marked with DesignerSerializationVisibilityAttribute(Content).
                     // Consider the case of a property with just a getter - we only want to serialize those

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.cs
@@ -655,7 +655,6 @@ namespace System.ComponentModel.Design.Serialization
             /// </summary>
             public override void ApplyResources(object value, string objectName, CultureInfo culture)
             {
-
                 if (culture == null)
                 {
                     culture = ReadCulture;
@@ -925,7 +924,6 @@ namespace System.ComponentModel.Design.Serialization
                         }
                         else
                         {
-
                             // Provide a sentinel so we don't repeatedly ask for the same resource.  If this is the invariant culture, always provide one.
                             if (culture.Equals(CultureInfo.InvariantCulture))
                             {
@@ -966,7 +964,6 @@ namespace System.ComponentModel.Design.Serialization
                 {
                     lastCulture = culture;
                     culture = culture.Parent;
-
                 } while (tryParents && !lastCulture.Equals(culture));
 
                 if (createIfNotExists)

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourcePropertyMemberCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourcePropertyMemberCodeDomSerializer.cs
@@ -12,7 +12,7 @@ namespace System.ComponentModel.Design.Serialization
     ///  This serializer replaces the property serializer for properties when we're
     ///  in localization mode.
     /// </summary>
-	internal class ResourcePropertyMemberCodeDomSerializer : MemberCodeDomSerializer
+    internal class ResourcePropertyMemberCodeDomSerializer : MemberCodeDomSerializer
     {
         private CodeDomLocalizationModel _model;
         private MemberCodeDomSerializer _serializer;
@@ -55,12 +55,12 @@ namespace System.ComponentModel.Design.Serialization
             {
                 // Check to see if our base component's localizable prop is true
                 RootContext rootCxt = manager.Context[typeof(RootContext)] as RootContext;
-                
+
                 if (rootCxt != null)
                 {
                     object comp = rootCxt.Value;
                     PropertyDescriptor prop = TypeDescriptor.GetProperties(comp)["LoadLanguage"];
-                    
+
                     if (prop != null && prop.PropertyType == typeof(CultureInfo))
                     {
                         localizationLanguage = (CultureInfo)prop.GetValue(comp);
@@ -79,7 +79,7 @@ namespace System.ComponentModel.Design.Serialization
             //unhook the event
             IDesignerSerializationManager manager = sender as IDesignerSerializationManager;
             Debug.Assert(manager != null, "manager should not be null!");
-            
+
             if (manager != null)
             {
                 manager.SerializationComplete -= new EventHandler(OnSerializationComplete);

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/TypeCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/TypeCodeDomSerializer.cs
@@ -140,7 +140,6 @@ namespace System.ComponentModel.Design.Serialization
                     {
                         foreach (CodeStatement statement in method.Statements)
                         {
-
                             if (statement is CodeVariableDeclarationStatement local)
                             {
                                 _nameTable[local.Name] = statement;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.cs
@@ -838,7 +838,6 @@ namespace System.ComponentModel.Design
             /// </summary>
             public virtual void ComponentRemoved(ComponentEventArgs e)
             {
-
                 // We should gather undo state in ComponentRemoved, but by this time the component's designer has been destroyed so it's too late.  Instead, we captured state in the Removing method.  But, it is possible for there to be component changes to other objects that happen between removing and removed,  so we need to reorder the removing event so it's positioned after any changes.
                 if (_events != null && e != null)
                 {
@@ -1250,7 +1249,6 @@ namespace System.ComponentModel.Design
                 /// </summary>
                 public bool ContainsChange(MemberDescriptor desc)
                 {
-
                     if (_member == null)
                     {
                         return true;

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxItem.cs
@@ -391,7 +391,6 @@ namespace System.Drawing.Design
                         {
                             init.InitializeNewComponent(defaultValues);
                             removeComponent = false;
-
                         }
                         finally
                         {
@@ -403,7 +402,6 @@ namespace System.Drawing.Design
                                 }
                             }
                         }
-
                     }
                 }
             }
@@ -413,11 +411,11 @@ namespace System.Drawing.Design
 
         protected virtual void Deserialize(SerializationInfo info, StreamingContext context)
         {
-            // Do this in a couple of passes -- first pass, try to pull	
-            // out our dictionary of property names.  We need to do this	
-            // for backwards compatibilty because if we throw everything	
-            // into the property dictionary we'll duplicate stuff people	
-            // have serialized by hand.	
+            // Do this in a couple of passes -- first pass, try to pull
+            // out our dictionary of property names.  We need to do this
+            // for backwards compatibilty because if we throw everything
+            // into the property dictionary we'll duplicate stuff people
+            // have serialized by hand.
 
             string[] propertyNames = null;
             foreach (SerializationEntry entry in info)
@@ -431,8 +429,8 @@ namespace System.Drawing.Design
 
             if (propertyNames == null)
             {
-                // For backwards compat, here are the default property	
-                // names we use	
+                // For backwards compat, here are the default property
+                // names we use
                 propertyNames = new string[] {
                     "AssemblyName",
                     "Bitmap",
@@ -445,9 +443,8 @@ namespace System.Drawing.Design
 
             foreach (SerializationEntry entry in info)
             {
-
-                // Check to see if this name is in our	
-                // propertyNames array.	
+                // Check to see if this name is in our
+                // propertyNames array.
                 foreach (string validName in propertyNames)
                 {
                     if (validName.Equals(entry.Name))
@@ -458,7 +455,7 @@ namespace System.Drawing.Design
                 }
             }
 
-            // Always do "Locked" last (otherwise we can't do the others!)	
+            // Always do "Locked" last (otherwise we can't do the others!)
             bool isLocked = info.GetBoolean("Locked");
             if (isLocked)
             {
@@ -575,7 +572,6 @@ namespace System.Drawing.Design
 
             if (ts != null)
             {
-
                 if (reference)
                 {
                     if (assemblyName != null)
@@ -585,8 +581,8 @@ namespace System.Drawing.Design
                     }
                     else
                     {
-                        // Just try loading the type.  If we succeed, then use this as the	
-                        // reference.	
+                        // Just try loading the type.  If we succeed, then use this as the
+                        // reference.
                         type = ts.GetType(typeName);
                         if (type == null)
                         {
@@ -708,11 +704,10 @@ namespace System.Drawing.Design
                 AssemblyName = assemblyName;
                 DisplayName = type.Name;
 
-                //if the Type is a reflectonly type, these values must be set through a config object or manually	
-                //after construction.	
+                //if the Type is a reflectonly type, these values must be set through a config object or manually
+                //after construction.
                 if (!type.Assembly.ReflectionOnly)
                 {
-
                     object[] companyattrs = type.Assembly.GetCustomAttributes(typeof(AssemblyCompanyAttribute), true);
                     if (companyattrs != null && companyattrs.Length > 0)
                     {
@@ -722,7 +717,7 @@ namespace System.Drawing.Design
                         }
                     }
 
-                    //set the description based off the description attribute of the given type.	
+                    //set the description based off the description attribute of the given type.
                     DescriptionAttribute descattr = (DescriptionAttribute)TypeDescriptor.GetAttributes(type)[typeof(DescriptionAttribute)];
                     if (descattr != null)
                     {
@@ -735,8 +730,8 @@ namespace System.Drawing.Design
                         Bitmap itemBitmap = attr.GetImage(type, false) as Bitmap;
                         if (itemBitmap != null)
                         {
-                            // Original bitmap is used when adding the item to the Visual Studio toolbox 	
-                            // if running on a machine with HDPI scaling enabled.	
+                            // Original bitmap is used when adding the item to the Visual Studio toolbox
+                            // if running on a machine with HDPI scaling enabled.
                             OriginalBitmap = itemBitmap;
                             if ((itemBitmap.Width != s_iconWidth || itemBitmap.Height != s_iconHeight))
                             {
@@ -778,13 +773,13 @@ namespace System.Drawing.Design
                 return null;
             }
 
-            //if looking for myself, just return it. (not a reference)	
+            //if looking for myself, just return it. (not a reference)
             if (type.Assembly.FullName == policiedAssemblyName.FullName)
             {
                 return policiedAssemblyName;
             }
 
-            //first search for an exact match -- we prefer this over a partial match.	
+            //first search for an exact match -- we prefer this over a partial match.
             foreach (AssemblyName name in type.Assembly.GetReferencedAssemblies())
             {
                 if (name.FullName == policiedAssemblyName.FullName)
@@ -793,7 +788,7 @@ namespace System.Drawing.Design
                 }
             }
 
-            //next search for a partial match -- we just compare the Name portions (ignore version and publickey)	
+            //next search for a partial match -- we just compare the Name portions (ignore version and publickey)
             foreach (AssemblyName name in type.Assembly.GetReferencedAssemblies())
             {
                 if (name.Name == policiedAssemblyName.Name)
@@ -802,10 +797,10 @@ namespace System.Drawing.Design
                 }
             }
 
-            //finally, the most expensive -- its possible that retargeting policy is on an assembly whose name changes	
-            // an example of this is the device System.Windows.Forms.Datagrid.dll	
-            // in this case, we need to try to load each device assemblyname through policy to see if it results	
-            // in assemblyname.	
+            //finally, the most expensive -- its possible that retargeting policy is on an assembly whose name changes
+            // an example of this is the device System.Windows.Forms.Datagrid.dll
+            // in this case, we need to try to load each device assemblyname through policy to see if it results
+            // in assemblyname.
             foreach (AssemblyName name in type.Assembly.GetReferencedAssemblies())
             {
                 try
@@ -818,7 +813,7 @@ namespace System.Drawing.Design
                 }
                 catch
                 {
-                    // Ignore all exceptions and just fall through if it fails (it shouldn't, but who knows).	
+                    // Ignore all exceptions and just fall through if it fails (it shouldn't, but who knows).
                 }
             }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/BaseContextMenuStrip.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/BaseContextMenuStrip.cs
@@ -126,7 +126,6 @@ namespace System.Windows.Forms.Design
                     {
                         selectionMenuItem.DropDown.ForeColor = (Color)uis.Styles["VsColorPanelText"];
                     }
-
                 }
 
                 selectionMenuItem.Text = SR.ContextMenuSelect;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
@@ -819,7 +819,6 @@ namespace System.Windows.Forms.Design.Behavior
                     User32.GetCursorPos(out Point pt);
                     User32.MapWindowPoints(IntPtr.Zero, Handle, ref pt, 1);
                     _behaviorService.PropagateHitTest(pt);
-
                 }
                 _behaviorService.OnDragEnter(null, e);
             }
@@ -1201,7 +1200,6 @@ namespace System.Windows.Forms.Design.Behavior
                                     // we did the work, stop the message propogation
                                     return true;
                                 }
-
                             }
                             finally
                             {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ContainerSelectorGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ContainerSelectorGlyph.cs
@@ -68,6 +68,5 @@ namespace System.Windows.Forms.Design.Behavior
         {
             pe.Graphics.DrawImage(MoveGlyph, _glyphBounds);
         }
-
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DropSourceBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DropSourceBehavior.cs
@@ -196,7 +196,6 @@ namespace System.Windows.Forms.Design.Behavior
         {
             if (dragImageRect != Rectangle.Empty)
             {
-
                 Rectangle rect = dragImageRect;
                 rect.Location = MapPointFromSourceToTarget(rect.Location);
 
@@ -488,7 +487,6 @@ namespace System.Windows.Forms.Design.Behavior
                             {
                                 selSvc.SetSelectedComponents(new object[] { dragComponents[i].dragComponent }, SelectionTypes.Add);
                             }
-
                         }
 
                         if ((!localDrag || performCopy) && componentChangeSvcSource != null && componentChangeSvcTarget != null)
@@ -1024,7 +1022,6 @@ namespace System.Windows.Forms.Design.Behavior
                                     GraphicsUnit.Pixel);
                     }
                 }
-
             }
 
             originalDragImageLocation = new Point(dragImageRect.X, dragImageRect.Y);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/GrabHandleGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/GrabHandleGlyph.cs
@@ -97,6 +97,5 @@ namespace System.Windows.Forms.Design.Behavior
         {
             DesignerUtils.DrawGrabHandle(pe.Graphics, bounds, _isPrimary, this);
         }
-
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/LockedBorderGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/LockedBorderGlyph.cs
@@ -39,6 +39,5 @@ namespace System.Windows.Forms.Design.Behavior
         {
             DesignerUtils.DrawSelectionBorder(pe.Graphics, bounds);
         }
-
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/LockedHandleGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/LockedHandleGlyph.cs
@@ -34,6 +34,5 @@ namespace System.Windows.Forms.Design.Behavior
         {
             DesignerUtils.DrawLockedHandle(pe.Graphics, bounds, _isPrimary, this);
         }
-
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/MiniLockedBorderGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/MiniLockedBorderGlyph.cs
@@ -44,6 +44,5 @@ namespace System.Windows.Forms.Design.Behavior
         {
             pe.Graphics.FillRectangle(new SolidBrush(SystemColors.ControlText), bounds);
         }
-
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/NoResizeHandleGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/NoResizeHandleGlyph.cs
@@ -29,7 +29,6 @@ namespace System.Windows.Forms.Design.Behavior
             // The handle is always upperleft
             bounds = new Rectangle(controlBounds.X - DesignerUtils.NORESIZEHANDLESIZE, controlBounds.Y - DesignerUtils.NORESIZEHANDLESIZE, DesignerUtils.NORESIZEHANDLESIZE, DesignerUtils.NORESIZEHANDLESIZE);
             hitBounds = bounds;
-
         }
 
         /// <summary>
@@ -39,6 +38,5 @@ namespace System.Windows.Forms.Design.Behavior
         {
             DesignerUtils.DrawNoResizeHandle(pe.Graphics, bounds, _isPrimary, this);
         }
-
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/SelectionManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/SelectionManager.cs
@@ -171,7 +171,6 @@ namespace System.Windows.Forms.Design.Behavior
             {
                 curCompIndex++;
             }
-
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ChangeToolStripParentVerb.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ChangeToolStripParentVerb.cs
@@ -115,7 +115,6 @@ namespace System.Windows.Forms.Design
                     changeParent.Cancel();
                     changeParent = null;
                 }
-
             }
             finally
             {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
@@ -973,7 +973,6 @@ namespace System.Windows.Forms.Design
                                 return;
                             }
                         }
-
                     }
                     bool firstTry = true;
                     // for each component, we round to the nearest snap offset for x and y
@@ -1776,7 +1775,6 @@ namespace System.Windows.Forms.Design
 
                         foreach (object obj in components)
                         {
-
                             name = null;
                             curComp = obj as IComponent;
                             // see if we can fish out the original name. When we serialized, we serialized an array of names at the head of the list.  This array matches the components that were created.
@@ -2331,7 +2329,6 @@ namespace System.Windows.Forms.Design
                     }
                 }
             }
-
         }
 
         /// <summary>
@@ -2644,7 +2641,6 @@ namespace System.Windows.Forms.Design
                         {
                             curLoc.X -= grid.Width * (primaryIndex - n);
                         }
-
                     }
                     else if (cmdID == MenuCommands.HorizSpaceMakeEqual && n > 0)
                     {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComponentTray.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComponentTray.cs
@@ -1282,7 +1282,6 @@ namespace System.Windows.Forms.Design
                             throw;
                         }
                     }
-
                 }
             }
         }
@@ -1960,7 +1959,6 @@ namespace System.Windows.Forms.Design
                 Text = name;
                 _inheritanceAttribute = (InheritanceAttribute)TypeDescriptor.GetAttributes(component)[typeof(InheritanceAttribute)];
                 TabStop = false;
-
             }
 
             /// <summary>
@@ -2438,7 +2436,6 @@ namespace System.Windows.Forms.Design
                     (specified & BoundsSpecified.Width) == BoundsSpecified.Width ||
                     (specified & BoundsSpecified.Height) == BoundsSpecified.Height)
                 {
-
                     base.SetBoundsCore(x, y, width, height, specified);
                 }
                 Rectangle bounds = Bounds;
@@ -2447,7 +2444,6 @@ namespace System.Windows.Forms.Design
                 {
                     base.SetBoundsCore(x, y, width, height, specified);
                 }
-
             }
 
             protected override void SetVisibleCore(bool value)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCodeDomSerializer.cs
@@ -57,7 +57,7 @@ namespace System.Windows.Forms.Design
 
             try
             {
-                // Find our base class's serializer.  
+                // Find our base class's serializer.
                 CodeDomSerializer serializer = (CodeDomSerializer)manager.GetSerializer(typeof(Component), typeof(CodeDomSerializer));
 
                 if (serializer == null)
@@ -162,7 +162,7 @@ namespace System.Windows.Forms.Design
                 throw new ArgumentNullException(manager == null ? "manager" : "value");
             }
 
-            // Find our base class's serializer.  
+            // Find our base class's serializer.
             CodeDomSerializer serializer = (CodeDomSerializer)manager.GetSerializer(typeof(Component), typeof(CodeDomSerializer));
 
             if (serializer == null)
@@ -204,7 +204,7 @@ namespace System.Windows.Forms.Design
                 }
 
                 CodeStatementCollection csCollection = retVal as CodeStatementCollection;
-                
+
                 if (csCollection != null)
                 {
                     Control control = (Control)value;
@@ -216,14 +216,14 @@ namespace System.Windows.Forms.Design
                         SerializeSuspendLayout(manager, csCollection, value);
                         SerializeResumeLayout(manager, csCollection, value);
                         ControlDesigner controlDesigner = host.GetDesigner(control) as ControlDesigner;
-                        
+
                         if (HasAutoSizedChildren(control) || (controlDesigner != null && controlDesigner.SerializePerformLayout))
                         {
                             SerializePerformLayout(manager, csCollection, value);
                         }
                     }
 
-                    // And now serialize the correct z-order relationships for the controls.  We only need to 
+                    // And now serialize the correct z-order relationships for the controls.  We only need to
                     // do this if there are controls in the collection that are inherited.
                     if (HasMixedInheritedChildren(control))
                     {
@@ -298,7 +298,7 @@ namespace System.Windows.Forms.Design
 
                 // Parent
                 Control parent = control.Parent;
-                
+
                 if (parent != null && parent.Site != null)
                 {
                     string parentName;
@@ -344,11 +344,10 @@ namespace System.Windows.Forms.Design
         private static Type[] ToTargetTypes(object context, Type[] runtimeTypes)
         {
             Type[] types = new Type[runtimeTypes.Length];
-            
+
             for (int i = 0; i < runtimeTypes.Length; i++)
             {
                 types[i] = ToTargetType(context, runtimeTypes[i]);
-            
             }
 
             return types;
@@ -364,24 +363,24 @@ namespace System.Windows.Forms.Design
                 string name = manager.GetName(control);
                 Trace(name + "." + methodName);
 
-                // Use IReflect to see if this method name exists on the control.  
+                // Use IReflect to see if this method name exists on the control.
                 paramTypes = ToTargetTypes(control, paramTypes);
                 MethodInfo mi = TypeDescriptor.GetReflectionType(control).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance, null, paramTypes, null);
-                
+
                 if (mi != null)
                 {
                     CodeExpression field = SerializeToExpression(manager, control);
                     CodeMethodReferenceExpression method = new CodeMethodReferenceExpression(field, methodName);
                     CodeMethodInvokeExpression methodInvoke = new CodeMethodInvokeExpression();
                     methodInvoke.Method = method;
-                    
+
                     if (parameters != null)
                     {
                         methodInvoke.Parameters.AddRange(parameters);
                     }
 
                     CodeExpressionStatement statement = new CodeExpressionStatement(methodInvoke);
-                    
+
                     switch (ordering)
                     {
                         case StatementOrdering.Prepend:
@@ -440,7 +439,7 @@ namespace System.Windows.Forms.Design
                     }
 
                     InheritanceAttribute attr = (InheritanceAttribute)TypeDescriptor.GetAttributes(child)[typeof(InheritanceAttribute)];
-                    
+
                     if (attr.InheritanceLevel == InheritanceLevel.InheritedReadOnly)
                     {
                         continue;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -1678,7 +1678,6 @@ namespace System.Windows.Forms.Design
                         // terminate the drag. TabControl loses shortcut menu options after adding ActiveX control.
                         OnMouseDragEnd(true);
                     }
-
                 }
                 return;
             }
@@ -1884,7 +1883,6 @@ namespace System.Windows.Forms.Design
                         else if (button == MouseButtons.Left)
                         {
                             OnMouseDragBegin(x, y);
-
                         }
                         else if (button == MouseButtons.Right)
                         {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewRowCollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewRowCollectionCodeDomSerializer.cs
@@ -33,7 +33,7 @@ namespace System.Windows.Forms.Design
         }
 
         /// <summery>
-        ///  Serializes the given collection.  targetExpression will refer to the expression used to rever to the 
+        ///  Serializes the given collection.  targetExpression will refer to the expression used to rever to the
         ///  collection, but it can be null.
         /// </summery>
         protected override object SerializeCollection(IDesignerSerializationManager manager, CodeExpression targetExpression, Type targetType, ICollection originalCollection, ICollection valuesToSerialize)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerVerbToolStripMenuItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerVerbToolStripMenuItem.cs
@@ -7,9 +7,9 @@ using System.ComponentModel.Design;
 namespace System.Windows.Forms.Design
 {
     /// <summary>
-	///  Associates DesignerVerb with ToolStripMenuItem.
-	/// </summary>
-	internal class DesignerVerbToolStripMenuItem : ToolStripMenuItem
+    ///  Associates DesignerVerb with ToolStripMenuItem.
+    /// </summary>
+    internal class DesignerVerbToolStripMenuItem : ToolStripMenuItem
     {
         readonly DesignerVerb _verb;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/EditorServiceContext.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/EditorServiceContext.cs
@@ -67,7 +67,6 @@ namespace System.Windows.Forms.Design
                 }
                 catch (CheckoutException)
                 {
-
                 }
             }
             return newValue;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormDocumentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormDocumentDesigner.cs
@@ -416,7 +416,6 @@ namespace System.Windows.Forms.Design
 
                 form.PerformLayout();
             }
-
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ISupportInSituService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ISupportInSituService.cs
@@ -25,6 +25,5 @@ namespace System.Windows.Forms.Design
         ///  Returns the Window Handle that gets all the Keyboarf messages once in InSitu.
         /// </summary>
         IntPtr GetEditWindow();
-
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageCollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageCollectionCodeDomSerializer.cs
@@ -27,9 +27,9 @@ namespace System.Windows.Forms.Design
                 throw new ArgumentNullException(manager == null ? "manager" : "codeObject");
             }
 
-            // Find our base class's serializer.  
+            // Find our base class's serializer.
             CodeDomSerializer serializer = (CodeDomSerializer)manager.GetSerializer(typeof(Component), typeof(CodeDomSerializer));
-            
+
             if (serializer == null)
             {
                 Debug.Fail("Unable to find a CodeDom serializer for 'Component'.  Has someone tampered with the serialization providers?");
@@ -48,7 +48,7 @@ namespace System.Windows.Forms.Design
             CodeDomSerializer baseSerializer = (CodeDomSerializer)manager.GetSerializer(typeof(ImageList).BaseType, typeof(CodeDomSerializer));
             object codeObject = baseSerializer.Serialize(manager, value);
             ImageList imageList = value as ImageList;
-            
+
             if (imageList != null)
             {
                 StringCollection imageKeys = imageList.Images.Keys;
@@ -56,7 +56,7 @@ namespace System.Windows.Forms.Design
                 if (codeObject is CodeStatementCollection)
                 {
                     CodeExpression imageListObject = GetExpression(manager, value);
-                    
+
                     if (imageListObject != null)
                     {
                         CodeExpression imageListImagesProperty = new CodePropertyReferenceExpression(imageListObject, "Images");

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ItemTypeToolStripMenuItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ItemTypeToolStripMenuItem.cs
@@ -8,9 +8,9 @@ using System.Drawing.Design;
 namespace System.Windows.Forms.Design
 {
     /// <summary>
-	///  Associates Type with ToolStripMenuItem.
-	/// </summary>
-	internal class ItemTypeToolStripMenuItem : ToolStripMenuItem
+    ///  Associates Type with ToolStripMenuItem.
+    /// </summary>
+    internal class ItemTypeToolStripMenuItem : ToolStripMenuItem
     {
         private static readonly string s_systemWindowsFormsNamespace = typeof(ToolStripItem).Namespace;
         private static readonly ToolboxItem s_invalidToolboxItem = new ToolboxItem();
@@ -67,6 +67,5 @@ namespace System.Windows.Forms.Design
             }
             base.Dispose(disposing);
         }
-
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDescriptor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDescriptor.cs
@@ -10,15 +10,15 @@ using System.Threading;
 namespace System.Windows.Forms.Design
 {
     /// <summary>
-    /// MaskDescriptor abstract class defines the set of methods mask descriptors need to implement for the 
+    /// MaskDescriptor abstract class defines the set of methods mask descriptors need to implement for the
     /// MaskedTextBox.Mask UITypeEditor to include as options in the property editor. MaskDescriptor
-    /// types are discovered at designed time by querying the ITypeDiscoveryService service provider from 
+    /// types are discovered at designed time by querying the ITypeDiscoveryService service provider from
     /// the UITypeEditor object.
-    /// </summary> 
+    /// </summary>
     public abstract class MaskDescriptor
     {
         /// <summary>
-        /// The mask being described.  
+        /// The mask being described.
         /// </summary>
         public abstract string Mask { get; }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDesignerDialog.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDesignerDialog.cs
@@ -69,21 +69,21 @@ namespace System.Windows.Forms.Design
             // Add default mask descriptors to the mask description list.
             AddDefaultMaskDescriptors(_maskedTextBox.Culture);
 
-            // 
+            //
             // maskDescriptionHeader
-            // 
+            //
             _maskDescriptionHeader.Text = SR.MaskDesignerDialogMaskDescription;
             _maskDescriptionHeader.Width = _listViewCannedMasks.Width / 3;
-            // 
+            //
             // dataFormatHeader
-            // 
+            //
             _dataFormatHeader.Text = SR.MaskDesignerDialogDataFormat;
             _dataFormatHeader.Width = _listViewCannedMasks.Width / 3;
-            // 
+            //
             // validatingTypeHeader
-            // 
+            //
             _validatingTypeHeader.Text = SR.MaskDesignerDialogValidatingType;
-            _validatingTypeHeader.Width = (_listViewCannedMasks.Width / 3) - SystemInformation.VerticalScrollBarWidth - 4;	// so no h-scrollbar.
+            _validatingTypeHeader.Width = (_listViewCannedMasks.Width / 3) - SystemInformation.VerticalScrollBarWidth - 4;  // so no h-scrollbar.
             ResumeLayout(false);
 
             HookEvents();
@@ -127,21 +127,21 @@ namespace System.Windows.Forms.Design
             _okCancelTableLayoutPanel.SuspendLayout();
             ((ISupportInitialize)(_errorProvider)).BeginInit();
             SuspendLayout();
-            // 
+            //
             // maskedTextBox
-            // 
+            //
             resources.ApplyResources(_maskedTextBox, "maskedTextBox");
             _maskedTextBox.Margin = new Padding(3, 3, 18, 0);
             _maskedTextBox.Name = "maskedTextBox";
-            // 
+            //
             // lblHeader
-            // 
+            //
             resources.ApplyResources(_lblHeader, "lblHeader");
             _lblHeader.Margin = new Padding(0, 0, 0, 3);
             _lblHeader.Name = "lblHeader";
-            // 
+            //
             // listViewCannedMasks
-            // 
+            //
             resources.ApplyResources(_listViewCannedMasks, "listViewCannedMasks");
             _listViewCannedMasks.Columns.AddRange(new ColumnHeader[] {
             _maskDescriptionHeader,
@@ -154,47 +154,47 @@ namespace System.Windows.Forms.Design
             _listViewCannedMasks.Name = "listViewCannedMasks";
             _listViewCannedMasks.Sorting = SortOrder.None; // We'll do the sorting ourselves.
             _listViewCannedMasks.View = View.Details;
-            // 
+            //
             // maskDescriptionHeader
-            // 
+            //
             resources.ApplyResources(_maskDescriptionHeader, "maskDescriptionHeader");
-            // 
+            //
             // dataFormatHeader
-            // 
+            //
             resources.ApplyResources(_dataFormatHeader, "dataFormatHeader");
-            // 
+            //
             // validatingTypeHeader
-            // 
+            //
             resources.ApplyResources(_validatingTypeHeader, "validatingTypeHeader");
-            // 
+            //
             // btnOK
-            // 
+            //
             resources.ApplyResources(_btnOK, "btnOK");
             _btnOK.DialogResult = DialogResult.OK;
             _btnOK.Margin = new Padding(0, 0, 3, 0);
             _btnOK.MinimumSize = new Drawing.Size(75, 23);
             _btnOK.Name = "btnOK";
             _btnOK.Padding = new Padding(10, 0, 10, 0);
-            // 
+            //
             // btnCancel
-            // 
+            //
             resources.ApplyResources(_btnCancel, "btnCancel");
             _btnCancel.DialogResult = DialogResult.Cancel;
             _btnCancel.Margin = new Padding(3, 0, 0, 0);
             _btnCancel.MinimumSize = new Drawing.Size(75, 23);
             _btnCancel.Name = "btnCancel";
             _btnCancel.Padding = new Padding(10, 0, 10, 0);
-            // 
+            //
             // checkBoxUseValidatingType
-            // 
+            //
             resources.ApplyResources(_checkBoxUseValidatingType, "checkBoxUseValidatingType");
             _checkBoxUseValidatingType.Checked = true;
             _checkBoxUseValidatingType.CheckState = CheckState.Checked;
             _checkBoxUseValidatingType.Margin = new Padding(0, 0, 0, 3);
             _checkBoxUseValidatingType.Name = "checkBoxUseValidatingType";
-            // 
+            //
             // maskTryItTable
-            // 
+            //
             resources.ApplyResources(_maskTryItTable, "maskTryItTable");
             _maskTryItTable.ColumnStyles.Add(new ColumnStyle());
             _maskTryItTable.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
@@ -208,27 +208,27 @@ namespace System.Windows.Forms.Design
             _maskTryItTable.Name = "maskTryItTable";
             _maskTryItTable.RowStyles.Add(new RowStyle());
             _maskTryItTable.RowStyles.Add(new RowStyle());
-            // 
+            //
             // lblMask
-            // 
+            //
             resources.ApplyResources(_lblMask, "lblMask");
             _lblMask.Margin = new Padding(0, 0, 3, 3);
             _lblMask.Name = "lblMask";
-            // 
+            //
             // txtBoxMask
-            // 
+            //
             resources.ApplyResources(_txtBoxMask, "txtBoxMask");
             _txtBoxMask.Margin = new Padding(3, 0, 18, 3);
             _txtBoxMask.Name = "txtBoxMask";
-            // 
+            //
             // lblTryIt
-            // 
+            //
             resources.ApplyResources(_lblTryIt, "lblTryIt");
             _lblTryIt.Margin = new Padding(0, 3, 3, 0);
             _lblTryIt.Name = "lblTryIt";
-            // 
+            //
             // overarchingTableLayoutPanel
-            // 
+            //
             resources.ApplyResources(_overarchingTableLayoutPanel, "overarchingTableLayoutPanel");
             _overarchingTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
             _overarchingTableLayoutPanel.Controls.Add(_maskTryItTable, 0, 3);
@@ -241,9 +241,9 @@ namespace System.Windows.Forms.Design
             _overarchingTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
             _overarchingTableLayoutPanel.RowStyles.Add(new RowStyle());
             _overarchingTableLayoutPanel.RowStyles.Add(new RowStyle());
-            // 
+            //
             // okCancelTableLayoutPanel
-            // 
+            //
             resources.ApplyResources(_okCancelTableLayoutPanel, "okCancelTableLayoutPanel");
             _okCancelTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
             _okCancelTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
@@ -252,14 +252,14 @@ namespace System.Windows.Forms.Design
             _okCancelTableLayoutPanel.Margin = new Padding(0, 6, 0, 0);
             _okCancelTableLayoutPanel.Name = "okCancelTableLayoutPanel";
             _okCancelTableLayoutPanel.RowStyles.Add(new RowStyle());
-            // 
+            //
             // errorProvider
-            // 
+            //
             _errorProvider.BlinkStyle = ErrorBlinkStyle.NeverBlink;
             _errorProvider.ContainerControl = this;
-            // 
+            //
             // MaskDesignerDialog
-            // 
+            //
             resources.ApplyResources(this, "$this");
             AcceptButton = _btnOK;
             CancelButton = _btnCancel;
@@ -280,7 +280,6 @@ namespace System.Windows.Forms.Design
             _okCancelTableLayoutPanel.PerformLayout();
             ((ISupportInitialize)(_errorProvider)).EndInit();
             ResumeLayout(false);
-
         }
 
         /// <summary>
@@ -480,11 +479,11 @@ namespace System.Windows.Forms.Design
             _maskDescriptors.Sort(new MaskDescriptorComparer(sortType, _listViewSortOrder));
 
             // Sorting the ListView items forces handle recreation, since we have the items sorted and know what item to select
-            // it is better for us to replace the items ourselves.  This way also avoids problems with the selected item  and 
+            // it is better for us to replace the items ourselves.  This way also avoids problems with the selected item  and
             // the custom entry not getting properly added.
             // this.listViewCannedMasks.Sort();
 
-            // Since we need to pre-process each item before inserting it in the ListView, it is better to remove all items 
+            // Since we need to pre-process each item before inserting it in the ListView, it is better to remove all items
             // from it first and then add the sorted ones back (no replace).  Stop redrawing while we change the list.
 
             UnsafeNativeMethods.SendMessage(_listViewCannedMasks.Handle, Interop.WindowMessages.WM_SETREDRAW, false, /* unused = */ 0);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskPropertyEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskPropertyEditor.cs
@@ -9,13 +9,13 @@ using System.Drawing.Design;
 namespace System.Windows.Forms.Design
 {
     /// <summary>
-    /// Design time editing class for the Mask property of the MaskedTextBox control.   
+    /// Design time editing class for the Mask property of the MaskedTextBox control.
     /// </summary>
     internal class MaskPropertyEditor : UITypeEditor
     {
         /// <summary>
-        /// Gets the mask property value fromt the MaskDesignerDialog.  
-        /// The IUIService is used to show the mask designer dialog within VS so it doesn't get blocked if focus 
+        /// Gets the mask property value fromt the MaskDesignerDialog.
+        /// The IUIService is used to show the mask designer dialog within VS so it doesn't get blocked if focus
         /// is moved to anoter app.
         /// </summary>
         internal static string EditMask(ITypeDiscoveryService discoverySvc, IUIService uiSvc, MaskedTextBox instance, IHelpService helpService)
@@ -86,6 +86,5 @@ namespace System.Windows.Forms.Design
         /// </summary>
         public override UITypeEditorEditStyle GetEditStyle(System.ComponentModel.ITypeDescriptorContext context)
             => UITypeEditorEditStyle.Modal;
-
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxDesigner.cs
@@ -121,7 +121,6 @@ namespace System.Windows.Forms.Design
                 default:
                     Debug.Fail("Unknown RejectionHint, defaulting to InvalidInput...");
                     goto case MaskedTextResultHint.InvalidInput;
-
             }
 
             return string.Format(CultureInfo.CurrentCulture, SR.MaskedTextBoxTextEditorErrorFormatString, e.Position, rejectionHint);
@@ -196,7 +195,7 @@ namespace System.Windows.Forms.Design
 
         /// <summary>
         ///  Shadows the PasswordChar.  UseSystemPasswordChar overrides PasswordChar so independent on the value
-        ///  of PasswordChar it will return the systemp password char.  However, the value of PasswordChar is 
+        ///  of PasswordChar it will return the systemp password char.  However, the value of PasswordChar is
         ///  cached so if UseSystemPasswordChar is reset at design time the PasswordChar value can be restored.
         ///  So in the case both properties are set, we need to serialize the real PasswordChar value as well.
         /// </summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxDesignerActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxDesignerActionList.cs
@@ -9,7 +9,7 @@ using System.Diagnostics;
 namespace System.Windows.Forms.Design
 {
     /// <summary>
-    /// Describes the list of actions that can be performed in the MaskedTextBox control from the 
+    /// Describes the list of actions that can be performed in the MaskedTextBox control from the
     /// Chrome pannel.
     /// </summary>
     internal class MaskedTextBoxDesignerActionList : DesignerActionList

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxTextEditorDropDown.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxTextEditorDropDown.cs
@@ -17,9 +17,9 @@ namespace System.Windows.Forms.Design
             ((System.ComponentModel.ISupportInitialize)(_errorProvider)).BeginInit();
 
             SuspendLayout();
-            // 
+            //
             // maskedTextBox
-            // 
+            //
             _cloneMtb.Dock = DockStyle.Fill;
 
             // Include prompt and literals always so editor can process the text value in a consistent way.
@@ -35,15 +35,15 @@ namespace System.Windows.Forms.Design
             _cloneMtb.MaskInputRejected += new MaskInputRejectedEventHandler(maskedTextBox_MaskInputRejected);
             _cloneMtb.KeyDown += new KeyEventHandler(maskedTextBox_KeyDown);
 
-            // 
+            //
             // errorProvider
-            // 
+            //
             _errorProvider.BlinkStyle = ErrorBlinkStyle.NeverBlink;
             _errorProvider.ContainerControl = this;
 
-            // 
+            //
             // MaskedTextBoxTextEditorDropDown
-            // 
+            //
             Controls.Add(_cloneMtb);
 
             BackColor = System.Drawing.SystemColors.Control;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/NewItemsContextMenuStrip.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/NewItemsContextMenuStrip.cs
@@ -43,7 +43,6 @@ namespace System.Windows.Forms.Design
                         toolItem.Enabled = false;
                     }
                 }
-
             }
             foreach (ToolStripItem item in ToolStripDesignerUtils.GetCustomItemMenuItems(_component, _onClick, _convertTo, _serviceProvider))
             {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
@@ -180,7 +180,6 @@ namespace System.Windows.Forms.Design
                         bounds.X = selectedControl.Location.X + GridSize.Width;
                         bounds.Y = selectedControl.Location.Y + GridSize.Height;
                     }
-
                 }
                 // If we were not given a size, ask the control for its default.  We also update the location here so the control is in the middle of the user's point, rather than at the edge.
                 if (hasSize)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionManager.cs
@@ -132,7 +132,6 @@ namespace System.Windows.Forms.Design
                     if (selType == GlyphSelectionType.SelectedPrimary ||
                         selType == GlyphSelectionType.Selected)
                     {
-
                         if (_curSelectionBounds[_curCompIndex] == Rectangle.Empty)
                         {
                             _curSelectionBounds[_curCompIndex] = bodyGlyph.Bounds;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionStyles.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionStyles.cs
@@ -22,6 +22,5 @@ namespace System.Windows.Forms.Design
         ///  An alternative selection border, indicating that a component is in active editing mode and that clicking and dragging on the component affects the component itself, not its position in the designer.
         /// </summary>
         Active = 0x02,
-
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIService.cs
@@ -1011,7 +1011,6 @@ namespace System.Windows.Forms.Design
             }
             finally
             {
-
                 if (!dragging)
                 {
                     _dragComponents = null;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StandardMenuStripVerb.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StandardMenuStripVerb.cs
@@ -396,7 +396,6 @@ namespace System.Windows.Forms.Design
                 SelectionManager selMgr = (SelectionManager)_provider.GetService(typeof(SelectionManager));
                 selMgr.Refresh();
             }
-
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutControlCollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutControlCollectionCodeDomSerializer.cs
@@ -11,11 +11,11 @@ namespace System.Windows.Forms.Design
 {
     //This is the serializer for TableLayoutControlCollection. It uses the Add(control, col, row)
     //syntax to add a control to the specific cell of the table whenever appropriate.
-    //most of the code is copied from CollectionCodeDomSerializer. 
+    //most of the code is copied from CollectionCodeDomSerializer.
     internal class TableLayoutControlCollectionCodeDomSerializer : CollectionCodeDomSerializer
     {
         /// <summary>
-        ///  Serializes the given collection.  targetExpression will refer to the expression used to rever to the 
+        ///  Serializes the given collection.  targetExpression will refer to the expression used to rever to the
         ///  collection, but it can be null.
         /// </summary>
         protected override object SerializeCollection(IDesignerSerializationManager manager, CodeExpression targetExpression, Type targetType, ICollection originalCollection, ICollection valuesToSerialize)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutPanelCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutPanelCodeDomSerializer.cs
@@ -11,7 +11,7 @@ namespace System.Windows.Forms.Design
 {
     /// <summary>
     ///  Custom serializer for the TableLayoutPanel. We need this so we can push the TableLayoutSettings object
-    ///  into the resx in localization mode. This is used by loc tools like WinRes to correctly setup the 
+    ///  into the resx in localization mode. This is used by loc tools like WinRes to correctly setup the
     ///  TableLayoutPanel with all its settings. Note that we don't serialize code to access the settings.
     /// </summary>
     internal class TableLayoutPanelCodeDomSerializer : CodeDomSerializer
@@ -38,7 +38,7 @@ namespace System.Windows.Forms.Design
             // First call the base serializer to serialize the object.
             object codeObject = GetBaseSerializer(manager).Serialize(manager, value);
 
-            // Now push our layout settings stuff into the resx if we are not inherited read only and 
+            // Now push our layout settings stuff into the resx if we are not inherited read only and
             // are in a localizable Form.
             TableLayoutPanel tlp = value as TableLayoutPanel;
             Debug.Assert(tlp != null, "Huh? We were expecting to be serializing a TableLayoutPanel here.");

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripAdornerWindowService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripAdornerWindowService.cs
@@ -159,7 +159,6 @@ namespace System.Windows.Forms.Design
                     _dropDownCollection = new ArrayList();
                 }
             }
-
         }
 
         /// <summary>
@@ -228,7 +227,6 @@ namespace System.Windows.Forms.Design
                     {
                         _designerFrame = null;
                     }
-
                 }
                 base.Dispose(disposing);
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripCodeDomSerializer.cs
@@ -12,7 +12,7 @@ namespace System.Windows.Forms.Design
         protected override bool HasSitedNonReadonlyChildren(Control parent)
         {
             ToolStrip toolStrip = parent as ToolStrip;
-            
+
             if (toolStrip == null)
             {
                 Debug.Fail("why were we passed a non winbar?");

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
@@ -247,7 +247,6 @@ namespace System.Windows.Forms.Design
                 {
                     _editingCollection--;
                 }
-
             }
         }
 
@@ -783,7 +782,6 @@ namespace System.Windows.Forms.Design
                 }
                 else
                 {
-
                     if (!ItemParentIsOverflow(item))
                     {
                         if (ToolStrip.OverflowButton.DropDown.Visible)
@@ -933,7 +931,6 @@ namespace System.Windows.Forms.Design
                                     int indexToInsert = ToolStrip.Items.IndexOf(selectedItem);
                                     ToolStrip.Items.Insert(indexToInsert, newItem);
                                 }
-
                             }
                             else if (count > 0)
                             {
@@ -1108,7 +1105,6 @@ namespace System.Windows.Forms.Design
                                 KeyboardHandlingService.SelectedDesignerControl = targetSelection;
                             }
                             SelectionService.SetSelectedComponents(null, SelectionTypes.Replace);
-
                         }
                         else
                         {
@@ -1233,7 +1229,6 @@ namespace System.Windows.Forms.Design
                     {
                         selectedItem = (IComponent)KeyboardHandlingService.SelectedDesignerControl;
                     }
-
                 }
                 // if one of the sub-items is selected, delegate to it.
                 if (selectedItem is ToolStripItem)
@@ -1282,7 +1277,6 @@ namespace System.Windows.Forms.Design
                                 itemDesigner != null &&
                                 itemDesigner.IsEditorActive)
                             {
-
                                 itemDesigner.Editor.Commit(false, false);
                             }
                         }
@@ -1396,7 +1390,6 @@ namespace System.Windows.Forms.Design
                 return true;
             }
             return base.GetHitTest(point);
-
         }
 
         /// <summary>
@@ -1928,7 +1921,6 @@ namespace System.Windows.Forms.Design
                             changeParent.Cancel();
                             changeParent = null;
                         }
-
                     }
                     finally
                     {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemCustomMenuItemCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemCustomMenuItemCollection.cs
@@ -379,7 +379,6 @@ namespace System.Windows.Forms.Design
                         dummyIndex++;
                     }
                 }
-
             }
 
             DesignerTransaction newItemTransaction = designerHost.CreateTransaction(SR.ToolStripAddingItem);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemDesigner.cs
@@ -851,7 +851,6 @@ namespace System.Windows.Forms.Design
                         {
                             imageTransProperty.SetValue(newItem, Color.Magenta);
                         }
-
                     }
 
                     parent.Items.Insert(dummyIndex, newItem);
@@ -953,7 +952,6 @@ namespace System.Windows.Forms.Design
                             //this will allow any Glyphs to re-paint
                             //after this control and its designer has painted
                             behaviorService.ProcessPaintMessage(r);
-
                         }
                     }
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripKeyboardHandlingService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripKeyboardHandlingService.cs
@@ -559,7 +559,6 @@ namespace System.Windows.Forms.Design
             {
                 CutOrDeleteInProgress = false;
             }
-
         }
 
         // Handler for Paste Command
@@ -704,7 +703,6 @@ namespace System.Windows.Forms.Design
                 // Process Keys only if we are a ToolStripItem and the TemplateNode is not in Insitu Mode.
                 if (item != null)
                 {
-
                     //only select the last item only if there is an Item added in addition to the TemplateNode...
                     ToolStrip parent = item.GetCurrentParent();
                     int count = parent.Items.Count;
@@ -1243,7 +1241,6 @@ namespace System.Windows.Forms.Design
                                         if (host.GetDesigner(dropDownItem) is ToolStripMenuItemDesigner designer)
                                         {
                                             designer.InitializeDropDown();
-
                                         }
                                     }
                                     return true;
@@ -1257,7 +1254,6 @@ namespace System.Windows.Forms.Design
                             {
                                 ToolStrip mainTool = owner.GetCurrentParent();
                                 targetSelection = GetNextItem(mainTool, owner, ArrowDirection.Left);
-
                             }
                             else
                             {
@@ -1722,7 +1718,6 @@ namespace System.Windows.Forms.Design
                             owner.OverflowButton.HideDropDown();
                         }
                         next = toolStripItem.Owner;
-
                     }
                     else
                     {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemCodeDomSerializer.cs
@@ -10,7 +10,7 @@ namespace System.Windows.Forms.Design
     /// <summary>
     ///  The Reason for having a CustomSerializer for ToolStripMenuItem is the existance of Dummy ToolStripMenuItem for ContextMenuStrips.
     ///  We add this Dummy ToolStripMenuItem on the "Non Site" ToolStrip to Host the DropDown which facilitates the entry of New MenuItems.
-    ///  These items are then added to the ContextMenuStrip that we are designing. 
+    ///  These items are then added to the ContextMenuStrip that we are designing.
     ///  But we dont want the Dummy ToolStripMenuItem to Serialize and hence the need for this Custom Serializer.
     /// </summary>
     internal class ToolStripMenuItemCodeDomSerializer : CodeDomSerializer
@@ -33,13 +33,13 @@ namespace System.Windows.Forms.Design
 
         /// <summary>
         /// We implement this for the abstract method on CodeDomSerializer.  This method
-        /// takes an object graph, and serializes the object into CodeDom elements.  
+        /// takes an object graph, and serializes the object into CodeDom elements.
         /// </summary>
         public override object Serialize(IDesignerSerializationManager manager, object value)
         {
             ToolStripMenuItem item = value as ToolStripMenuItem;
             ToolStrip parent = item.GetCurrentParent() as ToolStrip;
-            
+
             //Dont Serialize if we are Dummy Item ...
             if ((item != null) && !(item.IsOnDropDown) && (parent != null) && (parent.Site == null))
             {
@@ -49,7 +49,7 @@ namespace System.Windows.Forms.Design
             else
             {
                 CodeDomSerializer baseSerializer = (CodeDomSerializer)manager.GetSerializer(typeof(ImageList).BaseType, typeof(CodeDomSerializer));
-                
+
                 return baseSerializer.Serialize(manager, value);
             }
         }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemDesigner.cs
@@ -286,7 +286,6 @@ namespace System.Windows.Forms.Design
                     {
                         return true;
                     }
-
                 }
                 return false;
             }
@@ -2487,7 +2486,6 @@ namespace System.Windows.Forms.Design
                 minIndex++;
             }
             selSvc.SetSelectedComponents(selectedItems);
-
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripTemplateNode.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripTemplateNode.cs
@@ -501,7 +501,6 @@ namespace System.Windows.Forms.Design
                     }
                     _contextMenu = null;
                     ShowDropDownMenu();
-
                 }
                 else
                 {
@@ -1051,7 +1050,6 @@ namespace System.Windows.Forms.Design
             }
             switch (e.KeyCode)
             {
-
                 case Keys.Up:
                     Commit(false, true);
                     if (KeyboardService != null)
@@ -1638,7 +1636,6 @@ namespace System.Windows.Forms.Design
                 ToolStripItem item = GetSelectedItem();
                 if (item is ToolStripControlHost)
                 {
-
                     CommitAndSelectNext(forward);
                     return true;
                 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/CodeDomHelpers.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/CodeDomHelpers.cs
@@ -113,7 +113,7 @@ namespace WinForms.Common.Tests
                 {
                     return "string.Empty";
                 }
-                
+
                 return $"\"{s}\"";
             }
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs
@@ -132,7 +132,6 @@ namespace System.Windows.Forms.Design.Tests
             controlDesigner.Initialize(new Button());
             try
             {
-
                 controlDesigner.HookChildControlsMethod(new Control());
             }
             catch (Exception ex)

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationServiceTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationServiceTests.cs
@@ -277,7 +277,7 @@ namespace System.ComponentModel.Design.Serialization.Tests
             Assert.Null(info.GetValue("Resources", typeof(Hashtable)));
             Assert.Empty(Assert.IsType<List<string>>(info.GetValue("Shim", typeof(List<string>))));
         }
-    
+
         public static IEnumerable<object[]> CreateStore_CloseSerializeWithValidProvider_TestData()
         {
             yield return new object[] { null, null };

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ToolboxItemTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ToolboxItemTests.cs
@@ -1124,7 +1124,6 @@ namespace System.Drawing.Design.Tests
         public void ToolboxItem_Equals_Invoke_ReturnsExpected(ToolboxItem item, object other, bool expected)
         {
             Assert.Equal(expected, item.Equals(other));
-
         }
 
         public static IEnumerable<object[]> FilterPropertyValue_TestData()

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataMemberFieldConverterTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataMemberFieldConverterTests.cs
@@ -14,13 +14,13 @@ namespace System.Windows.Forms.Design.Tests
         private static DataMemberFieldConverter s_converter = new DataMemberFieldConverter();
         private static ITypeDescriptorContext s_context = new MyTypeDescriptorContext();
 
-        [Fact]    
+        [Fact]
         public static void CanConvertFrom()
         {
             Assert.True(s_converter.CanConvertFrom(s_context, typeof(string)));
             Assert.True(s_converter.CanConvertFrom(s_context, typeof(InstanceDescriptor)));
         }
-       
+
         [Theory]
         [InlineData("", "")]
         [InlineData(null, null)]

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.HDI.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.HDI.cs
@@ -47,11 +47,11 @@ internal static partial class Interop
             IMAGE = 0x0020,
 
             /// <summary>
-            /// While handling the message <c>HDM_GETITEM</c>, the header control may not 
-            /// have all the values needed to complete the request. 
-            /// In this case, the control must call the application back for the values 
+            /// While handling the message <c>HDM_GETITEM</c>, the header control may not
+            /// have all the values needed to complete the request.
+            /// In this case, the control must call the application back for the values
             /// via the <c>HDN_GETDISPINFO</c> notification. If <c>DI_SETITEM</c> has been passed
-            /// in the <c>HDM_GETITEM</c> message, the control will cache any values 
+            /// in the <c>HDM_GETITEM</c> message, the control will cache any values
             /// returned from <c>HDN_GETDISPINFO</c> (otherwise the values remain unset.)
             /// </summary>
             DI_SETITEM = 0x0040,
@@ -62,7 +62,7 @@ internal static partial class Interop
             ORDER = 0x0080,
 
             /// <summary>
-            /// The <c>type</c> and <c>pvFilter</c> members are valid. 
+            /// The <c>type</c> and <c>pvFilter</c> members are valid.
             /// This is used to filter out the values specified in the type member.
             /// </summary>
             FILTER = 0x0100,

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.LVIF.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.LVIF.cs
@@ -38,13 +38,13 @@ internal static partial class Interop
 
             /// <summary>
             /// The control will not generate <see cref="System.Windows.Forms.NativeMethods.LVN_GETDISPINFO"/>
-            /// to retrieve text information if it receives an <see cref="LVM.GETITEM"/> message. 
+            /// to retrieve text information if it receives an <see cref="LVM.GETITEM"/> message.
             /// Instead, the <c>pszText</c> member will contain <c>LPSTR_TEXTCALLBACK</c>.
             /// </summary>
             NORECOMPUTE = 0x00000800,
 
             /// <summary>
-            /// The <c>iGroupId</c> member is valid or must be set. 
+            /// The <c>iGroupId</c> member is valid or must be set.
             /// If this flag is not set when an <see cref="LVM.INSERTITEM"/> message is sent,
             /// the value of <c>iGroupId</c> is assumed to be <c>I_GROUPIDCALLBACK</c>.
             /// </summary>
@@ -57,13 +57,13 @@ internal static partial class Interop
 
             /// <summary>
             /// The operating system should store the requested list item information
-            /// and not ask for it again. This flag is used only with the 
+            /// and not ask for it again. This flag is used only with the
             /// <see cref="System.Windows.Forms.NativeMethods.LVN_GETDISPINFO"/> notification code.
             /// </summary>
             DI_SETITEM = 0x00001000,
 
             /// <summary>
-            /// The <c>piColFmt</c> member is valid or must be set. 
+            /// The <c>piColFmt</c> member is valid or must be set.
             /// If this flag is used, the <c>cColumns</c> member is valid or must be set.
             /// </summary>
             COLFMT = 0x00010000,

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.MCM.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.MCM.cs
@@ -136,32 +136,32 @@ internal static partial class Interop
             /// Represents MCM_GETCALENDARGRIDINFO const.
             /// </summary>
             GETCALENDARGRIDINFO = FIRST + 24,
-            
+
             /// <summary>
             /// Represents MCM_GETCALID const.
             /// </summary>
             GETCALID = FIRST + 27,
-            
+
             /// <summary>
             /// Represents MCM_SETCALID const.
             /// </summary>
             SETCALID = FIRST + 28,
-            
+
             /// <summary>
             /// Represents MCM_SIZERECTTOMIN const.
             /// </summary>
             SIZERECTTOMIN = FIRST + 29,
-            
+
             /// <summary>
             /// Represents MCM_SETCALENDARBORDER const.
             /// </summary>
             SETCALENDARBORDER = FIRST + 30,
-            
+
             /// <summary>
             /// Represents MCM_GETCALENDARBORDER const.
             /// </summary>
             GETCALENDARBORDER = FIRST + 31,
-            
+
             /// <summary>
             /// Represents SETCURRENTVIEW const.
             /// </summary>

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.GetUpdateRgn.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.GetUpdateRgn.cs
@@ -1,5 +1,4 @@
-﻿
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Windows.Forms.Primitives/src/Interop/IHandle.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/IHandle.cs
@@ -15,7 +15,7 @@ using System.Runtime.InteropServices;
 ///  of the classes (such as <see cref="System.Windows.Forms.Control"/>) that
 ///  meet this common pattern in interop and encourages correct alignment
 ///  with the proper owner.
-///  
+///
 ///  Note that keeping objects alive is necessary ONLY when the object has
 ///  a finalizer that will explicitly close the handle.
 /// </remarks>

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.LoadLibrary.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.LoadLibrary.cs
@@ -1,5 +1,4 @@
-﻿    
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.MultiByteToWideChar.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.MultiByteToWideChar.cs
@@ -9,10 +9,10 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        // SECREVIEW: From MSDN: Using the MultiByteToWideChar/WideCharToMultiByte function incorrectly can compromise the security of your application. 
-        //            Calling the WideCharToMultiByte function can easily cause a buffer overrun because the size of the In buffer equals the number 
-        //            of WCHARs in the string, while the size of the Out buffer equals the number of bytes. To avoid a buffer overrun, be sure to specify 
-        //            a buffer size appropriate for the data type the buffer receives. For more information, see Security Considerations: International Features. 
+        // SECREVIEW: From MSDN: Using the MultiByteToWideChar/WideCharToMultiByte function incorrectly can compromise the security of your application.
+        //            Calling the WideCharToMultiByte function can easily cause a buffer overrun because the size of the In buffer equals the number
+        //            of WCHARs in the string, while the size of the Out buffer equals the number of bytes. To avoid a buffer overrun, be sure to specify
+        //            a buffer size appropriate for the data type the buffer receives. For more information, see Security Considerations: International Features.
         //            Always call these functions passing a null destination buffer to get its size and the create the buffer with the exact size.
         [DllImport(ExternDll.Kernel32, ExactSpelling = true, CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern int MultiByteToWideChar(int CodePage, int dwFlags, byte[] lpMultiByteStr, int cchMultiByte, char[] lpWideCharStr, int cchWideChar);

--- a/src/System.Windows.Forms.Primitives/src/Interop/Mshtml/Interop.IWebBrowser2.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Mshtml/Interop.IWebBrowser2.cs
@@ -37,101 +37,101 @@ internal partial class Interop
 
             [DispId(-550)]
             void Refresh();
-            
+
             [DispId(105)]
             void Refresh2(
                 ref object level);
-            
+
             [DispId(106)]
             void Stop();
-            
+
             [DispId(200)]
             object Application { [return: MarshalAs(UnmanagedType.IDispatch)]get; }
-            
+
             [DispId(201)]
             object Parent { [return: MarshalAs(UnmanagedType.IDispatch)]get; }
-            
+
             [DispId(202)]
             object Container { [return: MarshalAs(UnmanagedType.IDispatch)]get; }
-            
+
             [DispId(203)]
             object Document { [return: MarshalAs(UnmanagedType.IDispatch)]get; }
-            
+
             [DispId(204)]
             bool TopLevelContainer { get; }
-            
+
             [DispId(205)]
             string Type { get; }
-            
+
             [DispId(206)]
             int Left { get; set; }
-            
+
             [DispId(207)]
             int Top { get; set; }
-            
+
             [DispId(208)]
             int Width { get; set; }
-            
+
             [DispId(209)]
             int Height { get; set; }
-            
+
             [DispId(210)]
             string LocationName { get; }
-            
+
             [DispId(211)]
             string LocationURL { get; }
-            
+
             [DispId(212)]
             bool Busy { get; }
-            
+
             // IWebBrowserApp members
             [DispId(300)]
             void Quit();
-            
+
             [DispId(301)]
             void ClientToWindow(
-                out int pcx, 
+                out int pcx,
                 out int pcy);
-            
+
             [DispId(302)]
             void PutProperty(
                 string property,
                 object vtValue);
-            
+
             [DispId(303)]
             object GetProperty(
                 string property);
-            
+
             [DispId(0)]
             string Name { get; }
-            
+
             [DispId(-515)]
             int HWND { get; }
-            
+
             [DispId(400)]
             string FullName { get; }
-            
+
             [DispId(401)]
             string Path { get; }
-            
+
             [DispId(402)]
             bool Visible { get; set; }
-            
+
             [DispId(403)]
             bool StatusBar { get; set; }
-            
+
             [DispId(404)]
             string StatusText { get; set; }
-            
+
             [DispId(405)]
             int ToolBar { get; set; }
-            
+
             [DispId(406)]
             bool MenuBar { get; set; }
-            
+
             [DispId(407)]
             bool FullScreen { get; set; }
-            
+
             // IWebBrowser2 members
             [DispId(500)]
             void Navigate2(
@@ -161,25 +161,25 @@ internal partial class Interop
 
             [DispId(-525)]
             Ole32.READYSTATE ReadyState { get; }
-            
+
             [DispId(550)]
             bool Offline { get; set; }
-            
+
             [DispId(551)]
             bool Silent { get; set; }
-            
+
             [DispId(552)]
             bool RegisterAsBrowser { get; set; }
-            
+
             [DispId(553)]
             bool RegisterAsDropTarget { get; set; }
-            
+
             [DispId(554)]
             bool TheaterMode { get; set; }
-            
+
             [DispId(555)]
             bool AddressBar { get; set; }
-            
+
             [DispId(556)]
             bool Resizable { get; set; }
         }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Mso/Interop.IMsoComponent.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Mso/Interop.IMsoComponent.cs
@@ -16,7 +16,7 @@ internal static partial class Interop
 
         /// <remarks>
         ///  WM_MOUSEACTIVATE Note (for top level compoenents and host)
-        ///  
+        ///
         ///  If the active (or tracking) comp's reg info indicates that it wants mouse
         ///  messages, then no MA_xxxANDEAT value should be returned  from WM_MOUSEACTIVATE,
         ///  so that the active (or tracking) comp will be able to process the resulting mouse
@@ -87,7 +87,7 @@ internal static partial class Interop
             /// <param name="fActive">
             ///  If <see cref="BOOL.TRUE"/>, the host app is being activated and <paramref name="dwOtherThreadID"/>
             ///  is the ID of the thread owning the window being deactivated.
-            ///  
+            ///
             ///  If <see cref="BOOL.FALSE"/>, the host app is being deactivated and <paramref name="dwOtherThreadID"/>
             ///  is the ID of the thread owning the window being activated.
             /// </param>
@@ -119,11 +119,11 @@ internal static partial class Interop
             ///  bit set, then <paramref name="pic"/> is being activated in "ExclusiveActive" mode.
             ///  Component should retrieve the top frame window that is hosting <paramref name="pic"/>
             ///  (via <see cref="HwndGetWindow"/> with <see cref="msocWindow.FrameToplevel"/>).
-            ///  
+            ///
             ///  If this window is different from component's own top frame window, component should
             ///  disable its windows and do other things it would do when receiving
             ///  <see cref="OnEnterState"/> with <see cref="msocstate.Modal" /> notification.
-            ///  
+            ///
             ///  Otherwise, if component is top-level, it should refuse to have its window activated
             ///  by appropriately processing WM_MOUSEACTIVATE (but see WM_MOUSEACTIVATE NOTE, above).
             ///  Component should remain in one of these states until the exclusive active mode ends,
@@ -136,10 +136,10 @@ internal static partial class Interop
             ///  <paramref name="fSameComponent"/> is TRUE if <paramref name="pic"/> is the same
             ///  component as the callee of this method, and <paramref name="pcrinfo"/> is the
             ///  reg info of <paramref name="pic"/>.
-            ///  
+            ///
             ///  If null and <paramref name="fHostIsActivating"/> is TRUE, then the host is the
             ///  object being activated, and <paramref name="pchostinfo"/> is its host info.
-            ///  
+            ///
             ///  If null and <paramref name="fHostIsActivating"/> is FALSE, then there is no
             ///  current active object.
             /// </param>
@@ -161,11 +161,11 @@ internal static partial class Interop
             ///  Component may periodically call <see cref="IMsoComponentManager.FContinueIdle"/>;
             ///  if this method returns FALSE, component should terminate its idle time
             ///  processing and return.
-            ///  
+            ///
             ///  Note: If a component reaches a point where it has no idle tasks and does not
             ///  need <see cref="FDoIdle"/> calls, it should remove its idle task registration
             ///  via <see cref="IMsoComponentManager.FUpdateComponentRegistration"/>.
-            ///  
+            ///
             ///  Note: If this method is called on while component is performing a tracking
             ///  operation, component should only perform idle time tasks that it deems are
             ///  appropriate to perform during tracking.
@@ -185,7 +185,7 @@ internal static partial class Interop
             ///  This method is called after peeking the next message in the queue (via PeekMessage)
             ///  but before the message is removed from the queue. The peeked message is passed in
             ///  the <paramref name="pMsgPeeked"/> param (null if no message is in the queue).
-            ///  
+            ///
             ///  This method may be additionally called when the next message has already been removed
             ///  from the queue, in which case <paramref name="pMsgPeeked"/> is passed as null.
             /// </remarks>
@@ -198,7 +198,7 @@ internal static partial class Interop
             /// <returns>
             ///  <see cref="BOOL.TRUE"/> if the message loop should continue,
             ///  <see cref="BOOL.FALSE"/> otherwise.
-            ///  
+            ///
             ///  If <see cref="BOOL.FALSE"/> is returned, the component manager terminates the
             ///  loop without removing <paramref name="pMsgPeeked"/> from the queue.
             /// </returns>
@@ -215,7 +215,7 @@ internal static partial class Interop
             /// <remarks>
             ///  If <paramref name="fPromptUser"/> is FALSE, component should simply return
             ///  TRUE if it can terminate, FALSE otherwise.
-            ///  
+            ///
             ///  If <paramref name="fPromptUser"/> is TRUE, component should return TRUE if
             ///  it can terminate without prompting the user; otherwise it should prompt the
             ///  user, either 1.) asking user if it can terminate and returning TRUE or FALSE

--- a/src/System.Windows.Forms.Primitives/src/Interop/Mso/Interop.IMsoComponentManager.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Mso/Interop.IMsoComponentManager.cs
@@ -17,13 +17,13 @@ internal static partial class Interop
 
         /// <remarks>
         ///  ** Comments on State Contexts **
-        ///  
+        ///
         ///  <see cref="FCreateSubComponentManager"/> allows one to create a hierarchical tree of component managers.
         ///  This tree is used to maintain multiple contexts with regard to <see cref="msocstate"/> states. These
         ///  contexts are referred to as 'state contexts'. Each component manager in the tree defines a state context.
         ///  The components registered with a particular component manager or any of its descendents live within that
         ///  component manager's state context.
-        ///  
+        ///
         ///  Calls to <see cref="OnComponentEnterState"/> and <see cref="FOnComponentExitState"/> can be used to affect
         ///  all components, only components within the component manager's state context, or only those components
         ///  that are outside of the component manager's state context. <see cref="FInState"/> is used to query the
@@ -156,7 +156,7 @@ internal static partial class Interop
             ///  component manager in <paramref name="rgpicmExclude"/>, via
             ///  <see cref="IMsoComponent.OnEnterState"/> (see "Comments on State Contexts" in
             ///  <see cref="IMsoComponentManager"/> remarks).
-            ///  
+            ///
             ///  Component Manager should also take appropriate action depending on the value of
             ///  <paramref name="uStateID"/>.
             ///
@@ -200,20 +200,20 @@ internal static partial class Interop
             /// <remarks>
             ///  <paramref name="uContext"/>, <paramref name="cpicmExclude"/>, and <paramref name="rgpicmExclude"/>
             ///  are as they are in <see cref="OnComponentEnterState"/>.
-            ///  
+            ///
             ///  Component manager should notify all appropriate interested components (taking into account
             ///  <paramref name="uContext"/>, <paramref name="cpicmExclude"/>, <paramref name="rgpicmExclude"/>)
             ///  via <see cref="IMsoComponent.OnEnterState" (see "Comments on State Contexts", above).
-            ///  
+            ///
             ///  Component manager should also take appropriate action depending on the value of <paramref name="uStateID"/>.
-            ///  
+            ///
             ///  Note: n calls to this method are symmetric with n calls to <see cref="OnComponentEnterState"/>.
             /// </remarks>
             /// <returns>
             ///  <see cref="BOOL.TRUE"/> if, at the end of this call, the state is still in effect at the root
             ///  of this component manager's state context (because the host or some other component is still in the state),
             ///  otherwise return <see cref="BOOL.FALSE"/> (ie. return what <see cref="FInState"/> would return).
-            ///  
+            ///
             ///  Callers can normally ignore the return value.
             /// </returns>
             [PreserveSig]
@@ -306,7 +306,7 @@ internal static partial class Interop
             ///  Return in <paramref name="ppic"/> an AddRef'ed ptr to the current active
             ///  or tracking component (as indicated by <paramref name="dwgac"/>, and its
             ///  registration information in <paramref name="pcrinfo"/>.
-            ///  
+            ///
             ///  <paramref name="ppic"/> and/or <paramref name="pcrinfo"/> can be
             ///  NULL if caller is not interested these values.  If <paramref name="pcrinfo"/>
             ///  is not <see langword="null" /> caller should set <see cref="MSOCRINFO.cbSize"/>

--- a/src/System.Windows.Forms.Primitives/src/Interop/Mso/Interop.MSOCRINFO.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Mso/Interop.MSOCRINFO.cs
@@ -19,7 +19,7 @@ internal static partial class Interop
             /// <summary>
             ///  The interval time, in milliseconds, of when a periodic idle phase
             ///  should occur. During the idle phase, the component needs to perform
-            ///  idle-time tasks. This member applies only if the msocrfNeedPeriodicIdleTime 
+            ///  idle-time tasks. This member applies only if the msocrfNeedPeriodicIdleTime
             ///  bit flag is registered in the <see cref="grfcrf" /> member.
             /// </summary>
             public uint uIdleTimeInterval;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Mso/Interop.msoccontext.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Mso/Interop.msoccontext.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
         ///  <see cref="IMsoComponentManager.FCreateSubComponentManager" /> allows one to create a hierarchical
         ///  tree of component managers. This tree is used to maintain multiple contexts with regard to
         ///  <see cref="msocstate"/> states. These contexts are referred to as 'state contexts'
-        /// 
+        ///
         ///  Each component manager in the tree defines a state context.  The components registered with a
         ///  particular component manager or any of its descendents live within that component manager's
         ///  state context.  Calls to <see cref="IMsoComponentManager.OnComponentEnterState"/>

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ITextRange.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ITextRange.cs
@@ -85,47 +85,47 @@ internal partial class Interop
             void Select();
 
             int StartOf(
-                int unit, 
+                int unit,
                 int extend);
 
             int EndOf(
-                int unit, 
+                int unit,
                 int extend);
 
             int Move(
-                int unit, 
+                int unit,
                 int count);
 
             int MoveStart(
-                int unit, 
+                int unit,
                 int count);
 
             int MoveEnd(
-                int unit, 
+                int unit,
                 int count);
 
             int MoveWhile(
-                object cset, 
+                object cset,
                 int count);
 
             int MoveStartWhile(
-                object cset, 
+                object cset,
                 int count);
 
             int MoveEndWhile(
-                object cset, 
+                object cset,
                 int count);
 
             int MoveUntil(
-                object cset, 
+                object cset,
                 int count);
 
             int MoveStartUntil(
-                object cset, 
+                object cset,
                 int count);
 
             int MoveEndUntil(
-                object cset, 
+                object cset,
                 int count);
 
             int FindText(

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CopyImage.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CopyImage.cs
@@ -20,7 +20,6 @@ internal static partial class Interop
             return result;
         }
 
-
         public enum IMAGE : uint
         {
             BITMAP       = 0,

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetWindowText.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetWindowText.cs
@@ -32,7 +32,7 @@ internal static partial class Interop
                 // GetWindowTextLengthW returns the length of the text not
                 // including the null terminator.
                 textLength = Math.Max(textLength, GetWindowTextLengthW(hWnd));
-                
+
                 // Use a buffer that has room for at least two additional chars
                 // (one for the null terminator, and one to detect if the text length
                 // has increased).

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.NMHDR.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.NMHDR.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
     {
         /// <remarks>
         /// NMHDR is defined in winuser.h and richedit.h. idFrom is a pointer in winuser.h but is an int
-        /// in richedit.h. The definition in richedit.h is inactive and we use the definition in winuser.h. 
+        /// in richedit.h. The definition in richedit.h is inactive and we use the definition in winuser.h.
         /// </remarks>
         public struct NMHDR
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SystemParametersInfoW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SystemParametersInfoW.cs
@@ -94,7 +94,7 @@ internal static partial class Interop
                     0,
                     dpi);
             }
-            
+
             return SystemParametersInfoW(ref metrics);
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.WindowMessage.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.WindowMessage.cs
@@ -29,7 +29,6 @@ internal static partial class Interop
         public const uint WM_REFLECT = WM_USER + 0x1C00;
         public const uint OCM__BASE  = WM_USER + 0x1C00;
 
-
         public static class RegisteredMessage
         {
             private static uint s_wmUnSubclass = uint.MaxValue;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ClientUtils.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ClientUtils.cs
@@ -55,7 +55,6 @@ namespace System.Windows.Forms
             Debug_SequentialEnumIsDefinedCheck(enumValue, minValue, maxValue);
 #endif
             return valid;
-
         }
 
         // Useful for sequential enum values which only use powers of two 0,1,2,4,8 etc: IsEnumValid(val, min, max, 1)
@@ -181,7 +180,6 @@ namespace System.Windows.Forms
                 }
                 MinValue = actualMinimum;
                 MaxValue = actualMaximum;
-
             }
             public int MinValue;
             public int MaxValue;
@@ -213,7 +211,6 @@ namespace System.Windows.Forms
                     enumValueInfo.Clear();
                 }
                 enumValueInfo[t] = sequentialEnumInfo;
-
             }
             if (minVal != sequentialEnumInfo.MinValue)
             {
@@ -225,7 +222,6 @@ namespace System.Windows.Forms
                 // put string allocation in the IF block so the common case doesnt build up the string.
                 Debug.Fail("Maximum passed in is not the actual maximum for the enum.  Consider changing the parameters or using a different function.");
             }
-
         }
 
         private static void Debug_ValidateMask(Enum value, uint mask)
@@ -269,7 +265,6 @@ namespace System.Windows.Forms
                if (foundValue != isValid) {
                     System.Diagnostics.Debug.Fail(string.Format(CultureInfo.InvariantCulture, "Returning {0} but we actually {1} found the value in the enum! Consider using a different overload to IsValidEnum.", isValid, ((foundValue) ? "have" : "have not")));
                }
-
            }
 #endif
 

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/HighDpiMode.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/HighDpiMode.cs
@@ -1,5 +1,4 @@
-﻿
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,7 +9,7 @@ namespace System.Windows.Forms
     /// </summary>
     /// <remarks>
     ///  <para>
-    ///  Specifying the high DPI mode is dependent on the OS version of the machine you're running your application on. 
+    ///  Specifying the high DPI mode is dependent on the OS version of the machine you're running your application on.
     ///  Setting the high DPI mode will work on machines running Windows 10 Creators Update (version 1703) or later versions.
     ///  </para>
     ///  <para>

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/VisualStyles/TextMetricsCharacterSet.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/VisualStyles/TextMetricsCharacterSet.cs
@@ -25,30 +25,30 @@ namespace System.Windows.Forms.VisualStyles
         Arabic = 178,
         Hebrew = 177,
         Thai = 222,
-        //		#define ANSI_CHARSET            0
-        //		#define BALTIC_CHARSET          186
-        //		#define CHINESEBIG5_CHARSET     136
-        //		#define DEFAULT_CHARSET         1
-        //		#define EASTEUROPE_CHARSET      238
-        //		#define GB2312_CHARSET          134
-        //		#define GREEK_CHARSET           161
-        //		#define HANGUL_CHARSET          129
-        //		#define MAC_CHARSET             77
-        //		#define OEM_CHARSET             255
-        //		#define RUSSIAN_CHARSET         204
-        //		#define SHIFTJIS_CHARSET        128
-        //		#define SYMBOL_CHARSET          2
-        //		#define TURKISH_CHARSET         162
-        //		#define VIETNAMESE_CHARSET      163
+        //      #define ANSI_CHARSET            0
+        //      #define BALTIC_CHARSET          186
+        //      #define CHINESEBIG5_CHARSET     136
+        //      #define DEFAULT_CHARSET         1
+        //      #define EASTEUROPE_CHARSET      238
+        //      #define GB2312_CHARSET          134
+        //      #define GREEK_CHARSET           161
+        //      #define HANGUL_CHARSET          129
+        //      #define MAC_CHARSET             77
+        //      #define OEM_CHARSET             255
+        //      #define RUSSIAN_CHARSET         204
+        //      #define SHIFTJIS_CHARSET        128
+        //      #define SYMBOL_CHARSET          2
+        //      #define TURKISH_CHARSET         162
+        //      #define VIETNAMESE_CHARSET      163
 
         // Korean
-        //		#define JOHAB_CHARSET           130
+        //      #define JOHAB_CHARSET           130
 
         // Middle East
-        //		#define ARABIC_CHARSET          178
-        //		#define HEBREW_CHARSET          177
+        //      #define ARABIC_CHARSET          178
+        //      #define HEBREW_CHARSET          177
 
         // Thai
-        //		#define THAI_CHARSET            222
+        //      #define THAI_CHARSET            222
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/Interop/Mso/IMsoComponentManagerTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/Interop/Mso/IMsoComponentManagerTests.cs
@@ -135,7 +135,6 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Mso
             Assert.Equal(BOOL.FALSE, manager.FSetTrackingComponent(default, BOOL.FALSE));
         }
 
-
         [Fact]
         public void FSetTrackingComponent()
         {
@@ -187,7 +186,6 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Mso
             manager.OnComponentEnterState(default, msocstate.Modal, msoccontext.Mine, 0, null, 0);
             mock.Verify(m => m.OnEnterState(msocstate.Modal, BOOL.TRUE), Times.Exactly(2));
         }
-
 
         [Fact]
         public void FOnComponentExitState_HandlesNull()

--- a/src/System.Windows.Forms.Primitives/tests/Interop/NtDll/RtlGetVersionTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/Interop/NtDll/RtlGetVersionTests.cs
@@ -5,7 +5,6 @@
 using Xunit;
 using static Interop.NtDll;
 
-
 namespace System.Windows.Forms.Primitives.Tests.Interop.NtDll
 {
     public class RtlGetVersionTests

--- a/src/System.Windows.Forms/src/System/Drawing/Design/PropertyValueUIItem.cs
+++ b/src/System.Windows.Forms/src/System/Drawing/Design/PropertyValueUIItem.cs
@@ -32,5 +32,4 @@ namespace System.Drawing.Design
         /// <summary>Resets the UI item.</summary>
         public virtual void Reset() { }
     }
-
 }

--- a/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
@@ -362,7 +362,6 @@ namespace System.Resources
                     nodeInfo.MimeType = ResXResourceWriter.DefaultSerializedObjectMimeType;
                 }
             }
-
         }
 
         private object GenerateObjectFromDataNodeInfo(DataNodeInfo dataNodeInfo, ITypeResolutionService typeResolver)
@@ -518,7 +517,6 @@ namespace System.Resources
                     // serialize to string inside the nodeInfo
                     FillDataNodeInfoFromObject(nodeInfo, value);
                 }
-
             }
             return nodeInfo;
         }
@@ -556,7 +554,6 @@ namespace System.Resources
             }
             else if (nodeInfo != null)
             {
-
                 // we dont have a fileref, try to resolve the type of the datanode
                 result = nodeInfo.TypeName;
                 // if typename is null, the default is just a string
@@ -705,7 +702,6 @@ namespace System.Resources
             Type resolvedType = null;
             if (typeResolver != null)
             {
-
                 // If we cannot find the strong-named type, then try to see
                 // if the TypeResolver can bind to partial names. For this,
                 // we will strip out the partial names and keep the rest of the
@@ -714,7 +710,6 @@ namespace System.Resources
                 resolvedType = typeResolver.GetType(typeName, false);
                 if (resolvedType == null)
                 {
-
                     string[] typeParts = typeName.Split(',');
 
                     // Break up the type name from the rest of the assembly strong name.

--- a/src/System.Windows.Forms/src/System/Resources/ResXFileRef.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXFileRef.cs
@@ -91,7 +91,6 @@ namespace System.Resources
                 if ((path1[i] != path2[i]) && (compareCase || (char.ToLower(path1[i], CultureInfo.InvariantCulture) != char.ToLower(path2[i], CultureInfo.InvariantCulture))))
                 {
                     break;
-
                 }
                 if (path1[i] == Path.DirectorySeparatorChar)
                 {

--- a/src/System.Windows.Forms/src/System/Resources/ResXResourceReader.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXResourceReader.cs
@@ -15,7 +15,6 @@ using System.Xml;
 
 namespace System.Resources
 {
-
     /// <summary>
     ///  ResX resource reader.
     /// </summary>
@@ -419,7 +418,6 @@ namespace System.Resources
 
             if (resHeaderMimeType == ResXResourceWriter.ResMimeType)
             {
-
                 Type readerType = typeof(ResXResourceReader);
                 Type writerType = typeof(ResXResourceWriter);
 
@@ -680,14 +678,12 @@ namespace System.Resources
         {
             int indexStart = typeName.IndexOf(',');
             return typeName.Substring(indexStart + 2);
-
         }
 
         private string GetTypeFromTypeName(string typeName)
         {
             int indexStart = typeName.IndexOf(',');
             return typeName.Substring(0, indexStart);
-
         }
 
         private sealed class ReaderAliasResolver : IAliasResolver
@@ -701,7 +697,6 @@ namespace System.Resources
 
             public AssemblyName ResolveAlias(string alias)
             {
-
                 AssemblyName result = null;
                 if (cachedAliases != null)
                 {
@@ -717,7 +712,6 @@ namespace System.Resources
                     cachedAliases[alias] = name;
                 }
             }
-
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleEvents.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleEvents.cs
@@ -49,7 +49,7 @@ namespace System.Windows.Forms
 
         /// <summary>
         /// <c>EVENT_SYSTEM_MENUPOPUPSTART</c>
-        ///  Sent when a menu popup comes up. 
+        ///  Sent when a menu popup comes up.
         /// </summary>
         /// <remarks>
         ///  Note that for a call to TrackPopupMenu(), a client will see <c>EVENT_SYSTEM_MENUSTART</c>
@@ -60,7 +60,7 @@ namespace System.Windows.Forms
 
         /// <summary>
         /// <c>EVENT_SYSTEM_MENUPOPUPEND</c>
-        ///  Sent when a menu popup just before it is taken down. 
+        ///  Sent when a menu popup just before it is taken down.
         /// </summary>
         /// <remarks>
         ///  Note that for a call to TrackPopupMenu(), a client will see <c>EVENT_SYSTEM_MENUSTART</c>
@@ -116,7 +116,7 @@ namespace System.Windows.Forms
         ///  Sent when a window enters drag drop mode.
         /// </summary>
         /// <seealso cref="SystemDragDropEnd"/>.
-        //  Note that it is up to apps and OLE to generate this, since the system doesn't know. 
+        //  Note that it is up to apps and OLE to generate this, since the system doesn't know.
         //  Like <c>EVENT_SYSTEM_SOUND</c>, it will be a while before this is prevalent.
         SystemDragDropStart = 0x000E,
 
@@ -125,7 +125,7 @@ namespace System.Windows.Forms
         ///  Sent when a window leaves drag drop mode.
         /// </summary>
         /// <seealso cref="SystemDragDropStart"/>.
-        //  Note that it is up to apps and OLE to generate this, since the system doesn't know. 
+        //  Note that it is up to apps and OLE to generate this, since the system doesn't know.
         //  Like <c>EVENT_SYSTEM_SOUND</c>, it will be a while before this is prevalent.
         SystemDragDropEnd = 0x000F,
 
@@ -211,36 +211,36 @@ namespace System.Windows.Forms
 
         /// <summary>
         ///  <c>EVENT_OBJECT_CREATE</c>
-        ///  Sent when an object has been created. 
+        ///  Sent when an object has been created.
         ///  The system sends this event for the following user interface elements:
-        ///  caret, header control, list-view control, tab control, toolbar control, tree view control, 
+        ///  caret, header control, list-view control, tab control, toolbar control, tree view control,
         ///  and window object. Server applications send this event for their accessible objects.
         /// </summary>
         Create = 0x8000,                // hwnd + ID + idChild is created item
 
         /// <summary>
         ///  <c>EVENT_OBJECT_DESTROY</c>
-        ///  Sent when an object has been destroyed. 
+        ///  Sent when an object has been destroyed.
         ///  The system sends this event for the following user interface elements:
-        ///  caret, header control, list-view control, tab control, toolbar control, tree view control, 
+        ///  caret, header control, list-view control, tab control, toolbar control, tree view control,
         ///  and window object. Server applications send this event for their accessible objects.
         /// </summary>
         Destroy = 0x8001,               // hwnd + ID + idChild is destroyed item
 
         /// <summary>
         /// <c>EVENT_OBJECT_SHOW</c>
-        ///  Sent when a hidden object is shown. 
+        ///  Sent when a hidden object is shown.
         ///  The system sends this event for the following user interface elements:
         ///  caret, cursor, and window object. Server applications send this event for their accessible objects.
-        ///  Clients assume that when this event is sent by a parent object, all child objects are already displayed. 
+        ///  Clients assume that when this event is sent by a parent object, all child objects are already displayed.
         ///  Therefore, server applications do not send this event for the child objects.
         /// </summary>
         Show = 0x8002,                  // hwnd + ID + idChild is shown item
 
         /// <summary>
         /// <c>EVENT_OBJECT_HIDE</c>
-        ///  Sent when an object is hidden. 
-        ///  The system sends this event for the following user interface elements: caret and cursor. 
+        ///  Sent when an object is hidden.
+        ///  The system sends this event for the following user interface elements: caret and cursor.
         ///  Server applications send this event for their accessible objects.
         ///  When this event is generated for a parent object, all child objects are already hidden.
         ///  Server applications do not send this event for the child objects.
@@ -250,7 +250,7 @@ namespace System.Windows.Forms
         /// <summary>
         /// <c>EVENT_OBJECT_REORDER</c>
         ///  Sent when a container object has added, removed, or reordered its children.
-        ///  The system sends this event for the following user interface elements: 
+        ///  The system sends this event for the following user interface elements:
         ///  header control, list-view control, toolbar control, and window object.
         ///  Server applications send this event as appropriate for their accessible objects.
         /// </summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -1133,7 +1133,6 @@ namespace System.Windows.Forms
                 }
                 return;
             }
-
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
@@ -310,7 +310,6 @@ namespace System.Windows.Forms
 
                 if (!DpiHelper.IsScalingRequirementMet || CommonUnsafeNativeMethods.TryFindDpiAwarenessContextsEqual(context, DpiAwarenessContext.DPI_AWARENESS_CONTEXT_UNSPECIFIED))
                 {
-
                     Debug.Assert(_parkingWindows.Count == 1, "parkingWindows count can not be > 1 for legacy OS/target framework versions");
                     return _parkingWindows[0];
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -19,7 +19,7 @@ namespace System.Windows.Forms
 {
     /// <summary>
     ///  Provides <see langword='static'/> methods and properties to manage an application, such as methods to run and quit an application,
-    ///  to process Windows messages, and properties to get information about an application. 
+    ///  to process Windows messages, and properties to get information about an application.
     ///  This class cannot be inherited.
     /// </summary>
     public sealed partial class Application

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ArrangedElement.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ArrangedElement.cs
@@ -79,12 +79,10 @@ namespace System.Windows.Forms
             get { return CommonProperties.GetMargin(this); }
             set
             {
-
                 Debug.Assert((value.Right >= 0 && value.Left >= 0 && value.Top >= 0 && value.Bottom >= 0), "who's setting margin negative?");
                 value = LayoutUtils.ClampNegativePaddingToZero(value);
                 if (Margin != value)
                 { CommonProperties.SetMargin(this, value); }
-
             }
         }
 
@@ -201,9 +199,7 @@ namespace System.Windows.Forms
                 OnBoundsChanged(oldBounds, bounds);
             }
         }
-
     }
-
 }
 
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.cs
@@ -103,7 +103,6 @@ namespace System.Windows.Forms
             object IReflect.InvokeMember(string name, BindingFlags invokeAttr, Binder binder,
                                                     object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters)
             {
-
                 foreach (DictionaryEntry e in containerCache)
                 {
                     string ctlName = GetNameForControl((Control)e.Key);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPerPropertyBrowsingEnum.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPerPropertyBrowsingEnum.cs
@@ -70,7 +70,6 @@ namespace System.Windows.Forms
 
                 try
                 {
-
                     // marshal the items.
                     object[] nameItems = nameMarshaller.Items;
                     object[] cookieItems = valueMarshaller.Items;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPropertyDescriptor.cs
@@ -84,7 +84,6 @@ namespace System.Windows.Forms
             {
                 get
                 {
-
                     if (dispid != null)
                     {
                         UpdateTypeConverterAndTypeEditorInternal(false, Dispid);
@@ -319,7 +318,6 @@ namespace System.Windows.Forms
             /// </summary>
             internal unsafe void UpdateTypeConverterAndTypeEditorInternal(bool force, Ole32.DispatchID dispid)
             {
-
                 // check to see if we're being forced here or if the work really
                 // needs to be done.
                 //
@@ -391,9 +389,7 @@ namespace System.Windows.Forms
                                     {
                                         axEnum.RefreshArrays(stringMarshaler, intMarshaler);
                                     }
-
                                 }
-
                             }
                             else
                             {
@@ -503,14 +499,12 @@ namespace System.Windows.Forms
 
             public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
             {
-
                 // make sure the converter has been properly refreshed -- calling
                 // the Converter property does this.
                 //
                 TypeConverter tc = this;
                 tc = target.Converter;
                 return base.GetStandardValues(context);
-
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
@@ -101,7 +101,6 @@ namespace System.Windows.Forms
                             {
                                 InitializeFromStream(new MemoryStream(dat));
                             }
-
                         }
                         catch (Exception e)
                         {
@@ -119,7 +118,6 @@ namespace System.Windows.Forms
                                 PropertyBagBinary = new PropertyBagStream();
                                 PropertyBagBinary.Read(new MemoryStream(dat));
                             }
-
                         }
                         catch (Exception e)
                         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -3688,7 +3688,7 @@ namespace System.Windows.Forms
             qaContainer.dwAmbientFlags = Ole32.QACONTAINERFLAGS.AUTOCLIP | Ole32.QACONTAINERFLAGS.MESSAGEREFLECT | Ole32.QACONTAINERFLAGS.SUPPORTSMNEMONICS;
             if (IsUserMode())
             {
-                // In design mode we'd ideally set QACONTAINER_UIDEAD on dwAmbientFlags 
+                // In design mode we'd ideally set QACONTAINER_UIDEAD on dwAmbientFlags
                 // so controls don't take keyboard input, but MFC controls return NOWHERE on
                 // NCHITTEST, which messes up the designer.
                 qaContainer.dwAmbientFlags |= Ole32.QACONTAINERFLAGS.USERMODE;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Binding.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Binding.cs
@@ -1285,7 +1285,6 @@ namespace System.Windows.Forms
                     _bindingManager.IsBinding &&
                     !(_bindingManager is CurrencyManager))
                 {
-
                     _fieldInfo.RemoveValueChanged(_bindingManager.Current, new EventHandler(PropValueChanged));
                 }
 
@@ -1311,7 +1310,6 @@ namespace System.Windows.Forms
                     if (_fieldInfo != null && _bindingManager.IsBinding &&
                         !(_bindingManager is CurrencyManager))
                     {
-
                         _fieldInfo.AddValueChanged(_bindingManager.Current, new EventHandler(PropValueChanged));
                     }
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingManagerBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingManagerBase.cs
@@ -165,7 +165,6 @@ namespace System.Windows.Forms
                         }
                     }
                 }
-
             }
             else
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingManagerDataErrorEventHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingManagerDataErrorEventHandler.cs
@@ -5,5 +5,4 @@
 namespace System.Windows.Forms
 {
     public delegate void BindingManagerDataErrorEventHandler(object sender, BindingManagerDataErrorEventArgs e);
-
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingNavigator.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingNavigator.cs
@@ -297,7 +297,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 if (movePreviousItem != null && movePreviousItem.IsDisposed)
                 {
                     movePreviousItem = null;
@@ -419,7 +418,6 @@ namespace System.Windows.Forms
                     deleteItemUserEnabled = value.Enabled;
                 }
                 WireUpButton(ref deleteItem, value, new EventHandler(OnDelete));
-
             }
         }
 
@@ -938,7 +936,5 @@ namespace System.Windows.Forms
                 RefreshItemsInternal();
             }
         }
-
     }
-
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Button.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Button.cs
@@ -67,7 +67,6 @@ namespace System.Windows.Forms
             }
             set
             {
-
                 if (!ClientUtils.IsEnumValid(value, (int)value, (int)AutoSizeMode.GrowAndShrink, (int)AutoSizeMode.GrowOnly))
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(AutoSizeMode));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
@@ -217,7 +217,6 @@ namespace System.Windows.Forms
                     else
                     {
                         cp.Style |= (int)User32.BS.CENTER;
-
                     }
                     if ((int)(align & WindowsFormsUtils.AnyTopAlign) != 0)
                     {
@@ -1150,7 +1149,6 @@ namespace System.Windows.Forms
             // call base last, so if it invokes any listeners that disable the button, we
             // don't have to recheck
             base.OnKeyUp(kevent);
-
         }
 
         /// <summary>
@@ -1277,7 +1275,6 @@ namespace System.Windows.Forms
                 {
                     return false;
                 }
-
             }
             set
             {
@@ -1406,7 +1403,6 @@ namespace System.Windows.Forms
                     return state;
                 }
             }
-
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonBaseAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonBaseAdapter.cs
@@ -179,7 +179,6 @@ namespace System.Windows.Forms.ButtonInternal
 
             using (WindowsGraphics wg = WindowsGraphics.FromGraphics(g))
             {
-
                 // Draw counter-clock-wise.
                 Point p1 = new Point(bounds.X + bounds.Width - 1, bounds.Y);  // upper inner right.
                 Point p2 = new Point(bounds.X, bounds.Y);  // upper left.
@@ -293,7 +292,6 @@ namespace System.Windows.Forms.ButtonInternal
         {
             using (WindowsGraphics wg = WindowsGraphics.FromGraphics(g))
             {
-
                 // Draw counter-clock-wise.
                 Point p1 = new Point(bounds.X + bounds.Width - 1, bounds.Y);  // upper inner right.
                 Point p2 = new Point(bounds.X, bounds.Y);  // upper left.
@@ -375,7 +373,6 @@ namespace System.Windows.Forms.ButtonInternal
 
             using (WindowsGraphics wg = WindowsGraphics.FromGraphics(g))
             {
-
                 // Draw counter-clock-wise.
                 Point p1 = new Point(bounds.X + bounds.Width - 1, bounds.Y);  // upper inner right.
                 Point p2 = new Point(bounds.X, bounds.Y);  // upper left.
@@ -501,7 +498,6 @@ namespace System.Windows.Forms.ButtonInternal
         {
             using (WindowsGraphics wg = WindowsGraphics.FromGraphics(g))
             {
-
                 // Draw counter-clock-wise.
                 Point p1 = new Point(r.Right - 1, r.Top);  // upper inner right.
                 Point p2 = new Point(r.Left, r.Top);  // upper left.
@@ -1325,7 +1321,6 @@ namespace System.Windows.Forms.ButtonInternal
 
             internal ContentAlignment RtlTranslateContent(ContentAlignment align)
             {
-
                 if (layoutRTL)
                 {
                     ContentAlignment[][] mapping = new ContentAlignment[3][];
@@ -1504,7 +1499,6 @@ namespace System.Windows.Forms.ButtonInternal
 
                     layout.imageBounds = LayoutUtils.Align(size, maxBounds, imageAlign);
                     layout.textBounds = LayoutUtils.Align(textSize, maxBounds, textAlign);
-
                 }
                 else
                 {
@@ -1630,7 +1624,6 @@ namespace System.Windows.Forms.ButtonInternal
                 //********** bottom = Math.Min(layout.imageBounds.Bottom, maxBounds.Bottom);
                 //********** layout.imageBounds.Y = Math.Max(layout.imageBounds.Y, maxBounds.Y);
                 //********** layout.imageBounds.Height = bottom - layout.imageBounds.Y;
-
             }
 
             protected virtual Size GetTextSize(Size proposedSize)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonPopupAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonPopupAdapter.cs
@@ -103,7 +103,6 @@ namespace System.Windows.Forms.ButtonInternal
                        highlight = new Pen(colors.highlight),
                        buttonShadow = new Pen(colors.buttonShadow))
                 {
-
                     // top, left white
                     g.DrawLine(windowFrame, r.Left + 1, r.Top + 1, r.Right - 2, r.Top + 1);
                     g.DrawLine(windowFrame, r.Left + 1, r.Top + 1, r.Left + 1, r.Bottom - 2);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/CheckBoxBaseAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/CheckBoxBaseAdapter.cs
@@ -83,7 +83,6 @@ namespace System.Windows.Forms.ButtonInternal
                 }
             }
             DrawCheckOnly(e, layout, colors, checkColor, checkBackground);
-
         }
 
         // used by DataGridViewCheckBoxCell
@@ -199,12 +198,10 @@ namespace System.Windows.Forms.ButtonInternal
         {
             using (WindowsGraphics wg = WindowsGraphics.FromGraphics(g))
             {
-
                 using (WindowsPen high = new WindowsPen(wg.DeviceContext, colors.highlight),
                    shadow = new WindowsPen(wg.DeviceContext, colors.buttonShadow),
                    face = new WindowsPen(wg.DeviceContext, colors.buttonFace))
                 {
-
                     wg.DrawLine(high, r.Right - 1, r.Top, r.Right - 1, r.Bottom);
                     wg.DrawLine(high, r.Left, r.Bottom - 1, r.Right, r.Bottom - 1);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/CheckableControlBaseAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/CheckableControlBaseAdapter.cs
@@ -99,6 +99,5 @@ namespace System.Windows.Forms.ButtonInternal
 
             return g.DpiX / 96;
         }
-
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/RadioButtonBaseAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/RadioButtonBaseAdapter.cs
@@ -43,7 +43,6 @@ namespace System.Windows.Forms.ButtonInternal
                        light = new Pen(colors.buttonFace),
                        lightlight = new Pen(colors.highlight))
                 {
-
                     bounds.Width--;
                     bounds.Height--;
                     // fall a little short of SW, NW, NE, SE because corners come out nasty
@@ -100,7 +99,7 @@ namespace System.Windows.Forms.ButtonInternal
             }
         }
 
-        // Helper method to overcome the poor GDI ellipse drawing routine		
+        // Helper method to overcome the poor GDI ellipse drawing routine
         private static void DrawAndFillEllipse(WindowsGraphics wg, WindowsPen borderPen, WindowsBrush fieldBrush, Rectangle bounds)
         {
             Debug.Assert(wg != null, "Calling DrawAndFillEllipse with null wg");
@@ -188,7 +187,6 @@ namespace System.Windows.Forms.ButtonInternal
             }
 
             return style;
-
         }
 
         protected void DrawCheckBox(PaintEventArgs e, LayoutData layout)
@@ -234,6 +232,5 @@ namespace System.Windows.Forms.ButtonInternal
 
             return layout;
         }
-
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonRenderer.cs
@@ -246,7 +246,6 @@ namespace System.Windows.Forms
         {
             switch (state)
             {
-
                 case PushButtonState.Pressed:
                     return ButtonState.Pushed;
                 case PushButtonState.Disabled:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckBox.cs
@@ -66,7 +66,6 @@ namespace System.Windows.Forms
 
             autoCheck = true;
             TextAlign = ContentAlignment.MiddleLeft;
-
         }
 
         private bool AccObjDoDefaultAction
@@ -255,7 +254,6 @@ namespace System.Windows.Forms
 
                 if (checkState != value)
                 {
-
                     bool oldChecked = Checked;
 
                     checkState = value;
@@ -320,7 +318,6 @@ namespace System.Windows.Forms
                     {
                         cp.Style |= (int)User32.BS.RIGHTBUTTON;
                     }
-
                 }
 
                 return cp;
@@ -518,7 +515,7 @@ namespace System.Windows.Forms
             {
                 AccessibilityNotifyClients(AccessibleEvents.SystemCaptureEnd, -1);
             }
-            
+
             ((EventHandler)Events[EVENT_CHECKEDCHANGED])?.Invoke(this, e);
         }
 
@@ -531,7 +528,7 @@ namespace System.Windows.Forms
             {
                 Refresh();
             }
-            
+
             ((EventHandler)Events[EVENT_CHECKSTATECHANGED])?.Invoke(this, e);
         }
 
@@ -673,7 +670,6 @@ namespace System.Windows.Forms
                     {
                         OnClick(EventArgs.Empty);
                     }
-
                 }
                 return true;
             }
@@ -769,7 +765,6 @@ namespace System.Windows.Forms
                         cb.AccObjDoDefaultAction = false;
                     }
                 }
-
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckBoxRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckBoxRenderer.cs
@@ -104,7 +104,6 @@ namespace System.Windows.Forms
                     ControlPaint.DrawCheckBox(g, glyphBounds, ConvertToButtonState(state));
                 }
             }
-
         }
 
         /// <summary>
@@ -233,7 +232,6 @@ namespace System.Windows.Forms
         {
             switch (state)
             {
-
                 case CheckBoxState.CheckedNormal:
                 case CheckBoxState.CheckedHot:
                     return ButtonState.Checked;
@@ -320,7 +318,6 @@ namespace System.Windows.Forms
         {
             switch (state)
             {
-
                 case CheckBoxState.MixedNormal:
                 case CheckBoxState.MixedHot:
                 case CheckBoxState.MixedPressed:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
@@ -90,7 +90,6 @@ namespace System.Windows.Forms
             // If a long item is drawn with ellipsis, we must redraw the ellipsed part
             // as well as the newly uncovered region.
             SetStyle(ControlStyles.ResizeRedraw, true);
-
         }
 
         /// <summary>
@@ -569,7 +568,6 @@ namespace System.Windows.Forms
         {
             base.OnHandleCreated(e);
             SendMessage((int)User32.LB.SETITEMHEIGHT, 0, ItemHeight);
-
         }
 
         /// <summary>
@@ -922,7 +920,6 @@ namespace System.Windows.Forms
         {
             base.OnSelectedIndexChanged(e);
             lastSelected = SelectedIndex;
-
         }
 
         /// <summary>
@@ -1112,7 +1109,6 @@ namespace System.Windows.Forms
             /// </summary>
             public int Add(object item, CheckState check)
             {
-
                 //validate the enum that's passed in here
                 //
                 // Valid values are 0-2 inclusive.
@@ -1296,7 +1292,6 @@ namespace System.Windows.Forms
                     return -1;
                 }
             }
-
         }
 
         public class CheckedItemCollection : IList
@@ -1562,7 +1557,6 @@ namespace System.Windows.Forms
 
             public override AccessibleObject HitTest(int x, int y)
             {
-
                 // Within a child element?
                 //
                 int count = GetChildCount();
@@ -1728,7 +1722,6 @@ namespace System.Windows.Forms
                     }
 
                     return state;
-
                 }
             }
 
@@ -1789,6 +1782,5 @@ namespace System.Windows.Forms
                 }
             }
         }
-
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Clipboard.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Clipboard.cs
@@ -35,7 +35,6 @@ namespace System.Windows.Forms
                             break;
                         default:
                             return false;
-
                     }
                 }
                 return true;
@@ -185,7 +184,7 @@ namespace System.Windows.Forms
                 {
                     throw new ThreadStateException(SR.ThreadMustBeSTA);
                 }
-                
+
                 return null;
             }
 
@@ -223,7 +222,7 @@ namespace System.Windows.Forms
                 {
                     return ido;
                 }
-                
+
                 return new DataObject(dataObject);
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
@@ -112,7 +112,6 @@ namespace System.Windows.Forms
 
             set
             {
-
                 // When the list is being deserialized we need
                 // to take the display index as is. ListView
                 // does correctly synchronize the indices.
@@ -137,7 +136,6 @@ namespace System.Windows.Forms
                 ColumnHeader movedHdr = null;
                 for (int i = 0; i < listview.Columns.Count; i++)
                 {
-
                     ColumnHeader hdr = listview.Columns[i];
                     if (hdr.DisplayIndex == DisplayIndexInternal)
                     {
@@ -303,7 +301,6 @@ namespace System.Windows.Forms
                     Site.Name = value;
                 }
             }
-
         }
 
         /// <summary>
@@ -334,7 +331,6 @@ namespace System.Windows.Forms
                     listview.SetColumnInfo(LVCF.TEXT, this);
                 }
             }
-
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeaderConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeaderConverter.cs
@@ -53,7 +53,6 @@ namespace System.Windows.Forms
                     {
                         id = new InstanceDescriptor(ctor, new object[] { col.ImageIndex }, false);
                     }
-
                 }
 
                 if (id == null && !string.IsNullOrEmpty(col.ImageKey))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -269,7 +269,6 @@ namespace System.Windows.Forms
             {
                 if (autoCompleteCustomSource != value)
                 {
-
                     if (autoCompleteCustomSource != null)
                     {
                         autoCompleteCustomSource.CollectionChanged -= new CollectionChangeEventHandler(OnAutoCompleteCustomSourceChanged);
@@ -426,7 +425,6 @@ namespace System.Windows.Forms
                 }
                 switch (DrawMode)
                 {
-
                     case DrawMode.OwnerDrawFixed:
                         cp.Style |= NativeMethods.CBS_OWNERDRAWFIXED;
                         break;
@@ -548,7 +546,6 @@ namespace System.Windows.Forms
                     {
                         SendMessage(NativeMethods.CB_SETDROPPEDWIDTH, value, 0);
                     }
-
                 }
             }
         }
@@ -617,7 +614,6 @@ namespace System.Windows.Forms
 
             set
             {
-
                 if (!IsHandleCreated)
                 {
                     CreateHandle();
@@ -740,13 +736,11 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 DrawMode drawMode = DrawMode;
                 if (drawMode == DrawMode.OwnerDrawFixed ||
                     drawMode == DrawMode.OwnerDrawVariable ||
                     !IsHandleCreated)
                 {
-
                     int itemHeight = Properties.GetInteger(PropItemHeight, out bool found);
                     if (found)
                     {
@@ -967,7 +961,6 @@ namespace System.Windows.Forms
             {
                 if (!FormattingEnabled)
                 {
-
                     //do preferred height the old broken way for everett apps
                     //we need this for compat reasons because (get this)
                     //  (a) everett preferredheight was always wrong.
@@ -1061,7 +1054,6 @@ namespace System.Windows.Forms
                     strings[i] = AutoCompleteCustomSource[i];
                 }
                 return strings;
-
             }
             else if (collection is ObjectCollection)
             {
@@ -1071,7 +1063,6 @@ namespace System.Windows.Forms
                     strings[i] = GetItemText(itemsCollection[i]);
                 }
                 return strings;
-
             }
             return Array.Empty<string>();
         }
@@ -1092,7 +1083,6 @@ namespace System.Windows.Forms
             {
                 if (IsHandleCreated)
                 {
-
                     return unchecked((int)(long)SendMessage(NativeMethods.CB_GETCURSEL, 0, 0));
                 }
                 else
@@ -1118,7 +1108,6 @@ namespace System.Windows.Forms
                     if (IsHandleCreated)
                     {
                         SendMessage(NativeMethods.CB_SETCURSEL, value, 0);
-
                     }
                     else
                     {
@@ -1326,7 +1315,6 @@ namespace System.Windows.Forms
             {
                 if (DropDownStyle != value)
                 {
-
                     // verify that 'value' is a valid enum type...
                     //valid values are 0x0 to 0x2
                     if (!ClientUtils.IsEnumValid(value, (int)value, (int)ComboBoxStyle.Simple, (int)ComboBoxStyle.DropDownList))
@@ -1366,7 +1354,6 @@ namespace System.Windows.Forms
             {
                 if (SelectedItem != null && !BindingFieldEmpty)
                 {
-
                     //preserve everett behavior if "formatting enabled == false" -- just return selecteditem text.
                     if (FormattingEnabled)
                     {
@@ -1409,7 +1396,6 @@ namespace System.Windows.Forms
                     else if (value != null &&
                         (selectedItem == null || (string.Compare(value, GetItemText(selectedItem), false, CultureInfo.CurrentCulture) != 0)))
                     {
-
                         int index = FindStringIgnoreCase(value);
 
                         //we cannot set the index to -1 unless we want to do something unusual and save/restore text
@@ -1664,7 +1650,6 @@ namespace System.Windows.Forms
             int comboYMid = PARAM.SignedHIWORD(m.LParam) + (editRectMid.top - comboRectMid.top);
 
             return new Point(comboXMid, comboYMid);
-
         }
 
         /// <summary>
@@ -2198,7 +2183,6 @@ namespace System.Windows.Forms
             if (DropDownStyle == ComboBoxStyle.DropDown
                 || DropDownStyle == ComboBoxStyle.DropDownList)
             {
-
                 proposedHeight = PreferredHeight;
             }
 
@@ -2236,7 +2220,6 @@ namespace System.Windows.Forms
 
             if (IsHandleCreated)
             {
-
                 int h = unchecked((int)(long)SendMessage(NativeMethods.CB_GETITEMHEIGHT, index, 0));
                 if (h == -1)
                 {
@@ -2537,7 +2520,6 @@ namespace System.Windows.Forms
                 IntPtr hwnd = User32.GetWindow(new HandleRef(this, Handle), User32.GW.CHILD);
                 if (hwnd != IntPtr.Zero)
                 {
-
                     // if it's a simple dropdown list, the first HWND is the list box.
                     //
                     if (DropDownStyle == ComboBoxStyle.Simple)
@@ -2610,7 +2592,6 @@ namespace System.Windows.Forms
                 }
             }
             // NOTE: Setting SelectedIndex must be the last thing we do.
-
         }
 
         /// <summary>
@@ -2918,7 +2899,6 @@ namespace System.Windows.Forms
                 {
                     SetAutoComplete(true, false);
                 }
-
             }
         }
 
@@ -3241,7 +3221,6 @@ namespace System.Windows.Forms
         {
             if (childEdit != null)
             {
-
                 // We do not use UI Automation provider for child edit, so do not need to release providers.
                 childEdit.ReleaseHandle();
                 childEdit = null;
@@ -3249,7 +3228,6 @@ namespace System.Windows.Forms
 
             if (childListBox != null)
             {
-
                 // Need to notify UI Automation that it can safely remove all map entries that refer to the specified window.
                 ReleaseUiaProvider(childListBox.Handle);
 
@@ -3259,7 +3237,6 @@ namespace System.Windows.Forms
 
             if (childDropDown != null)
             {
-
                 // Need to notify UI Automation that it can safely remove all map entries that refer to the specified window.
                 ReleaseUiaProvider(childDropDown.Handle);
 
@@ -3329,7 +3306,6 @@ namespace System.Windows.Forms
                         }
                         else
                         {
-
                             if (stringSource == null)
                             {
                                 stringSource = new StringSource(GetStringsForAutoComplete(AutoCompleteCustomSource));
@@ -3342,7 +3318,6 @@ namespace System.Windows.Forms
                             {
                                 stringSource.RefreshList(GetStringsForAutoComplete(AutoCompleteCustomSource));
                             }
-
                         }
                     }
                 }
@@ -3358,7 +3333,6 @@ namespace System.Windows.Forms
                             }
                             else
                             {
-
                                 if (stringSource == null)
                                 {
                                     stringSource = new StringSource(GetStringsForAutoComplete(Items));
@@ -3371,7 +3345,6 @@ namespace System.Windows.Forms
                                 {
                                     stringSource.RefreshList(GetStringsForAutoComplete(Items));
                                 }
-
                             }
                         }
                     }
@@ -3918,7 +3891,6 @@ namespace System.Windows.Forms
                         {
                             OnClick(new MouseEventArgs(MouseButtons.Left, 1, PARAM.SignedLOWORD(m.LParam), PARAM.SignedHIWORD(m.LParam), 0));
                             OnMouseClick(new MouseEventArgs(MouseButtons.Left, 1, PARAM.SignedLOWORD(m.LParam), PARAM.SignedHIWORD(m.LParam), 0));
-
                         }
                         base.WndProc(ref m);
                     }
@@ -3988,7 +3960,6 @@ namespace System.Windows.Forms
                                 {
                                     User32.EndPaint(new HandleRef(this, Handle), ref ps);
                                 }
-
                             }
                             return;
                         }
@@ -4078,7 +4049,6 @@ namespace System.Windows.Forms
                     case WindowMessages.WM_MOUSEMOVE:
                         if (_childWindowType == ChildWindowType.DropDownList)
                         {
-
                             // Need to track the selection change via mouse over to
                             // raise focus changed event for the items. Monitoring
                             // item change in setters does not guarantee that focus
@@ -4152,7 +4122,6 @@ namespace System.Windows.Forms
                 //
                 if (unchecked((int)(long)m.LParam) == User32.OBJID.CLIENT)
                 {
-
                     // Get the IAccessible GUID
                     //
                     Guid IID_IAccessible = new Guid(NativeMethods.uuid_IAccessible);
@@ -4195,7 +4164,6 @@ namespace System.Windows.Forms
                     DefWndProc(ref m);
                 }
             }
-
         }
 
         private sealed class ItemComparer : IComparer
@@ -4332,7 +4300,6 @@ namespace System.Windows.Forms
 
             private int AddInternal(object item)
             {
-
                 if (item == null)
                 {
                     throw new ArgumentNullException(nameof(item));
@@ -4406,7 +4373,6 @@ namespace System.Windows.Forms
 
             internal void AddRangeInternal(IList items)
             {
-
                 if (items == null)
                 {
                     throw new ArgumentNullException(nameof(items));
@@ -4457,7 +4423,6 @@ namespace System.Windows.Forms
 
             internal void ClearInternal()
             {
-
                 if (owner.IsHandleCreated)
                 {
                     owner.NativeClear();
@@ -4542,7 +4507,6 @@ namespace System.Windows.Forms
                     InnerList.Insert(index, item);
                     if (owner.IsHandleCreated)
                     {
-
                         bool successful = false;
 
                         try
@@ -4602,7 +4566,6 @@ namespace System.Windows.Forms
             /// </summary>
             public void Remove(object value)
             {
-
                 int index = InnerList.IndexOf(value);
 
                 if (index != -1)
@@ -4652,7 +4615,6 @@ namespace System.Windows.Forms
                     }
                 }
             }
-
         } // end ObjectCollection
 
         [ComVisible(true)]
@@ -6343,7 +6305,6 @@ namespace System.Windows.Forms
                     dropDownRect.X = clientRect.Width - dropDownRect.Right;
                     whiteFillRect.X = clientRect.Width - whiteFillRect.Right + 1;  // since we're filling, we need to move over to the next px.
                 }
-
             }
 
             public bool IsValid(ComboBox combo)
@@ -6433,7 +6394,6 @@ namespace System.Windows.Forms
 
                     using (Pen borderPen = new Pen(borderPenColor))
                     {
-
                         Pen innerPen = (comboBox.Enabled) ? borderPen : SystemPens.Control;
 
                         // around the dropdown
@@ -6448,10 +6408,8 @@ namespace System.Windows.Forms
 
                         // around the whole combobox.
                         g.DrawRectangle(borderPen, outerBorder);
-
                     }
                 }
-
             }
 
             /// <summary>
@@ -6459,7 +6417,6 @@ namespace System.Windows.Forms
             /// </summary>
             protected virtual void DrawFlatComboDropDown(ComboBox comboBox, Graphics g, Rectangle dropDownRect)
             {
-
                 g.FillRectangle(SystemBrushes.Control, dropDownRect);
 
                 Brush brush = (comboBox.Enabled) ? SystemBrushes.ControlText : SystemBrushes.ControlDark;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Command.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Command.cs
@@ -177,7 +177,7 @@ namespace System.Windows.Forms
             {
                 return false;
             }
-            
+
             executor.Execute();
             return true;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2AboutBoxPropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2AboutBoxPropertyDescriptor.cs
@@ -188,7 +188,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             {
                 return UITypeEditorEditStyle.Modal;
             }
-
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ColorConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ColorConverter.cs
@@ -64,12 +64,10 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             if (managedValue is Color)
             {
                 return ColorTranslator.ToOle(((Color)managedValue));
-
             }
             Debug.Fail("Don't know how to set type:" + managedValue.GetType().Name);
             return 0;
         }
-
     }
 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2Enum.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2Enum.cs
@@ -147,7 +147,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         {
             if (v != null)
             {
-
                 // in case this is a real enum...try to convert it.
                 //
                 if (values.Length > 0 && v.GetType() != values[0].GetType())

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ICategorizePropertiesHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ICategorizePropertiesHandler.cs
@@ -24,7 +24,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             {
                 return null;
             }
-    
+
             switch (categoryID)
             {
                 case VSSDK.PROPCAT.Nil:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IManagedPerPropertyBrowsingHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IManagedPerPropertyBrowsingHandler.cs
@@ -75,7 +75,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             Type[] types = new Type[attrTypeNames.Length];
             for (int i = 0; i < attrTypeNames.Length; i++)
             {
-
                 string attrName = attrTypeNames[i];
 
                 // try the name first
@@ -89,7 +88,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
                 if (t == null)
                 {
-
                     // check for an assembly name.
                     //
                     string assemblyName = string.Empty;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IPerPropertyBrowsingHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IPerPropertyBrowsingHandler.cs
@@ -90,7 +90,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             {
                 if (sender.TargetObject is Ole32.IPerPropertyBrowsing)
                 {
-
                     // if we are using the dropdown, don't convert the value
                     // or the values will change when we select them and call back
                     // for the display value.
@@ -171,7 +170,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 //
                 if (!hasStrings)
                 {
-
                     // this is a _bit_ of a backwards-compat work around...
                     // many older ActiveX controls will show a property page
                     // for all properties since the old grid would only put up the
@@ -204,7 +202,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
             public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destType)
             {
-
                 if (destType == typeof(string) && !itemsEnum.arraysFetched)
                 {
                     object curValue = itemsEnum.target.GetValue(itemsEnum.target.TargetObject);
@@ -298,7 +295,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
                     if (nameItems.Length > 0)
                     {
-
                         object[] valueItems = new object[cookieItems.Length];
                         var var = new Ole32.VARIANT();
                         int cookie;
@@ -347,7 +343,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                                 itemCount++;
                                 continue;
                             }
-                            
+
                             if (itemCount > 0)
                             {
                                 // shorten the arrays to ignore the failed ones.  this isn't terribly
@@ -356,7 +352,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                                 Array.Copy(nameItems, i, nameItems, i + 1, itemCount);
                                 Array.Copy(valueItems, i, valueItems, i + 1, itemCount);
                             }
-
                         }
 
                         // pass this data down to the base Com2Enum object...
@@ -385,7 +380,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
             public override string ToString(object v)
             {
-
                 // If the value is the object's current value, then
                 // ask GetDisplay string first.  This is a perf improvement
                 // because this way we don't populate the arrays when an object is selected, only
@@ -393,7 +387,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 //
                 if (target.IsCurrentValue(v))
                 {
-
                     bool success = false;
 
                     string displayString = Com2IPerPropertyBrowsingHandler.GetDisplayString((Ole32.IPerPropertyBrowsing)target.TargetObject, target.DISPID, ref success);
@@ -410,6 +403,5 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 return base.ToString(v);
             }
         }
-
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IProvidePropertyBuilderHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IProvidePropertyBuilderHandler.cs
@@ -43,7 +43,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 propDesc[i].QueryGetBaseAttributes += new GetAttributesEventHandler(OnGetBaseAttributes);
 
                 propDesc[i].QueryGetTypeConverterAndTypeEditor += new GetTypeConverterAndTypeEditorEventHandler(OnGetTypeConverterAndTypeEditor);
-
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IVsPerPropertyBrowsingHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IVsPerPropertyBrowsingHandler.cs
@@ -66,7 +66,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 propDesc[i].QueryResetValue += new Com2EventHandler(OnResetPropertyValue);
 
                 propDesc[i].QueryGetTypeConverterAndTypeEditor += new GetTypeConverterAndTypeEditorEventHandler(OnGetTypeConverterAndTypeEditor);
-
             }
         }
 
@@ -147,7 +146,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         {
             if (sender.TargetObject is VSSDK.IVsPerPropertyBrowsing vsObj)
             {
-
                 // get the localized name, if applicable
                 string[] pNameString = new string[1];
                 HRESULT hr = vsObj.GetLocalizedPropertyInfo(sender.DISPID, CultureInfo.CurrentCulture.LCID, pNameString, null);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2Properties.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2Properties.cs
@@ -116,7 +116,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             typeInfoVersions = GetTypeInfoVersions(obj);
 
             touchedTime = DateTime.Now.Ticks;
-
         }
 
         internal bool AlwaysValid
@@ -279,7 +278,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 //
                 if (t.IsInstanceOfType(target))
                 {
-
                     // since handlers must be stateless, check to see if we've already
                     // created one of this type
                     //
@@ -323,7 +321,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
             if (props != null)
             {
-
                 Disposed?.Invoke(this, EventArgs.Empty);
 
                 weakObjRef = null;
@@ -426,7 +423,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 }
                 return versionOffset;
             }
-
         }
 
         private unsafe long GetTypeInfoVersion(UnsafeNativeMethods.ITypeInfo pTypeInfo)
@@ -449,7 +445,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 }
                 catch
                 {
-
                     return 0;
                 }
 
@@ -500,7 +495,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             //
             if (valid && checkVersions)
             {
-
                 //
                 long[] newTypeInfoVersions = GetTypeInfoVersions(weakObjRef.Target);
 
@@ -514,7 +508,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                     //
                     for (int i = 0; i < newTypeInfoVersions.Length; i++)
                     {
-
                         if (newTypeInfoVersions[i] != typeInfoVersions[i])
                         {
                             valid = false;
@@ -525,7 +518,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
                 if (!valid)
                 {
-
                     // update to the new version list we have.
                     //
                     typeInfoVersions = newTypeInfoVersions;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyBuilderUITypeEditor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyBuilderUITypeEditor.cs
@@ -92,7 +92,5 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         {
             return UITypeEditorEditStyle.Modal;
         }
-
     }
-
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
@@ -201,7 +201,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         {
             get
             {
-
                 if (GetNeedsRefresh(Com2PropertyDescriptorRefresh.BaseAttributes))
                 {
                     SetNeedsRefresh(Com2PropertyDescriptorRefresh.BaseAttributes, false);
@@ -291,7 +290,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 inAttrQuery = true;
                 try
                 {
-
                     // demand get any extended attributes
                     ArrayList attrList = new ArrayList();
 
@@ -330,7 +328,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
                 return base.Attributes;
             }
-
         }
 
         /// <summary>
@@ -881,7 +878,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 editor = base.GetEditor(editorBaseType);
             }
             return editor;
-
         }
 
         /// <summary>
@@ -1514,7 +1510,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         public GetAttributesEvent(ArrayList attrList)
         {
             this.attrList = attrList;
-
         }
 
         public void Add(Attribute attribute)
@@ -1634,5 +1629,4 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             }
         }
     }
-
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2TypeInfoProcessor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2TypeInfoProcessor.cs
@@ -652,7 +652,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                         if (funcDesc.invkind == Ole32.INVOKEKIND.FUNC ||
                             (dispidToGet != Ole32.DispatchID.MEMBERID_NIL && funcDesc.memid != dispidToGet))
                         {
-
                             if (funcDesc.memid == Ole32.DispatchID.ABOUTBOX)
                             {
                                 addAboutBox = true;
@@ -667,10 +666,8 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
                         if (isPropGet)
                         {
-
                             if (funcDesc.cParams != 0)
                             {
-
                                 continue;
                             }
 
@@ -684,7 +681,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                             Debug.Assert(funcDesc.lprgelemdescParam != null, "ELEMDESC param is null!");
                             if (funcDesc.lprgelemdescParam == null || funcDesc.cParams != 1)
                             {
-
                                 continue;
                             }
 
@@ -829,7 +825,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                     // just build our enumerator
                     if (strs.Count > 0)
                     {
-
                         // get the IUnknown value of the ITypeInfo
                         IntPtr pTypeInfoUnk = Marshal.GetIUnknownForObject(enumTypeInfo);
 
@@ -870,7 +865,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                             }
                         }
                     }
-
                 }
                 finally
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.cs
@@ -261,7 +261,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             // walk the list every so many calls
             if ((++clearCount % CLEAR_INTERVAL) == 0)
             {
-
                 lock (nativeProps)
                 {
                     clearCount = 0;
@@ -274,7 +273,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                     //
                     foreach (DictionaryEntry de in nativeProps)
                     {
-
                         entry = de.Value as Com2Properties;
 
                         if (entry != null && entry.TooOld)
@@ -439,20 +437,17 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
                 lock (nativeProps)
                 {
-
                     // find the key
                     object key = propsInfo.TargetObject;
 
                     if (key == null && nativeProps.ContainsValue(propsInfo))
                     {
-
                         // need to find it - the target object has probably been cleaned out
                         // of the Com2Properties object already, so we run through the
                         // hashtable looking for the value, so we know what key to remove.
                         //
                         foreach (DictionaryEntry de in nativeProps)
                         {
-
                             if (de.Value == propsInfo)
                             {
                                 key = de.Key;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/Int32CAMarshaler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/Int32CAMarshaler.cs
@@ -42,5 +42,4 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             return addr.ToInt32();
         }
     }
-
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -25,7 +25,7 @@ namespace System.Windows.Forms
         /// <remarks>
         ///  The current focused control. Do not directly edit this value.
         /// </remarks>
-        private Control _focusedControl; 
+        private Control _focusedControl;
 
         /// <remarks>
         ///  The last control that requires validation. Do not directly edit this value.
@@ -694,7 +694,7 @@ namespace System.Windows.Forms
                 User32.ClientToScreen(new HandleRef(this, Handle), ref topLeftPoint);
                 return new Rectangle(topLeftPoint.X, topLeftPoint.Y, clientRectangle.right, clientRectangle.bottom);
             }
-            
+
             return base.GetToolNativeScreenRectangle();
         }
 
@@ -1313,7 +1313,7 @@ namespace System.Windows.Forms
             {
                 current = current.ParentInternal;
             }
-            
+
             return (ScrollableControl)current;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContextMenuStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContextMenuStrip.cs
@@ -84,7 +84,6 @@ namespace System.Windows.Forms
                     ToolStripMenuItem menuItem = item as ToolStripMenuItem;
                     contextMenuStrip.Items.Add(menuItem.Clone());
                 }
-
             }
             return contextMenuStrip;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -315,7 +315,6 @@ namespace System.Windows.Forms
                      dwSaveOption == Ole32.OLECLOSE.PROMPTSAVE) &&
                     _activeXState[s_isDirty])
                 {
-
                     if (_clientSite != null)
                     {
                         _clientSite.SaveObject();
@@ -645,7 +644,7 @@ namespace System.Windows.Forms
                         Debug.Unindent();
                         return true;
                     }
-                    
+
                     Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "IDispatch::Invoke failed. HR: 0x" + string.Format(CultureInfo.CurrentCulture, "{0:X}", hr));
                 }
 
@@ -1042,7 +1041,7 @@ namespace System.Windows.Forms
                 {
                     return HRESULT.S_OK;
                 }
-                
+
                 return HRESULT.S_FALSE;
             }
 
@@ -1769,7 +1768,6 @@ namespace System.Windows.Forms
                     [UnmanagedFunctionPointer(CallingConvention.StdCall)]
                     private delegate int AdviseD(IntPtr This, IntPtr punkEventSink, out uint pdwCookie);
                 }
-
             }
 
             /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
@@ -339,7 +339,6 @@ namespace System.Windows.Forms
                          previous != null;
                          previous = container.GetNextControl(previous, false))
                     {
-
                         // Stop when we hit a Label (whether visible or invisible)
                         if (previous is Label label)
                         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlCollection.cs
@@ -427,7 +427,6 @@ namespace System.Windows.Forms
                     {
                         return null;
                     }
-
                 }
             }
 
@@ -512,7 +511,6 @@ namespace System.Windows.Forms
                 child.UpdateZOrder();
 
                 LayoutTransaction.DoLayout(Owner, child, PropertyNames.ChildIndex);
-
             }
 
             /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ExtendedStates.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ExtendedStates.cs
@@ -56,7 +56,7 @@ namespace System.Windows.Forms
             IsActiveX = 0x00000400,
 
             UserPreferredSizeCache = 0x00000800,
-    
+
             TopMDIWindowClosing = 0x00001000,
 
             /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.Ime.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.Ime.cs
@@ -1231,7 +1231,6 @@ namespace System.Windows.Forms
                 default:
                     if (ImeModeConversion.ImeModeConversionBits.ContainsKey(imeMode))
                     {
-
                         // Update the conversion status
                         //
                         ImeModeConversion conversionEntry = (ImeModeConversion)ImeModeConversion.ImeModeConversionBits[imeMode];
@@ -1320,9 +1319,9 @@ namespace System.Windows.Forms
 
         /// <summary>
         ///  Supported input language ImeMode tables.
-        ///  	WARNING: Do not try to map 'active' IME modes from one table to another since they can have a different
-        ///  			 meaning depending on the language; for instance ImeMode.Off means 'disable' or 'alpha' to Chinese
-        ///  			 but to Japanese it is 'alpha' and to Korean it has no meaning.
+        ///     WARNING: Do not try to map 'active' IME modes from one table to another since they can have a different
+        ///              meaning depending on the language; for instance ImeMode.Off means 'disable' or 'alpha' to Chinese
+        ///              but to Japanese it is 'alpha' and to Korean it has no meaning.
         /// </summary>
         private static readonly ImeMode[] japaneseTable = {
             ImeMode.Inherit,
@@ -1445,7 +1444,6 @@ namespace System.Windows.Forms
             {
                 if (imeModeConversionBits == null)
                 {
-
                     // Create ImeModeConversionBits dictionary
                     imeModeConversionBits = new Dictionary<ImeMode, ImeModeConversion>(7);
                     ImeModeConversion conversion;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -930,7 +930,6 @@ namespace System.Windows.Forms
                     {
                         return c;
                     }
-
                 }
 
                 if (IsActiveX)
@@ -1462,7 +1461,6 @@ namespace System.Windows.Forms
                     OnContextMenuStripChanged(EventArgs.Empty);
                 }
             }
-
         }
 
         [SRCategory(nameof(SR.CatPropertyChanged)), SRDescription(nameof(SR.ControlContextMenuStripChangedDescr))]
@@ -2264,7 +2262,6 @@ namespace System.Windows.Forms
 
                 if (ambient != null && ambient.Font != null)
                 {
-
                     FontHandleWrapper fontHandle = null;
 
                     Font currentAmbient = (Font)Properties.GetObject(s_currentAmbientFontProperty);
@@ -3765,7 +3762,6 @@ namespace System.Windows.Forms
                                 WindowMessages.WM_CHANGEUISTATE,
                                 (IntPtr)(actionMask | (int)User32.UIS.SET),
                                 IntPtr.Zero);
-
                     }
                 }
                 return (_uiCuesState & UICuesStates.FocusMask) == UICuesStates.FocusShow;
@@ -3885,7 +3881,7 @@ namespace System.Windows.Forms
                 {
                     return true;
                 }
-                
+
                 return ParentInternal.Visible;
             }
             set => SetVisibleCore(value);
@@ -4978,7 +4974,6 @@ namespace System.Windows.Forms
                 _window.CreateHandle(cp);
 
                 UpdateReflectParent(true);
-
             }
             finally
             {
@@ -5211,7 +5206,6 @@ namespace System.Windows.Forms
 
                     if (controlsCollection != null)
                     {
-
                         // PERFNOTE: This is more efficient than using Foreach.  Foreach
                         // forces the creation of an array subset enum each time we
                         // enumerate
@@ -5235,7 +5229,6 @@ namespace System.Windows.Forms
             }
             else
             {
-
 #if FINALIZATION_WATCH
                 if (!GetState(States.DISPOSED)) {
                     Debug.Fail("Control of type '" + GetType().FullName +"' is being finalized that wasn't disposed\n" + allocationSite);
@@ -5438,7 +5431,6 @@ namespace System.Windows.Forms
                     {
                         Invalidate();
                     }
-
                 }
                 return true;
             }
@@ -8998,7 +8990,6 @@ namespace System.Windows.Forms
             // For every child control of this container control...
             foreach (Control c in Controls)
             {
-
                 // First, if the control is a container, recurse into its descendants.
                 if ((validationConstraints & ValidationConstraints.ImmediateChildren) != ValidationConstraints.ImmediateChildren &&
                     c.ShouldPerformContainerValidation() &&
@@ -10047,7 +10038,6 @@ namespace System.Windows.Forms
             */
             if (!performLayout)
             {
-
                 CommonProperties.xClearPreferredSizeCache(this);
                 ControlCollection controlsCollection = (ControlCollection)Properties.GetObject(s_controlsCollectionProperty);
 
@@ -10063,7 +10053,6 @@ namespace System.Windows.Forms
                     }
                 }
             }
-
         }
 
         /// <summary>
@@ -10177,7 +10166,6 @@ namespace System.Windows.Forms
             }
 
             LayoutTransaction.DoLayout(this, this, PropertyNames.Bounds);
-
         }
 
         /// <summary>
@@ -10578,7 +10566,6 @@ namespace System.Windows.Forms
                         && (!tabStopOnly || ctl.TabStop)
                         && (nested || ctl._parent == this))
                     {
-
                         if (ctl._parent is ToolStrip)
                         {
                             continue;
@@ -10817,7 +10804,6 @@ namespace System.Windows.Forms
             }
             finally
             {
-
                 // Initialize the scaling engine.
                 InitScaling(specified);
 
@@ -11104,7 +11090,7 @@ namespace System.Windows.Forms
                 if (!DesiredVisibility && !value && IsHandleCreated)
                 {
                     // PERF - setting Visible=false twice can get us into this else block
-                    // which makes us process WM_WINDOWPOS* messages - make sure we've already 
+                    // which makes us process WM_WINDOWPOS* messages - make sure we've already
                     // visible=false - if not, make it so.
                     if (!User32.IsWindowVisible(this).IsTrue())
                     {
@@ -11289,7 +11275,6 @@ namespace System.Windows.Forms
         {
             if (RightToLeft.Yes == RightToLeft)
             {
-
                 if ((align & WindowsFormsUtils.AnyTopAlign) != 0)
                 {
                     switch (align)
@@ -11759,7 +11744,6 @@ namespace System.Windows.Forms
                     {
                         break;
                     }
-
                 }
 
                 if (lastParentHandle != IntPtr.Zero)
@@ -11778,7 +11762,6 @@ namespace System.Windows.Forms
         {
             OnMouseCaptureChanged(EventArgs.Empty);
             DefWndProc(ref m);
-
         }
 
         /// <summary>
@@ -12342,7 +12325,6 @@ namespace System.Windows.Forms
                         //In Whidbey .. if the click in by MOUSE then pass the MouseEventArgs...
                         OnClick(new MouseEventArgs(button, clicks, PARAM.SignedLOWORD(m.LParam), PARAM.SignedHIWORD(m.LParam), 0));
                         OnMouseClick(new MouseEventArgs(button, clicks, PARAM.SignedLOWORD(m.LParam), PARAM.SignedHIWORD(m.LParam), 0));
-
                     }
 
                     else
@@ -12351,7 +12333,6 @@ namespace System.Windows.Forms
                         OnDoubleClick(new MouseEventArgs(button, 2, PARAM.SignedLOWORD(m.LParam), PARAM.SignedHIWORD(m.LParam), 0));
                         OnMouseDoubleClick(new MouseEventArgs(button, 2, PARAM.SignedLOWORD(m.LParam), PARAM.SignedHIWORD(m.LParam), 0));
                     }
-
                 }
 
                 //call the MouseUp Finally...
@@ -12598,7 +12579,6 @@ namespace System.Windows.Forms
                                     PaintWithErrorHandling(pevent, PaintLayerBackground);
                                     // Consider: This condition could be elimiated,
                                     //           do we have to save/restore the state of the buffered graphics?
-
                                 }
                             }
                             finally
@@ -12685,7 +12665,6 @@ namespace System.Windows.Forms
             {
                 DefWndProc(ref m);
             }
-
         }
 
         /// <summary>
@@ -12795,7 +12774,6 @@ namespace System.Windows.Forms
 
             if ((_state & States.Recreate) == 0)
             {
-
                 bool visible = m.WParam != IntPtr.Zero;
                 bool oldVisibleProperty = Visible;
 
@@ -12894,14 +12872,12 @@ namespace System.Windows.Forms
             UICues UIcues = UICues.None;
             if (((User32.UISF)PARAM.HIWORD(m.WParam) & User32.UISF.HIDEACCEL) != 0)
             {
-
                 // yes, clear means show.  nice api, guys.
                 //
                 bool showKeyboard = (cmd == User32.UIS.CLEAR);
 
                 if (showKeyboard != keyboard || !keyboardInitialized)
                 {
-
                     UIcues |= UICues.ChangeKeyboard;
 
                     // clear the old state.
@@ -12956,7 +12932,6 @@ namespace System.Windows.Forms
             if (_parent != null && User32.GetParent(new HandleRef(_window, InternalHandle)) == _parent.InternalHandle &&
                 (_state & States.NoZOrder) == 0)
             {
-
                 User32.WINDOWPOS* wp = (User32.WINDOWPOS*)m.LParam;
                 if ((wp->flags & User32.SWP.NOZORDER) == 0)
                 {
@@ -13454,7 +13429,6 @@ namespace System.Windows.Forms
                 return false;
             }
         }
-
 
         ///
         ///  Explicit support of DropTarget

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
@@ -561,7 +561,6 @@ namespace System.Windows.Forms
                     imageAttrib.SetWrapMode(WrapMode.TileFlipXY);
                     g.DrawImage(backgroundImage, imageRectangle, 0, 0, backgroundImage.Width, backgroundImage.Height, GraphicsUnit.Pixel, imageAttrib);
                     imageAttrib.Dispose();
-
                 }
             }
         }
@@ -1425,7 +1424,6 @@ namespace System.Windows.Forms
             {
                 if (checkImage == null || checkImage.Width != rectangle.Width || checkImage.Height != rectangle.Height)
                 {
-
                     if (checkImage != null)
                     {
                         checkImage.Dispose();
@@ -1539,7 +1537,7 @@ namespace System.Windows.Forms
                     g2.Clear(Color.Transparent);
 
                     using (WindowsGraphics wg = WindowsGraphics.FromGraphics(g2))
-                    { 
+                    {
                         // Get Win32 dc with Graphics properties applied to it.
                         User32.DrawFrameControl(new HandleRef(wg, wg.DeviceContext.Hdc), ref rcFrame, kind, state);
                     }
@@ -1654,7 +1652,6 @@ namespace System.Windows.Forms
             if (gridBrush == null || gridSize.Width != pixelsBetweenDots.Width
                 || gridSize.Height != pixelsBetweenDots.Height || invert != gridInvert)
             {
-
                 if (gridBrush != null)
                 {
                     gridBrush.Dispose();
@@ -2119,7 +2116,6 @@ namespace System.Windows.Forms
             {
                 using (Pen dark = new Pen(Dark(backColor)))
                 {
-
                     int minDim = Math.Min(width, height);
                     int right = x + width - 1;
                     int bottom = y + height - 2;
@@ -2369,7 +2365,6 @@ namespace System.Windows.Forms
             if (frameBrushActive == null ||
                 !frameColorActive.Equals(brushColor))
             {
-
                 if (frameBrushActive != null)
                 {
                     frameBrushActive.Dispose();
@@ -2421,7 +2416,6 @@ namespace System.Windows.Forms
                 focusPenColor.ToArgb() != baseColor.ToArgb() ||
                 hcFocusPen != highContrast)
             {
-
                 if (focusPen != null)
                 {
                     focusPen.Dispose();
@@ -2500,7 +2494,6 @@ namespace System.Windows.Forms
             if (frameBrushSelected == null ||
                 !frameColorSelected.Equals(brushColor))
             {
-
                 if (frameBrushSelected != null)
                 {
                     frameBrushSelected.Dispose();
@@ -2654,7 +2647,6 @@ namespace System.Windows.Forms
             }
 
             return new ColorMatrix(result);
-
         }
         //paint the border of the table
         internal static void PaintTableControlBorder(TableLayoutPanelCellBorderStyle borderStyle, Graphics g, Rectangle bound)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CurrencyManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CurrencyManager.cs
@@ -223,7 +223,6 @@ namespace System.Windows.Forms
                     }
                     throw new ArgumentException(string.Format(SR.ListManagerSetDataSource, tempList.GetType().FullName), "dataSource");
                 }
-
             }
         }
 
@@ -799,7 +798,6 @@ namespace System.Windows.Forms
                             // in the currencyManager, so controls will use the actual position
                             OnItemChanged(resetEvent);
                             break;
-
                         }
                         if (dbe.NewIndex < listposition)
                         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
@@ -70,7 +70,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Initializes a new instance of the <see cref='Cursor'/> class from the specified resource.
         /// </summary>
-        public Cursor(Type type, string resource) 
+        public Cursor(Type type, string resource)
             : this((type?? throw new ArgumentNullException(nameof(type))).Module.Assembly.GetManifestResourceStream(type, resource))
         {
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataFormats.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataFormats.cs
@@ -287,7 +287,7 @@ namespace System.Windows.Forms
         public class Format
         {
             /// <summary>
-            ///  Initializes a new instance of the <see cref='Format'/> class and 
+            ///  Initializes a new instance of the <see cref='Format'/> class and
             ///  specifies whether a Win32 handle is expected with this format.
             /// </summary>
             public Format(string name, int id)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.DataConnection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.DataConnection.cs
@@ -1394,7 +1394,6 @@ namespace System.Windows.Forms
                     {
                         editableObject.BeginEdit();
                     }
-
                 }
                 finally
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -1162,7 +1162,6 @@ namespace System.Windows.Forms
                     {
                         DataGridViewColumn dataGridViewColumn = (DataGridViewColumn)autoFillColumns[columnEntry];
                         weightSumDbg += dataGridViewColumn.UsedFillWeight;
-
                     }
                     Debug.Assert(Math.Abs(weightSum - weightSumDbg) < 1.0F);
 #endif

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAdvancedBorderStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAdvancedBorderStyle.cs
@@ -53,7 +53,6 @@ namespace System.Windows.Forms
             }
             set
             {
-
                 // Sequential enum.  Valid values are 0x0 to 0x7
                 if (!ClientUtils.IsEnumValid(value, (int)value, (int)DataGridViewAdvancedCellBorderStyle.NotSet, (int)DataGridViewAdvancedCellBorderStyle.OutsetPartial))
                 {
@@ -199,7 +198,6 @@ namespace System.Windows.Forms
             }
             set
             {
-
                 // Sequential enum.  Valid values are 0x0 to 0x7
                 if (!ClientUtils.IsEnumValid(value, (int)value, (int)DataGridViewAdvancedCellBorderStyle.NotSet, (int)DataGridViewAdvancedCellBorderStyle.OutsetPartial))
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.cs
@@ -783,7 +783,6 @@ namespace System.Windows.Forms
                                     {
                                         using (WindowsGraphics wg = WindowsGraphics.FromHdc(hdc))
                                         {
-
                                             WindowsBrush windowsBrush;
                                             if (colors.options.highContrast)
                                             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -53,7 +53,7 @@ namespace System.Windows.Forms
         private readonly PropertyStore propertyStore;          // Contains all properties that are not always set.
 
         /// <summary>
-        /// Contains non-empty neighboring cells around the current cell. 
+        /// Contains non-empty neighboring cells around the current cell.
         /// Used in <see cref='IKeyboardToolTip.GetNeighboringToolsRectangles'/> method.
         /// </summary>
         private readonly List<Rectangle> _nonEmptyNeighbors;
@@ -61,7 +61,7 @@ namespace System.Windows.Forms
         private static readonly Type stringType = typeof(string);        // cache the string type for performance
 
         private byte flags;  // see DATAGRIDVIEWCELL_flag* consts above
-        
+
         private bool _useDefaultToolTipText;  //  The tooltip text of this cell has not been set by a customer yet.
 
         /// <summary>
@@ -418,9 +418,9 @@ namespace System.Windows.Forms
         Rectangle IKeyboardToolTip.GetNativeScreenRectangle() => AccessibilityObject.Bounds;
 
         /// <summary>
-        ///  The method looks for 8 cells around the current cell 
+        ///  The method looks for 8 cells around the current cell
         ///  to find the optimal tooltip position in <see cref='ToolTip.GetOptimalToolTipPosition'/> method.
-        ///  The optimal tooltip position is the position outside DataGridView or on top of an empty cell. 
+        ///  The optimal tooltip position is the position outside DataGridView or on top of an empty cell.
         ///  This is done so that tooltips do not overlap the text of other cells whenever possible.
         /// </summary>
         /// <returns>
@@ -2620,10 +2620,10 @@ namespace System.Windows.Forms
         private string GetToolTipText(int rowIndex)
         {
             string toolTipText = GetInternalToolTipText(rowIndex);
-                                   
+
             if (ColumnIndex < 0 || RowIndex < 0)
             {
-                return toolTipText;  //  Cells in the Unit tests have ColumnIndex & RowIndex < 0 and 
+                return toolTipText;  //  Cells in the Unit tests have ColumnIndex & RowIndex < 0 and
                                      //  we should return an expected result. It doesn't have an impact on UI cells.
             }
 
@@ -2639,7 +2639,7 @@ namespace System.Windows.Forms
 
             return toolTipText;
         }
-        
+
         private protected string GetToolTipTextWithoutMnemonic(string toolTipText)
         {
             if (WindowsFormsUtils.ContainsMnemonic(toolTipText))
@@ -5187,7 +5187,6 @@ namespace System.Windows.Forms
                 if (owner.OwningColumn == owner.DataGridView.Columns.GetLastColumn(DataGridViewElementStates.Visible,
                                                                                              DataGridViewElementStates.None))
                 {
-
                     if (wrapAround)
                     {
                         // Return the first cell in the next visible row.
@@ -5208,7 +5207,6 @@ namespace System.Windows.Forms
                         {
                             return null;
                         }
-
                     }
                     else
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
@@ -62,7 +62,6 @@ namespace System.Windows.Forms
                 FlipXPThemesBitmap.Dispose();
             }
             base.Dispose(disposing);
-
         }
 
         [

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowCollection.cs
@@ -2826,7 +2826,6 @@ namespace System.Windows.Forms
             /// </summary>
             bool IEnumerator.MoveNext()
             {
-
                 if (current < owner.Count - 1)
                 {
                     current++;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
@@ -276,7 +276,6 @@ namespace System.Windows.Forms
                         return true;
                     }
                     break;
-
             }
             return base.ProcessKeyEventArgs(ref m);
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
@@ -455,7 +455,6 @@ namespace System.Windows.Forms
                 || format.Equals(DataFormats.UnicodeText)
                 || format.Equals(DataFormats.StringFormat))
             {
-
                 return new string[] {
                     DataFormats.StringFormat,
                     DataFormats.UnicodeText,
@@ -467,7 +466,6 @@ namespace System.Windows.Forms
                 || format.Equals(CF_DEPRECATED_FILENAME)
                 || format.Equals(CF_DEPRECATED_FILENAMEW))
             {
-
                 return new string[] {
                     DataFormats.FileDrop,
                     CF_DEPRECATED_FILENAMEW,
@@ -478,7 +476,6 @@ namespace System.Windows.Forms
             if (format.Equals(DataFormats.Bitmap)
                 || format.Equals((typeof(Bitmap)).FullName))
             {
-
                 return new string[] {
                     (typeof(Bitmap)).FullName,
                     DataFormats.Bitmap,
@@ -975,7 +972,6 @@ namespace System.Windows.Forms
             }
             else
             {
-
                 int pinvokeSize = UnsafeNativeMethods.WideCharToMultiByte(0 /*CP_ACP*/, 0, str, str.Length, null, 0, IntPtr.Zero, IntPtr.Zero);
 
                 byte[] strBytes = new byte[pinvokeSize];
@@ -984,7 +980,7 @@ namespace System.Windows.Forms
                 newHandle = Kernel32.GlobalReAlloc(
                     handle,
                     (uint)pinvokeSize + 1,
-                    
+
                     Kernel32.GMEM.MOVEABLE | Kernel32.GMEM.DDESHARE | Kernel32.GMEM.ZEROINIT);
                 if (newHandle == IntPtr.Zero)
                 {
@@ -1185,7 +1181,6 @@ namespace System.Windows.Forms
                                  || format.Equals(CF_DEPRECATED_FILENAME)
                                  || format.Equals(CF_DEPRECATED_FILENAMEW))
                         {
-
                             temp.tymed = TYMED.TYMED_HGLOBAL;
                         }
                         else
@@ -1206,7 +1201,6 @@ namespace System.Windows.Forms
                 Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "FormatEnumerator: Next");
                 if (this.current < formats.Count && celt > 0)
                 {
-
                     FORMATETC current = (FORMATETC)formats[this.current];
                     rgelt[0].cfFormat = current.cfFormat;
                     rgelt[0].tymed = current.tymed;
@@ -1288,7 +1282,6 @@ namespace System.Windows.Forms
             /// </summary>
             private unsafe object GetDataFromOleIStream(string format)
             {
-
                 FORMATETC formatetc = new FORMATETC();
                 STGMEDIUM medium = new STGMEDIUM();
 
@@ -1586,7 +1579,7 @@ namespace System.Windows.Forms
                 {
                     return ReadObjectFromHandleDeserializer(stream, restrictDeserialization);
                 }
-                
+
                 return stream;
             }
 
@@ -1607,7 +1600,6 @@ namespace System.Windows.Forms
             /// </summary>
             private string[] ReadFileListFromHandle(IntPtr hdrop)
             {
-
                 string[] files = null;
                 StringBuilder sb = new StringBuilder(Kernel32.MAX_PATH);
 
@@ -1874,7 +1866,6 @@ namespace System.Windows.Forms
             {
                 return GetFormats(true);
             }
-
         }
 
         //--------------------------------------------------------------------------
@@ -1922,7 +1913,6 @@ namespace System.Windows.Forms
                     && (dse == null || dse.autoConvert)
                     && (baseVar == null || baseVar is MemoryStream))
                 {
-
                     string[] mappedFormats = GetMappedFormats(format);
                     if (mappedFormats != null)
                     {
@@ -2022,11 +2012,10 @@ namespace System.Windows.Forms
                 {
                     throw new ArgumentNullException(nameof(data));
                 }
-    
+
                 if (data is ISerializable
                     && !this.data.ContainsKey(DataFormats.Serializable))
                 {
-
                     SetData(DataFormats.Serializable, data);
                 }
 
@@ -2096,7 +2085,6 @@ namespace System.Windows.Forms
                         Debug.Assert(data[baseVar[i]] != null, "Null item in data collection with key '" + baseVar[i] + "'");
                         if (((DataStoreEntry)data[baseVar[i]]).autoConvert)
                         {
-
                             string[] cur = GetMappedFormats(baseVar[i]);
                             Debug.Assert(cur != null, "GetMappedFormats returned null for '" + baseVar[i] + "'");
                             for (int j = 0; j < cur.Length; j++)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
@@ -514,7 +514,6 @@ namespace System.Windows.Forms
                 if ((value != null && !value.Equals(customFormat)) ||
                     (value == null && customFormat != null))
                 {
-
                     customFormat = value;
 
                     if (IsHandleCreated)
@@ -651,7 +650,6 @@ namespace System.Windows.Forms
 
                 if (format != value)
                 {
-
                     format = value;
                     RecreateHandle();
 
@@ -906,7 +904,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 return rightToLeftLayout;
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.cs
@@ -837,7 +837,6 @@ namespace System.Windows.Forms.Design
                                          state, ColorTranslator.ToWin32(SystemColors.Control), ColorTranslator.ToWin32(SystemColors.ControlText));
                             }
                             m.Result = (IntPtr)ComCtl32.CDRF.SKIPDEFAULT;
-
                         }
                         break;
                     case ComCtl32.CDDS.POSTPAINT:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DisplayInformation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DisplayInformation.cs
@@ -38,7 +38,6 @@ namespace System.Windows.Forms
                     // setting of an unused screen.
                     // According to EnumDisplayMonitors, a primary screen check should be sufficient
                     bitsPerPixel = (short)Screen.PrimaryScreen.BitsPerPixel;
-
                 }
                 return bitsPerPixel;
             }
@@ -51,7 +50,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 if (lowResSettingValid && !lowRes)
                 {
                     return lowRes;
@@ -136,7 +134,6 @@ namespace System.Windows.Forms
             terminalSettingValid = false;
             dropShadowSettingValid = false;
             menuAccessKeysUnderlinedValid = false;
-
         }
 
         ///<summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.cs
@@ -161,7 +161,6 @@ namespace System.Windows.Forms
             }
             set
             {
-
                 // Treat null as selecting no item
                 //
                 if (value == null)
@@ -299,7 +298,6 @@ namespace System.Windows.Forms
                     SelectIndex(0);
                 }
             }
-
         }
 
         /// <summary>
@@ -375,7 +373,6 @@ namespace System.Windows.Forms
                 {
                     index = 0;
                 }
-
             } while (!found && index != startPosition);
 
             return matchIndex;
@@ -411,12 +408,10 @@ namespace System.Windows.Forms
                     || uc == UnicodeCategory.OtherNumber
                     || uc == UnicodeCategory.UppercaseLetter)
                 {
-
                     // Attempt to match the character to a domain item
                     int matchIndex = MatchIndex(new string(character), false, domainIndex + 1);
                     if (matchIndex != -1)
                     {
-
                         // Select the matching domain item
                         SelectIndex(matchIndex);
                     }
@@ -490,7 +485,6 @@ namespace System.Windows.Forms
 
                 if (domainItems != null)
                 {
-
                     // Sort the domain values
                     ArrayList.Adapter(domainItems).Sort(new DomainUpDownItemCompare());
 
@@ -887,7 +881,6 @@ namespace System.Windows.Forms
 
             public override AccessibleObject GetChild(int index)
             {
-
                 if (index >= 0 && index < GetChildCount())
                 {
                     return new DomainItemAccessibleObject(((DomainUpDown)parent.Owner).Items[index].ToString(), this);
@@ -900,7 +893,6 @@ namespace System.Windows.Forms
             {
                 return ((DomainUpDown)parent.Owner).Items.Count;
             }
-
         }
 
         [ComVisible(true)]
@@ -959,6 +951,5 @@ namespace System.Windows.Forms
                 }
             }
         }
-
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
@@ -1269,7 +1269,6 @@ namespace System.Windows.Forms
                             dc.Dispose();
                         }
                     }
-
                 }
                 finally
                 {
@@ -1738,7 +1737,6 @@ namespace System.Windows.Forms
                             {
                                 for (int x = 0; x < size.Width; x++)
                                 {
-
                                     // see if bit is set in mask. bits in byte are reversed. 0 is black (set).
                                     if ((bits[y * widthInBytes + x / 8] & (1 << (7 - (x % 8)))) == 0)
                                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
@@ -737,7 +737,7 @@ namespace System.Windows.Forms
             {
                 return returnValue;
             }
-            
+
             return RunDialogOld(hWndOwner);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FlatButtonAppearance.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FlatButtonAppearance.cs
@@ -180,7 +180,6 @@ namespace System.Windows.Forms
                 }
             }
         }
-
     }
 
     internal sealed class ApplicableToButtonAttribute : Attribute

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -453,7 +453,6 @@ namespace System.Windows.Forms
                         // force the new property back to none so they
                         // don't compete.
                         AutoScaleMode = AutoScaleMode.None;
-
                     }
                     else
                     {
@@ -580,7 +579,6 @@ namespace System.Windows.Forms
             }
             set
             {
-
                 if (!ClientUtils.IsEnumValid(value, (int)value, (int)AutoSizeMode.GrowAndShrink, (int)AutoSizeMode.GrowOnly))
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(AutoSizeMode));
@@ -1362,7 +1360,6 @@ namespace System.Windows.Forms
             {
                 if (!value.Equals(MaximumSize))
                 {
-
                     if (value.Width < 0 || value.Height < 0)
                     {
                         throw new ArgumentOutOfRangeException(nameof(MaximumSize));
@@ -1375,7 +1372,6 @@ namespace System.Windows.Forms
                     //
                     if (!MinimumSize.IsEmpty && !value.IsEmpty)
                     {
-
                         if (Properties.GetInteger(PropMinTrackSizeWidth) > value.Width)
                         {
                             Properties.SetInteger(PropMinTrackSizeWidth, value.Width);
@@ -1949,7 +1945,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 return rightToLeftLayout;
             }
 
@@ -2397,7 +2392,6 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-
                     // The ordering is important here... Force handle creation
                     // (getHandle) then show the window (ShowWindow) then finish
                     // creating children using createControl...
@@ -2942,7 +2936,6 @@ namespace System.Windows.Forms
                 AutoScaleBaseSize = newVar;
             }
             Debug.Unindent();
-
         }
 
         /// <summary>
@@ -3028,7 +3021,6 @@ namespace System.Windows.Forms
             //
             if (correctClientSize.Height != currentClient.Height)
             {
-
                 int delta = correctClientSize.Height - currentClient.Height;
                 bounds.Height += delta;
                 Bounds = bounds;
@@ -3239,7 +3231,6 @@ namespace System.Windows.Forms
                 if (IsMdiChild
                     && (FormWindowState)formState[FormStateWindowState] == FormWindowState.Maximized)
                 {
-
                     // This is the reason why we see the blue borders
                     // when creating a maximized mdi child, unfortunately we cannot fix this now...
                     formState[FormStateWindowState] = (int)FormWindowState.Normal;
@@ -3293,7 +3284,6 @@ namespace System.Windows.Forms
                 {
                     TopMost = true;
                 }
-
             }
             finally
             {
@@ -4504,7 +4494,6 @@ namespace System.Windows.Forms
                     c.RecreateHandleCore();
                 }
             }
-
         }
 
         /// <summary>
@@ -4864,7 +4853,6 @@ namespace System.Windows.Forms
                 {
                     if (ownedForm.Equals(ownedForms[i]))
                     {
-
                         // clear out the reference.
                         //
                         ownedForms[i] = null;
@@ -5086,7 +5074,6 @@ namespace System.Windows.Forms
             formStateEx[FormStateExInScale] = 1;
             try
             {
-
                 // don't scale the location of MDI child forms
                 if (MdiParentInternal != null)
                 {
@@ -5275,7 +5262,7 @@ namespace System.Windows.Forms
             {
                 throw new InvalidOperationException(string.Format(SR.OwnsSelfOrOwner, "Show"));
             }
-            
+
             if (Visible)
             {
                 throw new InvalidOperationException(string.Format(SR.ShowDialogOnVisible, "Show"));
@@ -5326,7 +5313,6 @@ namespace System.Windows.Forms
                 // Set the new owner.
                 hWndOldOwner = UnsafeNativeMethods.GetWindowLong(new HandleRef(this, Handle), NativeMethods.GWL_HWNDPARENT);
                 UnsafeNativeMethods.SetWindowLong(new HandleRef(this, Handle), NativeMethods.GWL_HWNDPARENT, new HandleRef(owner, hWndOwner));
-
             }
             Visible = true;
         }
@@ -5348,32 +5334,32 @@ namespace System.Windows.Forms
             {
                 throw new ArgumentException(string.Format(SR.OwnsSelfOrOwner, "showDialog"), nameof(owner));
             }
-            
+
             if (Visible)
             {
                 throw new InvalidOperationException(string.Format(SR.ShowDialogOnVisible, "showDialog"));
             }
-            
+
             if (!Enabled)
             {
                 throw new InvalidOperationException(string.Format(SR.ShowDialogOnDisabled, "showDialog"));
             }
-            
+
             if (!TopLevel)
             {
                 throw new InvalidOperationException(string.Format(SR.ShowDialogOnNonTopLevel, "showDialog"));
             }
-            
+
             if (Modal)
             {
                 throw new InvalidOperationException(string.Format(SR.ShowDialogOnModal, "showDialog"));
             }
-           
+
             if (!SystemInformation.UserInteractive)
             {
                 throw new InvalidOperationException(SR.CantShowModalOnNonInteractive);
             }
-           
+
             if ((owner != null) && ((int)UnsafeNativeMethods.GetWindowLong(new HandleRef(owner, GetSafeHandle(owner)), NativeMethods.GWL_EXSTYLE)
                      & (int)User32.WS_EX.TOPMOST) == 0)
             {   // It's not the top-most window
@@ -5475,7 +5461,6 @@ namespace System.Windows.Forms
                     SetVisibleCore(false);
                     if (IsHandleCreated)
                     {
-
                         // If this is a dialog opened from an MDI Container, then invalidate
                         // so that child windows will be properly updated.
                         if (OwnerInternal != null &&
@@ -5709,7 +5694,6 @@ namespace System.Windows.Forms
 
                 if (transparencyKey.IsEmpty)
                 {
-
                     result = User32.SetLayeredWindowAttributes(this, 0, OpacityAsByte, User32.LWA.ALPHA);
                 }
                 else if (OpacityAsByte == 255)
@@ -5856,7 +5840,6 @@ namespace System.Windows.Forms
 
             if (ActiveMdiChildInternal != null)
             {
-
                 // do the new merging
                 foreach (ToolStrip sourceToolStrip in childrenToolStrips)
                 {
@@ -5983,7 +5966,6 @@ namespace System.Windows.Forms
                     //MERGEDEBUG Debug.WriteLineIf(ToolStrip.MDIMergeDebug.TraceVerbose, "UpdateMdiWindowListStrip: mdiwindowlist dd item count after:  " + sourceMenuStrip.MdiWindowListItem.DropDownItems.Count.ToString());
                     MdiWindowListStrip.MergedMenu = sourceMenuStrip;
                 }
-
             }
         }
 
@@ -6660,7 +6642,6 @@ namespace System.Windows.Forms
 
             if (callDefault)
             {
-
                 base.WndProc(ref m);
             }
         }
@@ -6785,7 +6766,7 @@ namespace System.Windows.Forms
                     // This is a work-around for the Win32 scroll bar; it doesn't release
                     // it's capture in response to a CAPTURECHANGED message, so we force
                     // capture away if no button is down.
-                    
+
                     if (Capture && MouseButtons == MouseButtons.None)
                     {
                         Capture = false;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Formatter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Formatter.cs
@@ -551,6 +551,5 @@ namespace System.Windows.Forms
         {
             return (type != null && !type.IsValueType) ? null : defaultDataSourceNullValue;
         }
-
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.cs
@@ -230,7 +230,6 @@ namespace System.Windows.Forms
 
                 if (flatStyle != value)
                 {
-
                     bool originalOwnerDraw = OwnerDraw;
                     flatStyle = value;
 
@@ -253,7 +252,6 @@ namespace System.Windows.Forms
                     {
                         Refresh();
                     }
-
                 }
             }
         }
@@ -809,5 +807,4 @@ namespace System.Windows.Forms
             }
         }
     }
-
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Help.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Help.cs
@@ -150,7 +150,6 @@ namespace System.Windows.Forms
             {
                 Marshal.FreeCoTaskMem(pszText);
             }
-
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HelpProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HelpProvider.cs
@@ -69,7 +69,7 @@ namespace System.Windows.Forms
             {
                 throw new ArgumentNullException(nameof(ctl));
             }
-            
+
             return (string)_keywords[ctl];
         }
 
@@ -102,7 +102,7 @@ namespace System.Windows.Forms
             {
                 throw new ArgumentNullException(nameof(ctl));
             }
-            
+
             return (string)_helpStrings[ctl];
         }
 
@@ -210,7 +210,7 @@ namespace System.Windows.Forms
             {
                 throw new ArgumentNullException(nameof(ctl));
             }
-            
+
             _keywords[ctl] = keyword;
             if (!string.IsNullOrEmpty(keyword))
             {
@@ -275,7 +275,7 @@ namespace System.Windows.Forms
             {
                 throw new ArgumentNullException(nameof(ctl));
             }
-            
+
             _showHelp.Remove(ctl);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlDocument.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlDocument.cs
@@ -34,7 +34,6 @@ namespace System.Windows.Forms
             Debug.Assert(NativeHtmlDocument2 != null, "The document should implement IHtmlDocument2");
 
             this.shimManager = shimManager;
-
         }
 
         internal IHTMLDocument2 NativeHtmlDocument2
@@ -547,7 +546,6 @@ namespace System.Windows.Forms
         {
             add => DocumentShim.AddHandler(EventMouseOver, value);
             remove => DocumentShim.RemoveHandler(EventMouseOver, value);
-
         }
 
         public event HtmlElementEventHandler MouseUp
@@ -573,7 +571,7 @@ namespace System.Windows.Forms
             public byte b;
         }
         private static readonly int VariantSize = (int)Marshal.OffsetOf(typeof(FindSizeOfVariant), "b");
-        
+
         /// <summary>
         ///  Convert a object[] into an array of VARIANT, allocated with CoTask allocators.
         /// </summary>
@@ -588,7 +586,7 @@ namespace System.Windows.Forms
             }
             return mem;
         }
-        
+
         /// <summary>
         ///  Free a Variant array created with the above function
         /// </summary>
@@ -691,7 +689,6 @@ namespace System.Windows.Forms
             ///  Support IHtmlDocument3.AttachHandler
             public override void AttachEventHandler(string eventName, EventHandler eventHandler)
             {
-
                 // IE likes to call back on an IDispatch of DISPID=0 when it has an event,
                 // the HtmlToClrEventProxy helps us fake out the CLR so that we can call back on
                 // our EventHandler properly.
@@ -709,7 +706,6 @@ namespace System.Windows.Forms
                 {
                     ((IHTMLDocument3)NativeHtmlDocument2).DetachEvent(eventName, proxy);
                 }
-
             }
 
             //
@@ -753,7 +749,6 @@ namespace System.Windows.Forms
                     }
                     htmlDocument = null;
                 }
-
             }
 
             protected override object GetEventSender()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElement.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElement.cs
@@ -41,7 +41,6 @@ namespace System.Windows.Forms
             Debug.Assert(NativeHtmlElement != null, "The element object should implement IHTMLElement");
 
             this.shimManager = shimManager;
-
         }
 
         public HtmlElementCollection All
@@ -527,7 +526,6 @@ namespace System.Windows.Forms
         {
             add => ElementShim.AddHandler(EventClick, value);
             remove => ElementShim.RemoveHandler(EventClick, value);
-
         }
 
         public event HtmlElementEventHandler DoubleClick
@@ -552,7 +550,6 @@ namespace System.Windows.Forms
         {
             add => ElementShim.AddHandler(EventDragLeave, value);
             remove => ElementShim.RemoveHandler(EventDragLeave, value);
-
         }
 
         public event HtmlElementEventHandler DragOver
@@ -571,7 +568,6 @@ namespace System.Windows.Forms
         {
             add => ElementShim.AddHandler(EventGotFocus, value);
             remove => ElementShim.RemoveHandler(EventGotFocus, value);
-
         }
 
         public event HtmlElementEventHandler LosingFocus
@@ -595,7 +591,6 @@ namespace System.Windows.Forms
         {
             add => ElementShim.AddHandler(EventKeyPress, value);
             remove => ElementShim.RemoveHandler(EventKeyPress, value);
-
         }
         public event HtmlElementEventHandler KeyUp
         {
@@ -1081,7 +1076,6 @@ namespace System.Windows.Forms
             ///  Support IHTMLElement2.AttachEventHandler
             public override void AttachEventHandler(string eventName, EventHandler eventHandler)
             {
-
                 // IE likes to call back on an IDispatch of DISPID=0 when it has an event,
                 // the HtmlToClrEventProxy helps us fake out the CLR so that we can call back on
                 // our EventHandler properly.
@@ -1126,7 +1120,6 @@ namespace System.Windows.Forms
                     cookie.Disconnect();
                     cookie = null;
                 }
-
             }
             protected override void Dispose(bool disposing)
             {
@@ -1142,7 +1135,6 @@ namespace System.Windows.Forms
             {
                 return htmlElement;
             }
-
         }
 
         #region operators

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlShim.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlShim.cs
@@ -90,7 +90,6 @@ namespace System.Windows.Forms
                     DetachEventHandler(proxy.EventName, eh);
                 }
             }
-
         }
 
         ///  return the sender for events, usually the HtmlWindow, HtmlElement, HtmlDocument
@@ -177,7 +176,6 @@ namespace System.Windows.Forms
             return null;
         }
     }
-
 }
 
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlShimManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlShimManager.cs
@@ -46,7 +46,6 @@ namespace System.Windows.Forms
             {
                 OnShimAdded(shim);
             }
-
         }
 
         /// <summary> AddWindowShim - adds a HtmlWindowShim to list of shims to manage
@@ -95,7 +94,6 @@ namespace System.Windows.Forms
             {
                 OnShimAdded(shim);
             }
-
         }
 
         internal HtmlDocument.HtmlDocumentShim GetDocumentShim(HtmlDocument document)
@@ -220,7 +218,6 @@ namespace System.Windows.Forms
         {
             if (disposing)
             {
-
                 if (htmlElementShims != null)
                 {
                     foreach (HtmlElement.HtmlElementShim shim in htmlElementShims.Values)
@@ -246,13 +243,11 @@ namespace System.Windows.Forms
                 htmlWindowShims = null;
                 htmlDocumentShims = null;
                 htmlWindowShims = null;
-
             }
         }
         ~HtmlShimManager()
         {
             Dispose(false);
         }
-
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlWindow.cs
@@ -486,7 +486,6 @@ namespace System.Windows.Forms
             ///  Support IHtmlDocument3.AttachHandler
             public override void AttachEventHandler(string eventName, EventHandler eventHandler)
             {
-
                 // IE likes to call back on an IDispatch of DISPID=0 when it has an event,
                 // the HtmlToClrEventProxy helps us fake out the CLR so that we can call back on
                 // our EventHandler properly.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlWindowCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlWindowCollection.cs
@@ -106,7 +106,6 @@ namespace System.Windows.Forms
 
             return htmlWindows.GetEnumerator();
         }
-
     }
 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageIndexConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageIndexConverter.cs
@@ -13,7 +13,6 @@ namespace System.Windows.Forms
     /// </summary>
     public class ImageIndexConverter : Int32Converter
     {
-
         /// <summary>
         ///  Gets a value that indicates whether a <see langword="null" /> value is valid in
         ///  the <see cref="TypeConverter.StandardValuesCollection" /> collection.
@@ -82,12 +81,12 @@ namespace System.Windows.Forms
         /// </summary>
         /// <param name="context">
         ///  An <see cref="ITypeDescriptorContext" /> that provides a format context, which can be used to extract
-        ///  additional information about the environment this type converter is being invoked from. 
+        ///  additional information about the environment this type converter is being invoked from.
         ///  This parameter or properties of this parameter can be <see langword="null" />.
         /// </param>
         /// <returns>
-        ///  A collection that holds a standard set of valid index values. 
-        ///  If no image list is found, this collection will contain a single object with a value of -1. 
+        ///  A collection that holds a standard set of valid index values.
+        ///  If no image list is found, this collection will contain a single object with a value of -1.
         ///  This returns <see langword="null" /> if the data type doesn't support a standard set of values.
         /// </returns>
         public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
@@ -113,7 +112,6 @@ namespace System.Windows.Forms
 
                     if (imageListProp == null)
                     {
-
                         // We didn't find the image list in this component.  See if the
                         // component has a "parent" property.  If so, walk the tree...
                         //
@@ -137,7 +135,6 @@ namespace System.Windows.Forms
 
                     if (imageList != null)
                     {
-
                         // Create array to contain standard values
                         //
                         object[] values;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageKeyConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageKeyConverter.cs
@@ -124,7 +124,6 @@ namespace System.Windows.Forms
 
                     if (imageListProp == null)
                     {
-
                         // We didn't find the image list in this component.  See if the
                         // component has a "parent" property.  If so, walk the tree...
                         //
@@ -148,7 +147,6 @@ namespace System.Windows.Forms
 
                     if (imageList != null)
                     {
-
                         // Create array to contain standard values
                         //
                         object[] values;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
@@ -134,7 +134,6 @@ namespace System.Windows.Forms
                     index = value;
                     useIntegerIndex = true;
                 }
-
             }
 
             public virtual int ActualIndex
@@ -498,7 +497,6 @@ namespace System.Windows.Forms
                 ownsBitmap = true;
             }
             return bitmap;
-
         }
 
         private int AddIconToHandle(Original original, Icon icon)
@@ -857,7 +855,6 @@ namespace System.Windows.Forms
                             ComCtl32.CLR.NONE,
                             ComCtl32.CLR.NONE,
                             ComCtl32.ILD.TRANSPARENT);
-
                     }
                     finally
                     {
@@ -1018,7 +1015,6 @@ namespace System.Windows.Forms
             {
                 Dispose(false);
             }
-
         }
 
         // An image before we add it to the image list, along with a few details about how to add it.
@@ -1134,7 +1130,6 @@ namespace System.Windows.Forms
             [Browsable(false)]
             public int Count
             {
-
                 get
                 {
                     Debug.Assert(owner != null, "ImageCollection has no owner (ImageList)");
@@ -1204,7 +1199,6 @@ namespace System.Windows.Forms
             [Browsable(false), DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
             public Image this[int index]
             {
-
                 get
                 {
                     if (index < 0 || index >= Count)
@@ -1277,7 +1271,6 @@ namespace System.Windows.Forms
 
             object IList.this[int index]
             {
-
                 get
                 {
                     return this[index];
@@ -1300,7 +1293,6 @@ namespace System.Windows.Forms
             /// </summary>
             public Image this[string key]
             {
-
                 get
                 {
                     // We do not support null and empty string as valid keys.
@@ -1319,7 +1311,6 @@ namespace System.Windows.Forms
                     {
                         return null;
                     }
-
                 }
             }
 
@@ -1339,7 +1330,6 @@ namespace System.Windows.Forms
                 // Add the image to the IList
                 Original original = new Original(image, OriginalOptions.Default);
                 Add(original, imageInfo);
-
             }
 
             /// <summary>
@@ -1358,7 +1348,6 @@ namespace System.Windows.Forms
                 // Add the image to the IList
                 Original original = new Original(icon, OriginalOptions.Default);
                 Add(original, imageInfo);
-
             }
 
             int IList.Add(object value)
@@ -1507,7 +1496,6 @@ namespace System.Windows.Forms
             /// </summary>
             public int AddStrip(Image value)
             {
-
                 if (value == null)
                 {
                     throw new ArgumentNullException(nameof(value));
@@ -1752,7 +1740,6 @@ namespace System.Windows.Forms
                     set { name = value; }
                 }
             }
-
         } // end class ImageCollection
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageListStreamer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageListStreamer.cs
@@ -93,7 +93,6 @@ namespace System.Windows.Forms
 
             while (idx < input.Length)
             {
-
                 byte current = input[idx++];
                 byte runLength = 1;
 
@@ -114,7 +113,6 @@ namespace System.Windows.Forms
 
             while (idx < input.Length)
             {
-
                 byte current = input[idx++];
                 byte runLength = 1;
 
@@ -271,6 +269,5 @@ namespace System.Windows.Forms
                 }
             }
         }
-
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/KeyboardToolTipStateMachine.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/KeyboardToolTipStateMachine.cs
@@ -20,7 +20,7 @@ namespace System.Windows.Forms
     ///  the keyboard ToolTip appear. <see cref="https://docs.microsoft.com/windows/win32/controls/ttm-getdelaytime">
     ///
     ///  Once visible, the keyboard ToolTip will be demonstrated for an amount of time specified with TTDT_AUTOPOP
-    ///  flag. The ToolTip will disappear afterwards. If the keyboard ToolTip is visible and the focus moves from 
+    ///  flag. The ToolTip will disappear afterwards. If the keyboard ToolTip is visible and the focus moves from
     ///  one ToolTip-enabled control to another, the keyboard ToolTip will be shown after a time interval specified
     ///  with TTDT_RESHOW flag has passed.
     /// </remarks>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/KeysConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/KeysConverter.cs
@@ -149,7 +149,6 @@ namespace System.Windows.Forms
         {
             if (value is string)
             {
-
                 string text = ((string)value).Trim();
 
                 if (text.Length == 0)
@@ -158,7 +157,6 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-
                     // Parse an array of key tokens.
                     //
                     string[] tokens = text.Split(new char[] { '+' });
@@ -178,7 +176,6 @@ namespace System.Windows.Forms
 
                         if (obj == null)
                         {
-
                             // Key was not found in our table.  See if it is a valid value in
                             // the Keys enum.
                             //
@@ -191,7 +188,6 @@ namespace System.Windows.Forms
 
                             if ((currentKey & Keys.KeyCode) != 0)
                             {
-
                                 // We found a match.  If we have previously found a
                                 // key code, then check to see that this guy
                                 // isn't a key code (it is illegal to have, say,
@@ -210,11 +206,9 @@ namespace System.Windows.Forms
                         }
                         else
                         {
-
                             // We did not match this key.  Report this as an error too.
                             //
                             throw new FormatException(string.Format(SR.KeysConverterInvalidKeyName, tokens[i]));
-
                         }
                     }
 
@@ -273,7 +267,6 @@ namespace System.Windows.Forms
                         Keys keyValue = (Keys)keyNames[keyString];
                         if (((int)(keyValue) & (int)modifiers) != 0)
                         {
-
                             if (asString)
                             {
                                 if (added)
@@ -309,7 +302,6 @@ namespace System.Windows.Forms
                         Keys keyValue = (Keys)keyNames[keyString];
                         if (keyValue.Equals(keyOnly))
                         {
-
                             if (asString)
                             {
                                 terms.Add((string)keyString);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
@@ -487,7 +487,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 if (ImageIndexer != null)
                 {
                     int index = ImageIndexer.Index;
@@ -497,7 +496,6 @@ namespace System.Windows.Forms
                         return ImageList.Images.Count - 1;
                     }
                     return index;
-
                 }
                 return -1;
             }
@@ -523,7 +521,7 @@ namespace System.Windows.Forms
 
         /// <summary>
         ///  Gets or sets the key accessor for the image list.  This specifies the image
-        ///	  from the image list to display on
+        ///   from the image list to display on
         ///  <see cref='Label'/>.
         /// </summary>
         [
@@ -539,7 +537,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 if (ImageIndexer != null)
                 {
                     return ImageIndexer.Key;
@@ -550,7 +547,6 @@ namespace System.Windows.Forms
             {
                 if (ImageKey != value)
                 {
-
                     // Image.set calls ImageIndex = -1
                     Properties.SetObject(PropImage, null);
 
@@ -577,7 +573,6 @@ namespace System.Windows.Forms
             {
                 Properties.SetObject(PropImageIndex, value);
             }
-
         }
 
         /// <summary>
@@ -599,7 +594,6 @@ namespace System.Windows.Forms
             {
                 if (ImageList != value)
                 {
-
                     EventHandler recreateHandler = new EventHandler(ImageListRecreateHandle);
                     EventHandler disposedHandler = new EventHandler(DetachImageList);
 
@@ -862,7 +856,6 @@ namespace System.Windows.Forms
             }
             set
             {
-
                 if (!WindowsFormsUtils.EnumValidator.IsValidContentAlignment(value))
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ContentAlignment));
@@ -878,7 +871,6 @@ namespace System.Windows.Forms
                         RecreateHandle();
                     }
                     OnTextAlignChanged(EventArgs.Empty);
-
                 }
             }
         }
@@ -972,7 +964,6 @@ namespace System.Windows.Forms
 
             set
             {
-
                 if (UseMnemonic != value)
                 {
                     labelState[StateUseMnemonic] = value ? 1 : 0;
@@ -992,7 +983,6 @@ namespace System.Windows.Forms
                         int style = WindowStyle;
                         if (!UseMnemonic)
                         {
-
                             style |= NativeMethods.SS_NOPREFIX;
                         }
                         else
@@ -1231,7 +1221,6 @@ namespace System.Windows.Forms
                 }
             }
             return bordersAndPadding;
-
         }
 
         public override Size GetPreferredSize(Size proposedSize)
@@ -1298,7 +1287,6 @@ namespace System.Windows.Forms
                         requiredSize = Size.Ceiling(measurementGraphics.MeasureString(Text, Font, bounds, stringFormat));
                     }
                 }
-
             }
 
             requiredSize += bordersAndPadding;
@@ -1380,7 +1368,6 @@ namespace System.Windows.Forms
         {
             if (!controlToolTip && !DesignMode && AutoEllipsis && showToolTip && textToolTip != null)
             {
-
                 try
                 {
                     controlToolTip = true;
@@ -1390,7 +1377,6 @@ namespace System.Windows.Forms
                 {
                     controlToolTip = false;
                 }
-
             }
             base.OnMouseEnter(e);
         }
@@ -1782,7 +1768,6 @@ namespace System.Windows.Forms
                 base.Index = value;
                 useIntegerIndex = true;
             }
-
         }
 
         public override int ActualIndex
@@ -1803,7 +1788,5 @@ namespace System.Windows.Forms
                 return -1;
             }
         }
-
     }
-
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/ArrangedElementCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/ArrangedElementCollection.cs
@@ -54,7 +54,7 @@ namespace System.Windows.Forms.Layout
             {
                 hash.Add(o);
             }
-            
+
             return hash.ToHashCode();
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/CommonProperties.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/CommonProperties.cs
@@ -159,7 +159,7 @@ namespace System.Windows.Forms.Layout
             return element.Bounds;
         }
 
-        ///  ResetPadding	
+        ///  ResetPadding
         ///  clears out the padding from the property store
         internal static void ResetPadding(IArrangedElement element)
         {
@@ -199,7 +199,6 @@ namespace System.Windows.Forms.Layout
             Debug.Assert(GetMargin(element) == value, "Error detected setting Margin.");
 
             LayoutTransaction.DoLayout(element.Container, element, PropertyNames.Margin);
-
         }
 
         ///  SetMaximumSize
@@ -310,7 +309,6 @@ namespace System.Windows.Forms.Layout
                 }
 
                 element.Properties.SetRectangle(_specifiedBoundsProperty, originalBounds);
-
             }
             else
             {
@@ -738,7 +736,6 @@ namespace System.Windows.Forms.Layout
                 diff = "For more info, try enabling PreferredSize trace switch";
             }
             return diff;
-
         }
 
         internal static void Debug_SnapProperties(IArrangedElement element)
@@ -757,7 +754,6 @@ namespace System.Windows.Forms.Layout
             Hashtable propertyHash = new Hashtable();
             if (PreferredSize.TraceVerbose)
             {
-
                 foreach (PropertyDescriptor pd in TypeDescriptor.GetProperties(obj))
                 {
                     if (pd.Name == "PreferredSize")
@@ -777,7 +773,6 @@ namespace System.Windows.Forms.Layout
                 }
             }
             return propertyHash;
-
         }
 
 #endif

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/LayoutUtils.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/LayoutUtils.cs
@@ -191,7 +191,6 @@ namespace System.Windows.Forms.Layout
                     default:
                         break;
                 }
-
             }
 
             return result;
@@ -620,7 +619,6 @@ namespace System.Windows.Forms.Layout
             ///  InvalidateCache should be made
             public Size GetTextSize(string text, Font font, Size proposedConstraints, TextFormatFlags flags)
             {
-
                 if (!TextRequiresWordBreak(text, font, proposedConstraints, flags))
                 {
                     // Text fits within proposed width
@@ -651,7 +649,6 @@ namespace System.Windows.Forms.Layout
                     // check the existing constraints from previous calls
                     foreach (PreferredSizeCache sizeCache in sizeCacheList)
                     {
-
                         if (sizeCache.ConstrainingSize == proposedConstraints)
                         {
                             return sizeCache.PreferredSize;
@@ -659,7 +656,6 @@ namespace System.Windows.Forms.Layout
                         else if ((sizeCache.ConstrainingSize.Width == proposedConstraints.Width)
                                   && (sizeCache.PreferredSize.Height <= proposedConstraints.Height))
                         {
-
                             // Caching a common case where the width matches perfectly, and the stored preferred height
                             // is smaller or equal to the constraining size.
                             //        prefSize = GetPreferredSize(w,Int32.MaxValue);
@@ -677,16 +673,13 @@ namespace System.Windows.Forms.Layout
                     sizeCacheList[nextCacheEntry] = new PreferredSizeCache(proposedConstraints, prefSize);
 
                     return prefSize;
-
                 }
-
             }
 
             ///  GetUnconstrainedSize
             ///  Gets the unconstrained (Int32.MaxValue, Int32.MaxValue) size for a piece of text
             private Size GetUnconstrainedSize(string text, Font font, TextFormatFlags flags)
             {
-
                 if (unconstrainedPreferredSize == LayoutUtils.InvalidSize)
                 {
                     // we also investigated setting the SingleLine flag, however this did not yield as much benefit as the word break
@@ -705,7 +698,6 @@ namespace System.Windows.Forms.Layout
             ///  the WordBreak flag is not necessary.
             public bool TextRequiresWordBreak(string text, Font font, Size size, TextFormatFlags flags)
             {
-
                 // if the unconstrained size of the string is larger than the proposed width
                 // we need the word break flag, otherwise we dont, its a perf hit to use it.
                 return GetUnconstrainedSize(text, font, flags).Width > size.Width;
@@ -721,9 +713,7 @@ namespace System.Windows.Forms.Layout
                 public Size ConstrainingSize;
                 public Size PreferredSize;
             }
-
         }
-
     }
 
     // Frequently when you need to do a PreformLayout, you also need to invalidate the
@@ -805,7 +795,6 @@ namespace System.Windows.Forms.Layout
             {
                 CommonProperties.xClearPreferredSizeCache(elementCausingLayout);
                 return new NullLayoutTransaction();
-
             }
         }
 
@@ -818,11 +807,9 @@ namespace System.Windows.Forms.Layout
                 {
                     CommonProperties.xClearPreferredSizeCache(elementToLayout);
                     elementToLayout.PerformLayout(elementCausingLayout, property);
-
                 }
             }
             Debug.Assert(elementCausingLayout != null, "LayoutTransaction.DoLayout - elementCausingLayout is null, no layout performed - did you mix up your parameters?");
-
         }
 
         // This overload should be used when a property has changed that affects preferred size,
@@ -842,7 +829,6 @@ namespace System.Windows.Forms.Layout
                 LayoutTransaction.DoLayout(elementToLayout, elementCausingLayout, property);
             }
         }
-
     }
     internal struct NullLayoutTransaction : IDisposable
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/TableLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/TableLayout.cs
@@ -338,7 +338,6 @@ namespace System.Windows.Forms.Layout
             }
 
             Debug_VerifyAssignmentsAreCurrent(container, containerInfo);
-
         }
 
         /// <summary>
@@ -465,7 +464,6 @@ namespace System.Windows.Forms.Layout
 
             while (fixedElement != null || flowElement != null)
             {
-
                 int colStop = currentCol;
                 int rowStop;
                 if (flowElement != null)
@@ -601,7 +599,6 @@ namespace System.Windows.Forms.Layout
 
             containerInfo.Valid = true;
             return true;
-
         }
 
         /// <summary>
@@ -947,7 +944,6 @@ namespace System.Windows.Forms.Layout
                 // we can skip over absolute row styles, as they've been preallocated
                 if (rowSpan > 1 || !IsAbsolutelySized(layoutInfo.RowStart, containerInfo.RowStyles))
                 {
-
                     int currentWidth = SumStrips(containerInfo.Columns, layoutInfo.ColumnStart, layoutInfo.ColumnSpan);
                     //make sure that the total width is the actual final width to avoid
                     //inconsistency of width between the ApplyStyles and SetElementBounds
@@ -966,7 +962,6 @@ namespace System.Windows.Forms.Layout
                 }
             }
             return DistributeStyles(containerInfo.CellBorderWidth, containerInfo.RowStyles, containerInfo.Rows, proposedConstraints.Height, dontHonorConstraint);
-
         }
 
         private Size GetElementSize(IArrangedElement element, Size proposedConstraints)
@@ -1170,10 +1165,8 @@ namespace System.Windows.Forms.Layout
             //          - divide space amongst % style columns using ratio of %/total % * total extra space
             if (totalPercent > 0)
             {
-
                 if (!dontHonorConstraint)
                 {
-
                     if (totalPercentAllocatedSpace > maxSize - totalAbsoluteAndAutoSizeAllocatedSpace)
                     {
                         // fixup for the case where we've actually allocated more space than we have.
@@ -1215,7 +1208,6 @@ namespace System.Windows.Forms.Layout
                             strip.MinSize = stripSize + cellBorderWidth;
                             strips[i] = strip;
                         }
-
                     }
                 }
                 else
@@ -1247,7 +1239,6 @@ namespace System.Windows.Forms.Layout
                     }
                     usedSpace += maxPercentWidth;
                 }
-
             }
             remainingSpace = maxSize - usedSpace;
 
@@ -1454,7 +1445,6 @@ namespace System.Windows.Forms.Layout
             }
             LayoutInfo layoutInfo = GetLayoutInfo(child);
             return new TableLayoutPanelCellPosition(layoutInfo.ColumnStart, layoutInfo.RowStart);
-
         }
         internal static LayoutInfo GetLayoutInfo(IArrangedElement element)
         {
@@ -1671,9 +1661,7 @@ namespace System.Windows.Forms.Layout
                 {
                     Debug.Assert(_rows.Length != value.Length, "PERF: should not allocate strips, we've already got an array");
                     _rows = value;
-
                 }
-
             }
 
             /// <summary>
@@ -1681,7 +1669,6 @@ namespace System.Windows.Forms.Layout
             /// </summary>
             public int MaxRows
             {
-
                 get { return _maxRows; }
                 set
                 {
@@ -1692,7 +1679,6 @@ namespace System.Windows.Forms.Layout
                         //invalidate the cache whenever we change the number of rows
                         Valid = false;
                     }
-
                 }
             }
 
@@ -1701,7 +1687,6 @@ namespace System.Windows.Forms.Layout
             /// </summary>
             public int MaxColumns
             {
-
                 get { return _maxColumns; }
 
                 set
@@ -1733,7 +1718,6 @@ namespace System.Windows.Forms.Layout
                 {
                     Debug.Assert(ChildInfoValid, "Fetching invalid information");
                     return _minColumns;
-
                 }
             }
 
@@ -1744,7 +1728,6 @@ namespace System.Windows.Forms.Layout
                 {
                     Debug.Assert(ChildInfoValid, "Fetching invalid information");
                     return _minRows;
-
                 }
             }
 
@@ -1778,7 +1761,6 @@ namespace System.Windows.Forms.Layout
                         _rowStyles = new TableLayoutRowStyleCollection(_container);
                     }
                     return _rowStyles;
-
                 }
                 set
                 {
@@ -1787,7 +1769,6 @@ namespace System.Windows.Forms.Layout
                     {
                         _rowStyles.EnsureOwnership(_container);
                     }
-
                 }
             }
 
@@ -1844,7 +1825,6 @@ namespace System.Windows.Forms.Layout
                             if (layoutInfo.IsAbsolutelyPositioned)
                             {
                                 _countFixedChildren++;
-
                             }
                             childInfo[index++] = layoutInfo;
                             _minRowsAndColumns += layoutInfo.RowSpan * layoutInfo.ColumnSpan;
@@ -1853,7 +1833,6 @@ namespace System.Windows.Forms.Layout
                                 _minColumns = Math.Max(_minColumns, layoutInfo.ColumnPosition + layoutInfo.ColumnSpan);
                                 _minRows = Math.Max(_minRows, layoutInfo.RowPosition + layoutInfo.RowSpan);
                             }
-
                         }
 
                         // shorten the array if necessary.
@@ -1968,7 +1947,6 @@ namespace System.Windows.Forms.Layout
                 }
                 return Size.Empty;
             }
-
         }
         #endregion
 
@@ -2197,7 +2175,6 @@ namespace System.Windows.Forms.Layout
                     _rows.RemoveAt(0);
                 }
             }
-
         }
         #endregion ReservationGrid
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
@@ -143,7 +143,6 @@ namespace System.Windows.Forms
             {
                 if (focusLink != value)
                 {
-
                     if (focusLink != null)
                     {
                         InvalidateLink(focusLink);
@@ -156,7 +155,6 @@ namespace System.Windows.Forms
                         InvalidateLink(focusLink);
 
                         UpdateAccessibilityLink(focusLink);
-
                     }
                 }
             }
@@ -685,7 +683,6 @@ namespace System.Windows.Forms
             string text = Text;
             try
             {
-
                 Font alwaysUnderlined = new Font(Font, Font.Style | FontStyle.Underline);
                 Graphics created = null;
 
@@ -744,7 +741,6 @@ namespace System.Windows.Forms
                                 iLeftMargin = dtParams.iLeftMargin;
                                 iRightMargin = dtParams.iRightMargin;
                             }
-
                         }
 
                         Rectangle visualRectangle = new Rectangle(clientRectWithPadding.X + iLeftMargin,
@@ -1037,7 +1033,6 @@ namespace System.Windows.Forms
                 if ((link.State & LinkState.Hover) == LinkState.Hover
                     || (link.State & LinkState.Active) == LinkState.Active)
                 {
-
                     bool activeChanged = (link.State & LinkState.Active) == LinkState.Active;
                     link.State &= ~(LinkState.Hover | LinkState.Active);
 
@@ -1411,7 +1406,6 @@ namespace System.Windows.Forms
             {
                 base.OnPaintBackground(e);
             }
-
         }
 
         protected override void OnFontChanged(EventArgs e)
@@ -1779,7 +1773,6 @@ namespace System.Windows.Forms
                     {
                         test = null;
                     }
-
                 } while (test != null
                          && !test.Enabled
                          && LinkInText(charStart, charEnd - charStart));
@@ -1856,7 +1849,6 @@ namespace System.Windows.Forms
                 // focused link, otherwise, we set the focus to the next link.
                 if (links.Count > 0)
                 {
-
                     // Find which link is currently focused
                     //
                     int focusIndex = -1;
@@ -1920,7 +1912,6 @@ namespace System.Windows.Forms
                 return Links[0].Start != 0 || Links[0]._length != -1;
             }
             return true;
-
         }
 
         /// <summary>
@@ -1956,7 +1947,6 @@ namespace System.Windows.Forms
         {
             if (!IsHandleCreated)
             {
-
                 return;
             }
 
@@ -1979,7 +1969,6 @@ namespace System.Windows.Forms
         {
             for (int x = 0; x < links.Count; x++)
             {
-
                 Link left = (Link)links[x];
                 if (left.Length < 0)
                 {
@@ -2086,7 +2075,6 @@ namespace System.Windows.Forms
             {
                 DefWndProc(ref m);
             }
-
         }
 
         protected override void WndProc(ref Message msg)
@@ -2177,7 +2165,6 @@ namespace System.Windows.Forms
                     {
                         return null;
                     }
-
                 }
             }
 
@@ -2256,7 +2243,6 @@ namespace System.Windows.Forms
                     && this[0].Start == 0
                     && this[0]._length == -1)
                 {
-
                     owner.links.Clear();
                     owner.FocusLink = null;
                 }
@@ -2285,7 +2271,6 @@ namespace System.Windows.Forms
                     && this[0].Start == 0
                     && this[0]._length == -1)
                 {
-
                     owner.links.Clear();
                     owner.FocusLink = null;
                 }
@@ -2470,7 +2455,6 @@ namespace System.Windows.Forms
 
             public void Remove(Link value)
             {
-
                 if (value.Owner != owner)
                 {
                     return;
@@ -2880,7 +2864,6 @@ namespace System.Windows.Forms
                     }
 
                     return state;
-
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkUtilities.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkUtilities.cs
@@ -31,7 +31,6 @@ namespace System.Windows.Forms
 
             if (key != null)
             {
-
                 // Since this comes from the registry, be very careful about its contents.
                 //
                 string s = (string)key.GetValue(name);
@@ -70,7 +69,6 @@ namespace System.Windows.Forms
             {
                 return Color.Red;
             }
-
         }
 
         public static Color IELinkColor

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBindingConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBindingConverter.cs
@@ -131,7 +131,6 @@ namespace System.Windows.Forms
 
             for (; lastItem >= 0; lastItem--)
             {
-
                 // null means no prop is available, we quit here.
                 //
                 if (ConstructorParameterProperties[lastItem] == null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBindingHelper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBindingHelper.cs
@@ -630,7 +630,6 @@ namespace System.Windows.Forms
                         //         pdc = new PropertyDescriptorCollection(merged.ToArray());
                         //     }
                         // }
-
                     }
                 }
             }
@@ -657,7 +656,6 @@ namespace System.Windows.Forms
                         pdc = TypeDescriptor.GetProperties(enumerable, BrowsableAttributeList);
                     }
                 }
-
             }
 
             // Return results
@@ -706,7 +704,5 @@ namespace System.Windows.Forms
 
             return instance;
         }
-
     }
-
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -723,7 +723,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 if (horizontalExtent > 0)
                 {
                     return horizontalExtent;
@@ -904,7 +903,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 SelectionMode current = (selectionModeChanging) ? cachedSelectionMode : selectionMode;
 
                 if (current == SelectionMode.None)
@@ -926,7 +924,6 @@ namespace System.Windows.Forms
             }
             set
             {
-
                 int itemCount = (itemsCollection == null) ? 0 : itemsCollection.Count;
 
                 if (value < -1 || value >= itemCount)
@@ -941,7 +938,6 @@ namespace System.Windows.Forms
 
                 if (selectionMode == SelectionMode.One && value != -1)
                 {
-
                     // Single select an individual value.
                     int currentIndex = SelectedIndex;
 
@@ -973,7 +969,6 @@ namespace System.Windows.Forms
                 {
                     if (!SelectedItems.GetSelected(value))
                     {
-
                         // Select this item while keeping any previously selected items selected.
                         //
                         SelectedItems.SetSelected(value, true);
@@ -1184,7 +1179,6 @@ namespace System.Windows.Forms
                 //
                 if (SelectionMode != SelectionMode.None && value != null && (SelectedItem == null || !value.Equals(GetItemText(SelectedItem))))
                 {
-
                     int cnt = Items.Count;
                     for (int index = 0; index < cnt; ++index)
                     {
@@ -1772,7 +1766,6 @@ namespace System.Windows.Forms
 
             switch (selectionMode)
             {
-
                 case SelectionMode.One:
                     int index = unchecked((int)(long)SendMessage((int)User32.LB.GETCURSEL, 0, 0));
                     if (index >= 0)
@@ -1885,7 +1878,6 @@ namespace System.Windows.Forms
 
             if (itemsCollection != null)
             {
-
                 int count = itemsCollection.Count;
 
                 for (int i = 0; i < count; i++)
@@ -1968,7 +1960,6 @@ namespace System.Windows.Forms
             {
                 Invalidate();
             }
-
         }
 
         /// <summary>
@@ -2074,7 +2065,6 @@ namespace System.Windows.Forms
                 {
                     graphics.Dispose();
                 }
-
             }
             base.Refresh();
         }
@@ -2147,7 +2137,6 @@ namespace System.Windows.Forms
                     }
                 }
             }
-
         }
 
         /// <summary>
@@ -2336,7 +2325,6 @@ namespace System.Windows.Forms
             UpdateHorizontalExtent();
             // clear the preferred size cache.
             CommonProperties.xClearPreferredSizeCache(this);
-
         }
 
         private void UpdateHorizontalExtent()
@@ -2369,7 +2357,6 @@ namespace System.Windows.Forms
             //
             if (maxWidth > -1)
             {
-
                 // Compute item width
                 //
                 int width;
@@ -2851,7 +2838,6 @@ namespace System.Windows.Forms
             /// </summary>
             public int IndexOf(object item, int stateMask)
             {
-
                 int virtualIndex = -1;
 
                 for (int i = 0; i < count; i++)
@@ -3379,7 +3365,6 @@ namespace System.Windows.Forms
             /// </summary>
             internal void ClearInternal()
             {
-
                 //update the width.. to reset Scrollbars..
                 // Clear the selection state.
                 //
@@ -3487,7 +3472,6 @@ namespace System.Windows.Forms
                     InnerArray.Insert(index, item);
                     if (owner.IsHandleCreated)
                     {
-
                         bool successful = false;
 
                         try
@@ -3514,7 +3498,6 @@ namespace System.Windows.Forms
             /// </summary>
             public void Remove(object value)
             {
-
                 int index = InnerArray.IndexOf(value, 0);
 
                 if (index != -1)
@@ -3713,7 +3696,6 @@ namespace System.Windows.Forms
             /// </summary>
             private int AddInternal(int item)
             {
-
                 EnsureSpace(1);
 
                 int index = IndexOf(item);
@@ -3839,7 +3821,6 @@ namespace System.Windows.Forms
             /// </summary>
             public void Remove(int item)
             {
-
                 int index = IndexOf(item);
 
                 if (index != -1)
@@ -3876,14 +3857,12 @@ namespace System.Windows.Forms
                 }
                 set
                 {
-
                     if (index < 0 || index >= count)
                     {
                         throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
                     }
                     innerArray[index] = (int)value;
                     owner.UpdateCustomTabOffsets();
-
                 }
             }
 
@@ -3903,7 +3882,6 @@ namespace System.Windows.Forms
                     {
                         this[index] = (int)value;
                     }
-
                 }
             }
 
@@ -3944,7 +3922,6 @@ namespace System.Windows.Forms
                 /// </summary>
                 bool IEnumerator.MoveNext()
                 {
-
                     if (current < items.Count - 1)
                     {
                         current++;
@@ -4059,7 +4036,6 @@ namespace System.Windows.Forms
 
             public int IndexOf(int selectedIndex)
             {
-
                 // Just what does this do?  The selectedIndex parameter above is the index into the
                 // main object collection.  We look at the state of that item, and if the state indicates
                 // that it is selected, we get back the virtualized index into this collection.  Indexes on
@@ -4068,7 +4044,6 @@ namespace System.Windows.Forms
                     selectedIndex < InnerArray.GetCount(0) &&
                     InnerArray.GetState(selectedIndex, SelectedObjectCollection.SelectedObjectMask))
                 {
-
                     return InnerArray.IndexOf(InnerArray.GetItem(selectedIndex, 0), SelectedObjectCollection.SelectedObjectMask);
                 }
 
@@ -4224,7 +4199,6 @@ namespace System.Windows.Forms
                 /// </summary>
                 bool IEnumerator.MoveNext()
                 {
-
                     if (current < items.Count - 1)
                     {
                         current++;
@@ -4294,7 +4268,6 @@ namespace System.Windows.Forms
                         SelectionMode current = (owner.selectionModeChanging) ? owner.cachedSelectionMode : owner.selectionMode;
                         switch (current)
                         {
-
                             case SelectionMode.None:
                                 return 0;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -489,7 +489,6 @@ namespace System.Windows.Forms
                 {
                     if (CheckBoxes != value)
                     {
-
                         if (value && View == View.Tile)
                         {
                             throw new NotSupportedException(SR.ListViewCheckBoxesNotSupportedInTileView);
@@ -536,7 +535,6 @@ namespace System.Windows.Forms
                 {
                     if (CheckBoxes != value)
                     {
-
                         if (value && View == View.Tile)
                         {
                             throw new NotSupportedException(SR.ListViewCheckBoxesNotSupportedInTileView);
@@ -578,7 +576,6 @@ namespace System.Windows.Forms
                         else
                         {
                             UpdateExtendedStyles();
-
                         }
 
                         if (CheckBoxes && savedCheckedItems != null)
@@ -615,7 +612,6 @@ namespace System.Windows.Forms
                         {
                             ArrangeIcons(Alignment);
                         }
-
                     }
                 }
             }
@@ -1097,7 +1093,6 @@ namespace System.Windows.Forms
             {
                 if (HotTracking != value)
                 {
-
                     listViewState[LISTVIEWSTATE_hotTracking] = value;
                     if (value)
                     {
@@ -1259,7 +1254,6 @@ namespace System.Windows.Forms
             {
                 if (value != imageListLarge)
                 {
-
                     EventHandler recreateHandler = new EventHandler(LargeImageListRecreateHandle);
                     EventHandler disposedHandler = new EventHandler(DetachImageList);
                     EventHandler changeHandler = new EventHandler(LargeImageListChangedHandle);
@@ -1403,7 +1397,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 return rightToLeftLayout;
             }
 
@@ -1533,7 +1526,6 @@ namespace System.Windows.Forms
             {
                 if (imageListSmall != value)
                 {
-
                     EventHandler recreateHandler = new EventHandler(SmallImageListRecreateHandle);
                     EventHandler disposedHandler = new EventHandler(DetachImageList);
 
@@ -1551,7 +1543,6 @@ namespace System.Windows.Forms
 
                     if (IsHandleCreated)
                     {
-
                         SendMessage((int)LVM.SETIMAGELIST, (IntPtr)NativeMethods.LVSIL_SMALL, value == null ? IntPtr.Zero : value.Handle);
 
                         if (View == View.SmallIcon)
@@ -1625,7 +1616,6 @@ namespace System.Windows.Forms
                         {
                             ((IconComparer)listItemSorter).SortOrder = sorting;
                         }
-
                     }
                     else if (value == SortOrder.None)
                     {
@@ -1663,7 +1653,6 @@ namespace System.Windows.Forms
                 {
                     if (imageListState != value)
                     {
-
                         EventHandler recreateHandler = new EventHandler(StateImageListRecreateHandle);
                         EventHandler disposedHandler = new EventHandler(DetachImageList);
 
@@ -1689,7 +1678,6 @@ namespace System.Windows.Forms
                 {
                     if (imageListState != value)
                     {
-
                         EventHandler recreateHandler = new EventHandler(StateImageListRecreateHandle);
                         EventHandler disposedHandler = new EventHandler(DetachImageList);
 
@@ -2329,7 +2317,6 @@ namespace System.Windows.Forms
             {
                 Sort();
             }
-
         }
 
         /// <summary>
@@ -2643,7 +2630,6 @@ namespace System.Windows.Forms
                         // If OwnerDraw is true, fire the onDrawItem event.
                         if (OwnerDraw)
                         {
-
                             Graphics g = Graphics.FromHdcInternal(nmcd->nmcd.hdc);
 
 #if DEBUGGING
@@ -2700,7 +2686,6 @@ namespace System.Windows.Forms
                             //(which means we can't just do our color/font work on SUBITEM|ITEM_PREPAINT)
                             //so fall through... and tell the end of SUBITEM|ITEM_PREPAINT not to mess
                             //with our return value...
-
                         }
 
                         //If it's not a report, we fall through and change the main item's styles
@@ -2724,7 +2709,6 @@ namespace System.Windows.Forms
                         // If OwnerDraw is true, fire the onDrawSubItem event.
                         if (OwnerDraw && !itemDrawDefault)
                         {
-
                             Graphics g = Graphics.FromHdcInternal(nmcd->nmcd.hdc);
                             DrawListViewSubItemEventArgs e = null;
 
@@ -2732,7 +2716,6 @@ namespace System.Windows.Forms
                             bool skipCustomDrawCode = true;
                             try
                             {
-
                                 //The ListView will send notifications for every column, even if no
                                 //corresponding subitem exists for a particular item. We shouldn't
                                 //fire events in such cases.
@@ -2976,7 +2959,6 @@ namespace System.Windows.Forms
         {
             if (!string.IsNullOrEmpty(fileName))
             {
-
                 IO.FileInfo fi = new IO.FileInfo(fileName);
                 if (fi.Exists)
                 {
@@ -3038,7 +3020,6 @@ namespace System.Windows.Forms
             }
 
             UpdateListViewItemsLocations();
-
         }
 
         /// <summary>
@@ -3089,7 +3070,6 @@ namespace System.Windows.Forms
 
                 if (!string.IsNullOrEmpty(backgroundImageFileName) || bkImgFileNames != null)
                 {
-
                     IO.FileInfo fi;
                     if (!string.IsNullOrEmpty(backgroundImageFileName))
                     {
@@ -3126,7 +3106,6 @@ namespace System.Windows.Forms
                     bkImgFileNames = null;
                     bkImgFileNamesCount = -1;
                 }
-
             }
 
             base.Dispose(disposing);
@@ -4196,7 +4175,6 @@ namespace System.Windows.Forms
                     }
                     finally
                     {
-
                         // Restore the item check event handler.
                         onItemCheck = oldOnItemCheck;
                     }
@@ -4389,7 +4367,6 @@ namespace System.Windows.Forms
             }
 
             ResetMouseEventArgs();
-
         }
 
         /// <summary>
@@ -4623,7 +4600,6 @@ namespace System.Windows.Forms
                     }
                 }
             }
-
         }
 
         protected override void OnHandleDestroyed(EventArgs e)
@@ -4632,7 +4608,6 @@ namespace System.Windows.Forms
             // user to cache the list view items in virtual mode
             if (!Disposing && !VirtualMode)
             {
-
                 int count = Items.Count;
                 for (int i = 0; i < count; i++)
                 {
@@ -5459,7 +5434,6 @@ namespace System.Windows.Forms
                     string txt = (z.Length > 40) ? z.Substring(0, 40) : z;
                     s += ", Items[0]: " + txt;
                 }
-
             }
             return s;
         }
@@ -5479,7 +5453,6 @@ namespace System.Windows.Forms
                     EndUpdate();
                 }
             }
-
         }
 
         private void UpdateColumnWidths(ColumnHeaderAutoResizeStyle headerAutoResize)
@@ -5697,7 +5670,6 @@ namespace System.Windows.Forms
             //If Validation is cancelled dont fire any events through the Windows ListView's message loop...
             if (!ValidationCancelled)
             {
-
                 if (CheckBoxes)
                 {
                     ListViewHitTestInfo lvhti = HitTest(x, y);
@@ -5726,7 +5698,6 @@ namespace System.Windows.Forms
                     DefWndProc(ref m);
                 }
             }
-
         }
 
         private unsafe bool WmNotify(ref Message m)
@@ -5746,7 +5717,6 @@ namespace System.Windows.Forms
                             {
                                 m.Result = (IntPtr)CDRF.NOTIFYITEMDRAW;
                                 return true; // we are done - don't do default handling
-
                             }
                         case CDDS.ITEMPREPAINT:
                             {
@@ -5772,7 +5742,6 @@ namespace System.Windows.Forms
                                     }
                                     else
                                     {
-
                                         m.Result = (IntPtr)CDRF.SKIPDEFAULT;
                                         return true; // we are done - don't do default handling
                                     }
@@ -5869,7 +5838,6 @@ namespace System.Windows.Forms
                          columnHeaderClickedWidth != -1 &&
                          columnHeaderClickedWidth != w))
                     {
-
                         //
                         // If the user double clicked on the column header and we still need to compensate for the column resize
                         // then don't fire ColumnWidthChanged because at this point the column header does not have the final width.
@@ -5885,7 +5853,6 @@ namespace System.Windows.Forms
                         {
                             OnColumnWidthChanged(new ColumnWidthChangedEventArgs(nmheader.iItem));
                         }
-
                     }
                 }
 
@@ -5948,11 +5915,9 @@ namespace System.Windows.Forms
                 NativeMethods.NMHEADER header = (NativeMethods.NMHEADER)m.GetLParam(typeof(NativeMethods.NMHEADER));
                 if (header.pItem != IntPtr.Zero)
                 {
-
                     HDITEMW hdItem = Marshal.PtrToStructure<HDITEMW>(header.pItem);
                     if ((hdItem.mask & HDI.ORDER) == HDI.ORDER)
                     {
-
                         int from = Columns[header.iItem].DisplayIndex;
                         int to = hdItem.iOrder;
                         // check this
@@ -5986,7 +5951,6 @@ namespace System.Windows.Forms
                             int[] indices = new int[Columns.Count];
                             for (int i = 0; i < Columns.Count; i++)
                             {
-
                                 ColumnHeader hdr = Columns[i];
                                 if (hdr.DisplayIndex == from)
                                 {
@@ -6098,7 +6062,6 @@ namespace System.Windows.Forms
             };
 
             return (int)User32.SendMessageW(this, (User32.WindowMessage)LVM.HITTEST, IntPtr.Zero, ref lvhi);
-
         }
 
         internal void RecreateHandleInternal()
@@ -6766,7 +6729,6 @@ namespace System.Windows.Forms
             {
                 get
                 {
-
                     if (index < 0)
                     {
                         throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
@@ -7047,7 +7009,6 @@ namespace System.Windows.Forms
                     {
                         return null;
                     }
-
                 }
             }
 
@@ -7268,7 +7229,6 @@ namespace System.Windows.Forms
                     return Array.Empty<ListViewItem>().GetEnumerator();
                 }
             }
-
         }
 
         [ListBindable(false)]
@@ -7350,7 +7310,6 @@ namespace System.Windows.Forms
             {
                 get
                 {
-
                     if (index < 0 || index >= Count)
                     {
                         throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
@@ -7358,7 +7317,6 @@ namespace System.Windows.Forms
 
                     if (owner.IsHandleCreated)
                     {
-
                         // Count through the selected items in the ListView, until
                         // we reach the 'index'th selected item.
                         //
@@ -7634,7 +7592,6 @@ namespace System.Windows.Forms
                         }
 
                         return lvitems;
-
                     }
                     else
                     {
@@ -7690,7 +7647,6 @@ namespace System.Windows.Forms
             {
                 get
                 {
-
                     if (owner.VirtualMode)
                     {
                         throw new InvalidOperationException(SR.ListViewCantAccessSelectedItemsCollectionWhenInVirtualMode);
@@ -7703,7 +7659,6 @@ namespace System.Windows.Forms
 
                     if (owner.IsHandleCreated)
                     {
-
                         // Count through the selected items in the ListView, until
                         // we reach the 'index'th selected item.
                         //
@@ -7752,7 +7707,6 @@ namespace System.Windows.Forms
                     {
                         return null;
                     }
-
                 }
             }
 
@@ -8000,7 +7954,6 @@ namespace System.Windows.Forms
                 lastAccessedIndex = -1;
                 return -1;
             }
-
         }
 
         [ListBindable(false)]
@@ -8065,7 +8018,6 @@ namespace System.Windows.Forms
                     {
                         return null;
                     }
-
                 }
             }
 
@@ -8766,7 +8718,6 @@ namespace System.Windows.Forms
                     {
                         return null;
                     }
-
                 }
             }
 
@@ -8949,7 +8900,6 @@ namespace System.Windows.Forms
 
                 for (int i = 0; i < listViewItems.Count; i++)
                 {
-
                     if (WindowsFormsUtils.SafeCompareStrings(listViewItems[i].Name, key, /* ignoreCase = */ true))
                     {
                         foundItems.Add(listViewItems[i]);
@@ -9205,7 +9155,6 @@ namespace System.Windows.Forms
 
                     if (owner.VirtualMode)
                     {
-
                         // if we are showing virtual items, we need to get the item from the user
                         RetrieveVirtualItemEventArgs rVI = new RetrieveVirtualItemEventArgs(displayIndex);
                         owner.OnRetrieveVirtualItem(rVI);
@@ -9331,7 +9280,6 @@ namespace System.Windows.Forms
                             }
                         }
                     }
-
                 }
                 finally
                 {
@@ -9392,7 +9340,6 @@ namespace System.Windows.Forms
                             Debug.Assert(item != null, "Failed to get item at index " + i.ToString(CultureInfo.InvariantCulture));
                             if (item != null)
                             {
-
                                 // if it's the one we're looking for, ask for the next one
                                 //
                                 if (i == nextSelected)
@@ -9432,7 +9379,6 @@ namespace System.Windows.Forms
                     }
                     else
                     {
-
                         int count = owner.Items.Count;
 
                         for (int i = 0; i < count; i++)
@@ -9459,13 +9405,11 @@ namespace System.Windows.Forms
                     {
                         owner.ItemCollectionChangedInMouseDown = true;
                     }
-
                 }
             }
 
             public bool Contains(ListViewItem item)
             {
-
                 owner.ApplyUpdateCachedItems();
                 if (owner.IsHandleCreated && !owner.ListViewHandleDestroyed)
                 {
@@ -9578,7 +9522,6 @@ namespace System.Windows.Forms
 
                 if (owner.IsHandleCreated)
                 {
-
                     Debug.Assert(owner.listItemsArray == null, "listItemsArray not null, even though handle created");
                     int retval = unchecked((int)(long)owner.SendMessage((int)LVM.DELETEITEM, index, 0));
 
@@ -9600,7 +9543,6 @@ namespace System.Windows.Forms
                 {
                     owner.ItemCollectionChangedInMouseDown = true;
                 }
-
             }
 
             public void CopyTo(Array dest, int index)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
@@ -63,7 +63,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Creates a ListViewGroup.
         /// </summary>
-    	public ListViewGroup(string header, HorizontalAlignment headerAlignment) : this(header)
+        public ListViewGroup(string header, HorizontalAlignment headerAlignment) : this(header)
         {
             _headerAlignment = headerAlignment;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewInsertionMark.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewInsertionMark.cs
@@ -28,10 +28,10 @@ namespace System.Windows.Forms
 
         /// <summary>
         ///  Specifies whether the insertion mark appears
-    	///  after the item - otherwise it appears
-    	///  before the item (the default).
+        ///  after the item - otherwise it appears
+        ///  before the item (the default).
         /// </summary>
-    	public bool AppearsAfterItem
+        public bool AppearsAfterItem
         {
             get
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
@@ -1987,7 +1987,6 @@ namespace System.Windows.Forms
                 {
                     return Array.Empty<ListViewSubItem>().GetEnumerator();
                 }
-
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItemStateImageIndexConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItemStateImageIndexConverter.cs
@@ -4,7 +4,6 @@
 
 using System.ComponentModel;
 
-
 namespace System.Windows.Forms
 {
     /// <summary>
@@ -33,7 +32,7 @@ namespace System.Windows.Forms
         /// </summary>
         /// <param name="context">
         ///  An object that provides a format context, which can be used to extract additional
-        ///  information about the environment this type converter is being invoked from. 
+        ///  information about the environment this type converter is being invoked from.
         ///  This parameter or its properties can be <see langword="null" />.
         /// </param>
         /// <returns>
@@ -71,7 +70,6 @@ namespace System.Windows.Forms
 
                 if (imageList != null)
                 {
-
                     // Create array to contain standard values
                     //
                     object[] values;
@@ -95,7 +93,6 @@ namespace System.Windows.Forms
 
                     return new StandardValuesCollection(values);
                 }
-
             }
             if (IncludeNoneAsStandardValue)
             {
@@ -105,8 +102,6 @@ namespace System.Windows.Forms
             {
                 return new StandardValuesCollection(Array.Empty<object>());
             }
-
         }
-
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MDIClient.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MDIClient.cs
@@ -11,12 +11,12 @@ using static Interop;
 namespace System.Windows.Forms
 {
     /// <summary>
-    /// Represents the container for multiple-document interface (MDI) child forms. 
+    /// Represents the container for multiple-document interface (MDI) child forms.
     /// This class cannot be inherited.
     /// </summary>
     /// <remarks>
     ///  Don't create an <see cref="MdiClient"/> control.
-    ///  A form creates and uses the <see cref="MdiClient"/> when you set the <see cref="Form.IsMdiContainer"/> property to <see langword="true"/>.  
+    ///  A form creates and uses the <see cref="MdiClient"/> when you set the <see cref="Form.IsMdiContainer"/> property to <see langword="true"/>.
     /// </remarks>
     [
     ComVisible(true),
@@ -221,7 +221,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Scales this form's location, size, padding, and margin. The <see cref="MdiClient" /> overrides 
+        ///  Scales this form's location, size, padding, and margin. The <see cref="MdiClient" /> overrides
         ///  <see cref="ScaleControl(SizeF,BoundsSpecified)" /> to enforce a minimum and maximum size.
         /// </summary>
         /// <param name="factor">The factor by which the height and width of the control will be scaled.</param>
@@ -378,7 +378,6 @@ namespace System.Windows.Forms
         {
             switch (m.Msg)
             {
-
                 case WindowMessages.WM_CREATE:
                     if (ParentInternal != null && ParentInternal.Site != null && ParentInternal.Site.DesignMode && Handle != IntPtr.Zero)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MDIControlStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MDIControlStrip.cs
@@ -212,7 +212,6 @@ namespace System.Windows.Forms
                 }
                 target = null;
             }
-
         }
 
         // when the system menu item shortcut is evaluated - pop the dropdown
@@ -251,7 +250,6 @@ namespace System.Windows.Forms
                 }
                 base.OnOwnerChanged(e);
             }
-
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MaskedTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MaskedTextBox.cs
@@ -2019,7 +2019,6 @@ namespace System.Windows.Forms
             {
                 if (!ReadOnly)
                 {
-
                     base.GetSelectionStartAndLength(out int startPosition, out int selectionLen);
 
                     switch (e.Modifiers)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MdiWindowListItemConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MdiWindowListItemConverter.cs
@@ -32,7 +32,6 @@ namespace System.Windows.Forms
                     }
                 }
                 return new StandardValuesCollection(list);
-
             }
             return base.GetStandardValues(context);
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MdiWindowListStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MdiWindowListStrip.cs
@@ -83,7 +83,6 @@ namespace System.Windows.Forms
                 Form[] forms = mdiParent.MdiChildren;
                 if (forms != null && forms.Length != 0)
                 {
-
                     if (includeSeparator)
                     {
                         ToolStripSeparator separator = new ToolStripSeparator
@@ -173,7 +172,6 @@ namespace System.Windows.Forms
                     DialogResult result = dialog.ShowDialog();
                     if (result == DialogResult.OK)
                     {
-
                         // AllWindows Assert above allows this...
                         //
                         dialog.ActiveChildForm.Activate();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MenuStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MenuStrip.cs
@@ -26,7 +26,6 @@ namespace System.Windows.Forms
             CanOverflow = false;
             GripStyle = ToolStripGripStyle.Hidden;
             Stretch = true;
-
         }
 
         internal override bool KeyboardActive
@@ -177,7 +176,7 @@ namespace System.Windows.Forms
             {
                 AccessibilityNotifyClients(AccessibleEvents.SystemMenuStart, -1);
             }
-            
+
             ((EventHandler)Events[EventMenuActivate])?.Invoke(this, e);
         }
 
@@ -187,7 +186,7 @@ namespace System.Windows.Forms
             {
                 AccessibilityNotifyClients(AccessibleEvents.SystemMenuEnd, -1);
             }
-            
+
             ((EventHandler)Events[EventMenuDeactivate])?.Invoke(this, e);
         }
 
@@ -242,7 +241,6 @@ namespace System.Windows.Forms
                 }
             }
             return base.ProcessCmdKey(ref m, keyData);
-
         }
         /// <summary>
         ///  Summary of WndProc.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MessageBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MessageBox.cs
@@ -79,7 +79,6 @@ namespace System.Windows.Forms
             if (helpInfoTable == null)
             {
                 Debug.Fail("Why are we being called when there's nothing to pop?");
-
             }
             else
             {
@@ -93,10 +92,8 @@ namespace System.Windows.Forms
                     HelpInfo[] newTable = new HelpInfo[newCount];
                     Array.Copy(helpInfoTable, newTable, newCount);
                     helpInfoTable = newTable;
-
                 }
             }
-
         }
         private static void PushHelpInfo(HelpInfo hpi)
         {
@@ -121,7 +118,6 @@ namespace System.Windows.Forms
             }
             newTable[lastCount] = hpi;
             helpInfoTable = newTable;
-
         }
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -336,7 +332,6 @@ namespace System.Windows.Forms
                 PopHelpInfo();
             }
             return result;
-
         }
 
         private static DialogResult ShowCore(IWin32Window owner, string text, string caption,
@@ -428,7 +423,6 @@ namespace System.Windows.Forms
             UnsafeNativeMethods.SendMessage(new HandleRef(owner, handle), WindowMessages.WM_SETFOCUS, 0, 0);
             return result;
         }
-
     }
 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -216,7 +216,6 @@ namespace System.Windows.Forms
 
                 if (value != null && value.Length > 0)
                 {
-
                     //add each boldeddate to our ArrayList...
                     for (int i = 0; i < value.Length; i++)
                     {
@@ -227,7 +226,6 @@ namespace System.Windows.Forms
                     {
                         monthsOfYear[value[i].Month - 1] |= 0x00000001 << (value[i].Day - 1);
                     }
-
                 }
                 RecreateHandle();
             }
@@ -318,13 +316,11 @@ namespace System.Windows.Forms
                 arrayOfDates.Clear();
                 if (value != null && value.Length > 0)
                 {
-
                     //add each boldeddate to our ArrayList...
                     for (int i = 0; i < value.Length; i++)
                     {
                         arrayOfDates.Add(value[i]);
                     }
-
                 }
                 RecreateHandle();
             }
@@ -645,7 +641,6 @@ namespace System.Windows.Forms
 
                 if (value != null && value.Length > 0)
                 {
-
                     //add each boldeddate to our ArrayList...
                     for (int i = 0; i < value.Length; i++)
                     {
@@ -656,7 +651,6 @@ namespace System.Windows.Forms
                     {
                         datesToBoldMonthly |= 0x00000001 << (value[i].Day - 1);
                     }
-
                 }
                 RecreateHandle();
             }
@@ -707,7 +701,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 return rightToLeftLayout;
             }
 
@@ -746,7 +739,6 @@ namespace System.Windows.Forms
             {
                 if (scrollChange != value)
                 {
-
                     if (value < 0)
                     {
                         throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(ScrollChange), value.ToString("D"), 0));
@@ -784,7 +776,6 @@ namespace System.Windows.Forms
             {
                 if (selectionEnd != value)
                 {
-
                     // Keep SelectionEnd within min and max
                     if (value < MinDate)
                     {
@@ -833,7 +824,6 @@ namespace System.Windows.Forms
             {
                 if (selectionStart != value)
                 {
-
                     // Keep SelectionStart within min and max
                     //
                     if (value < minDate)
@@ -1071,7 +1061,6 @@ namespace System.Windows.Forms
             {
                 if (!(todayDateSet) || (DateTime.Compare(value, todayDate) != 0))
                 {
-
                     // throw if trying to set the TodayDate to a value greater than MaxDate
                     if (DateTime.Compare(value, maxDate) > 0)
                     {
@@ -2146,7 +2135,6 @@ namespace System.Windows.Forms
             //
             if ((date2 - date1).Days >= maxSelectionCount)
             {
-
                 if (date1.Ticks == selectionStart.Ticks)
                 {
                     // Bring start date forward
@@ -2406,7 +2394,6 @@ namespace System.Windows.Forms
 
             //end subhag
             OnDateSelected(new DateRangeEventArgs(start, end));
-
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
@@ -127,7 +127,6 @@ namespace System.Windows.Forms
                                 100,
                                 out _) == IntPtr.Zero)
                             {
-
                                 //Debug.Fail("unable to ping HWND:" + handle.ToString() + " during finalization");
                             }
                         }
@@ -321,7 +320,6 @@ namespace System.Windows.Forms
 
                 _priorWindowProcHandle = User32.GetWindowLong(this, User32.GWL.WNDPROC);
                 Debug.Assert(_priorWindowProcHandle != IntPtr.Zero);
-
 
                 Debug.WriteLineIf(
                     WndProcChoice.TraceVerbose,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
@@ -644,7 +644,6 @@ namespace System.Windows.Forms
         {
             lock (syncObj)
             {
-
                 // Bail if in design mode...
                 //
                 if (DesignMode)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDown.cs
@@ -361,7 +361,6 @@ namespace System.Windows.Forms
             {
                 if (value != currentValue)
                 {
-
                     if (!initializing && ((value < minimum) || (value > maximum)))
                     {
                         throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidBoundArgument, nameof(Value), value, $"'{nameof(Minimum)}'", $"'{nameof(Maximum)}'"));
@@ -793,7 +792,6 @@ namespace System.Windows.Forms
             if (currentValueChanged || (!string.IsNullOrEmpty(Text) &&
                 !(Text.Length == 1 && Text == "-")))
             {
-
                 currentValueChanged = false;
                 ChangingText = true;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDownAcceleration.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDownAcceleration.cs
@@ -70,5 +70,4 @@ namespace System.Windows.Forms
             }
         }
     }
-
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
@@ -634,7 +634,6 @@ namespace System.Windows.Forms
                     ReadBlockSize,
                     new AsyncCallback(ReadCallBack),
                     responseStream);
-
             }
             catch (Exception error)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintControllerWithStatusDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintControllerWithStatusDialog.cs
@@ -234,7 +234,6 @@ namespace System.Windows.Forms
 
             internal StatusDialog(BackgroundThread backgroundThread, string dialogTitle)
             {
-
                 InitializeComponent();
                 this.backgroundThread = backgroundThread;
                 Text = dialogTitle;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintDialog.cs
@@ -154,7 +154,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 if (settings == null)
                 {
                     settings = new PrinterSettings();
@@ -599,7 +598,6 @@ namespace System.Windows.Forms
 
             settings.PrintRange = (PrintRange)(flags & printRangeMask);
         }
-
     }
 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -58,7 +58,6 @@ namespace System.Windows.Forms
             Size = new Size(100, 100);
             SetStyle(ControlStyles.ResizeRedraw, false);
             SetStyle(ControlStyles.Opaque | ControlStyles.OptimizedDoubleBuffer, true);
-
         }
 
         [
@@ -189,7 +188,6 @@ namespace System.Windows.Forms
             get { return rows; }
             set
             {
-
                 if (value < 1)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(Rows), value, 1));
@@ -447,7 +445,6 @@ namespace System.Windows.Forms
             }
             else
             {
-
                 PrintController oldController = document.PrintController;
                 PreviewPrintController previewController = new PreviewPrintController
                 {
@@ -614,7 +611,6 @@ namespace System.Windows.Forms
                                 int imageIndex = StartPage + column + row * columns;
                                 if (imageIndex < pageInfo.Length)
                                 {
-
                                     Size pageSize = pageInfo[imageIndex].PhysicalSize;
                                     if (autoZoom)
                                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewDialog.cs
@@ -116,7 +116,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 return base.AutoScroll;
             }
             set
@@ -903,7 +902,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 return base.RightToLeftLayout;
             }
 
@@ -1209,7 +1207,7 @@ namespace System.Windows.Forms
             closeToolStripButton});
             toolStrip1.Name = "toolStrip1";
 
-            // in High Contrast mode the color scheme provided by ToolStripSystemRenderer 
+            // in High Contrast mode the color scheme provided by ToolStripSystemRenderer
             // is not sufficiently contrast; so disable it in High Contrast mode.
             if (!SystemInformation.HighContrast)
             {
@@ -1434,7 +1432,6 @@ namespace System.Windows.Forms
                 menu.ShowCheckMargin = true;
                 menu.ShowImageMargin = false;
                 menu.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
-
             }
 
             //Create the ToolStripControlHost
@@ -1458,7 +1455,6 @@ namespace System.Windows.Forms
             toolStrip1.ResumeLayout(false);
             ResumeLayout(false);
             PerformLayout();
-
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ProfessionalColorTable.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ProfessionalColorTable.cs
@@ -549,7 +549,6 @@ namespace System.Windows.Forms
             {
                 return graphics.GetNearestColor(Color.FromArgb(r, g, b));
             }
-
         }
 
         private void InitCommonColors(ref Dictionary<KnownColors, Color> rgbTable)
@@ -573,7 +572,6 @@ namespace System.Windows.Forms
                 rgbTable[ProfessionalColorTable.KnownColors.ButtonCheckedHighlight] = SystemColors.ControlLight;
                 rgbTable[ProfessionalColorTable.KnownColors.ButtonSelectedHighlight] = SystemColors.ControlLight;
             }
-
         }
         internal void InitSystemColors(ref Dictionary<KnownColors, Color> rgbTable)
         {
@@ -615,7 +613,6 @@ namespace System.Windows.Forms
 
                 msocbvcrCBCtlBkgdMouseOver = GetAlphaBlendedColorHighRes(null, highlight, window, 30);
                 msocbvcrCBCtlBkgdMouseDown = GetAlphaBlendedColorHighRes(null, highlight, window, 50);
-
             }
 
             if (lowResolution || highContrast)
@@ -647,7 +644,6 @@ namespace System.Windows.Forms
                 rgbTable[ProfessionalColorTable.KnownColors.msocbvcrCBMenuBdrOuter] = GetAlphaBlendedColorHighRes(null, controlText, buttonShadow, 20);
                 rgbTable[ProfessionalColorTable.KnownColors.msocbvcrCBMenuBkgd] = GetAlphaBlendedColorHighRes(null, buttonFace, window, 143);
                 rgbTable[ProfessionalColorTable.KnownColors.msocbvcrCBSplitterLine] = GetAlphaBlendedColorHighRes(null, buttonShadow, window, 70);
-
             }
             rgbTable[ProfessionalColorTable.KnownColors.msocbvcrCBCtlBkgdSelected] = (lowResolution) ? SystemColors.ControlLight : highlight;
 
@@ -879,7 +875,6 @@ namespace System.Windows.Forms
             rgbTable[ProfessionalColorTable.KnownColors.msocbvcrWPTitleTextActive] = highlightText;
             rgbTable[ProfessionalColorTable.KnownColors.msocbvcrWPTitleTextInactive] = controlText;
             rgbTable[ProfessionalColorTable.KnownColors.msocbvcrXLFormulaBarBkgd] = buttonFace;
-
         }
 
         internal void InitOliveLunaColors(ref Dictionary<KnownColors, Color> rgbTable)
@@ -1582,7 +1577,6 @@ namespace System.Windows.Forms
             rgbTable[ProfessionalColorTable.KnownColors.msocbvcrPlacesBarBkgd] = Color.FromArgb(224, 223, 227); // msocbvcrPlacesBarBkgd
             rgbTable[ProfessionalColorTable.KnownColors.msocbvcrPubPrintDocScratchPageBkgd] = Color.FromArgb(152, 181, 226); // msocbvcrPubPrintDocScratchPageBkgd
             rgbTable[ProfessionalColorTable.KnownColors.msocbvcrPubWebDocScratchPageBkgd] = Color.FromArgb(193, 210, 238); // msocbvcrPubWebDocScratchPageBkgd
-
         }
 
         internal void InitThemedColors(ref Dictionary<KnownColors, Color> rgbTable)
@@ -1614,7 +1608,6 @@ namespace System.Windows.Forms
                     usingSystemColors = false;
                     initializedTable = true;
                 }
-
             }
             else if (string.Equals(aeroFileName, themeFileName, StringComparison.OrdinalIgnoreCase))
             {
@@ -1634,7 +1627,6 @@ namespace System.Windows.Forms
             }
             else if (string.Equals(royaleFileName, themeFileName, StringComparison.OrdinalIgnoreCase))
             {
-
                 // once we know it's royale (TabletPC/MCE) we know about two color scheme names
                 // which should do exactly the same thing
                 if (colorScheme == normalColorScheme || colorScheme == royaleColorScheme)
@@ -1643,7 +1635,6 @@ namespace System.Windows.Forms
                     usingSystemColors = false;
                     initializedTable = true;
                 }
-
             }
 
             if (!initializedTable)
@@ -1655,7 +1646,6 @@ namespace System.Windows.Forms
             }
 
             InitCommonColors(ref rgbTable);
-
         }
 
         internal void InitBlueLunaColors(ref Dictionary<KnownColors, Color> rgbTable)
@@ -2121,8 +2111,6 @@ namespace System.Windows.Forms
             ButtonCheckedHighlight,// not actually from MSO tables
             lastKnownColor = ButtonCheckedHighlight
         }
-
     }
-
 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ProfessionalColors.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ProfessionalColors.cs
@@ -411,8 +411,6 @@ namespace System.Windows.Forms
                 colorScheme = null;
             }
         }
-
     }
-
 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -775,7 +775,6 @@ namespace System.Windows.Forms
             }
             set
             {
-
                 if (value && IsHandleCreated && Visible)
                 {
                     if (0 == paintFrozen++)
@@ -795,7 +794,6 @@ namespace System.Windows.Forms
                         SendMessage(WindowMessages.WM_SETREDRAW, 1, 0);
                         Invalidate(true);
                     }
-
                 }
             }
         }
@@ -1160,7 +1158,6 @@ namespace System.Windows.Forms
                         // the grid with no selected row.
                     }
                 }
-
             }
         }
 
@@ -1293,7 +1290,6 @@ namespace System.Windows.Forms
 
                     if (!isSame)
                     {
-
                         EnsureDesignerEventService();
 
                         showEvents = showEvents && GetFlag(GotDesignerEventService);
@@ -1340,7 +1336,6 @@ namespace System.Windows.Forms
                         // throw away any extra component only tabs
                         if (!classesSame && !GetFlag(TabsChanging) && selectedViewTab < viewTabButtons.Length)
                         {
-
                             Type tabType = selectedViewTab == -1 ? null : viewTabs[selectedViewTab].GetType();
                             ToolStripButton viewTabButton = null;
                             RefreshTabs(PropertyTabScope.Component);
@@ -1426,7 +1421,6 @@ namespace System.Windows.Forms
                     if (propertiesChanged) {*/
                     if (!GetFlag(TabsChanging))
                     {
-
                         // ReInitTab means that we should set the tab back to what is used to be for a given designer.
                         // Basically, if you select an events tab for your designer and double click to go to code, it should
                         // be the events tab when you get back to the designer.
@@ -1538,7 +1532,6 @@ namespace System.Windows.Forms
             }
             set
             {
-
                 // Perf - the base class is possibly going to change the font via ambient properties service
                 SuspendAllLayout(this);
 
@@ -1555,7 +1548,6 @@ namespace System.Windows.Forms
                 }
 
                 ResumeAllLayout(this, true);
-
             }
         }
 
@@ -1725,7 +1717,6 @@ namespace System.Windows.Forms
             {
                 gridView.ForeColor = value;
                 gridView.Invalidate();
-
             }
         }
 
@@ -1946,7 +1937,6 @@ namespace System.Windows.Forms
                         // start after that
                         for (int i = 1; i < viewTabs.Length; i++)
                         {
-
                             // skip the event tab
                             if (viewTabs[i] is EventsTab)
                             {
@@ -2095,7 +2085,6 @@ namespace System.Windows.Forms
                 object param = null;
                 if (constructor == null)
                 {
-
                     // try a IDesignerHost ctor
                     constructor = tabType.GetConstructor(new Type[] { typeof(IDesignerHost) });
 
@@ -2220,11 +2209,9 @@ namespace System.Windows.Forms
 
                     if (site != null)
                     {
-
                         IMenuCommandService mcs = (IMenuCommandService)site.GetService(typeof(IMenuCommandService));
                         if (mcs != null)
                         {
-
                             // Got the menu command service.  Let it deal with the set of verbs for
                             // this component.
                             //
@@ -2233,14 +2220,12 @@ namespace System.Windows.Forms
                         }
                         else
                         {
-
                             // No menu command service.  Go straight to the component's designer.  We
                             // can only do this if the Object count is 1, because desginers do not
                             // support verbs across a multi-selection.
                             //
                             if (currentObjects.Length == 1 && GetUnwrappedObject(0) is IComponent)
                             {
-
                                 IDesignerHost designerHost = (IDesignerHost)site.GetService(typeof(IDesignerHost));
                                 if (designerHost != null)
                                 {
@@ -2260,7 +2245,6 @@ namespace System.Windows.Forms
             // don't show verbs if a prop grid is on the form at design time.
             if (!DesignMode)
             {
-
                 if (verbs != null && verbs.Length > 0)
                 {
                     hotcommands.SetVerbs(component, verbs);
@@ -2566,7 +2550,6 @@ namespace System.Windows.Forms
         {
             if (imageList[LARGE_BUTTONS] == null)
             {
-
                 imageList[LARGE_BUTTONS] = new ImageList
                 {
                     ImageSize = largeButtonSize
@@ -2629,7 +2612,6 @@ namespace System.Windows.Forms
 
             try
             {
-
                 if (designerHost != null)
                 {
                     designerHost.TransactionOpened -= new EventHandler(OnTransactionOpened);
@@ -2696,7 +2678,6 @@ namespace System.Windows.Forms
 
             for (i = 1; i < objs.Length && types > 0; i++)
             {
-
                 // get the tab attribute
                 tabAttr = (PropertyTabAttribute)TypeDescriptor.GetAttributes(objs[i])[typeof(PropertyTabAttribute)];
 
@@ -3001,7 +2982,6 @@ namespace System.Windows.Forms
             if (batchMode || GetFlag(InternalChange) || gridView.GetInPropertySet() ||
                (currentObjects == null) || (currentObjects.Length == 0))
             {
-
                 if (batchMode && !gridView.GetInPropertySet())
                 {
                     SetFlag(BatchModeChange, true);
@@ -3042,7 +3022,6 @@ namespace System.Windows.Forms
             {
                 if (e.Component == currentObjects[i])
                 {
-
                     object[] newObjects = new object[currentObjects.Length - 1];
                     Array.Copy(currentObjects, 0, newObjects, 0, i);
                     if (i < newObjects.Length)
@@ -3068,7 +3047,6 @@ namespace System.Windows.Forms
             }
 
             SetupToolbar();
-
         }
 
         //
@@ -3150,7 +3128,6 @@ namespace System.Windows.Forms
 
             try
             {
-
                 FreezePainting = true;
 
                 if (!dividerOnly)
@@ -3166,7 +3143,6 @@ namespace System.Windows.Forms
 
                     if (toolStrip.Visible)
                     {
-
                         int toolStripWidth = Width;
                         int toolStripHeight = ((LargeButtons) ? largeButtonSize : normalButtonSize).Height + toolStripButtonPaddingY;
                         Rectangle toolStripBounds = new Rectangle(0, 1, toolStripWidth, toolStripHeight);
@@ -3253,7 +3229,6 @@ namespace System.Windows.Forms
                 // place the help comment window
                 if (dcRequestedHeight > 0)
                 {
-
                     maxSpace -= cyDivider;
 
                     if (hcRequestedHeight == 0 || (dcRequestedHeight + hcRequestedHeight) < maxSpace)
@@ -3638,7 +3613,6 @@ namespace System.Windows.Forms
         {
             try
             {
-
                 FreezePainting = true;
 
                 // is this tab selected? If so, do nothing.
@@ -3687,14 +3661,12 @@ namespace System.Windows.Forms
                 FreezePainting = false;
             }
             OnButtonClick(sender, e);
-
         }
 
         private void OnViewTabButtonClick(object sender, EventArgs e)
         {
             try
             {
-
                 FreezePainting = true;
                 SelectViewTabButton((ToolStripButton)sender, true);
                 OnLayoutInternal(false);
@@ -3705,7 +3677,6 @@ namespace System.Windows.Forms
                 FreezePainting = false;
             }
             OnButtonClick(sender, e);
-
         }
 
         private void OnViewButtonClickPP(object sender, EventArgs e)
@@ -3751,11 +3722,9 @@ namespace System.Windows.Forms
 
                     if (success)
                     {
-
                         if (baseObject is IComponent &&
                             connectionPointCookies[0] == null)
                         {
-
                             ISite site = ((IComponent)baseObject).Site;
                             if (site != null)
                             {
@@ -3787,12 +3756,10 @@ namespace System.Windows.Forms
                                     {
                                         SetFlag(InternalChange, false);
                                     }
-
                                 }
                             }
                         }
                         gridView.Refresh();
-
                     }
                 }
                 catch (Exception ex)
@@ -3946,7 +3913,6 @@ namespace System.Windows.Forms
                     }
                     else
                     {
-
                         bool passToParent = false;
 
                         // this is forward
@@ -3974,7 +3940,6 @@ namespace System.Windows.Forms
                             {
                                 passToParent = true;
                             }
-
                         }
                         else if (hotcommands.ContainsFocus)
                         {
@@ -4027,7 +3992,6 @@ namespace System.Windows.Forms
                         }
                         break;
                     */
-
             }
             return base.ProcessDialogKey(keyData);
         }
@@ -4237,7 +4201,6 @@ namespace System.Windows.Forms
             {
                 if (viewTabScopes[i] >= classification)
                 {
-
                     // adjust the selected view tab because we're deleting.
                     if (selectedViewTab == i)
                     {
@@ -4560,7 +4523,6 @@ namespace System.Windows.Forms
 
             if (viewTypes > 0)
             {
-
                 int tab = state / viewTypes;
                 int view = state % viewTypes;
 
@@ -4794,7 +4756,6 @@ namespace System.Windows.Forms
         {
             if (viewTabs != null && viewTabs.Length > EVENTS && (viewTabs[EVENTS] is EventsTab))
             {
-
                 Debug.Assert(viewTabButtons != null && viewTabButtons.Length > EVENTS && viewTabButtons[EVENTS] != null, "Events button is not at EVENTS position");
                 viewTabButtons[EVENTS].Visible = value;
                 if (!value && selectedViewTab == EVENTS)
@@ -5507,7 +5468,6 @@ namespace System.Windows.Forms
                 }
                 owner.RemoveTab(propertyTabType);
             }
-
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/ArrayElementGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/ArrayElementGridEntry.cs
@@ -99,6 +99,5 @@ namespace System.Windows.Forms.PropertyGridInternal
         public override bool CanSetReadOnlyPropertyValue() {
            return this.ParentGridEntry.CanSetReadOnlyPropertyValue();
         }*/
-
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/CategoryGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/CategoryGridEntry.cs
@@ -387,5 +387,4 @@ namespace System.Windows.Forms.PropertyGridInternal
             internal override int Column => 0; // Category is in the first column.
         }
     }
-
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DocComment.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DocComment.cs
@@ -233,7 +233,6 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             if (IsHandleCreated && needUpdateUIWithFont)
             {
-
                 // Some fonts throw because Bold is not a valid option
                 // for them.  Fail gracefully.
                 try

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
@@ -146,7 +146,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     flags |= FLAG_FORCE_READONLY;
                 }
-
             }
             else
             {
@@ -299,7 +298,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 return parentPE.ComponentChangeService;
             }
-
         }
 
         /// <summary>
@@ -629,7 +627,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
 
                 return flags;
-
             }
             set
             {
@@ -648,7 +645,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             set
             {
-
                 if (Disposed)
                 {
                     return;
@@ -1424,7 +1420,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     InternalExpanded = false;
                 }
-
             }
             else
             {
@@ -1750,7 +1745,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             try
             {
-
                 bool forceReadOnly = ForceReadOnly;
 
                 if (!forceReadOnly)
@@ -1763,7 +1757,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 //
                 if (TypeConverter.GetPropertiesSupported(this) || AlwaysAllowExpand)
                 {
-
                     // ask the tab if we have one.
                     //
                     PropertyDescriptorCollection props = null;
@@ -1807,7 +1800,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                     //
                     if ((props == null || props.Count == 0) && objType != null && objType.IsArray && obj != null)
                     {
-
                         Array objArray = (Array)obj;
 
                         entries = new GridEntry[objArray.Length];
@@ -2132,7 +2124,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             else
             { // Normal case -- no pseudo-tooltip for the label
-
 #if PBRS_PAINT_DEBUG
                 blank = Brushes.Red;
 #endif
@@ -2214,7 +2205,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             // when Vistual style is enabled
             if (GridEntryHost.IsExplorerTreeSupported)
             {
-
                 // size of Explorer Tree style glyph (triangle) is different from +/- glyph,
                 // so when we change the visual style (such as changing Windows theme),
                 // we need to recaculate outlineRect
@@ -2228,7 +2218,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             // draw tree-view glyphs as +/-
             else
             {
-
                 // size of Explorer Tree style glyph (triangle) is different from +/- glyph,
                 // so when we change the visual style (such as changing Windows theme),
                 // we need to recaculate outlineRect
@@ -2436,7 +2425,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             // If we have text to paint, paint it
             if (strValue != null && strValue.Length > 0)
             {
-
                 Font f = GetFont(valueModified);
 
                 if (strValue.Length > maximumLengthOfPropertyString)
@@ -2603,7 +2591,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             // are we in the label?
             if (x >= 0 && x <= labelWidth)
             {
-
                 // are we on the outline?
                 if (Expandable)
                 {
@@ -2886,7 +2873,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (childCollection != null)
             {
-
                 // check to see if the value has changed.
                 //
                 if (InternalExpanded && cacheItems != null && cacheItems.lastValue != null && cacheItems.lastValue != PropertyValue)
@@ -3458,7 +3444,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             /// </summary>
             public override AccessibleObject GetFocused()
             {
-
                 if (owner.Focus)
                 {
                     return this;
@@ -3474,7 +3459,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             /// </summary>
             public override AccessibleObject Navigate(AccessibleNavigation navdir)
             {
-
                 PropertyGridView.PropertyGridViewAccessibleObject parent =
                 (PropertyGridView.PropertyGridViewAccessibleObject)Parent;
 
@@ -3498,12 +3482,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
 
                 return null;
-
             }
 
             public override void Select(AccessibleSelection flags)
             {
-
                 // make sure we're on the right thread.
                 //
                 if (PropertyGridView.InvokeRequired)
@@ -3654,5 +3636,4 @@ namespace System.Windows.Forms.PropertyGridInternal
             NewChildCount = newCount;
         }
     }
-
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/HotCommands.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/HotCommands.cs
@@ -246,7 +246,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
             }
         }
-
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MergePropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MergePropertyDescriptor.cs
@@ -156,7 +156,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                         break;
                     }
                 }
-
             }
             return (canReset == TriState.Yes);
         }
@@ -307,7 +306,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 else if ((obj == null && objCur == null) ||
                          (obj != null && obj.Equals(objCur)))
                 {
-
                     continue;
                 }
                 else
@@ -387,7 +385,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                     collection.Locked = false;
                 }
             }
-
         }
 
         /// <summary>
@@ -518,7 +515,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             /// </summary>
             public bool MergeCollection(ICollection newCollection)
             {
-
                 if (locked)
                 {
                     return true;
@@ -540,7 +536,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                         items = Array.Empty<object>();
                         return false;
                     }
-
                 }
                 return true;
             }
@@ -554,7 +549,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 items = new object[collection.Count];
                 collection.CopyTo(items, 0);
             }
-
         }
 
         private class MergedAttributeCollection : AttributeCollection

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiPropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiPropertyDescriptorGridEntry.cs
@@ -113,7 +113,6 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             try
             {
-
                 if (mergedPd.PropertyType.IsValueType || (Flags & GridEntry.FLAG_IMMUTABLE) != 0)
                 {
                     return base.CreateChildren(diffOldChildren);
@@ -213,7 +212,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                    ge is PropertyDescriptorGridEntry &&
                    ((PropertyDescriptorGridEntry)ge).propertyInfo.Attributes.Contains(NotifyParentPropertyAttribute.Yes))
             {
-
                 // find the next parent property with a differnet value owner
                 object owner = ge.GetValueOwner();
 
@@ -280,7 +278,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     if (objects != null && objects.Length > 0)
                     {
-
                         IDesignerHost host = DesignerHost;
                         DesignerTransaction trans = null;
 
@@ -290,7 +287,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                         }
                         try
                         {
-
                             bool needChangeNotify = !(objects[0] is IComponent) || ((IComponent)objects[0]).Site == null;
                             if (needChangeNotify)
                             {
@@ -414,6 +410,5 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
             }
         }
-
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiSelectRootGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiSelectRootGridEntry.cs
@@ -86,7 +86,6 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             public static MultiPropertyDescriptorGridEntry[] GetMergedProperties(object[] rgobjs, GridEntry parentEntry, PropertySort sort, PropertyTab tab)
             {
-
                 MultiPropertyDescriptorGridEntry[] result = null;
                 try
                 {
@@ -138,7 +137,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
 
                 return result;
-
             }
 
             // this returns an array list of the propertydescriptor arrays, one for each
@@ -176,7 +174,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     for (int j = 1; match && j < propCollections.Length; j++)
                     {
-
                         if (posArray[j] >= propCollections[j].Count)
                         {
                             match = false;
@@ -208,11 +205,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                         // where the matching item would be
                         while (PropertyComparer.Compare(jProp, pivotDesc) <= 0)
                         {
-
                             // got a match!
                             if (pivotDesc.Equals(jProp))
                             {
-
                                 if (!jProp.Attributes[typeof(MergablePropertyAttribute)].IsDefaultAttribute())
                                 {
                                     match = false;
@@ -260,7 +255,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             private static MultiPropertyDescriptorGridEntry[] SortParenEntries(MultiPropertyDescriptorGridEntry[] entries)
             {
-
                 MultiPropertyDescriptorGridEntry[] newEntries = null;
                 int newPos = 0;
 
@@ -300,13 +294,11 @@ namespace System.Windows.Forms.PropertyGridInternal
             /// </summary>
             private static ArrayList UnsortedMerge(PropertyDescriptor[] baseEntries, ArrayList sortedMergedEntries)
             {
-
                 ArrayList mergedEntries = new ArrayList();
                 PropertyDescriptor[] mergeArray = new PropertyDescriptor[((PropertyDescriptor[])sortedMergedEntries[0]).Length + 1];
 
                 for (int i = 0; i < baseEntries.Length; i++)
                 {
-
                     PropertyDescriptor basePd = baseEntries[i];
 
                     // first, do a binary search for a matching item
@@ -351,7 +343,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
                 return mergedEntries;
             }
-
         }
 
         private class PDComparer : IComparer

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
@@ -89,7 +89,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 if (helpKeyword == null)
                 {
-
                     object owner = GetValueOwner();
                     if (owner == null)
                     {
@@ -110,7 +109,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                         while (ge.ParentGridEntry != null)
                         {
-
                             ge = ge.ParentGridEntry;
 
                             // for value classes, the equality will never work, so
@@ -124,7 +122,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
                     else
                     {
-
                         string typeName = string.Empty;
 
                         Type componentType = propertyInfo.ComponentType;
@@ -135,7 +132,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                         }
                         else
                         {
-
                             // make sure this property is declared on a class that
                             // is related to the component we're looking at.
                             // if it's not, it could be a shadow property so we need
@@ -161,7 +157,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                             }
                             else
                             {
-
                                 //
 
                                 //if (helpAttribute != null && !helpAttribute.IsDefaultAttribute()) {
@@ -525,7 +520,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                    ge is PropertyDescriptorGridEntry &&
                    ((PropertyDescriptorGridEntry)ge).propertyInfo.Attributes.Contains(NotifyParentPropertyAttribute.Yes))
             {
-
                 // find the next parent property with a differnet value owner
                 object owner = ge.GetValueOwner();
 
@@ -595,7 +589,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
                     catch
                     {
-
                         if (exceptionConverter == null)
                         {
                             // clear the flags
@@ -612,7 +605,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
                     catch
                     {
-
                         if (exceptionConverter == null)
                         {
                             // clear the flags
@@ -710,7 +702,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             DesignerTransaction trans = null;
             try
             {
-
                 object oldValue = GetPropertyValueCore(obj);
 
                 if (objVal != null && objVal.Equals(oldValue))
@@ -752,7 +743,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                         }
                         throw coEx;
                     }
-
                 }
 
                 bool wasExpanded = InternalExpanded;
@@ -779,7 +769,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 //
                 if (obj != null && objVal is string)
                 {
-
                     if (eventBindings == null)
                     {
                         eventBindings = (IEventBindingService)GetService(typeof(IEventBindingService));
@@ -922,7 +911,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 if (target != null)
                 {
-
                     propertyInfo.SetValue(target, value);
 
                     // Microsoft, okay, since the value that we modified may not
@@ -1041,7 +1029,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 if (newHandler != null)
                 {
-
                     // now walk through all the matching methods to see if this one exists.
                     // if it doesn't we'll wanna show code.
                     //

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridCommands.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridCommands.cs
@@ -29,5 +29,4 @@ namespace System.Windows.Forms.PropertyGridInternal
         public static readonly CommandID Hide = new CommandID(wfcMenuCommand, 0x3002);
         public static readonly CommandID Commands = new CommandID(wfcMenuCommand, 0x3010);
     }
-
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -298,7 +298,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 if (btnDialog == null)
                 {
-
 #if DEBUG
                     if (ownerGrid.inGridViewCreate)
                     {
@@ -348,7 +347,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 if (edit == null)
                 {
-
 #if DEBUG
                     if (ownerGrid.inGridViewCreate)
                     {
@@ -795,7 +793,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             set
             {
-
                 // clear the column
                 tipInfo &= 0xFFFF;
 
@@ -812,7 +809,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             set
             {
-
                 // clear the row
                 tipInfo &= unchecked((int)0xFFFF0000);
 
@@ -1046,7 +1042,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 SetFlag(FlagDropDownClosing, true);
                 if (dropDownHolder != null && dropDownHolder.Visible)
                 {
-
                     if (dropDownHolder.Component == DropDownListBox && GetFlag(FlagDropDownCommit))
                     {
                         OnListClick(null, null);
@@ -1126,10 +1121,8 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (Edit.Focused || DialogButton.Focused || DropDownButton.Focused)
             {
-
                 if (IsHandleCreated && Visible && Enabled)
                 {
-
                     gotfocus = IntPtr.Zero != User32.SetFocus(new HandleRef(this, Handle));
                 }
             }
@@ -1213,12 +1206,10 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (rectTarget.IsEmpty)
             {
-
                 ctl.Visible = false;
             }
 
             currentEditor = ctl;
-
         }
 
         private /*protected virtual*/ int CountPropsFromOutline(GridEntryCollection rgipes)
@@ -2043,7 +2034,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                         return true;
                     }
                 }
-
             }
             return false;
         }
@@ -2115,7 +2105,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             for (int i = 0; i < ipeHier.Count; i++)
             {
-
                 if (ipeHier[i] == null)
                 {
                     continue;
@@ -2125,7 +2114,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 // expand it
                 if (targetEntry != null)
                 {
-
                     // how many do we have?
                     int items = rgipes.Count;
 
@@ -2246,7 +2234,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                     int equalsMatch = -1;
                     for (int i = 0; i < values.Length; i++)
                     {
-
                         object curValue = values[i];
 
                         // check real values against string values.
@@ -2283,7 +2270,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 Debug.Fail(e.ToString());
             }
             return -1;
-
         }
 
         public virtual int GetDefaultOutlineIndent()
@@ -2474,7 +2460,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             for (int i = 0; i < rgipesAll.Count; i++)
             {
-
                 // try for an exact match.  semantics of equals are a bit loose here...
                 //
                 if (gridEntry == rgipesAll[i])
@@ -3227,7 +3212,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (delta < SystemInformation.DoubleClickTime)
             {
-
                 Point screenPoint = Edit.PointToScreen(new Point(me.X, me.Y));
 
                 if (Math.Abs(screenPoint.X - rowSelectPos.X) < SystemInformation.DoubleClickSize.Width &&
@@ -3274,7 +3258,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (sender == Edit && Edit.Focused)
             {
-
                 // if we aren't in an error state, just quit
                 if (errorState == ERROR_NONE)
                 {
@@ -3291,7 +3274,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     if (selectedGridEntry != null)
                     {
-
                         string curTextValue = selectedGridEntry.GetPropertyTextValue();
                         needReset = originalTextValue != curTextValue && !(string.IsNullOrEmpty(originalTextValue) && string.IsNullOrEmpty(curTextValue));
                     }
@@ -3498,7 +3480,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                         }
                         if (selectedRow != -1)
                         { // actual paging.
-
                             int start = GetScrollOffset();
                             SetScrollOffset(start + offset);
                             SetConstants();
@@ -3731,7 +3712,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                     rowMoveCur = pt.Y;
                     onLabel = pt.X == ROWLABEL;
                 }
-
             }
 
             if (pt == InvalidPosition || me == null)
@@ -3869,11 +3849,9 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (wheelScrollLines == -1)
             {
-
                 // Equivalent to large change scrolls
                 if (fullNotches != 0)
                 {
-
                     int originalOffset = initialOffset;
                     int large = fullNotches * scrollBar.LargeChange;
                     int newOffset = Math.Max(0, initialOffset - large);
@@ -3898,14 +3876,12 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             else
             {
-
                 // SystemInformation.MouseWheelScrollLines doesn't work under terminal server,
                 // it default to the notches per scroll.
                 int scrollBands = (int)((float)wheelScrollLines * partialNotches);
 
                 if (scrollBands != 0)
                 {
-
                     if (ToolTip.Visible)
                     {
                         ToolTip.ToolTip = string.Empty;
@@ -3916,7 +3892,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     if (scrollBands > 0)
                     {
-
                         if (scrollBar.Value <= scrollBar.Minimum)
                         {
                             cumulativeVerticalWheelDelta = 0;
@@ -3928,7 +3903,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
                     else
                     {
-
                         if (scrollBar.Value > (scrollBar.Maximum - visibleRows + 1))
                         {
                             cumulativeVerticalWheelDelta = 0;
@@ -3949,7 +3923,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     cumulativeVerticalWheelDelta = 0;
                 }
-
             }
         }
 
@@ -4052,7 +4025,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                     {
                         try
                         {
-
                             // draw the line
                             cHeightCurRow = (i) * (RowHeight + 1) + loc.Y;
                             g.DrawLine(linePen, cLineStart, cHeightCurRow, cLineEnd, cHeightCurRow);
@@ -4176,7 +4148,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (lastMouseDown != InvalidPosition)
             {
-
                 // clear the row select time so we don't interpret this as a double click.
                 //
                 rowSelectTime = 0;
@@ -4254,7 +4225,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     ToolTip.Font = Font;
                 }
-
             }
 
             base.OnVisibleChanged(e);
@@ -4267,7 +4237,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (parent.Expanded)
             {
-
                 GridEntry[] entries = new GridEntry[allGridEntries.Count];
                 allGridEntries.CopyTo(entries, 0);
 
@@ -4318,7 +4287,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 allGridEntries.Clear();
                 allGridEntries.AddRange(entries);
                 AddGridEntryEvents(allGridEntries, parentIndex + 1, childCount);
-
             }
 
             if (e.OldChildCount != e.NewChildCount)
@@ -4447,7 +4415,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     IntPtr hdc = User32.GetDC(new HandleRef(DropDownListBox, DropDownListBox.Handle));
 
-                    // This creates a copy of the given Font, and as such we need to 
+                    // This creates a copy of the given Font, and as such we need to
                     IntPtr hFont = Font.ToHfont();
 
                     var tm = new Gdi32.TEXTMETRICW();
@@ -4611,7 +4579,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                                 {
                                     return base.ProcessDialogKey(keyData);
                                 }
-
                             }
                             else
                             {
@@ -4714,7 +4681,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 SelectGridEntry(ipeSelect, false);
                 Invalidate();
             }
-
         }
 
         public override void Refresh()
@@ -5331,14 +5297,12 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
 
             Edit.HookMouseDown = capture;
-
         }
 
         internal /*public virtual*/ void SetExpand(GridEntry gridEntry, bool value)
         {
             if (gridEntry != null && gridEntry.Expandable)
             {
-
                 int row = GetRowFromGridEntry(gridEntry);
                 int countFromEnd = visibleRows - row;
                 int curRow = selectedRow;
@@ -5349,7 +5313,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     // this will cause the commit
                     Focus();
-
                 }
 
                 int offset = GetScrollOffset();
@@ -5464,7 +5427,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             finally
             {
-
                 if (!success)
                 {
                     Edit.Focus();
@@ -5967,7 +5929,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             GridEntry temp = oldEntry;
             if (oldEntry != null && !oldEntry.Disposed)
             {
-
                 while (temp != null)
                 {
                     hsvc.RemoveContextAttribute("Keyword", temp.HelpKeyword);
@@ -6002,7 +5963,6 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             if (IsHandleCreated && GetFlag(FlagNeedUpdateUIBasedOnFont))
             {
-
                 try
                 {
                     if (listBox != null)
@@ -6187,7 +6147,6 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             switch (m.Msg)
             {
-
                 case WindowMessages.WM_SYSCOLORCHANGE:
                     Invalidate();
                     break;
@@ -6418,12 +6377,10 @@ namespace System.Windows.Forms.PropertyGridInternal
             /// </summary>
             public bool ResizeUp
             {
-
                 set
                 {
                     if (resizeUp != value)
                     {
-
                         // clear the glyph so we regenerate it.
                         //
                         sizeGripGlyph = null;
@@ -6454,7 +6411,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             protected override void Dispose(bool disposing)
             {
-
                 if (disposing && createNewLink != null)
                 {
                     createNewLink.Dispose();
@@ -6490,7 +6446,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             /// </summary>
             private InstanceCreationEditor GetInstanceCreationEditor(PropertyDescriptorGridEntry entry)
             {
-
                 if (entry == null)
                 {
                     return null;
@@ -6553,7 +6508,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                     glyphGraphics.Transform = m;
                     ControlPaint.DrawSizeGrip(glyphGraphics, BackColor, 0, 0, ResizeGripSize, ResizeGripSize);
                     glyphGraphics.ResetTransform();
-
                 }
                 sizeGripGlyph.MakeTransparent(BackColor);
                 return sizeGripGlyph;
@@ -6640,7 +6594,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     resizing = false;
                 }
-
             }
 
             private void OnNewLinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
@@ -6653,14 +6606,12 @@ namespace System.Windows.Forms.PropertyGridInternal
                     Type createType = gridView.SelectedGridEntry.PropertyType;
                     if (createType != null)
                     {
-
                         gridView.CloseDropDown();
 
                         object newValue = ice.CreateInstance(gridView.SelectedGridEntry, createType);
 
                         if (newValue != null)
                         {
-
                             // make sure we got what we asked for.
                             //
                             if (!createType.IsInstanceOfType(newValue))
@@ -6822,7 +6773,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 if (e.Button == MouseButtons.Left)
                 {
-
                     // reset the world.
                     //
                     currentMoveType = MoveTypeNone;
@@ -6883,7 +6833,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             public void SetComponent(Control ctl, bool resizable)
             {
-
                 this.resizable = resizable;
                 Font = gridView.Font;
 
@@ -6911,7 +6860,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 //
                 if (ctl != null)
                 {
-
                     currentControl = ctl;
                     Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "DropDownHolder:SetComponent(" + (ctl.GetType().Name) + ")");
 
@@ -6943,7 +6891,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                         //
                         if (editor != null)
                         {
-
                             // set up the link.
                             //
                             CreateNewLink.Text = editor.Text;
@@ -7009,7 +6956,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             protected override void WndProc(ref Message m)
             {
-
                 if (m.Msg == WindowMessages.WM_ACTIVATE)
                 {
                     SetState(States.Modal, true);
@@ -7112,7 +7058,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                     gridViewListBoxAccessibleObject.SetListBoxItemFocus();
                 }
             }
-
         }
 
         [ComVisible(true)]
@@ -7559,7 +7504,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             public bool DisableMouseHook
             {
-
                 set
                 {
                     mouseHook.DisableMouseHook = value;
@@ -7617,7 +7561,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             public void FilterKeyPress(char keyChar)
             {
-
                 if (IsInputChar(keyChar))
                 {
                     Focus();
@@ -7670,7 +7613,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             protected override void OnKeyDown(KeyEventArgs ke)
             {
-
                 // this is because on a dialog we may
                 // not get a chance to pre-process
                 //
@@ -7714,12 +7656,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
                     g.Dispose();
                 }
-
             }
 
             protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
             {
-
                 // make sure we allow the Edit to handle ctrl-z
                 switch (keyData & Keys.KeyCode)
                 {
@@ -7794,7 +7734,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             /// </summary>
             protected override bool ProcessDialogKey(Keys keyData)
             {
-
                 // We don't do anything with modified keys here.
                 //
                 if ((keyData & (Keys.Shift | Keys.Control | Keys.Alt)) == 0)
@@ -7847,7 +7786,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             private unsafe bool WmNotify(ref Message m)
             {
-
                 if (m.LParam != IntPtr.Zero)
                 {
                     User32.NMHDR* nmhdr = (User32.NMHDR*)m.LParam;
@@ -7871,7 +7809,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             protected override void WndProc(ref Message m)
             {
-
                 if (filter)
                 {
                     if (psheet.FilterEditWndProc(ref m))
@@ -7952,7 +7889,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             [ComVisible(true)]
             protected class GridViewEditAccessibleObject : ControlAccessibleObject
             {
-
                 private readonly PropertyGridView propertyGridView;
 
                 public GridViewEditAccessibleObject(GridViewEdit owner) : base(owner)
@@ -8055,9 +7991,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     get
                     {
-                        // Prevent sending same runtime ID for all edit boxes. Individual edit in 
+                        // Prevent sending same runtime ID for all edit boxes. Individual edit in
                         // each row should have unique runtime ID to prevent incorrect announcement.
-                        // For instance screen reader may announce row 2 for the third row edit 
+                        // For instance screen reader may announce row 2 for the third row edit
                         // as the sme TextBox control is used both in row 2 and row 3.
                         return null;
                     }
@@ -8175,7 +8111,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             public bool DisableMouseHook
             {
-
                 set
                 {
                     hookDisable = value;
@@ -8268,7 +8203,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                                 }
                                 break;
                         }
-
                     }
                 }
 
@@ -8810,7 +8744,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             /// </summary>
             public override AccessibleObject GetChild(int index)
             {
-
                 GridEntryCollection properties = ((PropertyGridView)Owner).AccessibilityGetGridEntries();
                 if (properties != null && index >= 0 && index < properties.Count)
                 {
@@ -8846,7 +8779,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             /// </summary>
             public override AccessibleObject GetFocused()
             {
-
                 GridEntry gridEntry = ((PropertyGridView)Owner).SelectedGridEntry;
                 if (gridEntry != null && gridEntry.Focus)
                 {
@@ -8887,7 +8819,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                     GridEntry gridEntry = ((PropertyGridView)Owner).GetGridEntryFromRow(pos.Y);
                     if (gridEntry != null)
                     {
-
                         // Return the accessible object for this grid entry
                         //
                         return gridEntry.AccessibilityObject;
@@ -8904,7 +8835,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             /// </summary>
             public override AccessibleObject Navigate(AccessibleNavigation navdir)
             {
-
                 if (GetChildCount() > 0)
                 {
                     // We're only handling FirstChild and LastChild here
@@ -8996,7 +8926,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                             }
                             gridView.SetScrollOffset(delta);
                         }
-
                     }
                 }
                 return entry;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/SingleSelectRootGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/SingleSelectRootGridEntry.cs
@@ -201,7 +201,6 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-
                 HelpKeywordAttribute helpAttribute = (HelpKeywordAttribute)TypeDescriptor.GetAttributes(objValue)[typeof(HelpKeywordAttribute)];
 
                 if (helpAttribute != null && !helpAttribute.IsDefaultAttribute())
@@ -309,7 +308,6 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             if (((PropertySort &= PropertySort.Categorized) != 0) != fCategories)
             {
-
                 if (fCategories)
                 {
                     PropertySort |= PropertySort.Categorized;
@@ -331,13 +329,11 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             if (Children.Count > 0)
             {
-
                 GridEntry[] childEntries = new GridEntry[Children.Count];
                 Children.CopyTo(childEntries, 0);
 
                 if ((PropertySort & PropertySort.Categorized) != 0)
                 {
-
                     // first, walk through all the entires and
                     // group them by their category by adding
                     // them to a hashtable of arraylists.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyStore.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyStore.cs
@@ -614,7 +614,6 @@ namespace System.Windows.Forms
                     Debug.Assert(storedObject == null, "object should either be null or ColorWrapper"); // could someone have SetObject to this key behind our backs?
                     SetObject(key, new ColorWrapper(value));
                 }
-
             }
         }
 
@@ -637,7 +636,6 @@ namespace System.Windows.Forms
                     Debug.Assert(storedObject == null, "object should either be null or PaddingWrapper"); // could someone have SetObject to this key behind our backs?
                     SetObject(key, new PaddingWrapper(value));
                 }
-
             }
         }
 
@@ -682,7 +680,6 @@ namespace System.Windows.Forms
                     Debug.Assert(storedObject == null, "object should either be null or SizeWrapper"); // could someone have SetObject to this key behind our backs?
                     SetObject(key, new SizeWrapper(value));
                 }
-
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RadioButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RadioButton.cs
@@ -574,7 +574,6 @@ namespace System.Windows.Forms
                             OnClick(mevent);
                             OnMouseClick(mevent);
                         }
-
                     }
                 }
             }
@@ -597,7 +596,6 @@ namespace System.Windows.Forms
                     OnClick(EventArgs.Empty);
                 }
             }
-
         }
 
         protected internal override bool ProcessMnemonic(char charCode)
@@ -677,6 +675,5 @@ namespace System.Windows.Forms
                 ((RadioButton)Owner).PerformClick();
             }
         }
-
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RelatedCurrencyManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RelatedCurrencyManager.cs
@@ -201,6 +201,5 @@ namespace System.Windows.Forms
             OnCurrentChanged(EventArgs.Empty);
             OnCurrentItemChanged(EventArgs.Empty);
         }
-
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RelatedPropertyManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RelatedPropertyManager.cs
@@ -104,6 +104,5 @@ namespace System.Windows.Forms
             bool anyCurrent = (parentManager.Position >= 0 && parentManager.Position < parentManager.Count);
             return anyCurrent ? parentManager.Current : null;
         }
-
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -266,7 +266,6 @@ namespace System.Windows.Forms
 
             set
             {
-
                 if (value < 0)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidArgument, nameof(BulletIndent), value));
@@ -807,7 +806,6 @@ namespace System.Windows.Forms
                     (int)RichTextBoxScrollBars.ForcedVertical,
                     (int)RichTextBoxScrollBars.ForcedBoth))
                 {
-
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(RichTextBoxScrollBars));
                 }
 
@@ -882,7 +880,6 @@ namespace System.Windows.Forms
                 };
                 switch (value)
                 {
-
                     case HorizontalAlignment.Left:
                         pf.wAlignment = RichTextBoxConstants.PFA_LEFT;
                         break;
@@ -1252,7 +1249,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 if (!IsHandleCreated)
                 {
                     return base.SelectionLength;
@@ -2137,7 +2133,6 @@ namespace System.Windows.Forms
 
                 UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), RichEditMessages.EM_EXSETSEL, 0, ref chrg);
                 SendMessage(EditMessages.EM_SCROLLCARET, 0, 0);
-
             }
 
             return position;
@@ -2216,9 +2211,8 @@ namespace System.Windows.Forms
                     cpMin = chrg.cpMin,
                     cpMax = chrg.cpMax
                 }
-
             };
-            
+
             // Characters we have slurped into memory in order to search
             var charBuffer = new UnicodeCharBuffer(CHAR_BUFFER_LEN + 1);
             txrg.lpstrText = charBuffer.AllocCoTaskMem();
@@ -2344,7 +2338,6 @@ namespace System.Windows.Forms
             if ((cf.dwMask & RichTextBoxConstants.CFM_COLOR) != 0
                 && ColorTranslator.ToWin32(value) == cf.crTextColor)
             {
-
                 return true;
             }
 
@@ -3192,7 +3185,6 @@ namespace System.Windows.Forms
 
                 // EM_GETLINECOUNT will cause the RichTextBox to recalculate its line indexes
                 SendMessage(EditMessages.EM_GETLINECOUNT, 0, 0);
-
             }
             finally
             {
@@ -3476,7 +3468,7 @@ namespace System.Windows.Forms
         ///  Converts a CHARRANGE to a string.
         /// </summary>
         /// <remarks>
-        ///  The behavior of this is dependent on the current window class name being used. 
+        ///  The behavior of this is dependent on the current window class name being used.
         ///  We have to create a CharBuffer of the type of RichTextBox DLL we're using,
         ///  not based on the SystemCharWidth.
         /// </remarks>
@@ -3746,16 +3738,13 @@ namespace System.Windows.Forms
             // Is either the Hangul or HangulFull IME currently in use?
             if (ImeMode == ImeMode.Hangul || ImeMode == ImeMode.HangulFull)
             {
-
                 // Is the IME CompositionWindow open?
                 int compMode = unchecked((int)(long)SendMessage(RichEditMessages.EM_GETIMECOMPMODE, 0, 0));
                 if (RichTextBoxConstants.ICM_NOTOPEN != compMode)
                 {
-
                     int textLength = User32.GetWindowTextLengthW(new HandleRef(this, Handle));
                     if (selStart == selEnd && textLength == MaxLength)
                     {
-
                         SendMessage(WindowMessages.WM_KILLFOCUS, 0, 0);
                         SendMessage(WindowMessages.WM_SETFOCUS, 0, 0);
                         User32.PostMessageW(this, (User32.WindowMessage)EditMessages.EM_SETSEL, (IntPtr)(selEnd - 1), (IntPtr)selEnd);
@@ -3964,14 +3953,12 @@ namespace System.Windows.Forms
 
             public HRESULT QueryAcceptData(IComDataObject lpdataobj, IntPtr lpcfFormat, uint reco, BOOL fReally, IntPtr hMetaPict)
             {
-
                 Debug.WriteLineIf(RichTextDbg.TraceVerbose, "IRichEditOleCallback::QueryAcceptData(reco=" + reco + ")");
 
                 if (reco == NativeMethods.RECO_DROP)
                 {
                     if (owner.AllowDrop || owner.EnableAutoDragDrop)
                     {
-
                         MouseButtons b = Control.MouseButtons;
                         Keys k = Control.ModifierKeys;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Screen.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Screen.cs
@@ -221,12 +221,10 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 //if the static Screen class has a different desktop change count
                 //than this instance then update the count and recalculate our working area
                 if (currentDesktopChangedCount != Screen.DesktopChangedCount)
                 {
-
                     Interlocked.Exchange(ref currentDesktopChangedCount, Screen.DesktopChangedCount);
 
                     if (!multiMonitorSupport || hmonitor == (IntPtr)PRIMARY_MONITOR)
@@ -261,10 +259,8 @@ namespace System.Windows.Forms
             {
                 if (desktopChangedCount == -1)
                 {
-
                     lock (syncLock)
                     {
-
                         //now that we have a lock, verify (again) our changecount...
                         if (desktopChangedCount == -1)
                         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.cs
@@ -219,7 +219,6 @@ namespace System.Windows.Forms
             {
                 if (_largeChange != value)
                 {
-
                     if (value < 0)
                     {
                         throw new ArgumentOutOfRangeException(nameof(value), string.Format(SR.InvalidLowBoundArgumentEx, nameof(LargeChange), value, 0));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBars.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBars.cs
@@ -28,6 +28,5 @@ namespace System.Windows.Forms
         ///  Both horizontal and vertical scroll bars are shown.
         /// </summary>
         Both = 3,
-
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollableControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollableControl.cs
@@ -402,7 +402,6 @@ namespace System.Windows.Forms
             bool defaultLayoutEngine = (LayoutEngine == DefaultLayout.Instance);
             if (!defaultLayoutEngine && CommonProperties.HasLayoutBounds(this))
             {
-
                 Size layoutBounds = CommonProperties.GetLayoutBounds(this);
 
                 if (layoutBounds.Width > maxX)
@@ -979,7 +978,6 @@ namespace System.Windows.Forms
                 || (!vert && VScroll)
                 || (vert && !VScroll))
             {
-
                 needLayout = true;
             }
 
@@ -1042,7 +1040,6 @@ namespace System.Windows.Forms
             bool needLayout = false;
             if (_displayRect.Width != width || _displayRect.Height != height)
             {
-
                 _displayRect.Width = width;
                 _displayRect.Height = height;
                 needLayout = true;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
@@ -144,7 +144,6 @@ namespace System.Windows.Forms
             ((WindowsFormsUtils.TypedControlCollection)Controls).AddInternal(panel1);
             ((WindowsFormsUtils.TypedControlCollection)Controls).AddInternal(panel2);
             UpdateSplitter();
-
         }
 
         /////////////////////////////////////////////////////////////////////////////////////////////
@@ -519,7 +518,6 @@ namespace System.Windows.Forms
                 {
                     return (Height >= Panel1MinSize + SplitterWidthInternal + Panel2MinSize);
                 }
-
             }
         }
 
@@ -626,7 +624,6 @@ namespace System.Windows.Forms
             if (collapsing)
             {
                 p.Visible = false;
-
             }
             else
             {
@@ -811,7 +808,6 @@ namespace System.Windows.Forms
 
                         if (Orientation == Orientation.Vertical)
                         {
-
                             if (value < Panel1MinSize)
                             {
                                 value = Panel1MinSize;
@@ -827,11 +823,9 @@ namespace System.Windows.Forms
                             splitDistance = value;
                             splitterDistance = value;
                             panel1.WidthInternal = SplitterDistance;
-
                         }
                         else
                         {
-
                             if (value < Panel1MinSize)
                             {
                                 value = Panel1MinSize;
@@ -906,7 +900,6 @@ namespace System.Windows.Forms
             }
             set
             {
-
                 if (value < 1)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(SplitterIncrement), value, 1));
@@ -1111,7 +1104,6 @@ namespace System.Windows.Forms
         {
             base.OnGotFocus(e);
             Invalidate();
-
         }
 
         /// <summary>
@@ -1157,7 +1149,6 @@ namespace System.Windows.Forms
                         {
                             splitterDistance = (splitterDistance + SplitterWidth > Height - Panel2MinSize - BORDERSIZE) ? splitterDistance - SplitterIncrement : splitterDistance;
                         }
-
                     }
 
                     if (!splitBegin)
@@ -1224,7 +1215,6 @@ namespace System.Windows.Forms
                 }
                 DrawFocus(g, SplitterRectangle);
             }
-
         }
 
         /// <summary>
@@ -1259,7 +1249,6 @@ namespace System.Windows.Forms
             base.OnMouseMove(e);
             if (!IsSplitterFixed && IsSplitterMovable)
             {
-
                 //change cursor if default and user hasnt changed the cursor.
                 if (Cursor == DefaultCursor && SplitterRectangle.Contains(e.Location))
                 {
@@ -1302,7 +1291,6 @@ namespace System.Windows.Forms
                     if (se.Cancel)
                     {
                         SplitEnd(false);
-
                     }
                 }
             }
@@ -1381,7 +1369,6 @@ namespace System.Windows.Forms
                 else
                 {
                     SplitEnd(false);
-
                 }
                 splitterClick = false;
                 splitterDrag = false;
@@ -1497,7 +1484,6 @@ namespace System.Windows.Forms
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidArgument, nameof(Panel2MinSize), value.ToString()));
                 }
-
             }
             else if (Orientation == Orientation.Horizontal)
             {
@@ -1528,7 +1514,6 @@ namespace System.Windows.Forms
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidArgument, nameof(SplitterWidth), value));
                 }
-
             }
             else if (Orientation == Orientation.Horizontal)
             {
@@ -1561,7 +1546,6 @@ namespace System.Windows.Forms
 
             if (Orientation == Orientation.Vertical)
             {
-
                 if (RightToLeft == RightToLeft.No)
                 {
                     splitterRect.X = Location.X + SplitterDistanceInternal;
@@ -1648,7 +1632,6 @@ namespace System.Windows.Forms
                     DrawSplitHelper(splitterDistance);
                     lastDrawSplit = splitterDistance;
                 }
-
             }
             else
             {
@@ -1755,7 +1738,6 @@ namespace System.Windows.Forms
                 Graphics g = CreateGraphicsInternal();
                 if (BackgroundImage != null)
                 {
-
                     using (TextureBrush textureBrush = new TextureBrush(BackgroundImage, WrapMode.Tile))
                     {
                         g.FillRectangle(textureBrush, ClientRectangle);
@@ -1866,7 +1848,6 @@ namespace System.Windows.Forms
                             panel1.Location = new Point(0, 0);
                         }
                     }
-
                 }
                 else if (Orientation == Orientation.Horizontal)
                 {
@@ -1875,7 +1856,6 @@ namespace System.Windows.Forms
                     {
                         if (FixedPanel == FixedPanel.Panel1)
                         {
-
                             //Default splitter distance from left or top.
                             panel1.Size = new Size(Width, panelSize);
                             int panel2Start = panelSize + SplitterWidthInternal;
@@ -1884,7 +1864,6 @@ namespace System.Windows.Forms
                         }
                         if (FixedPanel == FixedPanel.Panel2)
                         {
-
                             panel2.Size = new Size(Width, panelSize);
                             splitterDistance = Math.Max(Height - Panel2.Height - SplitterWidthInternal, Panel1MinSize);
                             panel1.HeightInternal = splitterDistance;
@@ -1904,7 +1883,6 @@ namespace System.Windows.Forms
                             int panel2Start = splitterDistance + SplitterWidthInternal;
                             panel2.Size = new Size(Width, Math.Max(Height - panel2Start, Panel2MinSize));
                             panel2.Location = new Point(0, panel2Start);
-
                         }
                         RepaintSplitterRect();
                         SetSplitterRect(false);
@@ -2146,7 +2124,6 @@ namespace System.Windows.Forms
             if (ctl == null || (ctl is SplitterPanel && !ctl.Visible))
             {
                 callBaseVersion = true;
-
             }
             //IF the CTL == typeof(SpliterPanel) find the NEXT Control... so that we know
             // we can focus the NEXT control within this SPLITCONTAINER....
@@ -2325,7 +2302,6 @@ namespace System.Windows.Forms
             if (accept)
             {
                 ApplySplitterDistance();
-
             }
             else if (splitterDistance != initialSplitterDistance)
             {
@@ -2333,7 +2309,6 @@ namespace System.Windows.Forms
                 splitterDistance = SplitterDistanceInternal = initialSplitterDistance;
             }
             anchor = Point.Empty;
-
         }
 
         /// <summary>
@@ -2354,7 +2329,6 @@ namespace System.Windows.Forms
                 //NO PANEL FIXED !!
                 if (!CollapsedMode)
                 {
-
                     panel1.HeightInternal = Height;
                     panel1.WidthInternal = splitterDistance; //Default splitter distance from left or top.
                     panel2.Size = new Size(Width - splitterDistance - SplitterWidthInternal, Height);
@@ -2376,7 +2350,6 @@ namespace System.Windows.Forms
                     {
                         ratioWidth = ((double)(Width) / (double)(panel1.Width) > 0) ? (double)(Width) / (double)(panel1.Width) : ratioWidth;
                     }
-
                 }
                 else
                 {
@@ -2465,7 +2438,6 @@ namespace System.Windows.Forms
             {
                 DefWndProc(ref m);
             }
-
         }
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2493,7 +2465,6 @@ namespace System.Windows.Forms
             {
                 SetInnerMostBorder(this);
             }
-
         }
 
         /// <summary>
@@ -2540,7 +2511,6 @@ namespace System.Windows.Forms
                         }
 
                         break;
-
                 }
             }
             return base.ProcessDialogKey(keyData);
@@ -2720,8 +2690,6 @@ namespace System.Windows.Forms
                 }
                 base.SetChildIndexInternal(child, newIndex);
             }
-
         }
-
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.cs
@@ -274,7 +274,6 @@ namespace System.Windows.Forms
 
             set
             {
-
                 if (!(value == DockStyle.Top || value == DockStyle.Bottom || value == DockStyle.Left || value == DockStyle.Right))
                 {
                     throw new ArgumentException(SR.SplitterInvalidDockEnum);
@@ -462,7 +461,6 @@ namespace System.Windows.Forms
                 spd.target.Bounds = bounds;
                 Application.DoEvents();
                 OnSplitterMoved(new SplitterEventArgs(Left, Top, (Left + bounds.Width / 2), (Top + bounds.Height / 2)));
-
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusBar.cs
@@ -78,7 +78,6 @@ namespace System.Windows.Forms
                 }
                 return renderer;
             }
-
         }
 
         private int SizeGripWidth
@@ -767,7 +766,6 @@ namespace System.Windows.Forms
                 ApplyPanelWidths();
                 ForcePanelUpdate();
             }
-
         }
 
         /// <summary>
@@ -802,7 +800,6 @@ namespace System.Windows.Forms
         {
             if (!showPanels && IsHandleCreated)
             {
-
                 int wparam = SIMPLE_INDEX + NativeMethods.SBT_NOBORDERS;
                 if (RightToLeft == RightToLeft.Yes)
                 {
@@ -851,7 +848,6 @@ namespace System.Windows.Forms
                 int copyOfLeftoverWidth = unchecked((int)0x80000000);
                 while (springPanelsLeft > 0)
                 {
-
                     int widthOfSpringPanel = (leftoverWidth) / springPanelsLeft;
                     if (leftoverWidth == copyOfLeftoverWidth)
                     {
@@ -937,7 +933,6 @@ namespace System.Windows.Forms
         {
             mainToolTip = t;
             toolTipSet = true;
-
         }
 
         internal void UpdateTooltip(StatusBarPanel panel)
@@ -1083,7 +1078,6 @@ namespace System.Windows.Forms
                     if (!((Form)parent).TopLevel
                         || Dock != DockStyle.Bottom)
                     {
-
                         callSuper = false;
                     }
 
@@ -1192,7 +1186,6 @@ namespace System.Windows.Forms
                 }
                 set
                 {
-
                     if (value == null)
                     {
                         throw new ArgumentNullException(nameof(StatusBarPanel));
@@ -1272,7 +1265,6 @@ namespace System.Windows.Forms
                     {
                         return null;
                     }
-
                 }
             }
 
@@ -1457,7 +1449,6 @@ namespace System.Windows.Forms
             /// </summary>
             public virtual void Insert(int index, StatusBarPanel value)
             {
-
                 //check for the value not to be null
                 if (value == null)
                 {
@@ -1523,7 +1514,6 @@ namespace System.Windows.Forms
             {
                 owner.RemoveAllPanelsWithoutUpdate();
                 owner.PerformLayout();
-
             }
 
             /// <summary>
@@ -1531,7 +1521,6 @@ namespace System.Windows.Forms
             /// </summary>
             public virtual void Remove(StatusBarPanel value)
             {
-
                 //check for the value not to be null
                 if (value == null)
                 {
@@ -1755,7 +1744,6 @@ namespace System.Windows.Forms
                 {
                     tools.Remove(key);
                 }
-
             }
 
             /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusBarPanel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusBarPanel.cs
@@ -175,7 +175,6 @@ namespace System.Windows.Forms
 
             set
             {
-
                 if (value != null && (((Icon)value).Height > SystemInformation.SmallIconSize.Height || ((Icon)value).Width > SystemInformation.SmallIconSize.Width))
                 {
                     icon = new Icon(value, SystemInformation.SmallIconSize);
@@ -189,7 +188,6 @@ namespace System.Windows.Forms
                 {
                     IntPtr handle = (icon == null) ? IntPtr.Zero : icon.Handle;
                     parent.SendMessage(NativeMethods.SB_SETICON, (IntPtr)GetIndex(), handle);
-
                 }
                 UpdateSize();
                 if (Created)
@@ -395,7 +393,6 @@ namespace System.Windows.Forms
 
                 if (!Text.Equals(value))
                 {
-
                     if (value.Length == 0)
                     {
                         text = null;
@@ -442,7 +439,6 @@ namespace System.Windows.Forms
 
                 if (!ToolTipText.Equals(value))
                 {
-
                     if (value.Length == 0)
                     {
                         toolTipText = null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusStrip.cs
@@ -42,7 +42,6 @@ namespace System.Windows.Forms
             Stretch = true;
             state[stateSizingGrip] = true;
             ResumeLayout(true);
-
         }
 
         [
@@ -101,7 +100,6 @@ namespace System.Windows.Forms
                     // was before, so the DisplayRectangle needs to shrink up by its height.
                     return new Padding(1, 3, 1, DefaultSize.Height);
                 }
-
             }
         }
 
@@ -333,16 +331,13 @@ namespace System.Windows.Forms
                     rtlLayoutGrip.Dispose();
                     rtlLayoutGrip = null;
                 }
-
             }
-
         }
 
         internal override Size GetPreferredSizeCore(Size proposedSize)
         {
             if (LayoutStyle == ToolStripLayoutStyle.Table)
             {
-
                 if (proposedSize.Width == 1)
                 {
                     proposedSize.Width = int.MaxValue;
@@ -401,11 +396,9 @@ namespace System.Windows.Forms
                     OnSpringTableLayoutCore();
                     base.OnLayout(levent);
                 }
-
             }
 
             EnsureRightToLeftGrip();
-
         }
 
         internal override bool SupportsUiaProviders => true;
@@ -433,7 +426,6 @@ namespace System.Windows.Forms
                     // visible.
                     if (overflow || ((IArrangedElement)item).ParticipatesInLayout)
                     {
-
                         if (overflow || (SizingGrip && item.Bounds.IntersectsWith(SizeGripBounds)))
                         {
                             // if the item collides with the size grip, set the location to nomansland.
@@ -513,7 +505,6 @@ namespace System.Windows.Forms
 
                 if (Orientation == Orientation.Horizontal)
                 {
-
                     //
                     // Horizontal layout
                     //
@@ -604,7 +595,6 @@ namespace System.Windows.Forms
                     {
                         TableLayoutSettings.RowStyles[i].SizeType = SizeType.AutoSize;
                     }
-
                 }
 
                 ResumeLayout(false);
@@ -657,9 +647,7 @@ namespace System.Windows.Forms
                                 return;
                             }
                         }
-
                     }
-
                 }
             }
             base.WndProc(ref m);
@@ -694,7 +682,6 @@ namespace System.Windows.Forms
                         m.Result = (IntPtr)NativeMethods.HTBOTTOMLEFT;
                         return;
                     }
-
                 }
                 base.WndProc(ref m);
             }
@@ -777,6 +764,5 @@ namespace System.Windows.Forms
                 return GetFocused();
             }
         }
-
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SystemInformation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SystemInformation.cs
@@ -88,7 +88,7 @@ namespace System.Windows.Forms
             {
                 return GetCurrentSystemMetrics(SystemMetric.SM_CXVSCROLL, (uint)dpi);
             }
-            
+
             return GetSystemMetrics(SystemMetric.SM_CXVSCROLL);
         }
 
@@ -106,7 +106,7 @@ namespace System.Windows.Forms
             {
                 return GetCurrentSystemMetrics(SystemMetric.SM_CYHSCROLL, (uint)dpi);
             }
-            
+
             return GetSystemMetrics(SystemMetric.SM_CYHSCROLL);
         }
 
@@ -137,7 +137,7 @@ namespace System.Windows.Forms
                 return new Size(GetCurrentSystemMetrics(SystemMetric.SM_CXBORDER, (uint)dpi),
                                 GetCurrentSystemMetrics(SystemMetric.SM_CYBORDER, (uint)dpi));
             }
-            
+
             return BorderSize;
         }
 
@@ -281,7 +281,7 @@ namespace System.Windows.Forms
             {
                 return GetCurrentSystemMetrics(SystemMetric.SM_CXHSCROLL, (uint)dpi);
             }
-            
+
             return GetSystemMetrics(SystemMetric.SM_CXHSCROLL);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabPageCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabPageCollection.cs
@@ -81,7 +81,6 @@ namespace System.Windows.Forms
 
             public void Add(TabPage value)
             {
-
                 if (value == null)
                 {
                     throw new ArgumentNullException(nameof(value));
@@ -344,7 +343,7 @@ namespace System.Windows.Forms
                 {
                     return Array.Empty<TabPage>().GetEnumerator();
                 }
-            
+
                 return tabPages.GetEnumerator();
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -661,7 +661,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 return _rightToLeftLayout;
             }
 
@@ -1021,7 +1020,6 @@ namespace System.Windows.Forms
             if (index >= 0)
             {
                 Insert(index, tabPage);
-
             }
             return index;
         }
@@ -1105,7 +1103,6 @@ namespace System.Windows.Forms
             if (tabPage == null)
             {
                 throw new ArgumentNullException(nameof(tabPage));
-
             }
             int index = FindTabPage(tabPage);
             DeselectTab(index);
@@ -1119,7 +1116,6 @@ namespace System.Windows.Forms
             if (tabPageName == null)
             {
                 throw new ArgumentNullException(nameof(tabPageName));
-
             }
             TabPage tabPage = TabPages[tabPageName];
             DeselectTab(tabPage);
@@ -1436,7 +1432,6 @@ namespace System.Windows.Forms
             {
                 SelectedTab.FireEnter(e);
             }
-
         }
 
         /// <summary>
@@ -1562,7 +1557,6 @@ namespace System.Windows.Forms
             {
                 SelectedTab.FireEnter(EventArgs.Empty);
             }
-
         }
 
         /// <summary>
@@ -1704,7 +1698,6 @@ namespace System.Windows.Forms
         private void ResetPadding()
         {
             Padding = DefaultPaddingPoint;
-
         }
 
         private void ResizePages()
@@ -1724,7 +1717,6 @@ namespace System.Windows.Forms
         {
             UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), (int)ComCtl32.TCM.SETTOOLTIPS, new HandleRef(toolTip, toolTip.Handle), 0);
             _controlTipText = controlToolTipText;
-
         }
 
         private void SetTabPage(int index, TabPage value)
@@ -1771,7 +1763,6 @@ namespace System.Windows.Forms
             if (tabPage == null)
             {
                 throw new ArgumentNullException(nameof(tabPage));
-
             }
             int index = FindTabPage(tabPage);
             SelectTab(index);
@@ -1785,7 +1776,6 @@ namespace System.Windows.Forms
             if (tabPageName == null)
             {
                 throw new ArgumentNullException(nameof(tabPageName));
-
             }
             TabPage tabPage = TabPages[tabPageName];
             SelectTab(tabPage);
@@ -1818,7 +1808,6 @@ namespace System.Windows.Forms
             }
             else
             {
-
                 int sel = SelectedIndex;
                 if (sel != -1)
                 {
@@ -1847,7 +1836,6 @@ namespace System.Windows.Forms
                         SetState(State.SelectFirstControl, !focused);
                         // Fire Selecting .. Selected on newly selected TabPage...
                         WmSelChange();
-
                     }
                     finally
                     {
@@ -1856,7 +1844,6 @@ namespace System.Windows.Forms
                         SetState(State.SelectFirstControl, false);
                         ke.Handled = true;
                     }
-
                 }
             }
         }
@@ -2034,7 +2021,6 @@ namespace System.Windows.Forms
             }
 
             Marshal.StructureToPtr(ttt, m.LParam, false);
-
         }
 
         private unsafe void WmReflectDrawItem(ref Message m)
@@ -2101,7 +2087,6 @@ namespace System.Windows.Forms
                 OnDeselected(new TabControlEventArgs(SelectedTab, SelectedIndex, TabControlAction.Deselected));
             }
             return tcc.Cancel;
-
         }
 
         private void WmTabBaseReLayout(ref Message m)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControlCancelEventHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControlCancelEventHandler.cs
@@ -5,7 +5,7 @@
 namespace System.Windows.Forms
 {
     /// <summary>
-    ///  Represents a method that handles the <see cref='TabControl.Deselected'/> and 
+    ///  Represents a method that handles the <see cref='TabControl.Deselected'/> and
     ///  <see cref='TabControl.Deselecting'/> events of a <see cref='TabControl'/>.
     /// </summary>
     public delegate void TabControlCancelEventHandler(object sender, TabControlCancelEventArgs e);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControlEventHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControlEventHandler.cs
@@ -5,7 +5,7 @@
 namespace System.Windows.Forms
 {
     /// <summary>
-    ///  Represents a method that handles the <see cref='TabControl.Selected'/> and 
+    ///  Represents a method that handles the <see cref='TabControl.Selected'/> and
     ///  <see cref='TabControl.Selecting'/> events of a <see cref='TabControl'/>.
     /// </summary>
     public delegate void TabControlEventHandler(object sender, TabControlEventArgs e);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutPanel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutPanel.cs
@@ -66,7 +66,6 @@ namespace System.Windows.Forms
                 {
                     throw new NotSupportedException(SR.TableLayoutSettingSettingsIsNotSupported);
                 }
-
             }
         }
 
@@ -485,7 +484,6 @@ namespace System.Windows.Forms
             {
                 ControlPaint.PaintTableControlBorder(cellBorderStyle, g, displayRect);
             }
-
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -561,7 +559,6 @@ namespace System.Windows.Forms
                     }
                 }
             }
-
         }
 
         #endregion

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutPanelCellPosition.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutPanelCellPosition.cs
@@ -122,7 +122,6 @@ namespace System.Windows.Forms
                     typeof(TableLayoutPanelCellPosition).GetConstructor(new Type[] { typeof(int), typeof(int) }),
                     new object[] { cellPosition.Column, cellPosition.Row }
                 );
-
             }
             return base.ConvertTo(context, culture, value, destinationType);
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutSettings.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutSettings.cs
@@ -116,7 +116,6 @@ namespace System.Windows.Forms
                 containerInfo.MaxColumns = value;
                 LayoutTransaction.DoLayout(Owner, Owner, PropertyNames.Columns);
                 Debug.Assert(ColumnCount == value, "the max columns should equal to the value we set it to");
-
             }
         }
 
@@ -146,7 +145,6 @@ namespace System.Windows.Forms
                 containerInfo.MaxRows = value;
                 LayoutTransaction.DoLayout(Owner, Owner, PropertyNames.Rows);
                 Debug.Assert(RowCount == value, "the max rows should equal to the value we set it to");
-
             }
         }
 
@@ -247,7 +245,6 @@ namespace System.Windows.Forms
                     _stub = settings._stub;
                 }
             }
-
         }
 
         #region Extended Properties
@@ -296,7 +293,6 @@ namespace System.Windows.Forms
                 LayoutTransaction.DoLayout(element.Container, element, PropertyNames.ColumnSpan);
                 Debug.Assert(GetColumnSpan(element) == value, "column span should equal to the value we set");
             }
-
         }
 
         public int GetRowSpan(object control)
@@ -563,7 +559,6 @@ namespace System.Windows.Forms
                         controlInfo.ColumnSpan = GetColumnSpan(c);
                         controlsInfo.Add(controlInfo);
                     }
-
                 }
                 return controlsInfo;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutSettingsTypeConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutSettingsTypeConverter.cs
@@ -75,7 +75,6 @@ namespace System.Windows.Forms.Layout
 
                 foreach (TableLayoutSettings.ControlInformation c in tableLayoutSettings.GetControlsInformation())
                 {
-
                     xmlWriter.WriteStartElement("Control");
                     xmlWriter.WriteAttributeString("Name", c.Name.ToString());
                     xmlWriter.WriteAttributeString("Row", c.Row.ToString(CultureInfo.CurrentCulture));
@@ -85,7 +84,6 @@ namespace System.Windows.Forms.Layout
                     xmlWriter.WriteAttributeString("ColumnSpan", c.ColumnSpan.ToString(CultureInfo.CurrentCulture));
 
                     xmlWriter.WriteEndElement();
-
                 }
                 xmlWriter.WriteEndElement(); // end Controls
 
@@ -125,7 +123,6 @@ namespace System.Windows.Forms.Layout
 
                 xmlWriter.Close();
                 return xmlStringBuilder.ToString();
-
             }
             return base.ConvertTo(context, culture, value, destinationType);
         }
@@ -171,9 +168,7 @@ namespace System.Windows.Forms.Layout
                     settings.SetRowSpan(name, rowSpan);
                     settings.SetColumnSpan(name, columnSpan);
                 }
-
             }
-
         }
 
         private void ParseStyles(TableLayoutSettings settings, XmlNodeList controlXmlFragments, bool columns)
@@ -196,7 +191,6 @@ namespace System.Windows.Forms.Layout
                     int nextIndex;
                     while (currentIndex < styleString.Length)
                     {
-
                         // ---- SizeType Parsing -----------------
                         nextIndex = currentIndex;
                         while (char.IsLetter(styleString[nextIndex]))
@@ -251,9 +245,7 @@ namespace System.Windows.Forms.Layout
                 }
             }
         }
-
     }
-
 }
 
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
@@ -221,7 +221,6 @@ namespace System.Windows.Forms
                     }
                     SetAutoComplete(false);
                 }
-
             }
         }
 
@@ -265,7 +264,6 @@ namespace System.Windows.Forms
             }
             set
             {
-
                 if (Multiline != value)
                 {
                     base.Multiline = value;
@@ -786,7 +784,6 @@ namespace System.Windows.Forms
                             }
                         }
                     }
-
                 }
                 else
                 {
@@ -999,6 +996,5 @@ namespace System.Windows.Forms
 
             public bool ShouldRenderPlaceHolderText(in Message m) => _textBox.ShouldRenderPlaceHolderText(m);
         }
-
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxAutoCompleteSourceConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxAutoCompleteSourceConverter.cs
@@ -31,7 +31,6 @@ namespace System.Windows.Forms
                 }
             }
             return new StandardValuesCollection(list);
-
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -696,7 +696,6 @@ namespace System.Windows.Forms
                 //unparse this string list...
                 if (value != null && value.Length > 0)
                 {
-
                     // Using a StringBuilder instead of a String
                     // speeds things up approx 150 times
                     StringBuilder text = new StringBuilder(value[0]);
@@ -774,7 +773,6 @@ namespace System.Windows.Forms
                 {
                     return textBoxFlags[modified];
                 }
-
             }
 
             set
@@ -1129,7 +1127,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 GetSelectionStartAndLength(out int start, out int length);
 
                 return length;
@@ -1166,7 +1163,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 GetSelectionStartAndLength(out int selStart, out int selLength);
 
                 return selStart;
@@ -1341,7 +1337,6 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-
                     int curHeight = Height;
 
                     // Changing the font of a multi-line textbox can sometimes cause a painting problem
@@ -1377,7 +1372,6 @@ namespace System.Windows.Forms
         {
             if (text.Length > 0)
             {
-
                 GetSelectionStartAndLength(out int selStart, out int selLength);
 
                 try
@@ -1773,7 +1767,6 @@ namespace System.Windows.Forms
                 {
                     if (UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), RichEditMessages.EM_GETOLEINTERFACE, 0, out editOle) != 0)
                     {
-
                         editOlePtr = Marshal.GetIUnknownForObject(editOle);
 
                         if (editOlePtr != IntPtr.Zero)
@@ -1787,7 +1780,6 @@ namespace System.Windows.Forms
 
                                 if (Marshal.GetObjectForIUnknown(iTextDocument) is Richedit.ITextDocument textDocument)
                                 {
-
                                     // When the user calls RichTextBox::ScrollToCaret we want the RichTextBox to show as
                                     // much text as possible.
                                     // Here is how we do that:
@@ -1906,7 +1898,6 @@ namespace System.Windows.Forms
 
                 SendMessage(EditMessages.EM_SETSEL, s, e);
                 //
-
             }
             else
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Timer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Timer.cs
@@ -111,7 +111,6 @@ namespace System.Windows.Forms
                                 // Create the timer window if needed.
                                 if (_timerWindow == null)
                                 {
-
                                     _timerWindow = new TimerNativeWindow(this);
                                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -259,7 +259,6 @@ namespace System.Windows.Forms
                     Rectangle bounds = CommonProperties.GetSpecifiedBounds(this);
                     bounds.Location = Location;
                     CommonProperties.UpdateSpecifiedBounds(this, bounds.X, bounds.Y, bounds.Width, bounds.Height, BoundsSpecified.Location);
-
                 }
                 base.AutoSize = value;
             }
@@ -369,7 +368,6 @@ namespace System.Windows.Forms
                 {
                     DropTargetManager.EnsureUnRegistered(this);
                 }
-
             }
         }
         /// <summary>
@@ -406,9 +404,7 @@ namespace System.Windows.Forms
                     {
                         DropTargetManager.EnsureUnRegistered(this);
                     }
-
                 }
-
             }
         }
 
@@ -723,7 +719,6 @@ namespace System.Windows.Forms
                             {
                                 direction = ToolStripDropDownDirection.Right;
                             }
-
                         }
                         else
                         {
@@ -845,13 +840,11 @@ namespace System.Windows.Forms
                     dropTargetManager = new ToolStripDropTargetManager(this);
                 }
                 return dropTargetManager;
-
             }
             set
             {
                 dropTargetManager = value;
             }
-
         }
         /// <summary>
         ///  Just here so we can add the default value attribute
@@ -882,7 +875,6 @@ namespace System.Windows.Forms
 
                 if ((LayoutEngine is ToolStripSplitStackLayout) && (GripStyle == ToolStripGripStyle.Visible))
                 {
-
                     if (Orientation == Orientation.Horizontal)
                     {
                         int gripwidth = Grip.GripThickness + Grip.Margin.Horizontal;
@@ -896,7 +888,6 @@ namespace System.Windows.Forms
                         rect.Y += gripheight;
                         rect.Height -= gripheight;
                     }
-
                 }
                 return rect;
             }
@@ -987,7 +978,6 @@ namespace System.Windows.Forms
                     LayoutTransaction.DoLayout(this, this, PropertyNames.GripStyle);
                 }
             }
-
         }
 
         /// <summary>
@@ -1191,7 +1181,6 @@ namespace System.Windows.Forms
             get
             {
                 return ToolStripPanelRow != null;
-
             }
         }
 
@@ -1370,7 +1359,6 @@ namespace System.Windows.Forms
                     lastMouseDownedItem = null;
                 }
                 return lastMouseDownedItem;
-
             }
         }
 
@@ -1546,7 +1534,6 @@ namespace System.Windows.Forms
                     }
                 }
                 return false;
-
             }
             set
             {
@@ -1554,7 +1541,6 @@ namespace System.Windows.Forms
                 {
                     SetToolStripState(STATE_MENUAUTOEXPAND, value);
                 }
-
             }
         }
 
@@ -1715,7 +1701,6 @@ namespace System.Windows.Forms
                             {
                                 UpdateOrientation(value.Orientation);
                             }
-
                         }
                     }
                     else
@@ -1727,9 +1712,7 @@ namespace System.Windows.Forms
                         UpdateLayoutStyle(Dock);
                     }
                 }
-
             }
-
         }
 
         [DefaultValue(false)]
@@ -1764,7 +1747,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 if (IsDropDown)
                 {
                     // PERF: since this is called a lot we dont want to make it virtual
@@ -1790,7 +1772,6 @@ namespace System.Windows.Forms
                     Renderer = ToolStripManager.CreateRenderer(RenderMode);
                 }
                 return renderer;
-
             }
             set
             {
@@ -1839,7 +1820,6 @@ namespace System.Windows.Forms
                     return ToolStripRenderMode.System;
                 }
                 return ToolStripRenderMode.Custom;
-
             }
             set
             {
@@ -1879,7 +1859,6 @@ namespace System.Windows.Forms
             get
             {
                 return ShowKeyboardCues;
-
             }
         }
 
@@ -2011,7 +1990,6 @@ namespace System.Windows.Forms
                         Items[i].OnOwnerTextDirectionChanged();
                     }
                 }
-
             }
         }
 
@@ -2070,9 +2048,7 @@ namespace System.Windows.Forms
                     // only toplevel menus auto expand when the selection changes.
                     tsNextItem.HandleAutoExpansion();
                 }
-
             }
-
         }
 
         protected virtual LayoutSettings CreateLayoutSettings(ToolStripLayoutStyle layoutStyle)
@@ -2119,7 +2095,6 @@ namespace System.Windows.Forms
 
             try
             {
-
                 for (int i = 0; i < DisplayedItems.Count; i++)
                 {
                     if (DisplayedItems[i] == item)
@@ -2165,7 +2140,6 @@ namespace System.Windows.Forms
                     Invalidate(regionRect, true);
                     Update();
                 }
-
             }
             finally
             {
@@ -2195,7 +2169,6 @@ namespace System.Windows.Forms
 
                 Invalidate(invalidate);
             }
-
         }
         private void ClearLastMouseDownedItem()
         {
@@ -2300,7 +2273,6 @@ namespace System.Windows.Forms
                 }
                 finally
                 {
-
                     ResumeLayout(false);
                     if (overflow != null)
                     {
@@ -2310,7 +2282,6 @@ namespace System.Windows.Forms
                 }
             }
             base.Dispose(disposing);
-
         }
 
         internal void DoLayoutIfHandleCreated(ToolStripItemEventArgs e)
@@ -2470,7 +2441,6 @@ namespace System.Windows.Forms
                     //ClearAllSelectionsExcept(Items[current]);
                     return DisplayedItems[current];
                 }
-
             } while (DisplayedItems[current] != start);
 
             return null;
@@ -2650,7 +2620,6 @@ namespace System.Windows.Forms
                 CommonProperties.xClearPreferredSizeCache(this);
             }
             return prefSize + newPadding.Size;
-
         }
 
         #region GetPreferredSizeHelpers
@@ -2883,7 +2852,6 @@ namespace System.Windows.Forms
             {
                 KeyboardActive = false;
             }
-
         }
 
         private void HookStaticEvents(bool hook)
@@ -2914,7 +2882,6 @@ namespace System.Windows.Forms
                 {
                     alreadyHooked = false;
                 }
-
             }
         }
 
@@ -3065,7 +3032,6 @@ namespace System.Windows.Forms
                 SetToolStripState(STATE_LOCATIONCHANGING, false);
                 base.SetBoundsCore(x, y, width, height, specified);
             }
-
         }
 
         internal void PaintParentRegion(Graphics g, Region region)
@@ -3126,7 +3092,6 @@ namespace System.Windows.Forms
                     Debug.WriteLineIf(SnapFocusDebug.TraceVerbose, "[ToolStrip.ProcessCmdKey] Detected a second ALT keypress while in Menu Mode.");
                     ToolStripManager.ModalMenuFilter.ExitMenuMode();
                 }
-
             }
 
             // Give the ToolStripItem very first chance at
@@ -3247,7 +3212,6 @@ namespace System.Windows.Forms
                         retVal = true;
                     }
                     break;
-
             }
 
             if (retVal)
@@ -3310,7 +3274,6 @@ namespace System.Windows.Forms
             // do not call base, as we dont want to walk through the controls collection and reprocess everything
             // we should have processed in the displayed items collection.
             return false;
-
         }
         private bool ProcessMnemonicInternal(char charCode)
         {
@@ -3597,7 +3560,6 @@ namespace System.Windows.Forms
                     Items[i].OnParentEnabledChanged(e);
                 }
             }
-
         }
 
         internal void OnDefaultFontChanged()
@@ -3692,7 +3654,7 @@ namespace System.Windows.Forms
                 // if we find an item that ParticipatesInLayout, mark us as having visible items.
                 HasVisibleItems = true;
             }
-            
+
             ((ToolStripItemEventHandler)Events[EventItemAdded])?.Invoke(this, e);
         }
 
@@ -3827,7 +3789,6 @@ namespace System.Windows.Forms
             {
                 base.OnMouseDown(mea);
             }
-
         }
 
         /// <summary>
@@ -3841,7 +3802,6 @@ namespace System.Windows.Forms
 
             if (!Grip.MovingToolStrip)
             {
-
                 // If we had a particular item that was "entered"
                 // notify it that we have entered.  It's fair to put
                 // this in the MouseMove event, as MouseEnter is fired during
@@ -3870,7 +3830,6 @@ namespace System.Windows.Forms
                     {
                         MouseHoverTimer.Start(lastMouseActiveItem);
                     }
-
                 }
             }
             else
@@ -3938,7 +3897,6 @@ namespace System.Windows.Forms
                 base.OnMouseUp(mea);
             }
             ClearLastMouseDownedItem();
-
         }
 
         protected override void OnPaint(PaintEventArgs e)
@@ -3954,7 +3912,6 @@ namespace System.Windows.Forms
 
             try
             {
-
                 // Paint the items
                 // The idea here is to let items pretend they are controls.
                 // they should get paint events at 0,0 and have proper clipping regions
@@ -4096,7 +4053,6 @@ namespace System.Windows.Forms
                             }
                         }
                     }
-
                 }
 
                 // Painting the edge effects...
@@ -4145,7 +4101,6 @@ namespace System.Windows.Forms
                     toolStripGrip.OnParentRightToLeftChanged(e);
                 }
             }
-
         }
 
         /// <summary>
@@ -4172,7 +4127,6 @@ namespace System.Windows.Forms
                     }
                 }
                 Renderer.DrawToolStripBackground(new ToolStripRenderEventArgs(g, this));
-
             }
             finally
             {
@@ -4217,7 +4171,6 @@ namespace System.Windows.Forms
                 ScrollInternal(se.OldValue - se.NewValue);
             }
             base.OnScroll(se);
-
         }
 
         private void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e)
@@ -4231,7 +4184,6 @@ namespace System.Windows.Forms
                     InvalidateTextItems();
                     break;
             }
-
         }
 
         protected override void OnTabStopChanged(EventArgs e)
@@ -4306,22 +4258,21 @@ namespace System.Windows.Forms
                     // draw two vertical lines
                     g.DrawLines(SystemPens.ControlText,
                         new Point[] { new Point(verticalBeamStart, lastInsertionMarkRect.Y), new Point(verticalBeamStart, lastInsertionMarkRect.Bottom-1), // first vertical line
-   								  new Point(verticalBeamStart+1, lastInsertionMarkRect.Y), new Point(verticalBeamStart+1, lastInsertionMarkRect.Bottom-1), //second  vertical line
+                                  new Point(verticalBeamStart+1, lastInsertionMarkRect.Y), new Point(verticalBeamStart+1, lastInsertionMarkRect.Bottom-1), //second  vertical line
                         });
                     // then two top horizontal
                     g.DrawLines(SystemPens.ControlText,
                         new Point[] { new Point(start, lastInsertionMarkRect.Bottom-1), new Point(start + widthOfBeam-1, lastInsertionMarkRect.Bottom-1), //bottom line
-   								  new Point(start+1, lastInsertionMarkRect.Bottom -2), new Point(start + widthOfBeam-2, lastInsertionMarkRect.Bottom-2),//bottom second line
+                                  new Point(start+1, lastInsertionMarkRect.Bottom -2), new Point(start + widthOfBeam-2, lastInsertionMarkRect.Bottom-2),//bottom second line
                         });
                     // then two bottom horizontal
                     g.DrawLines(SystemPens.ControlText,
                          new Point[] {  new Point(start, lastInsertionMarkRect.Y), new Point(start + widthOfBeam-1, lastInsertionMarkRect.Y), //top line
-   									new Point(start+1, lastInsertionMarkRect.Y+1), new Point(start + widthOfBeam-2, lastInsertionMarkRect.Y+1)//top second line
+                                    new Point(start+1, lastInsertionMarkRect.Y+1), new Point(start + widthOfBeam-2, lastInsertionMarkRect.Y+1)//top second line
                          });
                 }
                 else
                 {
-
                     widthOfBeam = insertionBeamWidth;
                     int start = lastInsertionMarkRect.Y;
                     int horizontalBeamStart = start + 2;
@@ -4329,20 +4280,19 @@ namespace System.Windows.Forms
                     // draw two horizontal lines
                     g.DrawLines(SystemPens.ControlText,
                         new Point[] { new Point(lastInsertionMarkRect.X, horizontalBeamStart), new Point(lastInsertionMarkRect.Right-1, horizontalBeamStart), // first vertical line
-    								  new Point(lastInsertionMarkRect.X, horizontalBeamStart+1), new Point(lastInsertionMarkRect.Right-1, horizontalBeamStart+1), //second  vertical line
-    								  });
+                                      new Point(lastInsertionMarkRect.X, horizontalBeamStart+1), new Point(lastInsertionMarkRect.Right-1, horizontalBeamStart+1), //second  vertical line
+                                      });
                     // then two left vertical
                     g.DrawLines(SystemPens.ControlText,
                         new Point[] { new Point(lastInsertionMarkRect.X, start), new Point(lastInsertionMarkRect.X, start + widthOfBeam-1), //left line
-    								  new Point(lastInsertionMarkRect.X+1, start+1), new Point(lastInsertionMarkRect.X+1, start + widthOfBeam-2), //second left line
-    								   });
+                                      new Point(lastInsertionMarkRect.X+1, start+1), new Point(lastInsertionMarkRect.X+1, start + widthOfBeam-2), //second left line
+                                       });
                     // then two right vertical
                     g.DrawLines(SystemPens.ControlText,
                          new Point[] { new Point(lastInsertionMarkRect.Right-1, start), new Point(lastInsertionMarkRect.Right-1, start + widthOfBeam-1), //right line
-    								  new Point(lastInsertionMarkRect.Right-2, start+1), new Point(lastInsertionMarkRect.Right-2, start + widthOfBeam-2), //second right line
+                                      new Point(lastInsertionMarkRect.Right-2, start+1), new Point(lastInsertionMarkRect.Right-2, start + widthOfBeam-2), //second right line
                                       });
                 }
-
             }
         }
 
@@ -4429,7 +4379,6 @@ namespace System.Windows.Forms
             }
 
             return null;
-
         }
 
         private void RestoreFocusInternal(bool wasInMenuMode)
@@ -4471,7 +4420,6 @@ namespace System.Windows.Forms
                 {
                     RestoreFocus();
                 }
-
             }
 
             // this matches the case where you click on a toolstrip control host
@@ -4481,7 +4429,6 @@ namespace System.Windows.Forms
             {
                 KeyboardActive = false;
             }
-
         }
 
         // override if you want to control (when TabStop = false) where the focus returns to
@@ -4720,7 +4667,6 @@ namespace System.Windows.Forms
             {
                 Grip.SetBounds(gripRectangle);
             }
-
         }
 
         /// <summary>
@@ -4741,10 +4687,8 @@ namespace System.Windows.Forms
             if (toolStripGrip != null && toolStripGrip.Visible)
             {
                 size = LayoutUtils.UnionSizes(size, toolStripGrip.Bounds.Size);
-
             }
             largestDisplayedItemSize = size;
-
         }
 
         /// <summary>
@@ -4786,7 +4730,6 @@ namespace System.Windows.Forms
                     // in pass 1, we go backward starting from the last (right) aligned item we found
                     for (; j >= 0 && j < Items.Count; j = (pass == 0) ? j + 1 : j - 1)
                     {
-
                         ToolStripItem item = Items[j];
                         ToolStripItemPlacement placement = item.Placement;
                         if (((IArrangedElement)item).ParticipatesInLayout)
@@ -4825,7 +4768,6 @@ namespace System.Windows.Forms
                             item.SetPlacement(ToolStripItemPlacement.None);
                         }
                     }
-
                 }
                 ToolStripOverflow overflow = GetOverflow();
                 if (overflow != null)
@@ -4840,7 +4782,6 @@ namespace System.Windows.Forms
                 {
                     DisplayedItems.Add(OverflowButton);
                 }
-
             }
             else
             {
@@ -4968,7 +4909,6 @@ namespace System.Windows.Forms
                     }
                 }
             }
-
         }
 
         // when we're control tabbing around we need to remember the original
@@ -5018,10 +4958,8 @@ namespace System.Windows.Forms
         {
             if (ShowItemToolTips)
             {
-
                 if (item != currentlyActiveTooltipItem && ToolTip != null)
                 {
-
                     ToolTip.Hide(this);
 
                     currentlyActiveTooltipItem = item;
@@ -5045,7 +4983,6 @@ namespace System.Windows.Forms
                     }
                 }
             }
-
         }
 
         private void UpdateLayoutStyle(DockStyle newDock)
@@ -5082,7 +5019,6 @@ namespace System.Windows.Forms
             {
                 using (new LayoutTransaction(this, this, PropertyNames.Orientation))
                 {
-
                     //
                     //  We want the ToolStrip to size appropriately when the rafting container orientation has switched.
                     //
@@ -5097,7 +5033,6 @@ namespace System.Windows.Forms
                     {
                         OnLayoutStyleChanged(EventArgs.Empty);
                     }
-
                 }
             }
             else
@@ -5105,7 +5040,6 @@ namespace System.Windows.Forms
                 // update the orientation but dont force a layout.
                 UpdateOrientation(newRaftingRowOrientation);
             }
-
         }
 
         private void UpdateOrientation(Orientation newOrientation)
@@ -5261,7 +5195,6 @@ namespace System.Windows.Forms
             /// </summary>
             public override AccessibleObject HitTest(int x, int y)
             {
-
                 Point clientHit = owner.PointToClient(new Point(x, y));
                 ToolStripItem item = owner.GetItemAt(clientHit);
                 return ((item != null) && (item.AccessibilityObject != null)) ?
@@ -5378,7 +5311,6 @@ namespace System.Windows.Forms
 
             internal AccessibleObject GetChildFragment(int fragmentIndex, bool getOverflowItem = false)
             {
-
                 ToolStripItemCollection items = getOverflowItem ? owner.OverflowItems : owner.DisplayedItems;
                 int childFragmentCount = items.Count;
 
@@ -5596,7 +5528,6 @@ namespace System.Windows.Forms
 
                 return base.GetPropertyValue(propertyID);
             }
-
         }
 
         private class ToolStripAccessibleObjectWrapperForItemsOnOverflow : ToolStripItem.ToolStripItemAccessibleObject
@@ -5630,7 +5561,6 @@ namespace System.Windows.Forms
 
             public bool PreFilterMessage(ref Message m)
             {
-
                 if (ownerToolStrip.Disposing || ownerToolStrip.IsDisposed || ownerToolStrip.IsDropDown)
                 {
                     return false;
@@ -5822,7 +5752,6 @@ namespace System.Windows.Forms
                 currentItem.FireEvent(EventArgs.Empty, ToolStripItemEventType.MouseHover);
             }
         }
-
     }
 
     ///  <devdoc/>
@@ -5846,7 +5775,6 @@ namespace System.Windows.Forms
             {
                 e.Effect = DragDropEffects.Move;
                 ShowItemDropPoint(owner.PointToClient(new Point(e.X, e.Y)));
-
             }
         }
 
@@ -5865,7 +5793,6 @@ namespace System.Windows.Forms
                 ToolStripItem item = (ToolStripItem)e.Data.GetData(typeof(ToolStripItem));
                 OnDropItem(item, owner.PointToClient(new Point(e.X, e.Y)));
             }
-
         }
         public void OnDragOver(DragEventArgs e)
         {
@@ -5886,7 +5813,6 @@ namespace System.Windows.Forms
                     e.Effect = DragDropEffects.None;
                 }
             }
-
         }
 
         public void OnGiveFeedback(GiveFeedbackEventArgs e)
@@ -5928,7 +5854,6 @@ namespace System.Windows.Forms
                 else if (((item.Alignment == ToolStripItemAlignment.Left) && (relativeLocation == RelativeLocation.Left)) ||
                     ((item.Alignment == ToolStripItemAlignment.Right) && (relativeLocation == RelativeLocation.Right)))
                 {
-
                     // the item alignment is Tail & dropped to right of the center of the item
                     // or the item alignment is Head & dropped to the left of the center of the item
 
@@ -5954,7 +5879,6 @@ namespace System.Windows.Forms
 
                 owner.Items.MoveItem(Math.Max(0, insertIndex), droppedItem);
                 owner.ClearInsertionMark();
-
             }
             else if (toolStripItemIndex == -1 && owner.Items.Count == 0)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripButton.ToolStripButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripButton.ToolStripButtonAccessibleObject.cs
@@ -41,7 +41,7 @@ namespace System.Windows.Forms
                     {
                         return AccessibleRole.CheckButton;
                     }
-                    
+
                     return base.Role;
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripComboBox.cs
@@ -206,7 +206,6 @@ namespace System.Windows.Forms
         {
             get { return ComboBox.DropDownHeight; }
             set { ComboBox.DropDownHeight = value; }
-
         }
 
         [
@@ -565,7 +564,6 @@ namespace System.Windows.Forms
 
             internal class ToolStripComboBoxFlatComboAdapter : FlatComboAdapter
             {
-
                 public ToolStripComboBoxFlatComboAdapter(ComboBox comboBox) : base(comboBox, /*smallButton=*/true)
                 {
                 }
@@ -688,7 +686,6 @@ namespace System.Windows.Forms
                         new Point(middle.X + FlatComboAdapter.Offset2Pixels + 1, middle.Y - 1),
                         new Point(middle.X, middle.Y + FlatComboAdapter.Offset2Pixels)
                     });
-
                 }
             }
 
@@ -715,7 +712,6 @@ namespace System.Windows.Forms
 
             internal class ToolStripComboBoxControlAccessibleObject : ComboBoxAccessibleObject
             {
-
                 private readonly ChildAccessibleObject childAccessibleObject;
 
                 public ToolStripComboBoxControlAccessibleObject(ToolStripComboBoxControl toolStripComboBoxControl) : base(toolStripComboBoxControl)
@@ -776,11 +772,7 @@ namespace System.Windows.Forms
 
                     return base.IsPatternSupported(patternId);
                 }
-
             }
-
         }
-
     }
-
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripContainer.cs
@@ -52,7 +52,6 @@ namespace System.Windows.Forms
                     controlCollection.AddInternal(bottomPanel);
                 }
                 // else consider throw new exception
-
             }
             finally
             {
@@ -433,7 +432,6 @@ namespace System.Windows.Forms
             {
                 c.ResumeLayout();
             }
-
         }
 
         internal override void RecreateHandleCore()
@@ -447,7 +445,6 @@ namespace System.Windows.Forms
                 }
             }
             base.RecreateHandleCore();
-
         }
 
         internal override bool AllowsKeyboardToolTip()
@@ -519,9 +516,6 @@ namespace System.Windows.Forms
                 }
                 base.SetChildIndexInternal(child, newIndex);
             }
-
         }
-
     }
-
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripContentPanel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripContentPanel.cs
@@ -118,7 +118,6 @@ namespace System.Windows.Forms
 
             set
             {
-
                 // To support transparency on ToolStripContainer, we need this check
                 // to ensure that background color of the container reflects the
                 // ContentPanel
@@ -378,7 +377,6 @@ namespace System.Windows.Forms
             {
                 base.OnPaintBackground(e);
             }
-
         }
 
         protected virtual void OnRendererChanged(EventArgs e)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.ToolStripHostedControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.ToolStripHostedControlAccessibleObject.cs
@@ -37,7 +37,7 @@ namespace System.Windows.Forms
                         && _toolStripControlHost != null // ToolStripControlHost is a container for ToolStripControl.
                         && _toolStripControlHost.Owner != null) // Owner is the ToolStrip.
                     {
-                        return _toolStripControlHost.Owner.AccessibilityObject; 
+                        return _toolStripControlHost.Owner.AccessibilityObject;
                     }
 
                     return base.FragmentRoot;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
@@ -753,7 +753,6 @@ namespace System.Windows.Forms
                 control.VisibleChanged += new EventHandler(HandleControlVisibleChanged);
                 control.Validating += new CancelEventHandler(HandleValidating);
                 control.Validated += new EventHandler(HandleValidated);
-
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
@@ -601,7 +601,6 @@ namespace System.Windows.Forms
                 {
                     ownerToolStrip.KeyboardActive = value;
                 }
-
             }
         }
 
@@ -1148,13 +1147,11 @@ namespace System.Windows.Forms
                 {
                     ApplyTopMost(true);
                 }
-
             }
             if (DesignMode)
             {
                 SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.OptimizedDoubleBuffer, false);
             }
-
         }
 
         public void Close()
@@ -1225,12 +1222,10 @@ namespace System.Windows.Forms
                     parentClientPoint = suggestedBounds.Location;
                 }
                 dropDownBounds = new Rectangle(parentClientPoint, suggestedBounds.Size);
-
             }
             Debug.WriteLineIf(DropDownDebugBounds.TraceVerbose, "DropDownBounds for " + suggestedBounds + "is" + dropDownBounds);
 
             return dropDownBounds;
-
         }
 
         internal Rectangle CalculateDropDownLocation(Point start, ToolStripDropDownDirection dropDownDirection)
@@ -1268,7 +1263,6 @@ namespace System.Windows.Forms
                 dropDownBounds = WindowsFormsUtils.ConstrainToScreenWorkingAreaBounds(dropDownBounds);
             }
             return dropDownBounds;
-
         }
 
         internal Size GetSuggestedSize()
@@ -1307,7 +1301,7 @@ namespace System.Windows.Forms
         }
         /// <summary>
         ///  Set some common properties
-        /// </summary>	
+        /// </summary>
         internal virtual void Initialize()
         {
             SetState(States.Visible, false);
@@ -1336,7 +1330,7 @@ namespace System.Windows.Forms
                     AccessibilityNotifyClients(AccessibleEvents.SystemMenuPopupEnd, -1);
                 }
             }
-            
+
             ((ToolStripDropDownClosedEventHandler)Events[EventClosed])?.Invoke(this, e);
         }
 
@@ -1374,7 +1368,6 @@ namespace System.Windows.Forms
                     }
                 }
             }
-
         }
 
         protected override void OnLayout(LayoutEventArgs e)
@@ -1383,7 +1376,6 @@ namespace System.Windows.Forms
             // the layout engine and SetDisplayedItems know how big the container is.
             AdjustSize();
             base.OnLayout(e);
-
         }
 
         protected virtual void OnOpening(CancelEventArgs e)
@@ -1404,7 +1396,7 @@ namespace System.Windows.Forms
                     AccessibilityNotifyClients(AccessibleEvents.SystemMenuPopupStart, -1);
                 }
             }
-            
+
             ((EventHandler)Events[EventOpened])?.Invoke(this, e);
         }
 
@@ -1525,7 +1517,6 @@ namespace System.Windows.Forms
                 Debug.WriteLineIf(ToolStrip.SnapFocusDebug.TraceVerbose, "[ToolStripDropDown.SelectPreviousToolStrip] No previous toolstrip to select - exiting menu mode.");
                 ToolStripManager.ModalMenuFilter.ExitMenuMode();
             }
-
         }
 
         /// <summary>
@@ -1541,7 +1532,6 @@ namespace System.Windows.Forms
 
             if (keyCode == Keys.Left || keyCode == Keys.Right)
             {
-
                 bool rightAligned = SystemInformation.RightAlignedMenus;
                 bool forward = (keyCode == Keys.Left && rightAligned) || (keyCode == Keys.Right && !rightAligned);
 
@@ -1562,7 +1552,6 @@ namespace System.Windows.Forms
 
                     if (closeOnHorizontalKey)
                     {
-
                         ToolStrip toplevelToolStrip = GetToplevelOwnerToolStrip();
                         ToolStripItem rootItem = GetToplevelOwnerItem();
 
@@ -1818,7 +1807,6 @@ namespace System.Windows.Forms
                 }
 
                 WindowStyle = styleFlags;
-
             }
         }
 
@@ -2044,7 +2032,6 @@ namespace System.Windows.Forms
                                         }
                                     }
                                 }
-
                             }
                         }
                     }
@@ -2105,7 +2092,6 @@ namespace System.Windows.Forms
             displayLocation = control.PointToScreen(position);
             Location = displayLocation;
             ShowCore();
-
         }
 
         public void Show(Control control, Point position, ToolStripDropDownDirection direction)
@@ -2230,7 +2216,6 @@ namespace System.Windows.Forms
                 {
                     dropDown.Visible = false;
                 }
-
             }
             else
             {
@@ -2260,7 +2245,6 @@ namespace System.Windows.Forms
         {
             if (m.WParam != IntPtr.Zero /*activating*/)
             {
-
                 if (!sendingActivateMessage)
                 {
                     sendingActivateMessage = true;
@@ -2285,13 +2269,11 @@ namespace System.Windows.Forms
                 }
                 DefWndProc(ref m);
                 return;
-
             }
             else
             {
                 base.WndProc(ref m);
             }
-
         }
         #endregion
         /// <summary>
@@ -2400,7 +2382,6 @@ namespace System.Windows.Forms
                     return AccessibleRole.MenuPopup;
                 }
             }
-
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownButton.cs
@@ -270,7 +270,6 @@ namespace System.Windows.Forms
 
             public override Size GetPreferredSize(Size constrainingSize)
             {
-
                 Size preferredSize = base.GetPreferredSize(constrainingSize);
                 if (ownerItem.ShowDropDownArrow)
                 {
@@ -292,10 +291,8 @@ namespace System.Windows.Forms
 
                 if (ownerItem.ShowDropDownArrow)
                 {
-
                     if (ownerItem.TextDirection == ToolStripTextDirection.Horizontal)
                     {
-
                         // We're rendering horizontal....  make sure to take care of RTL issues.
 
                         int widthOfDropDown = dropDownArrowSize.Width + scaledDropDownArrowPadding.Horizontal;
@@ -303,7 +300,6 @@ namespace System.Windows.Forms
 
                         if (ownerItem.RightToLeft == RightToLeft.Yes)
                         {
-
                             // if RightToLeft.Yes: [ v | rest of drop down button ]
                             options.client.Offset(widthOfDropDown, 0);
                             dropDownArrowRect = new Rectangle(scaledDropDownArrowPadding.Left, 0, dropDownArrowSize.Width, ownerItem.Bounds.Height);
@@ -312,7 +308,6 @@ namespace System.Windows.Forms
                         {
                             // if RightToLeft.No [ rest of drop down button | v ]
                             dropDownArrowRect = new Rectangle(options.client.Right, 0, dropDownArrowSize.Width, ownerItem.Bounds.Height);
-
                         }
                     }
                     else
@@ -324,9 +319,7 @@ namespace System.Windows.Forms
 
                         //  [ rest of button / v]
                         dropDownArrowRect = new Rectangle(0, options.client.Bottom + scaledDropDownArrowPadding.Top, ownerItem.Bounds.Width - 1, dropDownArrowSize.Height);
-
                     }
-
                 }
                 return options;
             }
@@ -338,9 +331,7 @@ namespace System.Windows.Forms
                     return dropDownArrowRect;
                 }
             }
-
         }
-
     }
 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
@@ -79,7 +79,6 @@ namespace System.Windows.Forms
             {
                 if (dropDown != value)
                 {
-
                     if (dropDown != null)
                     {
                         dropDown.Opened -= new EventHandler(DropDown_Opened);
@@ -96,9 +95,7 @@ namespace System.Windows.Forms
                         dropDown.ItemClicked += new ToolStripItemClickedEventHandler(DropDown_ItemClicked);
                         dropDown.AssignToDropDownItem();
                     }
-
                 }
-
             }
         }
 
@@ -146,16 +143,13 @@ namespace System.Windows.Forms
                                     dropDownDirection = newDropDownDirection;
                                 }
                             }
-
                         }
                         return dropDownDirection;
-
                     }
                 }
 
                 // someone has set a custom override
                 return toolStripDropDownDirection;
-
             }
             set
             {
@@ -202,7 +196,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 if (ParentInternal == null || !HasDropDownItems)
                 {
                     return Point.Empty;
@@ -377,7 +370,6 @@ namespace System.Windows.Forms
 
             if (Rectangle.Intersect(dropDownBounds, itemScreenBounds).Height > 1)
             {
-
                 bool rtl = (RightToLeft == RightToLeft.Yes);
 
                 // try positioning to the left
@@ -394,7 +386,6 @@ namespace System.Windows.Forms
             }
 
             return dropDownBounds;
-
         }
 
         /// <summary>
@@ -538,7 +529,6 @@ namespace System.Windows.Forms
 
             if (HasDropDownItems)
             {
-
                 // Items on the overflow should have the same kind of keyboard handling as a toplevel
                 bool isToplevel = (!IsOnDropDown || IsOnOverflow);
 
@@ -554,11 +544,9 @@ namespace System.Windows.Forms
                         DropDown.SelectNextToolStripItem(null, true);
                     }// else eat the key
                     return true;
-
                 }
                 else if (!isToplevel)
                 {
-
                     // if we're on a DropDown - then cascade out.
                     bool menusCascadeRight = (((int)DropDownDirection & 0x0001) == 0);
                     bool forward = ((keyCode == Keys.Enter) || (SupportsSpaceKey && keyCode == Keys.Space));
@@ -576,7 +564,6 @@ namespace System.Windows.Forms
                         } // else eat the key
                         return true;
                     }
-
                 }
             }
 
@@ -603,7 +590,6 @@ namespace System.Windows.Forms
                     // else if (parent.IsFirstDropDown)
                     //    the base handling (ToolStripDropDown.ProcessArrowKey) will perform auto-expansion of
                     //    the previous item in the menu.
-
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownMenu.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownMenu.cs
@@ -122,7 +122,6 @@ namespace System.Windows.Forms
                 Rectangle rect = base.DisplayRectangle;
                 if (GetToolStripState(STATE_SCROLLBUTTONS))
                 {
-
                     rect.Y += UpScrollButton.Height + UpScrollButton.Margin.Vertical;
                     rect.Height -= UpScrollButton.Height + UpScrollButton.Margin.Vertical + DownScrollButton.Height + DownScrollButton.Margin.Vertical;
                     // Because we're going to draw the scroll buttons on top of the padding, we need to add it back in here.
@@ -424,7 +423,6 @@ namespace System.Windows.Forms
                 nextPoint.X = checkRectangle.Right + scaledCheckPadding.Right + scaledImagePadding.Left;
                 nextPoint.Y = scaledImagePadding.Top;
                 imageRectangle = LayoutUtils.Align(maxImageSize, new Rectangle(nextPoint.X, nextPoint.Y, maxImageSize.Width, maxItemSize.Height), ContentAlignment.MiddleCenter);
-
             }
             else if (ShowCheckMargin)
             {
@@ -438,7 +436,6 @@ namespace System.Windows.Forms
                 checkRectangle = LayoutUtils.Align(maxCheckSize, new Rectangle(nextPoint.X, nextPoint.Y, checkAndImageMarginWidth, maxItemSize.Height), ContentAlignment.MiddleCenter);
 
                 imageRectangle = Rectangle.Empty;
-
             }
             else if (ShowImageMargin)
             {
@@ -499,7 +496,6 @@ namespace System.Windows.Forms
                 textRectangle.X = width - textRectangle.Right;
                 arrowRectangle.X = width - arrowRectangle.Right;
                 imageMarginBounds.X = width - imageMarginBounds.Right;
-
             }
             else
             {
@@ -526,7 +522,6 @@ namespace System.Windows.Forms
                 if (!displayRect.Contains(displayRect.X, nextItem.Bounds.Top)
                     || !displayRect.Contains(displayRect.X, nextItem.Bounds.Bottom))
                 {
-
                     int delta;
                     if (displayRect.Y > nextItem.Bounds.Top)
                     {
@@ -613,7 +608,6 @@ namespace System.Windows.Forms
         {
             tabWidth = -1;
             base.OnFontChanged(e);
-
         }
         protected override void OnPaintBackground(PaintEventArgs e)
         {
@@ -804,7 +798,6 @@ namespace System.Windows.Forms
             base.SetDisplayedItems();
             if (RequiresScrollButtons)
             {
-
                 DisplayedItems.Add(UpScrollButton);
                 DisplayedItems.Add(DownScrollButton);
                 UpdateScrollButtonLocations();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropTargetManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropTargetManager.cs
@@ -35,7 +35,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Summary of ToolStripDropTargetManager.
         /// </summary>
-        /// <param name=owner></param>	
+        /// <param name=owner></param>
         public ToolStripDropTargetManager(ToolStrip owner)
         {
             this.owner = owner;
@@ -48,7 +48,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Summary of EnsureRegistered.
         /// </summary>
-        /// <param name=dropTarget></param>	
+        /// <param name=dropTarget></param>
         public void EnsureRegistered(IDropTarget dropTarget)
         {
             Debug.WriteLineIf(DragDropDebug.TraceVerbose, "Ensuring drop target registered");
@@ -58,7 +58,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Summary of EnsureUnRegistered.
         /// </summary>
-        /// <param name=dropTarget></param>	
+        /// <param name=dropTarget></param>
         public void EnsureUnRegistered(IDropTarget dropTarget)
         {
             Debug.WriteLineIf(DragDropDebug.TraceVerbose, "Attempting to unregister droptarget");
@@ -67,7 +67,7 @@ namespace System.Windows.Forms
                 if (owner.Items[i].AllowDrop)
                 {
                     Debug.WriteLineIf(DragDropDebug.TraceVerbose, "An item still has allowdrop set to true - cant unregister");
-                    return; // can't unregister this as a drop target unless everyone is done.			
+                    return; // can't unregister this as a drop target unless everyone is done.
                 }
             }
             if (owner.AllowDrop || owner.AllowItemReorder)
@@ -84,7 +84,7 @@ namespace System.Windows.Forms
         ///  Takes a screen point and converts it into an item. May return null.
         /// </summary>
         /// <param name=x></param>
-        /// <param name=y></param>	
+        /// <param name=y></param>
         private ToolStripItem FindItemAtPoint(int x, int y)
         {
             return owner.GetItemAt(owner.PointToClient(new Point(x, y)));
@@ -92,7 +92,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Summary of OnDragEnter.
         /// </summary>
-        /// <param name=e></param>	
+        /// <param name=e></param>
         public void OnDragEnter(DragEventArgs e)
         {
             Debug.WriteLineIf(DragDropDebug.TraceVerbose, "[DRAG ENTER] ==============");
@@ -103,7 +103,6 @@ namespace System.Windows.Forms
             {
                 Debug.WriteLineIf(DragDropDebug.TraceVerbose, "ItemReorderTarget taking this...");
                 lastDropTarget = owner.ItemReorderDropTarget;
-
             }
             else
             {
@@ -121,7 +120,6 @@ namespace System.Windows.Forms
                     // the ToolStrip wants this event
                     Debug.WriteLineIf(DragDropDebug.TraceVerbose, "ToolStrip taking this because AllowDrop set to true.");
                     lastDropTarget = ((IDropTarget)owner);
-
                 }
                 else
                 {
@@ -136,7 +134,6 @@ namespace System.Windows.Forms
                     Debug.WriteLineIf(DragDropDebug.TraceVerbose, "No one wanted it.");
 
                     lastDropTarget = null;
-
                 }
             }
             if (lastDropTarget != null)
@@ -152,7 +149,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Summary of OnDragOver.
         /// </summary>
-        /// <param name=e></param>	
+        /// <param name=e></param>
         public void OnDragOver(DragEventArgs e)
         {
             Debug.WriteLineIf(DragDropDebug.TraceVerbose, "[DRAG OVER] ==============");
@@ -203,13 +200,12 @@ namespace System.Windows.Forms
                 Debug.WriteLineIf(DragDropDebug.TraceVerbose, "Calling OnDragOver on target...");
                 lastDropTarget.OnDragOver(e);
             }
-
         }
 
         /// <summary>
         ///  Summary of OnDragLeave.
         /// </summary>
-        /// <param name=e></param>	
+        /// <param name=e></param>
         public void OnDragLeave(EventArgs e)
         {
             Debug.WriteLineIf(DragDropDebug.TraceVerbose, "[DRAG LEAVE] ==============");
@@ -221,7 +217,6 @@ namespace System.Windows.Forms
                 dropTargetIsEntered = false;
 #endif
                 lastDropTarget.OnDragLeave(e);
-
             }
 #if DEBUG
             else
@@ -235,7 +230,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Summary of OnDragDrop.
         /// </summary>
-        /// <param name=e></param>	
+        /// <param name=e></param>
         public void OnDragDrop(DragEventArgs e)
         {
             Debug.WriteLineIf(DragDropDebug.TraceVerbose, "[DRAG DROP] ==============");
@@ -257,7 +252,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Used to actually register the control as a drop target.
         /// </summary>
-        /// <param name=accept></param>	
+        /// <param name=accept></param>
         private void SetAcceptDrops(bool accept)
         {
             if (accept && owner.IsHandleCreated)
@@ -293,12 +288,11 @@ namespace System.Windows.Forms
         ///  left the ToolStrip's client area.
         /// </summary>
         /// <param name=newTarget></param>
-        /// <param name=e></param>	
+        /// <param name=e></param>
         private void UpdateDropTarget(IDropTarget newTarget, DragEventArgs e)
         {
             if (newTarget != lastDropTarget)
             {
-
                 // tell the last drag target you've left
                 if (lastDropTarget != null)
                 {
@@ -316,9 +310,6 @@ namespace System.Windows.Forms
                     OnDragEnter(dragEnterArgs);
                 }
             }
-
         }
-
     }
-
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripGrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripGrip.cs
@@ -123,9 +123,7 @@ namespace System.Windows.Forms
                 else
                 {
                     preferredSize = new Size(gripThickness, ParentInternal.Height);
-
                 }
-
             }
             // Constrain ourselves
             if (preferredSize.Width > constrainingSize.Width)
@@ -169,7 +167,6 @@ namespace System.Windows.Forms
             bool leftMouseButtonDown = LeftMouseButtonIsDown();
             if (!MovingToolStrip && leftMouseButtonDown)
             {
-
                 // determine if we've moved far enough such that the toolstrip
                 // can be considered as moving.
                 Point currentLocation = TranslatePoint(mea.Location, ToolStripPointType.ToolStripItemCoords, ToolStripPointType.ScreenCoords);
@@ -195,7 +192,6 @@ namespace System.Windows.Forms
                         MovingToolStrip = true;
                     }
                 }
-
             }
             if (MovingToolStrip)
             {
@@ -235,7 +231,6 @@ namespace System.Windows.Forms
                 oldCursor = null;
             }
             base.OnMouseEnter(e);
-
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripHighContrastRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripHighContrastRenderer.cs
@@ -80,7 +80,6 @@ namespace System.Windows.Forms
                     }
 
                     g.FillRectangles(SystemBrushes.ControlLight, shadowRects);
-
                 }
             }
             else
@@ -103,7 +102,6 @@ namespace System.Windows.Forms
                     e.Graphics.DrawRectangle(SystemPens.ButtonHighlight, new Rectangle(0, 0, e.Item.Width - 1, e.Item.Height - 1));
                 }
             }
-
         }
 
         protected override void OnRenderItemCheck(ToolStripItemImageRenderEventArgs e)
@@ -155,7 +153,6 @@ namespace System.Windows.Forms
                 if (item.Pressed)
                 {
                     g.DrawRectangle(SystemPens.ButtonHighlight, bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);
-
                 }
                 else if (item.Selected)
                 {
@@ -197,13 +194,11 @@ namespace System.Windows.Forms
         {
             if (FillWhenSelected)
             {
-
                 RenderItemInternalFilled(e, /*pressFill = */false);
                 ToolStripItem item = e.Item;
                 Graphics g = e.Graphics;
                 Color arrowColor = item.Enabled ? SystemColors.ControlText : SystemColors.ControlDark;
                 DrawArrow(new ToolStripArrowRenderEventArgs(g, item, new Rectangle(Point.Empty, item.Size), arrowColor, ArrowDirection.Down));
-
             }
             else
             {
@@ -254,14 +249,12 @@ namespace System.Windows.Forms
 
             if (e.ToolStrip is ToolStripDropDown)
             {
-
                 g.DrawRectangle(SystemPens.ButtonHighlight, bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);
 
                 if (!(e.ToolStrip is ToolStripOverflow))
                 {
                     // make the neck connected.
                     g.FillRectangle(SystemBrushes.Control, e.ConnectedArea);
-
                 }
             }
             else if (e.ToolStrip is MenuStrip)
@@ -271,7 +264,6 @@ namespace System.Windows.Forms
             else if (e.ToolStrip is StatusStrip)
             {
                 g.DrawRectangle(SystemPens.ButtonShadow, bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);
-
             }
             else
             {
@@ -286,7 +278,6 @@ namespace System.Windows.Forms
 
             if (DottedBorder)
             {
-
                 using (Pen p = new Pen(SystemColors.ButtonShadow))
                 {
                     p.DashStyle = System.Drawing.Drawing2D.DashStyle.Dot;
@@ -320,7 +311,6 @@ namespace System.Windows.Forms
                     {
                         // bottom left
                         g.FillRectangle(SystemBrushes.ButtonShadow, new Rectangle(1, bounds.Height - 2, 1, 1));
-
                     }
 
                     // top and bottom right conntecting pixel - drawn only if height and width are odd
@@ -329,7 +319,6 @@ namespace System.Windows.Forms
                         // bottom right
                         g.FillRectangle(SystemBrushes.ButtonShadow, new Rectangle(bounds.Width - 2, bounds.Height - 2, 1, 1));
                     }
-
                 }
             }
             else
@@ -339,7 +328,6 @@ namespace System.Windows.Forms
                 bounds.Height -= 1;
                 g.DrawRectangle(SystemPens.ButtonShadow, bounds);
             }
-
         }
         protected override void OnRenderSeparator(ToolStripSeparatorRenderEventArgs e)
         {
@@ -358,7 +346,6 @@ namespace System.Windows.Forms
                 int startX = bounds.Width / 2;
 
                 g.DrawLine(foreColorPen, startX, bounds.Top, startX, bounds.Bottom - 1);
-
             }
             else
             {
@@ -373,9 +360,7 @@ namespace System.Windows.Forms
                 int startY = bounds.Height / 2;
 
                 g.DrawLine(foreColorPen, bounds.Left, startY, bounds.Right - 1, startY);
-
             }
-
         }
 
         // Indicates whether system is currently set to high contrast 'white on black' mode
@@ -489,9 +474,7 @@ namespace System.Windows.Forms
                 g.FillRectangle(SystemBrushes.Highlight, bounds);
                 g.DrawRectangle(SystemPens.ControlLight, bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);
             }
-
         }
-
     }
 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -177,7 +177,6 @@ namespace System.Windows.Forms
             CommonProperties.SetAutoSize(this, true);
             state[stateContstructing] = false;
             AutoToolTip = DefaultAutoToolTip;
-
         }
 
         protected ToolStripItem(string text, Image image, EventHandler onClick) : this(text, image, onClick, null)
@@ -316,7 +315,6 @@ namespace System.Windows.Forms
                 Properties.SetInteger(PropAccessibleRole, (int)value);
                 OnAccessibleRoleChanged(EventArgs.Empty);
             }
-
         }
 
         /// <summary>
@@ -477,7 +475,6 @@ namespace System.Windows.Forms
             get
             {
                 return Properties.GetObject(PropBackgroundImage) as Image;
-
             }
             set
             {
@@ -688,7 +685,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 // since we dont support DefaultLayout go directly against the CommonProperties
                 return CommonProperties.xGetDock(this);
             }
@@ -814,7 +810,6 @@ namespace System.Windows.Forms
                         OnDisplayStyleChanged(EventArgs.Empty);
                     }
                 }
-
             }
         }
 
@@ -971,7 +966,6 @@ namespace System.Windows.Forms
                         {
                             KeyboardToolTipStateMachine.Instance.NotifyAboutLostFocus(this);
                         }
-
                     }
                     OnEnabledChanged(EventArgs.Empty);
                     Invalidate();
@@ -1081,7 +1075,6 @@ namespace System.Windows.Forms
             }
             set
             {
-
                 Font local = (Font)Properties.GetObject(PropFont);
                 if ((local != value))
                 {
@@ -1205,7 +1198,6 @@ namespace System.Windows.Forms
             }
             set
             {
-
                 if (!WindowsFormsUtils.EnumValidator.IsValidContentAlignment(value))
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ContentAlignment));
@@ -1299,7 +1291,6 @@ namespace System.Windows.Forms
                     }
                     Invalidate();
                 }
-
             }
         }
 
@@ -1382,7 +1373,6 @@ namespace System.Windows.Forms
                 Properties.SetObject(PropImage, null);
 
                 InvalidateItemLayout(PropertyNames.ImageKey);
-
             }
         }
 
@@ -1468,7 +1458,6 @@ namespace System.Windows.Forms
             {
                 return state[stateDisposed];
             }
-
         }
 
         [Browsable(false)]
@@ -1476,7 +1465,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 if (ParentInternal != null)
                 {
                     return ParentInternal.IsDropDown;
@@ -1914,7 +1902,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 if ((DisplayStyle & ToolStripItemDisplayStyle.Image) != ToolStripItemDisplayStyle.Image)
                 {
                     return Size.Empty;
@@ -1943,7 +1930,6 @@ namespace System.Windows.Forms
                 }
 
                 return imageSize;
-
             }
         }
 
@@ -1973,7 +1959,6 @@ namespace System.Windows.Forms
             get
             {
                 return CanSelect && state[statePressed];
-
             }
         }
 
@@ -2014,7 +1999,6 @@ namespace System.Windows.Forms
                     return Owner.Renderer;
                 }
                 return ParentInternal?.Renderer;
-
             }
         }
 
@@ -2265,7 +2249,6 @@ namespace System.Windows.Forms
                     return propertyStore.GetObject(ToolStripItem.PropTag);
                 }
                 return null;
-
             }
             set
             {
@@ -2289,7 +2272,6 @@ namespace System.Windows.Forms
                     return (string)Properties.GetObject(ToolStripItem.PropText);
                 }
                 return "";
-
             }
             set
             {
@@ -2297,10 +2279,8 @@ namespace System.Windows.Forms
                 {
                     Properties.SetObject(ToolStripItem.PropText, value);
                     OnTextChanged(EventArgs.Empty);
-
                 }
             }
-
         }
 
         /// <summary>
@@ -2448,7 +2428,6 @@ namespace System.Windows.Forms
             {
                 SetVisibleCore(value);
             }
-
         }
 
         [SRCategory(nameof(SR.CatPropertyChanged)), SRDescription(nameof(SR.ToolStripItemOnVisibleChangedDescr))]
@@ -2529,7 +2508,6 @@ namespace System.Windows.Forms
         {
             if (Control.ModifierKeys == Keys.Alt)
             {
-
                 if (ParentInternal.Items.Contains(this) && ParentInternal.AllowItemReorder)
                 {
                     // we only drag
@@ -2537,7 +2515,6 @@ namespace System.Windows.Forms
                     DoDragDrop(item, DragDropEffects.Move);
                     return true;
                 }
-
             }
             return false;
         }
@@ -2621,7 +2598,6 @@ namespace System.Windows.Forms
                 }
                 else if (data is ToolStripItem)
                 {
-
                     // it seems that the DataObject does string comparison
                     // on the type, so you can't ask for GetDataPresent of
                     // a base type (e.g. ToolStripItem) when you are really
@@ -2920,7 +2896,6 @@ namespace System.Windows.Forms
                      && ParentInternal.CanHotTrack
                      && ParentInternal.ShouldSelectItem())
                 {
-
                     if (Enabled)
                     {
                         // calling select can dismiss a child dropdown which would break auto-expansion.
@@ -3462,7 +3437,6 @@ namespace System.Windows.Forms
         {
             InvalidateItemLayout(PropertyNames.RightToLeft);
             RaiseEvent(EventRightToLeft, e);
-
         }
 
         [EditorBrowsable(EditorBrowsableState.Advanced)]
@@ -4030,7 +4004,6 @@ namespace System.Windows.Forms
                     Debug.Assert((toPointType == ToolStripPointType.ToolStripCoords), "why are we here! - investigate");
                     toPoint = fromPoint;
                 }
-
             }
             return toPoint;
         }
@@ -4285,7 +4258,6 @@ namespace System.Windows.Forms
                         return (mnemonic == (char)0) ? string.Empty : mnemonic.ToString();
                     }
                     return (mnemonic == (char)0) ? string.Empty : ("Alt+" + mnemonic);
-
                 }
             }
 
@@ -4387,7 +4359,6 @@ namespace System.Windows.Forms
                     {
                         return AccessibleRole.PushButton;
                     }
-
                 }
             }
 
@@ -4509,9 +4480,7 @@ namespace System.Windows.Forms
                             nextItem = (Owner.IsOnDropDown) ? parent.GetNextItem(Owner, ArrowDirection.Down) :
                                                                parent.GetNextItem(Owner, ArrowDirection.Right, /*RTLAware=*/true);
                             break;
-
                     }
-
                 }
                 if (nextItem != null)
                 {
@@ -4542,7 +4511,6 @@ namespace System.Windows.Forms
                 {
                     return "ToolStripItemAccessibleObject: Owner = null";
                 }
-
             }
 
             /// <summary>
@@ -4576,7 +4544,6 @@ namespace System.Windows.Forms
                         return dropDown.AccessibilityObject;
                     }
                     return (Owner.Parent != null) ? Owner.Parent.AccessibilityObject : base.Parent;
-
                 }
             }
 
@@ -4713,7 +4680,6 @@ namespace System.Windows.Forms
                 }
             }
         }
-
     }
 
     // We need a special way to defer to the ToolStripItem's image
@@ -4845,7 +4811,6 @@ namespace System.Windows.Forms
             textFormat |= ControlPaint.TranslateAlignmentForGDI(alignment);
             textFormat |= ControlPaint.TranslateLineAlignmentForGDI(alignment);
             return textFormat;
-
         }
 
         protected virtual ToolStripItemLayoutOptions CommonLayoutOptions()
@@ -4907,7 +4872,6 @@ namespace System.Windows.Forms
 
             ButtonBaseAdapter.LayoutData data = currentLayoutOptions.Layout();
             return data;
-
         }
         public virtual Size GetPreferredSize(Size constrainingSize)
         {
@@ -4961,9 +4925,7 @@ namespace System.Windows.Forms
                     cachedProposedConstraints = proposedConstraints;
                 }
                 return cachedSize;
-
             }
-
         }
         private class ToolStripLayoutData
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemCollection.cs
@@ -78,7 +78,6 @@ namespace System.Windows.Forms
                 {
                     return null;
                 }
-
             }
         }
 
@@ -113,7 +112,6 @@ namespace System.Windows.Forms
                 owner.OnItemAdded(new ToolStripItemEventArgs(value));
             }
             return retVal;
-
         }
 
         public void AddRange(ToolStripItem[] toolStripItems)
@@ -159,7 +157,6 @@ namespace System.Windows.Forms
                     Add(toolStripItems[i]);
                 }
             }
-
         }
 
         public bool Contains(ToolStripItem value)
@@ -237,7 +234,6 @@ namespace System.Windows.Forms
                     throw new NotSupportedException(SR.ToolStripItemCircularReference);
                 }
             }
-
         }
 
         /// <summary>
@@ -351,7 +347,6 @@ namespace System.Windows.Forms
                 owner.OnItemAddedInternal(value);
                 owner.OnItemAdded(new ToolStripItemEventArgs(value));
             }
-
         }
 
         public int IndexOf(ToolStripItem value)
@@ -494,7 +489,6 @@ namespace System.Windows.Forms
                 }
             }
             Add(value);
-
         }
 
         internal void MoveItem(int index, ToolStripItem value)
@@ -521,14 +515,12 @@ namespace System.Windows.Forms
                 }
             }
             Insert(index, value);
-
         }
 
         private void SetOwner(ToolStripItem item)
         {
             if (itemsCollection)
             {
-
                 if (item != null)
                 {
                     if (item.Owner != null)
@@ -544,8 +536,6 @@ namespace System.Windows.Forms
                 }
             }
         }
-
     }
-
 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemOverflow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemOverflow.cs
@@ -9,8 +9,8 @@ namespace System.Windows.Forms
     /// </summary>
     public enum ToolStripItemOverflow
     {
-        Never,		// on the main ToolStrip itself,
-        Always,		// on the overflow window
-        AsNeeded	// DEFAULT try for main, overflow as necessary
+        Never,      // on the main ToolStrip itself,
+        Always,     // on the overflow window
+        AsNeeded    // DEFAULT try for main, overflow as necessary
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripLabel.cs
@@ -265,7 +265,6 @@ namespace System.Windows.Forms
                 }
             }
             base.OnMouseEnter(e);
-
         }
 
         protected override void OnMouseLeave(EventArgs e)
@@ -279,7 +278,6 @@ namespace System.Windows.Forms
                 }
             }
             base.OnMouseLeave(e);
-
         }
 
         private void ResetActiveLinkColor()
@@ -397,7 +395,6 @@ namespace System.Windows.Forms
                     FireEvent(ToolStripItemEventType.Click);
                 }
                 return true;
-
             }
             return false;
         }
@@ -491,9 +488,7 @@ namespace System.Windows.Forms
                 return layoutOptions;
             }
         }
-
     }
-
 }
 
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.cs
@@ -335,7 +335,6 @@ namespace System.Windows.Forms
             {
                 PruneToolStripList();
             }
-
         }
 
         /// <summary> removes dead entries from the toolstrip weak reference collection. </summary>
@@ -453,9 +452,7 @@ namespace System.Windows.Forms
                     else
                     {
                         Debug.WriteLineIf(ToolStrip.ControlTabDebug.TraceVerbose, "\tREVERSE skipping wrap candidate " + toolStrip.Name + toolStrip.TabIndex.ToString(CultureInfo.CurrentCulture));
-
                     }
-
                 }
                 if (nextControl != null
                     && Math.Abs(nextControl.TabIndex - startTabIndex) <= 1)
@@ -469,7 +466,6 @@ namespace System.Windows.Forms
             {
                 Debug.WriteLineIf(ToolStrip.ControlTabDebug.TraceVerbose, "SELECTING " + nextControl.Name);
                 return ChangeSelection(start, nextControl);
-
             }
             else if (wrappedControl != null)
             {
@@ -549,7 +545,6 @@ namespace System.Windows.Forms
                     defaultRenderer = value;
 
                     ((EventHandler)GetEventHandler(staticEventDefaultRendererChanged))?.Invoke(null, EventArgs.Empty);
-
                 }
             }
         }
@@ -591,7 +586,6 @@ namespace System.Windows.Forms
             }
             set
             {
-
                 ///
                 if (!ClientUtils.IsEnumValid(value, (int)value, (int)ToolStripManagerRenderMode.Custom, (int)ToolStripManagerRenderMode.Professional))
                 {
@@ -892,7 +886,6 @@ namespace System.Windows.Forms
                             control.HandleCreated += new EventHandler(OnActiveHwndHandleCreated);
                         }
                     }
-
                 }
             }
 
@@ -913,7 +906,6 @@ namespace System.Windows.Forms
                     if (Instance.menuKeyToggle != value)
                     {
                         Instance.menuKeyToggle = value;
-
                     }
                 }
             }
@@ -968,7 +960,6 @@ namespace System.Windows.Forms
                     // fire timer messages to force our filter to get evaluated.
                     ProcessMessages(true);
                 }
-
             }
 
             internal void NotifyLastLastFocusedToolAboutFocusLoss()
@@ -989,7 +980,6 @@ namespace System.Windows.Forms
             // ToolStrip analog to WM_EXITMENULOOP
             private void ExitMenuModeCore()
             {
-
                 // ensure we've cleaned up the timer.
                 ProcessMessages(false);
 
@@ -1046,9 +1036,7 @@ namespace System.Windows.Forms
                         bool textStyleChanged = _showUnderlines;
                         _showUnderlines = false;
                         ToolStripManager.NotifyMenuModeChange(/*textStyleChanged*/textStyleChanged, /*activationChanged*/true);
-
                     }
-
                 }
             }
 
@@ -1109,12 +1097,10 @@ namespace System.Windows.Forms
                         ModalMenuFilter.Instance.ShowUnderlines = true;
                     }
                 }
-
             }
 
             internal static void CloseActiveDropDown(ToolStripDropDown activeToolStripDropDown, ToolStripDropDownCloseReason reason)
             {
-
                 activeToolStripDropDown.SetCloseReason(reason);
                 activeToolStripDropDown.Visible = false;
 
@@ -1130,7 +1116,6 @@ namespace System.Windows.Forms
                         activeToolStripDropDown.OwnerItem.Unselect();
                     }
                 }
-
             }
 
             // fire a timer event to ensure we have a message in the queue every 500ms
@@ -1170,7 +1155,6 @@ namespace System.Windows.Forms
                         {
                             if (activeToolStrip is ToolStripDropDown activeToolStripDropDown)
                             {
-
                                 if (!(activeToolStripDropDown.OwnerToolStrip != null
                                     && activeToolStripDropDown.OwnerToolStrip.Handle == hwndMouseMessageIsFrom
                                     && activeToolStripDropDown.OwnerDropDownItem != null
@@ -1203,7 +1187,6 @@ namespace System.Windows.Forms
                         break;
                     }
                 }
-
             }
             private bool ProcessActivationChange()
             {
@@ -1220,7 +1203,6 @@ namespace System.Windows.Forms
                 return true;
                 //}
                 //return false;
-
             }
 
             internal static void SetActiveToolStrip(ToolStrip toolStrip, bool menuKeyPressed)
@@ -1240,7 +1222,6 @@ namespace System.Windows.Forms
 
             private void SetActiveToolStripCore(ToolStrip toolStrip)
             {
-
                 if (toolStrip == null)
                 {
                     return;
@@ -1285,7 +1266,6 @@ namespace System.Windows.Forms
                                   && (ToolStripDropDown.GetFirstDropDown(toolStrip)
                                   != ToolStripDropDown.GetFirstDropDown(currentActiveToolStrip)))
                         {
-
                             Debug.WriteLineIf(ToolStrip.SnapFocusDebug.TraceVerbose, "[ModalMenuFilter.SetActiveToolStripCore] Detected a new dropdown not in this chain opened, Dismissing everything in the old chain. ");
                             _inputFilterQueue.Remove(currentActiveToolStrip);
 
@@ -1438,7 +1418,6 @@ namespace System.Windows.Forms
                                 // double check it's not a child control of the active toolstrip.
                                 if (!IsChildOrSameWindow(hwndActiveToolStrip, new HandleRef(null, m.HWnd)))
                                 {
-
                                     // it is NOT a child of the current active toolstrip.
 
                                     ToolStrip toplevelToolStrip = GetCurrentToplevelToolStrip();
@@ -1513,7 +1492,6 @@ namespace System.Windows.Forms
                                 Debug.WriteLineIf(ToolStrip.SnapFocusDebug.TraceVerbose, "[ModalMenuFilter.PreFilterMessage] got Keyboard message " + m.ToString());
                             }
                             break;
-
                     }
                 }
 
@@ -1528,7 +1506,6 @@ namespace System.Windows.Forms
 
                 public HostedWindowsFormsMessageHook()
                 {
-
 #if DEBUG
                     try
                     {
@@ -1627,9 +1604,7 @@ namespace System.Windows.Forms
                         }
                     }
                 }
-
             }
-
         }
 
         internal static bool ShowMenuFocusCues
@@ -1797,7 +1772,6 @@ namespace System.Windows.Forms
                     }
                     else if (toolStrip.Shortcuts.ContainsKey(shortcut))
                     {
-
                         if (toolStrip.IsDropDown)
                         {
                             // we dont want to process someone else's context menu (e.g. button1 and button2 have context menus)
@@ -1853,7 +1827,6 @@ namespace System.Windows.Forms
                                             rootWindowsMatch = (toolStripForm == mainForm.ActiveMdiChildInternal);
                                         }
                                     }
-
                                 }
                             }
                         }
@@ -1876,10 +1849,8 @@ namespace System.Windows.Forms
                     PruneToolStripList();
                 }
                 return retVal;
-
             }
             return false;
-
         }
 
         /// <summary> this function handles when Alt is pressed.
@@ -1918,7 +1889,6 @@ namespace System.Windows.Forms
                         menuStripToActivate = GetMainMenuStrip(toplevelControl);
                     }
                     Debug.WriteLineIf(ToolStrip.SnapFocusDebug.TraceVerbose, string.Format(CultureInfo.CurrentCulture, "[ProcessMenuKey] MenuStripToActivate is: {0}", menuStripToActivate));
-
                 }
             }
             // the data that comes into the LParam is the ASCII code, not the VK_* code.
@@ -1971,7 +1941,6 @@ namespace System.Windows.Forms
                         return true;
                     }
                 }
-
             }
             return false;
         }
@@ -2200,7 +2169,6 @@ namespace System.Windows.Forms
                             case MergeAction.MatchOnly:
                                 if (item is ToolStripDropDownItem tsddownDest && source is ToolStripDropDownItem tsddownSrc && tsddownSrc.DropDownItems.Count != 0)
                                 {
-
                                     int originalCount = tsddownSrc.DropDownItems.Count;
 
                                     if (originalCount > 0)
@@ -2214,7 +2182,6 @@ namespace System.Windows.Forms
                                             // the dropdown.
                                             for (int i = 0, itemToLookAt = 0; i < originalCount; i++)
                                             {
-
                                                 MergeRecursive(tsddownSrc.DropDownItems[itemToLookAt], tsddownDest.DropDownItems, history);
 
                                                 int numberOfItemsMerged = lastCount - tsddownSrc.DropDownItems.Count;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.cs
@@ -338,7 +338,6 @@ namespace System.Windows.Forms
                     return checkedImage;
                 }
                 return null;
-
             }
         }
 
@@ -534,7 +533,6 @@ namespace System.Windows.Forms
                     }
                 }
             }
-
         }
 
         [
@@ -594,7 +592,6 @@ namespace System.Windows.Forms
                     {
                         LayoutTransaction.DoLayout(parent, this, "ShortcutKeys");
                         parent.AdjustSize();
-
                     }
                 }
             }
@@ -639,7 +636,6 @@ namespace System.Windows.Forms
                     return Properties.GetObject(PropMdiForm) as Form;
                 }
                 return null;
-
             }
         }
 
@@ -735,7 +731,6 @@ namespace System.Windows.Forms
                     {
                         Properties.SetObject(PropMdiForm, null);
                     }
-
                 }
             }
             base.Dispose(disposing);
@@ -878,7 +873,7 @@ namespace System.Windows.Forms
                 image.MakeTransparent(SystemColors.Control);
                 return image;
             }
-            
+
             return null;
         }
 
@@ -949,7 +944,6 @@ namespace System.Windows.Forms
                 }
                 Invalidate();
             }
-
         }
 
         /// <summary>
@@ -1010,7 +1004,6 @@ namespace System.Windows.Forms
             Debug.WriteLineIf(ToolStrip.MenuAutoExpandDebug.TraceVerbose, "[ToolStripMenuItem.OnMouseDown] MenuTimer.Cancel called");
             MenuTimer.Cancel(this);
             OnMouseButtonStateChange(e, /*isMouseDown=*/true);
-
         }
 
         protected override void OnMouseUp(MouseEventArgs e)
@@ -1039,14 +1032,12 @@ namespace System.Windows.Forms
             if (e.Button == MouseButtons.Left ||
               (e.Button == MouseButtons.Right && SupportsRightClick))
             {
-
                 if (isMouseDown && showDropDown)
                 {
                     // opening should happen on mouse down.
                     Debug.Assert(ParentInternal != null, "Parent is null here, not going to get accurate ID");
                     openMouseId = (ParentInternal == null) ? (byte)0 : ParentInternal.GetMouseId();
                     ShowDropDown(/*mousePush =*/true);
-
                 }
                 else if (!isMouseDown && !showDropDown)
                 {
@@ -1061,9 +1052,7 @@ namespace System.Windows.Forms
                         ToolStripManager.ModalMenuFilter.CloseActiveDropDown(DropDown, ToolStripDropDownCloseReason.AppClicked);
                         Select();
                     }
-
                 }
-
             }
         }
 
@@ -1072,7 +1061,7 @@ namespace System.Windows.Forms
         {
             Debug.Assert(ParentInternal != null, "Why is parent null");
 
-            // If we are in a submenu pop down the submenu.		
+            // If we are in a submenu pop down the submenu.
             if (ParentInternal != null && ParentInternal.MenuAutoExpand && Selected)
             {
                 Debug.WriteLineIf(ToolStripItem.MouseDebugging.TraceVerbose, "received mouse enter - calling drop down");
@@ -1081,7 +1070,6 @@ namespace System.Windows.Forms
 
                 MenuTimer.Cancel(this);
                 MenuTimer.Start(this);
-
             }
             base.OnMouseEnter(e);
         }
@@ -1152,7 +1140,6 @@ namespace System.Windows.Forms
 
                 if (InternalLayout is ToolStripMenuItemInternalLayout menuItemInternalLayout && menuItemInternalLayout.UseMenuLayout)
                 {
-
                     // Support for special DropDownMenu layout
 #if DEBUG_PAINT
                         g.DrawRectangle(Pens.Green, menuItemInternalLayout.TextRectangle);
@@ -1176,7 +1163,6 @@ namespace System.Windows.Forms
 
                     if ((DisplayStyle & ToolStripItemDisplayStyle.Text) == ToolStripItemDisplayStyle.Text)
                     {
-
                         // render text AND shortcut
                         renderer.DrawItemText(new ToolStripItemTextRenderEventArgs(g, this, Text, InternalLayout.TextRectangle, textColor, Font, (rightToLeft) ? ContentAlignment.MiddleRight : ContentAlignment.MiddleLeft));
                         bool showShortCut = ShowShortcutKeys;
@@ -1193,7 +1179,6 @@ namespace System.Windows.Forms
 
                     if (HasDropDownItems)
                     {
-
                         ArrowDirection arrowDir = (rightToLeft) ? ArrowDirection.Left : ArrowDirection.Right;
                         Color arrowColor = (Selected || Pressed) ? SystemColors.HighlightText : SystemColors.MenuText;
                         arrowColor = (Enabled) ? arrowColor : SystemColors.ControlDark;
@@ -1204,11 +1189,9 @@ namespace System.Windows.Forms
                     {
                         renderer.DrawItemImage(new ToolStripItemImageRenderEventArgs(g, this, InternalLayout.ImageRectangle));
                     }
-
                 }
                 else
                 {
-
                     // Toplevel item support, menu items hosted on a plain ToolStrip dropdown
                     if ((DisplayStyle & ToolStripItemDisplayStyle.Text) == ToolStripItemDisplayStyle.Text)
                     {
@@ -1220,9 +1203,7 @@ namespace System.Windows.Forms
                         renderer.DrawItemImage(new ToolStripItemImageRenderEventArgs(g, this, InternalLayout.ImageRectangle));
                     }
                 }
-
             }
-
         }
 
         /// <summary>
@@ -1393,7 +1374,6 @@ namespace System.Windows.Forms
             // since MenuShowDelay is registry tweakable we've gotta make sure we've got some sort
             // of interval
             slowShow = Math.Max(quickShow, SystemInformation.MenuShowDelay);
-
         }
         // the current item to autoexpand.
         private ToolStripMenuItem CurrentItem
@@ -1460,7 +1440,6 @@ namespace System.Windows.Forms
             // set up the current item to be the toItem so it will be auto expanded when complete.
             CurrentItem = toItem;
             InTransition = true;
-
         }
 
         public void Cancel()
@@ -1470,7 +1449,6 @@ namespace System.Windows.Forms
                 return;
             }
             CancelCore();
-
         }
         ///<summary> cancels if and only if this item was the one that
         ///  requested the timer
@@ -1506,9 +1484,7 @@ namespace System.Windows.Forms
                 {
                     lastSelected.HideDropDown();
                 }
-
             }
-
         }
         internal void HandleToolStripMouseLeave(ToolStrip toolStrip)
         {
@@ -1525,7 +1501,6 @@ namespace System.Windows.Forms
             }
             else
             {
-
                 // because we've split up selected/pressed, we need to make sure
                 // that onmouseleave we make sure there's a selected menu item.
                 if (toolStrip.IsDropDown && toolStrip.ActiveDropDowns.Count > 0)
@@ -1554,7 +1529,6 @@ namespace System.Windows.Forms
                 CurrentItem.OnMenuAutoExpand();
             }
         }
-
     }
 
     internal class ToolStripMenuItemInternalLayout : ToolStripItemInternalLayout
@@ -1652,7 +1626,6 @@ namespace System.Windows.Forms
                 {
                     if (ownerItem.Owner is ToolStripDropDownMenu menu)
                     {
-
                         // since menuItem.Padding isnt taken into consideration, we've got to recalc the centering of
                         // the image rect per item
                         Rectangle imageRect = menu.ImageRectangle;
@@ -1709,5 +1682,4 @@ namespace System.Windows.Forms
             return base.GetPreferredSize(constrainingSize);
         }
     }
-
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflow.cs
@@ -135,7 +135,6 @@ namespace System.Windows.Forms
                 }
             }
             base.OnLayout(e);
-
         }
 
         protected override void SetDisplayedItems()
@@ -173,7 +172,5 @@ namespace System.Windows.Forms
                 return ((ToolStripOverflow)Owner).DisplayedItems.Count;
             }
         }
-
     }
-
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflowButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflowButton.cs
@@ -126,7 +126,6 @@ namespace System.Windows.Forms
         {
             if (ParentInternal != null && ParentInternal.LayoutEngine is ToolStripSplitStackLayout)
             {
-
                 if (ParentInternal.Orientation == Orientation.Horizontal)
                 {
                     bounds.Height = ParentInternal.Height;
@@ -188,8 +187,6 @@ namespace System.Windows.Forms
 
                 return base.GetPropertyValue(propertyID);
             }
-
         }
-
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.cs
@@ -144,7 +144,6 @@ namespace System.Windows.Forms
             {
                 base.AutoSize = value;
             }
-
         }
 
         ///  Override base AutoSizeChanged to we can change visibility/browsability attributes
@@ -212,7 +211,6 @@ namespace System.Windows.Forms
             {
                 return DesignMode;
             }
-
         }
 
         public override LayoutEngine LayoutEngine
@@ -446,7 +444,6 @@ namespace System.Windows.Forms
             {
                 state[stateEndInit] = false;
             }
-
         }
 
         #endregion ISupportInitialize
@@ -486,7 +483,6 @@ namespace System.Windows.Forms
                 FlowLayout.SetFlowDirection(this, FlowDirection.LeftToRight);
             }
             FlowLayout.SetWrapContents(this, false);
-
         }
         private Point GetStartLocation(ToolStrip toolStripToDrag)
         {
@@ -543,7 +539,6 @@ namespace System.Windows.Forms
                     BeginInit();
                 }
             }
-
         }
 
         protected override void OnControlRemoved(ControlEventArgs e)
@@ -576,7 +571,6 @@ namespace System.Windows.Forms
         {
             base.OnLayoutSuspended();
             state[stateLayoutSuspended] = true;
-
         }
 
         internal override void OnLayoutResuming(bool resumeLayout)
@@ -626,7 +620,6 @@ namespace System.Windows.Forms
             {
                 state[stateRightToLeftChanged] = true;
             }
-
         }
 
         protected virtual void OnRendererChanged(EventArgs e)
@@ -663,7 +656,6 @@ namespace System.Windows.Forms
             {
                 JoinControls(forceLayout);
             }
-
         }
         private void ResetRenderMode()
         {
@@ -731,7 +723,6 @@ namespace System.Windows.Forms
                 }
             }
             state[stateRightToLeftChanged] = false;
-
         }
 
         #region Feedback
@@ -771,7 +762,6 @@ namespace System.Windows.Forms
             {
                 Debug.WriteLineIf(ToolStripPanelFeedbackDebug.TraceVerbose, "FEEDBACK: Moving feedback to " + screenLocation.ToString());
                 CurrentFeedbackRect.Move(screenLocation);
-
             }
         }
 
@@ -789,7 +779,6 @@ namespace System.Windows.Forms
             {
                 oldFeedback.Dispose();
             }
-
         }
 
         private static FeedbackRectangle CurrentFeedbackRect
@@ -814,7 +803,6 @@ namespace System.Windows.Forms
             public FeedbackRectangle(Rectangle bounds)
             {
                 dropDown = new FeedbackDropDown(bounds);
-
             }
             public bool Visible
             {
@@ -869,7 +857,6 @@ namespace System.Windows.Forms
 
             private class FeedbackDropDown : ToolStripDropDown
             {
-
                 private const int MAX_PAINTS_TO_SERVICE = 20;
                 private int _numPaintsServiced = 0; // member variable to protect against re-entrancy
 
@@ -1003,7 +990,6 @@ namespace System.Windows.Forms
             }
 
             Join(toolStripToDrag, location);
-
         }
 
         public void Join(ToolStrip toolStripToDrag, int x, int y)
@@ -1077,7 +1063,6 @@ namespace System.Windows.Forms
             // In design mode we get bogus values for client location.
             if (toolStripToDrag.Site != null && toolStripToDrag.Site.DesignMode && IsHandleCreated)
             {
-
                 if (clientLocation.X < 0 || clientLocation.Y < 0)
                 {
                     Point currentCursorLoc = PointToClient(WindowsFormsUtils.LastCursorPoint);
@@ -1181,7 +1166,6 @@ namespace System.Windows.Forms
                         Debug.WriteLineIf(ToolStripPanelRow.ToolStripPanelRowCreationDebug.TraceVerbose, "Inserting a new row at " + index.ToString(CultureInfo.InvariantCulture));
                         row = new ToolStripPanelRow(this);
                         RowsInternal.Insert(index, row);
-
                     }
                 }
                 else if (!row.CanMove(toolStripToDrag))
@@ -1252,7 +1236,6 @@ namespace System.Windows.Forms
                         Cursor.Position = cursorLoc;
                     }
                 }
-
             }
 
 #if DEBUG
@@ -1289,7 +1272,6 @@ namespace System.Windows.Forms
             {
                 GiveToolStripPanelFeedback(toolStripToDrag, screenLocation);
             }
-
         }
 
         /// <summary>
@@ -1335,7 +1317,6 @@ namespace System.Windows.Forms
                 ToolStripPanelRow row = RowsInternal[i];
                 foreach (ToolStripPanelCell cell in row.Cells)
                 {
-
                     if (cell.Control != null)
                     {
                         ToolStripPanelRow currentlyAssignedRow = ((ISupportToolStripPanel)cell.Control).ToolStripPanelRow;
@@ -1413,12 +1394,9 @@ namespace System.Windows.Forms
                             !RowsInternal.Contains(draggedToolStrip2.ToolStripPanelRow) ? "unknown" : RowsInternal.IndexOf(draggedToolStrip2.ToolStripPanelRow).ToString(CultureInfo.CurrentCulture),
                             draggedToolStrip2.ToolStripPanelRow.Bounds);
                         Debug.Fail(fail);
-
                     }
                 }
-
             }
-
         }
 
         ArrangedElementCollection IArrangedElement.Children
@@ -1467,7 +1445,6 @@ namespace System.Windows.Forms
                 int retVal = InnerList.Add(value);
                 OnAdd(value, retVal);
                 return retVal;
-
             }
 
             public void AddRange(ToolStripPanelRow[] value)
@@ -1524,7 +1501,6 @@ namespace System.Windows.Forms
                         currentOwner.ResumeLayout();
                     }
                 }
-
             }
 
             public bool Contains(ToolStripPanelRow value)
@@ -1584,7 +1560,6 @@ namespace System.Windows.Forms
 
                 InnerList.Insert(index, value);
                 OnAdd(value, index);
-
             }
 
             private void OnAdd(ToolStripPanelRow value, int index)
@@ -1600,7 +1575,6 @@ namespace System.Windows.Forms
             /// </summary>
             private void OnAfterRemove(ToolStripPanelRow row)
             {
-
 #if DEBUG
                 if (ToolStripPanelMissingRowDebug.TraceVerbose)
                 {
@@ -1636,7 +1610,6 @@ namespace System.Windows.Forms
             {
                 InnerList.CopyTo(array, index);
             }
-
         }
 
         internal class ToolStripPanelControlCollection : WindowsFormsUtils.TypedControlCollection
@@ -1662,7 +1635,6 @@ namespace System.Windows.Forms
                 {
                     base.AddInternal(value);
                 }
-
             }
 
             internal void Sort()
@@ -1700,7 +1672,6 @@ namespace System.Windows.Forms
                         return 1;
                     }
                     return 1;
-
                 }
             }
 
@@ -1727,10 +1698,8 @@ namespace System.Windows.Forms
                         return 1;
                     }
                     return 1;
-
                 }
             }
-
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelCell.cs
@@ -56,7 +56,6 @@ namespace System.Windows.Forms
             CommonProperties.SetAutoSize(this, true);
             _wrappedToolStrip.LocationChanging += new ToolStripLocationCancelEventHandler(OnToolStripLocationChanging);
             _wrappedToolStrip.VisibleChanged += new EventHandler(OnToolStripVisibleChanged);
-
         }
 
         public Rectangle CachedBounds
@@ -105,9 +104,7 @@ namespace System.Windows.Forms
                     }
                     parent = value;
                     Margin = Padding.Empty;
-
                 }
-
             }
         }
 
@@ -152,7 +149,6 @@ namespace System.Windows.Forms
             {
                 return GrowHorizontal(growBy);
             }
-
         }
 
         private int GrowVertical(int growBy)
@@ -185,7 +181,6 @@ namespace System.Windows.Forms
                 return growBy;
             }
             return 0;
-
         }
 
         private int GrowHorizontal(int growBy)
@@ -218,7 +213,6 @@ namespace System.Windows.Forms
                 return growBy;
             }
             return 0;
-
         }
         protected override void Dispose(bool disposing)
         {
@@ -328,11 +322,8 @@ namespace System.Windows.Forms
                         Debug.WriteLineIf(ToolStripPanelRow.ToolStripPanelMouseDebug.TraceVerbose, "[CELL] NOT DRAGGING calling SetBounds " + bounds.ToString());
                         base.SetBoundsCore(bounds, specified);
                         InnerElement.SetBounds(bounds, specified);
-
                     }
-
                 }
-
             }
             finally
             {
@@ -407,7 +398,6 @@ namespace System.Windows.Forms
                 && !_wrappedToolStrip.IsDisposed      // ensure we have a live-runtime only toolstrip.
                 && !_wrappedToolStrip.Disposing)
             {
-
                 // Rejoin the row when visibility is toggled.
                 // we dont want to do this logic at DT, as the DropSourceBehavior
                 // will set the toolstrip visible = false.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRow.cs
@@ -72,7 +72,6 @@ namespace System.Windows.Forms
                 Margin = DefaultMargin;
                 CommonProperties.SetAutoSize(this, true);
             }
-
         }
 
         public Rectangle Bounds
@@ -174,7 +173,6 @@ namespace System.Windows.Forms
                     }
                 }
                 return ToolStripPanel.RowMargin;
-
             }
         }
 
@@ -313,7 +311,6 @@ namespace System.Windows.Forms
             {
                 if (disposing)
                 {
-
                     Debug.WriteLineIf(ToolStripPanelRowCreationDebug.TraceVerbose, "Disposed ToolStripPanelRow");
                     state[stateDisposing] = true;
                     ControlsInternal.Clear();
@@ -430,7 +427,6 @@ namespace System.Windows.Forms
                     {
                         OnLayoutVerticalPostFix();
                     }
-
                 }
                 finally
                 {
@@ -532,7 +528,6 @@ namespace System.Windows.Forms
             }
 
             ApplyCachedBounds();
-
         }
 
         private void OnLayoutVerticalPostFix()
@@ -623,7 +618,6 @@ namespace System.Windows.Forms
             }
 
             ApplyCachedBounds();
-
         }
 
 #if DEBUG_PAINT
@@ -930,10 +924,8 @@ namespace System.Windows.Forms
                             return cell;
                         }
                     }
-
                 }
                 return null;
-
             }
 
             /// <summary>
@@ -1044,14 +1036,12 @@ namespace System.Windows.Forms
 
                         if ((!ToolStripPanel.Visible || LayoutUtils.IsZeroWidthOrHeight(raftingDisplayRectangle)) && (ToolStripPanel.ParentInternal != null))
                         {
-
                             // if were layed out before we're visible we have the wrong display rectangle, so we need to calculate it.
                             displayRect.Width = ToolStripPanel.ParentInternal.DisplayRectangle.Width - (ToolStripPanel.Margin.Horizontal + ToolStripPanel.Padding.Horizontal) - Row.Margin.Horizontal;
                         }
                         else
                         {
                             displayRect.Width = raftingDisplayRectangle.Width - Row.Margin.Horizontal;
-
                         }
                     }
 
@@ -1094,7 +1084,6 @@ namespace System.Windows.Forms
             /// </summary>
             public override bool CanMove(ToolStrip toolStripToDrag)
             {
-
                 if (base.CanMove(toolStripToDrag))
                 {
                     Size totalSize = Size.Empty;
@@ -1134,7 +1123,6 @@ namespace System.Windows.Forms
                         cellMargin.Left -= spaceToFree;
                         cellMargin.Right = 0;
                         spaceToFree = 0;
-
                     }
                     else
                     {
@@ -1185,7 +1173,6 @@ namespace System.Windows.Forms
 
             private int MoveLeft(int index, int spaceToFree)
             {
-
                 Debug.WriteLineIf(ToolStripPanelMouseDebug.TraceVerbose, "MoveLeft: " + spaceToFree.ToString(CultureInfo.InvariantCulture));
                 int freedSpace = 0;
 
@@ -1217,7 +1204,6 @@ namespace System.Windows.Forms
                             cellMargin.Left -= requiredSpace;
                             cellMargin.Right = 0;
                             cell.Margin = cellMargin;
-
                         }
                         else
                         {
@@ -1257,13 +1243,11 @@ namespace System.Windows.Forms
 
             private int MoveRight(int index, int spaceToFree)
             {
-
                 Debug.WriteLineIf(ToolStripPanelMouseDebug.TraceVerbose, "MoveRight: " + spaceToFree.ToString(CultureInfo.InvariantCulture));
                 int freedSpace = 0;
                 Row.SuspendLayout();
                 try
                 {
-
                     if (spaceToFree == 0 || index < 0 || index >= Row.ControlsInternal.Count)
                     {
                         Debug.WriteLineIf(ToolStripPanelMouseDebug.TraceVerbose, "MoveRight Early EXIT - 0 ");
@@ -1292,7 +1276,6 @@ namespace System.Windows.Forms
                             cellMargin.Left -= requiredSpace;
                             cellMargin.Right = 0;
                             cell.Margin = cellMargin;
-
                         }
                         else
                         {
@@ -1317,7 +1300,6 @@ namespace System.Windows.Forms
                         {
                             freedSpace += DisplayRectangle.Width;
                         }
-
                     }
 
                     // set the margin of the control that's moving.
@@ -1358,7 +1340,6 @@ namespace System.Windows.Forms
                             Row.ResumeLayout(true);
                             return spaceToFree;
                         }
-
                     }
 
                     if (Row.Cells.Count == 1)
@@ -1371,7 +1352,6 @@ namespace System.Windows.Forms
                             cell.Margin = cellMargin;
                         }
                     }
-
                 }
                 finally
                 {
@@ -1424,7 +1404,6 @@ namespace System.Windows.Forms
 
             public override void JoinRow(ToolStrip toolStripToDrag, Point locationToDrag)
             {
-
                 Debug.WriteLineIf(ToolStripPanelMouseDebug.TraceVerbose, "Horizontal JoinRow called ");
                 int index;
 
@@ -1436,7 +1415,6 @@ namespace System.Windows.Forms
                     {
                         if (Row.ControlsInternal.Count > 0)
                         {
-
                             // walk through the columns and determine which column you want to insert into.
                             for (index = 0; index < Row.Cells.Count; index++)
                             {
@@ -1459,7 +1437,6 @@ namespace System.Windows.Forms
                                 {
                                     break;
                                 }
-
                             }
 
                             Control controlToPushAside = Row.ControlsInternal[index];
@@ -1519,9 +1496,7 @@ namespace System.Windows.Forms
                                         nextCellMargin.Left = Math.Max(0, nextCellMargin.Left - freedSpace);
                                         nextCell.Margin = nextCellMargin;
                                     }
-
                                 }
-
                             }
                             else
                             {
@@ -1558,11 +1533,9 @@ namespace System.Windows.Forms
                                     newCell.Margin = newCellMargin;
                                 }
                             }
-
                         }
                         else
                         {
-
                             // we're adding to the beginning.
                             Row.ControlsInternal.Add(toolStripToDrag);
 
@@ -1587,7 +1560,6 @@ namespace System.Windows.Forms
                                     cell.Margin = cellMargin;
                                 }
                             }
-
                         }
                     }
                     finally
@@ -1601,7 +1573,6 @@ namespace System.Windows.Forms
             {
                 base.OnBoundsChanged(oldBounds, newBounds);
             }
-
         }
 
         private class VerticalRowManager : ToolStripPanelRowManager
@@ -1677,7 +1648,6 @@ namespace System.Windows.Forms
             /// </summary>
             public override bool CanMove(ToolStrip toolStripToDrag)
             {
-
                 if (base.CanMove(toolStripToDrag))
                 {
                     Size totalSize = Size.Empty;
@@ -1717,7 +1687,6 @@ namespace System.Windows.Forms
                         cellMargin.Top -= spaceToFree;
                         cellMargin.Bottom = 0;
                         spaceToFree = 0;
-
                     }
                     else
                     {
@@ -1740,7 +1709,6 @@ namespace System.Windows.Forms
 
             public override void MoveControl(ToolStrip movingControl, Point clientStartLocation, Point clientEndLocation)
             {
-
                 if (Row.Locked)
                 {
                     return;
@@ -1799,7 +1767,6 @@ namespace System.Windows.Forms
                             cellMargin.Top -= requiredSpace;
                             cellMargin.Bottom = 0;
                             cell.Margin = cellMargin;
-
                         }
                         else
                         {
@@ -1840,13 +1807,11 @@ namespace System.Windows.Forms
 
             private int MoveDown(int index, int spaceToFree)
             {
-
                 Debug.WriteLineIf(ToolStripPanelMouseDebug.TraceVerbose, "MoveDown: " + spaceToFree.ToString(CultureInfo.InvariantCulture));
                 int freedSpace = 0;
                 Row.SuspendLayout();
                 try
                 {
-
                     if (spaceToFree == 0 || index < 0 || index >= Row.ControlsInternal.Count)
                     {
                         Debug.WriteLineIf(ToolStripPanelMouseDebug.TraceVerbose, "MoveDown Early EXIT - 0 ");
@@ -1876,7 +1841,6 @@ namespace System.Windows.Forms
                             cellMargin.Top -= requiredSpace;
                             cellMargin.Bottom = 0;
                             cell.Margin = cellMargin;
-
                         }
                         else
                         {
@@ -1933,7 +1897,6 @@ namespace System.Windows.Forms
                             Row.ResumeLayout(true);
                             return spaceToFree;
                         }
-
                     }
 
                     if (Row.Cells.Count == 1)
@@ -1946,7 +1909,6 @@ namespace System.Windows.Forms
                             cell.Margin = cellMargin;
                         }
                     }
-
                 }
                 finally
                 {
@@ -1961,13 +1923,11 @@ namespace System.Windows.Forms
 
             protected internal override void OnBoundsChanged(Rectangle oldBounds, Rectangle newBounds)
             {
-
                 base.OnBoundsChanged(oldBounds, newBounds);
 
                 // if our bounds have changed - we should shove the toolbars up so they're in view.
                 if (Row.Cells.Count > 0)
                 {
-
                     // take a look at the last guy.  if his right edge exceeds
                     // the new bounds, then we should go ahead and push him into view.
                     ToolStripPanelCell lastCell = GetNextVisibleCell(Row.Cells.Count - 1, /*forward=*/false);
@@ -1984,12 +1944,10 @@ namespace System.Windows.Forms
                         // the toolstrip into view. (space after the fact doesnt count).
                         if (cellMargin.Top >= spaceToFree)
                         {
-
                             cellMargin.Top -= spaceToFree;
                             cellMargin.Bottom = 0;
                             lastCellOnRow.Margin = cellMargin;
                             spaceToFree = 0;
-
                         }
                         else
                         {
@@ -2002,24 +1960,19 @@ namespace System.Windows.Forms
                         // start moving the toolstrips before this guy.
                         MoveUp(Row.Cells.Count - 1, spaceToFree);
                     }
-
                 }
-
             }
 
             protected internal override void OnControlRemoved(Control c, int index)
             {
-
             }
 
             protected internal override void OnControlAdded(Control control, int index)
             {
-
             }
 
             public override void JoinRow(ToolStrip toolStripToDrag, Point locationToDrag)
             {
-
                 Debug.WriteLineIf(ToolStripPanelMouseDebug.TraceVerbose, "Vertical JoinRow called ");
                 int index;
 
@@ -2030,7 +1983,6 @@ namespace System.Windows.Forms
                     {
                         if (Row.ControlsInternal.Count > 0)
                         {
-
                             // walk through the columns and determine which column you want to insert into.
                             for (index = 0; index < Row.Cells.Count; index++)
                             {
@@ -2052,7 +2004,6 @@ namespace System.Windows.Forms
                                 {
                                     break;
                                 }
-
                             }
 
                             Control controlToPushAside = Row.ControlsInternal[index];
@@ -2085,7 +2036,6 @@ namespace System.Windows.Forms
 
                             if (index < Row.ControlsInternal.Count - 1)
                             {
-
                                 ToolStripPanelCell nextCell = GetNextVisibleCell(index + 1,  /*forward*/true);
                                 if (nextCell != null)
                                 {
@@ -2116,10 +2066,8 @@ namespace System.Windows.Forms
                                             nextCellMargin.Top -= freedSpace;
                                             nextCell.Margin = nextCellMargin;
                                         }
-
                                     }
                                 }
-
                             }
                             else
                             {
@@ -2135,7 +2083,6 @@ namespace System.Windows.Forms
                                     lastCell.Margin = lastCellMargin;
                                     freedSpace = requiredSpace;
                                 }
-
                             }
 
                             // If we still need more space, then...
@@ -2157,11 +2104,9 @@ namespace System.Windows.Forms
                                     newCell.Margin = newCellMargin;
                                 }
                             }
-
                         }
                         else
                         {
-
                             // we're adding to the beginning.
                             Row.ControlsInternal.Add(toolStripToDrag);
 
@@ -2199,7 +2144,6 @@ namespace System.Windows.Forms
                 {
                     if (index < Row.ControlsInternal.Count - 1 /*not the last one in the row*/)
                     {
-
                         ToolStripPanelCell cell = (ToolStripPanelCell)Row.Cells[index];
                         if (cell.Visible)
                         {
@@ -2380,7 +2324,6 @@ namespace System.Windows.Forms
                     control = cell?.Control;
                 }
                 return control;
-
             }
             private int IndexOfControl(Control c)
             {
@@ -2393,7 +2336,6 @@ namespace System.Windows.Forms
                     }
                 }
                 return -1;
-
             }
 
             void IList.Clear() { Clear(); }
@@ -2468,11 +2410,9 @@ namespace System.Windows.Forms
                     if (ToolStripPanel != null && ToolStripPanel.ParentInternal != null)
                     {
                         layoutTransaction = new LayoutTransaction(ToolStripPanel, ToolStripPanel.ParentInternal, PropertyNames.Parent);
-
                     }
                     try
                     {
-
                         if (controlToBeDragged != null)
                         {
                             controlToBeDragged.ToolStripPanelRow = owner;
@@ -2483,7 +2423,6 @@ namespace System.Windows.Forms
                                 owner.OnControlAdded(control, index);
                             }
                         }
-
                     }
                     finally
                     {
@@ -2492,7 +2431,6 @@ namespace System.Windows.Forms
                             layoutTransaction.Dispose();
                         }
                     }
-
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripProfessionalLowResolutionRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripProfessionalLowResolutionRenderer.cs
@@ -87,7 +87,6 @@ namespace System.Windows.Forms
                 {
                     // bottom left
                     g.FillRectangle(SystemBrushes.ButtonShadow, new Rectangle(1, bounds.Height - 2, 1, 1));
-
                 }
 
                 // top and bottom right conntecting pixel - drawn only if height and width are odd
@@ -96,7 +95,6 @@ namespace System.Windows.Forms
                     // bottom right
                     g.FillRectangle(SystemBrushes.ButtonShadow, new Rectangle(bounds.Width - 2, bounds.Height - 2, 1, 1));
                 }
-
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripProgressBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripProgressBar.cs
@@ -178,7 +178,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 return ProgressBar.RightToLeftLayout;
             }
 
@@ -312,7 +311,6 @@ namespace System.Windows.Forms
                 bar.RightToLeftLayoutChanged -= new EventHandler(HandleRightToLeftLayoutChanged);
             }
             base.OnUnsubscribeControlEvents(control);
-
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripRenderer.cs
@@ -94,7 +94,6 @@ namespace System.Windows.Forms
                     transparency[4] = new float[5] { 0, 0, 0, 0, 0 };
 
                     disabledImageColorMatrix = ControlPaint.MultiplyColorMatrix(transparency, greyscale);
-
                 }
 
                 return disabledImageColorMatrix;
@@ -354,7 +353,6 @@ namespace System.Windows.Forms
             {
                 eh(this, e);
             }
-
         }
 
         /// <summary>
@@ -494,7 +492,6 @@ namespace System.Windows.Forms
             {
                 eh(this, e);
             }
-
         }
 
         /// <summary>
@@ -508,7 +505,6 @@ namespace System.Windows.Forms
             {
                 eh(this, e);
             }
-
         }
 
         //
@@ -588,7 +584,6 @@ namespace System.Windows.Forms
                 offset4Y = DpiHelper.LogicalToDeviceUnitsY(OFFSET_4PIXELS);
             }
             isScalingInitialized = true;
-
         }
 
         protected static void ScaleArrowOffsetsIfNeeded(int dpi)
@@ -601,7 +596,6 @@ namespace System.Windows.Forms
 
         /// <include file='doc\WinBarRenderer.uex' path='docs/doc[@for="ToolStripRenderer.OnRenderArrow"]/*' />
         protected virtual void OnRenderArrow(ToolStripArrowRenderEventArgs e){
-
             if (RendererOverride != null)
             {
                 RendererOverride.OnRenderArrow(e);
@@ -611,7 +605,6 @@ namespace System.Windows.Forms
             Rectangle dropDownRect = e.ArrowRectangle;
             using (Brush brush = new SolidBrush(e.ArrowColor))
             {
-
                 Point middle = new Point(dropDownRect.Left + dropDownRect.Width / 2, dropDownRect.Top + dropDownRect.Height / 2);
                 // if the width is odd - favor pushing it over one pixel right.
                 //middle.X += (dropDownRect.Width % 2);
@@ -714,7 +707,6 @@ namespace System.Windows.Forms
                 RendererOverride.OnRenderItemBackground(e);
                 return;
             }
-
         }
 
         /// <summary>
@@ -727,7 +719,6 @@ namespace System.Windows.Forms
                 RendererOverride.OnRenderImageMargin(e);
                 return;
             }
-
         }
         /// <summary>
         ///  Draw the button background
@@ -739,7 +730,6 @@ namespace System.Windows.Forms
                 RendererOverride.OnRenderButtonBackground(e);
                 return;
             }
-
         }
 
         /// <summary>
@@ -752,7 +742,6 @@ namespace System.Windows.Forms
                 RendererOverride.OnRenderDropDownButtonBackground(e);
                 return;
             }
-
         }
 
         /// <summary>
@@ -796,7 +785,6 @@ namespace System.Windows.Forms
                 if (e.Item.ImageScaling == ToolStripItemImageScaling.None)
                 {
                     e.Graphics.DrawImage(image, imageRect, new Rectangle(Point.Empty, imageRect.Size), GraphicsUnit.Pixel);
-
                 }
                 else
                 {
@@ -861,7 +849,6 @@ namespace System.Windows.Forms
                 Size textSize = LayoutUtils.FlipSize(textRect.Size);
                 using (Bitmap textBmp = new Bitmap(textSize.Width, textSize.Height, PixelFormat.Format32bppPArgb))
                 {
-
                     using (Graphics textGraphics = Graphics.FromImage(textBmp))
                     {
                         // now draw the text..
@@ -888,7 +875,6 @@ namespace System.Windows.Forms
                 RendererOverride.OnRenderLabelBackground(e);
                 return;
             }
-
         }
         /// <summary>
         ///  Draw the items background
@@ -913,7 +899,6 @@ namespace System.Windows.Forms
                 RendererOverride.OnRenderSeparator(e);
                 return;
             }
-
         }
 
         protected virtual void OnRenderToolStripPanelBackground(ToolStripPanelRenderEventArgs e)
@@ -983,14 +968,12 @@ namespace System.Windows.Forms
                             baseRect.Offset(-1, -1);
                         }
                         greyRectangles[i] = baseRect;
-
                     }
 
                     g.FillRectangles(SystemBrushes.ButtonHighlight, whiteRectangles);
                     g.FillRectangles(SystemBrushes.ButtonShadow, greyRectangles);
                 }
             }
-
         }
         /// <summary>
         ///  Draw the item's background.
@@ -1024,7 +1007,6 @@ namespace System.Windows.Forms
             Bitmap disabledBitmap = new Bitmap(size.Width, size.Height);
             using (Graphics graphics = Graphics.FromImage(disabledBitmap))
             {
-
                 graphics.DrawImage(normalImage,
                                    new Rectangle(0, 0, size.Width, size.Height),
                                    0, 0, size.Width, size.Height,
@@ -1034,6 +1016,5 @@ namespace System.Windows.Forms
 
             return disabledBitmap;
         }
-
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripRendererSwitcher.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripRendererSwitcher.cs
@@ -36,7 +36,6 @@ namespace System.Windows.Forms
             {
                 OnControlVisibleChanged(owner, EventArgs.Empty);
             }
-
         }
 
         public ToolStripRenderer Renderer
@@ -56,7 +55,6 @@ namespace System.Windows.Forms
                     Renderer = ToolStripManager.CreateRenderer(RenderMode);
                 }
                 return renderer;
-
             }
             set
             {
@@ -96,7 +94,6 @@ namespace System.Windows.Forms
                     return ToolStripRenderMode.System;
                 }
                 return ToolStripRenderMode.Custom;
-
             }
             set
             {
@@ -181,6 +178,5 @@ namespace System.Windows.Forms
         {
             RenderMode = defaultRenderMode;
         }
-
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripScrollButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripScrollButton.cs
@@ -198,7 +198,6 @@ namespace System.Windows.Forms
 
             protected override void WndProc(ref Message m)
             {
-
                 if (m.Msg >= WindowMessages.WM_KEYFIRST && m.Msg <= WindowMessages.WM_KEYLAST)
                 {
                     //

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSeparator.ToolStripSeparatorAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSeparator.ToolStripSeparatorAccessibleObject.cs
@@ -30,7 +30,7 @@ namespace System.Windows.Forms
                     {
                         return role;
                     }
-                    
+
                     return AccessibleRole.Separator;
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSeparator.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSeparator.cs
@@ -72,7 +72,6 @@ namespace System.Windows.Forms
         {
             get => base.Enabled;
             set => base.Enabled = value;
-
         }
 
         [Browsable(false)]
@@ -272,7 +271,7 @@ namespace System.Windows.Forms
             {
                 return new Size(parent.Width - (parent.Padding.Horizontal - dropDownMenu.ImageMargin.Width), SeparatorThickness);
             }
-            
+
             if (parent.LayoutStyle != ToolStripLayoutStyle.HorizontalStackWithOverflow || parent.LayoutStyle != ToolStripLayoutStyle.VerticalStackWithOverflow)
             {
                 // we dont actually know what size to make it, so just keep it a stock size.
@@ -283,7 +282,7 @@ namespace System.Windows.Forms
             {
                 return new Size(SeparatorThickness, constrainingSize.Height);
             }
-            
+
             return new Size(constrainingSize.Width, SeparatorThickness);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSettings.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSettings.cs
@@ -465,7 +465,6 @@ namespace System.Windows.Forms
                 Location = toolStrip.Location;
                 Name = toolStrip.Name;
                 ItemOrder = GetItemOrder(toolStrip);
-
             }
             public SettingsStub(ToolStripSettings toolStripSettings)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSplitButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSplitButton.cs
@@ -104,7 +104,6 @@ namespace System.Windows.Forms
             get
             {
                 return SplitButtonButton.Pressed;
-
             }
         }
 
@@ -195,7 +194,6 @@ namespace System.Windows.Forms
             {
                 return DropDown.Visible != true;
             }
-
         }
 
         internal override Rectangle DropDownButtonArea
@@ -213,7 +211,6 @@ namespace System.Windows.Forms
             {
                 return dropDownButtonBounds;
             }
-
         }
         /// <summary>
         ///  Summary of DropDownButtonBounds.
@@ -313,7 +310,7 @@ namespace System.Windows.Forms
         }
         /// <summary>
         ///  Summary of SplitButtonButtonLayout.
-        /// </summary>	
+        /// </summary>
         internal ToolStripItemInternalLayout SplitButtonButtonLayout
         {
             get
@@ -372,7 +369,7 @@ namespace System.Windows.Forms
         }
         /// <summary>
         ///  Summary of CalculateLayout.
-        /// </summary>	
+        /// </summary>
         private void CalculateLayout()
         {
             // Figure out where the DropDown image goes.
@@ -401,12 +398,10 @@ namespace System.Windows.Forms
                 // the split button goes on the right.
                 splitButtonButtonBounds.Offset(DropDownButtonWidth + splitterWidth, 0);
                 splitterBounds = new Rectangle(dropDownButtonBounds.Right, dropDownButtonBounds.Top, splitterWidth, dropDownButtonBounds.Height);
-
             }
 
             SplitButtonButton.SetBounds(splitButtonButtonBounds);
             SetDropDownButtonBounds(dropDownButtonBounds);
-
         }
 
         protected override AccessibleObject CreateAccessibilityInstance()
@@ -425,7 +420,6 @@ namespace System.Windows.Forms
             // whenever the master layout is invalidated - invalidate the splitbuttonbutton layout.
             splitButtonButtonLayout = null;
             return new ToolStripItemInternalLayout(this);
-
         }
 
         public override Size GetPreferredSize(Size constrainingSize)
@@ -437,7 +431,7 @@ namespace System.Windows.Forms
 
         /// <summary>
         ///  Summary of InvalidateSplitButtonLayout.
-        /// </summary>	
+        /// </summary>
         private void InvalidateSplitButtonLayout()
         {
             splitButtonButtonLayout = null;
@@ -501,7 +495,6 @@ namespace System.Windows.Forms
                     eh(this, e);
                 }
             }
-
         }
 
         /// <summary>
@@ -513,7 +506,6 @@ namespace System.Windows.Forms
             {
                 if (e.Button == MouseButtons.Left)
                 {
-
                     if (!DropDown.Visible)
                     {
                         Debug.Assert(ParentInternal != null, "Parent is null here, not going to get accurate ID");
@@ -526,7 +518,6 @@ namespace System.Windows.Forms
             {
                 SplitButtonButton.Push(true);
             }
-
         }
 
         /// <summary>
@@ -587,7 +578,6 @@ namespace System.Windows.Forms
                     OnButtonClick(EventArgs.Empty);
                 }
             }
-
         }
         protected override void OnMouseLeave(EventArgs e)
         {
@@ -727,7 +717,6 @@ namespace System.Windows.Forms
 
             public override Image Image
             {
-
                 get
                 {
                     if ((owner.DisplayStyle & ToolStripItemDisplayStyle.Image) == ToolStripItemDisplayStyle.Image)
@@ -749,7 +738,6 @@ namespace System.Windows.Forms
             {
                 get
                 {
-
                     if (owner != null)
                     {
                         return owner.Selected;
@@ -776,7 +764,6 @@ namespace System.Windows.Forms
                     // do nothing
                 }
             }
-
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSplitStackLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSplitStackLayout.cs
@@ -345,7 +345,6 @@ namespace System.Windows.Forms
                         lastRight = x - itemMargin.Left;
                         alignedRightItems = (alignedRightItems == Rectangle.Empty) ? new Rectangle(x, y, itemSize.Width, itemSize.Height)
                                                 : Rectangle.Union(alignedRightItems, new Rectangle(x, y, itemSize.Width, itemSize.Height));
-
                     }
                     else
                     {
@@ -359,7 +358,6 @@ namespace System.Windows.Forms
                         lastLeft = x + itemSize.Width + itemMargin.Right;
                         alignedLeftItems = (alignedLeftItems == Rectangle.Empty) ? new Rectangle(x, y, itemSize.Width, itemSize.Height)
                                                 : Rectangle.Union(alignedLeftItems, new Rectangle(x, y, itemSize.Width, itemSize.Height));
-
                     }
 
                     item.ParentInternal = ToolStrip;
@@ -471,7 +469,6 @@ namespace System.Windows.Forms
 
                     // since we havent parented the item yet - the auto size wont have reset the size yet.
                     itemSize = item.AutoSize ? item.GetPreferredSize(Size.Empty) : item.Size;
-
                 }
 
                 // if it turns out we dont need the overflow (because there are no Overflow.Always items and the height of everything
@@ -582,7 +579,6 @@ namespace System.Windows.Forms
                         itemLocation = noMansLand;
                         item.SetPlacement(ToolStripItemPlacement.None);
                     }
-
                 }
                 else
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripStatusLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripStatusLabel.cs
@@ -186,7 +186,6 @@ namespace System.Windows.Forms
                     {
                         LayoutTransaction.DoLayout(ParentInternal, this, PropertyNames.Spring);
                     }
-
                 }
             }
         }
@@ -313,9 +312,7 @@ namespace System.Windows.Forms
                 return layoutOptions;
             }
         }
-
     }
-
 }
 
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSystemRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSystemRenderer.cs
@@ -63,7 +63,6 @@ namespace System.Windows.Forms
                 }
                 return renderer;
             }
-
         }
 
         /// <summary>
@@ -247,7 +246,6 @@ namespace System.Windows.Forms
                                                e.BackColor : SystemColors.MenuBar);
                 }
             }
-
         }
 
         /// <summary>
@@ -305,7 +303,6 @@ namespace System.Windows.Forms
 
             if (ToolStripManager.VisualStylesEnabled && VisualStyleRenderer.IsElementDefined(VisualStyleElement.Rebar.Gripper.Normal))
             {
-
                 VisualStyleRenderer vsRenderer = VisualStyleRenderer;
 
                 if (verticalGrip)
@@ -345,7 +342,6 @@ namespace System.Windows.Forms
                 }
 
                 RenderSmall3DBorderInternal(g, bounds, ToolBarState.Hot, (e.ToolStrip.RightToLeft == RightToLeft.Yes));
-
             }
         }
 
@@ -487,9 +483,7 @@ namespace System.Windows.Forms
                         }
                     }
                 }
-
             }
-
         }
 
         /// <summary>
@@ -529,7 +523,6 @@ namespace System.Windows.Forms
                 && VisualStyleRenderer.IsElementDefined(splitButtonDropDownPart)
                 && VisualStyleRenderer.IsElementDefined(splitButtonPart))
             {
-
                 VisualStyleRenderer vsRenderer = VisualStyleRenderer;
 
                 // Draw the SplitButton Button portion of it.
@@ -575,7 +568,6 @@ namespace System.Windows.Forms
             }
             else
             {
-
                 // Draw the split button button
                 Rectangle splitButtonButtonRect = splitButton.ButtonBounds;
 
@@ -614,9 +606,7 @@ namespace System.Windows.Forms
                 }
 
                 DrawArrow(new ToolStripArrowRenderEventArgs(g, splitButton, dropDownRect, arrowColor, ArrowDirection.Down));
-
             }
-
         }
 
         /// <summary>
@@ -639,7 +629,6 @@ namespace System.Windows.Forms
             if (ToolStripManager.VisualStylesEnabled
                 && (VisualStyleRenderer.IsElementDefined(toolBarElement)))
             {
-
                 VisualStyleRenderer vsRenderer = VisualStyleRenderer;
                 vsRenderer.SetParameters(toolBarElement.ClassName, toolBarElement.Part, (int)state);
                 vsRenderer.DrawBackground(g, new Rectangle(Point.Empty, item.Size));
@@ -663,7 +652,6 @@ namespace System.Windows.Forms
                     FillBackground(g, fillRect, item.BackColor);
                 }
             }
-
         }
 
         /// <summary>
@@ -682,7 +670,6 @@ namespace System.Windows.Forms
             }
             else
             {
-
                 Color foreColor = item.ForeColor;
                 Color backColor = item.BackColor;
 
@@ -709,7 +696,6 @@ namespace System.Windows.Forms
                         // Draw highlight one pixel to the right
                         startX++;
                         g.DrawLine(rightPen, startX, bounds.Top, startX, bounds.Bottom);
-
                     }
                     else
                     {
@@ -728,7 +714,6 @@ namespace System.Windows.Forms
                         startY++;
                         g.DrawLine(SystemPens.ButtonHighlight, bounds.Left, startY, bounds.Right, startY);
                     }
-
                 }
                 finally
                 {
@@ -755,7 +740,6 @@ namespace System.Windows.Forms
                 g.DrawLine(leftPen, bounds.Left, bounds.Top, bounds.Left, bounds.Bottom - 1);
                 g.DrawLine(rightPen, bounds.Right - 1, bounds.Top, bounds.Right - 1, bounds.Bottom - 1);
                 g.DrawLine(bottomPen, bounds.Left, bounds.Bottom - 1, bounds.Right - 1, bounds.Bottom - 1);
-
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.cs
@@ -203,7 +203,6 @@ namespace System.Windows.Forms
                 textBox.MultilineChanged += new EventHandler(HandleMultilineChanged);
                 textBox.ReadOnlyChanged += new EventHandler(HandleReadOnlyChanged);
                 textBox.TextAlignChanged += new EventHandler(HandleTextBoxTextAlignChanged);
-
             }
 
             base.OnSubscribeControlEvents(control);
@@ -224,7 +223,6 @@ namespace System.Windows.Forms
                 textBox.TextAlignChanged -= new EventHandler(HandleTextBoxTextAlignChanged);
             }
             base.OnUnsubscribeControlEvents(control);
-
         }
 
         internal override bool ShouldSerializeFont()
@@ -690,14 +688,12 @@ namespace System.Windows.Forms
             {
                 base.OnLostFocus(e);
                 InvalidateNonClient();
-
             }
 
             protected override void OnMouseEnter(EventArgs e)
             {
                 base.OnMouseEnter(e);
                 MouseIsOver = true;
-
             }
 
             protected override void OnMouseLeave(EventArgs e)
@@ -733,7 +729,6 @@ namespace System.Windows.Forms
                         alreadyHooked = false;
                     }
                 }
-
             }
 
             private void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e)
@@ -772,7 +767,6 @@ namespace System.Windows.Forms
 
             private void WmNCPaint(ref Message m)
             {
-
                 if (!IsPopupTextBox)
                 {
                     base.WndProc(ref m);
@@ -803,7 +797,6 @@ namespace System.Windows.Forms
                     }
                     using (Graphics g = Graphics.FromHdcInternal(hdc))
                     {
-
                         Rectangle clientRect = AbsoluteClientRectangle;
 
                         // could have set up a clip and fill-rectangled, thought this would be faster.
@@ -820,7 +813,6 @@ namespace System.Windows.Forms
                         {
                             g.DrawRectangle(p, 0, 0, Width - 1, Height - 1);
                         }
-
                     }
                 }
                 finally
@@ -829,7 +821,6 @@ namespace System.Windows.Forms
                 }
                 // we've handled WM_NCPAINT.
                 m.Result = IntPtr.Zero;
-
             }
             protected override void WndProc(ref Message m)
             {
@@ -872,5 +863,4 @@ namespace System.Windows.Forms
             }
         }
     }
-
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -750,7 +750,6 @@ namespace System.Windows.Forms
             IntPtr userCookie = ThemingScope.Activate(Application.UseVisualStyles);
             try
             {
-
                 var icc = new ComCtl32.INITCOMMONCONTROLSEX
                 {
                     dwICC = ComCtl32.ICC.TAB_CLASSES
@@ -891,7 +890,6 @@ namespace System.Windows.Forms
             Control ctl = (Control)sender;
             if (!_created.ContainsKey(ctl) && ctl.IsHandleCreated && TopLevelControl != null)
             {
-
                 CreateRegion(ctl);
             }
 
@@ -1880,7 +1878,6 @@ namespace System.Windows.Forms
 
             if (tool != null)
             {
-
                 // Lets find the Form for associated Control .
                 // and hook up to the Deactivated event to Hide the Shown tooltip
                 Form baseFrom = tool.FindForm();
@@ -2206,7 +2203,6 @@ namespace System.Windows.Forms
 
                 if (((tt.TipType & TipInfo.Type.SemiAbsolute) != 0) && tt.Position == Point.Empty)
                 {
-
                     Screen screen = Screen.FromPoint(cursorPos);
                     if (currentCursor != null)
                     {
@@ -2229,7 +2225,6 @@ namespace System.Windows.Forms
                 }
                 else if ((tt.TipType & TipInfo.Type.SemiAbsolute) != 0 && tt.Position != Point.Empty)
                 {
-
                     Screen screen = Screen.FromPoint(tt.Position);
                     wp->x = tt.Position.X;
                     if (wp->x + wp->cx > screen.WorkingArea.Right)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolstripProfessionalRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolstripProfessionalRenderer.cs
@@ -185,7 +185,7 @@ namespace System.Windows.Forms
             // in RTL the white highlight goes BEFORE the black triangle.
             int rightToLeftShift = (rightToLeft && horizontal) ? -1 : 1;
 
-            // draw highlight	
+            // draw highlight
             overflowArrowRect.Offset(1 * rightToLeftShift, 1);
             RenderArrowInternal(g, overflowArrowRect, direction, SystemBrushes.ButtonHighlight);
 
@@ -267,7 +267,6 @@ namespace System.Windows.Forms
 
             if (e.Item is ToolStripSplitButton item)
             {
-
                 Rectangle bounds = new Rectangle(Point.Empty, item.Size);
                 if (item.BackgroundImage != null)
                 {
@@ -374,7 +373,6 @@ namespace System.Windows.Forms
                     {
                         g.DrawRectangle(p, bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);
                     }
-
                 }
                 else
                 {
@@ -390,10 +388,8 @@ namespace System.Windows.Forms
                     {
                         g.DrawRectangle(p, bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);
                     }
-
                 }
             }
-
         }
 
         protected override void OnRenderToolStripBorder(ToolStripRenderEventArgs e)
@@ -444,7 +440,6 @@ namespace System.Windows.Forms
                             // one pix corner rounding (right bottom)
                             g.DrawLine(p, bounds.Width - 2, bounds.Height - 2, bounds.Width - 1, bounds.Height - 3);
                         }
-
                     }
                 }
 
@@ -457,7 +452,6 @@ namespace System.Windows.Forms
                     }
                     else
                     {
-
                         // Draw 1PX edging to round off the toolStrip
                         Rectangle edging = Rectangle.Empty;
                         if (toolStrip.Orientation == Orientation.Horizontal)
@@ -467,7 +461,6 @@ namespace System.Windows.Forms
                         else
                         {
                             edging = new Rectangle(3, bounds.Height - 1, bounds.Width - 3, bounds.Height - 1);
-
                         }
                         ScaleObjectSizesIfNeeded(toolStrip.DeviceDpi);
                         FillWithDoubleGradient(ColorTable.OverflowButtonGradientBegin, ColorTable.OverflowButtonGradientMiddle, ColorTable.OverflowButtonGradientEnd, e.Graphics, edging, iconWellGradientWidth, iconWellGradientWidth, LinearGradientMode.Vertical, /*flipHorizontal=*/false);
@@ -615,12 +608,10 @@ namespace System.Windows.Forms
             }
             else
             {
-
                 if (item.Pressed)
                 {
                     // Toplevel toolstrip rendering
                     RenderPressedGradient(g, bounds);
-
                 }
                 else if (item.Selected)
                 {
@@ -630,7 +621,6 @@ namespace System.Windows.Forms
 
                     if (item.Enabled)
                     {
-
                         if (UseSystemColors)
                         {
                             borderColor = SystemColors.Highlight;
@@ -668,7 +658,6 @@ namespace System.Windows.Forms
                     }
                 }
             }
-
         }
 
         protected override void OnRenderArrow(ToolStripArrowRenderEventArgs e)
@@ -940,7 +929,6 @@ namespace System.Windows.Forms
                 g.FillRectangle(b, toolStrip.Width - 2, 0, 1, 1);
                 g.FillRectangle(b, toolStrip.Width - 1, 1, 1, 1);
             }
-
         }
 
         ///<summary>
@@ -1108,7 +1096,6 @@ namespace System.Windows.Forms
             {
                 ControlPaint.DrawBackgroundImage(g, item.BackgroundImage, item.BackColor, item.BackgroundImageLayout, bounds, fillRect);
             }
-
         }
 
         private void RenderBackgroundGradient(Graphics g, Control control, Color beginColor, Color endColor)
@@ -1172,7 +1159,6 @@ namespace System.Windows.Forms
             // fill up the background
             LinearGradientMode mode = (toolStrip.Orientation == Orientation.Horizontal) ? LinearGradientMode.Vertical : LinearGradientMode.Horizontal;
             FillWithDoubleGradient(ColorTable.ToolStripGradientBegin, ColorTable.ToolStripGradientMiddle, ColorTable.ToolStripGradientEnd, e.Graphics, bounds, iconWellGradientWidth, iconWellGradientWidth, mode, /*flipHorizontal=*/false);
-
         }
 
         private void RenderToolStripDropDownBackground(ToolStripRenderEventArgs e)
@@ -1269,7 +1255,6 @@ namespace System.Windows.Forms
                 // draw shadow pixel on bottom left +1, +1
                 using (Pen p = new Pen(overflowBottomLeftShadow/*Color.HotPink*/))
                 {
-
                     Point start = new Point(overflowBoundsFill.Left - 1, overflowBoundsFill.Height - 2);
                     Point end = new Point(overflowBoundsFill.Left, overflowBoundsFill.Height - 2);
                     if (rightToLeft)
@@ -1328,7 +1313,6 @@ namespace System.Windows.Forms
                     }
                 }
             }
-
         }
 
         private void RenderToolStripCurve(ToolStripRenderEventArgs e)
@@ -1378,13 +1362,11 @@ namespace System.Windows.Forms
                     }
                 }
                 g.FillRectangles(b, paintRects);
-
             }
 
             // Draw in rounded shadow pixels on the bottom left
             using (Brush b = new SolidBrush(ColorTable.ToolStripGradientEnd))
             {
-
                 // this gradient is the one just before the dark shadow line starts on pixel #3.
                 Point gradientCopyPixel = bottomLeft;
                 gradientCopyPixel.Offset(1, -1);
@@ -1441,13 +1423,11 @@ namespace System.Windows.Forms
             }
             else
             {
-
                 Color fillColor = ColorTable.ButtonCheckedHighlight;
 
                 using (Brush b = new SolidBrush(fillColor))
                 {
                     g.FillRectangle(b, bounds);
-
                 }
             }
         }
@@ -1494,13 +1474,11 @@ namespace System.Windows.Forms
                             // like the line meets up with the text).
                             bounds.X += 2;
                             bounds.Width = dropDownMenu.Width - bounds.X - dropDownMenu.Padding.Right;
-
                         }
                     }
                     else
                     {
                         isAHorizontalSeparatorNotOnDropDownMenu = true;
-
                     }
                 }
             }
@@ -1577,7 +1555,6 @@ namespace System.Windows.Forms
             }
             else
             {
-
                 Color fillColor = ColorTable.ButtonPressedHighlight;
                 using (Brush b = new SolidBrush(fillColor))
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -514,7 +514,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 return rightToLeftLayout;
             }
 
@@ -1058,7 +1057,6 @@ namespace System.Windows.Forms
         {
             if (minimum != minValue || maximum != maxValue)
             {
-
                 // The Minimum and Maximum properties contain the logic for
                 // ensuring that minValue <= maxValue. It is possible, however,
                 // that this function will be called somewhere other than from
@@ -1105,7 +1103,6 @@ namespace System.Windows.Forms
         {
             if (IsHandleCreated)
             {
-
                 // There are two situations where we want to reflect the track bar position:
                 //
                 // 1. For a vertical trackbar, it seems to make more sense for the trackbar to increase in value

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
@@ -96,7 +96,6 @@ namespace System.Windows.Forms
                 }
                 set { Debug.Assert(false, "We should never set the image list"); }
             }
-
         }
 
         internal TreeNodeImageIndexer ImageIndexer
@@ -123,7 +122,6 @@ namespace System.Windows.Forms
                 }
 
                 return selectedImageIndexer;
-
             }
         }
 
@@ -370,7 +368,7 @@ namespace System.Windows.Forms
             }
         }
 
-        /// <summary>	
+        /// <summary>
         ///  Indicates whether the node's checkbox is checked.
         /// </summary>
         [SRCategory(nameof(SR.CatBehavior))]
@@ -1343,7 +1341,6 @@ namespace System.Windows.Forms
                         newOrder[i].SortChildren(parentTreeView);
                     }
                     children = newOrder;
-
                 }
             }
         }
@@ -1385,7 +1382,6 @@ namespace System.Windows.Forms
 
             try
             {
-
                 if (tv != null)
                 {
                     tv.nodesCollectionClear = true;
@@ -1527,7 +1523,6 @@ namespace System.Windows.Forms
 
             tv.Invalidate();
             collapseOnRealization = false;
-
         }
 
         /// <summary>
@@ -1717,7 +1712,6 @@ namespace System.Windows.Forms
 
             if (treeView.CheckBoxes && treeView.StateImageList != null)
             {
-
                 if (!string.IsNullOrEmpty(StateImageKey))
                 {
                     StateImageIndex = (Checked) ? 1 : 0;
@@ -1774,7 +1768,6 @@ namespace System.Windows.Forms
             {
                 children[i].ExpandAll();
             }
-
         }
         /// <summary>
         ///  Locate this tree node's containing tree view control by scanning
@@ -1978,7 +1971,6 @@ namespace System.Windows.Forms
                     UnsafeNativeMethods.SendMessage(new HandleRef(tv, tv.Handle), WindowMessages.WM_SETREDRAW, 1, 0);
                     nodesCleared = false;
                 }
-
             }
 
             for (int i = childCount - 1; i >= 0; i--)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeCollection.cs
@@ -109,7 +109,6 @@ namespace System.Windows.Forms
                 {
                     return null;
                 }
-
             }
         }
         // Make this property available to Intellisense. (Removed the EditorBrowsable attribute.)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -675,7 +675,6 @@ namespace System.Windows.Forms
             {
                 if (value != imageList)
                 {
-
                     DetachImageListHandlers();
 
                     imageList = value;
@@ -758,7 +757,6 @@ namespace System.Windows.Forms
             {
                 if (value != stateImageList)
                 {
-
                     DetachStateImageListHandlers();
                     stateImageList = value;
                     AttachStateImageListHandlers();
@@ -786,7 +784,6 @@ namespace System.Windows.Forms
                             RefreshNodes();
                         }
                     }
-
                 }
             }
         }
@@ -957,7 +954,6 @@ namespace System.Windows.Forms
                     if (IsHandleCreated)
                     {
                         SendMessage(NativeMethods.TVM_SETLINECOLOR, 0, ColorTranslator.ToWin32(lineColor));
-
                     }
                 }
             }
@@ -1078,7 +1074,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 return rightToLeftLayout;
             }
 
@@ -1482,7 +1477,6 @@ namespace System.Windows.Forms
                 {
                     topNode = value;
                 }
-
             }
         }
 
@@ -1694,7 +1688,6 @@ namespace System.Windows.Forms
         {
             internalStateImageList = null;
             StateImageList = null;
-
         }
 
         protected override void Dispose(bool disposing)
@@ -1708,7 +1701,6 @@ namespace System.Windows.Forms
                     DetachStateImageListHandlers();
                     stateImageList = null;
                 }
-
             }
 
             base.Dispose(disposing);
@@ -2062,7 +2054,6 @@ namespace System.Windows.Forms
             int oldSize = 0;
             try
             {
-
                 treeViewState[TREEVIEWSTATE_stopResizeWindowMsgs] = true;
                 oldSize = Width;
                 User32.SWP flags = User32.SWP.NOZORDER | User32.SWP.NOACTIVATE | User32.SWP.NOMOVE;
@@ -2214,7 +2205,6 @@ namespace System.Windows.Forms
             }
 
             ResetMouseEventArgs();
-
         }
 
         /// <summary>
@@ -2690,7 +2680,6 @@ namespace System.Windows.Forms
                     {
                         SetStateImageList(internalStateImageList.Handle);
                     }
-
                 }
             }
         }
@@ -2738,7 +2727,6 @@ namespace System.Windows.Forms
             {
                 DefWndProc(ref m);
             }
-
         }
 
         /// <summary>
@@ -3099,7 +3087,6 @@ namespace System.Windows.Forms
                                 OnNodeMouseClick(new TreeNodeMouseClickEventArgs(NodeFromHandle(hnode), button, 1, pos.X, pos.Y));
                                 OnClick(new MouseEventArgs(button, 1, pos.X, pos.Y, 0));
                                 OnMouseClick(new MouseEventArgs(button, 1, pos.X, pos.Y, 0));
-
                             }
                         }
                         if (nmtv->nmhdr.code == (int)ComCtl32.NM.RCLICK)
@@ -3115,7 +3102,6 @@ namespace System.Windows.Forms
                                 User32.SendMessageW(this, User32.WindowMessage.WM_CONTEXTMENU, Handle, (IntPtr)User32.GetMessagePos());
                             }
                             m.Result = (IntPtr)1;
-
                         }
 
                         if (!treeViewState[TREEVIEWSTATE_mouseUpFired])
@@ -3129,7 +3115,6 @@ namespace System.Windows.Forms
                                 OnMouseUp(new MouseEventArgs(button, 1, pos.X, pos.Y, 0));
                                 treeViewState[TREEVIEWSTATE_mouseUpFired] = true;
                             }
-
                         }
                         break;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewImageIndexConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewImageIndexConverter.cs
@@ -28,7 +28,6 @@ namespace System.Windows.Forms
         {
             if (value is string strValue)
             {
-
                 if (string.Compare(strValue, SR.toStringDefault, true, culture) == 0)
                 {
                     return -1;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewImageKeyConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewImageKeyConverter.cs
@@ -41,7 +41,6 @@ namespace System.Windows.Forms
 
             return base.ConvertTo(context, culture, value, destinationType);
         }
-
     }
 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
@@ -458,7 +458,6 @@ namespace System.Windows.Forms
         {
             get
             {
-
                 int height = FontHeight;
 
                 // Adjust for the border style
@@ -603,7 +602,6 @@ namespace System.Windows.Forms
 
                 if (upDownAlign != value)
                 {
-
                     upDownAlign = value;
                     PositionControls();
                     Invalidate();
@@ -789,7 +787,6 @@ namespace System.Windows.Forms
             OnKeyDown(e);
             if (interceptArrowKeys)
             {
-
                 // Intercept up arrow
                 if (e.KeyData == Keys.Up)
                 {
@@ -820,7 +817,6 @@ namespace System.Windows.Forms
         protected virtual void OnTextBoxKeyPress(object source, KeyPressEventArgs e)
         {
             OnKeyPress(e);
-
         }
 
         /// <summary>
@@ -1085,7 +1081,6 @@ namespace System.Windows.Forms
                 upDownButtons.Bounds = upDownButtonsBounds;
                 upDownButtons.Invalidate();
             }
-
         }
 
         /// <summary>
@@ -1200,7 +1195,6 @@ namespace System.Windows.Forms
             internal UpDownEdit(UpDownBase parent)
             : base()
             {
-
                 SetStyle(ControlStyles.FixedHeight |
                          ControlStyles.FixedWidth, true);
 
@@ -1247,7 +1241,6 @@ namespace System.Windows.Forms
             /// </summary>
             protected override void OnMouseUp(MouseEventArgs e)
             {
-
                 Point pt = new Point(e.X, e.Y);
                 pt = PointToScreen(pt);
 
@@ -1385,7 +1378,6 @@ namespace System.Windows.Forms
 
             : base()
             {
-
                 SetStyle(ControlStyles.Opaque | ControlStyles.FixedHeight |
                          ControlStyles.FixedWidth, true);
 
@@ -1500,7 +1492,6 @@ namespace System.Windows.Forms
             /// </summary>
             protected override void OnMouseMove(MouseEventArgs e)
             {
-
                 // If the mouse is captured by the buttons (i.e. an updown button
                 // was pushed, and the mouse button has not yet been released),
                 // determine the new state of the buttons depending on where
@@ -1508,7 +1499,6 @@ namespace System.Windows.Forms
 
                 if (Capture)
                 {
-
                     // Determine button area
 
                     Rectangle rect = ClientRectangle;
@@ -1523,24 +1513,20 @@ namespace System.Windows.Forms
 
                     if (rect.Contains(e.X, e.Y))
                     {
-
                         // Inside button
                         // Repush the button if necessary
 
                         if (pushed != captured)
                         {
-
                             // Restart the timer
                             StartTimer();
 
                             pushed = captured;
                             Invalidate();
                         }
-
                     }
                     else
                     {
-
                         // Outside button
                         // Retain the capture, but pop the button up whilst
                         // the mouse remains outside the button and the
@@ -1548,7 +1534,6 @@ namespace System.Windows.Forms
 
                         if (pushed != ButtonID.None)
                         {
-
                             // Stop the timer for updown events
                             StopTimer();
 
@@ -1590,7 +1575,6 @@ namespace System.Windows.Forms
             /// </summary>
             protected override void OnMouseUp(MouseEventArgs e)
             {
-
                 if (!parent.ValidationCancelled && e.Button == MouseButtons.Left)
                 {
                     EndButtonPress();
@@ -1753,7 +1737,6 @@ namespace System.Windows.Forms
             /// </summary>
             private void TimerHandler(object source, EventArgs args)
             {
-
                 // Make sure we've got mouse capture
                 if (!Capture)
                 {
@@ -1912,7 +1895,6 @@ namespace System.Windows.Forms
                     }
                 }
 
-
                 public override string Name
                 {
                     get
@@ -1939,7 +1921,7 @@ namespace System.Windows.Forms
                     get
                     {
                         AccessibleRole role = Owner.AccessibleRole;
-                        
+
                         if (role != AccessibleRole.Default)
                         {
                             return role;
@@ -2092,7 +2074,6 @@ namespace System.Windows.Forms
                     }
                 }
             }
-
         } // end class UpDownButtons
 
         // Button identifiers

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UserControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UserControl.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Drawing;
@@ -12,7 +11,6 @@ using static Interop;
 
 namespace System.Windows.Forms
 {
-
     /// <summary>
     ///  Represents an empty control that can be used in the Forms Designer to create other  controls.   By extending form, UserControl inherits all of
     ///  the standard positioning and mnemonic handling code that is necessary
@@ -346,7 +344,6 @@ namespace System.Windows.Forms
             {
                 base.WndProc(ref m);
             }
-
         }
 
         [EditorBrowsable(EditorBrowsableState.Advanced)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/BackgroundType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/BackgroundType.cs
@@ -9,8 +9,8 @@ namespace System.Windows.Forms.VisualStyles
         ImageFile = 0,
         BorderFill = 1,
         None = 2,
-        //		TM_ENUM(0, BT, IMAGEFILE)
-        //		TM_ENUM(1, BT, BORDERFILL)
-        //		TM_ENUM(2, BT, NONE)
+        //      TM_ENUM(0, BT, IMAGEFILE)
+        //      TM_ENUM(1, BT, BORDERFILL)
+        //      TM_ENUM(2, BT, NONE)
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/BorderType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/BorderType.cs
@@ -9,8 +9,8 @@ namespace System.Windows.Forms.VisualStyles
         Rectangle = 0,
         RoundedRectangle = 1,
         Ellipse = 2,
-        //		TM_ENUM(0, BT, RECT)
-        //		TM_ENUM(1, BT, ROUNDRECT)
-        //		TM_ENUM(2, BT, ELLIPSE)
+        //      TM_ENUM(0, BT, RECT)
+        //      TM_ENUM(1, BT, ROUNDRECT)
+        //      TM_ENUM(2, BT, ELLIPSE)
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/ContentAlignment.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/ContentAlignment.cs
@@ -9,8 +9,8 @@ namespace System.Windows.Forms.VisualStyles
         Left = 0,
         Center = 1,
         Right = 2,
-        //		TM_ENUM(0, CA, LEFT)
-        //		TM_ENUM(1, CA, CENTER)
-        //		TM_ENUM(2, CA, RIGHT)
+        //      TM_ENUM(0, CA, LEFT)
+        //      TM_ENUM(1, CA, CENTER)
+        //      TM_ENUM(2, CA, RIGHT)
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/FillType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/FillType.cs
@@ -11,10 +11,10 @@ namespace System.Windows.Forms.VisualStyles
         HorizontalGradient = 2,
         RadialGradient = 3,
         TileImage = 4,
-        //		TM_ENUM(0, FT, SOLID)
-        //		TM_ENUM(1, FT, VERTGRADIENT)
-        //		TM_ENUM(2, FT, HORZGRADIENT)
-        //		TM_ENUM(3, FT, RADIALGRADIENT)
-        //		TM_ENUM(4, FT, TILEIMAGE)
+        //      TM_ENUM(0, FT, SOLID)
+        //      TM_ENUM(1, FT, VERTGRADIENT)
+        //      TM_ENUM(2, FT, HORZGRADIENT)
+        //      TM_ENUM(3, FT, RADIALGRADIENT)
+        //      TM_ENUM(4, FT, TILEIMAGE)
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/GlyphFontSizingType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/GlyphFontSizingType.cs
@@ -9,8 +9,8 @@ namespace System.Windows.Forms.VisualStyles
         None = 0,
         Size = 1,
         Dpi = 2,
-        //		TM_ENUM(0, GFST, NONE)
-        //		TM_ENUM(1, GFST, SIZE)
-        //		TM_ENUM(2, GFST, DPI)
+        //      TM_ENUM(0, GFST, NONE)
+        //      TM_ENUM(1, GFST, SIZE)
+        //      TM_ENUM(2, GFST, DPI)
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/GlyphType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/GlyphType.cs
@@ -9,8 +9,8 @@ namespace System.Windows.Forms.VisualStyles
         None = 0,
         ImageGlyph = 1,
         FontGlyph = 2,
-        //		TM_ENUM(0, GT, NONE)
-        //		TM_ENUM(1, GT, IMAGEGLYPH)
-        //		TM_ENUM(2, GT, FONTGLYPH)
+        //      TM_ENUM(0, GT, NONE)
+        //      TM_ENUM(1, GT, IMAGEGLYPH)
+        //      TM_ENUM(2, GT, FONTGLYPH)
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/HitTestCode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/HitTestCode.cs
@@ -16,15 +16,15 @@ namespace System.Windows.Forms.VisualStyles
         TopRight = 14,
         BottomLeft = 16,
         BottomRight = 17
-        //		#define HTNOWHERE           0
-        //		#define HTCLIENT            1
-        //		#define HTLEFT              10
-        //		#define HTRIGHT             11
-        //		#define HTTOP               12
-        //		#define HTTOPLEFT           13
-        //		#define HTTOPRIGHT          14
-        //		#define HTBOTTOM            15
-        //		#define HTBOTTOMLEFT        16
-        //		#define HTBOTTOMRIGHT       17
+        //      #define HTNOWHERE           0
+        //      #define HTCLIENT            1
+        //      #define HTLEFT              10
+        //      #define HTRIGHT             11
+        //      #define HTTOP               12
+        //      #define HTTOPLEFT           13
+        //      #define HTTOPRIGHT          14
+        //      #define HTBOTTOM            15
+        //      #define HTBOTTOMLEFT        16
+        //      #define HTBOTTOMRIGHT       17
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/HitTestOptions.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/HitTestOptions.cs
@@ -43,7 +43,7 @@ namespace System.Windows.Forms.VisualStyles
         //#define HTTB_RESIZINGBORDER_BOTTOM  0x0080  // Hit test bottom resizing border
 
         //#define HTTB_RESIZINGBORDER         (HTTB_RESIZINGBORDER_LEFT|HTTB_RESIZINGBORDER_TOP|\
-        //		HTTB_RESIZINGBORDER_RIGHT|HTTB_RESIZINGBORDER_BOTTOM)
+        //      HTTB_RESIZINGBORDER_RIGHT|HTTB_RESIZINGBORDER_BOTTOM)
 
         // Resizing border is specified as a template, not just window edges.
         // This option is mutually exclusive with HTTB_SYSTEMSIZINGWIDTH; HTTB_SIZINGTEMPLATE takes precedence

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/HorizontalAlign.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/HorizontalAlign.cs
@@ -9,8 +9,8 @@ namespace System.Windows.Forms.VisualStyles
         Left = 0,
         Center = 1,
         Right = 2,
-        //		TM_ENUM(0, HA, LEFT)
-        //		TM_ENUM(1, HA, CENTER)
-        //		TM_ENUM(2, HA, RIGHT)
+        //      TM_ENUM(0, HA, LEFT)
+        //      TM_ENUM(1, HA, CENTER)
+        //      TM_ENUM(2, HA, RIGHT)
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/IconEffect.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/IconEffect.cs
@@ -11,10 +11,10 @@ namespace System.Windows.Forms.VisualStyles
         Shadow = 2,
         Pulse = 3,
         Alpha = 4,
-        //		TM_ENUM(0, ICE, NONE)
-        //		TM_ENUM(1, ICE, GLOW)
-        //		TM_ENUM(2, ICE, SHADOW)
-        //		TM_ENUM(3, ICE, PULSE)
-        //		TM_ENUM(4, ICE, ALPHA)
+        //      TM_ENUM(0, ICE, NONE)
+        //      TM_ENUM(1, ICE, GLOW)
+        //      TM_ENUM(2, ICE, SHADOW)
+        //      TM_ENUM(3, ICE, PULSE)
+        //      TM_ENUM(4, ICE, ALPHA)
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/ImageOrientation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/ImageOrientation.cs
@@ -8,7 +8,7 @@ namespace System.Windows.Forms.VisualStyles
     {
         Vertical = 0,
         Horizontal = 1,
-        //		TM_ENUM(0, IL, VERTICAL)
-        //		TM_ENUM(1, IL, HORIZONTAL)
+        //      TM_ENUM(0, IL, VERTICAL)
+        //      TM_ENUM(1, IL, HORIZONTAL)
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/ImageSelectType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/ImageSelectType.cs
@@ -9,8 +9,8 @@ namespace System.Windows.Forms.VisualStyles
         None = 0,
         Size = 1,
         Dpi = 2,
-        //		TM_ENUM(0, IST, NONE)
-        //		TM_ENUM(1, IST, SIZE)
-        //		TM_ENUM(2, IST, DPI)
+        //      TM_ENUM(0, IST, NONE)
+        //      TM_ENUM(1, IST, SIZE)
+        //      TM_ENUM(2, IST, DPI)
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/OffsetType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/OffsetType.cs
@@ -20,19 +20,19 @@ namespace System.Windows.Forms.VisualStyles
         RightOfLastButton = 11,
         AboveLastButton = 12,
         BelowLastButton = 13,
-        //		TM_ENUM(0, OT, TOPLEFT)
-        //		TM_ENUM(1, OT, TOPRIGHT)
-        //		TM_ENUM(2, OT, TOPMIDDLE)
-        //		TM_ENUM(3, OT, BOTTOMLEFT)
-        //		TM_ENUM(4, OT, BOTTOMRIGHT)
-        //		TM_ENUM(5, OT, BOTTOMMIDDLE)
-        //		TM_ENUM(6, OT, MIDDLELEFT)
-        //		TM_ENUM(7, OT, MIDDLERIGHT)
-        //		TM_ENUM(8, OT, LEFTOFCAPTION)
-        //		TM_ENUM(9, OT, RIGHTOFCAPTION)
-        //		TM_ENUM(10, OT, LEFTOFLASTBUTTON)
-        //		TM_ENUM(11, OT, RIGHTOFLASTBUTTON)
-        //		TM_ENUM(12, OT, ABOVELASTBUTTON)
-        //		TM_ENUM(13, OT, BELOWLASTBUTTON)
+        //      TM_ENUM(0, OT, TOPLEFT)
+        //      TM_ENUM(1, OT, TOPRIGHT)
+        //      TM_ENUM(2, OT, TOPMIDDLE)
+        //      TM_ENUM(3, OT, BOTTOMLEFT)
+        //      TM_ENUM(4, OT, BOTTOMRIGHT)
+        //      TM_ENUM(5, OT, BOTTOMMIDDLE)
+        //      TM_ENUM(6, OT, MIDDLELEFT)
+        //      TM_ENUM(7, OT, MIDDLERIGHT)
+        //      TM_ENUM(8, OT, LEFTOFCAPTION)
+        //      TM_ENUM(9, OT, RIGHTOFCAPTION)
+        //      TM_ENUM(10, OT, LEFTOFLASTBUTTON)
+        //      TM_ENUM(11, OT, RIGHTOFLASTBUTTON)
+        //      TM_ENUM(12, OT, ABOVELASTBUTTON)
+        //      TM_ENUM(13, OT, BELOWLASTBUTTON)
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/SizingType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/SizingType.cs
@@ -9,8 +9,8 @@ namespace System.Windows.Forms.VisualStyles
         FixedSize = 0,
         Stretch = 1,
         Tile = 2,
-        //		TM_ENUM(0, ST, TRUESIZE)
-        //		TM_ENUM(1, ST, STRETCH)
-        //		TM_ENUM(2, ST, TILE)
+        //      TM_ENUM(0, ST, TRUESIZE)
+        //      TM_ENUM(1, ST, STRETCH)
+        //      TM_ENUM(2, ST, TILE)
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/TextShadowType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/TextShadowType.cs
@@ -9,8 +9,8 @@ namespace System.Windows.Forms.VisualStyles
         None = 0,
         Single = 1,
         Continuous = 2,
-        //		TM_ENUM(0, TST, NONE)
-        //		TM_ENUM(1, TST, SINGLE)
-        //		TM_ENUM(2, TST, CONTINUOUS)
+        //      TM_ENUM(0, TST, NONE)
+        //      TM_ENUM(1, TST, SINGLE)
+        //      TM_ENUM(2, TST, CONTINUOUS)
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/TrueSizeScalingType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/TrueSizeScalingType.cs
@@ -9,8 +9,8 @@ namespace System.Windows.Forms.VisualStyles
         None = 0,
         Size = 1,
         Dpi = 2,
-        //		TM_ENUM(0, TSST, NONE)
-        //		TM_ENUM(1, TSST, SIZE)
-        //		TM_ENUM(2, TSST, DPI)
+        //      TM_ENUM(0, TSST, NONE)
+        //      TM_ENUM(1, TSST, SIZE)
+        //      TM_ENUM(2, TSST, DPI)
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VerticalAlignment.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VerticalAlignment.cs
@@ -9,8 +9,8 @@ namespace System.Windows.Forms.VisualStyles
         Top = 0,
         Center = 1,
         Bottom = 2,
-        //		TM_ENUM(0, VA, TOP)
-        //		TM_ENUM(1, VA, CENTER)
-        //		TM_ENUM(2, VA, BOTTOM)
+        //      TM_ENUM(0, VA, TOP)
+        //      TM_ENUM(1, VA, CENTER)
+        //      TM_ENUM(2, VA, BOTTOM)
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleElement.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleElement.cs
@@ -796,7 +796,6 @@ namespace System.Windows.Forms.VisualStyles
                 private static VisualStyleElement disabled;
 
                 public static VisualStyleElement Disabled => disabled ??= new VisualStyleElement(className, part, 4);
-
             }
 
             public static class TopTabItemLeftEdge
@@ -839,7 +838,6 @@ namespace System.Windows.Forms.VisualStyles
                 private static VisualStyleElement disabled;
 
                 public static VisualStyleElement Disabled => disabled ??= new VisualStyleElement(className, part, 4);
-
             }
 
             public static class TopTabItemBothEdges
@@ -858,7 +856,6 @@ namespace System.Windows.Forms.VisualStyles
                 private static VisualStyleElement normal;
 
                 public static VisualStyleElement Normal => normal ??= new VisualStyleElement(className, part, 0);
-
             }
 
             public static class Body
@@ -868,7 +865,6 @@ namespace System.Windows.Forms.VisualStyles
                 private static VisualStyleElement normal;
 
                 public static VisualStyleElement Normal => normal ??= new VisualStyleElement(className, part, 0);
-
             }
         } // END TAB
 
@@ -883,7 +879,6 @@ namespace System.Windows.Forms.VisualStyles
                 private static VisualStyleElement normal;
 
                 public static VisualStyleElement Normal => normal ??= new VisualStyleElement(className, part, 0);
-
             }
 
             public static class HeaderClose
@@ -956,7 +951,6 @@ namespace System.Windows.Forms.VisualStyles
                 private static VisualStyleElement normal;
 
                 public static VisualStyleElement Normal => normal ??= new VisualStyleElement(className, part, 0);
-
             }
 
             public static class NormalGroupCollapse
@@ -1009,7 +1003,6 @@ namespace System.Windows.Forms.VisualStyles
                 private static VisualStyleElement normal;
 
                 public static VisualStyleElement Normal => normal ??= new VisualStyleElement(className, part, 0);
-
             }
 
             public static class SpecialGroupCollapse
@@ -1053,7 +1046,6 @@ namespace System.Windows.Forms.VisualStyles
                 private static VisualStyleElement normal;
 
                 public static VisualStyleElement Normal => normal ??= new VisualStyleElement(className, part, 0);
-
             }
         } // END EXPLORERBAR
 
@@ -1189,7 +1181,6 @@ namespace System.Windows.Forms.VisualStyles
                 private static VisualStyleElement normal;
 
                 public static VisualStyleElement Normal => normal ??= new VisualStyleElement(className, part, 0);
-
             }
         } // END LISTVIEW
 
@@ -1373,7 +1364,6 @@ namespace System.Windows.Forms.VisualStyles
                 private static VisualStyleElement normal;
 
                 public static VisualStyleElement Normal => normal ??= new VisualStyleElement(className, part, 0);
-
             }
 
             public static class Chevron
@@ -1840,7 +1830,6 @@ namespace System.Windows.Forms.VisualStyles
 
                 public static VisualStyleElement Normal => normal ??= new VisualStyleElement(className, part, 0);
             }
-
         } // END TOOLBAR
 
         public static class ToolTip

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleInformation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleInformation.cs
@@ -10,9 +10,9 @@ namespace System.Windows.Forms.VisualStyles
 {
     /// <summary>
     ///  Provides information about the current visual style.
-    ///  
+    ///
     ///  NOTE:
-    ///  
+    ///
     ///  1) These properties (except SupportByOS, which is always meaningful) are meaningful only
     ///  if visual styles are supported and have currently been applied by the user.
     ///  2) A subset of these use VisualStyleRenderer objects, so they are
@@ -301,7 +301,6 @@ namespace System.Windows.Forms.VisualStyles
                     if (visualStyleRenderer == null)
                     {
                         visualStyleRenderer = new VisualStyleRenderer(VisualStyleElement.Button.PushButton.Normal);
-
                     }
                     else
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
@@ -71,7 +71,6 @@ namespace System.Windows.Forms.VisualStyles
                 }
 
                 return supported;
-
             }
         }
 
@@ -601,7 +600,6 @@ namespace System.Windows.Forms.VisualStyles
             Region region = Region.FromHrgn(hRegion);
             Gdi32.DeleteObject(hRegion);
             return region;
-
         }
 
         /// <summary>
@@ -1132,7 +1130,7 @@ namespace System.Windows.Forms.VisualStyles
                     {
                         throw new InvalidOperationException(SR.VisualStyleHandleCreationFailed, e);
                     }
-                    
+
                     return null;
                 }
 
@@ -1142,7 +1140,7 @@ namespace System.Windows.Forms.VisualStyles
                     {
                         throw new InvalidOperationException(SR.VisualStyleHandleCreationFailed);
                     }
-                    
+
                     return null;
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.cs
@@ -988,7 +988,7 @@ namespace System.Windows.Forms
         [SRCategory(nameof(SR.CatAction))]
         [SRDescription(nameof(SR.WebBrowserNavigatedDescr))]
         public event WebBrowserNavigatedEventHandler Navigated;
-        
+
         /// <summary>
         ///  Occurs before browser control navigation occurs.
         ///  Fires before browser navigation occurs. Allows navigation to be canceled if
@@ -997,7 +997,7 @@ namespace System.Windows.Forms
         [SRCategory(nameof(SR.CatAction))]
         [SRDescription(nameof(SR.WebBrowserNavigatingDescr))]
         public event WebBrowserNavigatingEventHandler Navigating;
-        
+
         /// <summary>
         ///  Occurs when a new browser window is created.
         ///  Can be used to cancel the creation of the new browser window. Maps to DWebBrowserEvents2:NewWindow2.
@@ -1005,7 +1005,7 @@ namespace System.Windows.Forms
         [SRCategory(nameof(SR.CatAction))]
         [SRDescription(nameof(SR.WebBrowserNewWindowDescr))]
         public event CancelEventHandler NewWindow;
-        
+
         /// <summary>
         ///  Occurs when an update to the progress of a download occurs.
         ///  Fires whenever the browser control has updated info on the download. Can be
@@ -1015,7 +1015,7 @@ namespace System.Windows.Forms
         [SRCategory(nameof(SR.CatAction))]
         [SRDescription(nameof(SR.WebBrowserProgressChangedDescr))]
         public event WebBrowserProgressChangedEventHandler ProgressChanged;
-        
+
         /// <summary>
         ///  Occurs whenever the status text changes.
         ///  Can be used to keep a status bar populated with uptodate text.
@@ -1478,7 +1478,7 @@ namespace System.Windows.Forms
                 {
                     return HRESULT.E_INVALIDARG;
                 }
-                
+
                 if (pt->X == 0 && pt->Y == 0)
                 {
                     // IDocHostUIHandler::ShowContextMenu sends (0,0) when the context menu is invoked via the keyboard

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
@@ -235,7 +235,6 @@ namespace System.Windows.Forms
             // the focus would be changed to the next control on the form! We don't want
             // that
 
-
             // If the ActiveX control doesn't want to handle the key, it calls back into
             // WebBrowserSiteBase's IOleControlSite.TranslateAccelerator implementation. There, we
             // set a flag and call back into this method. In this method, we first check
@@ -1361,7 +1360,6 @@ namespace System.Windows.Forms
                 }
                 axReloadingState = WebBrowserHelper.AXState.Passive;
             }
-
         }
 
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never),

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserContainer.cs
@@ -464,5 +464,4 @@ namespace System.Windows.Forms
             }
         }
     }
-
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserHelper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserHelper.cs
@@ -9,7 +9,6 @@ using System.Diagnostics;
 using System.Drawing;
 using static Interop;
 
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WinFormsUtils.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WinFormsUtils.cs
@@ -12,7 +12,6 @@ using System.Text;
 using System.Windows.Forms.Internal;
 using static Interop;
 
-
 namespace System.Windows.Forms
 {
     internal sealed class WindowsFormsUtils
@@ -626,7 +625,6 @@ namespace System.Windows.Forms
                     Debug.Assert((selectResult == RegionType.SIMPLEREGION ||
                                   selectResult == RegionType.NULLREGION),
                                   "SIMPLEREGION or NULLLREGION expected.");
-
                 }
                 catch (Exception ex) when (!ClientUtils.IsSecurityOrCriticalException(ex))
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WindowsFormsSectionHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WindowsFormsSectionHandler.cs
@@ -8,14 +8,14 @@ namespace System.Windows.Forms
     // Keeping the skeleton to unblock compile scenarios, if any.
     // And to receive feedback if there are any users  of this class that we do not know
     public sealed class WindowsFormsSection
-	{
+    {
         internal static WindowsFormsSection GetSection()
-		{
+        {
             throw new NotImplementedException();
         }
 
         public WindowsFormsSection()
-		{
+        {
             throw new NotImplementedException();
         }
 

--- a/src/System.Windows.Forms/src/misc/GDI/DeviceContext.cs
+++ b/src/System.Windows.Forms/src/misc/GDI/DeviceContext.cs
@@ -47,7 +47,7 @@ namespace System.Windows.Forms.Internal
         ///  be able to keep the GDI+ and GDI HDCs in sync.
         ///
         ///  A few other persisting properties have been implemented in DeviceContext2, among them:
-        ///  
+        ///
         ///   1. Window origin.
         ///   2. Bounding rectangle.
         ///   3. DC origin.

--- a/src/System.Windows.Forms/src/misc/GDI/DeviceContext2.cs
+++ b/src/System.Windows.Forms/src/misc/GDI/DeviceContext2.cs
@@ -102,7 +102,6 @@ namespace System.Windows.Forms.Internal
 
 #endif
                         return font;
-
                     }
                 }
 #endif

--- a/src/System.Windows.Forms/src/misc/GDI/WindowsGraphics.cs
+++ b/src/System.Windows.Forms/src/misc/GDI/WindowsGraphics.cs
@@ -161,7 +161,6 @@ namespace System.Windows.Forms.Internal
                     // beteween the original DC clip region and the GDI+ one - for display Graphics it is the same as
                     // Graphics.VisibleClipBounds.
                     wg.DeviceContext.IntersectClip(wr);
-
                 }
             }
 
@@ -212,7 +211,6 @@ namespace System.Windows.Forms.Internal
                         _graphics.ReleaseHdcInternal(DeviceContext.Hdc);
                         _graphics = null;
                     }
-
                 }
                 catch (Exception ex)
                 {

--- a/src/System.Windows.Forms/src/misc/GDI/WindowsGraphics2.cs
+++ b/src/System.Windows.Forms/src/misc/GDI/WindowsGraphics2.cs
@@ -124,9 +124,9 @@ namespace System.Windows.Forms.Internal
         /// <summary>
         ///  Draws the text in the given bounds, using the given Font, foreColor and backColor, and according to the specified
         ///  TextFormatFlags flags.
-        ///  
+        ///
         ///  If font is null, the font currently selected in the hdc is used.
-        ///  
+        ///
         ///  If foreColor and/or backColor are Color.Empty, the hdc current text and/or background color are used.
         /// </summary>
         public void DrawText(string text, WindowsFont font, Rectangle bounds, Color foreColor, Color backColor, User32.DT flags)
@@ -252,7 +252,6 @@ namespace System.Windows.Forms.Internal
                 case TextPaddingOptions.NoPadding:
                 default:
                     break;
-
             }
 
             return new User32.DRAWTEXTPARAMS

--- a/src/System.Windows.Forms/src/misc/GDI/WindowsSolidBrush.cs
+++ b/src/System.Windows.Forms/src/misc/GDI/WindowsSolidBrush.cs
@@ -13,7 +13,7 @@ namespace System.Windows.Forms.Internal
         protected override void CreateBrush()
         {
             IntPtr nativeHandle = Gdi32.CreateSolidBrush(ColorTranslator.ToWin32(Color));
-            
+
             // Don't use Debug.Assert, DbgUtil.GetLastErrorStr would always be evaluated.
             if (nativeHandle == IntPtr.Zero)
             {

--- a/src/System.Windows.Forms/tests/AccessibilityTests/CommonControls1.cs
+++ b/src/System.Windows.Forms/tests/AccessibilityTests/CommonControls1.cs
@@ -63,7 +63,6 @@ namespace AccessibilityTests
 
         private void maskedTextBox1_MaskInputRejected(object sender, MaskInputRejectedEventArgs e)
         {
-
         }
     }
 }

--- a/src/System.Windows.Forms/tests/AccessibilityTests/ContainersTesting.cs
+++ b/src/System.Windows.Forms/tests/AccessibilityTests/ContainersTesting.cs
@@ -16,7 +16,6 @@ namespace AccessibilityTests
 
         private void Label2_Click(object sender, EventArgs e)
         {
-
         }
     }
 }

--- a/src/System.Windows.Forms/tests/AccessibilityTests/DataControls.cs
+++ b/src/System.Windows.Forms/tests/AccessibilityTests/DataControls.cs
@@ -41,7 +41,7 @@ namespace AccessibilityTests
             dataGridView1.BeginEdit(false);
             DataGridViewComboBoxEditingControl cbox = dataGridView1.EditingControl as DataGridViewComboBoxEditingControl;
             if (cbox != null)
-                cbox.DroppedDown = true;    
+                cbox.DroppedDown = true;
         }
     }
 }

--- a/src/System.Windows.Forms/tests/AccessibilityTests/DialogsTesting.cs
+++ b/src/System.Windows.Forms/tests/AccessibilityTests/DialogsTesting.cs
@@ -35,7 +35,6 @@ namespace AccessibilityTests
         {
             OpenFileDialog openFileDialog = new OpenFileDialog();
             openFileDialog.ShowDialog();
-
         }
 
         private void SaveFileDialog_Click(object sender, EventArgs e)

--- a/src/System.Windows.Forms/tests/AccessibilityTests/Main.cs
+++ b/src/System.Windows.Forms/tests/AccessibilityTests/Main.cs
@@ -61,6 +61,5 @@ namespace AccessibilityTests
             ContainersTesting containerControl = new ContainersTesting();
             containerControl.Show();
         }
-
     }
 }

--- a/src/System.Windows.Forms/tests/AccessibilityTests/PrintingTesting.cs
+++ b/src/System.Windows.Forms/tests/AccessibilityTests/PrintingTesting.cs
@@ -23,20 +23,17 @@ namespace AccessibilityTests
             {
                 e.Graphics.DrawString(this.txtPrint.Text.ToString(), font, bru, i * 20, i * 20);
             }
-
         }
 
         private void BtnSetting_Click(object sender, EventArgs e)
         {
             pageSetupDialog1.Document = printDocument1;
             this.pageSetupDialog1.ShowDialog();
-
         }
 
         private void BtnPreView_Click(object sender, EventArgs e)
         {
             this.printPreviewDialog1.ShowDialog();
-           
         }
 
         private void BtnPrint_Click(object sender, EventArgs e)

--- a/src/System.Windows.Forms/tests/AccessibilityTests/RemainingControls.cs
+++ b/src/System.Windows.Forms/tests/AccessibilityTests/RemainingControls.cs
@@ -18,7 +18,6 @@ namespace AccessibilityTests
         {
             propertyGrid1.SelectedObject = domainUpDown1;
             propertyGrid2.SelectedObject = trackBar1;
-          
         }
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/TestHelpers.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/TestHelpers.cs
@@ -409,6 +409,5 @@ namespace System.Windows.Forms.IntegrationTests.Common
                 return false;
             }
         }
-
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests/Mocks/MainObject.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests/Mocks/MainObject.cs
@@ -34,6 +34,5 @@ namespace System.Windows.Forms.IntegrationTests.Mocks
         }
 
         public bool IsPropertyChangedAssigned { get { return _propertyChanged != null; } }
-
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/CollectionEditors.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/CollectionEditors.cs
@@ -27,7 +27,6 @@ namespace WinformsControlsTest.UserControls
         {
             InitializeComponent();
 
-
             var imageList = new ImageList();
             imageList.Images.Add("SmallA", Image.FromFile("Images\\SmallA.bmp"));
             imageList.Images.Add(Image.FromFile("Images\\SmallABlue.bmp"));

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.cs
@@ -29,7 +29,6 @@ namespace WinformsControlsTest
             listView1.Items[2].ImageIndex = 2;
             listView1.Click += (s, e) =>
             {
-
                 //listView1.TileSize = new Size(random.Next(100, 300), random.Next(25, 50));
 
                 Point pos = Cursor.Position;

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MenuStripAndCheckedListBox.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MenuStripAndCheckedListBox.cs
@@ -44,7 +44,6 @@ namespace WinformsControlsTest
             menuStrip1.Font = new Font(f.FontFamily, f.Size * factor, f.Style);
 
             menuStrip1.ResumeLayout();
-
         }
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MultipleControls.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MultipleControls.cs
@@ -43,6 +43,5 @@ namespace WinformsControlsTest
         {
             checkedListBox1.Items.Add("Pennsylvania", CheckState.Checked);
         }
-
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/RichTextBoxes.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/RichTextBoxes.cs
@@ -26,7 +26,7 @@ namespace WinformsControlsTest
 \pard\sa200\sl276\slmult1\f0\fs22\lang9  for more information.\par
 }";
         }
-      
+
         private void richTextBox1_LinkClicked(object sender, LinkClickedEventArgs e)
         {
             MessageBox.Show(this, e.LinkText, "link clicked");

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ScalingBeforeChanges.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ScalingBeforeChanges.cs
@@ -9,7 +9,6 @@ using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using static Interop;
 
-
 namespace WinformsControlsTest
 {
     public partial class ScalingBeforeChanges : Form
@@ -102,7 +101,6 @@ namespace WinformsControlsTest
                     }
                     m.Result = IntPtr.Zero;
                     break;
-
             }
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewCellAccessibleObjectTests.cs
@@ -45,8 +45,8 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             DataGridView dataGridView = new DataGridView();
             dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
             dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
-            dataGridView.Rows.Add(new DataGridViewRow()); 
-            dataGridView.Rows.Add(new DataGridViewRow()); 
+            dataGridView.Rows.Add(new DataGridViewRow());
+            dataGridView.Rows.Add(new DataGridViewRow());
 
             dataGridView.Rows[0].Cells[0].ReadOnly = true;
             dataGridView.Rows[1].ReadOnly = true;

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DomainUpDownAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DomainUpDownAccessibleObjectTests.cs
@@ -23,8 +23,8 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             string accessibleName = numericUpDown.AccessibilityObject.Name;
             string controlType = SR.SpinnerAccessibleName;
 
-            // Mas requires us to have no same AccessibleName and LocalizedControlType, 
-            // please see the requirement (Section 508 502.3.1). 
+            // Mas requires us to have no same AccessibleName and LocalizedControlType,
+            // please see the requirement (Section 508 502.3.1).
             // So we need to check if these properties are not equal.
             // In this specific case, we can't have some positive Assert.
             // ToLower method used to be case insensitive.

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ErrorProviderAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ErrorProviderAccessibleObjectTests.cs
@@ -100,7 +100,6 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
 
             actual = _controlItem2.Error;
             Assert.Equal(expected, actual);
-
         }
 
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/NumericUpDownAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/NumericUpDownAccessibleObjectTests.cs
@@ -23,8 +23,8 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             string accessibleName = numericUpDown.AccessibilityObject.Name;
             string controlType = SR.SpinnerAccessibleName;
 
-            // Mas requires us to have no same AccessibleName and LocalizedControlType, 
-            // please see the requirement (Section 508 502.3.1). 
+            // Mas requires us to have no same AccessibleName and LocalizedControlType,
+            // please see the requirement (Section 508 502.3.1).
             // So we need to check if these properties are not equal.
             // In this specific case, we can't have some positive Assert.
             // ToLower method used to be case insensitive.

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridViewRowsAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridViewRowsAccessibleObjectTests.cs
@@ -86,7 +86,5 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             Controls.Add(domainUpDown);
             Load += TestForm_Load;
         }
-
     }
-
 }

--- a/src/System.Windows.Forms/tests/UnitTests/CheckedListBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/CheckedListBoxTests.cs
@@ -322,6 +322,5 @@ namespace System.Windows.Forms.Tests
 
             Assert.Equal(expected, box.GetItemCheckState(0));
         }
-
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/DataStreamFromComStreamTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/DataStreamFromComStreamTests.cs
@@ -1,6 +1,6 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.	
-// The .NET Foundation licenses this file to you under the MIT license.	
-// See the LICENSE file in the project root for more information.	
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using Moq;

--- a/src/System.Windows.Forms/tests/UnitTests/SerializableTypesTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/SerializableTypesTests.cs
@@ -221,7 +221,6 @@ namespace System.Windows.Forms.Tests.Serialization
                 netBlob = BinarySerialization.ToBase64String(listViewSubItem);
             }
 
-
             // ensure we can deserialise NET serialised data and continue to match the payload
             ValidateResult(netBlob);
             // ensure we can deserialise NET Fx serialised data and continue to match the payload

--- a/src/System.Windows.Forms/tests/UnitTests/System/Drawing/Design/PaintValueEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Drawing/Design/PaintValueEventArgsTests.cs
@@ -1,6 +1,6 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.	
-// The .NET Foundation licenses this file to you under the MIT license.	
-// See the LICENSE file in the project root for more information.	
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Drawing/Design/PropertyValueUIItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Drawing/Design/PropertyValueUIItemTests.cs
@@ -1,6 +1,6 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.	
-// The .NET Foundation licenses this file to you under the MIT license.	
-// See the LICENSE file in the project root for more information.	
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Drawing/Design/UITypeEditorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Drawing/Design/UITypeEditorTests.cs
@@ -1,6 +1,6 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.	
-// The .NET Foundation licenses this file to you under the MIT license.	
-// See the LICENSE file in the project root for more information.	
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjectTests.cs
@@ -38,7 +38,7 @@ namespace System.Windows.Forms.Tests
                 Name = value
             };
             Assert.Null(accessibleObject.Name);
-            
+
             // Set same.
             accessibleObject.Name = value;
             Assert.Null(accessibleObject.Name);
@@ -53,7 +53,7 @@ namespace System.Windows.Forms.Tests
                 Value = value
             };
             Assert.Empty(accessibleObject.Value);
-            
+
             // Set same.
             accessibleObject.Value = value;
             Assert.Empty(accessibleObject.Value);
@@ -534,7 +534,7 @@ namespace System.Windows.Forms.Tests
             var accessibleObject = new AccessibleObject();
             accessibleObject.Select(flags);
         }
-        
+
         public static IEnumerable<object[]> UseStdAccessibleObjects_IntPtr_InvalidHandle_TestData()
         {
             yield return new object[] { IntPtr.Zero };
@@ -598,7 +598,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(AccessibleStates.ReadOnly, accessibleObject.State);
             Assert.Null(accessibleObject.Value);
         }
-        
+
         public static IEnumerable<object[]> UseStdAccessibleObjects_IntPtr_Int_InvalidHandle_TestData()
         {
             yield return new object[] { IntPtr.Zero, 0 };
@@ -862,7 +862,7 @@ namespace System.Windows.Forms.Tests
             Assert.Same(result, iAccessible.accFocus);
             mockAccessibleObject.Verify(a => a.GetFocused(), Times.Once());
         }
-        
+
         [WinFormsFact]
         public void AccessibleObject_IAccessiblaccFocus_InvokeDefaultSelf_ReturnsExpected()
         {
@@ -1327,7 +1327,7 @@ namespace System.Windows.Forms.Tests
             Assert.Same(result, iAccessible.accSelection);
             mockAccessibleObject.Verify(a => a.GetSelected(), Times.Once());
         }
-        
+
         [WinFormsFact]
         public void AccessibleObject_IAccessiblaccSelection_InvokeDefaultSelf_ReturnsExpected()
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHost.ConnectionPointCookieTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHost.ConnectionPointCookieTests.cs
@@ -73,7 +73,7 @@ namespace System.Windows.Forms.Tests
             Type eventInterface = typeof(Ole32.IPropertyNotifySink);
             Assert.Throws<InvalidCastException>(() => new AxHost.ConnectionPointCookie(source, sink, eventInterface));
         }
-        
+
         [WinFormsFact]
         public void ConnectionPointCookie_Disconnect_InvokeMultipleTimes_Success()
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonBaseTests.cs
@@ -207,7 +207,6 @@ namespace System.Windows.Forms.Tests
 
         public class SubButtonBase : ButtonBase
         {
-
             public new bool CanEnableIme => base.CanEnableIme;
 
             public new bool CanRaiseEvents => base.CanRaiseEvents;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonTests.cs
@@ -419,7 +419,6 @@ namespace System.Windows.Forms.Tests
 
         public class SubButton : Button
         {
-
             public new bool CanEnableIme => base.CanEnableIme;
 
             public new bool CanRaiseEvents => base.CanRaiseEvents;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColorDialogTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColorDialogTests.cs
@@ -121,7 +121,7 @@ namespace System.Windows.Forms.Tests
                 Color = value
             };
             Assert.Equal(expected, dialog.Color);
-            
+
             // Set same.
             dialog.Color = value;
             Assert.Equal(expected, dialog.Color);
@@ -135,10 +135,10 @@ namespace System.Windows.Forms.Tests
             {
                 Color = Color.Blue
             };
-            
+
             dialog.Color = value;
             Assert.Equal(expected, dialog.Color);
-            
+
             // Set same.
             dialog.Color = value;
             Assert.Equal(expected, dialog.Color);
@@ -211,7 +211,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, dialog.CustomColors);
             Assert.NotSame(value, dialog.CustomColors);
             Assert.NotSame(dialog.CustomColors, dialog.CustomColors);
-            
+
             // Set same.
             dialog.CustomColors = value;
             Assert.Equal(expected, dialog.CustomColors);
@@ -227,12 +227,12 @@ namespace System.Windows.Forms.Tests
             {
                 CustomColors = new int[1]
             };
-            
+
             dialog.CustomColors = value;
             Assert.Equal(expected, dialog.CustomColors);
             Assert.NotSame(value, dialog.CustomColors);
             Assert.NotSame(dialog.CustomColors, dialog.CustomColors);
-            
+
             // Set same.
             dialog.CustomColors = value;
             Assert.Equal(expected, dialog.CustomColors);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeaderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeaderTests.cs
@@ -239,7 +239,6 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<ArgumentOutOfRangeException>("DisplayIndex", () => header.DisplayIndex = value);
         }
 
-
         [WinFormsFact]
         public void ColumnHeader_DisplayIndex_ShouldSerializeValue_Success()
         {
@@ -652,7 +651,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, createdCallCount);
         }
 
-
         [WinFormsTheory]
         [InlineData(null)]
         [InlineData("")]
@@ -859,7 +857,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, header.Name);
             Assert.Equal(value, header.Site.Name);
         }
-
 
         [WinFormsFact]
         public void ColumnHeader_Name_ResetValue_Success()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnStyleTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnStyleTests.cs
@@ -57,7 +57,7 @@ namespace System.Windows.Forms.Tests
                 Width = value
             };
             Assert.Equal(value, style.Width);
-            
+
             // Set same.
             style.Width = value;
             Assert.Equal(value, style.Width);
@@ -85,7 +85,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(value, style.Width);
             Assert.Equal(expectedLayoutCallCount, layoutCallCount);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             style.Width = value;
             Assert.Equal(value, style.Width);
@@ -125,7 +125,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expectedLayoutCallCount * 2, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set same.
             style.Width = value;
             Assert.Equal(value, style.Width);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -803,7 +803,7 @@ namespace System.Windows.Forms.Tests
             using var control = new ComboBox();
             Assert.Empty(control.SelectedText);
             Assert.True(control.IsHandleCreated);
-            
+
             // Get again.
             Assert.Empty(control.SelectedText);
             Assert.True(control.IsHandleCreated);
@@ -817,7 +817,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.Empty(control.SelectedText);
             Assert.True(control.IsHandleCreated);
-            
+
             // Get again.
             Assert.Empty(control.SelectedText);
             Assert.True(control.IsHandleCreated);
@@ -829,7 +829,7 @@ namespace System.Windows.Forms.Tests
             using var control = new ComboBox();
             Assert.Equal(0, control.SelectionLength);
             Assert.True(control.IsHandleCreated);
-            
+
             // Get again.
             Assert.Equal(0, control.SelectionLength);
             Assert.True(control.IsHandleCreated);
@@ -843,7 +843,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.Equal(0, control.SelectionLength);
             Assert.True(control.IsHandleCreated);
-            
+
             // Get again.
             Assert.Equal(0, control.SelectionLength);
             Assert.True(control.IsHandleCreated);
@@ -855,7 +855,7 @@ namespace System.Windows.Forms.Tests
             using var control = new ComboBox();
             Assert.Equal(0, control.SelectionStart);
             Assert.True(control.IsHandleCreated);
-            
+
             // Get again.
             Assert.Equal(0, control.SelectionStart);
             Assert.True(control.IsHandleCreated);
@@ -869,12 +869,12 @@ namespace System.Windows.Forms.Tests
 
             Assert.Equal(0, control.SelectionStart);
             Assert.True(control.IsHandleCreated);
-            
+
             // Get again.
             Assert.Equal(0, control.SelectionStart);
             Assert.True(control.IsHandleCreated);
         }
-        
+
         [WinFormsFact]
         public void ComboBox_GetAutoSizeMode_Invoke_ReturnsExpected()
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CommonDialogTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CommonDialogTests.cs
@@ -11,7 +11,6 @@ using WinForms.Common.Tests;
 using Xunit;
 using static Interop;
 
-
 namespace System.Windows.Forms.Tests
 {
     public class CommonDialogTests
@@ -132,7 +131,7 @@ namespace System.Windows.Forms.Tests
             {
                 bool runDialogResult = bool.Parse(runDialogResultString);
                 DialogResult expectedDialogResult = (DialogResult)Enum.Parse(typeof(DialogResult), expectedDialogResultString);
-                
+
                 Application.EnableVisualStyles();
 
                 using var dialog = new SubCommonDialog

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComponentModel/Com2Interop/COM2PictureConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComponentModel/Com2Interop/COM2PictureConverterTests.cs
@@ -21,7 +21,6 @@ namespace System.Windows.Forms.Tests.ComponentModel.Com2Interop
             default,
             default));
 
-
         [Fact]
         public void ConvertNativeToManaged_Null()
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -928,7 +928,7 @@ namespace System.Windows.Forms.Tests
             IAccessible iAccessible = accessibleObject;
             Assert.Null(iAccessible.accFocus);
         }
-        
+
         [WinFormsTheory]
         [InlineData(-1, -2)]
         [InlineData(0, 0)]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.ControlCollection.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.ControlCollection.cs
@@ -243,7 +243,7 @@ namespace System.Windows.Forms.Tests
                 .Setup(e => e.InitLayout(control, BoundsSpecified.All))
                 .Verifiable();
             control.SetLayoutEngine(mockLayoutEngine.Object);
-    
+
             try
             {
                 affectedProperty = "Parent";
@@ -256,7 +256,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(owner.IsHandleCreated);
                 Assert.False(control.IsHandleCreated);
                 mockLayoutEngine.Verify(e => e.InitLayout(control, BoundsSpecified.All), Times.Once());
-                
+
                 // Add existing.
                 affectedProperty = "ChildIndex";
                 collection.Add(control);
@@ -292,7 +292,7 @@ namespace System.Windows.Forms.Tests
             Assert.Same(owner, control1.Parent);
             Assert.Equal(1, control1.TabIndex);
             Assert.Equal(0, tabIndexChangedCallCount1);
-            
+
             // Add another.
             using var control2 = new SubControl();
             int tabIndexChangedCallCount2 = 0;
@@ -305,7 +305,7 @@ namespace System.Windows.Forms.Tests
             Assert.Same(owner, control2.Parent);
             Assert.Equal(2, control2.TabIndex);
             Assert.Equal(0, tabIndexChangedCallCount2);
-            
+
             // Add another.
             control1.TabIndex = 10;
             using var control3 = new SubControl();
@@ -561,7 +561,7 @@ namespace System.Windows.Forms.Tests
             control.BackColorChanged += (sender, e) => backColorChangedCallCount++;
             control.RightToLeftChanged += (sender, e) => rightToLeftChangedCallCount++;
             control.BindingContextChanged += (sender, e) => bindingContextChangedCallCount++;
-            
+
             collection.Add(control);
             Assert.Same(owner, control.Parent);
             Assert.Equal(1, parentChangedCallCount);
@@ -605,7 +605,7 @@ namespace System.Windows.Forms.Tests
             control.BackColorChanged += (sender, e) => backColorChangedCallCount++;
             control.RightToLeftChanged += (sender, e) => rightToLeftChangedCallCount++;
             control.BindingContextChanged += (sender, e) => bindingContextChangedCallCount++;
-            
+
             collection.Add(control);
             Assert.Same(owner, control.Parent);
             Assert.Equal(1, parentChangedCallCount);
@@ -642,7 +642,7 @@ namespace System.Windows.Forms.Tests
             using var owner = new Control();
             using var control = new Control();
             var collection = new Control.ControlCollection(owner);
-            
+
             owner.Enabled = false;
             Assert.True(control.Enabled);
             owner.Visible = false;
@@ -747,7 +747,7 @@ namespace System.Windows.Forms.Tests
                 rightToLeftChangedCallCount++;
             };
             control.BindingContextChanged += (sender, e) => bindingContextChangedCallCount++;
-            
+
             try
             {
                 collection.Add(control);
@@ -905,7 +905,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(backColorChangedCallCount - 1, bindingContextChangedCallCount);
                 bindingContextChangedCallCount++;
             };
-            
+
             try
             {
                 collection.Add(control);
@@ -981,7 +981,7 @@ namespace System.Windows.Forms.Tests
             ((Control)control).BackColorChanged += (sender, e) => backColorChangedCallCount++;
             ((Control)control).RightToLeftChanged += (sender, e) => rightToLeftChangedCallCount++;
             ((Control)control).BindingContextChanged += (sender, e) => bindingContextChangedCallCount++;
-            
+
             collection.Add(control);
             try
             {
@@ -1015,7 +1015,7 @@ namespace System.Windows.Forms.Tests
             using var owner = new Control();
             using var control = new SubAxHost("8856f961-340a-11d0-a96b-00c04fd705a2");
             var collection = new Control.ControlCollection(owner);
-            
+
             owner.Enabled = false;
             Assert.True(control.Enabled);
             owner.Visible = false;
@@ -1060,7 +1060,7 @@ namespace System.Windows.Forms.Tests
             ((Control)control).BackColorChanged += (sender, e) => backColorChangedCallCount++;
             ((Control)control).RightToLeftChanged += (sender, e) => rightToLeftChangedCallCount++;
             ((Control)control).BindingContextChanged += (sender, e) => bindingContextChangedCallCount++;
-            
+
             try
             {
                 collection.Add(control);
@@ -1090,7 +1090,7 @@ namespace System.Windows.Forms.Tests
                 control.ParentChanged -= parentChangedHandler;
             }
         }
-        
+
         private class SubAxHost : AxHost
         {
             public SubAxHost(string clsid) : base(clsid)
@@ -1131,7 +1131,7 @@ namespace System.Windows.Forms.Tests
             });
             thread.Start();
             thread.Join();
-            
+
             var control = new Control();
             var collection = new Control.ControlCollection(owner);
             Assert.Throws<ArgumentException>(null, () => collection.Add(control));
@@ -1148,7 +1148,7 @@ namespace System.Windows.Forms.Tests
             });
             thread.Start();
             thread.Join();
-            
+
             var owner = new Control();
             var collection = new Control.ControlCollection(owner);
             Assert.Throws<ArgumentException>(null, () => collection.Add(control));
@@ -1190,7 +1190,6 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<ArgumentException>(null, () => collection.Add(grandparent));
         }
 
-
         [WinFormsFact]
         public void ControlCollection_AddRange_Invoke_Success()
         {
@@ -1228,7 +1227,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(child1.IsHandleCreated);
                 Assert.False(child2.IsHandleCreated);
                 Assert.False(child3.IsHandleCreated);
-                
+
                 affectedControl = child1;
                 affectedProperty = "ChildIndex";
                 collection.AddRange(new Control[] { child1, child2, null, child3 });
@@ -1311,7 +1310,7 @@ namespace System.Windows.Forms.Tests
             Assert.False(child1.IsHandleCreated);
             Assert.False(child2.IsHandleCreated);
             Assert.False(child3.IsHandleCreated);
-            
+
             // Clear again.
             collection.Clear();
             Assert.Empty(collection);
@@ -1429,12 +1428,12 @@ namespace System.Windows.Forms.Tests
             collection.Add(child3);
 
             Assert.Equal(expected, collection.ContainsKey(key));
-            
+
             // Call again.
             Assert.Equal(expected, collection.ContainsKey(key));
             Assert.Equal(-1, collection.IndexOfKey("NoSuchKey"));
         }
-        
+
         [WinFormsTheory]
         [InlineData("name2")]
         [InlineData("NAME2")]
@@ -1481,7 +1480,7 @@ namespace System.Windows.Forms.Tests
 
             // Don't search all children.
             Assert.Equal(new Control[] { child2, child3 }, collection.Find(key, searchAllChildren: false));
-            
+
             // Call again..
             Assert.Equal(new Control[] { child2, child3 }, collection.Find(key, searchAllChildren: false));
         }
@@ -1602,11 +1601,11 @@ namespace System.Windows.Forms.Tests
 
                 Assert.False(enumerator.MoveNext());
                 Assert.Null(enumerator.Current);
-                
+
                 // Call again.
                 Assert.False(enumerator.MoveNext());
                 Assert.Null(enumerator.Current);
-            
+
                 enumerator.Reset();
             }
         }
@@ -1630,13 +1629,13 @@ namespace System.Windows.Forms.Tests
 
                 Assert.True(enumerator.MoveNext());
                 Assert.Same(child1, enumerator.Current);
-                
+
                 Assert.True(enumerator.MoveNext());
                 Assert.Same(child2, enumerator.Current);
-                
+
                 Assert.True(enumerator.MoveNext());
                 Assert.Same(child3, enumerator.Current);
-                
+
                 Assert.False(enumerator.MoveNext());
                 Assert.Same(child3, enumerator.Current);
 
@@ -1662,11 +1661,11 @@ namespace System.Windows.Forms.Tests
 
                 Assert.False(enumerator.MoveNext());
                 Assert.Null(enumerator.Current);
-                
+
                 // Call again.
                 Assert.False(enumerator.MoveNext());
                 Assert.Null(enumerator.Current);
-            
+
                 enumerator.Reset();
             }
         }
@@ -1690,7 +1689,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.True(enumerator.MoveNext());
             Assert.Same(child2, enumerator.Current);
-            
+
             Assert.True(enumerator.MoveNext());
             Assert.Same(child3, enumerator.Current);
 
@@ -1719,13 +1718,13 @@ namespace System.Windows.Forms.Tests
 
             Assert.True(enumerator.MoveNext());
             Assert.Same(child1, enumerator.Current);
-            
+
             Assert.True(enumerator.MoveNext());
             Assert.Same(child2, enumerator.Current);
-            
+
             Assert.True(enumerator.MoveNext());
             Assert.Same(child3, enumerator.Current);
-            
+
             collection.Remove(child1);
             Assert.Throws<ArgumentOutOfRangeException>("index", () => enumerator.Current);
 
@@ -1787,7 +1786,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(child3);
 
             Assert.Equal(expected, collection.IndexOfKey(key));
-            
+
             // Call again.
             Assert.Equal(expected, collection.IndexOfKey(key));
             Assert.Equal(-1, collection.IndexOfKey("NoSuchKey"));
@@ -1818,7 +1817,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(child3);
 
             Assert.Equal(collection[expectedIndex], collection[key]);
-            
+
             // Call again.
             Assert.Equal(collection[expectedIndex], collection[key]);
             Assert.Null(collection["NoSuchKey"]);
@@ -1852,7 +1851,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(child3);
 
             Assert.Null(collection[key]);
-            
+
             // Call again.
             Assert.Null(collection[key]);
             Assert.Null(collection["NoSuchKey"]);
@@ -1908,7 +1907,7 @@ namespace System.Windows.Forms.Tests
             var collection = new Control.ControlCollection(owner);
             collection.Add(child1);
             collection.Add(child2);
-            
+
             int layoutCallCount = 0;
             child1.Layout += (sender, e) => layoutCallCount++;
             int parentLayoutCallCount = 0;
@@ -1931,7 +1930,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(owner.IsHandleCreated);
                 Assert.False(child1.IsHandleCreated);
                 Assert.False(child2.IsHandleCreated);
-                
+
                 // Remove again.
                 collection.Remove(child1);
                 Assert.Equal(new Control[] { child2 }, collection.Cast<Control>());
@@ -1969,7 +1968,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(child2);
             owner.ActiveControl = child1;
             Assert.Same(child1, owner.ActiveControl);
-            
+
             int layoutCallCount = 0;
             child1.Layout += (sender, e) => layoutCallCount++;
             int parentLayoutCallCount = 0;
@@ -1993,7 +1992,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(owner.IsHandleCreated);
                 Assert.False(child1.IsHandleCreated);
                 Assert.False(child2.IsHandleCreated);
-                
+
                 // Remove again.
                 collection.Remove(child1);
                 Assert.Equal(new Control[] { child2 }, collection.Cast<Control>());
@@ -2004,7 +2003,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(owner.IsHandleCreated);
                 Assert.False(child1.IsHandleCreated);
                 Assert.False(child2.IsHandleCreated);
-                
+
                 // Remove null.
                 collection.Remove(null);
                 Assert.Equal(new Control[] { child2 }, collection.Cast<Control>());
@@ -2031,7 +2030,7 @@ namespace System.Windows.Forms.Tests
             Control.ControlCollection collection = owner.Controls;
             collection.Add(child1);
             collection.Add(child2);
-            
+
             int layoutCallCount = 0;
             child1.Layout += (sender, e) => layoutCallCount++;
             int parentLayoutCallCount = 0;
@@ -2064,7 +2063,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, styleChangedCallCount);
                 Assert.Equal(0, createdCallCount);
                 Assert.False(child2.IsHandleCreated);
-                
+
                 // Remove again.
                 collection.Remove(child1);
                 Assert.Equal(new Control[] { child2 }, collection.Cast<Control>());
@@ -2077,7 +2076,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, styleChangedCallCount);
                 Assert.Equal(0, createdCallCount);
                 Assert.False(child2.IsHandleCreated);
-                
+
                 // Remove null.
                 collection.Remove(null);
                 Assert.Equal(new Control[] { child2 }, collection.Cast<Control>());
@@ -2106,7 +2105,7 @@ namespace System.Windows.Forms.Tests
             Control.ControlCollection collection = owner.Controls;
             collection.Add(child1);
             collection.Add(child2);
-            
+
             int layoutCallCount = 0;
             child1.Layout += (sender, e) => layoutCallCount++;
             int parentLayoutCallCount = 0;
@@ -2148,7 +2147,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, styleChangedCallCount);
                 Assert.Equal(0, createdCallCount);
                 Assert.True(child2.IsHandleCreated);
-                
+
                 // Remove again.
                 collection.Remove(child1);
                 Assert.Equal(new Control[] { child2 }, collection.Cast<Control>());
@@ -2164,7 +2163,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, styleChangedCallCount);
                 Assert.Equal(0, createdCallCount);
                 Assert.True(child2.IsHandleCreated);
-                
+
                 // Remove null.
                 collection.Remove(null);
                 Assert.Equal(new Control[] { child2 }, collection.Cast<Control>());
@@ -2199,14 +2198,14 @@ namespace System.Windows.Forms.Tests
             var collection2 = new Control.ControlCollection(owner2);
             collection1.Add(control1);
             collection2.Add(control2);
-            
+
             // Remove with parent.
             collection1.Remove(control2);
             Assert.Equal(new Control[] { control1 }, collection1.Cast<Control>());
             Assert.Equal(new Control[] { control2 }, collection2.Cast<Control>());
             Assert.Same(owner1, control1.Parent);
             Assert.Same(owner2, control2.Parent);
-            
+
             // Remove without parent.
             collection1.Remove(control3);
             Assert.Equal(new Control[] { control1 }, collection1.Cast<Control>());
@@ -2239,7 +2238,7 @@ namespace System.Windows.Forms.Tests
             control.BackColorChanged += (sender, e) => backColorChangedCallCount++;
             control.RightToLeftChanged += (sender, e) => rightToLeftChangedCallCount++;
             control.BindingContextChanged += (sender, e) => bindingContextChangedCallCount++;
-            
+
             collection.Remove(control);
             Assert.Null(control.Parent);
             Assert.Equal(1, parentChangedCallCount);
@@ -2284,7 +2283,7 @@ namespace System.Windows.Forms.Tests
             control.BackColorChanged += (sender, e) => backColorChangedCallCount++;
             control.RightToLeftChanged += (sender, e) => rightToLeftChangedCallCount++;
             control.BindingContextChanged += (sender, e) => bindingContextChangedCallCount++;
-            
+
             collection.Remove(control);
             Assert.Null(control.Parent);
             Assert.Equal(1, parentChangedCallCount);
@@ -2322,7 +2321,7 @@ namespace System.Windows.Forms.Tests
             using var control = new Control();
             var collection = new Control.ControlCollection(owner);
             collection.Add(control);
-            
+
             owner.Enabled = false;
             Assert.False(control.Enabled);
             owner.Visible = false;
@@ -2426,7 +2425,7 @@ namespace System.Windows.Forms.Tests
                 rightToLeftChangedCallCount++;
             };
             control.BindingContextChanged += (sender, e) => bindingContextChangedCallCount++;
-            
+
             collection.Remove(control);
             Assert.Null(control.Parent);
             Assert.Equal(1, parentChangedCallCount);
@@ -2464,7 +2463,7 @@ namespace System.Windows.Forms.Tests
             using var control = new Control();
             var collection = new Control.ControlCollection(owner);
             collection.Add(control);
-            
+
             owner.Enabled = false;
             Assert.False(control.Enabled);
             owner.Visible = false;
@@ -2554,7 +2553,7 @@ namespace System.Windows.Forms.Tests
                 rightToLeftChangedCallCount++;
             };
             control.BindingContextChanged += (sender, e) => bindingContextChangedCallCount++;
-            
+
             try
             {
                 collection.Remove(control);
@@ -2593,7 +2592,7 @@ namespace System.Windows.Forms.Tests
             using var control = new SubAxHost("8856f961-340a-11d0-a96b-00c04fd705a2");
             var collection = new Control.ControlCollection(owner);
             collection.Add(control);
-            
+
             owner.Enabled = false;
             Assert.False(control.Enabled);
             owner.Visible = false;
@@ -2627,7 +2626,7 @@ namespace System.Windows.Forms.Tests
             ((Control)control).BackColorChanged += (sender, e) => backColorChangedCallCount++;
             ((Control)control).RightToLeftChanged += (sender, e) => rightToLeftChangedCallCount++;
             ((Control)control).BindingContextChanged += (sender, e) => bindingContextChangedCallCount++;
-            
+
             collection.Remove(control);
             Assert.Null(control.Parent);
             Assert.Equal(1, parentChangedCallCount);
@@ -2655,7 +2654,7 @@ namespace System.Windows.Forms.Tests
             using var control = new SubAxHost("8856f961-340a-11d0-a96b-00c04fd705a2");
             var collection = new Control.ControlCollection(owner);
             collection.Add(control);
-            
+
             owner.Enabled = false;
             Assert.False(control.Enabled);
             owner.Visible = false;
@@ -2700,7 +2699,7 @@ namespace System.Windows.Forms.Tests
             ((Control)control).BackColorChanged += (sender, e) => backColorChangedCallCount++;
             ((Control)control).RightToLeftChanged += (sender, e) => rightToLeftChangedCallCount++;
             ((Control)control).BindingContextChanged += (sender, e) => bindingContextChangedCallCount++;
-            
+
             try
             {
                 collection.Remove(control);
@@ -2823,7 +2822,7 @@ namespace System.Windows.Forms.Tests
             var collection = new Control.ControlCollection(owner);
             collection.Add(child1);
             collection.Add(child2);
-            
+
             int layoutCallCount = 0;
             child1.Layout += (sender, e) => layoutCallCount++;
             int parentLayoutCallCount = 0;
@@ -2848,7 +2847,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(owner.IsHandleCreated);
                 Assert.False(child1.IsHandleCreated);
                 Assert.False(child2.IsHandleCreated);
-                
+
                 // Remove again.
                 affectedControl = child1;
                 collection.RemoveAt(0);
@@ -2912,7 +2911,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(child1);
             collection.Add(child2);
             collection.Add(child3);
-            
+
             int layoutCallCount = 0;
             child2.Layout += (sender, e) => layoutCallCount++;
             int parentLayoutCallCount = 0;
@@ -2939,7 +2938,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(child1.IsHandleCreated);
                 Assert.False(child2.IsHandleCreated);
                 Assert.False(child3.IsHandleCreated);
-                
+
                 // Remove again.
                 affectedControl = child3;
                 collection.RemoveByKey(key);
@@ -2988,7 +2987,7 @@ namespace System.Windows.Forms.Tests
 
             collection.RemoveByKey(key);
             Assert.Equal(new Control[] { child1, child2, child3 }, collection.Cast<Control>());
-            
+
             // Call again.
             collection.RemoveByKey(key);
             Assert.Equal(new Control[] { child1, child2, child3 }, collection.Cast<Control>());
@@ -3005,7 +3004,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(child1);
             collection.Add(child2);
             collection.Add(child3);
-            
+
             int layoutCallCount = 0;
             child1.Layout += (sender, e) => layoutCallCount++;
             int parentLayoutCallCount = 0;
@@ -3017,7 +3016,7 @@ namespace System.Windows.Forms.Tests
                 parentLayoutCallCount++;
             }
             owner.Layout += parentHandler;
-        
+
             try
             {
                 // Set middle.
@@ -3029,7 +3028,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(child1.IsHandleCreated);
                 Assert.False(child2.IsHandleCreated);
                 Assert.False(child3.IsHandleCreated);
-                
+
                 // Set same.
                 collection.SetChildIndex(child1, 1);
                 Assert.Equal(new Control[] { child2, child1, child3 }, collection.Cast<Control>());
@@ -3039,7 +3038,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(child1.IsHandleCreated);
                 Assert.False(child2.IsHandleCreated);
                 Assert.False(child3.IsHandleCreated);
-                
+
                 // Set start.
                 collection.SetChildIndex(child1, 0);
                 Assert.Equal(new Control[] { child1, child2, child3 }, collection.Cast<Control>());
@@ -3070,7 +3069,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(child1);
             collection.Add(child2);
             collection.Add(child3);
-            
+
             int layoutCallCount = 0;
             child1.Layout += (sender, e) => layoutCallCount++;
             int parentLayoutCallCount = 0;
@@ -3094,7 +3093,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(child1.IsHandleCreated);
                 Assert.False(child2.IsHandleCreated);
                 Assert.False(child3.IsHandleCreated);
-                
+
                 // Set same.
                 collection.SetChildIndex(child1, index);
                 Assert.Equal(new Control[] { child2, child3, child1 }, collection.Cast<Control>());
@@ -3122,7 +3121,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(child1);
             collection.Add(child2);
             collection.Add(child3);
-            
+
             int layoutCallCount = 0;
             child1.Layout += (sender, e) => layoutCallCount++;
             int parentLayoutCallCount = 0;
@@ -3156,7 +3155,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, createdCallCount);
                 Assert.False(child2.IsHandleCreated);
                 Assert.False(child3.IsHandleCreated);
-                
+
                 // Set same.
                 collection.SetChildIndex(child1, 1);
                 Assert.Equal(new Control[] { child2, child1, child3 }, collection.Cast<Control>());
@@ -3169,7 +3168,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, createdCallCount);
                 Assert.False(child2.IsHandleCreated);
                 Assert.False(child3.IsHandleCreated);
-                
+
                 // Set start.
                 collection.SetChildIndex(child1, 0);
                 Assert.Equal(new Control[] { child1, child2, child3 }, collection.Cast<Control>());
@@ -3200,7 +3199,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(child1);
             collection.Add(child2);
             collection.Add(child3);
-            
+
             int layoutCallCount = 0;
             child1.Layout += (sender, e) => layoutCallCount++;
             int parentLayoutCallCount = 0;
@@ -3243,7 +3242,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, createdCallCount);
                 Assert.True(child2.IsHandleCreated);
                 Assert.True(child3.IsHandleCreated);
-                
+
                 // Set same.
                 collection.SetChildIndex(child1, 1);
                 Assert.Equal(new Control[] { child2, child1, child3 }, collection.Cast<Control>());
@@ -3259,7 +3258,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, createdCallCount);
                 Assert.True(child2.IsHandleCreated);
                 Assert.True(child3.IsHandleCreated);
-                
+
                 // Set start.
                 collection.SetChildIndex(child1, 0);
                 Assert.Equal(new Control[] { child1, child2, child3 }, collection.Cast<Control>());
@@ -3277,7 +3276,7 @@ namespace System.Windows.Forms.Tests
                 Assert.True(child3.IsHandleCreated);
             }
             finally
-            {    
+            {
                 owner.Layout -= parentHandler;
             }
         }
@@ -3293,7 +3292,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(child1);
             collection.Add(child2);
             collection.Add(child3);
-            
+
             int layoutCallCount = 0;
             child1.Layout += (sender, e) => layoutCallCount++;
             int parentLayoutCallCount = 0;
@@ -3328,7 +3327,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(child1.IsHandleCreated);
                 Assert.True(child2.IsHandleCreated);
                 Assert.True(child3.IsHandleCreated);
-                
+
                 // Set same.
                 collection.SetChildIndex(child1, 1);
                 Assert.Equal(new Control[] { child2, child1, child3 }, collection.Cast<Control>());
@@ -3341,7 +3340,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(child1.IsHandleCreated);
                 Assert.True(child2.IsHandleCreated);
                 Assert.True(child3.IsHandleCreated);
-                
+
                 // Set start.
                 collection.SetChildIndex(child1, 0);
                 Assert.Equal(new Control[] { child1, child2, child3 }, collection.Cast<Control>());
@@ -3451,7 +3450,7 @@ namespace System.Windows.Forms.Tests
                 owner.Layout -= parentHandler;
             }
         }
-        
+
         [WinFormsFact]
         public void ControlCollection_IListAdd_NotControl_ThrowsArgumentException()
         {
@@ -3470,7 +3469,7 @@ namespace System.Windows.Forms.Tests
             IList collection = new Control.ControlCollection(owner);
             collection.Add(child1);
             collection.Add(child2);
-            
+
             int layoutCallCount = 0;
             child1.Layout += (sender, e) => layoutCallCount++;
             int parentLayoutCallCount = 0;
@@ -3493,7 +3492,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(owner.IsHandleCreated);
                 Assert.False(child1.IsHandleCreated);
                 Assert.False(child2.IsHandleCreated);
-                
+
                 // Remove again.
                 collection.Remove(child1);
                 Assert.Equal(new Control[] { child2 }, collection.Cast<Control>());
@@ -3519,7 +3518,7 @@ namespace System.Windows.Forms.Tests
                 owner.Layout -= parentHandler;
             }
         }
-        
+
         [WinFormsFact]
         public void ControlCollection_IListRemove_NotControl_ThrowsArgumentException()
         {
@@ -3528,7 +3527,7 @@ namespace System.Windows.Forms.Tests
             collection.Remove(new object());
             collection.Remove(null);
         }
-        
+
         private class CustomLayoutEngineControl : Control
         {
             private LayoutEngine _layoutEngine;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Handlers.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Handlers.cs
@@ -796,12 +796,12 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.ChangeUICues += handler;
             control.OnChangeUICues(eventArgs);
             Assert.Equal(1, callCount);
-        
+
            // Remove handler.
            control.ChangeUICues -= handler;
            control.OnChangeUICues(eventArgs);
@@ -1215,12 +1215,12 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.DockChanged += handler;
             control.OnDockChanged(eventArgs);
             Assert.Equal(1, callCount);
-        
+
             // Remove handler.
             control.DockChanged -= handler;
             control.OnDockChanged(eventArgs);
@@ -1263,18 +1263,18 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.DpiChangedAfterParent += handler;
             control.OnDpiChangedAfterParent(eventArgs);
             Assert.Equal(1, callCount);
-        
+
            // Remove handler.
            control.DpiChangedAfterParent -= handler;
            control.OnDpiChangedAfterParent(eventArgs);
            Assert.Equal(1, callCount);
         }
-        
+
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
         public void Control_OnDpiChangedBeforeParent_Invoke_CallsDpiChangedBeforeParent(EventArgs eventArgs)
@@ -1287,12 +1287,12 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.DpiChangedBeforeParent += handler;
             control.OnDpiChangedBeforeParent(eventArgs);
             Assert.Equal(1, callCount);
-        
+
            // Remove handler.
            control.DpiChangedBeforeParent -= handler;
            control.OnDpiChangedBeforeParent(eventArgs);
@@ -2096,12 +2096,12 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.GotFocus += handler;
             control.OnGotFocus(eventArgs);
             Assert.Equal(1, callCount);
-        
+
            // Remove handler.
            control.GotFocus -= handler;
            control.OnGotFocus(eventArgs);
@@ -2750,20 +2750,20 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.Invalidated += handler;
             control.OnInvalidated(eventArgs);
             Assert.Equal(1, callCount);
             Assert.False(control.IsHandleCreated);
-        
+
             // Remove handler.
             control.Invalidated -= handler;
             control.OnInvalidated(eventArgs);
             Assert.Equal(1, callCount);
             Assert.False(control.IsHandleCreated);
         }
-        
+
         public static IEnumerable<object[]> OnInvalidated_WithChildren_TestData()
         {
             yield return new object[] { true, Color.Empty, null };
@@ -2816,7 +2816,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.Invalidated += handler;
             control.OnInvalidated(eventArgs);
@@ -2824,7 +2824,7 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.IsHandleCreated);
             Assert.False(child1.IsHandleCreated);
             Assert.False(child2.IsHandleCreated);
-        
+
             // Remove handler.
             control.Invalidated -= handler;
             control.OnInvalidated(eventArgs);
@@ -2851,7 +2851,7 @@ namespace System.Windows.Forms.Tests
             control.StyleChanged += (sender, e) => styleChangedCallCount++;
             int createdCallCount = 0;
             control.HandleCreated += (sender, e) => createdCallCount++;
-        
+
             // Call with handler.
             control.Invalidated += handler;
             control.OnInvalidated(eventArgs);
@@ -2859,7 +2859,7 @@ namespace System.Windows.Forms.Tests
             Assert.True(control.IsHandleCreated);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-        
+
             // Remove handler.
             control.Invalidated -= handler;
             control.OnInvalidated(eventArgs);
@@ -2868,7 +2868,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
         }
-        
+
         public static IEnumerable<object[]> OnInvalidated_WithChildrenWithHandle_TestData()
         {
             yield return new object[] { true, Color.Empty, new InvalidateEventArgs(Rectangle.Empty), 0 };
@@ -2933,7 +2933,7 @@ namespace System.Windows.Forms.Tests
             child2.StyleChanged += (sender, e) => styleChangedCallCount2++;
             int createdCallCount2 = 0;
             child2.HandleCreated += (sender, e) => createdCallCount2++;
-        
+
             // Call with handler.
             control.Invalidated += handler;
             control.OnInvalidated(eventArgs);
@@ -2949,7 +2949,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expectedChildInvalidatedCallCount, invalidatedCallCount2);
             Assert.Equal(0, styleChangedCallCount2);
             Assert.Equal(0, createdCallCount2);
-        
+
             // Remove handler.
             control.Invalidated -= handler;
             control.OnInvalidated(eventArgs);
@@ -3307,7 +3307,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, moveCallCount);
             Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
         }
-        
+
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
         public void Control_OnLostFocus_Invoke_CallsLostFocus(EventArgs eventArgs)
@@ -3320,12 +3320,12 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.LostFocus += handler;
             control.OnLostFocus(eventArgs);
             Assert.Equal(1, callCount);
-        
+
            // Remove handler.
            control.LostFocus -= handler;
            control.OnLostFocus(eventArgs);
@@ -3344,18 +3344,18 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.MarginChanged += handler;
             control.OnMarginChanged(eventArgs);
             Assert.Equal(1, callCount);
-        
+
            // Remove handler.
            control.MarginChanged -= handler;
            control.OnMarginChanged(eventArgs);
            Assert.Equal(1, callCount);
         }
-        
+
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
         public void Control_OnMouseCaptureChanged_Invoke_CallsMouseCaptureChanged(EventArgs eventArgs)
@@ -3368,12 +3368,12 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.MouseCaptureChanged += handler;
             control.OnMouseCaptureChanged(eventArgs);
             Assert.Equal(1, callCount);
-        
+
            // Remove handler.
            control.MouseCaptureChanged -= handler;
            control.OnMouseCaptureChanged(eventArgs);
@@ -3819,7 +3819,7 @@ namespace System.Windows.Forms.Tests
                 }
             }
         }
-        
+
         [WinFormsTheory]
         [MemberData(nameof(OnPaintBackground_TestData))]
         public void Control_OnPaintBackground_Invoke_Success(bool supportsTransparentBackColor, Color backColor, Image backgroundImage, ImageLayout backgroundImageLayout)
@@ -3894,7 +3894,7 @@ namespace System.Windows.Forms.Tests
                 yield return new object[] { parent, false, Color.Red, new Bitmap(10, 10, PixelFormat.Format32bppArgb), ImageLayout.Tile, 1 };
             }
         }
-        
+
         [WinFormsTheory]
         [MemberData(nameof(OnPaintBackground_WithParent_TestData))]
         public void Control_OnPaintBackground_InvokeWithParent_CallsPaint(Control parent, bool supportsTransparentBackColor, Color backColor, Image backgroundImage, ImageLayout backgroundImageLayout, int expectedPaintCallCount)
@@ -3944,7 +3944,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expectedPaintCallCount, parentCallCount);
             Assert.False(control.IsHandleCreated);
         }
-        
+
         [WinFormsTheory]
         [MemberData(nameof(OnPaintBackground_TestData))]
         public void Control_OnPaintBackground_InvokeWithHandle_Success(bool supportsTransparentBackColor, Color backColor, Image backgroundImage, ImageLayout backgroundImageLayout)
@@ -4021,7 +4021,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { false, Color.Empty, new Bitmap(10, 10, PixelFormat.Format32bppArgb), ImageLayout.Tile, 1 };
             yield return new object[] { false, Color.Red, new Bitmap(10, 10, PixelFormat.Format32bppArgb), ImageLayout.Tile, 1 };
         }
-        
+
         [WinFormsTheory]
         [MemberData(nameof(OnPaintBackground_WithParentWithHandle_TestData))]
         public void Control_OnPaintBackground_InvokeWithParentWithHandle_CallsPaint(bool supportsTransparentBackColor, Color backColor, Image backgroundImage, ImageLayout backgroundImageLayout, int expectedPaintCallCount)
@@ -5060,7 +5060,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
         }
-        
+
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
         public void Control_OnSystemColorsChanged_InvokeWithChildren_CallsSystemColorsChanged(EventArgs eventArgs)
@@ -5205,12 +5205,12 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.Validating += handler;
             control.OnValidating(eventArgs);
             Assert.Equal(1, callCount);
-        
+
             // Remove handler.
             control.Validating -= handler;
             control.OnValidating(eventArgs);
@@ -5229,12 +5229,12 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.Validated += handler;
             control.OnValidated(eventArgs);
             Assert.Equal(1, callCount);
-        
+
             // Remove handler.
             control.Validated -= handler;
             control.OnValidated(eventArgs);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.cs
@@ -1131,7 +1131,7 @@ namespace System.Windows.Forms.Tests
                 control.Disposed -= handler;
             }
         }
-        
+
         [WinFormsFact]
         public void Control_Dispose_InvokeWithBindings_Success()
         {
@@ -1299,7 +1299,7 @@ namespace System.Windows.Forms.Tests
                 control.Disposed -= handler;
             }
         }
-        
+
         [WinFormsFact]
         public void Control_Dispose_InvokeNotDisposing_Success()
         {
@@ -1506,7 +1506,7 @@ namespace System.Windows.Forms.Tests
                 control.Disposed -= handler;
             }
         }
-        
+
         [WinFormsFact]
         public void Control_Dispose_InvokeNotDisposingWithChildren_Success()
         {
@@ -1620,7 +1620,7 @@ namespace System.Windows.Forms.Tests
                 control.Disposed -= handler;
             }
         }
-        
+
         [WinFormsFact]
         public void Control_Dispose_InvokeNotDisposingWithBindings_Success()
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Properties.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Properties.cs
@@ -28,7 +28,7 @@ namespace System.Windows.Forms.Tests
             Assert.True(control.IsHandleCreated);
             Assert.Same(control, accessibleObject.Owner);
         }
-        
+
         [WinFormsFact]
         public void Control_AccessibilityObject_GetWithHandle_ReturnsExpected()
         {
@@ -92,7 +92,7 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(value, control.AccessibleDefaultActionDescription);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             control.AccessibleDefaultActionDescription = value;
             Assert.Equal(value, control.AccessibleDefaultActionDescription);
@@ -109,7 +109,7 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(value, control.AccessibleDescription);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             control.AccessibleDescription = value;
             Assert.Equal(value, control.AccessibleDescription);
@@ -126,7 +126,7 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(value, control.AccessibleName);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             control.AccessibleName = value;
             Assert.Equal(value, control.AccessibleName);
@@ -143,7 +143,7 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(value, control.AccessibleRole);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             control.AccessibleRole = value;
             Assert.Equal(value, control.AccessibleRole);
@@ -257,7 +257,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
         }
-        
+
         private class CustomDropTarget : Ole32.IDropTarget
         {
             public HRESULT DragEnter([MarshalAs(UnmanagedType.Interface)] object pDataObj, uint grfKeyState, Point pt, ref uint pdwEffect)
@@ -539,12 +539,12 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { AnchorStyles.Bottom, AnchorStyles.Bottom, AnchorStyles.Bottom, 0, 0 };
             yield return new object[] { AnchorStyles.Left, AnchorStyles.Bottom, AnchorStyles.Bottom, 1, 1 };
             yield return new object[] { AnchorStyles.Right, AnchorStyles.Bottom, AnchorStyles.Bottom, 1, 1 };
-            
+
             yield return new object[] { AnchorStyles.Top, AnchorStyles.Left, AnchorStyles.Left, 1, 1 };
             yield return new object[] { AnchorStyles.Bottom, AnchorStyles.Left, AnchorStyles.Left, 1, 1 };
             yield return new object[] { AnchorStyles.Left, AnchorStyles.Left, AnchorStyles.Left, 0, 0 };
             yield return new object[] { AnchorStyles.Right, AnchorStyles.Left, AnchorStyles.Left, 1, 1 };
-            
+
             yield return new object[] { AnchorStyles.Top, AnchorStyles.Right, AnchorStyles.Right, 1, 1 };
             yield return new object[] { AnchorStyles.Bottom, AnchorStyles.Right, AnchorStyles.Right, 1, 1 };
             yield return new object[] { AnchorStyles.Left, AnchorStyles.Right, AnchorStyles.Right, 1, 1 };
@@ -617,12 +617,12 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { AnchorStyles.Bottom, AnchorStyles.Top | AnchorStyles.Bottom, AnchorStyles.Top | AnchorStyles.Bottom, 1, 1, 0, 0 };
             yield return new object[] { AnchorStyles.Left, AnchorStyles.Top | AnchorStyles.Bottom, AnchorStyles.Top | AnchorStyles.Bottom, 1, 1, 0, 0 };
             yield return new object[] { AnchorStyles.Right, AnchorStyles.Top | AnchorStyles.Bottom, AnchorStyles.Top | AnchorStyles.Bottom, 1, 1, 1, 1 };
-            
+
             yield return new object[] { AnchorStyles.Top, AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left, AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left, 1, 1, 0, 0 };
             yield return new object[] { AnchorStyles.Bottom, AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left, AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left, 1, 1, 0, 0 };
             yield return new object[] { AnchorStyles.Left, AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left, AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left, 1, 1, 0, 0 };
             yield return new object[] { AnchorStyles.Right, AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left, AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left, 1, 1, 1, 1 };
-            
+
             yield return new object[] { AnchorStyles.Top, AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left, AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left, 1, 1, 0, 0 };
             yield return new object[] { AnchorStyles.Bottom, AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left, AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left, 1, 1, 0, 0 };
             yield return new object[] { AnchorStyles.Left, AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left, AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left, 1, 1, 0, 0 };
@@ -657,12 +657,12 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { AnchorStyles.Bottom, AnchorStyles.Bottom, AnchorStyles.Bottom, 0, 0, 0, 0 };
             yield return new object[] { AnchorStyles.Left, AnchorStyles.Bottom, AnchorStyles.Bottom, 1, 1, 0, 0 };
             yield return new object[] { AnchorStyles.Right, AnchorStyles.Bottom, AnchorStyles.Bottom, 1, 1, 1, 1 };
-            
+
             yield return new object[] { AnchorStyles.Top, AnchorStyles.Left, AnchorStyles.Left, 1, 1, 0, 0 };
             yield return new object[] { AnchorStyles.Bottom, AnchorStyles.Left, AnchorStyles.Left, 1, 1, 1, 1 };
             yield return new object[] { AnchorStyles.Left, AnchorStyles.Left, AnchorStyles.Left, 0, 0, 0, 0 };
             yield return new object[] { AnchorStyles.Right, AnchorStyles.Left, AnchorStyles.Left, 1, 1, 1, 1 };
-            
+
             yield return new object[] { AnchorStyles.Top, AnchorStyles.Right, AnchorStyles.Right, 1, 1, 0, 0 };
             yield return new object[] { AnchorStyles.Bottom, AnchorStyles.Right, AnchorStyles.Right, 1, 1, 1, 1 };
             yield return new object[] { AnchorStyles.Left, AnchorStyles.Right, AnchorStyles.Right, 1, 1, 0, 0 };
@@ -859,7 +859,7 @@ namespace System.Windows.Forms.Tests
                 parent.Layout -= parentHandler;
             }
         }
-        
+
         [WinFormsTheory]
         [MemberData(nameof(Anchor_Set_TestData))]
         public void Control_Anchor_SetWithHandle_GetReturnsExpected(AnchorStyles value, AnchorStyles expected)
@@ -2144,7 +2144,7 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Same(bindingContext, control.BindingContext);
         }
-        
+
         [WinFormsFact]
         public void Control_BindingContext_GetWithParentCantAccessProperties_ReturnsExpected()
         {
@@ -3126,12 +3126,12 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(value, control.Capture);
             Assert.Equal(value, control.IsHandleCreated);
-            
+
             // Set same.
             control.Capture = value;
             Assert.Equal(value, control.Capture);
             Assert.Equal(value, control.IsHandleCreated);
-            
+
             // Set different.
             control.Capture = !value;
             Assert.Equal(!value, control.Capture);
@@ -3157,7 +3157,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set same.
             control.Capture = value;
             Assert.Equal(value, control.Capture);
@@ -3165,7 +3165,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set different.
             control.Capture = !value;
             Assert.Equal(!value, control.Capture);
@@ -3653,7 +3653,6 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.IsHandleCreated);
         }
 
-
         private class CustomCreateControlsInstanceControl : Control
         {
             public Control.ControlCollection CreateControlsResult { get; set; }
@@ -3695,7 +3694,7 @@ namespace System.Windows.Forms.Tests
             control.Cursor = cursor2;
             Assert.Same(cursor2, control.Cursor);
         }
-        
+
         [WinFormsFact]
         public void Control_Cursor_GetWithParentCantAccessProperties_ReturnsExpected()
         {
@@ -4080,7 +4079,7 @@ namespace System.Windows.Forms.Tests
             using var control = new Control();
             int layoutCallCount = 0;
             control.Layout += (sender, e) => layoutCallCount++;
-            
+
             control.Dock = value;
             Assert.Equal(value, control.Dock);
             Assert.Equal(AnchorStyles.Top | AnchorStyles.Left, control.Anchor);
@@ -4129,7 +4128,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { DockStyle.Right, 1 };
             yield return new object[] { DockStyle.Top, 1 };
         }
-        
+
         [WinFormsTheory]
         [MemberData(nameof(Dock_SetWithParent_TestData))]
         public void Control_Dock_SetWithParent_GetReturnsExpected(DockStyle value, int expectedParentLayoutCallCount)
@@ -4150,7 +4149,7 @@ namespace System.Windows.Forms.Tests
                 parentLayoutCallCount++;
             }
             parent.Layout += parentHandler;
-            
+
             try
             {
                 control.Dock = value;
@@ -4182,35 +4181,35 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { DockStyle.None, DockStyle.Bottom, 1 };
             yield return new object[] { DockStyle.Right, DockStyle.Bottom, 1 };
             yield return new object[] { DockStyle.Top, DockStyle.Bottom, 1 };
-            
+
             yield return new object[] { DockStyle.Bottom, DockStyle.Fill, 1 };
             yield return new object[] { DockStyle.Fill, DockStyle.Fill, 0 };
             yield return new object[] { DockStyle.Left, DockStyle.Fill, 1 };
             yield return new object[] { DockStyle.None, DockStyle.Fill, 1 };
             yield return new object[] { DockStyle.Right, DockStyle.Fill, 1 };
             yield return new object[] { DockStyle.Top, DockStyle.Fill, 1 };
-            
+
             yield return new object[] { DockStyle.Bottom, DockStyle.Left, 1 };
             yield return new object[] { DockStyle.Fill, DockStyle.Left, 1 };
             yield return new object[] { DockStyle.Left, DockStyle.Left, 0 };
             yield return new object[] { DockStyle.None, DockStyle.Left, 1 };
             yield return new object[] { DockStyle.Right, DockStyle.Left, 1 };
             yield return new object[] { DockStyle.Top, DockStyle.Left, 1 };
-            
+
             yield return new object[] { DockStyle.Bottom, DockStyle.None, 1 };
             yield return new object[] { DockStyle.Fill, DockStyle.None, 1 };
             yield return new object[] { DockStyle.Left, DockStyle.None, 1 };
             yield return new object[] { DockStyle.None, DockStyle.None, 0 };
             yield return new object[] { DockStyle.Right, DockStyle.None, 1 };
             yield return new object[] { DockStyle.Top, DockStyle.None, 1 };
-            
+
             yield return new object[] { DockStyle.Bottom, DockStyle.Right, 1 };
             yield return new object[] { DockStyle.Fill, DockStyle.Right, 1 };
             yield return new object[] { DockStyle.Left, DockStyle.Right, 1 };
             yield return new object[] { DockStyle.None, DockStyle.Right, 1 };
             yield return new object[] { DockStyle.Right, DockStyle.Right, 0 };
             yield return new object[] { DockStyle.Top, DockStyle.Right, 1 };
-            
+
             yield return new object[] { DockStyle.Bottom, DockStyle.Top, 1 };
             yield return new object[] { DockStyle.Fill, DockStyle.Top, 1 };
             yield return new object[] { DockStyle.Left, DockStyle.Top, 1 };
@@ -4218,7 +4217,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { DockStyle.Right, DockStyle.Top, 1 };
             yield return new object[] { DockStyle.Top, DockStyle.Top, 0 };
         }
-        
+
         [WinFormsTheory]
         [MemberData(nameof(Control_Dock_SetWithOldValueWithParent_TestData))]
         public void Control_Dock_SetWithOldValueWithParent_GetReturnsExpected(DockStyle oldValue, DockStyle value, int expectedParentLayoutCallCount)
@@ -4240,7 +4239,7 @@ namespace System.Windows.Forms.Tests
                 parentLayoutCallCount++;
             }
             parent.Layout += parentHandler;
-            
+
             try
             {
                 control.Dock = value;
@@ -4308,7 +4307,7 @@ namespace System.Windows.Forms.Tests
             control.HandleCreated += (sender, e) => createdCallCount++;
             int layoutCallCount = 0;
             control.Layout += (sender, e) => layoutCallCount++;
-            
+
             control.Dock = value;
             Assert.Equal(value, control.Dock);
             Assert.Equal(AnchorStyles.Top | AnchorStyles.Left, control.Anchor);
@@ -4762,7 +4761,7 @@ namespace System.Windows.Forms.Tests
             control.Font = font2;
             Assert.Same(font2, control.Font);
         }
-        
+
         [WinFormsFact]
         public void Control_Font_GetWithParentCantAccessProperties_ReturnsExpected()
         {
@@ -6538,12 +6537,12 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(value, control.IsAccessible);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             control.IsAccessible = value;
             Assert.Equal(value, control.IsAccessible);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set different.
             control.IsAccessible = !value;
             Assert.Equal(!value, control.IsAccessible);
@@ -6555,7 +6554,7 @@ namespace System.Windows.Forms.Tests
         {
             using var control = new Control();
             Assert.False(control.IsMirrored);
-            
+
             // Call again to test caching behavior.
             Assert.False(control.IsMirrored);
         }
@@ -6565,7 +6564,7 @@ namespace System.Windows.Forms.Tests
         {
             using var control = new RightToLeftControl();
             Assert.True(control.IsMirrored);
-            
+
             // Call again to test caching behavior.
             Assert.True(control.IsMirrored);
         }
@@ -6576,7 +6575,7 @@ namespace System.Windows.Forms.Tests
             using var control = new RightToLeftControl();
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             Assert.True(control.IsMirrored);
-            
+
             // Call again to test caching behavior.
             Assert.True(control.IsMirrored);
         }
@@ -6587,7 +6586,7 @@ namespace System.Windows.Forms.Tests
             using var control = new Control();
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             Assert.False(control.IsMirrored);
-            
+
             // Call again to test caching behavior.
             Assert.False(control.IsMirrored);
         }
@@ -10044,7 +10043,7 @@ namespace System.Windows.Forms.Tests
             control.RightToLeft = RightToLeft.Inherit;
             Assert.Equal(RightToLeft.No, control.RightToLeft);
             Assert.False(property.CanResetValue(control));
-            
+
             control.RightToLeft = RightToLeft.No;
             Assert.Equal(RightToLeft.No, control.RightToLeft);
             Assert.True(property.CanResetValue(control));
@@ -10072,7 +10071,7 @@ namespace System.Windows.Forms.Tests
             control.RightToLeft = RightToLeft.Inherit;
             Assert.Equal(RightToLeft.No, control.RightToLeft);
             Assert.False(property.ShouldSerializeValue(control));
-            
+
             control.RightToLeft = RightToLeft.No;
             Assert.Equal(RightToLeft.No, control.RightToLeft);
             Assert.True(property.ShouldSerializeValue(control));
@@ -10089,7 +10088,7 @@ namespace System.Windows.Forms.Tests
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             Assert.False(control.ShowFocusCues);
         }
-        
+
         [WinFormsTheory]
         [InlineData((int)User32.UIS.CLEAR | ((int)User32.UISF.ACTIVE << 16), false)]
         [InlineData((int)User32.UIS.CLEAR | ((int)User32.UISF.HIDEACCEL << 16), false)]
@@ -10110,7 +10109,7 @@ namespace System.Windows.Forms.Tests
             User32.SendMessageW(control.Handle, User32.WindowMessage.WM_UPDATEUISTATE, (IntPtr)wParam, IntPtr.Zero);
             Assert.Equal(expected, control.ShowFocusCues);
         }
-        
+
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void Control_ShowFocusCues_GetWithSiteWithHandle_ReturnsExpected(bool designMode)
@@ -10132,7 +10131,7 @@ namespace System.Windows.Forms.Tests
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             Assert.False(control.ShowFocusCues);
         }
-        
+
         [WinFormsFact]
         public void Control_ShowKeyboardCues_GetWithHandle_ReturnsExpected()
         {
@@ -10140,7 +10139,7 @@ namespace System.Windows.Forms.Tests
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             Assert.False(control.ShowKeyboardCues);
         }
-        
+
         [WinFormsTheory]
         [InlineData((int)User32.UIS.CLEAR | ((int)User32.UISF.ACTIVE << 16), false)]
         [InlineData((int)User32.UIS.CLEAR | ((int)User32.UISF.HIDEACCEL << 16), true)]
@@ -10161,7 +10160,7 @@ namespace System.Windows.Forms.Tests
             User32.SendMessageW(control.Handle, User32.WindowMessage.WM_UPDATEUISTATE, (IntPtr)wParam, IntPtr.Zero);
             Assert.Equal(expected, control.ShowKeyboardCues);
         }
-        
+
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void Control_ShowKeyboardCues_GetWithSiteWithHandle_ReturnsExpected(bool designMode)
@@ -11620,7 +11619,7 @@ namespace System.Windows.Forms.Tests
             control.Text = null;
             Assert.Empty(control.Text);
             Assert.False(property.CanResetValue(control));
-            
+
             // Set empty.
             control.Text = string.Empty;
             Assert.Empty(control.Text);
@@ -11647,7 +11646,7 @@ namespace System.Windows.Forms.Tests
             control.Text = null;
             Assert.Empty(control.Text);
             Assert.False(property.ShouldSerializeValue(control));
-            
+
             // Set empty.
             control.Text = string.Empty;
             Assert.Empty(control.Text);
@@ -12176,18 +12175,18 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(value, control.UseWaitCursor);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             control.UseWaitCursor = value;
             Assert.Equal(value, control.UseWaitCursor);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set different.
             control.UseWaitCursor = !value;
             Assert.Equal(!value, control.UseWaitCursor);
             Assert.False(control.IsHandleCreated);
         }
-        
+
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void Control_UseWaitCursor_SetWithChildren_GetReturnsExpected(bool value)
@@ -12197,20 +12196,20 @@ namespace System.Windows.Forms.Tests
             using var child2 = new Control();
             control.Controls.Add(child1);
             control.Controls.Add(child2);
-            
+
             control.UseWaitCursor = value;
             Assert.Equal(value, control.UseWaitCursor);
             Assert.Equal(value, child1.UseWaitCursor);
             Assert.Equal(value, child2.UseWaitCursor);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             control.UseWaitCursor = value;
             Assert.Equal(value, control.UseWaitCursor);
             Assert.Equal(value, child1.UseWaitCursor);
             Assert.Equal(value, child2.UseWaitCursor);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set different.
             control.UseWaitCursor = !value;
             Assert.Equal(!value, control.UseWaitCursor);
@@ -12218,7 +12217,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(!value, child2.UseWaitCursor);
             Assert.False(control.IsHandleCreated);
         }
-        
+
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void Control_UseWaitCursor_SetWithHandle_GetReturnsExpected(bool value)
@@ -12238,7 +12237,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set same.
             control.UseWaitCursor = value;
             Assert.Equal(value, control.UseWaitCursor);
@@ -12246,7 +12245,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set different.
             control.UseWaitCursor = !value;
             Assert.Equal(!value, control.UseWaitCursor);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowTests.cs
@@ -3471,7 +3471,6 @@ namespace System.Windows.Forms.Tests
             row.Cells.Add(new CantSetDataGridViewCell());
             Assert.False(row.SetValues(new object[] { 1 }));
             Assert.Null(Assert.Single(row.Cells.Cast<DataGridViewCell>()).Value);
-
         }
 
         private class CantSetDataGridViewCell : DataGridViewCell

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSelectedRowCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSelectedRowCollectionTests.cs
@@ -372,7 +372,7 @@ namespace System.Windows.Forms.Tests
             Assert.False(iList.Contains(new DataGridViewRow()));
             Assert.False(iList.Contains(null));
         }
-        
+
         [WinFormsFact]
         public void DataGridViewSelectedRowCollection_IListGetEnumerator_InvokeEmpty_Success()
         {
@@ -391,7 +391,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Throws<InvalidOperationException>(() => enumerator.Current);
             }
         }
-        
+
         [WinFormsFact]
         public void DataGridViewSelectedRowCollection_IListGetEnumerator_InvokeNotEmpty_Success()
         {
@@ -413,10 +413,10 @@ namespace System.Windows.Forms.Tests
 
                 Assert.True(enumerator.MoveNext());
                 Assert.Same(control.Rows[2], enumerator.Current);
-                
+
                 Assert.True(enumerator.MoveNext());
                 Assert.Same(control.Rows[0], enumerator.Current);
-    
+
                 Assert.False(enumerator.MoveNext());
                 Assert.Throws<InvalidOperationException>(() => enumerator.Current);
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
@@ -1,6 +1,6 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.	
-// The .NET Foundation licenses this file to you under the MIT license.	
-// See the LICENSE file in the project root for more information.	
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -191,7 +191,7 @@ namespace System.Windows.Forms.Tests
             var dataObject = new DataObject();
             Assert.Null(dataObject.GetAudioStream());
         }
-        
+
         public static IEnumerable<object[]> GetAudioStream_TestData()
         {
             yield return new object[] { null, null };
@@ -523,7 +523,6 @@ namespace System.Windows.Forms.Tests
             mockDataObject.Verify(o => o.GetDataPresent(format, autoConvert), Times.Once());
         }
 
-
         [Theory]
         [InlineData(typeof(int))]
         [InlineData(null)]
@@ -564,7 +563,7 @@ namespace System.Windows.Forms.Tests
             var dataObject = new DataObject();
             Assert.Empty(dataObject.GetFileDropList());
         }
-        
+
         public static IEnumerable<object[]> GetFileDropList_TestData()
         {
             yield return new object[] { null, Array.Empty<string>() };
@@ -689,7 +688,7 @@ namespace System.Windows.Forms.Tests
             var dataObject = new DataObject();
             Assert.Null(dataObject.GetImage());
         }
-        
+
         public static IEnumerable<object[]> GetImage_TestData()
         {
             yield return new object[] { null, null };
@@ -771,7 +770,7 @@ namespace System.Windows.Forms.Tests
             var dataObject = new DataObject();
             Assert.Empty(dataObject.GetText(format));
         }
-        
+
         public static IEnumerable<object[]> GetText_TextDataFormat_TestData()
         {
             yield return new object[] { TextDataFormat.Text, DataFormats.UnicodeText, null, string.Empty };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/ComponentEditorPageTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/ComponentEditorPageTests.cs
@@ -855,7 +855,7 @@ namespace System.Windows.Forms.Design.Tests
         {
             using var control = new SubComponentEditorPage();
             Assert.False(control.SupportsHelp());
-            
+
             // Call again.
             Assert.False(control.SupportsHelp());
         }
@@ -969,7 +969,7 @@ namespace System.Windows.Forms.Design.Tests
             public new void EnterLoadingMode() => base.EnterLoadingMode();
 
             public new void ExitLoadingMode() => base.ExitLoadingMode();
-            
+
             public new AutoSizeMode GetAutoSizeMode() => base.GetAutoSizeMode();
 
             public new Control GetControl() => base.GetControl();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DrawListViewSubItemEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DrawListViewSubItemEventArgsTests.cs
@@ -148,7 +148,7 @@ namespace System.Windows.Forms.Tests
 /*
         public static IEnumerable<object[]> _TestData()
         {
-            
+
         }
 
         public static IEnumerable<object[]> DrawText_HasGraphicsWithoutFlags_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProviderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProviderTests.cs
@@ -129,7 +129,7 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(value, provider.BlinkStyle);
             Assert.Equal(250, provider.BlinkRate);
-            
+
             // Set same.
             provider.BlinkStyle = value;
             Assert.Equal(value, provider.BlinkStyle);
@@ -148,7 +148,7 @@ namespace System.Windows.Forms.Tests
             provider.BlinkStyle = value;
             Assert.Equal(value, provider.BlinkStyle);
             Assert.Equal(250, provider.BlinkRate);
-            
+
             // Set same.
             provider.BlinkStyle = value;
             Assert.Equal(value, provider.BlinkStyle);
@@ -166,7 +166,7 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(ErrorBlinkStyle.NeverBlink, provider.BlinkStyle);
             Assert.Equal(0, provider.BlinkRate);
-            
+
             // Set same.
             provider.BlinkStyle = value;
             Assert.Equal(ErrorBlinkStyle.NeverBlink, provider.BlinkStyle);
@@ -229,7 +229,7 @@ namespace System.Windows.Forms.Tests
                 DataMember = value
             };
             Assert.Equal(expected, provider.DataMember);
-            
+
             // Set same.
             provider.DataMember = value;
             Assert.Equal(expected, provider.DataMember);
@@ -246,7 +246,7 @@ namespace System.Windows.Forms.Tests
 
             provider.DataMember = value;
             Assert.Equal(expected, provider.DataMember);
-            
+
             // Set same.
             provider.DataMember = value;
             Assert.Equal(expected, provider.DataMember);
@@ -593,11 +593,11 @@ namespace System.Windows.Forms.Tests
                 RightToLeft = value
             };
             Assert.Equal(value, provider.RightToLeft);
-            
+
             // Set same.
             provider.RightToLeft = value;
             Assert.Equal(value, provider.RightToLeft);
-            
+
             // Set different.
             provider.RightToLeft = !value;
             Assert.Equal(!value, provider.RightToLeft);
@@ -618,22 +618,22 @@ namespace System.Windows.Forms.Tests
                 callCount++;
             };
             provider.RightToLeftChanged += handler;
-        
+
             // Set different.
             provider.RightToLeft = false;
             Assert.False(provider.RightToLeft);
             Assert.Equal(1, callCount);
-        
+
             // Set same.
             provider.RightToLeft = false;
             Assert.False(provider.RightToLeft);
             Assert.Equal(1, callCount);
-        
+
             // Set different.
             provider.RightToLeft = true;
             Assert.True(provider.RightToLeft);
             Assert.Equal(2, callCount);
-        
+
             // Remove handler.
             provider.RightToLeftChanged -= handler;
             provider.RightToLeft = false;
@@ -671,7 +671,7 @@ namespace System.Windows.Forms.Tests
                 Site = value
             };
             Assert.Same(value, provider.Site);
-            
+
             // Set same.
             provider.Site = value;
             Assert.Same(value, provider.Site);
@@ -692,7 +692,7 @@ namespace System.Windows.Forms.Tests
 
             provider.Site = value;
             Assert.Same(value, provider.Site);
-            
+
             // Set same.
             provider.Site = value;
             Assert.Same(value, provider.Site);
@@ -741,7 +741,7 @@ namespace System.Windows.Forms.Tests
                 Tag = value
             };
             Assert.Same(value, provider.Tag);
-            
+
             // Set same.
             provider.Tag = value;
             Assert.Same(value, provider.Tag);
@@ -777,7 +777,7 @@ namespace System.Windows.Forms.Tests
             Assert.Same(newDataSource, provider.DataSource);
             Assert.Same(newDataMember, provider.DataMember);
         }
-        
+
         public static IEnumerable<object[]> BindToDataAndErrors_WithBindingContext_TestData()
         {
             foreach (string dataMember in new string[] { null, string.Empty })
@@ -996,12 +996,12 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             provider.RightToLeftChanged += handler;
             provider.OnRightToLeftChanged(eventArgs);
             Assert.Equal(1, callCount);
-        
+
            // Remove handler.
            provider.RightToLeftChanged -= handler;
            provider.OnRightToLeftChanged(eventArgs);
@@ -1135,7 +1135,7 @@ namespace System.Windows.Forms.Tests
                 // Call event properties - without handle.
                 control.Location = new Point(1, 2);
                 Assert.Equal(new Point(1, 2), control.Location);
-                
+
                 control.Size = new Size(2, 3);
                 Assert.Equal(new Size(2, 3), control.Size);
 
@@ -1167,7 +1167,7 @@ namespace System.Windows.Forms.Tests
 
                 control.Location = new Point(2, 3);
                 Assert.Equal(new Point(2, 3), control.Location);
-                
+
                 control.Size = new Size(4, 5);
                 Assert.Equal(new Size(4, 5), control.Size);
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FlowLayoutSettingsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FlowLayoutSettingsTests.cs
@@ -1,5 +1,4 @@
-﻿
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FontDialogTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FontDialogTests.cs
@@ -735,12 +735,12 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             dialog.Apply += handler;
             dialog.OnApply(eventArgs);
             Assert.Equal(1, callCount);
-        
+
             // Remove handler.
             dialog.Apply -= handler;
             dialog.OnApply(eventArgs);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
@@ -1870,13 +1870,13 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.HandleCreated += handler;
             control.OnHandleCreated(eventArgs);
             Assert.Equal(1, callCount);
             Assert.False(control.IsHandleCreated);
-        
+
             // Remove handler.
             control.HandleCreated -= handler;
             control.OnHandleCreated(eventArgs);
@@ -1897,13 +1897,13 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.HandleCreated += handler;
             control.OnHandleCreated(eventArgs);
             Assert.Equal(1, callCount);
             Assert.True(control.IsHandleCreated);
-        
+
             // Remove handler.
             control.HandleCreated -= handler;
             control.OnHandleCreated(eventArgs);
@@ -1922,13 +1922,13 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.HandleDestroyed += handler;
             control.OnHandleDestroyed(eventArgs);
             Assert.Equal(1, callCount);
             Assert.False(control.IsHandleCreated);
-        
+
             // Remove handler.
             control.HandleDestroyed -= handler;
             control.OnHandleDestroyed(eventArgs);
@@ -1949,13 +1949,13 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.HandleDestroyed += handler;
             control.OnHandleDestroyed(eventArgs);
             Assert.Equal(1, callCount);
             Assert.True(control.IsHandleCreated);
-        
+
             // Remove handler.
             control.HandleDestroyed -= handler;
             control.OnHandleDestroyed(eventArgs);
@@ -1966,7 +1966,7 @@ namespace System.Windows.Forms.Tests
         private class SubForm : Form
         {
             public new void OnHandleCreated(EventArgs e) => base.OnHandleCreated(e);
-            
+
             public new void OnHandleDestroyed(EventArgs e) => base.OnHandleDestroyed(e);
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/GroupBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/GroupBoxTests.cs
@@ -600,7 +600,7 @@ namespace System.Windows.Forms.Tests
         {
             using var control = new SubGroupBox();
             control.SetStyle(ControlStyles.ContainerControl, false);
-            
+
             control.FlatStyle = value;
             Assert.Equal(value, control.FlatStyle);
             Assert.Equal(containerControl, control.GetStyle(ControlStyles.ContainerControl));
@@ -609,7 +609,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(ownerDraw, control.GetStyle(ControlStyles.ResizeRedraw));
             Assert.Equal(userMouse, control.GetStyle(ControlStyles.UserMouse));
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             control.FlatStyle = value;
             Assert.Equal(value, control.FlatStyle);
@@ -654,7 +654,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(ownerDraw, control.GetStyle(ControlStyles.ResizeRedraw));
             Assert.Equal(userMouse, control.GetStyle(ControlStyles.UserMouse));
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             control.FlatStyle = value;
             Assert.Equal(containerControl, control.GetStyle(ControlStyles.ContainerControl));
@@ -694,7 +694,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(expectedCreatedCallCount, createdCallCount);
-            
+
             // Set same.
             control.FlatStyle = value;
             Assert.Equal(value, control.FlatStyle);
@@ -751,7 +751,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
                 Assert.Equal(0, styleChangedCallCount);
                 Assert.Equal(expectedCreatedCallCount, createdCallCount);
-                
+
                 // Set same.
                 control.FlatStyle = value;
                 Assert.Equal(value, control.FlatStyle);
@@ -1177,12 +1177,12 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(value, control.UseCompatibleTextRendering);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             control.UseCompatibleTextRendering = value;
             Assert.Equal(value, control.UseCompatibleTextRendering);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set different.
             control.UseCompatibleTextRendering = !value;
             Assert.Equal(!value, control.UseCompatibleTextRendering);
@@ -1221,14 +1221,14 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, layoutCallCount);
                 Assert.Equal(expectedParentLayoutCallCount1, parentLayoutCallCount);
                 Assert.False(control.IsHandleCreated);
-                
+
                 // Set same.
                 control.UseCompatibleTextRendering = value;
                 Assert.Equal(value, control.UseCompatibleTextRendering);
                 Assert.Equal(0, layoutCallCount);
                 Assert.Equal(expectedParentLayoutCallCount1, parentLayoutCallCount);
                 Assert.False(control.IsHandleCreated);
-                
+
                 // Set different.
                 control.UseCompatibleTextRendering = !value;
                 Assert.Equal(!value, control.UseCompatibleTextRendering);
@@ -1267,7 +1267,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set same.
             control.UseCompatibleTextRendering = value;
             Assert.Equal(value, control.UseCompatibleTextRendering);
@@ -1275,7 +1275,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-    
+
             // Set different.
             control.UseCompatibleTextRendering = !value;
             Assert.Equal(!value, control.UseCompatibleTextRendering);
@@ -1327,7 +1327,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
                 Assert.Equal(0, styleChangedCallCount);
                 Assert.Equal(0, createdCallCount);
-    
+
                 // Set same.
                 control.UseCompatibleTextRendering = value;
                 Assert.Equal(value, control.UseCompatibleTextRendering);
@@ -1337,7 +1337,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
                 Assert.Equal(0, styleChangedCallCount);
                 Assert.Equal(0, createdCallCount);
-                
+
                 // Set different.
                 control.UseCompatibleTextRendering = !value;
                 Assert.Equal(!value, control.UseCompatibleTextRendering);
@@ -2320,7 +2320,7 @@ namespace System.Windows.Forms.Tests
             public new void OnKeyUp(KeyEventArgs e) => base.OnKeyUp(e);
 
             public new void OnMouseClick(MouseEventArgs e) => base.OnMouseClick(e);
-            
+
             public new void OnMouseDoubleClick(MouseEventArgs e) => base.OnMouseDoubleClick(e);
 
             public new void OnMouseDown(MouseEventArgs e) => base.OnMouseDown(e);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HScrollBarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HScrollBarTests.cs
@@ -199,7 +199,7 @@ namespace System.Windows.Forms.Tests
             var control = new SubHScrollBar();
             Assert.Throws<InvalidEnumArgumentException>("value", () => control.RightToLeft = value);
         }
-        
+
         [WinFormsFact]
         public void HScrollBar_GetAutoSizeMode_Invoke_ReturnsExpected()
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageList.ImageCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageList.ImageCollectionTests.cs
@@ -845,7 +845,6 @@ namespace System.Windows.Forms.Tests
                 var bitmap = new Bitmap(16, 16);
                 bitmap.SetPixel(0, 0, Color.FromArgb(0x12, 0x34, 0x56, 0x78));
                 yield return new object[] { transparentColor, bitmap, 1 };
-
             }
         }
 
@@ -887,7 +886,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(Enumerable.Repeat(string.Empty, expectedCount), collection.Keys.Cast<string>());
             Assert.True(list.HandleCreated);
         }
-        
+
         [WinFormsFact]
         public void ImageCollection_AddStrip_NullValue_ThrowsArgumentNullException()
         {
@@ -933,7 +932,7 @@ namespace System.Windows.Forms.Tests
             Assert.True(collection.Empty);
 #pragma warning restore xUnit2013
             Assert.False(list.HandleCreated);
-            
+
             // Clear again.
             collection.Clear();
             Assert.Empty(collection);
@@ -959,7 +958,7 @@ namespace System.Windows.Forms.Tests
             Assert.True(collection.Empty);
 #pragma warning restore xUnit2013
             Assert.False(list.HandleCreated);
-            
+
             // Clear again.
             collection.Clear();
             Assert.Empty(collection);
@@ -984,7 +983,7 @@ namespace System.Windows.Forms.Tests
             Assert.True(collection.Empty);
 #pragma warning restore xUnit2013
             Assert.True(list.HandleCreated);
-            
+
             // Clear again.
             collection.Clear();
             Assert.Empty(collection);
@@ -1011,7 +1010,7 @@ namespace System.Windows.Forms.Tests
             Assert.True(collection.Empty);
 #pragma warning restore xUnit2013
             Assert.True(list.HandleCreated);
-            
+
             // Clear again.
             collection.Clear();
             Assert.Empty(collection);
@@ -1094,11 +1093,11 @@ namespace System.Windows.Forms.Tests
 
                 Assert.False(enumerator.MoveNext());
                 Assert.Throws<InvalidOperationException>(() => enumerator.Current);
-                
+
                 enumerator.Reset();
             }
         }
-        
+
         [WinFormsFact]
         public void ImageListCollection_GetEnumerator_InvokeWithHandleEmpty_Success()
         {
@@ -1114,11 +1113,11 @@ namespace System.Windows.Forms.Tests
 
                 Assert.False(enumerator.MoveNext());
                 Assert.Throws<InvalidOperationException>(() => enumerator.Current);
-                
+
                 enumerator.Reset();
             }
         }
-        
+
         [WinFormsFact]
         public void ImageListCollection_GetEnumerator_InvokeWithoutHandleNotEmpty_Success()
         {
@@ -1142,20 +1141,20 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(new Size(16, 16), result1.Size);
                 Assert.Equal(PixelFormat.Format32bppArgb, result1.PixelFormat);
                 Assert.Equal(((Bitmap)collection[0]).GetPixel(0, 0), result1.GetPixel(0, 0));
-                
+
                 Assert.True(enumerator.MoveNext());
                 Bitmap result2 = Assert.IsType<Bitmap>(enumerator.Current);
                 Assert.Equal(new Size(16, 16), result2.Size);
                 Assert.Equal(PixelFormat.Format32bppArgb, result2.PixelFormat);
                 Assert.Equal(((Bitmap)collection[1]).GetPixel(0, 0), result2.GetPixel(0, 0));
-                
+
                 Assert.False(enumerator.MoveNext());
                 Assert.Throws<InvalidOperationException>(() => enumerator.Current);
 
                 enumerator.Reset();
             }
         }
-        
+
         [WinFormsFact]
         public void ImageListCollection_GetEnumerator_InvokeWithHandleNotEmpty_Success()
         {
@@ -1180,13 +1179,13 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(new Size(16, 16), result1.Size);
                 Assert.Equal(PixelFormat.Format32bppArgb, result1.PixelFormat);
                 Assert.Equal(((Bitmap)collection[0]).GetPixel(0, 0), result1.GetPixel(0, 0));
-                
+
                 Assert.True(enumerator.MoveNext());
                 Bitmap result2 = Assert.IsType<Bitmap>(enumerator.Current);
                 Assert.Equal(new Size(16, 16), result2.Size);
                 Assert.Equal(PixelFormat.Format32bppArgb, result2.PixelFormat);
                 Assert.Equal(((Bitmap)collection[1]).GetPixel(0, 0), result2.GetPixel(0, 0));
-                
+
                 Assert.False(enumerator.MoveNext());
                 Assert.Throws<InvalidOperationException>(() => enumerator.Current);
 
@@ -1394,7 +1393,7 @@ namespace System.Windows.Forms.Tests
             Assert.True(list.HandleCreated);
             Assert.Equal(2, collection.Count);
             Assert.False(collection.Empty);
-            
+
             // Call again.
             collection.RemoveByKey("image2");
             Assert.True(list.HandleCreated);
@@ -1444,7 +1443,7 @@ namespace System.Windows.Forms.Tests
             Assert.False(collection.Empty);
             Assert.Equal(color1, ((Bitmap)collection[0]).GetPixel(0, 0));
             Assert.Equal(color3, ((Bitmap)collection[1]).GetPixel(0, 0));
-            
+
             // Call again.
             collection.RemoveByKey("image2");
             Assert.True(list.HandleCreated);
@@ -1500,7 +1499,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(color1, ((Bitmap)collection[0]).GetPixel(0, 0));
             Assert.Equal(color2, ((Bitmap)collection[1]).GetPixel(0, 0));
             Assert.Equal(color3, ((Bitmap)collection[2]).GetPixel(0, 0));
-            
+
             // Call again.
             collection.RemoveByKey(key);
             Assert.True(list.HandleCreated);
@@ -1516,7 +1515,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { 0, null, new string[] { string.Empty, string.Empty } };
             yield return new object[] { 0, string.Empty, new string[] { string.Empty, string.Empty } };
             yield return new object[] { 0, "name", new string[] { "name", string.Empty } };
-            
+
             yield return new object[] { 1, null, new string[] { "KeyName", string.Empty } };
             yield return new object[] { 1, string.Empty, new string[] { "KeyName", string.Empty } };
             yield return new object[] { 1, "name", new string[] { "KeyName", "name" } };
@@ -1536,7 +1535,7 @@ namespace System.Windows.Forms.Tests
             collection.SetKeyName(index, name);
             Assert.Equal(expectedKeys, collection.Keys.Cast<string>());
             Assert.False(list.HandleCreated);
-            
+
             // Set again.
             collection.SetKeyName(index, name);
             Assert.Equal(expectedKeys, collection.Keys.Cast<string>());
@@ -1558,7 +1557,7 @@ namespace System.Windows.Forms.Tests
             collection.SetKeyName(index, name);
             Assert.Equal(expectedKeys, collection.Keys.Cast<string>());
             Assert.True(list.HandleCreated);
-            
+
             // Set again.
             collection.SetKeyName(index, name);
             Assert.Equal(expectedKeys, collection.Keys.Cast<string>());

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
@@ -844,7 +844,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, list.Images.Count);
 #pragma warning restore xUnit2013
             Assert.True(list.HandleCreated);
-            
+
             // Call again.
             list.Dispose();
             Assert.False(list.HandleCreated);
@@ -864,7 +864,7 @@ namespace System.Windows.Forms.Tests
             list.Dispose();
             Assert.Equal(2, list.Images.Count);
             Assert.False(list.HandleCreated);
-            
+
             // Call again.
             list.Dispose();
             Assert.Equal(2, list.Images.Count);
@@ -899,7 +899,7 @@ namespace System.Windows.Forms.Tests
             list.Dispose();
             Assert.Empty(list.Images);
             Assert.False(list.HandleCreated);
-            
+
             // Call again.
             list.Dispose();
             Assert.Empty(list.Images);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxTests.cs
@@ -44,7 +44,7 @@ namespace System.Windows.Forms.Tests
             Assert.True(control.CausesValidation);
             Assert.Equal(new Size(116, 92), control.ClientSize);
             Assert.Equal(new Rectangle(0, 0, 116, 92), control.ClientRectangle);
-            Assert.Equal(0, control.ColumnWidth); 
+            Assert.Equal(0, control.ColumnWidth);
             Assert.Null(control.Container);
             Assert.False(control.ContainsFocus);
             Assert.Null(control.ContextMenuStrip);
@@ -754,7 +754,7 @@ namespace System.Windows.Forms.Tests
             var control = new ListBox();
             Assert.Throws<InvalidEnumArgumentException>("value", () => control.RightToLeft = value);
         }
-        
+
         [WinFormsFact]
         public void ListBox_GetAutoSizeMode_Invoke_ReturnsExpected()
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewInsertionMarkTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewInsertionMarkTests.cs
@@ -36,18 +36,18 @@ namespace System.Windows.Forms.Tests
             insertionMark.AppearsAfterItem = value;
             Assert.Equal(value, insertionMark.AppearsAfterItem);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             insertionMark.AppearsAfterItem = value;
             Assert.Equal(value, insertionMark.AppearsAfterItem);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set different.
             insertionMark.AppearsAfterItem = !value;
             Assert.Equal(!value, insertionMark.AppearsAfterItem);
             Assert.False(control.IsHandleCreated);
         }
-        
+
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void ListViewInsertionMark_AppearsAfterItem_SetWithHandle_GetReturnsExpected(bool value)
@@ -68,7 +68,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set same.
             insertionMark.AppearsAfterItem = value;
             Assert.Equal(value, insertionMark.AppearsAfterItem);
@@ -76,7 +76,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set different.
             insertionMark.AppearsAfterItem = !value;
             Assert.Equal(!value, insertionMark.AppearsAfterItem);
@@ -482,7 +482,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(-1, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
                 Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
-                
+
                 // Set negative one.
                 Assert.NotEqual(IntPtr.Zero, control.Handle);
                 control.InsertionMark.Index = -1;
@@ -537,7 +537,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(-1, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
                 Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
-                
+
                 // Set negative one.
                 Assert.NotEqual(IntPtr.Zero, control.Handle);
                 control.InsertionMark.Index = -1;
@@ -609,7 +609,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.Equal(result, insertionMark.NearestIndex(new Point(1, 2)));
         }
-        
+
         private class CustomInsertMarkHitTestListView : ListView
         {
             public int InsertMarkHitTestResult { get; set; }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItemTests.cs
@@ -1,5 +1,4 @@
-﻿
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendarTests.cs
@@ -981,7 +981,7 @@ namespace System.Windows.Forms.Tests
             Assert.True(range[1].wSecond >= 0);
             Assert.True(range[1].wMilliseconds >= 0);
         }
-        
+
         [WinFormsFact]
         public void MonthCalendar_Handle_GetWithMaxSelectionCount_Success()
         {
@@ -1012,7 +1012,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, date.wSecond);
             Assert.Equal(0, date.wMilliseconds);
         }
-        
+
         [WinFormsFact]
         public void MonthCalendar_Handle_GetWithForeColor_Success()
         {
@@ -1023,7 +1023,7 @@ namespace System.Windows.Forms.Tests
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             Assert.Equal((IntPtr)0x785634, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.MCM.GETCOLOR, (IntPtr)ComCtl32.MCSC.TEXT, IntPtr.Zero));
         }
-        
+
         [WinFormsFact]
         public void MonthCalendar_Handle_GetWithBackColor_Success()
         {
@@ -1034,7 +1034,7 @@ namespace System.Windows.Forms.Tests
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             Assert.Equal((IntPtr)0x563412, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.MCM.GETCOLOR, (IntPtr)ComCtl32.MCSC.MONTHBK, IntPtr.Zero));
         }
-        
+
         [WinFormsFact]
         public void MonthCalendar_Handle_GetWithTitleBackColor_Success()
         {
@@ -1045,7 +1045,7 @@ namespace System.Windows.Forms.Tests
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             Assert.Equal((IntPtr)0x785634, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.MCM.GETCOLOR, (IntPtr)ComCtl32.MCSC.TITLEBK, IntPtr.Zero));
         }
-        
+
         [WinFormsFact]
         public void MonthCalendar_Handle_GetWithTitleForeColor_Success()
         {
@@ -1056,7 +1056,7 @@ namespace System.Windows.Forms.Tests
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             Assert.Equal((IntPtr)0x785634, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.MCM.GETCOLOR, (IntPtr)ComCtl32.MCSC.TITLETEXT, IntPtr.Zero));
         }
-        
+
         [WinFormsFact]
         public void MonthCalendar_Handle_GetWithTrailingForeColor_Success()
         {
@@ -1067,7 +1067,7 @@ namespace System.Windows.Forms.Tests
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             Assert.Equal((IntPtr)0x785634, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.MCM.GETCOLOR, (IntPtr)ComCtl32.MCSC.TRAILINGTEXT, IntPtr.Zero));
         }
-        
+
         [WinFormsFact]
         public void MonthCalendar_Handle_GetWithDefaultFirstDayOfWeek_Success()
         {
@@ -1083,7 +1083,7 @@ namespace System.Windows.Forms.Tests
             }
             Assert.Equal((IntPtr)expected, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.MCM.GETFIRSTDAYOFWEEK, IntPtr.Zero, IntPtr.Zero));
         }
-        
+
         [WinFormsFact]
         public void MonthCalendar_Handle_GetWithFirstDayOfWeek_Success()
         {
@@ -1094,7 +1094,7 @@ namespace System.Windows.Forms.Tests
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             Assert.Equal((IntPtr)0x10001, User32.SendMessageW(control.Handle, (User32.WindowMessage)ComCtl32.MCM.GETFIRSTDAYOFWEEK, IntPtr.Zero, IntPtr.Zero));
         }
-        
+
         [WinFormsFact]
         public void MonthCalendar_Handle_GetWithRange_Success()
         {
@@ -1123,7 +1123,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(6, range[1].wSecond);
             Assert.Equal(0, range[1].wMilliseconds);
         }
-        
+
         [WinFormsFact]
         public void MonthCalendar_Handle_GetWithScrollChange_Success()
         {
@@ -1638,7 +1638,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal("RightToLeftLayout", e.AffectedProperty);
                 layoutCallCount++;
             };
-            
+
             control.RightToLeftLayout = value;
             Assert.Equal(value, control.RightToLeftLayout);
             Assert.Equal(expectedLayoutCallCount, layoutCallCount);
@@ -3471,13 +3471,13 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.HandleCreated += handler;
             control.OnHandleCreated(eventArgs);
             Assert.Equal(1, callCount);
             Assert.False(control.IsHandleCreated);
-        
+
             // Remove handler.
             control.HandleCreated -= handler;
             control.OnHandleCreated(eventArgs);
@@ -3498,20 +3498,20 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.HandleCreated += handler;
             control.OnHandleCreated(eventArgs);
             Assert.Equal(1, callCount);
             Assert.True(control.IsHandleCreated);
-        
+
             // Remove handler.
             control.HandleCreated -= handler;
             control.OnHandleCreated(eventArgs);
             Assert.Equal(1, callCount);
             Assert.True(control.IsHandleCreated);
         }
-        
+
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
         public void MonthCalendar_OnHandleDestroyed_Invoke_CallsHandleDestroyed(EventArgs eventArgs)
@@ -3524,20 +3524,20 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.HandleDestroyed += handler;
             control.OnHandleDestroyed(eventArgs);
             Assert.Equal(1, callCount);
             Assert.False(control.IsHandleCreated);
-        
+
             // Remove handler.
             control.HandleDestroyed -= handler;
             control.OnHandleDestroyed(eventArgs);
             Assert.Equal(1, callCount);
             Assert.False(control.IsHandleCreated);
         }
-        
+
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
         public void MonthCalendar_OnHandleDestroyed_InvokeWithHandle_CallsHandleDestroyed(EventArgs eventArgs)
@@ -3551,13 +3551,13 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.HandleDestroyed += handler;
             control.OnHandleDestroyed(eventArgs);
             Assert.Equal(1, callCount);
             Assert.True(control.IsHandleCreated);
-        
+
             // Remove handler.
             control.HandleDestroyed -= handler;
             control.OnHandleDestroyed(eventArgs);
@@ -3675,7 +3675,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, callCount);
             Assert.False(control.IsHandleCreated);
         }
-        
+
         public static IEnumerable<object[]> OnRightToLeftLayoutChanged_WithHandle_TestData()
         {
             yield return new object[] { RightToLeft.Yes, null, 1 };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NativeWindowTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NativeWindowTests.cs
@@ -56,7 +56,7 @@ namespace System.Windows.Forms.Tests
             var window = new NativeWindow();
             window.AssignHandle(control.Handle);
             Assert.Equal(control.Handle, window.Handle);
-            
+
             window.ReleaseHandle();
             Assert.Equal(IntPtr.Zero, window.Handle);
 
@@ -211,7 +211,7 @@ namespace System.Windows.Forms.Tests
             try
             {
                 Assert.NotEqual(IntPtr.Zero, window1.Handle);
-                
+
                 var window2 = new NativeWindow();
                 var cp2 = new CreateParams
                 {
@@ -299,7 +299,7 @@ namespace System.Windows.Forms.Tests
             using var control = new Control();
             var window = new WndProcTrackingNativeWindow();
             window.AssignHandle(control.Handle);
-            
+
             try
             {
                 var m = new Message

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NotifyIconTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NotifyIconTests.cs
@@ -61,7 +61,7 @@ namespace System.Windows.Forms.Tests
                 BalloonTipIcon = value
             };
             Assert.Equal(value, notifyIcon.BalloonTipIcon);
-            
+
             // Set same.
             notifyIcon.BalloonTipIcon = value;
             Assert.Equal(value, notifyIcon.BalloonTipIcon);
@@ -168,7 +168,7 @@ namespace System.Windows.Forms.Tests
             {
                 ContextMenuStrip = menu
             };
-            
+
             notifyIcon.ContextMenuStrip = value;
             Assert.Equal(value, notifyIcon.ContextMenuStrip);
 
@@ -207,7 +207,7 @@ namespace System.Windows.Forms.Tests
                 Icon = value
             };
             Assert.Same(value, notifyIcon.Icon);
-            
+
             // Set same.
             notifyIcon.Icon = value;
             Assert.Same(value, notifyIcon.Icon);
@@ -225,7 +225,7 @@ namespace System.Windows.Forms.Tests
 
             notifyIcon.Icon = value;
             Assert.Same(value, notifyIcon.Icon);
-            
+
             // Set same.
             notifyIcon.Icon = value;
             Assert.Same(value, notifyIcon.Icon);
@@ -241,7 +241,7 @@ namespace System.Windows.Forms.Tests
                 Icon = value
             };
             Assert.Same(value, notifyIcon.Icon);
-            
+
             // Set same.
             notifyIcon.Icon = value;
             Assert.Same(value, notifyIcon.Icon);
@@ -461,11 +461,11 @@ namespace System.Windows.Forms.Tests
                 Visible = value
             };
             Assert.Equal(value, notifyIcon.Visible);
-            
+
             // Set same.
             notifyIcon.Visible = value;
             Assert.Equal(value, notifyIcon.Visible);
-            
+
             // Set different.
             notifyIcon.Visible = !value;
             Assert.Equal(!value, notifyIcon.Visible);
@@ -482,11 +482,11 @@ namespace System.Windows.Forms.Tests
                 Visible = value
             };
             Assert.Equal(value, notifyIcon.Visible);
-            
+
             // Set same.
             notifyIcon.Visible = value;
             Assert.Equal(value, notifyIcon.Visible);
-            
+
             // Set different.
             notifyIcon.Visible = !value;
             Assert.Equal(!value, notifyIcon.Visible);
@@ -511,12 +511,12 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(value, notifyIcon.Visible);
             mockSite.Verify(s => s.DesignMode, Times.Exactly(expectedDesignModeCallCount));
-            
+
             // Set same.
             notifyIcon.Visible = value;
             Assert.Equal(value, notifyIcon.Visible);
             mockSite.Verify(s => s.DesignMode, Times.Exactly(expectedDesignModeCallCount));
-            
+
             // Set different.
             notifyIcon.Visible = !value;
             Assert.Equal(!value, notifyIcon.Visible);
@@ -729,7 +729,7 @@ namespace System.Windows.Forms.Tests
             Assert.Empty(notifyIcon.Text);
             Assert.False(notifyIcon.Visible);
             Assert.Equal(1, callCount);
-            
+
             notifyIcon.Dispose();
 
             Assert.Equal(ToolTipIcon.None, notifyIcon.BalloonTipIcon);
@@ -744,7 +744,7 @@ namespace System.Windows.Forms.Tests
             Assert.False(notifyIcon.Visible);
             Assert.Equal(2, callCount);
         }
-        
+
         public static IEnumerable<object[]> Dispose_WithProperties_TestData()
         {
             foreach (bool visible in new bool[] { true, false })
@@ -787,7 +787,7 @@ namespace System.Windows.Forms.Tests
             Assert.Empty(notifyIcon.Text);
             Assert.Equal(visible, notifyIcon.Visible);
             Assert.Equal(1, callCount);
-            
+
             notifyIcon.Dispose();
             Assert.Equal(ToolTipIcon.Error, notifyIcon.BalloonTipIcon);
             Assert.Equal("BalloonTipText", notifyIcon.BalloonTipText);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PanelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PanelTests.cs
@@ -628,7 +628,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(new Size(26, 31), control.PreferredSize);
         }
 
-
         private class BorderedPanel : Panel
         {
             protected override CreateParams CreateParams

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ProfessionalColorTableTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ProfessionalColorTableTests.cs
@@ -140,11 +140,11 @@ namespace System.Windows.Forms.Tests
                 UseSystemColors = value
             };
             Assert.Equal(value, table.UseSystemColors);
-            
+
             // Set same.
             table.UseSystemColors = value;
             Assert.Equal(value, table.UseSystemColors);
-            
+
             // Set different.
             table.UseSystemColors = !value;
             Assert.Equal(!value, table.UseSystemColors);
@@ -163,11 +163,11 @@ namespace System.Windows.Forms.Tests
 
             table.UseSystemColors = value;
             Assert.Equal(value, table.UseSystemColors);
-            
+
             // Set same.
             table.UseSystemColors = value;
             Assert.Equal(value, table.UseSystemColors);
-            
+
             // Set different.
             table.UseSystemColors = !value;
             Assert.Equal(!value, table.UseSystemColors);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ProgressBarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ProgressBarTests.cs
@@ -908,7 +908,6 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { int.MaxValue };
         }
 
-
         [WinFormsTheory]
         [MemberData(nameof(Maximum_Set_TestData))]
         public void ProgressBar_Maximum_Set_GetReturnsExpected(int value)
@@ -1203,7 +1202,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal("RightToLeftLayout", e.AffectedProperty);
                 layoutCallCount++;
             };
-            
+
             control.RightToLeftLayout = value;
             Assert.Equal(value, control.RightToLeftLayout);
             Assert.Equal(expectedLayoutCallCount, layoutCallCount);
@@ -2391,7 +2390,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, callCount);
             Assert.False(control.IsHandleCreated);
         }
-        
+
         public static IEnumerable<object[]> OnRightToLeftLayoutChanged_WithHandle_TestData()
         {
             yield return new object[] { RightToLeft.Yes, null, 1 };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RadioButtonTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RadioButtonTests.cs
@@ -181,7 +181,6 @@ namespace System.Windows.Forms.Tests
 
         public class SubRadioButton : RadioButton
         {
-
             public new bool CanEnableIme => base.CanEnableIme;
 
             public new bool CanRaiseEvents => base.CanRaiseEvents;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
@@ -157,7 +157,7 @@ namespace System.Windows.Forms.Tests
             using var control = new RichTextBox();
             Assert.Empty(control.SelectedText);
             Assert.True(control.IsHandleCreated);
-            
+
             // Get again.
             Assert.Empty(control.SelectedText);
             Assert.True(control.IsHandleCreated);
@@ -180,7 +180,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Get again.
             Assert.Empty(control.SelectedText);
             Assert.True(control.IsHandleCreated);
@@ -188,14 +188,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
         }
-        
+
         [WinFormsFact]
         public void RichTextBox_SelectedRtf_GetWithoutHandle_ReturnsExpected()
         {
             using var control = new RichTextBox();
             Assert.NotNull(control.SelectedRtf);
             Assert.True(control.IsHandleCreated);
-            
+
             // Call again.
             Assert.NotNull(control.SelectedRtf);
             Assert.True(control.IsHandleCreated);
@@ -218,7 +218,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Call again.
             Assert.NotNull(control.SelectedRtf);
             Assert.True(control.IsHandleCreated);
@@ -233,7 +233,7 @@ namespace System.Windows.Forms.Tests
             using var control = new RichTextBox();
             Assert.Equal(HorizontalAlignment.Left, control.SelectionAlignment);
             Assert.True(control.IsHandleCreated);
-            
+
             // Call again.
             Assert.Equal(HorizontalAlignment.Left, control.SelectionAlignment);
             Assert.True(control.IsHandleCreated);
@@ -256,7 +256,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Call again.
             Assert.Equal(HorizontalAlignment.Left, control.SelectionAlignment);
             Assert.True(control.IsHandleCreated);
@@ -271,7 +271,7 @@ namespace System.Windows.Forms.Tests
             using var control = new RichTextBox();
             Assert.False(control.SelectionBullet);
             Assert.True(control.IsHandleCreated);
-            
+
             // Call again.
             Assert.False(control.SelectionBullet);
             Assert.True(control.IsHandleCreated);
@@ -294,7 +294,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Call again.
             Assert.False(control.SelectionBullet);
             Assert.True(control.IsHandleCreated);
@@ -309,7 +309,7 @@ namespace System.Windows.Forms.Tests
             using var control = new RichTextBox();
             Assert.Equal(0, control.SelectionCharOffset);
             Assert.True(control.IsHandleCreated);
-            
+
             // Call again.
             Assert.Equal(0, control.SelectionCharOffset);
             Assert.True(control.IsHandleCreated);
@@ -332,7 +332,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Call again.
             Assert.Equal(0, control.SelectionCharOffset);
             Assert.True(control.IsHandleCreated);
@@ -340,14 +340,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
         }
-        
+
         [WinFormsFact]
         public void RichTextBox_SelectionColor_GetWithoutHandle_ReturnsExpected()
         {
             using var control = new RichTextBox();
             Assert.Equal(Color.Black, control.SelectionColor);
             Assert.True(control.IsHandleCreated);
-            
+
             // Call again.
             Assert.Equal(Color.Black, control.SelectionColor);
             Assert.True(control.IsHandleCreated);
@@ -370,7 +370,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Call again.
             Assert.Equal(Color.Black, control.SelectionColor);
             Assert.True(control.IsHandleCreated);
@@ -386,14 +386,14 @@ namespace System.Windows.Forms.Tests
             Font result1 = control.SelectionFont;
             Assert.NotNull(result1);
             Assert.True(control.IsHandleCreated);
-            
+
             // Call again.
             Font result2 = control.SelectionFont;
             Assert.NotNull(result2);
             Assert.NotSame(result1, result2);
             Assert.True(control.IsHandleCreated);
         }
-        
+
         [WinFormsFact]
         public void RichTextBox_SelectionFont_GetWithHandle_ReturnsExpected()
         {
@@ -412,7 +412,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Call again.
             Font result2 = control.SelectionFont;
             Assert.NotNull(result2);
@@ -422,14 +422,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
         }
-        
+
         [WinFormsFact]
         public void RichTextBox_SelectionHangingIndent_GetWithoutHandle_ReturnsExpected()
         {
             using var control = new RichTextBox();
             Assert.Equal(0, control.SelectionHangingIndent);
             Assert.True(control.IsHandleCreated);
-            
+
             // Call again.
             Assert.Equal(0, control.SelectionHangingIndent);
             Assert.True(control.IsHandleCreated);
@@ -452,7 +452,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Call again.
             Assert.Equal(0, control.SelectionHangingIndent);
             Assert.True(control.IsHandleCreated);
@@ -460,14 +460,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
         }
-        
+
         [WinFormsFact]
         public void RichTextBox_SelectionIndent_GetWithoutHandle_ReturnsExpected()
         {
             using var control = new RichTextBox();
             Assert.Equal(0, control.SelectionIndent);
             Assert.True(control.IsHandleCreated);
-            
+
             // Call again.
             Assert.Equal(0, control.SelectionIndent);
             Assert.True(control.IsHandleCreated);
@@ -490,7 +490,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Call again.
             Assert.Equal(0, control.SelectionIndent);
             Assert.True(control.IsHandleCreated);
@@ -505,7 +505,7 @@ namespace System.Windows.Forms.Tests
             using var control = new RichTextBox();
             Assert.Equal(0, control.SelectionLength);
             Assert.True(control.IsHandleCreated);
-            
+
             // Get again.
             Assert.Equal(0, control.SelectionLength);
             Assert.True(control.IsHandleCreated);
@@ -528,7 +528,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Get again.
             Assert.Equal(0, control.SelectionLength);
             Assert.True(control.IsHandleCreated);
@@ -536,14 +536,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
         }
-        
+
         [WinFormsFact]
         public void RichTextBox_SelectionProtected_GetWithoutHandle_ReturnsExpected()
         {
             using var control = new RichTextBox();
             Assert.False(control.SelectionProtected);
             Assert.True(control.IsHandleCreated);
-            
+
             // Call again.
             Assert.False(control.SelectionProtected);
             Assert.True(control.IsHandleCreated);
@@ -566,7 +566,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Call again.
             Assert.False(control.SelectionProtected);
             Assert.True(control.IsHandleCreated);
@@ -574,14 +574,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
         }
-        
+
         [WinFormsFact]
         public void RichTextBox_SelectionRightIndent_GetWithoutHandle_ReturnsExpected()
         {
             using var control = new RichTextBox();
             Assert.Equal(0, control.SelectionRightIndent);
             Assert.True(control.IsHandleCreated);
-            
+
             // Call again.
             Assert.Equal(0, control.SelectionRightIndent);
             Assert.True(control.IsHandleCreated);
@@ -604,7 +604,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Call again.
             Assert.Equal(0, control.SelectionRightIndent);
             Assert.True(control.IsHandleCreated);
@@ -619,7 +619,7 @@ namespace System.Windows.Forms.Tests
             using var control = new RichTextBox();
             Assert.Equal(0, control.SelectionStart);
             Assert.True(control.IsHandleCreated);
-            
+
             // Get again.
             Assert.Equal(0, control.SelectionStart);
             Assert.True(control.IsHandleCreated);
@@ -642,7 +642,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Get again.
             Assert.Equal(0, control.SelectionStart);
             Assert.True(control.IsHandleCreated);
@@ -650,14 +650,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
         }
-        
+
         [WinFormsFact]
         public void RichTextBox_SelectionTabs_GetWithoutHandle_ReturnsExpected()
         {
             using var control = new RichTextBox();
             Assert.Empty(control.SelectionTabs);
             Assert.True(control.IsHandleCreated);
-            
+
             // Call again.
             Assert.Empty(control.SelectionTabs);
             Assert.True(control.IsHandleCreated);
@@ -680,7 +680,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Call again.
             Assert.Empty(control.SelectionTabs);
             Assert.True(control.IsHandleCreated);
@@ -688,14 +688,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
         }
-        
+
         [WinFormsFact]
         public void RichTextBox_SelectionType_GetWithoutHandle_ReturnsExpected()
         {
             using var control = new RichTextBox();
             Assert.Equal(RichTextBoxSelectionTypes.Empty, control.SelectionType);
             Assert.True(control.IsHandleCreated);
-            
+
             // Call again.
             Assert.Equal(RichTextBoxSelectionTypes.Empty, control.SelectionType);
             Assert.True(control.IsHandleCreated);
@@ -718,7 +718,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Call again.
             Assert.Equal(RichTextBoxSelectionTypes.Empty, control.SelectionType);
             Assert.True(control.IsHandleCreated);
@@ -733,7 +733,7 @@ namespace System.Windows.Forms.Tests
             using var control = new RichTextBox();
             Assert.Equal(0, control.TextLength);
             Assert.True(control.IsHandleCreated);
-            
+
             // Call again.
             Assert.Equal(0, control.TextLength);
             Assert.True(control.IsHandleCreated);
@@ -756,7 +756,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Call again.
             Assert.Equal(0, control.TextLength);
             Assert.True(control.IsHandleCreated);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RowStyleTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RowStyleTests.cs
@@ -57,7 +57,7 @@ namespace System.Windows.Forms.Tests
                 Height = value
             };
             Assert.Equal(value, style.Height);
-            
+
             // Set same.
             style.Height = value;
             Assert.Equal(value, style.Height);
@@ -85,7 +85,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(value, style.Height);
             Assert.Equal(expectedLayoutCallCount, layoutCallCount);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             style.Height = value;
             Assert.Equal(value, style.Height);
@@ -125,7 +125,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expectedLayoutCallCount * 2, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set same.
             style.Height = value;
             Assert.Equal(value, style.Height);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBarTests.cs
@@ -1408,7 +1408,7 @@ namespace System.Windows.Forms.Tests
             Assert.Same("text", control.Text);
             Assert.Equal(2, callCount);
         }
-        
+
         [WinFormsTheory]
         [InlineData(0)]
         [InlineData(5)]
@@ -1572,7 +1572,7 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<ArgumentOutOfRangeException>("value", () => control.Value = value);
             Assert.Equal(0, control.Value);
         }
-        
+
         [WinFormsFact]
         public void ScrollBar_GetAutoSizeMode_Invoke_ReturnsExpected()
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/SplitterPanelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/SplitterPanelTests.cs
@@ -186,7 +186,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(2, callCount);
         }
 
-
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(AutoSizeMode))]
         [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryDataInvalid), typeof(AutoSizeMode))]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/StatusStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/StatusStripTests.cs
@@ -484,7 +484,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(EventArgs.Empty, e);
                 rendererChangedCallCount++;
             };
-            
+
             // Set same.
             control.RenderMode = ToolStripRenderMode.System;
             Assert.Equal(ToolStripRenderMode.System, control.RenderMode);
@@ -492,19 +492,19 @@ namespace System.Windows.Forms.Tests
             Assert.Same(control.Renderer, control.Renderer);
             Assert.IsType<ToolStripSystemRenderer>(control.Renderer);
             Assert.Equal(1, rendererChangedCallCount);
-            
+
             // Set different.
             control.RenderMode = value;
             Assert.Equal(value, control.RenderMode);
             Assert.IsType(expectedRendererType, control.Renderer);
             Assert.Equal(2, rendererChangedCallCount);
-            
+
             // Set same.
             control.RenderMode = value;
             Assert.Equal(value, control.RenderMode);
             Assert.IsType(expectedRendererType, control.Renderer);
             Assert.Equal(expectedSameRendererChangedCallCount, rendererChangedCallCount);
-            
+
             // Set System.
             control.RenderMode = ToolStripRenderMode.System;
             Assert.Equal(ToolStripRenderMode.System, control.RenderMode);
@@ -530,18 +530,18 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(EventArgs.Empty, e);
                 rendererChangedCallCount++;
             };
-            
+
             control.RenderMode = value;
             Assert.Equal(value, control.RenderMode);
             Assert.IsType(expectedRendererType, control.Renderer);
             Assert.Equal(1, rendererChangedCallCount);
-            
+
             // Set same.
             control.RenderMode = value;
             Assert.Equal(value, control.RenderMode);
             Assert.IsType(expectedRendererType, control.Renderer);
             Assert.Equal(expectedSameRendererChangedCallCount, rendererChangedCallCount);
-            
+
             // Set System.
             control.RenderMode = ToolStripRenderMode.System;
             Assert.Equal(ToolStripRenderMode.System, control.RenderMode);
@@ -732,7 +732,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { RightToLeft.Yes, true, 1, 0 };
             yield return new object[] { RightToLeft.No, true, 0, 0 };
             yield return new object[] { RightToLeft.Inherit, true, 0, 0 };
-            
+
             yield return new object[] { RightToLeft.Yes, false, 0, 1 };
             yield return new object[] { RightToLeft.No, false, 0, 0 };
             yield return new object[] { RightToLeft.Inherit, false, 0, 0 };
@@ -1013,7 +1013,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { RightToLeft.Yes, true, 1 };
             yield return new object[] { RightToLeft.No, true, 0 };
             yield return new object[] { RightToLeft.Inherit, true, 0 };
-            
+
             yield return new object[] { RightToLeft.Yes, false, 0 };
             yield return new object[] { RightToLeft.No, false, 0 };
             yield return new object[] { RightToLeft.Inherit, false, 0 };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.ControlCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.ControlCollectionTests.cs
@@ -113,7 +113,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(value1.IsHandleCreated);
                 Assert.False(value2.IsHandleCreated);
                 Assert.False(owner.IsHandleCreated);
-                
+
                 // Add again.
                 collection.Add(value1);
                 Assert.Equal(new Control[] { value2, value1 }, collection.Cast<Control>());
@@ -154,7 +154,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { TabAppearance.Buttons, Size.Empty, 0 };
             yield return new object[] { TabAppearance.FlatButtons, Size.Empty, 1 };
             yield return new object[] { TabAppearance.Normal, Size.Empty, 0 };
-            
+
             yield return new object[] { TabAppearance.Buttons, new Size(100, 120), 0 };
             yield return new object[] { TabAppearance.FlatButtons, new Size(100, 120), 1 };
             yield return new object[] { TabAppearance.Normal, new Size(100, 120), 0 };
@@ -264,7 +264,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(expectedParentInvalidatedCallCount * 2, parentInvalidatedCallCount);
                 Assert.Equal(0, parentStyleChangedCallCount);
                 Assert.Equal(0, parentCreatedCallCount);
-                
+
                 // Add again.
                 collection.Add(value1);
                 Assert.Equal(new Control[] { value2, value1 }, collection.Cast<Control>());
@@ -417,7 +417,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, styleChangedCallCount2);
                 Assert.Equal(0, createdCallCount2);
                 Assert.False(owner.IsHandleCreated);
-                
+
                 // Add again.
                 collection.Add(value1);
                 Assert.Equal(new Control[] { value2, value1 }, collection.Cast<Control>());
@@ -586,7 +586,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(expectedParentInvalidatedCallCount * 2, parentInvalidatedCallCount);
                 Assert.Equal(0, parentStyleChangedCallCount);
                 Assert.Equal(0, parentCreatedCallCount);
-                
+
                 // Add again.
                 collection.Add(value1);
                 Assert.Equal(new Control[] { value2, value1 }, collection.Cast<Control>());
@@ -733,7 +733,7 @@ namespace System.Windows.Forms.Tests
         {
             using var owner = new TabControl();
             TabControl.ControlCollection collection = Assert.IsType<TabControl.ControlCollection>(owner.Controls);
-            
+
             var items = new List<TabPage>();
             for (int i = 0; i < 24; i++)
             {
@@ -791,7 +791,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(int.MaxValue, item.cchTextMax);
             Assert.Equal(expectedText, new string(item.pszText));
             Assert.Equal(1, item.iImage);
-            
+
             // Get item 2.
             Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WindowMessage)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
@@ -800,7 +800,7 @@ namespace System.Windows.Forms.Tests
             Assert.Empty(new string(item.pszText));
             Assert.Equal(-1, item.iImage);
         }
-        
+
         [WinFormsTheory]
         [InlineData("Text", "Text")]
         [InlineData("&&Text", "&&Text")]
@@ -859,7 +859,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(int.MaxValue, item.cchTextMax);
             Assert.Equal(expectedText, new string(item.pszText));
             Assert.Equal(1, item.iImage);
-            
+
             // Get item 2.
             Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WindowMessage)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
@@ -906,7 +906,7 @@ namespace System.Windows.Forms.Tests
             var collection = new TabControl.ControlCollection(owner);
             collection.Add(value1);
             collection.Add(value2);
-            
+
             int layoutCallCount1 = 0;
             value1.Layout += (sender, e) => layoutCallCount1++;
             int layoutCallCount2 = 0;
@@ -942,7 +942,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(value1.IsHandleCreated);
                 Assert.False(value2.IsHandleCreated);
                 Assert.False(owner.IsHandleCreated);
-                
+
                 // Remove again.
                 collection.Remove(value2);
                 Assert.Same(value1, Assert.Single(collection));
@@ -962,7 +962,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(value1.IsHandleCreated);
                 Assert.False(value2.IsHandleCreated);
                 Assert.False(owner.IsHandleCreated);
-                
+
                 // Remove first.
                 collection.Remove(value1);
                 Assert.Empty(collection);
@@ -1001,7 +1001,7 @@ namespace System.Windows.Forms.Tests
             var collection = new TabControl.ControlCollection(owner);
             collection.Add(value1);
             collection.Add(value2);
-            
+
             int layoutCallCount1 = 0;
             value1.Layout += (sender, e) => layoutCallCount1++;
             int layoutCallCount2 = 0;
@@ -1054,7 +1054,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, createdCallCount1);
                 Assert.True(value2.IsHandleCreated);
                 Assert.False(owner.IsHandleCreated);
-                
+
                 // Remove again.
                 collection.Remove(value2);
                 Assert.Same(value1, Assert.Single(collection));
@@ -1080,7 +1080,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, styleChangedCallCount2);
                 Assert.Equal(0, createdCallCount2);
                 Assert.False(owner.IsHandleCreated);
-                
+
                 // Remove first.
                 collection.Remove(value1);
                 Assert.Empty(collection);
@@ -1125,7 +1125,7 @@ namespace System.Windows.Forms.Tests
             TabControl.ControlCollection collection = Assert.IsType<TabControl.ControlCollection>(owner.Controls);
             collection.Add(value1);
             collection.Add(value2);
-            
+
             int layoutCallCount1 = 0;
             value1.Layout += (sender, e) => layoutCallCount1++;
             int layoutCallCount2 = 0;
@@ -1171,7 +1171,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, parentInvalidatedCallCount);
                 Assert.Equal(0, parentStyleChangedCallCount);
                 Assert.Equal(0, parentCreatedCallCount);
-                
+
                 // Remove again.
                 collection.Remove(value2);
                 Assert.Same(value1, Assert.Single(collection));
@@ -1194,7 +1194,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, parentInvalidatedCallCount);
                 Assert.Equal(0, parentStyleChangedCallCount);
                 Assert.Equal(0, parentCreatedCallCount);
-                
+
                 // Remove first.
                 collection.Remove(value1);
                 Assert.Empty(collection);
@@ -1236,7 +1236,7 @@ namespace System.Windows.Forms.Tests
             TabControl.ControlCollection collection = Assert.IsType<TabControl.ControlCollection>(owner.Controls);
             collection.Add(value1);
             collection.Add(value2);
-            
+
             int layoutCallCount1 = 0;
             value1.Layout += (sender, e) => layoutCallCount1++;
             int layoutCallCount2 = 0;
@@ -1289,7 +1289,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, createdCallCount1);
                 Assert.True(value2.IsHandleCreated);
                 Assert.False(owner.IsHandleCreated);
-                
+
                 // Remove again.
                 collection.Remove(value2);
                 Assert.Same(value1, Assert.Single(collection));
@@ -1315,7 +1315,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, styleChangedCallCount2);
                 Assert.Equal(0, createdCallCount2);
                 Assert.False(owner.IsHandleCreated);
-                
+
                 // Remove first.
                 collection.Remove(value1);
                 Assert.Empty(collection);
@@ -1368,17 +1368,17 @@ namespace System.Windows.Forms.Tests
             collection.Remove(value2);
             Assert.Equal(new Control[] { value1, value3, value4 }, collection.Cast<TabPage>());
             Assert.Null(owner.SelectedTab);
-            
+
             // Remove selected.
             collection.Remove(value4);
             Assert.Equal(new Control[] { value1, value3 }, collection.Cast<TabPage>());
             Assert.Null(owner.SelectedTab);
-            
+
             // Remove selected again.
             collection.Remove(value1);
             Assert.Equal(new Control[] { value3 }, collection.Cast<TabPage>());
             Assert.Null(owner.SelectedTab);
-            
+
             // Remove selected again.
             collection.Remove(value3);
             Assert.Empty(collection);
@@ -1406,17 +1406,17 @@ namespace System.Windows.Forms.Tests
             collection.Remove(value2);
             Assert.Equal(new Control[] { value1, value3, value4 }, collection.Cast<TabPage>());
             Assert.Same(value4, owner.SelectedTab);
-            
+
             // Remove selected.
             collection.Remove(value4);
             Assert.Equal(new Control[] { value1, value3 }, collection.Cast<TabPage>());
             Assert.Same(value1, owner.SelectedTab);
-            
+
             // Remove selected again.
             collection.Remove(value1);
             Assert.Equal(new Control[] { value3 }, collection.Cast<TabPage>());
             Assert.Same(value3, owner.SelectedTab);
-            
+
             // Remove selected again.
             collection.Remove(value3);
             Assert.Empty(collection);
@@ -1428,7 +1428,7 @@ namespace System.Windows.Forms.Tests
         {
             using var owner = new TabControl();
             TabControl.ControlCollection collection = Assert.IsType<TabControl.ControlCollection>(owner.Controls);
-            
+
             var items = new List<TabPage>();
             for (int i = 0; i < 24; i++)
             {
@@ -1439,7 +1439,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(items, owner.TabPages.Cast<TabPage>());
                 Assert.Same(owner, value.Parent);
             }
-            
+
             for (int i = 0; i < 24; i++)
             {
                 items.RemoveAt(0);
@@ -1495,7 +1495,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(int.MaxValue, item.cchTextMax);
             Assert.Empty(new string(item.pszText));
             Assert.Equal(-1, item.iImage);
-            
+
             // Get item 2.
             Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WindowMessage)ComCtl32.TCM.GETITEMW, (IntPtr)1, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
@@ -1504,7 +1504,7 @@ namespace System.Windows.Forms.Tests
             Assert.Empty(new string(item.pszText));
             Assert.Equal(-1, item.iImage);
         }
-        
+
         [WinFormsFact]
         public unsafe void TabControlControlCollection_Remove_GetItemsDesignModeWithHandle_Success()
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabPageCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabPageCollectionTests.cs
@@ -101,7 +101,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(value1.IsHandleCreated);
                 Assert.False(value2.IsHandleCreated);
                 Assert.False(owner.IsHandleCreated);
-                
+
                 // Add again.
                 collection.Add(value1);
                 Assert.Equal(new TabPage[] { value1, value2, value1 }, collection.Cast<TabPage>());
@@ -143,7 +143,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { TabAppearance.Buttons, Size.Empty, 0 };
             yield return new object[] { TabAppearance.FlatButtons, Size.Empty, 1 };
             yield return new object[] { TabAppearance.Normal, Size.Empty, 0 };
-            
+
             yield return new object[] { TabAppearance.Buttons, new Size(100, 120), 0 };
             yield return new object[] { TabAppearance.FlatButtons, new Size(100, 120), 1 };
             yield return new object[] { TabAppearance.Normal, new Size(100, 120), 0 };
@@ -255,7 +255,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(expectedParentInvalidatedCallCount * 2, parentInvalidatedCallCount);
                 Assert.Equal(0, parentStyleChangedCallCount);
                 Assert.Equal(0, parentCreatedCallCount);
-                
+
                 // Add again.
                 collection.Add(value1);
                 Assert.Equal(new TabPage[] { value1, value2, value1 }, collection.Cast<TabPage>());
@@ -411,7 +411,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, styleChangedCallCount2);
                 Assert.Equal(0, createdCallCount2);
                 Assert.False(owner.IsHandleCreated);
-                
+
                 // Add again.
                 collection.Add(value1);
                 Assert.Equal(new TabPage[] { value1, value2, value1, }, collection.Cast<TabPage>());
@@ -583,7 +583,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(expectedParentInvalidatedCallCount * 2, parentInvalidatedCallCount);
                 Assert.Equal(0, parentStyleChangedCallCount);
                 Assert.Equal(0, parentCreatedCallCount);
-                
+
                 // Add again.
                 collection.Add(value1);
                 Assert.Equal(new TabPage[] { value1, value2, value1 }, collection.Cast<TabPage>());
@@ -731,7 +731,7 @@ namespace System.Windows.Forms.Tests
         {
             using var owner = new TabControl();
             var collection = new TabControl.TabPageCollection(owner);
-            
+
             var items = new List<TabPage>();
             for (int i = 0; i < 24; i++)
             {
@@ -790,7 +790,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(int.MaxValue, item.cchTextMax);
             Assert.Equal(expectedText, new string(item.pszText));
             Assert.Equal(1, item.iImage);
-            
+
             // Get item 2.
             Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WindowMessage)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
@@ -799,7 +799,7 @@ namespace System.Windows.Forms.Tests
             Assert.Empty(new string(item.pszText));
             Assert.Equal(-1, item.iImage);
         }
-        
+
         [WinFormsTheory]
         [InlineData("Text", "Text")]
         [InlineData("&&Text", "&&Text")]
@@ -858,7 +858,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(int.MaxValue, item.cchTextMax);
             Assert.Equal(expectedText, new string(item.pszText));
             Assert.Equal(1, item.iImage);
-            
+
             // Get item 2.
             Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WindowMessage)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
@@ -1025,7 +1025,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(value1.IsHandleCreated);
                 Assert.False(value2.IsHandleCreated);
                 Assert.False(owner.IsHandleCreated);
-                
+
                 // Add again.
                 iList.Add(value1);
                 Assert.Equal(new TabPage[] { value1, value2, value1 }, collection.Cast<TabPage>());
@@ -1105,7 +1105,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(child1.IsHandleCreated);
                 Assert.False(child2.IsHandleCreated);
                 Assert.False(child3.IsHandleCreated);
-                
+
                 collection.AddRange(new TabPage[] { child1, child2, child3 });
                 Assert.Equal(new TabPage[] { child1, child2, child3, child1, child2, child3 }, collection.Cast<TabPage>());
                 Assert.Same(owner, child1.Parent);
@@ -1158,7 +1158,7 @@ namespace System.Windows.Forms.Tests
             Assert.False(iList.IsSynchronized);
             Assert.Same(collection, iList.SyncRoot);
         }
-        
+
         [WinFormsFact]
         public void TabPageCollection_Ctor_NullOwner_ThrowsArgumentNullException()
         {
@@ -1239,7 +1239,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, parentLayoutCallCount);
                 Assert.Equal(0, controlRemovedCallCount);
                 Assert.False(owner.IsHandleCreated);
-                
+
                 // Clear again.
                 collection.Clear();
                 Assert.Empty(collection);
@@ -1293,7 +1293,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(child1.IsHandleCreated);
                 Assert.False(child2.IsHandleCreated);
                 Assert.False(child3.IsHandleCreated);
-                
+
                 // Clear again.
                 collection.Clear();
                 Assert.Empty(collection);
@@ -1346,7 +1346,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, parentInvalidatedCallCount);
                 Assert.Equal(0, parentStyleChangedCallCount);
                 Assert.Equal(0, parentCreatedCallCount);
-                
+
                 // Clear again.
                 collection.Clear();
                 Assert.Empty(collection);
@@ -1414,7 +1414,7 @@ namespace System.Windows.Forms.Tests
                 Assert.True(child1.IsHandleCreated);
                 Assert.False(child2.IsHandleCreated);
                 Assert.False(child3.IsHandleCreated);
-                
+
                 // Clear again.
                 collection.Clear();
                 Assert.Empty(collection);
@@ -1549,7 +1549,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(child3);
 
             Assert.Equal(expected, collection.ContainsKey(key));
-            
+
             // Call again.
             Assert.Equal(expected, collection.ContainsKey(key));
             Assert.False(collection.ContainsKey("NoSuchKey"));
@@ -1563,7 +1563,7 @@ namespace System.Windows.Forms.Tests
             var collection = new TabControl.TabPageCollection(owner);
 
             Assert.False(collection.ContainsKey(key));
-            
+
             // Call again.
             Assert.False(collection.ContainsKey(key));
             Assert.False(collection.ContainsKey("NoSuchKey"));
@@ -1581,11 +1581,11 @@ namespace System.Windows.Forms.Tests
 
                 Assert.False(enumerator.MoveNext());
                 Assert.Throws<InvalidOperationException>(() => enumerator.Current);
-                
+
                 // Call again.
                 Assert.False(enumerator.MoveNext());
                 Assert.Throws<InvalidOperationException>(() => enumerator.Current);
-            
+
                 enumerator.Reset();
             }
         }
@@ -1609,13 +1609,13 @@ namespace System.Windows.Forms.Tests
 
                 Assert.True(enumerator.MoveNext());
                 Assert.Same(child1, enumerator.Current);
-                
+
                 Assert.True(enumerator.MoveNext());
                 Assert.Same(child2, enumerator.Current);
-                
+
                 Assert.True(enumerator.MoveNext());
                 Assert.Same(child3, enumerator.Current);
-                
+
                 Assert.False(enumerator.MoveNext());
                 Assert.Throws<InvalidOperationException>(() => enumerator.Current);
 
@@ -1641,11 +1641,11 @@ namespace System.Windows.Forms.Tests
 
                 Assert.False(enumerator.MoveNext());
                 Assert.Throws<InvalidOperationException>(() => enumerator.Current);
-                
+
                 // Call again.
                 Assert.False(enumerator.MoveNext());
                 Assert.Throws<InvalidOperationException>(() => enumerator.Current);
-            
+
                 enumerator.Reset();
             }
         }
@@ -1669,13 +1669,13 @@ namespace System.Windows.Forms.Tests
 
             Assert.True(enumerator.MoveNext());
             Assert.Same(child1, enumerator.Current);
-            
+
             Assert.True(enumerator.MoveNext());
             Assert.Same(child2, enumerator.Current);
 
             Assert.True(enumerator.MoveNext());
             Assert.Same(child3, enumerator.Current);
-            
+
             Assert.False(enumerator.MoveNext());
             Assert.Throws<InvalidOperationException>(() => enumerator.Current);
 
@@ -1701,13 +1701,13 @@ namespace System.Windows.Forms.Tests
 
             Assert.True(enumerator.MoveNext());
             Assert.Same(child1, enumerator.Current);
-            
+
             Assert.True(enumerator.MoveNext());
             Assert.Same(child2, enumerator.Current);
-            
+
             Assert.True(enumerator.MoveNext());
             Assert.Same(child3, enumerator.Current);
-            
+
             collection.Remove(child1);
             Assert.Same(child3, enumerator.Current);
 
@@ -1815,7 +1815,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(child3);
 
             Assert.Equal(expected, collection.IndexOfKey(key));
-            
+
             // Call again.
             Assert.Equal(expected, collection.IndexOfKey(key));
             Assert.Equal(-1, collection.IndexOfKey("NoSuchKey"));
@@ -1829,7 +1829,7 @@ namespace System.Windows.Forms.Tests
             var collection = new TabControl.TabPageCollection(owner);
 
             Assert.Equal(-1, collection.IndexOfKey(key));
-            
+
             // Call again.
             Assert.Equal(-1, collection.IndexOfKey(key));
             Assert.Equal(-1, collection.IndexOfKey("NoSuchKey"));
@@ -1913,7 +1913,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(value1.IsHandleCreated);
                 Assert.False(value2.IsHandleCreated);
                 Assert.False(owner.IsHandleCreated);
-                
+
                 // Add again.
                 collection.Insert(2, value1);
                 Assert.Empty(collection);
@@ -2062,7 +2062,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(expectedParentInvalidatedCallCount * 2, parentInvalidatedCallCount);
                 Assert.Equal(0, parentStyleChangedCallCount);
                 Assert.Equal(0, parentCreatedCallCount);
-                
+
                 // Add again.
                 collection.Insert(2, value1);
                 Assert.Equal(new TabPage[] { value2, value1, value1 }, collection.Cast<TabPage>());
@@ -2224,7 +2224,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, styleChangedCallCount2);
                 Assert.Equal(0, createdCallCount2);
                 Assert.False(owner.IsHandleCreated);
-                
+
                 // Add again.
                 collection.Insert(2, value1);
                 Assert.Empty(collection);
@@ -2402,7 +2402,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(expectedParentInvalidatedCallCount * 2, parentInvalidatedCallCount);
                 Assert.Equal(0, parentStyleChangedCallCount);
                 Assert.Equal(0, parentCreatedCallCount);
-                
+
                 // Add again.
                 collection.Insert(2, value1);
                 Assert.Equal(new TabPage[] { value2, value1, value1 }, collection.Cast<TabPage>());
@@ -2555,7 +2555,7 @@ namespace System.Windows.Forms.Tests
             using var owner = new TabControl();
             var collection = new TabControl.TabPageCollection(owner);
             Assert.NotEqual(IntPtr.Zero, owner.Handle);
-            
+
             var items = new List<TabPage>();
             for (int i = 0; i < 24; i++)
             {
@@ -2692,7 +2692,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(int.MaxValue, item.cchTextMax);
             Assert.Equal(expectedText, new string(item.pszText));
             Assert.Equal(1, item.iImage);
-            
+
             // Get item 2.
             Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WindowMessage)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
             Assert.Equal(ComCtl32.TCIS.BUTTONPRESSED, item.dwState);
@@ -2760,7 +2760,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(int.MaxValue, item.cchTextMax);
             Assert.Equal(expectedText, new string(item.pszText));
             Assert.Equal(1, item.iImage);
-            
+
             // Get item 2.
             Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WindowMessage)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
             Assert.Equal(ComCtl32.TCIS.BUTTONPRESSED, item.dwState);
@@ -2899,7 +2899,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(child3);
 
             Assert.Equal(collection[expectedIndex], collection[key]);
-            
+
             // Call again.
             Assert.Equal(collection[expectedIndex], collection[key]);
             Assert.Null(collection["NoSuchKey"]);
@@ -2933,7 +2933,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(child3);
 
             Assert.Null(collection[key]);
-            
+
             // Call again.
             Assert.Null(collection[key]);
             Assert.Null(collection["NoSuchKey"]);
@@ -2947,7 +2947,7 @@ namespace System.Windows.Forms.Tests
             var collection = new TabControl.TabPageCollection(owner);
 
             Assert.Null(collection[key]);
-            
+
             // Call again.
             Assert.Null(collection[key]);
             Assert.Null(collection["NoSuchKey"]);
@@ -2965,7 +2965,7 @@ namespace System.Windows.Forms.Tests
             Assert.Same(page1, collection[0]);
             Assert.Same(page2, collection[1]);
         }
-        
+
         [WinFormsTheory]
         [InlineData(-1)]
         [InlineData(0)]
@@ -2976,7 +2976,7 @@ namespace System.Windows.Forms.Tests
             var collection = new TabControl.TabPageCollection(owner);
             Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index]);
         }
-        
+
         [WinFormsTheory]
         [InlineData(-1)]
         [InlineData(1)]
@@ -3004,7 +3004,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(page1);
             collection.Add(page2);
             collection.Add(page3);
-            
+
             using var newPage = new TabPage();
             collection[index] = newPage;
             Assert.Same(newPage, collection[index]);
@@ -3047,7 +3047,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(page1);
             collection.Add(page2);
             collection.Add(page3);
-            
+
             using var newPage = new TabPage();
             collection[index] = newPage;
             Assert.Same(newPage, collection[index]);
@@ -3085,7 +3085,7 @@ namespace System.Windows.Forms.Tests
             owner.StyleChanged += (sender, e) => parentStyleChangedCallCount++;
             int parentCreatedCallCount = 0;
             owner.HandleCreated += (sender, e) => parentCreatedCallCount++;
-            
+
             using var newPage = new TabPage();
             collection[index] = newPage;
             Assert.Same(newPage, collection[index]);
@@ -3139,7 +3139,7 @@ namespace System.Windows.Forms.Tests
             owner.StyleChanged += (sender, e) => parentStyleChangedCallCount++;
             int parentCreatedCallCount = 0;
             owner.HandleCreated += (sender, e) => parentCreatedCallCount++;
-            
+
             using var newPage = new TabPage();
             collection[index] = newPage;
             Assert.Same(newPage, collection[index]);
@@ -3205,7 +3205,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(int.MaxValue, item.cchTextMax);
             Assert.Equal(expectedText, new string(item.pszText));
             Assert.Equal(1, item.iImage);
-            
+
             // Get item 2.
             Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WindowMessage)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
@@ -3214,7 +3214,7 @@ namespace System.Windows.Forms.Tests
             Assert.Empty(new string(item.pszText));
             Assert.Equal(-1, item.iImage);
         }
-        
+
         [WinFormsTheory]
         [InlineData("Text", "Text")]
         [InlineData("&&Text", "&&Text")]
@@ -3244,7 +3244,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(page2);
             collection.Add(page3);
             Assert.NotEqual(IntPtr.Zero, owner.Handle);
-            
+
             using var value = new TabPage
             {
                 Text = text,
@@ -3275,7 +3275,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(int.MaxValue, item.cchTextMax);
             Assert.Equal(expectedText, new string(item.pszText));
             Assert.Equal(1, item.iImage);
-            
+
             // Get item 2.
             Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WindowMessage)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
@@ -3307,7 +3307,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.Throws<ArgumentNullException>("value", () => collection[0] = null);
         }
-        
+
         [WinFormsTheory]
         [InlineData(-1)]
         [InlineData(0)]
@@ -3319,7 +3319,7 @@ namespace System.Windows.Forms.Tests
             var collection = new TabControl.TabPageCollection(owner);
             Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index] = page);
         }
-        
+
         [WinFormsTheory]
         [InlineData(-1)]
         [InlineData(1)]
@@ -3333,7 +3333,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(page1);
             Assert.Throws<ArgumentOutOfRangeException>("index", () => collection[index] = page2);
         }
-        
+
         [WinFormsFact]
         public void TabPageCollection_IListItem_GetValidIndex_ReturnsExpected()
         {
@@ -3347,7 +3347,7 @@ namespace System.Windows.Forms.Tests
             Assert.Same(page1, iList[0]);
             Assert.Same(page2, iList[1]);
         }
-        
+
         [WinFormsTheory]
         [InlineData(-1)]
         [InlineData(0)]
@@ -3359,7 +3359,7 @@ namespace System.Windows.Forms.Tests
             IList iList = collection;
             Assert.Throws<ArgumentOutOfRangeException>("index", () => iList[index]);
         }
-        
+
         [WinFormsTheory]
         [InlineData(-1)]
         [InlineData(1)]
@@ -3389,7 +3389,7 @@ namespace System.Windows.Forms.Tests
             iList.Add(page1);
             iList.Add(page2);
             iList.Add(page3);
-            
+
             using var newPage = new TabPage();
             iList[index] = newPage;
             Assert.Same(newPage, iList[index]);
@@ -3433,7 +3433,7 @@ namespace System.Windows.Forms.Tests
             iList.Add(page1);
             iList.Add(page2);
             iList.Add(page3);
-            
+
             using var newPage = new TabPage();
             iList[index] = newPage;
             Assert.Same(newPage, iList[index]);
@@ -3472,7 +3472,7 @@ namespace System.Windows.Forms.Tests
             owner.StyleChanged += (sender, e) => parentStyleChangedCallCount++;
             int parentCreatedCallCount = 0;
             owner.HandleCreated += (sender, e) => parentCreatedCallCount++;
-            
+
             using var newPage = new TabPage();
             iList[index] = newPage;
             Assert.Same(newPage, iList[index]);
@@ -3527,7 +3527,7 @@ namespace System.Windows.Forms.Tests
             owner.StyleChanged += (sender, e) => parentStyleChangedCallCount++;
             int parentCreatedCallCount = 0;
             owner.HandleCreated += (sender, e) => parentCreatedCallCount++;
-            
+
             using var newPage = new TabPage();
             iList[index] = newPage;
             Assert.Same(newPage, iList[index]);
@@ -3564,7 +3564,7 @@ namespace System.Windows.Forms.Tests
             iList.Add(page);
             Assert.Throws<ArgumentException>(null, () => iList[0] = value);
         }
-        
+
         [WinFormsTheory]
         [InlineData(-1)]
         [InlineData(0)]
@@ -3577,7 +3577,7 @@ namespace System.Windows.Forms.Tests
             IList iList = collection;
             Assert.Throws<ArgumentOutOfRangeException>("index", () => iList[index] = page);
         }
-        
+
         [WinFormsTheory]
         [InlineData(-1)]
         [InlineData(1)]
@@ -3605,7 +3605,7 @@ namespace System.Windows.Forms.Tests
             var collection = new TabControl.TabPageCollection(owner);
             collection.Add(value1);
             collection.Add(value2);
-            
+
             int layoutCallCount1 = 0;
             value1.Layout += (sender, e) => layoutCallCount1++;
             int layoutCallCount2 = 0;
@@ -3642,7 +3642,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(value1.IsHandleCreated);
                 Assert.False(value2.IsHandleCreated);
                 Assert.False(owner.IsHandleCreated);
-                
+
                 // Remove again.
                 collection.Remove(value2);
                 Assert.Same(value1, Assert.Single(collection));
@@ -3663,7 +3663,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(value1.IsHandleCreated);
                 Assert.False(value2.IsHandleCreated);
                 Assert.False(owner.IsHandleCreated);
-                
+
                 // Remove first.
                 collection.Remove(value1);
                 Assert.Empty(collection);
@@ -3703,7 +3703,7 @@ namespace System.Windows.Forms.Tests
             var collection = new TabControl.TabPageCollection(owner);
             collection.Add(value1);
             collection.Add(value2);
-            
+
             int layoutCallCount1 = 0;
             value1.Layout += (sender, e) => layoutCallCount1++;
             int layoutCallCount2 = 0;
@@ -3757,7 +3757,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, createdCallCount1);
                 Assert.True(value2.IsHandleCreated);
                 Assert.False(owner.IsHandleCreated);
-                
+
                 // Remove again.
                 collection.Remove(value2);
                 Assert.Same(value1, Assert.Single(collection));
@@ -3784,7 +3784,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, styleChangedCallCount2);
                 Assert.Equal(0, createdCallCount2);
                 Assert.False(owner.IsHandleCreated);
-                
+
                 // Remove first.
                 collection.Remove(value1);
                 Assert.Empty(collection);
@@ -3830,7 +3830,7 @@ namespace System.Windows.Forms.Tests
             var collection = new TabControl.TabPageCollection(owner);
             collection.Add(value1);
             collection.Add(value2);
-            
+
             int layoutCallCount1 = 0;
             value1.Layout += (sender, e) => layoutCallCount1++;
             int layoutCallCount2 = 0;
@@ -3877,7 +3877,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, parentInvalidatedCallCount);
                 Assert.Equal(0, parentStyleChangedCallCount);
                 Assert.Equal(0, parentCreatedCallCount);
-                
+
                 // Remove again.
                 collection.Remove(value2);
                 Assert.Same(value1, Assert.Single(collection));
@@ -3901,7 +3901,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, parentInvalidatedCallCount);
                 Assert.Equal(0, parentStyleChangedCallCount);
                 Assert.Equal(0, parentCreatedCallCount);
-                
+
                 // Remove first.
                 collection.Remove(value1);
                 Assert.Empty(collection);
@@ -3944,7 +3944,7 @@ namespace System.Windows.Forms.Tests
             var collection = new TabControl.TabPageCollection(owner);
             collection.Add(value1);
             collection.Add(value2);
-            
+
             int layoutCallCount1 = 0;
             value1.Layout += (sender, e) => layoutCallCount1++;
             int layoutCallCount2 = 0;
@@ -3998,7 +3998,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, createdCallCount1);
                 Assert.True(value2.IsHandleCreated);
                 Assert.False(owner.IsHandleCreated);
-                
+
                 // Remove again.
                 collection.Remove(value2);
                 Assert.Same(value1, Assert.Single(collection));
@@ -4025,7 +4025,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0, styleChangedCallCount2);
                 Assert.Equal(0, createdCallCount2);
                 Assert.False(owner.IsHandleCreated);
-                
+
                 // Remove first.
                 collection.Remove(value1);
                 Assert.Empty(collection);
@@ -4079,17 +4079,17 @@ namespace System.Windows.Forms.Tests
             collection.Remove(value2);
             Assert.Equal(new Control[] { value1, value3, value4 }, collection.Cast<TabPage>());
             Assert.Null(owner.SelectedTab);
-            
+
             // Remove selected.
             collection.Remove(value4);
             Assert.Equal(new Control[] { value1, value3 }, collection.Cast<TabPage>());
             Assert.Null(owner.SelectedTab);
-            
+
             // Remove selected again.
             collection.Remove(value1);
             Assert.Equal(new Control[] { value3 }, collection.Cast<TabPage>());
             Assert.Null(owner.SelectedTab);
-            
+
             // Remove selected again.
             collection.Remove(value3);
             Assert.Empty(collection);
@@ -4117,17 +4117,17 @@ namespace System.Windows.Forms.Tests
             collection.Remove(value2);
             Assert.Equal(new Control[] { value1, value3, value4 }, collection.Cast<TabPage>());
             Assert.Same(value4, owner.SelectedTab);
-            
+
             // Remove selected.
             collection.Remove(value4);
             Assert.Equal(new Control[] { value1, value3 }, collection.Cast<TabPage>());
             Assert.Same(value1, owner.SelectedTab);
-            
+
             // Remove selected again.
             collection.Remove(value1);
             Assert.Equal(new Control[] { value3 }, collection.Cast<TabPage>());
             Assert.Same(value3, owner.SelectedTab);
-            
+
             // Remove selected again.
             collection.Remove(value3);
             Assert.Empty(collection);
@@ -4139,7 +4139,7 @@ namespace System.Windows.Forms.Tests
         {
             using var owner = new TabControl();
             var collection = new TabControl.TabPageCollection(owner);
-            
+
             var items = new List<TabPage>();
             for (int i = 0; i < 24; i++)
             {
@@ -4150,7 +4150,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(items, owner.TabPages.Cast<TabPage>());
                 Assert.Same(owner, value.Parent);
             }
-            
+
             for (int i = 0; i < 24; i++)
             {
                 items.RemoveAt(0);
@@ -4216,7 +4216,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(int.MaxValue, item.cchTextMax);
             Assert.Empty(new string(item.pszText));
             Assert.Equal(-1, item.iImage);
-            
+
             // Get item 2.
             Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WindowMessage)ComCtl32.TCM.GETITEMW, (IntPtr)1, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
@@ -4225,7 +4225,7 @@ namespace System.Windows.Forms.Tests
             Assert.Empty(new string(item.pszText));
             Assert.Equal(-1, item.iImage);
         }
-        
+
         [WinFormsFact]
         public unsafe void TabControlControlCollection_Remove_GetItemsDesignModeWithHandle_Success()
         {
@@ -4305,7 +4305,7 @@ namespace System.Windows.Forms.Tests
             IList iList = collection;
             iList.Add(value1);
             iList.Add(value2);
-            
+
             int layoutCallCount1 = 0;
             value1.Layout += (sender, e) => layoutCallCount1++;
             int layoutCallCount2 = 0;
@@ -4341,7 +4341,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(value1.IsHandleCreated);
                 Assert.False(value2.IsHandleCreated);
                 Assert.False(owner.IsHandleCreated);
-                
+
                 // Remove again.
                 iList.Remove(value2);
                 Assert.Same(value1, Assert.Single(collection));
@@ -4361,7 +4361,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(value1.IsHandleCreated);
                 Assert.False(value2.IsHandleCreated);
                 Assert.False(owner.IsHandleCreated);
-                
+
                 // Remove first.
                 iList.Remove(value1);
                 Assert.Empty(collection);
@@ -4414,7 +4414,7 @@ namespace System.Windows.Forms.Tests
             var collection = new TabControl.TabPageCollection(owner);
             collection.Add(child1);
             collection.Add(child2);
-            
+
             int layoutCallCount = 0;
             child1.Layout += (sender, e) => layoutCallCount++;
             int parentLayoutCallCount = 0;
@@ -4439,7 +4439,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(owner.IsHandleCreated);
                 Assert.False(child1.IsHandleCreated);
                 Assert.False(child2.IsHandleCreated);
-                
+
                 // Remove again.
                 affectedControl = child1;
                 collection.RemoveAt(0);
@@ -4503,7 +4503,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(child1);
             collection.Add(child2);
             collection.Add(child3);
-            
+
             int layoutCallCount = 0;
             child2.Layout += (sender, e) => layoutCallCount++;
             int parentLayoutCallCount = 0;
@@ -4530,7 +4530,7 @@ namespace System.Windows.Forms.Tests
                 Assert.False(child1.IsHandleCreated);
                 Assert.False(child2.IsHandleCreated);
                 Assert.False(child3.IsHandleCreated);
-                
+
                 // Remove again.
                 affectedControl = child3;
                 collection.RemoveByKey(key);
@@ -4579,7 +4579,7 @@ namespace System.Windows.Forms.Tests
 
             collection.RemoveByKey(key);
             Assert.Equal(new TabPage[] { child1, child2, child3 }, collection.Cast<TabPage>());
-            
+
             // Call again.
             collection.RemoveByKey(key);
             Assert.Equal(new TabPage[] { child1, child2, child3 }, collection.Cast<TabPage>());

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPageTests.TabPageControlCollection.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPageTests.TabPageControlCollection.cs
@@ -26,7 +26,6 @@ namespace System.Windows.Forms.Tests
             Assert.Same(owner, collection.Owner);
         }
 
-
         [WinFormsFact]
         public void TabPageControlCollection_Add_ControlExistingCollection_Success()
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPageTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPageTests.cs
@@ -626,7 +626,7 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.UseVisualStyleBackColor);
             Assert.False(control.IsHandleCreated);
         }
-        
+
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetBackColorTheoryData))]
         public void TabPage_BackColor_SetDesignModeWithUseVisualStyleBackColor_GetReturnsExpected(Color value, Color expected)
@@ -669,7 +669,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(value.IsEmpty, control.UseVisualStyleBackColor);
             Assert.False(control.IsHandleCreated);
         }
-        
+
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetBackColorTheoryData))]
         public void TabPage_BackColor_SetDesignModeWithInvalidDescriptor_GetReturnsExpected(Color value, Color expected)
@@ -824,7 +824,7 @@ namespace System.Windows.Forms.Tests
             {
                 Dock = DockStyle.Top
             };
-             
+
             control.Dock = value;
             Assert.Equal(value, control.Dock);
             Assert.Equal(AnchorStyles.Top | AnchorStyles.Left, control.Anchor);
@@ -843,7 +843,7 @@ namespace System.Windows.Forms.Tests
             {
                 Anchor = anchor
             };
-             
+
             control.Dock = value;
             Assert.Equal(value, control.Dock);
             Assert.Equal(expectedAnchor, control.Anchor);
@@ -1175,7 +1175,7 @@ namespace System.Windows.Forms.Tests
             parent.StyleChanged += (sender, e) => parentStyleChangedCallCount++;
             int parentCreatedCallCount = 0;
             parent.HandleCreated += (sender, e) => parentCreatedCallCount++;
-            
+
             control.ImageIndex = value;
             Assert.Equal(value, control.ImageIndex);
             Assert.Empty(control.ImageKey);
@@ -1241,7 +1241,7 @@ namespace System.Windows.Forms.Tests
             parent.StyleChanged += (sender, e) => parentStyleChangedCallCount++;
             int parentCreatedCallCount = 0;
             parent.HandleCreated += (sender, e) => parentCreatedCallCount++;
-            
+
             control.ImageIndex = value;
             Assert.Equal(value, control.ImageIndex);
             Assert.Empty(control.ImageKey);
@@ -1314,7 +1314,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(int.MaxValue, item.cchTextMax);
             Assert.Equal("Text", new string(item.pszText));
             Assert.Equal(imageIndex, item.iImage);
-            
+
             // Get item 2.
             Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WindowMessage)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
@@ -1381,7 +1381,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(int.MaxValue, item.cchTextMax);
             Assert.Equal("Text", new string(item.pszText));
             Assert.Equal(imageIndex, item.iImage);
-            
+
             // Get item 2.
             Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WindowMessage)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
@@ -1555,7 +1555,7 @@ namespace System.Windows.Forms.Tests
             parent.StyleChanged += (sender, e) => parentStyleChangedCallCount++;
             int parentCreatedCallCount = 0;
             parent.HandleCreated += (sender, e) => parentCreatedCallCount++;
-            
+
             control.ImageKey = value;
             Assert.Equal(-1, control.ImageIndex);
             Assert.Equal(value, control.ImageKey);
@@ -1619,7 +1619,7 @@ namespace System.Windows.Forms.Tests
             parent.StyleChanged += (sender, e) => parentStyleChangedCallCount++;
             int parentCreatedCallCount = 0;
             parent.HandleCreated += (sender, e) => parentCreatedCallCount++;
-            
+
             control.ImageKey = value;
             Assert.Equal(-1, control.ImageIndex);
             Assert.Equal(value, control.ImageKey);
@@ -1689,7 +1689,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(int.MaxValue, item.cchTextMax);
             Assert.Equal("Text", new string(item.pszText));
             Assert.Equal(-1, item.iImage);
-            
+
             // Get item 2.
             Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WindowMessage)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
@@ -1753,7 +1753,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(int.MaxValue, item.cchTextMax);
             Assert.Equal("Text", new string(item.pszText));
             Assert.Equal(-1, item.iImage);
-            
+
             // Get item 2.
             Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WindowMessage)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
@@ -2286,7 +2286,7 @@ namespace System.Windows.Forms.Tests
             property.ResetValue(control);
             Assert.Equal(new Point(1, 2), control.Location);
             Assert.False(property.CanResetValue(control));
-            
+
             control.Location = Point.Empty;
             Assert.Equal(Point.Empty, control.Location);
             Assert.False(property.CanResetValue(control));
@@ -2314,7 +2314,7 @@ namespace System.Windows.Forms.Tests
             property.ResetValue(control);
             Assert.Equal(new Point(1, 2), control.Location);
             Assert.True(property.ShouldSerializeValue(control));
-            
+
             control.Location = Point.Empty;
             Assert.Equal(Point.Empty, control.Location);
             Assert.False(property.ShouldSerializeValue(control));
@@ -2408,7 +2408,7 @@ namespace System.Windows.Forms.Tests
             {
                 Parent = oldParent
             };
-            
+
             control.Parent = value;
             Assert.Same(value, control.Parent);
             Assert.Empty(oldParent.Controls);
@@ -2682,7 +2682,7 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.TabStop);
             Assert.Equal(2, callCount);
         }
-        
+
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
         public void TabPage_Text_Set_GetReturnsExpected(string value, string expected)
@@ -2943,7 +2943,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(int.MaxValue, item.cchTextMax);
             Assert.Equal(expectedText, new string(item.pszText));
             Assert.Equal(1, item.iImage);
-            
+
             // Get item 2.
             Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WindowMessage)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
@@ -3010,7 +3010,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(int.MaxValue, item.cchTextMax);
             Assert.Equal(expectedText, new string(item.pszText));
             Assert.Equal(1, item.iImage);
-            
+
             // Get item 2.
             Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WindowMessage)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
@@ -3054,7 +3054,7 @@ namespace System.Windows.Forms.Tests
             Assert.Same("text", control.Text);
             Assert.Equal(2, callCount);
         }
-        
+
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
         public void TabPage_ToolTipText_Set_GetReturnsExpected(string value, string expected)
@@ -3094,7 +3094,7 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.IsHandleCreated);
             Assert.False(parent.IsHandleCreated);
         }
-        
+
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
         public void TabPage_ToolTipText_SetWithDesignModeParent_GetReturnsExpected(string value, string expected)
@@ -3316,7 +3316,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(int.MaxValue, item.cchTextMax);
             Assert.Equal("Text", new string(item.pszText));
             Assert.Equal(1, item.iImage);
-            
+
             // Get item 2.
             Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WindowMessage)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
@@ -3380,7 +3380,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(int.MaxValue, item.cchTextMax);
             Assert.Equal("Text", new string(item.pszText));
             Assert.Equal(1, item.iImage);
-            
+
             // Get item 2.
             Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WindowMessage)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
@@ -3400,12 +3400,12 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(value, control.UseVisualStyleBackColor);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             control.UseVisualStyleBackColor = value;
             Assert.Equal(value, control.UseVisualStyleBackColor);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set different.
             control.UseVisualStyleBackColor = !value;
             Assert.Equal(!value, control.UseVisualStyleBackColor);
@@ -3432,7 +3432,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set same.
             control.UseVisualStyleBackColor = value;
             Assert.Equal(value, control.UseVisualStyleBackColor);
@@ -3760,12 +3760,12 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.Enter += handler;
             control.OnEnter(eventArgs);
             Assert.Equal(0, callCount);
-        
+
             // Remove handler.
             control.Enter -= handler;
             control.OnEnter(eventArgs);
@@ -3788,12 +3788,12 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.Enter += handler;
             control.OnEnter(eventArgs);
             Assert.Equal(0, callCount);
-        
+
             // Remove handler.
             control.Enter -= handler;
             control.OnEnter(eventArgs);
@@ -3812,12 +3812,12 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.Leave += handler;
             control.OnLeave(eventArgs);
             Assert.Equal(0, callCount);
-        
+
             // Remove handler.
             control.Leave -= handler;
             control.OnLeave(eventArgs);
@@ -3840,18 +3840,18 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.Leave += handler;
             control.OnLeave(eventArgs);
             Assert.Equal(0, callCount);
-        
+
             // Remove handler.
             control.Leave -= handler;
             control.OnLeave(eventArgs);
             Assert.Equal(0, callCount);
         }
-        
+
         public static IEnumerable<object[]> OnPaintBackground_TestData()
         {
             foreach (Image backgroundImage in new Image[] { null, new Bitmap(10, 10, PixelFormat.Format32bppRgb), new Bitmap(10, 10, PixelFormat.Format32bppArgb) })
@@ -3867,7 +3867,7 @@ namespace System.Windows.Forms.Tests
                 }
             }
         }
-        
+
         [WinFormsTheory]
         [MemberData(nameof(OnPaintBackground_TestData))]
         public void TabPage_OnPaintBackground_Invoke_Success(bool supportsTransparentBackColor, Color backColor, Image backgroundImage, ImageLayout backgroundImageLayout)
@@ -3937,7 +3937,7 @@ namespace System.Windows.Forms.Tests
                 }
             }
         }
-        
+
         [WinFormsTheory]
         [MemberData(nameof(OnPaintBackground_WithParent_TestData))]
         public void TabPage_OnPaintBackground_InvokeWithParent_CallsPaint(TabAppearance appearance, bool useVisualStyleBackColor, bool supportsTransparentBackColor, Color backColor, Image backgroundImage, ImageLayout backgroundImageLayout, int expectedPaintCallCount)
@@ -3993,7 +3993,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expectedPaintCallCount, parentCallCount);
             Assert.False(control.IsHandleCreated);
         }
-        
+
         [WinFormsTheory]
         [MemberData(nameof(OnPaintBackground_TestData))]
         public void TabPage_OnPaintBackground_InvokeWithHandle_Success(bool supportsTransparentBackColor, Color backColor, Image backgroundImage, ImageLayout backgroundImageLayout)
@@ -4076,7 +4076,7 @@ namespace System.Windows.Forms.Tests
                 }
             }
         }
-        
+
         [WinFormsTheory]
         [MemberData(nameof(OnPaintBackground_WithParentWithHandle_TestData))]
         public void TabPage_OnPaintBackground_InvokeWithParentWithHandle_CallsPaint(TabAppearance appearance, bool useVisualStyleBackColor, bool supportsTransparentBackColor, Color backColor, Image backgroundImage, ImageLayout backgroundImageLayout, int expectedPaintCallCount)
@@ -4818,7 +4818,7 @@ namespace System.Windows.Forms.Tests
             public SubTabPage() : base()
             {
             }
-            
+
             public SubTabPage(string text) : base(text)
             {
             }
@@ -4900,9 +4900,9 @@ namespace System.Windows.Forms.Tests
             public new void SetStyle(ControlStyles flag, bool value) => base.SetStyle(flag, value);
 
             public new void OnEnter(EventArgs e) => base.OnEnter(e);
-            
+
             public new void OnLeave(EventArgs e) => base.OnLeave(e);
-            
+
             public new void OnPaintBackground(PaintEventArgs e) => base.OnPaintBackground(e);
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TableLayoutStyleTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TableLayoutStyleTests.cs
@@ -30,7 +30,7 @@ namespace System.Windows.Forms.Tests
                 SizeType = value
             };
             Assert.Equal(value, style.SizeType);
-            
+
             // Set same.
             style.SizeType = value;
             Assert.Equal(value, style.SizeType);
@@ -60,7 +60,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(value, style.SizeType);
             Assert.Equal(expectedLayoutCallCount, layoutCallCount);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             style.SizeType = value;
             Assert.Equal(value, style.SizeType);
@@ -102,7 +102,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expectedLayoutCallCount * 2, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set same.
             style.SizeType = value;
             Assert.Equal(value, style.SizeType);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TextRendererTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TextRendererTests.cs
@@ -38,11 +38,11 @@ namespace System.Windows.Forms.Tests
             using Graphics graphics = Graphics.FromImage(image);
             graphics.TextRenderingHint = textRenderingHint;
             TextRenderer.DrawText(graphics, text, font, pt, foreColor);
-            
+
             // Call again to test caching.
             TextRenderer.DrawText(graphics, text, font, pt, foreColor);
         }
-        
+
         public static IEnumerable<object[]> DrawText_IDeviceContext_String_Font_Point_Color_Color_TestData()
         {
             foreach (TextRenderingHint hint in Enum.GetValues(typeof(TextRenderingHint)))
@@ -72,11 +72,11 @@ namespace System.Windows.Forms.Tests
             using Graphics graphics = Graphics.FromImage(image);
             graphics.TextRenderingHint = textRenderingHint;
             TextRenderer.DrawText(graphics, text, font, pt, foreColor, backColor);
-            
+
             // Call again to test caching.
             TextRenderer.DrawText(graphics, text, font, pt, foreColor, backColor);
         }
-        
+
         public static IEnumerable<object[]> DrawText_IDeviceContext_String_Font_Point_Color_TextFormatFlags_TestData()
         {
             foreach (TextRenderingHint hint in Enum.GetValues(typeof(TextRenderingHint)))
@@ -109,11 +109,11 @@ namespace System.Windows.Forms.Tests
             using Graphics graphics = Graphics.FromImage(image);
             graphics.TextRenderingHint = textRenderingHint;
             TextRenderer.DrawText(graphics, text, font, pt, foreColor, flags);
-            
+
             // Call again to test caching.
             TextRenderer.DrawText(graphics, text, font, pt, foreColor, flags);
         }
-        
+
         public static IEnumerable<object[]> DrawText_IDeviceContext_String_Font_Point_Color_Color_TextFormatFlags_TestData()
         {
             foreach (TextRenderingHint hint in Enum.GetValues(typeof(TextRenderingHint)))
@@ -150,7 +150,7 @@ namespace System.Windows.Forms.Tests
             using Graphics graphics = Graphics.FromImage(image);
             graphics.TextRenderingHint = textRenderingHint;
             TextRenderer.DrawText(graphics, text, font, pt, foreColor, backColor, flags);
-            
+
             // Call again to test caching.
             TextRenderer.DrawText(graphics, text, font, pt, foreColor, backColor, flags);
         }
@@ -182,11 +182,11 @@ namespace System.Windows.Forms.Tests
             using Graphics graphics = Graphics.FromImage(image);
             graphics.TextRenderingHint = textRenderingHint;
             TextRenderer.DrawText(graphics, text, font, bounds, foreColor);
-            
+
             // Call again to test caching.
             TextRenderer.DrawText(graphics, text, font, bounds, foreColor);
         }
-        
+
         public static IEnumerable<object[]> DrawText_IDeviceContext_String_Font_Rectangle_Color_Color_TestData()
         {
             foreach (TextRenderingHint hint in Enum.GetValues(typeof(TextRenderingHint)))
@@ -218,11 +218,11 @@ namespace System.Windows.Forms.Tests
             using Graphics graphics = Graphics.FromImage(image);
             graphics.TextRenderingHint = textRenderingHint;
             TextRenderer.DrawText(graphics, text, font, rectangle, foreColor, backColor);
-            
+
             // Call again to test caching.
             TextRenderer.DrawText(graphics, text, font, rectangle, foreColor, backColor);
         }
-        
+
         public static IEnumerable<object[]> DrawText_IDeviceContext_String_Font_Rectangle_Color_TextFormatFlags_TestData()
         {
             foreach (TextRenderingHint hint in Enum.GetValues(typeof(TextRenderingHint)))
@@ -258,11 +258,11 @@ namespace System.Windows.Forms.Tests
             using Graphics graphics = Graphics.FromImage(image);
             graphics.TextRenderingHint = textRenderingHint;
             TextRenderer.DrawText(graphics, text, font, rectangle, foreColor, flags);
-            
+
             // Call again to test caching.
             TextRenderer.DrawText(graphics, text, font, rectangle, foreColor, flags);
         }
-        
+
         public static IEnumerable<object[]> DrawText_IDeviceContext_String_Font_Rectangle_Color_Color_TextFormatFlags_TestData()
         {
             foreach (TextRenderingHint hint in Enum.GetValues(typeof(TextRenderingHint)))
@@ -302,7 +302,7 @@ namespace System.Windows.Forms.Tests
             using Graphics graphics = Graphics.FromImage(image);
             graphics.TextRenderingHint = textRenderingHint;
             TextRenderer.DrawText(graphics, text, font, rectangle, foreColor, backColor, flags);
-            
+
             // Call again to test caching.
             TextRenderer.DrawText(graphics, text, font, rectangle, foreColor, backColor, flags);
         }
@@ -465,7 +465,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { "string", SystemFonts.MenuFont, new Size(1, 2), TextFormatFlags.Default };
             yield return new object[] { "string", SystemFonts.MenuFont, new Size(100, 200), TextFormatFlags.Default };
             yield return new object[] { "string", SystemFonts.MenuFont, new Size(int.MaxValue, int.MaxValue), TextFormatFlags.Default };
-            
+
             yield return new object[] { "string", SystemFonts.MenuFont, new Size(100, 200), TextFormatFlags.VerticalCenter | TextFormatFlags.HorizontalCenter };
             yield return new object[] { "string", SystemFonts.MenuFont, new Size(100, 200), TextFormatFlags.Bottom | TextFormatFlags.Right };
             yield return new object[] { "string", SystemFonts.MenuFont, new Size(100, 200), TextFormatFlags.SingleLine };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButtonTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButtonTests.cs
@@ -654,7 +654,7 @@ namespace System.Windows.Forms.Tests
             owner.StyleChanged += (sender, e) => styleChangedCallCount++;
             int createdCallCount = 0;
             owner.HandleCreated += (sender, e) => createdCallCount++;
-            
+
             item.Checked = value;
             Assert.Equal(value, item.Checked);
             Assert.Equal(expectedCheckState1, item.CheckState);
@@ -727,7 +727,7 @@ namespace System.Windows.Forms.Tests
             parent.StyleChanged += (sender, e) => styleChangedCallCount++;
             int createdCallCount = 0;
             parent.HandleCreated += (sender, e) => createdCallCount++;
-            
+
             item.Checked = value;
             Assert.Equal(value, item.Checked);
             Assert.Equal(expectedCheckState1, item.CheckState);
@@ -778,32 +778,32 @@ namespace System.Windows.Forms.Tests
                 checkStateCallCount++;
             };
             item.CheckStateChanged += checkStateHandler;
-        
+
             // Set different.
             item.Checked = false;
             Assert.False(item.Checked);
             Assert.Equal(1, callCount);
             Assert.Equal(1, checkStateCallCount);
-        
+
             // Set same.
             item.Checked = false;
             Assert.False(item.Checked);
             Assert.Equal(1, callCount);
             Assert.Equal(1, checkStateCallCount);
-        
+
             // Set different.
             item.Checked = true;
             Assert.True(item.Checked);
             Assert.Equal(2, callCount);
             Assert.Equal(2, checkStateCallCount);
-        
+
             // Remove handler.
             item.CheckedChanged -= handler;
             item.Checked = false;
             Assert.False(item.Checked);
             Assert.Equal(2, callCount);
             Assert.Equal(3, checkStateCallCount);
-            
+
             // Remove other handler.
             item.CheckStateChanged -= checkStateHandler;
             item.Checked = true;
@@ -822,7 +822,7 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(value, item.CheckState);
             Assert.Equal(value != CheckState.Unchecked, item.Checked);
-            
+
             // Set same.
             item.CheckState = value;
             Assert.Equal(value, item.CheckState);
@@ -842,7 +842,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(value, item.CheckState);
             Assert.Equal(value != CheckState.Unchecked, item.Checked);
             Assert.False(owner.IsHandleCreated);
-            
+
             // Set same.
             item.CheckState = value;
             Assert.Equal(value, item.CheckState);
@@ -866,7 +866,7 @@ namespace System.Windows.Forms.Tests
             owner.StyleChanged += (sender, e) => styleChangedCallCount++;
             int createdCallCount = 0;
             owner.HandleCreated += (sender, e) => createdCallCount++;
-            
+
             item.CheckState = value;
             Assert.Equal(value, item.CheckState);
             Assert.Equal(value != CheckState.Unchecked, item.Checked);
@@ -874,7 +874,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set same.
             item.CheckState = value;
             Assert.Equal(value, item.CheckState);
@@ -908,32 +908,32 @@ namespace System.Windows.Forms.Tests
                 checkStateCallCount++;
             };
             item.CheckStateChanged += checkStateHandler;
-        
+
             // Set different.
             item.CheckState = CheckState.Unchecked;
             Assert.Equal(CheckState.Unchecked, item.CheckState);
             Assert.Equal(1, callCount);
             Assert.Equal(1, checkStateCallCount);
-        
+
             // Set same.
             item.CheckState = CheckState.Unchecked;
             Assert.Equal(CheckState.Unchecked, item.CheckState);
             Assert.Equal(1, callCount);
             Assert.Equal(1, checkStateCallCount);
-        
+
             // Set different.
             item.CheckState = CheckState.Indeterminate;
             Assert.Equal(CheckState.Indeterminate, item.CheckState);
             Assert.Equal(2, callCount);
             Assert.Equal(2, checkStateCallCount);
-        
+
             // Remove handler.
             item.CheckedChanged -= handler;
             item.CheckState = CheckState.Unchecked;
             Assert.Equal(CheckState.Unchecked, item.CheckState);
             Assert.Equal(2, callCount);
             Assert.Equal(3, checkStateCallCount);
-            
+
             // Remove other handler.
             item.CheckStateChanged -= checkStateHandler;
             item.CheckState = CheckState.Indeterminate;
@@ -1076,12 +1076,12 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             item.CheckedChanged += handler;
             item.OnCheckedChanged(eventArgs);
             Assert.Equal(1, callCount);
-        
+
             // Remove handler.
             item.CheckedChanged -= handler;
             item.OnCheckedChanged(eventArgs);
@@ -1100,12 +1100,12 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             item.CheckStateChanged += handler;
             item.OnCheckStateChanged(eventArgs);
             Assert.Equal(1, callCount);
-        
+
             // Remove handler.
             item.CheckStateChanged -= handler;
             item.OnCheckStateChanged(eventArgs);
@@ -1124,13 +1124,13 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             item.Click += handler;
             item.OnClick(eventArgs);
             Assert.Equal(1, callCount);
             Assert.False(item.Checked);
-        
+
             // Remove handler.
             item.Click -= handler;
             item.OnClick(eventArgs);
@@ -1153,13 +1153,13 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             item.Click += handler;
             item.OnClick(eventArgs);
             Assert.Equal(1, callCount);
             Assert.True(item.Checked);
-        
+
             // Remove handler.
             item.Click -= handler;
             item.OnClick(eventArgs);
@@ -1196,7 +1196,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { ContentAlignment.MiddleCenter, RightToLeft.No, ToolStripItemDisplayStyle.None, 0, 0, TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter | TextFormatFlags.HidePrefix };
             yield return new object[] { ContentAlignment.MiddleCenter, RightToLeft.No, ToolStripItemDisplayStyle.Image, 1, 0, TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter | TextFormatFlags.HidePrefix };
             yield return new object[] { ContentAlignment.MiddleCenter, RightToLeft.No, ToolStripItemDisplayStyle.ImageAndText, 1, 1, TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter | TextFormatFlags.HidePrefix };
-            
+
             yield return new object[] { ContentAlignment.TopLeft, RightToLeft.Yes, ToolStripItemDisplayStyle.Text, 0, 1, TextFormatFlags.Left | TextFormatFlags.Top | TextFormatFlags.HidePrefix | TextFormatFlags.RightToLeft };
             yield return new object[] { ContentAlignment.TopLeft, RightToLeft.Inherit, ToolStripItemDisplayStyle.Text, 0, 1, TextFormatFlags.Left | TextFormatFlags.Top | TextFormatFlags.HidePrefix };
             yield return new object[] { ContentAlignment.TopLeft, RightToLeft.No, ToolStripItemDisplayStyle.Text, 0, 1, TextFormatFlags.Left | TextFormatFlags.Top | TextFormatFlags.HidePrefix };
@@ -1206,7 +1206,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { ContentAlignment.TopRight, RightToLeft.Yes, ToolStripItemDisplayStyle.Text, 0, 1, TextFormatFlags.Right | TextFormatFlags.Top | TextFormatFlags.HidePrefix | TextFormatFlags.RightToLeft };
             yield return new object[] { ContentAlignment.TopRight, RightToLeft.Inherit, ToolStripItemDisplayStyle.Text, 0, 1, TextFormatFlags.Right | TextFormatFlags.Top | TextFormatFlags.HidePrefix };
             yield return new object[] { ContentAlignment.TopRight, RightToLeft.No, ToolStripItemDisplayStyle.Text, 0, 1, TextFormatFlags.Right | TextFormatFlags.Top | TextFormatFlags.HidePrefix };
-            
+
             yield return new object[] { ContentAlignment.MiddleLeft, RightToLeft.Yes, ToolStripItemDisplayStyle.Text, 0, 1, TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.HidePrefix | TextFormatFlags.RightToLeft };
             yield return new object[] { ContentAlignment.MiddleLeft, RightToLeft.Inherit, ToolStripItemDisplayStyle.Text, 0, 1, TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.HidePrefix };
             yield return new object[] { ContentAlignment.MiddleLeft, RightToLeft.No, ToolStripItemDisplayStyle.Text, 0, 1, TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.HidePrefix };
@@ -1216,7 +1216,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { ContentAlignment.MiddleRight, RightToLeft.Yes, ToolStripItemDisplayStyle.Text, 0, 1, TextFormatFlags.Right | TextFormatFlags.VerticalCenter | TextFormatFlags.HidePrefix | TextFormatFlags.RightToLeft };
             yield return new object[] { ContentAlignment.MiddleRight, RightToLeft.Inherit, ToolStripItemDisplayStyle.Text, 0, 1, TextFormatFlags.Right | TextFormatFlags.VerticalCenter | TextFormatFlags.HidePrefix };
             yield return new object[] { ContentAlignment.MiddleRight, RightToLeft.No, ToolStripItemDisplayStyle.Text, 0, 1, TextFormatFlags.Right | TextFormatFlags.VerticalCenter | TextFormatFlags.HidePrefix };
-            
+
             yield return new object[] { ContentAlignment.BottomLeft, RightToLeft.Yes, ToolStripItemDisplayStyle.Text, 0, 1, TextFormatFlags.Left | TextFormatFlags.Bottom | TextFormatFlags.HidePrefix | TextFormatFlags.RightToLeft };
             yield return new object[] { ContentAlignment.BottomLeft, RightToLeft.Inherit, ToolStripItemDisplayStyle.Text, 0, 1, TextFormatFlags.Left | TextFormatFlags.Bottom | TextFormatFlags.HidePrefix };
             yield return new object[] { ContentAlignment.BottomLeft, RightToLeft.No, ToolStripItemDisplayStyle.Text, 0, 1, TextFormatFlags.Left | TextFormatFlags.Bottom | TextFormatFlags.HidePrefix };
@@ -1253,7 +1253,7 @@ namespace System.Windows.Forms.Tests
                 TextDirection = ToolStripTextDirection.Vertical270,
                 Owner = owner
             };
-            
+
             int renderButtonBackgroundCallCount = 0;
             renderer.RenderButtonBackground += (sender, e) =>
             {
@@ -1344,7 +1344,7 @@ namespace System.Windows.Forms.Tests
                 TextDirection = ToolStripTextDirection.Vertical270,
                 Owner = owner
             };
-            
+
             int renderButtonBackgroundCallCount = 0;
             renderer.RenderButtonBackground += (sender, e) =>
             {
@@ -1441,7 +1441,7 @@ namespace System.Windows.Forms.Tests
                 TextDirection = ToolStripTextDirection.Vertical270,
                 Parent = parent
             };
-            
+
             int renderButtonBackgroundCallCount = 0;
             renderer.RenderButtonBackground += (sender, e) => renderButtonBackgroundCallCount++;
             int renderItemImageCallCount = 0;
@@ -1667,15 +1667,15 @@ namespace System.Windows.Forms.Tests
             public SubToolStripButton() : base()
             {
             }
-            
+
             public SubToolStripButton(string text) : base(text)
             {
             }
-            
+
             public SubToolStripButton(Image image) : base(image)
             {
             }
-            
+
             public SubToolStripButton(string text, Image image) : base(text, image)
             {
             }
@@ -1721,7 +1721,7 @@ namespace System.Windows.Forms.Tests
             public new void OnCheckStateChanged(EventArgs e) => base.OnCheckStateChanged(e);
 
             public new void OnClick(EventArgs e) => base.OnClick(e);
-            
+
             public new void OnPaint(PaintEventArgs e) => base.OnPaint(e);
 
             public new bool ProcessDialogKey(Keys keyData) => base.ProcessDialogKey(keyData);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripContentPanelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripContentPanelTests.cs
@@ -465,7 +465,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(2, callCount);
         }
 
-
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(AutoSizeMode))]
         [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryDataInvalid), typeof(AutoSizeMode))]
@@ -1117,7 +1116,7 @@ namespace System.Windows.Forms.Tests
             };
             Assert.IsType<ToolStripSystemRenderer>(control.Renderer);
             Assert.Equal(1, rendererChangedCallCount);
-            
+
             Assert.Same(control.Renderer, control.Renderer);
             Assert.Equal(1, rendererChangedCallCount);
         }
@@ -1150,7 +1149,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(ToolStripRenderMode.Custom, control.RenderMode);
             Assert.Equal(expectedDoubleBuffered, control.GetStyle(ControlStyles.OptimizedDoubleBuffer));
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             control.Renderer = value;
             Assert.Same(value, control.Renderer);
@@ -1167,7 +1166,7 @@ namespace System.Windows.Forms.Tests
             Assert.True(control.GetStyle(ControlStyles.OptimizedDoubleBuffer));
             Assert.False(control.IsHandleCreated);
         }
-        
+
         [WinFormsTheory]
         [MemberData(nameof(Renderer_Set_TestData))]
         public void ToolStripContentPanel_Renderer_SetWithHandle_ReturnsExpected(bool visible, bool doubleBuffered, ToolStripRenderer value, bool expectedDoubleBuffered)
@@ -1193,7 +1192,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(2, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set same.
             control.Renderer = value;
             Assert.Same(value, control.Renderer);
@@ -1229,7 +1228,7 @@ namespace System.Windows.Forms.Tests
             control.Renderer = mockToolStripRenderer.Object;
             Assert.Same(mockToolStripRenderer.Object, control.Renderer);
             mockToolStripRenderer.Protected().Verify("InitializeContentPanel", Times.Once(), control);
-            
+
             // Call again.
             control.Renderer = mockToolStripRenderer.Object;
             Assert.Same(mockToolStripRenderer.Object, control.Renderer);
@@ -1254,7 +1253,7 @@ namespace System.Windows.Forms.Tests
             control.Renderer = renderer;
             Assert.Same(renderer, control.Renderer);
             Assert.Equal(2, callCount);
-            
+
             // Set same.
             control.Renderer = renderer;
             Assert.Same(renderer, control.Renderer);
@@ -1292,7 +1291,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(EventArgs.Empty, e);
                 rendererChangedCallCount++;
             };
-            
+
             // Set same.
             control.RenderMode = ToolStripRenderMode.System;
             Assert.Equal(ToolStripRenderMode.System, control.RenderMode);
@@ -1301,14 +1300,14 @@ namespace System.Windows.Forms.Tests
             Assert.IsType<ToolStripSystemRenderer>(control.Renderer);
             Assert.Equal(2, rendererChangedCallCount);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set different.
             control.RenderMode = value;
             Assert.Equal(value, control.RenderMode);
             Assert.IsType(expectedRendererType, control.Renderer);
             Assert.Equal(3, rendererChangedCallCount);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             control.RenderMode = value;
             Assert.Equal(value, control.RenderMode);
@@ -1333,20 +1332,20 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(EventArgs.Empty, e);
                 rendererChangedCallCount++;
             };
-            
+
             control.RenderMode = value;
             Assert.Equal(value, control.RenderMode);
             Assert.IsType(expectedRendererType, control.Renderer);
             Assert.Equal(1, rendererChangedCallCount);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             control.RenderMode = value;
             Assert.Equal(value, control.RenderMode);
             Assert.IsType(expectedRendererType, control.Renderer);
             Assert.Equal(2, rendererChangedCallCount);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set ManagerRenderMode.
             control.RenderMode = ToolStripRenderMode.ManagerRenderMode;
             Assert.Equal(ToolStripRenderMode.ManagerRenderMode, control.RenderMode);
@@ -1378,7 +1377,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(EventArgs.Empty, e);
                 rendererChangedCallCount++;
             };
-            
+
             // Set same.
             control.RenderMode = ToolStripRenderMode.System;
             Assert.Equal(ToolStripRenderMode.System, control.RenderMode);
@@ -1390,7 +1389,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(2, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set different.
             control.RenderMode = value;
             Assert.Equal(value, control.RenderMode);
@@ -1400,7 +1399,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(3, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set same.
             control.RenderMode = value;
             Assert.Equal(value, control.RenderMode);
@@ -1724,7 +1723,7 @@ namespace System.Windows.Forms.Tests
         {
             using var control = new ToolStripContentPanel();
             Assert.NotNull(control.Renderer);
-            
+
             control.Visible = value;
             Assert.Equal(value, control.Visible);
             Assert.False(control.IsHandleCreated);
@@ -1739,7 +1738,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(!value, control.Visible);
             Assert.False(control.IsHandleCreated);
         }
-
 
         [WinFormsFact]
         public void ToolStripContentPanel_Visible_SetWithHandler_CallsVisibleChanged()
@@ -1798,14 +1796,14 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.HandleCreated += handler;
             control.OnHandleCreated(eventArgs);
             Assert.Equal(1, callCount);
             Assert.Equal(1, loadCallCount);
             Assert.False(control.IsHandleCreated);
-        
+
             // Remove handler.
             control.HandleCreated -= handler;
             control.OnHandleCreated(eventArgs);
@@ -1826,18 +1824,18 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.Load += handler;
             control.OnLoad(eventArgs);
             Assert.Equal(1, callCount);
-        
+
             // Remove handler.
             control.Load -= handler;
             control.OnLoad(eventArgs);
             Assert.Equal(1, callCount);
         }
-        
+
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void ToolStripContentPanel_OnPaintBackground_Invoke_CallsRenderToolStripContentPanelBackground(bool handled)
@@ -1866,7 +1864,7 @@ namespace System.Windows.Forms.Tests
 
             control.OnPaintBackground(eventArgs);
             Assert.Equal(1, callCount);
-            
+
             // Call again.
             control.OnPaintBackground(eventArgs);
             Assert.Equal(2, callCount);
@@ -1910,14 +1908,14 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.RendererChanged += handler;
             control.OnRendererChanged(eventArgs);
             Assert.Equal(1, callCount);
             Assert.Equal(expectedDoubleBuffered, control.GetStyle(ControlStyles.OptimizedDoubleBuffer));
             Assert.False(control.IsHandleCreated);
-        
+
             // Remove handler.
             control.RendererChanged -= handler;
             control.OnRendererChanged(eventArgs);
@@ -1925,7 +1923,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expectedDoubleBuffered, control.GetStyle(ControlStyles.OptimizedDoubleBuffer));
             Assert.False(control.IsHandleCreated);
         }
-        
+
         [WinFormsTheory]
         [MemberData(nameof(OnRendererChanged_TestData))]
         public void ToolStripContentPanel_OnRendererChanged_InvokeWithHandle_CallsRendererChanged(bool doubleBuffered, ToolStripRenderer renderer, EventArgs eventArgs, bool expectedDoubleBuffered)
@@ -1949,7 +1947,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.RendererChanged += handler;
             control.OnRendererChanged(eventArgs);
@@ -1959,7 +1957,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-        
+
             // Remove handler.
             control.RendererChanged -= handler;
             control.OnRendererChanged(eventArgs);
@@ -1984,10 +1982,10 @@ namespace System.Windows.Forms.Tests
             control.Renderer = mockToolStripRenderer.Object;
             Assert.Same(mockToolStripRenderer.Object, control.Renderer);
             mockToolStripRenderer.Protected().Verify("InitializeContentPanel", Times.Once(), control);
-            
+
             control.OnRendererChanged(eventArgs);
             mockToolStripRenderer.Protected().Verify("InitializeContentPanel", Times.Exactly(2), control);
-            
+
             // Call again.
             control.OnRendererChanged(eventArgs);
             mockToolStripRenderer.Protected().Verify("InitializeContentPanel", Times.Exactly(3), control);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripControlHostTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripControlHostTests.cs
@@ -3080,7 +3080,7 @@ namespace System.Windows.Forms.Tests
             Assert.Empty(c.Controls);
             Assert.False(c.IsHandleCreated);
         }
-        
+
         [WinFormsTheory]
         [MemberData(nameof(Parent_Set_TestData))]
         public void ToolStripControlHost_OnParentChanged_InvokeControlWithoutParent_Success(bool enabled, bool visible, Image image, bool allowDrop)
@@ -3149,7 +3149,7 @@ namespace System.Windows.Forms.Tests
             Assert.Empty(otherParent.Controls);
             Assert.Equal(new Padding(0, 1, 0, 2), item.Margin);
         }
-        
+
         [WinFormsTheory]
         [MemberData(nameof(Parent_Set_TestData))]
         public void ToolStripControlHost_OnParentChanged_InvokeControlWithParent_Success(bool enabled, bool visible, Image image, bool allowDrop)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemImageRenderEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemImageRenderEventArgsTests.cs
@@ -86,7 +86,6 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { null, null, null, Rectangle.Empty };
             yield return new object[] { graphics, new ToolStripButton(), otherImage, new Rectangle(1, 2, 3, 4) };
             yield return new object[] { graphics, new ToolStripButton() { Image = image }, otherImage, new Rectangle(1, 2, 3, 4) };
-
         }
 
         [Theory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemTests.cs
@@ -4099,7 +4099,7 @@ namespace System.Windows.Forms.Tests
             item.Image = otherImage;
             Assert.Same(otherImage, item.Image);
             Assert.True(property.CanResetValue(item));
-            
+
             property.ResetValue(item);
             Assert.Null(item.Image);
             Assert.False(property.CanResetValue(item));
@@ -4774,11 +4774,11 @@ namespace System.Windows.Forms.Tests
             item.ImageIndex = 0;
             Assert.Equal(0, item.ImageIndex);
             Assert.False(property.CanResetValue(item));
-            
+
             item.ImageIndex = 0;
             Assert.Equal(0, item.ImageIndex);
             Assert.False(property.CanResetValue(item));
-            
+
             item.ImageIndex = -1;
             Assert.Equal(-1, item.ImageIndex);
             Assert.False(property.CanResetValue(item));
@@ -4852,11 +4852,11 @@ namespace System.Windows.Forms.Tests
             item.ImageIndex = 0;
             Assert.Equal(0, item.ImageIndex);
             Assert.True(property.ShouldSerializeValue(item));
-            
+
             item.ImageIndex = 0;
             Assert.Equal(0, item.ImageIndex);
             Assert.True(property.ShouldSerializeValue(item));
-            
+
             item.ImageIndex = -1;
             Assert.Equal(-1, item.ImageIndex);
             Assert.False(property.ShouldSerializeValue(item));
@@ -5203,7 +5203,7 @@ namespace System.Windows.Forms.Tests
             item.ImageKey = null;
             Assert.Empty(item.ImageKey);
             Assert.False(property.CanResetValue(item));
-            
+
             // Set empty.
             item.ImageKey = string.Empty;
             Assert.Empty(item.ImageKey);
@@ -5234,7 +5234,7 @@ namespace System.Windows.Forms.Tests
             item.ImageKey = null;
             Assert.Empty(item.ImageKey);
             Assert.False(property.CanResetValue(item));
-            
+
             // Set empty.
             item.ImageKey = string.Empty;
             Assert.Empty(item.ImageKey);
@@ -5270,11 +5270,11 @@ namespace System.Windows.Forms.Tests
             item.ImageKey = "Image";
             Assert.Equal("Image", item.ImageKey);
             Assert.False(property.CanResetValue(item));
-            
+
             item.ImageKey = "NoSuchImage";
             Assert.Equal("NoSuchImage", item.ImageKey);
             Assert.False(property.CanResetValue(item));
-            
+
             item.ImageKey = string.Empty;
             Assert.Empty(item.ImageKey);
             Assert.False(property.CanResetValue(item));
@@ -5295,7 +5295,7 @@ namespace System.Windows.Forms.Tests
             item.ImageKey = null;
             Assert.Empty(item.ImageKey);
             Assert.False(property.ShouldSerializeValue(item));
-            
+
             // Set empty.
             item.ImageKey = string.Empty;
             Assert.Empty(item.ImageKey);
@@ -5326,7 +5326,7 @@ namespace System.Windows.Forms.Tests
             item.ImageKey = null;
             Assert.Empty(item.ImageKey);
             Assert.False(property.ShouldSerializeValue(item));
-            
+
             // Set empty.
             item.ImageKey = string.Empty;
             Assert.Empty(item.ImageKey);
@@ -5362,11 +5362,11 @@ namespace System.Windows.Forms.Tests
             item.ImageKey = "Image";
             Assert.Equal("Image", item.ImageKey);
             Assert.True(property.ShouldSerializeValue(item));
-            
+
             item.ImageKey = "NoSuchImage";
             Assert.Equal("NoSuchImage", item.ImageKey);
             Assert.False(property.ShouldSerializeValue(item));
-            
+
             item.ImageKey = string.Empty;
             Assert.Empty(item.ImageKey);
             Assert.False(property.ShouldSerializeValue(item));
@@ -5633,7 +5633,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(value, item.ImageTransparentColor);
             Assert.False(owner.IsHandleCreated);
         }
-        
+
         public static IEnumerable<object[]> ImageTransparentColor_SetWithOwnerWithHandle_TestData()
         {
             yield return new object[] { null, Color.Empty, 0 };
@@ -5700,7 +5700,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(value, item.ImageTransparentColor);
             Assert.False(parent.IsHandleCreated);
         }
-        
+
         public static IEnumerable<object[]> ImageTransparentColor_SetWithParentWithHandle_TestData()
         {
             yield return new object[] { null, Color.Empty, 0 };
@@ -7367,7 +7367,7 @@ namespace System.Windows.Forms.Tests
             item.RightToLeft = RightToLeft.Inherit;
             Assert.Equal(RightToLeft.Inherit, item.RightToLeft);
             Assert.False(property.CanResetValue(item));
-            
+
             item.RightToLeft = RightToLeft.No;
             Assert.Equal(RightToLeft.No, item.RightToLeft);
             Assert.True(property.CanResetValue(item));
@@ -7395,7 +7395,7 @@ namespace System.Windows.Forms.Tests
             item.RightToLeft = RightToLeft.Inherit;
             Assert.Equal(RightToLeft.Inherit, item.RightToLeft);
             Assert.False(property.ShouldSerializeValue(item));
-            
+
             item.RightToLeft = RightToLeft.No;
             Assert.Equal(RightToLeft.No, item.RightToLeft);
             Assert.True(property.ShouldSerializeValue(item));
@@ -8936,7 +8936,7 @@ namespace System.Windows.Forms.Tests
             item.ToolTipText = null;
             Assert.Null(item.ToolTipText);
             Assert.False(property.CanResetValue(item));
-            
+
             // Set empty.
             item.ToolTipText = string.Empty;
             Assert.Empty(item.ToolTipText);
@@ -8963,7 +8963,7 @@ namespace System.Windows.Forms.Tests
             item.ToolTipText = null;
             Assert.Null(item.ToolTipText);
             Assert.False(property.ShouldSerializeValue(item));
-            
+
             // Set empty.
             item.ToolTipText = string.Empty;
             Assert.Empty(item.ToolTipText);
@@ -11983,7 +11983,7 @@ namespace System.Windows.Forms.Tests
 
             // Call again.
             item.OnOwnerFontChanged(eventArgs);
-            
+
             // Call with font.
             item.Font = new Font("Arial", 8.25f);
             item.OnOwnerFontChanged(eventArgs);
@@ -12019,7 +12019,7 @@ namespace System.Windows.Forms.Tests
                 item.OnOwnerFontChanged(eventArgs);
                 Assert.Equal(expectedOwnerLayoutCallCount * 2, ownerLayoutCallCount);
                 Assert.False(owner.IsHandleCreated);
-                
+
                 // Call with font.
                 owner.Layout -= ownerHandler;
                 item.Font = new Font("Arial", 8.25f);
@@ -12343,12 +12343,12 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             item.RightToLeftChanged += handler;
             item.OnParentRightToLeftChanged(eventArgs);
             Assert.Equal(1, callCount);
-        
+
             // Remove handler.
             item.RightToLeftChanged -= handler;
             item.OnParentRightToLeftChanged(eventArgs);
@@ -13697,7 +13697,7 @@ namespace System.Windows.Forms.Tests
         public void ToolStripItem_ResetDisplayStyle_Invoke_Success()
         {
             using var item = new SubToolStripItem();
-            
+
             // Reset without value.
             item.ResetDisplayStyle();
             Assert.Equal(ToolStripItemDisplayStyle.ImageAndText, item.DisplayStyle);
@@ -13717,19 +13717,19 @@ namespace System.Windows.Forms.Tests
         {
             using var font = new Font("Arial", 8.25f);
             using var item = new SubToolStripItem();
-            
+
             // Reset without value.
             Assert.NotSame(font, item.Font);
             Assert.NotSame(Control.DefaultFont, item.Font);
             Assert.Same(item.Font, item.Font);
-            
+
             // Reset with value.
             item.Font = font;
             item.ResetFont();
             Assert.NotSame(font, item.Font);
             Assert.NotSame(Control.DefaultFont, item.Font);
             Assert.Same(item.Font, item.Font);
-            
+
             // Reset again.
             item.ResetFont();
             Assert.NotSame(font, item.Font);
@@ -13760,7 +13760,7 @@ namespace System.Windows.Forms.Tests
         public void ToolStripItem_ResetImage_Invoke_Success()
         {
             using var item = new SubToolStripItem();
-            
+
             // Reset without value.
             item.ResetImage();
             Assert.Null(item.Image);
@@ -13788,7 +13788,7 @@ namespace System.Windows.Forms.Tests
             item.Margin = new Padding(1, 2, 3, 4);
             item.ResetMargin();
             Assert.Equal(new Padding(0, 1, 0, 2), item.Margin);
-            
+
             // Reset again.
             item.ResetMargin();
             Assert.Equal(new Padding(0, 1, 0, 2), item.Margin);
@@ -13807,7 +13807,7 @@ namespace System.Windows.Forms.Tests
             item.Padding = new Padding(1, 2, 3, 4);
             item.ResetPadding();
             Assert.Equal(Padding.Empty, item.Padding);
-            
+
             // Reset again.
             item.ResetPadding();
             Assert.Equal(Padding.Empty, item.Padding);
@@ -13817,7 +13817,7 @@ namespace System.Windows.Forms.Tests
         public void ToolStripItem_ResetRightToLeft_Invoke_Success()
         {
             using var item = new SubToolStripItem();
-            
+
             // Reset without value.
             item.ResetRightToLeft();
             Assert.Equal(RightToLeft.Inherit, item.RightToLeft);
@@ -13826,7 +13826,7 @@ namespace System.Windows.Forms.Tests
             item.RightToLeft = RightToLeft.Yes;
             item.ResetRightToLeft();
             Assert.Equal(RightToLeft.Inherit, item.RightToLeft);
-            
+
             // Reset again.
             item.ResetRightToLeft();
             Assert.Equal(RightToLeft.Inherit, item.RightToLeft);
@@ -13867,13 +13867,13 @@ namespace System.Windows.Forms.Tests
             item.Select();
             Assert.True(item.Selected);
         }
-        
+
         public static IEnumerable<object[]> Select_WithoutToolStripItemAccessibleObject_TestData()
         {
             yield return new object[] { null };
             yield return new object[] { new AccessibleObject() };
         }
-        
+
         [WinFormsTheory]
         [MemberData(nameof(Select_WithoutToolStripItemAccessibleObject_TestData))]
         public void ToolStripItem_Select_InvokeWithoutToolStripItemAccessibleObject_Success(AccessibleObject result)
@@ -14801,7 +14801,7 @@ namespace System.Windows.Forms.Tests
             using var item = new NullTextToolStripItem();
             Assert.Equal("System.Windows.Forms.Tests.ToolStripItemTests+NullTextToolStripItem", item.ToString());
         }
-        
+
         private class NullTextToolStripItem : ToolStripItem
         {
             public override string Text

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripRendererTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripRendererTests.cs
@@ -61,7 +61,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-            
+
             // Call with handler.
             renderer.RenderArrow += handler;
             renderer.DrawArrow(eventArgs);
@@ -92,7 +92,7 @@ namespace System.Windows.Forms.Tests
         {
             yield return new object[] { null };
             yield return new object[] { new ToolStripItemRenderEventArgs(null, null) };
-            
+
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
             yield return new object[] { new ToolStripItemRenderEventArgs(graphics, new SubToolStripItem()) };
@@ -110,7 +110,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-            
+
             // Call with handler.
             renderer.RenderButtonBackground += handler;
             renderer.DrawButtonBackground(eventArgs);
@@ -134,7 +134,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-            
+
             // Call with handler.
             renderer.RenderDropDownButtonBackground += handler;
             renderer.DrawDropDownButtonBackground(eventArgs);
@@ -150,7 +150,7 @@ namespace System.Windows.Forms.Tests
         {
             yield return new object[] { null };
             yield return new object[] { new ToolStripGripRenderEventArgs(null, new ToolStrip()) };
-            
+
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
             yield return new object[] { new ToolStripGripRenderEventArgs(graphics, new ToolStrip()) };
@@ -168,7 +168,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-            
+
             // Call with handler.
             renderer.RenderGrip += handler;
             renderer.DrawGrip(eventArgs);
@@ -192,7 +192,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-            
+
             // Call with handler.
             renderer.RenderItemBackground += handler;
             renderer.DrawItemBackground(eventArgs);
@@ -209,7 +209,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { null, null, null, Rectangle.Empty };
             yield return new object[] { null, null, null, new Rectangle(1, 2, 3, 4) };
             yield return new object[] { null, null, new Bitmap(10, 10), Rectangle.Empty };
-            
+
             var image = new Bitmap(10, 10);
             Graphics graphics = Graphics.FromImage(image);
             yield return new object[] { graphics, new SubToolStripItem(), new Bitmap(10, 10), new Rectangle(1, 2, 3, 4) };
@@ -235,7 +235,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-            
+
             // Call with handler.
             renderer.RenderItemCheck += handler;
             renderer.DrawItemCheck(eventArgs);
@@ -278,7 +278,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-            
+
             // Call with handler.
             renderer.RenderItemImage += handler;
             renderer.DrawItemImage(eventArgs);
@@ -319,7 +319,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-            
+
             // Call with handler.
             renderer.RenderImageMargin += handler;
             renderer.DrawImageMargin(eventArgs);
@@ -363,7 +363,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-            
+
             // Call with handler.
             renderer.RenderItemText += handler;
             renderer.DrawItemText(eventArgs);
@@ -403,7 +403,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-            
+
             // Call with handler.
             renderer.RenderLabelBackground += handler;
             renderer.DrawLabelBackground(eventArgs);
@@ -427,7 +427,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-            
+
             // Call with handler.
             renderer.RenderMenuItemBackground += handler;
             renderer.DrawMenuItemBackground(eventArgs);
@@ -451,7 +451,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-            
+
             // Call with handler.
             renderer.RenderOverflowButtonBackground += handler;
             renderer.DrawOverflowButtonBackground(eventArgs);
@@ -462,7 +462,7 @@ namespace System.Windows.Forms.Tests
             renderer.DrawOverflowButtonBackground(eventArgs);
             Assert.Equal(1, callCount);
         }
-        
+
         public static IEnumerable<object[]> ToolStripSeparatorRenderEventArgs_TestData()
         {
             yield return new object[] { null };
@@ -489,7 +489,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-            
+
             // Call with handler.
             renderer.RenderSeparator += handler;
             renderer.DrawSeparator(eventArgs);
@@ -513,7 +513,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-            
+
             // Call with handler.
             renderer.RenderSplitButtonBackground += handler;
             renderer.DrawSplitButton(eventArgs);
@@ -549,7 +549,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-            
+
             // Call with handler.
             renderer.RenderStatusStripSizingGrip += handler;
             renderer.DrawStatusStripSizingGrip(eventArgs);
@@ -584,7 +584,7 @@ namespace System.Windows.Forms.Tests
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
             yield return new object[] { new ToolStripRenderEventArgs(graphics, new ToolStrip()) };
-            
+
             yield return new object[] { new ToolStripRenderEventArgs(graphics, new StatusStrip()) };
         }
 
@@ -600,7 +600,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-            
+
             // Call with handler.
             renderer.RenderToolStripBackground += handler;
             renderer.DrawToolStripBackground(eventArgs);
@@ -624,7 +624,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-            
+
             // Call with handler.
             renderer.RenderToolStripBorder += handler;
             renderer.DrawToolStripBorder(eventArgs);
@@ -648,7 +648,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-            
+
             // Call with handler.
             renderer.RenderToolStripContentPanelBackground += handler;
             renderer.DrawToolStripContentPanelBackground(eventArgs);
@@ -659,7 +659,7 @@ namespace System.Windows.Forms.Tests
             renderer.DrawToolStripContentPanelBackground(eventArgs);
             Assert.Equal(1, callCount);
         }
-        
+
         public static IEnumerable<object[]> ToolStripPanelRenderEventArgs_TestData()
         {
             yield return new object[] { null };
@@ -683,7 +683,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-            
+
             // Call with handler.
             renderer.RenderToolStripPanelBackground += handler;
             renderer.DrawToolStripPanelBackground(eventArgs);
@@ -707,7 +707,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-            
+
             // Call with handler.
             renderer.RenderToolStripStatusLabelBackground += handler;
             renderer.DrawToolStripStatusLabelBackground(eventArgs);
@@ -718,7 +718,7 @@ namespace System.Windows.Forms.Tests
             renderer.DrawToolStripStatusLabelBackground(eventArgs);
             Assert.Equal(1, callCount);
         }
-        
+
         public static IEnumerable<object[]> ToolStripContentPanelRenderEventArgs_TestData()
         {
             yield return new object[] { null };
@@ -1026,7 +1026,7 @@ namespace System.Windows.Forms.Tests
             renderer.OnRenderSplitButtonBackground(e);
             Assert.Equal(0, callCount);
         }
-        
+
         [WinFormsTheory]
         [MemberData(nameof(StatusStripSizingGrip_TestData))]
         public void ToolStripRenderer_OnRenderStatusStripSizingGrip_Invoke_Nop(ToolStrip toolStrip)
@@ -1141,9 +1141,9 @@ namespace System.Windows.Forms.Tests
         private class SubToolStripRenderer : ToolStripRenderer
         {
             public new void Initialize(ToolStrip toolStrip) => base.Initialize(toolStrip);
-            
+
             public new void InitializeContentPanel(ToolStripContentPanel contentPanel) => base.InitializeContentPanel(contentPanel);
-            
+
             public new void InitializeItem(ToolStripItem item) => base.InitializeItem(item);
 
             public new void InitializePanel(ToolStripPanel toolStripPanel) => base.InitializePanel(toolStripPanel);
@@ -1159,11 +1159,11 @@ namespace System.Windows.Forms.Tests
             public new void OnRenderImageMargin(ToolStripRenderEventArgs e) => base.OnRenderImageMargin(e);
 
             public new void OnRenderItemBackground(ToolStripItemRenderEventArgs e) => base.OnRenderItemBackground(e);
-            
+
             public new void OnRenderItemCheck(ToolStripItemImageRenderEventArgs e) => base.OnRenderItemCheck(e);
 
             public new void OnRenderItemImage(ToolStripItemImageRenderEventArgs e) => base.OnRenderItemImage(e);
-            
+
             public new void OnRenderItemText(ToolStripItemTextRenderEventArgs e) => base.OnRenderItemText(e);
 
             public new void OnRenderLabelBackground(ToolStripItemRenderEventArgs e) => base.OnRenderLabelBackground(e);
@@ -1176,18 +1176,18 @@ namespace System.Windows.Forms.Tests
 
             public new void OnRenderSplitButtonBackground(ToolStripItemRenderEventArgs e) => base.OnRenderSplitButtonBackground(e);
 
-            public new void OnRenderStatusStripSizingGrip(ToolStripRenderEventArgs e) => base.OnRenderStatusStripSizingGrip(e);            
+            public new void OnRenderStatusStripSizingGrip(ToolStripRenderEventArgs e) => base.OnRenderStatusStripSizingGrip(e);
 
             public new void OnRenderToolStripBackground(ToolStripRenderEventArgs e) => base.OnRenderToolStripBackground(e);
-            
+
             public new void OnRenderToolStripBorder(ToolStripRenderEventArgs e) => base.OnRenderToolStripBorder(e);
 
             public new void OnRenderToolStripContentPanelBackground(ToolStripContentPanelRenderEventArgs e) => base.OnRenderToolStripContentPanelBackground(e);
 
             public new void OnRenderToolStripPanelBackground(ToolStripPanelRenderEventArgs e) => base.OnRenderToolStripPanelBackground(e);
-            
+
             public new void OnRenderToolStripStatusLabelBackground(ToolStripItemRenderEventArgs e) => base.OnRenderToolStripStatusLabelBackground(e);
-            
+
             public static new void ScaleArrowOffsetsIfNeeded() => ToolStripRenderer.ScaleArrowOffsetsIfNeeded();
 
             public static new void ScaleArrowOffsetsIfNeeded(int dpi) => ToolStripRenderer.ScaleArrowOffsetsIfNeeded(dpi);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripSeparatorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripSeparatorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -778,7 +778,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { ToolStripLayoutStyle.HorizontalStackWithOverflow, new Size(10, 20), new Size(6, 23) };
             yield return new object[] { ToolStripLayoutStyle.HorizontalStackWithOverflow, new Size(30, 40), new Size(6, 23) };
             yield return new object[] { ToolStripLayoutStyle.HorizontalStackWithOverflow, new Size(int.MaxValue, int.MaxValue), new Size(6, 23) };
-            
+
             yield return new object[] { ToolStripLayoutStyle.StackWithOverflow, Size.Empty, new Size(6, 23) };
             yield return new object[] { ToolStripLayoutStyle.StackWithOverflow, new Size(-1, -2), new Size(6, 23) };
             yield return new object[] { ToolStripLayoutStyle.StackWithOverflow, new Size(10, 20), new Size(6, 23) };
@@ -790,7 +790,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { ToolStripLayoutStyle.Table, new Size(10, 20), new Size(6, 23) };
             yield return new object[] { ToolStripLayoutStyle.Table, new Size(30, 40), new Size(6, 23) };
             yield return new object[] { ToolStripLayoutStyle.Table, new Size(int.MaxValue, int.MaxValue), new Size(6, 23) };
-            
+
             yield return new object[] { ToolStripLayoutStyle.VerticalStackWithOverflow, Size.Empty, new Size(23, 6) };
             yield return new object[] { ToolStripLayoutStyle.VerticalStackWithOverflow, new Size(-1, -2), new Size(23, 6) };
             yield return new object[] { ToolStripLayoutStyle.VerticalStackWithOverflow, new Size(10, 20), new Size(23, 6) };
@@ -863,7 +863,7 @@ namespace System.Windows.Forms.Tests
             // Call again.
             Assert.Equal(expected, item.GetPreferredSize(proposedSize));
         }
-        
+
         public static IEnumerable<object[]> GetPreferredSize_WithToolStripDropDownMenuParent_TestData()
         {
             yield return new object[] { ToolStripLayoutStyle.Flow, Size.Empty, new Size(91, 6) };
@@ -877,7 +877,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { ToolStripLayoutStyle.HorizontalStackWithOverflow, new Size(10, 20), new Size(91, 6) };
             yield return new object[] { ToolStripLayoutStyle.HorizontalStackWithOverflow, new Size(30, 40), new Size(91, 6) };
             yield return new object[] { ToolStripLayoutStyle.HorizontalStackWithOverflow, new Size(int.MaxValue, int.MaxValue), new Size(91, 6) };
-            
+
             yield return new object[] { ToolStripLayoutStyle.StackWithOverflow, Size.Empty, new Size(52, 6) };
             yield return new object[] { ToolStripLayoutStyle.StackWithOverflow, new Size(-1, -2), new Size(52, 6) };
             yield return new object[] { ToolStripLayoutStyle.StackWithOverflow, new Size(10, 20), new Size(52, 6) };
@@ -889,7 +889,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { ToolStripLayoutStyle.Table, new Size(10, 20), new Size(91, 6) };
             yield return new object[] { ToolStripLayoutStyle.Table, new Size(30, 40), new Size(91, 6) };
             yield return new object[] { ToolStripLayoutStyle.Table, new Size(int.MaxValue, int.MaxValue), new Size(91, 6) };
-            
+
             yield return new object[] { ToolStripLayoutStyle.VerticalStackWithOverflow, Size.Empty, new Size(52, 6) };
             yield return new object[] { ToolStripLayoutStyle.VerticalStackWithOverflow, new Size(-1, -2), new Size(52, 6) };
             yield return new object[] { ToolStripLayoutStyle.VerticalStackWithOverflow, new Size(10, 20), new Size(52, 6) };
@@ -938,7 +938,6 @@ namespace System.Windows.Forms.Tests
             // Call again.
             item.OnFontChanged(eventArgs);
         }
-
 
         [WinFormsTheory]
         [MemberData(nameof(OnFontChanged_TestData))]
@@ -1113,7 +1112,7 @@ namespace System.Windows.Forms.Tests
             item.OnPaint(eventArgs);
             Assert.Equal(0, callCount);
         }
-        
+
         public static IEnumerable<object[]> OnPaint_WithOwner_TestData()
         {
             foreach (ToolStripLayoutStyle layoutStyle in Enum.GetValues(typeof(ToolStripLayoutStyle)))
@@ -1661,7 +1660,7 @@ namespace System.Windows.Forms.Tests
             public new AccessibleObject CreateAccessibilityInstance() => base.CreateAccessibilityInstance();
 
             public new void OnFontChanged(EventArgs e) => base.OnFontChanged(e);
-            
+
             public new void OnPaint(PaintEventArgs e) => base.OnPaint(e);
 
             public new void SetBounds(Rectangle bounds) => base.SetBounds(bounds);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
@@ -2677,7 +2677,7 @@ namespace System.Windows.Forms.Tests
                 yield return new object[] { dock, ToolStripLayoutStyle.VerticalStackWithOverflow, ToolStripLayoutStyle.Table, ToolStripLayoutStyle.Table, Orientation.Horizontal, ToolStripGripDisplayStyle.Horizontal, 1 };
                 yield return new object[] { dock, ToolStripLayoutStyle.VerticalStackWithOverflow, ToolStripLayoutStyle.VerticalStackWithOverflow, ToolStripLayoutStyle.VerticalStackWithOverflow, Orientation.Vertical, ToolStripGripDisplayStyle.Horizontal, 0 };
             }
-            
+
             foreach (DockStyle dock in new DockStyle[] { DockStyle.Right }) //, DockStyle.Left })
             {
                 yield return new object[] { dock, ToolStripLayoutStyle.Flow, ToolStripLayoutStyle.Flow, ToolStripLayoutStyle.Flow, Orientation.Horizontal, ToolStripGripDisplayStyle.Horizontal, 0 };
@@ -2861,7 +2861,7 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Same(value, control.Renderer);
             Assert.Equal(ToolStripRenderMode.Custom, control.RenderMode);
-            
+
             // Set same.
             control.Renderer = value;
             Assert.Same(value, control.Renderer);
@@ -2893,7 +2893,7 @@ namespace System.Windows.Forms.Tests
             control.Renderer = renderer;
             Assert.Same(renderer, control.Renderer);
             Assert.Equal(1, callCount);
-            
+
             // Set same.
             control.Renderer = renderer;
             Assert.Same(renderer, control.Renderer);
@@ -2930,7 +2930,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(EventArgs.Empty, e);
                 rendererChangedCallCount++;
             };
-            
+
             // Set same.
             control.RenderMode = ToolStripRenderMode.ManagerRenderMode;
             Assert.Equal(ToolStripRenderMode.ManagerRenderMode, control.RenderMode);
@@ -2938,19 +2938,19 @@ namespace System.Windows.Forms.Tests
             Assert.Same(control.Renderer, control.Renderer);
             Assert.IsType<ToolStripProfessionalRenderer>(control.Renderer);
             Assert.Equal(0, rendererChangedCallCount);
-            
+
             // Set different.
             control.RenderMode = value;
             Assert.Equal(value, control.RenderMode);
             Assert.IsType(expectedRendererType, control.Renderer);
             Assert.Equal(1, rendererChangedCallCount);
-            
+
             // Set same.
             control.RenderMode = value;
             Assert.Equal(value, control.RenderMode);
             Assert.IsType(expectedRendererType, control.Renderer);
             Assert.Equal(2, rendererChangedCallCount);
-            
+
             // Set ManagerRenderMode.
             control.RenderMode = ToolStripRenderMode.ManagerRenderMode;
             Assert.Equal(ToolStripRenderMode.ManagerRenderMode, control.RenderMode);
@@ -2976,18 +2976,18 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(EventArgs.Empty, e);
                 rendererChangedCallCount++;
             };
-            
+
             control.RenderMode = value;
             Assert.Equal(value, control.RenderMode);
             Assert.IsType(expectedRendererType, control.Renderer);
             Assert.Equal(1, rendererChangedCallCount);
-            
+
             // Set same.
             control.RenderMode = value;
             Assert.Equal(value, control.RenderMode);
             Assert.IsType(expectedRendererType, control.Renderer);
             Assert.Equal(2, rendererChangedCallCount);
-            
+
             // Set ManagerRenderMode.
             control.RenderMode = ToolStripRenderMode.ManagerRenderMode;
             Assert.Equal(ToolStripRenderMode.ManagerRenderMode, control.RenderMode);
@@ -3090,12 +3090,12 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(value, control.ShowItemToolTips);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             control.ShowItemToolTips = value;
             Assert.Equal(value, control.ShowItemToolTips);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set different.
             control.ShowItemToolTips = !value;
             Assert.Equal(!value, control.ShowItemToolTips);
@@ -3114,12 +3114,12 @@ namespace System.Windows.Forms.Tests
             control.ShowItemToolTips = value;
             Assert.Equal(value, control.ShowItemToolTips);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             control.ShowItemToolTips = value;
             Assert.Equal(value, control.ShowItemToolTips);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set different.
             control.ShowItemToolTips = !value;
             Assert.Equal(!value, control.ShowItemToolTips);
@@ -3133,18 +3133,18 @@ namespace System.Windows.Forms.Tests
         {
             using var control = new ToolStrip();
             Assert.NotNull(control.OverflowButton);
-            
+
             control.ShowItemToolTips = value;
             Assert.Equal(value, control.ShowItemToolTips);
             Assert.Equal(value, control.OverflowButton.DropDown.ShowItemToolTips);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             control.ShowItemToolTips = value;
             Assert.Equal(value, control.ShowItemToolTips);
             Assert.Equal(value, control.OverflowButton.DropDown.ShowItemToolTips);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set different.
             control.ShowItemToolTips = !value;
             Assert.Equal(!value, control.ShowItemToolTips);
@@ -3722,7 +3722,7 @@ namespace System.Windows.Forms.Tests
                 control.Disposed -= handler;
             }
         }
-        
+
         [WinFormsFact]
         public void ToolStrip_Dispose_InvokeWithItems_Success()
         {
@@ -3798,7 +3798,7 @@ namespace System.Windows.Forms.Tests
                 control.Disposed -= handler;
             }
         }
-        
+
         [WinFormsFact]
         public void ToolStrip_Dispose_InvokeDisposing_Success()
         {
@@ -3845,7 +3845,7 @@ namespace System.Windows.Forms.Tests
                 control.Disposed -= handler;
             }
         }
-        
+
         [WinFormsFact]
         public void ToolStrip_Dispose_InvokeNotDisposing_Success()
         {
@@ -3882,7 +3882,7 @@ namespace System.Windows.Forms.Tests
                 control.Disposed -= handler;
             }
         }
-        
+
         [WinFormsFact]
         public void ToolStrip_Dispose_InvokeDisposingWithItems_Success()
         {
@@ -3958,7 +3958,7 @@ namespace System.Windows.Forms.Tests
                 control.Disposed -= handler;
             }
         }
-        
+
         [WinFormsFact]
         public void ToolStrip_Dispose_InvokeNotDisposingWithItems_Success()
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolTipTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolTipTests.cs
@@ -105,11 +105,11 @@ namespace System.Windows.Forms.Tests
                 Active = value
             };
             Assert.Equal(value, toolTip.Active);
-            
+
             // Set same
             toolTip.Active = value;
             Assert.Equal(value, toolTip.Active);
-            
+
             // Set different
             toolTip.Active = !value;
             Assert.Equal(!value, toolTip.Active);
@@ -129,11 +129,11 @@ namespace System.Windows.Forms.Tests
                 Active = value
             };
             Assert.Equal(value, toolTip.Active);
-            
+
             // Set same
             toolTip.Active = value;
             Assert.Equal(value, toolTip.Active);
-            
+
             // Set different
             toolTip.Active = !value;
             Assert.Equal(!value, toolTip.Active);
@@ -156,7 +156,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expectedAutoPopDelay, toolTip.AutoPopDelay);
             Assert.Equal(value, toolTip.InitialDelay);
             Assert.Equal(expectedReshowDelay, toolTip.ReshowDelay);
-            
+
             // Set same
             toolTip.AutomaticDelay = value;
             Assert.Equal(value, toolTip.AutomaticDelay);
@@ -203,7 +203,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(value, toolTip.AutoPopDelay);
             Assert.Equal(500, toolTip.InitialDelay);
             Assert.Equal(100, toolTip.ReshowDelay);
-            
+
             // Set same
             toolTip.AutoPopDelay = value;
             Assert.Equal(500, toolTip.AutomaticDelay);
@@ -262,7 +262,7 @@ namespace System.Windows.Forms.Tests
             toolTip.ForeColor = value;
             Assert.Equal(value, toolTip.ForeColor);
         }
-        
+
         [Fact]
         public void ToolTip_ForeColor_SetEmpty_ThrowsArgumentException()
         {
@@ -287,7 +287,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(5000, toolTip.AutoPopDelay);
             Assert.Equal(value, toolTip.InitialDelay);
             Assert.Equal(100, toolTip.ReshowDelay);
-            
+
             // Set same
             toolTip.InitialDelay = value;
             Assert.Equal(500, toolTip.AutomaticDelay);
@@ -326,11 +326,11 @@ namespace System.Windows.Forms.Tests
                 IsBalloon = value
             };
             Assert.Equal(value, toolTip.IsBalloon);
-            
+
             // Set same
             toolTip.IsBalloon = value;
             Assert.Equal(value, toolTip.IsBalloon);
-            
+
             // Set different
             toolTip.IsBalloon = !value;
             Assert.Equal(!value, toolTip.IsBalloon);
@@ -345,11 +345,11 @@ namespace System.Windows.Forms.Tests
                 OwnerDraw = value
             };
             Assert.Equal(value, toolTip.OwnerDraw);
-            
+
             // Set same
             toolTip.OwnerDraw = value;
             Assert.Equal(value, toolTip.OwnerDraw);
-            
+
             // Set different
             toolTip.OwnerDraw = !value;
             Assert.Equal(!value, toolTip.OwnerDraw);
@@ -372,7 +372,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(5000, toolTip.AutoPopDelay);
             Assert.Equal(500, toolTip.InitialDelay);
             Assert.Equal(value, toolTip.ReshowDelay);
-            
+
             // Set same
             toolTip.ReshowDelay = value;
             Assert.Equal(500, toolTip.AutomaticDelay);
@@ -411,11 +411,11 @@ namespace System.Windows.Forms.Tests
                 ShowAlways = value
             };
             Assert.Equal(value, toolTip.ShowAlways);
-            
+
             // Set same
             toolTip.ShowAlways = value;
             Assert.Equal(value, toolTip.ShowAlways);
-            
+
             // Set different
             toolTip.ShowAlways = !value;
             Assert.Equal(!value, toolTip.ShowAlways);
@@ -430,11 +430,11 @@ namespace System.Windows.Forms.Tests
                 StripAmpersands = value
             };
             Assert.Equal(value, toolTip.StripAmpersands);
-            
+
             // Set same
             toolTip.StripAmpersands = value;
             Assert.Equal(value, toolTip.StripAmpersands);
-            
+
             // Set different
             toolTip.StripAmpersands = !value;
             Assert.Equal(!value, toolTip.StripAmpersands);
@@ -449,7 +449,7 @@ namespace System.Windows.Forms.Tests
                 Tag = value
             };
             Assert.Same(value, toolTip.Tag);
-            
+
             // Set same
             toolTip.Tag = value;
             Assert.Same(value, toolTip.Tag);
@@ -464,7 +464,7 @@ namespace System.Windows.Forms.Tests
                 ToolTipIcon = value
             };
             Assert.Equal(value, toolTip.ToolTipIcon);
-            
+
             // Set same
             toolTip.ToolTipIcon = value;
             Assert.Equal(value, toolTip.ToolTipIcon);
@@ -477,7 +477,7 @@ namespace System.Windows.Forms.Tests
             var toolTip = new ToolTip();
             Assert.Throws<InvalidEnumArgumentException>("value", () => toolTip.ToolTipIcon = value);
         }
-        
+
         [Theory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
         public void ToolTip_ToolTipTitle_Set_GetReturnsExpected(string value, string expected)
@@ -487,7 +487,7 @@ namespace System.Windows.Forms.Tests
                 ToolTipTitle = value
             };
             Assert.Equal(expected, toolTip.ToolTipTitle);
-            
+
             // Set same
             toolTip.ToolTipTitle = value;
             Assert.Equal(expected, toolTip.ToolTipTitle);
@@ -502,11 +502,11 @@ namespace System.Windows.Forms.Tests
                 UseAnimation = value
             };
             Assert.Equal(value, toolTip.UseAnimation);
-            
+
             // Set same
             toolTip.UseAnimation = value;
             Assert.Equal(value, toolTip.UseAnimation);
-            
+
             // Set different
             toolTip.UseAnimation = !value;
             Assert.Equal(!value, toolTip.UseAnimation);
@@ -521,11 +521,11 @@ namespace System.Windows.Forms.Tests
                 UseFading = value
             };
             Assert.Equal(value, toolTip.UseFading);
-            
+
             // Set same
             toolTip.UseFading = value;
             Assert.Equal(value, toolTip.UseFading);
-            
+
             // Set different
             toolTip.UseFading = !value;
             Assert.Equal(!value, toolTip.UseFading);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -3003,7 +3003,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal("RightToLeftLayout", e.AffectedProperty);
                 layoutCallCount++;
             };
-            
+
             control.RightToLeftLayout = value;
             Assert.Equal(value, control.RightToLeftLayout);
             Assert.Equal(expectedLayoutCallCount, layoutCallCount);
@@ -6421,7 +6421,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, callCount);
             Assert.False(control.IsHandleCreated);
         }
-        
+
         public static IEnumerable<object[]> OnRightToLeftLayoutChanged_WithHandle_TestData()
         {
             yield return new object[] { RightToLeft.Yes, null, 1 };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBaseTests.cs
@@ -194,7 +194,7 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.GetScrollState(SubUpDownBase.ScrollStateAutoScrolling));
             Assert.Equal(0, layoutCallCount);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set different.
             control.AutoScroll = !value;
             Assert.False(control.AutoScroll);
@@ -236,7 +236,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set different.
             control.AutoScroll = !value;
             Assert.False(control.AutoScroll);
@@ -276,7 +276,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Null(e.AffectedProperty);
                 layoutCallCount++;
             };
-            
+
             control.AutoScrollMargin = value;
             Assert.Equal(value, control.AutoScrollMargin);
             Assert.False(control.AutoScroll);
@@ -314,7 +314,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Null(e.AffectedProperty);
                 layoutCallCount++;
             };
-            
+
             control.AutoScrollMargin = value;
             Assert.Equal(value, control.AutoScrollMargin);
             Assert.False(control.AutoScroll);
@@ -770,12 +770,12 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(value, control.ChangingText);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             control.ChangingText = value;
             Assert.Equal(value, control.ChangingText);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set different.
             control.ChangingText = !value;
             Assert.Equal(!value, control.ChangingText);
@@ -801,7 +801,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set same.
             control.ChangingText = value;
             Assert.Equal(value, control.ChangingText);
@@ -809,7 +809,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set different.
             control.ChangingText = !value;
             Assert.Equal(!value, control.ChangingText);
@@ -984,12 +984,12 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(value, control.InterceptArrowKeys);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             control.InterceptArrowKeys = value;
             Assert.Equal(value, control.InterceptArrowKeys);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set different.
             control.InterceptArrowKeys = !value;
             Assert.Equal(!value, control.InterceptArrowKeys);
@@ -1015,7 +1015,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set same.
             control.InterceptArrowKeys = value;
             Assert.Equal(value, control.InterceptArrowKeys);
@@ -1023,7 +1023,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set different.
             control.InterceptArrowKeys = !value;
             Assert.Equal(!value, control.InterceptArrowKeys);
@@ -1131,12 +1131,12 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(value, control.ReadOnly);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             control.ReadOnly = value;
             Assert.Equal(value, control.ReadOnly);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set different.
             control.ReadOnly = !value;
             Assert.Equal(!value, control.ReadOnly);
@@ -1162,7 +1162,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set same.
             control.ReadOnly = value;
             Assert.Equal(value, control.ReadOnly);
@@ -1170,7 +1170,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set different.
             control.ReadOnly = !value;
             Assert.Equal(!value, control.ReadOnly);
@@ -1189,7 +1189,7 @@ namespace System.Windows.Forms.Tests
                 yield return new object[] { changingText, true, string.Empty, string.Empty, 1, 0, true };
                 yield return new object[] { changingText, false, string.Empty, string.Empty, 0, 0, false };
             }
-            
+
             yield return new object[] { true, true, "text", "text", 1, 1, true };
             yield return new object[] { false, true, "text", "text", 1, 1, true };
             yield return new object[] { true, false, "text", "text", 0, 1, false };
@@ -1353,7 +1353,7 @@ namespace System.Windows.Forms.Tests
             control.StyleChanged += (sender, e) => styleChangedCallCount++;
             int createdCallCount = 0;
             control.HandleCreated += (sender, e) => createdCallCount++;
-            
+
             control.TextAlign = value;
             Assert.Equal(value, control.TextAlign);
             Assert.True(control.IsHandleCreated);
@@ -1437,7 +1437,7 @@ namespace System.Windows.Forms.Tests
             control.StyleChanged += (sender, e) => styleChangedCallCount++;
             int createdCallCount = 0;
             control.HandleCreated += (sender, e) => createdCallCount++;
-            
+
             control.UpDownAlign = value;
             Assert.Equal(value, control.UpDownAlign);
             Assert.True(control.IsHandleCreated);
@@ -1472,12 +1472,12 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(value, control.UserEdit);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             control.UserEdit = value;
             Assert.Equal(value, control.UserEdit);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set different.
             control.UserEdit = !value;
             Assert.Equal(!value, control.UserEdit);
@@ -1503,7 +1503,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set same.
             control.UserEdit = value;
             Assert.Equal(value, control.UserEdit);
@@ -1511,7 +1511,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set different.
             control.UserEdit = !value;
             Assert.Equal(!value, control.UserEdit);
@@ -1544,7 +1544,7 @@ namespace System.Windows.Forms.Tests
             using var control = new SubUpDownBase();
             Assert.Equal(new Size(123, control.PreferredHeight), control.GetPreferredSize(proposedSize));
             Assert.False(control.IsHandleCreated);
-            
+
             // Call again.
             Assert.Equal(new Size(123, control.PreferredHeight), control.GetPreferredSize(proposedSize));
             Assert.False(control.IsHandleCreated);
@@ -1560,7 +1560,7 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(new Size(33, control.PreferredHeight), control.GetPreferredSize(proposedSize));
             Assert.False(control.IsHandleCreated);
-            
+
             // Call again.
             Assert.Equal(new Size(33, control.PreferredHeight), control.GetPreferredSize(proposedSize));
             Assert.False(control.IsHandleCreated);
@@ -1600,7 +1600,7 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(new Size(expectedWidth, control.PreferredHeight), control.GetPreferredSize(proposedSize));
             Assert.False(control.IsHandleCreated);
-            
+
             // Call again.
             Assert.Equal(new Size(expectedWidth, control.PreferredHeight), control.GetPreferredSize(proposedSize));
             Assert.False(control.IsHandleCreated);
@@ -1857,7 +1857,6 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.Created);
             Assert.False(control.IsHandleCreated);
         }
-
 
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
@@ -2542,7 +2541,7 @@ namespace System.Windows.Forms.Tests
             };
             control.Select(start, length);
             Assert.False(control.IsHandleCreated);
-            
+
             // Call again.
             control.Select(start, length);
             Assert.False(control.IsHandleCreated);
@@ -2572,7 +2571,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Call again.
             control.Select(start, length);
             Assert.True(control.IsHandleCreated);
@@ -2717,7 +2716,7 @@ namespace System.Windows.Forms.Tests
             using var control = new SubUpDownBase();
             control.ValidateEditText();
             Assert.False(control.IsHandleCreated);
-            
+
             // Call again.
             control.ValidateEditText();
             Assert.False(control.IsHandleCreated);
@@ -2740,7 +2739,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Call again.
             control.ValidateEditText();
             Assert.True(control.IsHandleCreated);
@@ -2748,7 +2747,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
         }
-        
+
         [WinFormsFact]
         public void UpDownBase_WndProc_InvokeKillFocusWithoutHandle_Success()
         {
@@ -2945,7 +2944,7 @@ namespace System.Windows.Forms.Tests
                 get => base.UserEdit;
                 set => base.UserEdit = value;
             }
-            
+
             public Action ValidateEditTextAction { get; set; }
 
             protected override void ValidateEditText() => ValidateEditTextAction();
@@ -2968,7 +2967,7 @@ namespace System.Windows.Forms.Tests
             public new bool CanEnableIme => base.CanEnableIme;
 
             public new bool CanRaiseEvents => base.CanRaiseEvents;
-            
+
             public new bool ChangingText
             {
                 get => base.ChangingText;
@@ -3028,7 +3027,7 @@ namespace System.Windows.Forms.Tests
             public new bool ShowFocusCues => base.ShowFocusCues;
 
             public new bool ShowKeyboardCues => base.ShowKeyboardCues;
-            
+
             public new bool UserEdit
             {
                 get => base.UserEdit;
@@ -3065,11 +3064,11 @@ namespace System.Windows.Forms.Tests
             public new void OnMouseDown(MouseEventArgs e) => base.OnMouseDown(e);
 
             public new void OnMouseEnter(EventArgs e) => base.OnMouseEnter(e);
-            
+
             public new void OnMouseHover(EventArgs e) => base.OnMouseHover(e);
-            
+
             public new void OnMouseLeave(EventArgs e) => base.OnMouseLeave(e);
-            
+
             public new void OnMouseMove(MouseEventArgs e) => base.OnMouseMove(e);
 
             public new void OnMouseUp(MouseEventArgs mevent) => base.OnMouseUp(mevent);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/VScrollBarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/VScrollBarTests.cs
@@ -191,7 +191,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(RightToLeft.No, control.RightToLeft);
             Assert.Equal(0, callCount);
         }
-        
+
         [WinFormsFact]
         public void VScrollBar_GetAutoSizeMode_Invoke_ReturnsExpected()
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/VisualStyles/VisualStyleInformationTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/VisualStyles/VisualStyleInformationTests.cs
@@ -151,7 +151,6 @@ namespace System.Windows.Forms.VisualStyles.Tests
             Assert.NotNull(url);
             Assert.Equal(url, VisualStyleInformation.Url);
             Assert.DoesNotContain('\0', url);
-
         }
 
         [Fact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WindowsFormsSynchronizationContextTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WindowsFormsSynchronizationContextTests.cs
@@ -28,7 +28,7 @@ namespace System.Windows.Forms.Tests
             };
             copy.Send(callback, state);
             Assert.Equal(1, callCount);
-            
+
             // Call again.
             copy.Send(callback, state);
             Assert.Equal(2, callCount);
@@ -43,7 +43,7 @@ namespace System.Windows.Forms.Tests
             context.Dispose();
             context.Send(callback, new object());
             Assert.Equal(0, callCount);
-            
+
             // Call again.
             context.Dispose();
             context.Send(callback, new object());
@@ -69,7 +69,7 @@ namespace System.Windows.Forms.Tests
             var context = new WindowsFormsSynchronizationContext();
             context.Send(callback, state);
             Assert.Equal(1, callCount);
-            
+
             // Call again.
             context.Send(callback, state);
             Assert.Equal(2, callCount);
@@ -102,7 +102,7 @@ namespace System.Windows.Forms.Tests
 
             context.Send(callback, state);
             Assert.Equal(0, callCount);
-            
+
             // Call again.
             context.Send(callback, state);
             Assert.Equal(0, callCount);
@@ -127,7 +127,7 @@ namespace System.Windows.Forms.Tests
             var context = new WindowsFormsSynchronizationContext();
             context.Post(callback, state);
             Assert.Equal(0, callCount);
-            
+
             // Call again.
             context.Post(callback, state);
             Assert.Equal(0, callCount);
@@ -144,7 +144,7 @@ namespace System.Windows.Forms.Tests
 
             context.Post(callback, state);
             Assert.Equal(0, callCount);
-            
+
             // Call again.
             context.Post(callback, state);
             Assert.Equal(0, callCount);

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.cs
@@ -152,7 +152,7 @@ namespace System.Windows.Forms.Tests
             using var control = new SubTextBox();
             Assert.True(control.CanEnableIme);
             Assert.True(control.IsHandleCreated);
-            
+
             // Get again.
             Assert.True(control.CanEnableIme);
             Assert.True(control.IsHandleCreated);
@@ -175,7 +175,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Get again.
             Assert.True(control.CanEnableIme);
             Assert.True(control.IsHandleCreated);
@@ -190,7 +190,7 @@ namespace System.Windows.Forms.Tests
             using var control = new SubTextBox();
             Assert.Equal(ImeMode.NoControl, control.ImeMode);
             Assert.True(control.IsHandleCreated);
-            
+
             // Get again.
             Assert.Equal(ImeMode.NoControl, control.ImeMode);
             Assert.True(control.IsHandleCreated);
@@ -213,7 +213,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Get again.
             Assert.Equal(ImeMode.NoControl, control.ImeMode);
             Assert.True(control.IsHandleCreated);
@@ -228,7 +228,7 @@ namespace System.Windows.Forms.Tests
             using var control = new SubTextBox();
             Assert.Equal(ImeMode.NoControl, control.ImeModeBase);
             Assert.True(control.IsHandleCreated);
-            
+
             // Get again.
             Assert.Equal(ImeMode.NoControl, control.ImeModeBase);
             Assert.True(control.IsHandleCreated);
@@ -251,7 +251,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Get again.
             Assert.Equal(ImeMode.NoControl, control.ImeModeBase);
             Assert.True(control.IsHandleCreated);
@@ -266,7 +266,7 @@ namespace System.Windows.Forms.Tests
             using var control = new SubTextBox();
             Assert.Equal('\0', control.PasswordChar);
             Assert.True(control.IsHandleCreated);
-            
+
             // Get again.
             Assert.Equal('\0', control.PasswordChar);
             Assert.True(control.IsHandleCreated);
@@ -289,7 +289,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Get again.
             Assert.Equal('\0', control.PasswordChar);
             Assert.True(control.IsHandleCreated);

--- a/src/System.Windows.Forms/tests/UnitTests/ToolStripDropDownTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/ToolStripDropDownTests.cs
@@ -529,13 +529,13 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.HandleCreated += handler;
             control.OnHandleCreated(eventArgs);
             Assert.Equal(1, callCount);
             Assert.False(control.IsHandleCreated);
-        
+
             // Remove handler.
             control.HandleCreated -= handler;
             control.OnHandleCreated(eventArgs);
@@ -556,13 +556,13 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.HandleCreated += handler;
             control.OnHandleCreated(eventArgs);
             Assert.Equal(1, callCount);
             Assert.True(control.IsHandleCreated);
-        
+
             // Remove handler.
             control.HandleCreated -= handler;
             control.OnHandleCreated(eventArgs);
@@ -582,13 +582,13 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.HandleDestroyed += handler;
             control.OnHandleDestroyed(eventArgs);
             Assert.Equal(1, callCount);
             Assert.False(control.IsHandleCreated);
-        
+
             // Remove handler.
             control.HandleDestroyed -= handler;
             control.OnHandleDestroyed(eventArgs);
@@ -609,13 +609,13 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.HandleDestroyed += handler;
             control.OnHandleDestroyed(eventArgs);
             Assert.Equal(1, callCount);
             Assert.True(control.IsHandleCreated);
-        
+
             // Remove handler.
             control.HandleDestroyed -= handler;
             control.OnHandleDestroyed(eventArgs);
@@ -629,8 +629,8 @@ namespace System.Windows.Forms.Tests
             TestForm testForm = new TestForm();
             Application.Run(testForm); //it needs for correct work of ToolStripDropDown.CanProcessMnemonic method
 
-            //TestResult property is made as separate for the reason that 
-            //when the Assert is inside FormLoaded method and it fails, 
+            //TestResult property is made as separate for the reason that
+            //when the Assert is inside FormLoaded method and it fails,
             //the Application doesn't exit and the process freezes.
             Assert.True(testForm.TestResult);
         }
@@ -651,7 +651,7 @@ namespace System.Windows.Forms.Tests
             private void FormLoaded(object sender, EventArgs e)
             {
                 toolStrip.Enabled = true; // it needs for correct work of Control.CanProcessMnemonic method
-                toolStrip.Visible = true; // 
+                toolStrip.Visible = true; //
 
                 _result &= !(toolStrip.ProcessDialogCharTest('F'));
 

--- a/src/System.Windows.Forms/tests/UnitTests/TrackBarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TrackBarTests.cs
@@ -203,7 +203,7 @@ namespace System.Windows.Forms.Tests
                 RightToLeft = rightToLeft,
                 RightToLeftLayout = rightToLeftLayout
             };
-            
+
             CreateParams createParams = control.CreateParams;
             Assert.Null(createParams.Caption);
             Assert.Equal("msctls_trackbar32", createParams.ClassName);
@@ -1530,7 +1530,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal("RightToLeftLayout", e.AffectedProperty);
                 layoutCallCount++;
             };
-            
+
             control.RightToLeftLayout = value;
             Assert.Equal(value, control.RightToLeftLayout);
             Assert.Equal(expectedLayoutCallCount, layoutCallCount);
@@ -1828,7 +1828,7 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(value, control.TickFrequency);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             control.TickFrequency = value;
             Assert.Equal(value, control.TickFrequency);
@@ -1851,14 +1851,14 @@ namespace System.Windows.Forms.Tests
             control.StyleChanged += (sender, e) => styleChangedCallCount++;
             int createdCallCount = 0;
             control.HandleCreated += (sender, e) => createdCallCount++;
-            
+
             control.TickFrequency = value;
             Assert.Equal(value, control.TickFrequency);
             Assert.True(control.IsHandleCreated);
             Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            
+
             // Set same.
             control.TickFrequency = value;
             Assert.Equal(value, control.TickFrequency);
@@ -1878,7 +1878,7 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(value, control.TickStyle);
             Assert.False(control.IsHandleCreated);
-            
+
             // Set same.
             control.TickStyle = value;
             Assert.Equal(value, control.TickStyle);
@@ -1900,14 +1900,14 @@ namespace System.Windows.Forms.Tests
             control.StyleChanged += (sender, e) => styleChangedCallCount++;
             int createdCallCount = 0;
             control.HandleCreated += (sender, e) => createdCallCount++;
-            
+
             control.TickStyle = value;
             Assert.Equal(value, control.TickStyle);
             Assert.True(control.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(expectedCreatedCallCount, createdCallCount);
-            
+
             // Set same.
             control.TickStyle = value;
             Assert.Equal(value, control.TickStyle);
@@ -1983,7 +1983,7 @@ namespace System.Windows.Forms.Tests
         {
             using var control = new TrackBar();
             control.BeginInit();
-            
+
             control.Value = value;
             Assert.Equal(10, control.Maximum);
             Assert.Equal(0, control.Minimum);
@@ -2016,7 +2016,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { Orientation.Vertical, RightToLeft.No, false, 0, 10 };
             yield return new object[] { Orientation.Vertical, RightToLeft.Inherit, true, 0, 10 };
             yield return new object[] { Orientation.Vertical, RightToLeft.Inherit, false, 0, 10 };
-            
+
             yield return new object[] { Orientation.Horizontal, RightToLeft.Yes, true, 1, 1 };
             yield return new object[] { Orientation.Horizontal, RightToLeft.Yes, false, 1, 9 };
             yield return new object[] { Orientation.Horizontal, RightToLeft.No, true, 1, 1 };
@@ -2029,7 +2029,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { Orientation.Vertical, RightToLeft.No, false, 1, 9 };
             yield return new object[] { Orientation.Vertical, RightToLeft.Inherit, true, 1, 9 };
             yield return new object[] { Orientation.Vertical, RightToLeft.Inherit, false, 1, 9 };
-            
+
             yield return new object[] { Orientation.Horizontal, RightToLeft.Yes, true, 5, 5 };
             yield return new object[] { Orientation.Horizontal, RightToLeft.Yes, false, 5, 5 };
             yield return new object[] { Orientation.Horizontal, RightToLeft.No, true, 5, 5 };
@@ -2042,7 +2042,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { Orientation.Vertical, RightToLeft.No, false, 5, 5 };
             yield return new object[] { Orientation.Vertical, RightToLeft.Inherit, true, 5, 5 };
             yield return new object[] { Orientation.Vertical, RightToLeft.Inherit, false, 5, 5 };
-            
+
             yield return new object[] { Orientation.Horizontal, RightToLeft.Yes, true, 9, 9 };
             yield return new object[] { Orientation.Horizontal, RightToLeft.Yes, false, 9, 1 };
             yield return new object[] { Orientation.Horizontal, RightToLeft.No, true, 9, 9 };
@@ -2055,7 +2055,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { Orientation.Vertical, RightToLeft.No, false, 9, 1 };
             yield return new object[] { Orientation.Vertical, RightToLeft.Inherit, true, 9, 1 };
             yield return new object[] { Orientation.Vertical, RightToLeft.Inherit, false, 9, 1 };
-            
+
             yield return new object[] { Orientation.Horizontal, RightToLeft.Yes, true, 10, 10 };
             yield return new object[] { Orientation.Horizontal, RightToLeft.Yes, false, 10, 0 };
             yield return new object[] { Orientation.Horizontal, RightToLeft.No, true, 10, 10 };
@@ -2129,7 +2129,7 @@ namespace System.Windows.Forms.Tests
         {
             using var control = new TrackBar();
             control.BeginInit();
-            
+
             // Call again.
             control.BeginInit();
         }
@@ -2321,12 +2321,12 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.Click += handler;
             control.OnClick(eventArgs);
             Assert.Equal(1, callCount);
-        
+
             // Remove handler.
             control.Click -= handler;
             control.OnClick(eventArgs);
@@ -2345,12 +2345,12 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.DoubleClick += handler;
             control.OnDoubleClick(eventArgs);
             Assert.Equal(1, callCount);
-        
+
             // Remove handler.
             control.DoubleClick -= handler;
             control.OnDoubleClick(eventArgs);
@@ -2435,7 +2435,6 @@ namespace System.Windows.Forms.Tests
             control.OnMouseClick(eventArgs);
             Assert.Equal(1, callCount);
         }
-
 
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetMouseEventArgsTheoryData))]
@@ -2564,7 +2563,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, callCount);
             Assert.False(control.IsHandleCreated);
         }
-        
+
         public static IEnumerable<object[]> OnRightToLeftLayoutChanged_WithHandle_TestData()
         {
             yield return new object[] { RightToLeft.Yes, null, 1 };
@@ -2656,12 +2655,12 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.Scroll += handler;
             control.OnScroll(eventArgs);
             Assert.Equal(1, callCount);
-        
+
             // Remove handler.
             control.Scroll -= handler;
             control.OnScroll(eventArgs);
@@ -2744,12 +2743,12 @@ namespace System.Windows.Forms.Tests
                 Assert.Same(eventArgs, e);
                 callCount++;
             };
-        
+
             // Call with handler.
             control.ValueChanged += handler;
             control.OnValueChanged(eventArgs);
             Assert.Equal(1, callCount);
-        
+
             // Remove handler.
             control.ValueChanged -= handler;
             control.OnValueChanged(eventArgs);
@@ -3069,7 +3068,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
         }
-        
+
         public static IEnumerable<object[]> WndProc_Scroll_TestData()
         {
             yield return new object[] { User32.WM_REFLECT + WindowMessages.WM_HSCROLL, IntPtr.Zero };
@@ -3084,7 +3083,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { User32.WM_REFLECT + WindowMessages.WM_HSCROLL, PARAM.FromLowHigh(7, int.MaxValue) };
             yield return new object[] { User32.WM_REFLECT + WindowMessages.WM_HSCROLL, PARAM.FromLowHigh(8, int.MaxValue) };
             yield return new object[] { User32.WM_REFLECT + WindowMessages.WM_HSCROLL, PARAM.FromLowHigh(9, int.MaxValue) };
-            
+
             yield return new object[] { User32.WM_REFLECT + WindowMessages.WM_VSCROLL, IntPtr.Zero };
             yield return new object[] { User32.WM_REFLECT + WindowMessages.WM_VSCROLL, PARAM.FromLowHigh(-1, int.MaxValue) };
             yield return new object[] { User32.WM_REFLECT + WindowMessages.WM_VSCROLL, PARAM.FromLowHigh(0, int.MaxValue) };
@@ -3199,19 +3198,19 @@ namespace System.Windows.Forms.Tests
             public new bool IsInputKey(Keys keyData) => base.IsInputKey(keyData);
 
             public new void OnBackColorChanged(EventArgs e) => base.OnBackColorChanged(e);
-            
+
             public new void OnClick(EventArgs e) => base.OnClick(e);
-            
+
             public new void OnDoubleClick(EventArgs e) => base.OnDoubleClick(e);
 
             public new void OnForeColorChanged(EventArgs e) => base.OnForeColorChanged(e);
 
             public new void OnHandleCreated(EventArgs e) => base.OnHandleCreated(e);
-            
+
             public new void OnHandleDestroyed(EventArgs e) => base.OnHandleDestroyed(e);
 
             public new void OnMouseClick(MouseEventArgs e) => base.OnMouseClick(e);
-            
+
             public new void OnMouseDoubleClick(MouseEventArgs e) => base.OnMouseDoubleClick(e);
 
             public new void OnMouseWheel(MouseEventArgs e) => base.OnMouseWheel(e);


### PR DESCRIPTION
Mostly the rules are around blank line placement. But I also enabled the 'no trailing whitespace' rule and 'use tabs properly' rules. All changes to code were the result of automated code fixes from the analyzers.

As previously agreed with @RussKie 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2651)