### PR TITLE
Add ListViewGroup.Footer/FooterAlignment

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,7 @@
+System.Windows.Forms.ListViewGroup.Footer.get -> string
+System.Windows.Forms.ListViewGroup.Footer.set -> void
+System.Windows.Forms.ListViewGroup.FooterAlignment.get -> System.Windows.Forms.HorizontalAlignment
+System.Windows.Forms.ListViewGroup.FooterAlignment.set -> void
 System.Windows.Forms.DomainUpDown.DomainUpDownAccessibleObject.DomainUpDownAccessibleObject(System.Windows.Forms.DomainUpDown owner) -> void
 System.Windows.Forms.VisualStyles.EdgeEffects.Flat = 16384 -> System.Windows.Forms.VisualStyles.EdgeEffects
 System.Windows.Forms.VisualStyles.EdgeEffects.Soft = 4096 -> System.Windows.Forms.VisualStyles.EdgeEffects

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -5462,10 +5462,11 @@ namespace System.Windows.Forms
         private unsafe IntPtr SendGroupMessage(ListViewGroup group, LVM msg, IntPtr lParam, LVGF additionalMask)
         {
             string header = group.Header;
+            string footer = group.Footer;
             var lvgroup = new LVGROUPW
             {
                 cbSize = (uint)sizeof(LVGROUPW),
-                mask = LVGF.HEADER | LVGF.ALIGN | additionalMask,
+                mask = LVGF.HEADER | LVGF.FOOTER | LVGF.ALIGN | additionalMask,
                 cchHeader = header.Length,
                 iGroupId = group.ID
             };
@@ -5484,7 +5485,26 @@ namespace System.Windows.Forms
             }
 
             fixed (char* pHeader = header)
+            fixed (char* pFooter = footer)
             {
+                if (!string.IsNullOrEmpty(footer))
+                {
+                    lvgroup.cchFooter = footer.Length;
+                    lvgroup.pszFooter = pFooter;
+                    switch (group.FooterAlignment)
+                    {
+                        case HorizontalAlignment.Left:
+                            lvgroup.uAlign |= LVGA.FOOTER_LEFT;
+                            break;
+                        case HorizontalAlignment.Right:
+                            lvgroup.uAlign |= LVGA.FOOTER_RIGHT;
+                            break;
+                        case HorizontalAlignment.Center:
+                            lvgroup.uAlign |= LVGA.FOOTER_CENTER;
+                            break;
+                    }
+                }
+
                 lvgroup.pszHeader = pHeader;
                 return User32.SendMessageW(this, (User32.WM)msg, lParam, ref lvgroup);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
@@ -22,6 +22,8 @@ namespace System.Windows.Forms
     {
         private string _header;
         private HorizontalAlignment _headerAlignment = HorizontalAlignment.Left;
+        private string _footer;
+        private HorizontalAlignment _footerAlignment = HorizontalAlignment.Left;
 
         private ListView.ListViewItemCollection _items;
 
@@ -79,11 +81,13 @@ namespace System.Windows.Forms
             get => _header ?? string.Empty;
             set
             {
-                if (_header != value)
+                if (_header == value)
                 {
-                    _header = value;
-                    UpdateListView();
+                    return;
                 }
+
+                _header = value;
+                UpdateListView();
             }
         }
 
@@ -102,11 +106,57 @@ namespace System.Windows.Forms
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(HorizontalAlignment));
                 }
 
-                if (_headerAlignment != value)
+                if (_headerAlignment == value)
                 {
-                    _headerAlignment = value;
-                    UpdateListView();
+                    return;
                 }
+
+                _headerAlignment = value;
+                UpdateListView();
+            }
+        }
+
+        /// <summary>
+        ///  The text displayed in the group footer.
+        /// </summary>
+        [SRCategory(nameof(SR.CatAppearance))]
+        public string Footer
+        {
+            get => _footer ?? string.Empty;
+            set
+            {
+                if (_footer == value)
+                {
+                    return;
+                }
+
+                _footer = value;
+                UpdateListView();
+            }
+        }
+
+        /// <summary>
+        ///  The alignment of the group footer.
+        /// </summary>
+        [DefaultValue(HorizontalAlignment.Left)]
+        [SRCategory(nameof(SR.CatAppearance))]
+        public HorizontalAlignment FooterAlignment
+        {
+            get => _footerAlignment;
+            set
+            {
+                if (!ClientUtils.IsEnumValid(value, (int)value, (int)HorizontalAlignment.Left, (int)HorizontalAlignment.Center))
+                {
+                    throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(HorizontalAlignment));
+                }
+
+                if (_footerAlignment == value)
+                {
+                    return;
+                }
+
+                _footerAlignment = value;
+                UpdateListView();
             }
         }
 
@@ -153,6 +203,14 @@ namespace System.Windows.Forms
                 {
                     HeaderAlignment = (HorizontalAlignment)entry.Value;
                 }
+                else if (entry.Name == "Footer")
+                {
+                    Footer = (string)entry.Value;
+                }
+                else if (entry.Name == "FooterAlignment")
+                {
+                    FooterAlignment = (HorizontalAlignment)entry.Value;
+                }
                 else if (entry.Name == "Tag")
                 {
                     Tag = entry.Value;
@@ -191,6 +249,8 @@ namespace System.Windows.Forms
         {
             info.AddValue(nameof(Header), Header);
             info.AddValue(nameof(HeaderAlignment), HeaderAlignment);
+            info.AddValue(nameof(Footer), Footer);
+            info.AddValue(nameof(FooterAlignment), FooterAlignment);
             info.AddValue(nameof(Tag), Tag);
             if (!string.IsNullOrEmpty(Name))
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -1481,21 +1481,21 @@ namespace System.Windows.Forms.Tests
         {
             foreach (bool showGroups in new bool[] { true, false })
             {
-                yield return new object[] { showGroups, null, HorizontalAlignment.Left, string.Empty, 0x00000001 };
-                yield return new object[] { showGroups, null, HorizontalAlignment.Center, string.Empty, 0x00000002 };
-                yield return new object[] { showGroups, null, HorizontalAlignment.Right, string.Empty, 0x00000004 };
+                yield return new object[] { showGroups, null, HorizontalAlignment.Left, null, HorizontalAlignment.Right, string.Empty, string.Empty, 0x00000001 };
+                yield return new object[] { showGroups, null, HorizontalAlignment.Center, null, HorizontalAlignment.Center, string.Empty, string.Empty, 0x00000002 };
+                yield return new object[] { showGroups, null, HorizontalAlignment.Right, null, HorizontalAlignment.Left, string.Empty, string.Empty, 0x00000004 };
 
-                yield return new object[] { showGroups, string.Empty, HorizontalAlignment.Left, string.Empty, 0x00000001 };
-                yield return new object[] { showGroups, string.Empty, HorizontalAlignment.Center, string.Empty, 0x00000002 };
-                yield return new object[] { showGroups, string.Empty, HorizontalAlignment.Right, string.Empty, 0x00000004 };
+                yield return new object[] { showGroups, string.Empty, HorizontalAlignment.Left, string.Empty, HorizontalAlignment.Right, string.Empty, 0x00000001 };
+                yield return new object[] { showGroups, string.Empty, HorizontalAlignment.Center, string.Empty, HorizontalAlignment.Center, string.Empty, 0x00000002 };
+                yield return new object[] { showGroups, string.Empty, HorizontalAlignment.Right, string.Empty, HorizontalAlignment.Left, string.Empty, 0x00000004 };
 
-                yield return new object[] { showGroups, "text", HorizontalAlignment.Left, "text", 0x00000001 };
-                yield return new object[] { showGroups, "text", HorizontalAlignment.Center, "text", 0x00000002 };
-                yield return new object[] { showGroups, "text", HorizontalAlignment.Right, "text", 0x00000004 };
+                yield return new object[] { showGroups, "header", HorizontalAlignment.Left, "footer", HorizontalAlignment.Right, "header", "footer", 00000021 };
+                yield return new object[] { showGroups, "header", HorizontalAlignment.Center, "footer", HorizontalAlignment.Center, "header", "footer", 0x00000012 };
+                yield return new object[] { showGroups, "header", HorizontalAlignment.Right, "footer", HorizontalAlignment.Left, "header", "footer", 0x00000012 };
 
-                yield return new object[] { showGroups, "te\0xt", HorizontalAlignment.Left, "te", 0x00000001 };
-                yield return new object[] { showGroups, "te\0xt", HorizontalAlignment.Center, "te", 0x00000002 };
-                yield return new object[] { showGroups, "te\0xt", HorizontalAlignment.Right, "te", 0x00000004 };
+                yield return new object[] { showGroups, "he\0der", HorizontalAlignment.Left, "fo\0oter", HorizontalAlignment.Right, "he", "fo", 00000021 };
+                yield return new object[] { showGroups, "he\0der", HorizontalAlignment.Center, "fo\0oter", HorizontalAlignment.Center, "he", "fo", 0x00000012 };
+                yield return new object[] { showGroups, "he\0der", HorizontalAlignment.Right, "fo\0oter", HorizontalAlignment.Left, "he", "fo", 0x00000012 };
             }
         }
 
@@ -1510,8 +1510,11 @@ namespace System.Windows.Forms.Tests
                     bool showGroups = (bool)data[0];
                     string header = (string)data[1];
                     HorizontalAlignment headerAlignment = (HorizontalAlignment)data[2];
-                    string expectedHeaderText = (string)data[3];
-                    int expectedAlign = (int)data[4];
+                    string footer = (string)data[3];
+                    HorizontalAlignment footerAlignment = (HorizontalAlignment)data[4];
+                    string expectedHeaderText = (string)data[5];
+                    string expectedFooterText = (string)data[6];
+                    int expectedAlign = (int)data[7];
 
                     Application.EnableVisualStyles();
 
@@ -1523,34 +1526,43 @@ namespace System.Windows.Forms.Tests
                     var group2 = new ListViewGroup
                     {
                         Header = header,
-                        HeaderAlignment = headerAlignment
+                        HeaderAlignment = headerAlignment,
+                        Footer = footer,
+                        FooterAlignment = footerAlignment
                     };
                     listView.Groups.Add(group1);
                     listView.Groups.Add(group2);
 
                     Assert.Equal((IntPtr)2, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, IntPtr.Zero, IntPtr.Zero));
-                    char* buffer = stackalloc char[256];
+                    char* headerBuffer = stackalloc char[256];
+                    char* footerBuffer = stackalloc char[256];
                     var lvgroup1 = new ComCtl32.LVGROUPW
                     {
-                        cbSize = (uint)Marshal.SizeOf<ComCtl32.LVGROUPW>(),
-                        mask = ComCtl32.LVGF.HEADER | ComCtl32.LVGF.GROUPID | ComCtl32.LVGF.ALIGN,
-                        pszHeader = buffer,
-                        cchHeader = 256
+                        cbSize = (uint)sizeof(ComCtl32.LVGROUPW),
+                        mask = ComCtl32.LVGF.HEADER | ComCtl32.LVGF.FOOTER | ComCtl32.LVGF.GROUPID | ComCtl32.LVGF.ALIGN,
+                        pszHeader = headerBuffer,
+                        cchHeader = 256,
+                        pszFooter = footerBuffer,
+                        cchFooter = 256,
                     };
                     Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPINFOBYINDEX, (IntPtr)0, ref lvgroup1));
                     Assert.Equal("ListViewGroup", new string(lvgroup1.pszHeader));
+                    Assert.Empty(new string(lvgroup1.pszFooter));
                     Assert.True(lvgroup1.iGroupId >= 0);
                     Assert.Equal(0x00000001, (int)lvgroup1.uAlign);
 
                     var lvgroup2 = new ComCtl32.LVGROUPW
                     {
-                        cbSize = (uint)Marshal.SizeOf<ComCtl32.LVGROUPW>(),
-                        mask = ComCtl32.LVGF.HEADER | ComCtl32.LVGF.GROUPID | ComCtl32.LVGF.ALIGN,
-                        pszHeader = buffer,
-                        cchHeader = 256
+                        cbSize = (uint)sizeof(ComCtl32.LVGROUPW),
+                        mask = ComCtl32.LVGF.HEADER | ComCtl32.LVGF.FOOTER | ComCtl32.LVGF.GROUPID | ComCtl32.LVGF.ALIGN,
+                        pszHeader = headerBuffer,
+                        cchHeader = 256,
+                        pszFooter = footerBuffer,
+                        cchFooter = 256,
                     };
                     Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPINFOBYINDEX, (IntPtr)1, ref lvgroup2));
                     Assert.Equal(expectedHeaderText, new string(lvgroup2.pszHeader));
+                    Assert.Equal(expectedFooterText, new string(lvgroup2.pszFooter));
                     Assert.True(lvgroup2.iGroupId > 0);
                     Assert.Equal(expectedAlign, (int)lvgroup2.uAlign);
                     Assert.True(lvgroup2.iGroupId > lvgroup1.iGroupId);


### PR DESCRIPTION
Fixes #2653 

## Proposed changes

- Add ListViewGroup.Footer
- Add ListViewGroup.FooterAlignment

## Customer Impact
- New APIs to align with native comctl32 feature set

## Regression? 
- No

## Risk
- Minimal

## Screenshots

![image](https://user-images.githubusercontent.com/1275900/76226750-336ff800-6216-11ea-9e6d-a546074357cb.png)

## Test methodology
- Unit tests
- Integration tests
- Manual tests

## Accessibility testing
- Inspect.exe and accessibility checker

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2654)