### PR TITLE
Merge pull request #2707 from RussKie/Unblock_flow_to_WindowsDesktop

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -10,60 +10,60 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
   </ProductDependencies>
   <ToolsetDependencies>
     <!-- Core Setup for coherency -->
-    <Dependency Name="Microsoft.NETCore.App" Version="5.0.0-alpha.1.20062.3">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>773f64296d3c6932f716ae6c8932662ade93b284</Sha>
+    <Dependency Name="Microsoft.NETCore.App" Version="5.0.0-alpha1.19514.1">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>4ace84dbf94128b4825c76cdd09b46dba7473478</Sha>
     </Dependency>
     <!-- CoreFX via Core Setup -->
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha.1.20062.3" CoherentParentDependency="Microsoft.NETCore.App">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>773f64296d3c6932f716ae6c8932662ade93b284</Sha>
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha1.19504.7" CoherentParentDependency="Microsoft.NETCore.App">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>a434a52ae3f1175bc1cad8b1a02b0921ef3b1f55</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha.1.20062.3" CoherentParentDependency="Microsoft.NETCore.App">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>773f64296d3c6932f716ae6c8932662ade93b284</Sha>
+    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha1.19504.7" CoherentParentDependency="Microsoft.NETCore.App">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>a434a52ae3f1175bc1cad8b1a02b0921ef3b1f55</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha.1.20062.3" CoherentParentDependency="Microsoft.NETCore.App">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>773f64296d3c6932f716ae6c8932662ade93b284</Sha>
+    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha1.19504.7" CoherentParentDependency="Microsoft.NETCore.App">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>a434a52ae3f1175bc1cad8b1a02b0921ef3b1f55</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="5.0.0-alpha.1.20062.3" CoherentParentDependency="Microsoft.NETCore.App">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>773f64296d3c6932f716ae6c8932662ade93b284</Sha>
+    <Dependency Name="System.CodeDom" Version="5.0.0-alpha1.19504.7" CoherentParentDependency="Microsoft.NETCore.App">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>a434a52ae3f1175bc1cad8b1a02b0921ef3b1f55</Sha>
     </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-alpha.1.20062.3" CoherentParentDependency="Microsoft.NETCore.App">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>773f64296d3c6932f716ae6c8932662ade93b284</Sha>
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-alpha1.19504.7" CoherentParentDependency="Microsoft.NETCore.App">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>a434a52ae3f1175bc1cad8b1a02b0921ef3b1f55</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha.1.20062.3" CoherentParentDependency="Microsoft.NETCore.App">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>773f64296d3c6932f716ae6c8932662ade93b284</Sha>
+    <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha1.19504.7" CoherentParentDependency="Microsoft.NETCore.App">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>a434a52ae3f1175bc1cad8b1a02b0921ef3b1f55</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha.1.20062.3" CoherentParentDependency="Microsoft.NETCore.App">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>773f64296d3c6932f716ae6c8932662ade93b284</Sha>
+    <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha1.19504.7" CoherentParentDependency="Microsoft.NETCore.App">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>a434a52ae3f1175bc1cad8b1a02b0921ef3b1f55</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha.1.20062.3" CoherentParentDependency="Microsoft.NETCore.App">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>773f64296d3c6932f716ae6c8932662ade93b284</Sha>
+    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha1.19504.7" CoherentParentDependency="Microsoft.NETCore.App">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>a434a52ae3f1175bc1cad8b1a02b0921ef3b1f55</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha.1.20062.3" CoherentParentDependency="Microsoft.NETCore.App">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>773f64296d3c6932f716ae6c8932662ade93b284</Sha>
+    <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha1.19504.7" CoherentParentDependency="Microsoft.NETCore.App">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>a434a52ae3f1175bc1cad8b1a02b0921ef3b1f55</Sha>
     </Dependency>
-    <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha.1.20062.3" CoherentParentDependency="Microsoft.NETCore.App">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>773f64296d3c6932f716ae6c8932662ade93b284</Sha>
+    <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha1.19504.7" CoherentParentDependency="Microsoft.NETCore.App">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>a434a52ae3f1175bc1cad8b1a02b0921ef3b1f55</Sha>
     </Dependency>
     <!-- CoreCLR via Core Setup -->
-    <Dependency Name="Microsoft.NET.Sdk.IL" Version="5.0.0-alpha.1.20062.3" CoherentParentDependency="Microsoft.NETCore.App">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>773f64296d3c6932f716ae6c8932662ade93b284</Sha>
+    <Dependency Name="Microsoft.NET.Sdk.IL" Version="5.0.0-alpha1.19513.3" CoherentParentDependency="Microsoft.NETCore.App">
+      <Uri>https://github.com/dotnet/coreclr</Uri>
+      <Sha>b415b57a15b0c6ba77e63df901823bb46b8aafda</Sha>
       <SourceBuildId>5596</SourceBuildId>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.ILAsm" Version="5.0.0-alpha.1.20062.3" CoherentParentDependency="Microsoft.NETCore.App">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>773f64296d3c6932f716ae6c8932662ade93b284</Sha>
+    <Dependency Name="Microsoft.NETCore.ILAsm" Version="5.0.0-alpha1.19513.3" CoherentParentDependency="Microsoft.NETCore.App">
+      <Uri>https://github.com/dotnet/coreclr</Uri>
+      <Sha>b415b57a15b0c6ba77e63df901823bb46b8aafda</Sha>
       <SourceBuildId>5596</SourceBuildId>
     </Dependency>
     <!-- Arcade -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,25 +10,25 @@
   <!-- Below have corresponding entries in Versions.Details.XML because they are updated via Maestro -->
   <!-- Core Setup for coherency -->
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>5.0.0-alpha.1.20062.3</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>5.0.0-alpha1.19514.1</MicrosoftNETCoreAppPackageVersion>
   </PropertyGroup>
   <!-- CoreFX via Core Setup -->
   <PropertyGroup>
-    <MicrosoftNETCorePlatformsPackageVersion>5.0.0-alpha.1.20062.3</MicrosoftNETCorePlatformsPackageVersion>
-    <MicrosoftWin32RegistryPackageVersion>5.0.0-alpha.1.20062.3</MicrosoftWin32RegistryPackageVersion>
-    <MicrosoftWin32SystemEventsPackageVersion>5.0.0-alpha.1.20062.3</MicrosoftWin32SystemEventsPackageVersion>
-    <SystemCodeDomPackageVersion>5.0.0-alpha.1.20062.3</SystemCodeDomPackageVersion>
-    <SystemConfigurationConfigurationManagerPackageVersion>5.0.0-alpha.1.20062.3</SystemConfigurationConfigurationManagerPackageVersion>
-    <SystemDrawingCommonPackageVersion>5.0.0-alpha.1.20062.3</SystemDrawingCommonPackageVersion>
-    <SystemResourcesExtensionsPackageVersion>5.0.0-alpha.1.20062.3</SystemResourcesExtensionsPackageVersion>
-    <SystemSecurityCryptographyCngPackageVersion>5.0.0-alpha.1.20062.3</SystemSecurityCryptographyCngPackageVersion>
-    <SystemSecurityPermissionsPackageVersion>5.0.0-alpha.1.20062.3</SystemSecurityPermissionsPackageVersion>
-    <SystemWindowsExtensionsPackageVersion>5.0.0-alpha.1.20062.3</SystemWindowsExtensionsPackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>5.0.0-alpha1.19504.7</MicrosoftNETCorePlatformsPackageVersion>
+    <MicrosoftWin32RegistryPackageVersion>5.0.0-alpha1.19504.7</MicrosoftWin32RegistryPackageVersion>
+    <MicrosoftWin32SystemEventsPackageVersion>5.0.0-alpha1.19504.7</MicrosoftWin32SystemEventsPackageVersion>
+    <SystemCodeDomPackageVersion>5.0.0-alpha1.19504.7</SystemCodeDomPackageVersion>
+    <SystemConfigurationConfigurationManagerPackageVersion>5.0.0-alpha1.19504.7</SystemConfigurationConfigurationManagerPackageVersion>
+    <SystemDrawingCommonPackageVersion>5.0.0-alpha1.19504.7</SystemDrawingCommonPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>5.0.0-alpha1.19504.7</SystemResourcesExtensionsPackageVersion>
+    <SystemSecurityCryptographyCngPackageVersion>5.0.0-alpha1.19504.7</SystemSecurityCryptographyCngPackageVersion>
+    <SystemSecurityPermissionsPackageVersion>5.0.0-alpha1.19504.7</SystemSecurityPermissionsPackageVersion>
+    <SystemWindowsExtensionsPackageVersion>5.0.0-alpha1.19504.7</SystemWindowsExtensionsPackageVersion>
   </PropertyGroup>
   <!-- CoreCLR via Core Setup -->
   <PropertyGroup>
-    <MicrosoftNETCoreILVersion>3.0.0-preview5-27616-73</MicrosoftNETCoreILVersion>
-    <MicrosoftNETCoreILAsmVersion>5.0.0-alpha.1.20062.3</MicrosoftNETCoreILAsmVersion>
+    <MicrosoftNETCoreILPackageVersion>3.0.0-preview5-27616-73</MicrosoftNETCoreILPackageVersion>
+    <MicrosoftNETCoreILAsmPackageVersion>5.0.0-alpha1.19513.3</MicrosoftNETCoreILAsmPackageVersion>
   </PropertyGroup>
   <!-- Arcade -->
   <PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -18,7 +18,7 @@
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20062.1",
     "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20062.1",
     "FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
-    "Microsoft.NET.Sdk.IL": "5.0.0-alpha.1.20062.3"
+    "Microsoft.NET.Sdk.IL": "5.0.0-alpha1.19513.3"
   },
   "native-tools": {
     "dotnet-api-docs_netcoreapp3.0": "0.0.0.1"

--- a/pkg/Microsoft.Private.Winforms/FrameworkListFiles.props
+++ b/pkg/Microsoft.Private.Winforms/FrameworkListFiles.props
@@ -1,0 +1,16 @@
+<Project>
+
+  <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">
+    <FrameworkListFileClass Include="Microsoft.VisualBasic.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="Microsoft.VisualBasic.Forms.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="System.Design.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="System.Drawing.Common.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="System.Drawing.Design.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="System.Drawing.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="System.Windows.Forms.Design.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="System.Windows.Forms.Design.Editors.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="System.Windows.Forms.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="System.Windows.Forms.Primities.dll" Profile="WindowsForms" />
+  </ItemGroup>
+
+</Project>

--- a/pkg/Microsoft.Private.Winforms/Microsoft.Private.Winforms.csproj
+++ b/pkg/Microsoft.Private.Winforms/Microsoft.Private.Winforms.csproj
@@ -51,6 +51,13 @@
       <PrivateAssets>All</PrivateAssets>
     </ProjectReference>
   </ItemDefinitionGroup>
+  
+  <ItemGroup>
+    <None Include="FrameworkListFiles.props">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+  </ItemGroup>
 
   <!-- Any projects referenced here will have their outputs automatically put into the package -->
   <!-- If you add a new csproj, and you want the outputs in the package, you must add it here -->


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

- Ship WinForms references in transport package

	Enables https://github.com/dotnet/windowsdesktop/pull/365

	To reduce the x-repo overhead of managing Windows Forms assemblies ship the list of assemblies in our transport package.
	This will allow for a simpler ingestion by WindowsDesktop repo, yet retains ability to break ingestion if the list of assemblies is outdated.

- Revert to #2497 (revert to versions to f3ac1266 level)

	Revert versions to f3ac1266 level, where `MicrosoftNETCoreApppackageVersion=5.0.0-alpha1.19514.1` until https://github.com/dotnet/wpf/pull/2399#issuecomment-572241063 is resolved.
	This version is very likely compatible with the WPF repo right now.

	Enables https://github.com/dotnet/wpf/pull/2399



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2707)