### PR TITLE
Move GetUpdateRect to Interop User32

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
@@ -904,7 +904,7 @@ namespace System.Windows.Forms.Design.Behavior
                         User32.GetUpdateRgn(m.HWnd, hrgn, BOOL.TRUE);
                         // The region we have to update in terms of the smallest rectangle that completely encloses the update region of the window gives us the clip rectangle
                         RECT clip = new RECT();
-                        NativeMethods.GetUpdateRect(m.HWnd, ref clip, true);
+                        User32.GetUpdateRect(m.HWnd, ref clip, BOOL.TRUE);
                         Rectangle paintRect = new Rectangle(clip.left, clip.top, clip.right - clip.left, clip.bottom - clip.top);
 
                         try

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -2002,7 +2002,7 @@ namespace System.Windows.Forms.Design
                     RECT clip = new RECT();
                     IntPtr hrgn = Gdi32.CreateRectRgn(0, 0, 0, 0);
                     User32.GetUpdateRgn(m.HWnd, hrgn, BOOL.FALSE);
-                    NativeMethods.GetUpdateRect(m.HWnd, ref clip, false);
+                    User32.GetUpdateRect(m.HWnd, ref clip, BOOL.FALSE);
                     Region r = Region.FromHrgn(hrgn);
                     Rectangle paintRect = Rectangle.Empty;
                     try

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetUpdateRect.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetUpdateRect.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern BOOL GetUpdateRect(IntPtr hwnd, ref RECT rc, BOOL fErase);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -1074,8 +1074,5 @@ namespace System.Windows.Forms
 
         // Threading stuff
         public const uint STILL_ACTIVE = 259;
-
-        [DllImport(ExternDll.User32, ExactSpelling = true)]
-        public static extern bool GetUpdateRect(IntPtr hwnd, ref RECT rc, bool fErase);
     }
 }


### PR DESCRIPTION
## Proposed changes

- Move GetUpdateRect to Interop User32.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2696)