### PR TITLE
Improve PaddingConverter CreateInstance implementation

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PaddingConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PaddingConverterTests.cs
@@ -157,10 +157,21 @@ namespace System.Windows.Forms.Tests
         }
 
         [Fact]
-        public void PaddingConverter_CreateInstance_NullContext_ThrowsArgumentNullException()
+        public void PaddingConverter_CreateInstance_ValidPropertyValuesNullContext_ReturnsExpected()
         {
             var converter = new PaddingConverter();
-            Assert.Throws<ArgumentNullException>("context", () => converter.CreateInstance(null, new Dictionary<string, object>()));
+            Padding expected = new Padding(1, 2, 3, 4);
+            Padding padding = Assert.IsType<Padding>(converter.CreateInstance(
+                null, new Dictionary<string, object>
+                {
+                    {nameof(Padding.All), expected.All},
+                    {nameof(Padding.Left), expected.Left},
+                    {nameof(Padding.Top), expected.Top},
+                    {nameof(Padding.Right), expected.Right},
+                    {nameof(Padding.Bottom), expected.Bottom}
+                })
+            );
+            Assert.Equal(expected, padding);
         }
 
         [Fact]
@@ -355,7 +366,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [Fact]
-        public void PaddingConverter_CreateInstance_InvalidInstanceType_ThrowsInvalidCastException()
+        public void PaddingConverter_CreateInstance_UnknownInstanceType_ReturnsExpected()
         {
             var converter = new PaddingConverter();
             var mockContext = new Mock<ITypeDescriptorContext>(MockBehavior.Strict);
@@ -374,7 +385,10 @@ namespace System.Windows.Forms.Tests
                 {nameof(Padding.Right), 3},
                 {nameof(Padding.Bottom), 4},
             };
-            Assert.Throws<InvalidCastException>(() => converter.CreateInstance(mockContext.Object, propertyValues));
+
+            Padding expected = new Padding(2, 2, 3, 4);
+            Padding padding = Assert.IsType<Padding>(converter.CreateInstance(mockContext.Object, propertyValues));
+            Assert.Equal(expected, padding);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #2677

## Proposed changes

- The context argument may be null for callers other than the PropertyGrid, this should not lead to an exception, in particular since `GetCreateInstanceSupported` returns true for a null context. Also every other implementation of CreateInstance I could find in WinForms and System.Drawing supports a null context, so PaddingConverter is an outlier.

## Regression? 

- No

## Risk

- Callers which depend on an exception being thrown in a previously unsupported scenario will no longer see an exception

### Before

- `PaddingConverter.CreateInstance(null, properties)` throws an exception even though `PaddingConverter.GetCreateInstanceSupported(null)` returns true

### After

- `PaddingConverter.CreateInstance(null, properties)` creates an instance based on the given properties like any other TypeConverter defined in WinForms and System.Drawing

## Test methodology

- Tests have not been updated yet, this is WIP for discussion


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2679)