### PR TITLE
fix casing in csproj

### DIFF
--- a/src/System.Windows.Forms/src/System.Windows.Forms.csproj
+++ b/src/System.Windows.Forms/src/System.Windows.Forms.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>System.Windows.Forms</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLSCompliant>true</CLSCompliant>
-    <!--the obsolete usage in public surface can't be removed-->
+    
     <NoWarn>$(NoWarn);618</NoWarn>
     <DefineConstants>$(DefineConstants);OPTIMIZED_MEASUREMENTDC;</DefineConstants>
     <Win32Manifest>Resources\System\Windows\Forms\XPThemes.manifest</Win32Manifest>
@@ -393,7 +393,7 @@
     <EmbeddedResource Include="Resources\System\Windows\Forms\Printing\PrintDialog.ico">
       <LogicalName>System.Windows.Forms.PrintDialog</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="Resources\System\Windows\Forms\PropertyGrid\Arrow.ico">
+    <EmbeddedResource Include="Resources\System\Windows\Forms\PropertyGrid\arrow.ico">
       <LogicalName>System.Windows.Forms.Arrow</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="Resources\System\Windows\Forms\PropertyGrid\dotdotdot.ico">
@@ -474,13 +474,13 @@
     <EmbeddedResource Include="Resources\System\Windows\Forms\west.cur">
       <LogicalName>System.Windows.Forms.west.cur</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="resources\System\Windows\Forms\up.ico">
+    <EmbeddedResource Include="Resources\System\Windows\Forms\up.ico">
       <LogicalName>System.Windows.Forms.up</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="resources\System\Windows\Forms\down.ico">
+    <EmbeddedResource Include="Resources\System\Windows\Forms\down.ico">
       <LogicalName>System.Windows.Forms.down</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="resources\System\Windows\Forms\design\componenteditorpage.ico">
+    <EmbeddedResource Include="Resources\System\Windows\Forms\Design\ComponentEditorPage.ico">
       <LogicalName>System.Windows.Forms.Design.ComponentEditorPage</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\ScrollButtonUp.ico">
@@ -585,31 +585,31 @@
     <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\deleteToolStripMenuItem.ico">
       <LogicalName>System.Windows.Forms.delete</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\viewcodeToolStripMenuItem.ico">
+    <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\viewcodetoolstripmenuitem.ico">
       <LogicalName>System.Windows.Forms.viewcode</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\propertiesToolStripMenuItem.ico">
+    <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\propertiestoolstripmenuitem.ico">
       <LogicalName>System.Windows.Forms.properties</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\imageToolStripMenuItem.ico">
+    <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\imagetoolstripmenuitem.ico">
       <LogicalName>System.Windows.Forms.image</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\alignmentToolStripMenuItem.ico">
+    <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\alignmenttoolstripmenuitem.ico">
       <LogicalName>System.Windows.Forms.alignment</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\displaystyleToolStripMenuItem.ico">
+    <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\displaystyletoolstripmenuitem.ico">
       <LogicalName>System.Windows.Forms.displaystyle</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\editdropdownlistToolStripMenuItem.ico">
+    <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\editdropdownlisttoolstripmenuitem.ico">
       <LogicalName>System.Windows.Forms.editdropdownlist</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\printToolStripMenuItem.ico">
+    <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\printToolstripMenuItem.ico">
       <LogicalName>System.Windows.Forms.print</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\printPreviewToolStripMenuItem.ico">
       <LogicalName>System.Windows.Forms.printPreview</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\saveToolStripMenuItem.ico">
+    <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\saveToolstripMenuItem.ico">
       <LogicalName>System.Windows.Forms.save</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\lockControls.ico">
@@ -624,7 +624,7 @@
     <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\SendToBackHS.ico">
       <LogicalName>System.Windows.Forms.sendToBack</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\blanktoolStrip.ico">
+    <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\BlankToolstrip.ico">
       <LogicalName>System.Windows.Forms.blank</LogicalName>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

See https://github.com/dotnet/winforms/issues/2636 for context

## Proposed changes

- Fix all resource files referenced in `System.Windows.Forms` to have the same casing as they have in the file system.

## Customer Impact

- `System.Windows.Forms` will compile on file systems with sensitive casing (e.g. ext4)


## Test methodology <!-- How did you ensure quality? -->

- `dotnet build` passes before and after
- `dotnet test` yields same results before and after

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2661)