### PR TITLE
fix: Race conditions adding `ThreadContext` to TLS

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
@@ -107,7 +107,11 @@ namespace System.Windows.Forms
                 _id = Kernel32.GetCurrentThreadId();
                 _messageLoopCount = 0;
                 t_currentThreadContext = this;
-                s_contextHash[_id] = this;
+
+                lock (s_tcInternalSyncObject)
+                {
+                    s_contextHash[_id] = this;
+                }
             }
 
             public ApplicationContext ApplicationContext { get; private set; }


### PR DESCRIPTION
It appears we have a bug in `ThreadContext`, specifically how it adds new instances of TC to the hashtable (line:110):
https://github.com/dotnet/winforms/blob/0f6796745088c68bb77bdc5abfb32d6eeece7969/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs#L95-L111

Note, there is no synchronisation when executing `s_contextHash[_id] = this`. [Hashtables are not thread-safe](https://docs.microsoft.com/en-us/dotnet/api/system.collections.hashtable?view=netcore-3.1#thread-safety) (for writing), so when we execute thousands of concurrent tests, each wiring to `Application.ThreadException` we end up creating a lot of instances of `ThreadContext`, all of which get written int to the shared hashtable.

This causes `InvalidOperationException: Hashtable insert failed. Load factor too high. The most common cause is multiple threads writing to the Hashtable simultaneously.` exceptions.
By adding a lock here, we serialise the write and, thus, avoid the exception.

Furthermore, whilst some tests are being primed for execution, some tests complete. Some completed tests tear down their applications, and thus execute `ThreadContext.ExitCommon(Boolean disposing)` method:
https://github.com/dotnet/winforms/blob/0f6796745088c68bb77bdc5abfb32d6eeece7969/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs#L672-L680

Note the lock here, the access to the hashtable is serialised, so it can perform modifications. But because we don't have a lock in the constructor, under heavy load `s_contextHash` is modified (by creating a new TC somewhere else) in a windows between lines 678 and 679 and, thus, results in `IndexOutOfRangeException: Index was outside the bounds of the array.` exceptions.
By adding the lock to the constructor we also address this issue as well.

Resolves #2706

<!-- Please read CONTRIBUTING.md before submitting a pull request -->



## Test methodology <!-- How did you ensure quality? -->

- verified that the fix makes internal builds pass

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2713)