### PR TITLE
Update .editorConfig to add support for VB and move all dotnet rules …

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,38 +13,17 @@ indent_size = 4
 [*.json]
 indent_size = 2
 
-# C# files
-[*.cs]
+# C# and VB files
+[*.{cs,vb}]
 charset = utf-8-bom
 insert_final_newline = true
 trim_trailing_whitespace = true
-# New line preferences
-csharp_new_line_before_open_brace = all
-csharp_new_line_before_else = true
-csharp_new_line_before_catch = true
-csharp_new_line_before_finally = true
-csharp_new_line_before_members_in_object_initializers = true
-csharp_new_line_before_members_in_anonymous_types = true
-csharp_new_line_between_query_expression_clauses = true
-
-# Indentation preferences
-csharp_indent_block_contents = true
-csharp_indent_braces = false
-csharp_indent_case_contents = true
-csharp_indent_switch_labels = true
-csharp_indent_labels = one_less_than_current
 
 # avoid this. unless absolutely necessary
 dotnet_style_qualification_for_field = false:suggestion
 dotnet_style_qualification_for_property = false:suggestion
 dotnet_style_qualification_for_method = false:suggestion
 dotnet_style_qualification_for_event = false:suggestion
-
-# only use var when it's obvious what the variable type is
-csharp_style_var_for_built_in_types = false:none
-csharp_style_var_when_type_is_apparent = false:none
-csharp_style_var_elsewhere = false:suggestion
-
 # use language keywords instead of BCL types
 dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 dotnet_style_predefined_type_for_member_access = true:suggestion
@@ -68,10 +47,12 @@ dotnet_naming_symbols.static_fields.applicable_kinds   = field
 dotnet_naming_symbols.static_fields.required_modifiers = static
 
 dotnet_naming_style.static_prefix_style.required_prefix = s_
-dotnet_naming_style.static_prefix_style.capitalization = camel_case 
+dotnet_naming_style.static_prefix_style.capitalization = camel_case
 
+# The Comment on the next Line makes no sense
 # Comment this group and uncomment out the next group if you don't want _ prefixed fields.
 
+# The next 8 lines are 2 copies of the 4 following lines
 # internal and private fields should be _camelCase
 #dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
 #dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
@@ -86,12 +67,10 @@ dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
 dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
 
 dotnet_naming_style.camel_case_underscore_style.required_prefix = _
-dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case 
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
 
 # Code style defaults
 dotnet_sort_system_directives_first = true
-csharp_preserve_single_line_blocks = true
-csharp_preserve_single_line_statements = false
 
 # Expression-level preferences
 dotnet_style_object_initializer = true:suggestion
@@ -99,6 +78,34 @@ dotnet_style_collection_initializer = true:suggestion
 dotnet_style_explicit_tuple_names = true:suggestion
 dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_null_propagation = true:suggestion
+
+# C# files
+[*.cs]
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+
+# only use var when it's obvious what the variable type is
+csharp_style_var_for_built_in_types = false:none
+csharp_style_var_when_type_is_apparent = false:none
+csharp_style_var_elsewhere = false:suggestion
+
+
+# Code style defaults
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = false
 
 # Expression-bodied members
 csharp_style_expression_bodied_methods = false:none
@@ -141,6 +148,11 @@ csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
 
+# Visual Basic files
+[*.vb]
+# Modifier preferences
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion
+
 # C++ Files
 [*.{cpp,h,in}]
 curly_bracket_next_line = true
@@ -171,5 +183,6 @@ insert_final_newline = true
 # Shell scripts
 [*.sh]
 end_of_line = lf
-[*.{cmd, bat}]
+
+[*.{cmd,bat}]
 end_of_line = crlf


### PR DESCRIPTION
…together. Added comment about issues in existing document

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #
Lack of VB support in .editorConfig

## Proposed changes
Consolidate all dotnet entries under [*.{cs,vb}]
Add section for [*.vb] to list modifier order
Add comments questioning 4 line comment and duplicate lines that conflict with comment, Maybe
an existing issue.
<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
Enforces code style for VB code in Repo

## Regression? 
- No

## Risk
Minimal no code changes and no additional suggestions, 1 less suggestion   
<!-- end TELL-MODE -->
## Test methodology <!-- How did you ensure quality? -->
One less EC117 item
Existing EC112 items unchanged 

<!-- Mention language, UI scaling, or anything else that might be relevant -->
VB now supported to follow dotnet style

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2715)