### PR TITLE
Fix VisualBasic Mouse tests

### DIFF
--- a/src/Microsoft.VisualBasic/tests/UnitTests/Microsoft/VisualBasic/Devices/MouseTests.cs
+++ b/src/Microsoft.VisualBasic/tests/UnitTests/Microsoft/VisualBasic/Devices/MouseTests.cs
@@ -3,32 +3,60 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Windows.Forms;
 using Xunit;
 
 namespace Microsoft.VisualBasic.Devices.Tests
 {
     public class MouseTests
     {
-        [Fact]
-        public void Properties()
+        public static bool NoMousePresent => !SystemInformation.MousePresent;
+
+        public static bool NoMouseWheelPresent => NoMousePresent || !SystemInformation.MouseWheelPresent;
+
+        [ConditionalFact(typeof(SystemInformation), nameof(SystemInformation.MousePresent))]
+        public void Mouse_ButtonsSwapped_Get_ReturnsExpected()
         {
             var mouse = new Mouse();
-            Invoke(() => _ = mouse.ButtonsSwapped);
-            Invoke(() => _ = mouse.WheelExists);
-            Invoke(() => _ = mouse.WheelScrollLines);
+            Assert.Equal(SystemInformation.MouseButtonsSwapped, mouse.ButtonsSwapped);
+            Assert.Equal(mouse.ButtonsSwapped, mouse.ButtonsSwapped);
         }
 
-        private static void Invoke(Action action)
+        [ConditionalFact(nameof(NoMousePresent))]
+        public void Mouse_ButtonsSwapped_GetNoMousePresent_ThrowsInvalidOperationException()
         {
-            if (System.Windows.Forms.SystemInformation.MousePresent)
-            {
-                action();
-            }
-            else
-            {
-                // Exception.ToString() called to verify message is constructed successfully.
-                _ = Assert.Throws<InvalidOperationException>(action).ToString();
-            }
+            var mouse = new Mouse();
+            Assert.Throws<InvalidOperationException>(() => mouse.ButtonsSwapped);
+        }
+
+        [ConditionalFact(typeof(SystemInformation), nameof(SystemInformation.MousePresent))]
+        public void Mouse_WheelExists_Get_ReturnsExpected()
+        {
+            var mouse = new Mouse();
+            Assert.Equal(SystemInformation.MouseWheelPresent, mouse.WheelExists);
+            Assert.Equal(mouse.WheelExists, mouse.WheelExists);
+        }
+
+        [ConditionalFact(nameof(NoMousePresent))]
+        public void Mouse_WheelExists_GetNoMousePresent_ThrowsInvalidOperationException()
+        {
+            var mouse = new Mouse();
+            Assert.Throws<InvalidOperationException>(() => mouse.WheelExists);
+        }
+
+        [ConditionalFact(typeof(SystemInformation), nameof(SystemInformation.MousePresent), nameof(SystemInformation.MouseWheelPresent))]
+        public void Mouse_WheelScrollLines_Get_ReturnsExpected()
+        {
+            var mouse = new Mouse();
+            Assert.Equal(SystemInformation.MouseWheelScrollLines, mouse.WheelScrollLines);
+            Assert.Equal(mouse.WheelScrollLines, mouse.WheelScrollLines);
+        }
+
+        [ConditionalFact(nameof(NoMouseWheelPresent))]
+        public void Mouse_WheelScrollLines_GetNoMouseWheelPresent_ThrowsInvalidOperationException()
+        {
+            var mouse = new Mouse();
+            Assert.Throws<InvalidOperationException>(() => mouse.WheelScrollLines);
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes
Fails on remote desktop or anywhere where we don't have a mouse wheel, e.g.
```cs
[xUnit.net 00:00:08.38]     Microsoft.VisualBasic.Devices.Tests.MouseTests.Properties [FAIL]
  X Microsoft.VisualBasic.Devices.Tests.MouseTests.Properties [9ms]
  Error Message:
   System.InvalidOperationException : No mouse wheel is present.
  Stack Trace:
     at Microsoft.VisualBasic.Devices.Mouse.get_WheelScrollLines() in C:\Users\hughbe\Documents\GitHub\winforms\src\Microsoft.VisualBasic.Forms\src\Microsoft\VisualBasic\Devices\Mouse.vb:line 69
   at Microsoft.VisualBasic.Devices.Tests.MouseTests.<>c__DisplayClass0_0.<Properties>b__2() in C:\Users\hughbe\Documents\GitHub\winforms\src\Microsoft.VisualBasic\tests\UnitTests\Microsoft\VisualBasic\Devices\MouseTests.cs:line 18
   at Microsoft.VisualBasic.Devices.Tests.MouseTests.Invoke(Action action) in C:\Users\hughbe\Documents\GitHub\winforms\src\Microsoft.VisualBasic\tests\UnitTests\Microsoft\VisualBasic\Devices\MouseTests.cs:line 25
   at Microsoft.VisualBasic.Devices.Tests.MouseTests.Properties() in C:\Users\hughbe\Documents\GitHub\winforms\src\Microsoft.VisualBasic\tests\UnitTests\Microsoft\VisualBasic\Devices\MouseTests.cs:line 18
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2716)