### PR TITLE
Fix missing reference

### DIFF
--- a/pkg/Microsoft.Private.Winforms/Microsoft.Private.Winforms.csproj
+++ b/pkg/Microsoft.Private.Winforms/Microsoft.Private.Winforms.csproj
@@ -67,6 +67,9 @@
     <!-- Reference and Source System.Windows.Forms includes -->
     <ProjectReference Include="..\..\src\System.Windows.Forms\src\System.Windows.Forms.csproj" />
 
+    <!-- Reference and Source System.Windows.Forms.Primitives includes -->
+    <ProjectReference Include="..\..\src\System.Windows.Forms.Primitives\src\System.Windows.Forms.Primitives.csproj" />
+
     <!-- Reference and Source System.Windows.Forms.Design includes -->
     <ProjectReference Include="..\..\src\System.Windows.Forms.Design\src\System.Windows.Forms.Design.csproj" />
     


### PR DESCRIPTION
Our downstream consumers are broken missing System.Windows.Forms.Primitives.dll, e.g. https://github.com/dotnet/wpf/pull/2399

Follow up for #2518


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2652)