### PR TITLE
Remove IsWindow from UnsafeNativeMethods.cs

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.IsWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.IsWindow.cs
@@ -10,7 +10,13 @@ internal static partial class Interop
     internal static partial class User32
     {
         [DllImport(Libraries.User32, ExactSpelling = true)]
-
         public static extern BOOL IsWindow(IntPtr hWnd);
+
+        public static BOOL IsWindow(HandleRef hWnd)
+        {
+            BOOL result = IsWindow(hWnd.Handle);
+            GC.KeepAlive(hWnd.Wrapper);
+            return result;
+        }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -324,9 +324,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.Gdi32, SetLastError = true, CharSet = CharSet.Unicode)]
         public static extern IntPtr CreateIC(string lpszDriverName, string lpszDeviceName, string lpszOutput, HandleRef /*DEVMODE*/ lpInitData);
 
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern bool IsWindow(HandleRef hWnd);
-
         //for RegionData
         [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
         public static extern int GetRegionData(HandleRef hRgn, int size, IntPtr lpRgnData);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadWindows.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadWindows.cs
@@ -77,7 +77,7 @@ namespace System.Windows.Forms
                 for (int i = 0; i < _windowCount; i++)
                 {
                     IntPtr hWnd = _windows[i];
-                    if (UnsafeNativeMethods.IsWindow(new HandleRef(null, hWnd)))
+                    if (User32.IsWindow(hWnd).IsTrue())
                     {
                         Control c = Control.FromHandle(hWnd);
                         if (c != null)
@@ -109,7 +109,7 @@ namespace System.Windows.Forms
                 {
                     IntPtr hWnd = _windows[i];
                     Debug.WriteLineIf(CompModSwitches.MSOComponentManager.TraceInfo, "ComponentManager : Changing enabled on window: " + hWnd.ToString() + " : " + state.ToString());
-                    if (UnsafeNativeMethods.IsWindow(new HandleRef(null, hWnd)))
+                    if (User32.IsWindow(hWnd).IsTrue())
                     {
                         User32.EnableWindow(hWnd, state.ToBOOL());
                     }
@@ -125,12 +125,12 @@ namespace System.Windows.Forms
                 // we are created with a TRUE for onlyWinForms.
                 if (!_onlyWinForms && state)
                 {
-                    if (_activeHwnd != IntPtr.Zero && UnsafeNativeMethods.IsWindow(new HandleRef(null, _activeHwnd)))
+                    if (_activeHwnd != IntPtr.Zero && User32.IsWindow(_activeHwnd).IsTrue())
                     {
                         User32.SetActiveWindow(_activeHwnd);
                     }
 
-                    if (_focusedHwnd != IntPtr.Zero && UnsafeNativeMethods.IsWindow(new HandleRef(null, _focusedHwnd)))
+                    if (_focusedHwnd != IntPtr.Zero && User32.IsWindow(_focusedHwnd).IsTrue())
                     {
                         User32.SetFocus(_focusedHwnd);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -1072,7 +1072,7 @@ namespace System.Windows.Forms
         /// </summary>
         internal static void ParkHandle(HandleRef handle, DpiAwarenessContext dpiAwarenessContext = DpiAwarenessContext.DPI_AWARENESS_CONTEXT_UNSPECIFIED)
         {
-            Debug.Assert(UnsafeNativeMethods.IsWindow(handle), "Handle being parked is not a valid window handle");
+            Debug.Assert(User32.IsWindow(handle).IsTrue(), "Handle being parked is not a valid window handle");
             Debug.Assert(((int)User32.GetWindowLong(handle, User32.GWL.STYLE) & (int)User32.WS.CHILD) != 0, "Only WS_CHILD windows should be parked.");
 
             ThreadContext cxt = GetContextForHandle(handle);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -6162,7 +6162,7 @@ namespace System.Windows.Forms
             else
             {
                 IntPtr hWnd = window.Handle;
-                if (hWnd == IntPtr.Zero || UnsafeNativeMethods.IsWindow(new HandleRef(null, hWnd)))
+                if (hWnd == IntPtr.Zero || User32.IsWindow(hWnd).IsTrue())
                 {
                     return hWnd;
                 }
@@ -9869,7 +9869,7 @@ namespace System.Windows.Forms
                     // But the parent is not a managed WinForm Control, or this.Parent == null
                     && (FromHandle(parentHandle.Handle) == null || _parent == null)
                     // Still, parentHandle is a valid native Win32 window handle, e.g. the desktop window.
-                    && UnsafeNativeMethods.IsWindow(parentHandle))
+                    && User32.IsWindow(parentHandle).IsTrue())
                 {
                     // correctly parent back up to where we were before.
                     // if we were parented to a proper windows forms control, CreateControl would have properly parented

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -5403,16 +5403,16 @@ namespace System.Windows.Forms
                     // Call SetActiveWindow before setting Visible = false.
                     //
 
-                    if (!UnsafeNativeMethods.IsWindow(new HandleRef(null, hWndActive)))
+                    if (User32.IsWindow(hWndActive).IsFalse())
                     {
                         hWndActive = hWndOwner;
                     }
 
-                    if (UnsafeNativeMethods.IsWindow(new HandleRef(null, hWndActive)) && User32.IsWindowVisible(hWndActive).IsTrue())
+                    if (User32.IsWindow(hWndActive).IsTrue() && User32.IsWindowVisible(hWndActive).IsTrue())
                     {
                         User32.SetActiveWindow(hWndActive);
                     }
-                    else if (UnsafeNativeMethods.IsWindow(new HandleRef(null, hWndOwner)) && User32.IsWindowVisible(hWndOwner).IsTrue())
+                    else if (User32.IsWindow(hWndOwner).IsTrue() && User32.IsWindowVisible(hWndOwner).IsTrue())
                     {
                         User32.SetActiveWindow(hWndOwner);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Timer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Timer.cs
@@ -290,7 +290,7 @@ namespace System.Windows.Forms
                 // Locking 'this' here is ok since this is an internal class.
                 lock (this)
                 {
-                    if (_stoppingTimer || hWnd == IntPtr.Zero || !UnsafeNativeMethods.IsWindow(new HandleRef(this, hWnd)))
+                    if (_stoppingTimer || hWnd == IntPtr.Zero || User32.IsWindow(new HandleRef(this, hWnd)).IsFalse())
                     {
                         return;
                     }


### PR DESCRIPTION
## Proposed changes

- Remove IsWindow from UnsafeNativeMethods.cs.
- Replace is usages with the Interop User32 methods.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2695)