### PR TITLE
WIP: [Accessibility] Fixing TabPage keyboard tooltips

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -2,6 +2,7 @@ System.Windows.Forms.DomainUpDown.DomainUpDownAccessibleObject.DomainUpDownAcces
 System.Windows.Forms.VisualStyles.EdgeEffects.Flat = 16384 -> System.Windows.Forms.VisualStyles.EdgeEffects
 System.Windows.Forms.VisualStyles.EdgeEffects.Soft = 4096 -> System.Windows.Forms.VisualStyles.EdgeEffects
 const System.Windows.Forms.TabControl.TabBaseReLayoutMessageName = "_TabBaseReLayout" -> string
-override System.Windows.Forms.TabPage.OnGotFocus(System.EventArgs e) -> void
 override System.Windows.Forms.TabControl.OnGotFocus(System.EventArgs e) -> void
 override System.Windows.Forms.TabControl.OnLostFocus(System.EventArgs e) -> void
+override System.Windows.Forms.TabPage.OnGotFocus(System.EventArgs e) -> void
+override System.Windows.Forms.TabPage.OnLostFocus(System.EventArgs e) -> void

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -6,3 +6,10 @@ override System.Windows.Forms.TabControl.OnGotFocus(System.EventArgs e) -> void
 override System.Windows.Forms.TabControl.OnLostFocus(System.EventArgs e) -> void
 override System.Windows.Forms.TabPage.OnGotFocus(System.EventArgs e) -> void
 override System.Windows.Forms.TabPage.OnLostFocus(System.EventArgs e) -> void
+virtual System.Windows.Forms.Control.SetToolTip(System.Windows.Forms.ToolTip toolTip, string toolTipText) -> void
+override System.Windows.Forms.UpDownBase.SetToolTip(System.Windows.Forms.ToolTip toolTip, string toolTipText) -> void
+override System.Windows.Forms.TabControl.SetToolTip(System.Windows.Forms.ToolTip toolTip, string toolTipText) -> void
+override System.Windows.Forms.Label.SetToolTip(System.Windows.Forms.ToolTip toolTip, string toolTipText) -> void
+override System.Windows.Forms.ListView.SetToolTip(System.Windows.Forms.ToolTip toolTip, string toolTipText) -> void
+override System.Windows.Forms.TabPage.SetToolTip(System.Windows.Forms.ToolTip toolTip, string toolTipText) -> void
+override System.Windows.Forms.TreeView.SetToolTip(System.Windows.Forms.ToolTip toolTip, string toolTipText) -> void

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,7 @@
+System.Windows.Forms.DomainUpDown.DomainUpDownAccessibleObject.DomainUpDownAccessibleObject(System.Windows.Forms.DomainUpDown owner) -> void
+System.Windows.Forms.VisualStyles.EdgeEffects.Flat = 16384 -> System.Windows.Forms.VisualStyles.EdgeEffects
+System.Windows.Forms.VisualStyles.EdgeEffects.Soft = 4096 -> System.Windows.Forms.VisualStyles.EdgeEffects
+const System.Windows.Forms.TabControl.TabBaseReLayoutMessageName = "_TabBaseReLayout" -> string
+override System.Windows.Forms.TabPage.OnGotFocus(System.EventArgs e) -> void
+override System.Windows.Forms.TabControl.OnGotFocus(System.EventArgs e) -> void
+override System.Windows.Forms.TabControl.OnLostFocus(System.EventArgs e) -> void

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,7 +1,3 @@
-System.Windows.Forms.DomainUpDown.DomainUpDownAccessibleObject.DomainUpDownAccessibleObject(System.Windows.Forms.DomainUpDown owner) -> void
-System.Windows.Forms.VisualStyles.EdgeEffects.Flat = 16384 -> System.Windows.Forms.VisualStyles.EdgeEffects
-System.Windows.Forms.VisualStyles.EdgeEffects.Soft = 4096 -> System.Windows.Forms.VisualStyles.EdgeEffects
-const System.Windows.Forms.TabControl.TabBaseReLayoutMessageName = "_TabBaseReLayout" -> string
 override System.Windows.Forms.TabControl.OnGotFocus(System.EventArgs e) -> void
 override System.Windows.Forms.TabControl.OnLostFocus(System.EventArgs e) -> void
 override System.Windows.Forms.TabPage.OnGotFocus(System.EventArgs e) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -14149,8 +14149,10 @@ namespace System.Windows.Forms
 
         bool IKeyboardToolTip.IsHoveredWithMouse()
         {
-            return ClientRectangle.Contains(PointToClient(MousePosition));
+            return IsHoveredWithMouse;
         }
+
+        private protected virtual bool IsHoveredWithMouse => ClientRectangle.Contains(PointToClient(MousePosition));
 
         bool IKeyboardToolTip.HasRtlModeEnabled()
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -10918,6 +10918,19 @@ namespace System.Windows.Forms
             return result;
         }
 
+        protected virtual void SetToolTip(ToolTip toolTip, string toolTipText)
+        { }
+
+        internal void SetToolTipInternal(ToolTip toolTip, string toolTipText)
+        {
+            if (!IsHandleCreated || toolTip == null)
+            {
+                return;
+            }
+
+            SetToolTip(toolTip, toolTipText);
+        }
+
         protected void SetTopLevel(bool value)
         {
             if (value && IsActiveX)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/KeyboardToolTipStateMachine.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/KeyboardToolTipStateMachine.cs
@@ -57,29 +57,47 @@ namespace System.Windows.Forms
         }
 
         private SmState Transition(IKeyboardToolTip tool, ToolTip tooltip, SmEvent @event)
-            => (_currentState, @event) switch
+        {
+            switch (_currentState, @event)
             {
-                (SmState.Hidden, SmEvent.FocusedTool) => SetupInitShowTimer(tool, tooltip),
-                (SmState.Hidden, SmEvent.LeftTool) => _currentState, // OK
-                (SmState.ReadyForInitShow, SmEvent.FocusedTool) => _currentState, // unlikely: focus without leave
-                (SmState.ReadyForInitShow, SmEvent.LeftTool) => FullFsmReset(),
-                (SmState.ReadyForInitShow, SmEvent.InitialDelayTimerExpired) => ShowToolTip(tool, tooltip),
+                case (SmState.Hidden, SmEvent.FocusedTool):
+                    return SetupInitShowTimer(tool, tooltip);
+                case (SmState.Hidden, SmEvent.LeftTool):
+                    return _currentState; // OK
 
-                (SmState.Shown, SmEvent.FocusedTool) => _currentState, // unlikely: focus without leave
-                (SmState.Shown, SmEvent.LeftTool) => HideAndStartWaitingForRefocus(tool, tooltip),
-                (SmState.Shown, SmEvent.AutoPopupDelayTimerExpired) => FullFsmReset(),
+                case (SmState.ReadyForInitShow, SmEvent.FocusedTool):
+                    return _currentState; // unlikely: focus without leave
+                case (SmState.ReadyForInitShow, SmEvent.LeftTool):
+                    return FullFsmReset();
+                case (SmState.ReadyForInitShow, SmEvent.InitialDelayTimerExpired):
+                    return ShowToolTip(tool, tooltip);
 
-                (SmState.WaitForRefocus, SmEvent.FocusedTool) => SetupReshowTimer(tool, tooltip),
-                (SmState.WaitForRefocus, SmEvent.LeftTool) => _currentState, // OK
-                (SmState.WaitForRefocus, SmEvent.RefocusWaitDelayExpired) => FullFsmReset(),
+                case (SmState.Shown, SmEvent.FocusedTool):
+                    return _currentState; // unlikely: focus without leave
+                case (SmState.Shown, SmEvent.LeftTool):
+                    return HideAndStartWaitingForRefocus(tool, tooltip);
+                case (SmState.Shown, SmEvent.AutoPopupDelayTimerExpired):
+                    return FullFsmReset();
 
-                (SmState.ReadyForReshow, SmEvent.FocusedTool) => _currentState, // unlikely: focus without leave
-                (SmState.ReadyForReshow, SmEvent.LeftTool) => StartWaitingForRefocus(tool),
-                (SmState.ReadyForReshow, SmEvent.ReshowDelayTimerExpired) => ShowToolTip(tool, tooltip),
+                case (SmState.WaitForRefocus, SmEvent.FocusedTool):
+                    return SetupReshowTimer(tool, tooltip);
+                case (SmState.WaitForRefocus, SmEvent.LeftTool):
+                    return _currentState; // OK
+                case (SmState.WaitForRefocus, SmEvent.RefocusWaitDelayExpired):
+                    return FullFsmReset();
+
+                case (SmState.ReadyForReshow, SmEvent.FocusedTool):
+                    return _currentState; // unlikely: focus without leave
+                case (SmState.ReadyForReshow, SmEvent.LeftTool):
+                    return StartWaitingForRefocus(tool);
+                case (SmState.ReadyForReshow, SmEvent.ReshowDelayTimerExpired):
+                    return ShowToolTip(tool, tooltip);
 
                 // This is what we would have thrown historically
-                (_, _) => throw new KeyNotFoundException()
-            };
+                default:
+                    throw new KeyNotFoundException();
+            }
+        }
 
         public void ResetStateMachine(ToolTip toolTip)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
@@ -1601,7 +1601,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Called by ToolTip to poke in that Tooltip into this ComCtl so that the Native ChildToolTip is not exposed.
         /// </summary>
-        internal void SetToolTip(ToolTip toolTip)
+        protected override void SetToolTip(ToolTip toolTip, string toolTipText)
         {
             if (toolTip != null && !controlToolTip)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -5072,8 +5072,13 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Called by ToolTip to poke in that Tooltip into this ComCtl so that the Native ChildToolTip is not exposed.
         /// </summary>
-        internal void SetToolTip(ToolTip toolTip, string toolTipCaption)
+        protected override void SetToolTip(ToolTip toolTip, string toolTipCaption)
         {
+            if (toolTip == null)
+            {
+                return;
+            }
+
             this.toolTipCaption = toolTipCaption;
 
             // native ListView expects tooltip HWND as a wParam and ignores lParam

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -5072,14 +5072,14 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Called by ToolTip to poke in that Tooltip into this ComCtl so that the Native ChildToolTip is not exposed.
         /// </summary>
-        protected override void SetToolTip(ToolTip toolTip, string toolTipCaption)
+        protected override void SetToolTip(ToolTip toolTip, string toolTipText)
         {
             if (toolTip == null)
             {
                 return;
             }
 
-            this.toolTipCaption = toolTipCaption;
+            this.toolTipCaption = toolTipText;
 
             // native ListView expects tooltip HWND as a wParam and ignores lParam
             IntPtr oldHandle = User32.SendMessageW(this, (User32.WM)LVM.SETTOOLTIPS, toolTip.Handle, IntPtr.Zero);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -1360,6 +1360,20 @@ namespace System.Windows.Forms
             _onDrawItem?.Invoke(this, e);
         }
 
+        protected override void OnGotFocus(EventArgs e)
+        {
+            if (TabCount > 0 && SelectedTab != null)
+            {
+                KeyboardToolTipStateMachine.Instance.NotifyAboutGotFocus(SelectedTab);
+            }
+            else
+            {
+                KeyboardToolTipStateMachine.Instance.NotifyAboutGotFocus(this);
+            }
+
+            base.OnGotFocus(e);
+        }
+
         /// <summary>
         ///  Actually goes and fires the OnLeave event.  Inheriting controls
         ///  should use this to know when the event is fired [this is preferable to
@@ -1409,8 +1423,21 @@ namespace System.Windows.Forms
                 SelectedTab.FireLeave(e);
             }
 
-            KeyboardToolTipStateMachine.Instance.NotifyAboutLostFocus(this);
             base.OnLeave(e);
+        }
+
+        protected override void OnLostFocus(EventArgs e)
+        {
+            if (TabCount > 0 && SelectedTab != null)
+            {
+                KeyboardToolTipStateMachine.Instance.NotifyAboutLostFocus(SelectedTab);
+            }
+            else
+            {
+                KeyboardToolTipStateMachine.Instance.NotifyAboutLostFocus(this);
+            }
+
+            base.OnLostFocus(e);
         }
 
         /// <summary>
@@ -1491,6 +1518,11 @@ namespace System.Windows.Forms
             UpdateTabSelection(GetState(State.UISelection));
             SetState(State.UISelection, false);
             _onSelectedIndexChanged?.Invoke(this, e);
+
+            if (TabCount > 0 && SelectedTab != null)
+            {
+                KeyboardToolTipStateMachine.Instance.NotifyAboutGotFocus(SelectedTab);
+            }
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -1723,7 +1723,7 @@ namespace System.Windows.Forms
 
             User32.SendMessageW(this, (User32.WM)ComCtl32.TCM.SETTOOLTIPS, toolTip.Handle);
             GC.KeepAlive(toolTip);
-            _controlTipText = controlToolTipText;
+            _controlTipText = toolTipText;
         }
 
         private void SetTabPage(int index, TabPage value)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -1714,8 +1714,13 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Called by ToolTip to poke in that Tooltip into this ComCtl so that the Native ChildToolTip is not exposed.
         /// </summary>
-        internal void SetToolTip(ToolTip toolTip, string controlToolTipText)
+        protected override void SetToolTip(ToolTip toolTip, string toolTipText)
         {
+            if (toolTip == null || !ShowToolTips)
+            {
+                return;
+            }
+
             User32.SendMessageW(this, (User32.WM)ComCtl32.TCM.SETTOOLTIPS, toolTip.Handle);
             GC.KeepAlive(toolTip);
             _controlTipText = controlToolTipText;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -1106,6 +1106,19 @@ namespace System.Windows.Forms
             return _tabPages[index];
         }
 
+        internal Rectangle GetItemRectangle(int index)
+        {
+            if (index < 0 || index >= TabCount)
+            {
+                return Rectangle.Empty;
+            }
+
+            RECT rectangle = new RECT();
+            User32.SendMessageW(this, (User32.WM)ComCtl32.TCM.GETITEMRECT, (IntPtr)index, ref rectangle);
+
+            return RectangleToScreen(rectangle);
+        }
+
         /// <summary>
         ///  This has package scope so that TabStrip and TabControl can call it.
         /// </summary>
@@ -1396,7 +1409,7 @@ namespace System.Windows.Forms
                 SelectedTab.FireEnter(e);
             }
 
-            if (TabPages.Count == 0 && Enabled)
+            if (TabCount == 0 && Enabled)
             {
                 KeyboardToolTipStateMachine.Instance.NotifyAboutGotFocus(this);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -1381,6 +1381,11 @@ namespace System.Windows.Forms
             {
                 SelectedTab.FireEnter(e);
             }
+
+            if (TabPages.Count == 0 && Enabled)
+            {
+                KeyboardToolTipStateMachine.Instance.NotifyAboutGotFocus(this);
+            }
         }
 
         /// <summary>
@@ -1403,6 +1408,8 @@ namespace System.Windows.Forms
             {
                 SelectedTab.FireLeave(e);
             }
+
+            KeyboardToolTipStateMachine.Instance.NotifyAboutLostFocus(this);
             base.OnLeave(e);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
@@ -400,7 +400,6 @@ namespace System.Windows.Forms
             }
         }
 
-
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public new bool Visible
@@ -570,7 +569,6 @@ namespace System.Windows.Forms
                 }
 
                 KeyboardToolTipStateMachine.Instance.NotifyAboutLostFocus(this);
-                // ToolTip.Hide(this);
                 _leaveFired = false;
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
@@ -507,7 +507,7 @@ namespace System.Windows.Forms
                 return Rectangle.Empty;
             }
 
-            Rectangle rectangle = new Rectangle();
+            RECT rectangle = new RECT();
             User32.SendMessageW(Parent, (User32.WindowMessage)ComCtl32.TCM.GETITEMRECT, (IntPtr)index, ref rectangle);
 
             return ParentInternal.RectangleToScreen(rectangle);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
@@ -367,9 +367,6 @@ namespace System.Windows.Forms
                     value = string.Empty;
                 }
 
-                ToolTip.SetToolTip(this, value);
-                KeyboardToolTipStateMachine.Instance.Hook(this, ToolTip);
-
                 if (value == _toolTipText)
                 {
                     return;
@@ -377,6 +374,9 @@ namespace System.Windows.Forms
 
                 _toolTipText = value;
                 UpdateParent();
+
+                ToolTip.SetToolTip(this, value);
+                KeyboardToolTipStateMachine.Instance.Hook(this, ToolTip);
             }
         }
 
@@ -511,22 +511,6 @@ namespace System.Windows.Forms
             User32.SendMessageW(Parent, (User32.WM)ComCtl32.TCM.GETITEMRECT, (IntPtr)index, ref rectangle);
 
             return ParentInternal.RectangleToScreen(rectangle);
-        }
-
-        internal void SetToolTip(ToolTip tooltip, string text)
-        {
-            _toolTipText = text;
-
-            if (_toolTip == tooltip)
-            {
-                return;
-            }
-
-            // Remove an old tooltip
-            ToolTip.SetToolTip(this, null);
-
-            // Change a tooltip instance
-            _toolTip = tooltip;
         }
 
         internal ToolTip ToolTip

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
@@ -367,7 +367,7 @@ namespace System.Windows.Forms
             get => _toolTipText;
             set
             {
-                if (value == null || !value.Any(c => !char.IsControl(c) && c != ' '))
+                if (string.IsNullOrWhiteSpace(value))
                 {
                     value = string.Empty;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
@@ -502,7 +502,9 @@ namespace System.Windows.Forms
 
         private Rectangle GetItemRectangle(int index)
         {
-            if (index < 0)
+            int pagesCount = (ParentInternal as TabControl)?.TabCount ?? 0;
+
+            if (index < 0 || index >= pagesCount)
             {
                 return Rectangle.Empty;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
@@ -367,11 +367,8 @@ namespace System.Windows.Forms
                     value = string.Empty;
                 }
 
-                if (IsHandleCreated)
-                {
-                    ToolTip.SetToolTip(this, value);
-                    KeyboardToolTipStateMachine.Instance.Hook(this, ToolTip);
-                }
+                ToolTip.SetToolTip(this, value);
+                KeyboardToolTipStateMachine.Instance.Hook(this, ToolTip);
 
                 if (value == _toolTipText)
                 {
@@ -517,14 +514,15 @@ namespace System.Windows.Forms
 
         internal void SetToolTip(ToolTip tooltip, string text)
         {
-            if (ToolTip == tooltip)
+            _toolTipText = text;
+
+            if (_toolTip == tooltip)
             {
                 return;
             }
 
             ToolTip.SetToolTip(this, null);
-            ToolTip = tooltip;
-            ToolTipText = text;
+            _toolTip = tooltip;
         }
 
         ToolTip _toolTip;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
@@ -508,7 +508,7 @@ namespace System.Windows.Forms
             }
 
             RECT rectangle = new RECT();
-            User32.SendMessageW(Parent, (User32.WindowMessage)ComCtl32.TCM.GETITEMRECT, (IntPtr)index, ref rectangle);
+            User32.SendMessageW(Parent, (User32.WM)ComCtl32.TCM.GETITEMRECT, (IntPtr)index, ref rectangle);
 
             return ParentInternal.RectangleToScreen(rectangle);
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
@@ -551,6 +551,13 @@ namespace System.Windows.Forms
             }
         }
 
+        protected override void OnLostFocus(EventArgs e)
+        {
+            KeyboardToolTipStateMachine.Instance.NotifyAboutLostFocus(this);
+
+            base.OnLostFocus(e);
+        }
+
         protected override void OnPaintBackground(PaintEventArgs e)
         {
             // Utilize the TabRenderer new to Whidbey to draw the tab pages so that the panels are

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
@@ -466,6 +466,13 @@ namespace System.Windows.Forms
             OnEnter(e);
         }
 
+        protected override void OnGotFocus(EventArgs e)
+        {
+            KeyboardToolTipStateMachine.Instance.NotifyAboutGotFocus(this);
+
+            base.OnGotFocus(e);
+        }
+
         /// <summary>
         ///  Actually goes and fires the OnEnter event. Inheriting controls should use this to know
         ///  when the event is fired [this is preferable to adding an event handler on yourself for
@@ -485,7 +492,6 @@ namespace System.Windows.Forms
                 }
 
                 _enterFired = false;
-                KeyboardToolTipStateMachine.Instance.NotifyAboutGotFocus(this);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
@@ -8,6 +8,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Design;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Forms.Layout;
 using static Interop;
@@ -362,7 +363,7 @@ namespace System.Windows.Forms
             get => _toolTipText;
             set
             {
-                if (value == null)
+                if (value == null || !value.Any(c => !char.IsControl(c) && c != ' '))
                 {
                     value = string.Empty;
                 }
@@ -388,7 +389,7 @@ namespace System.Windows.Forms
                 {
                     for (int i = 0; i < tabControl.TabCount; i++)
                     {
-                        if (GetItemRectangle(i).Contains(MousePosition))
+                        if (tabControl.GetItemRectangle(i).Contains(MousePosition))
                         {
                             return true;
                         }
@@ -500,25 +501,10 @@ namespace System.Windows.Forms
             // A tooltip will be shown near a selected tab
             if (ParentInternal is TabControl tabControl)
             {
-                return GetItemRectangle(tabControl.SelectedIndex);
+                return tabControl.GetItemRectangle(tabControl.SelectedIndex);
             }
 
             return Rectangle.Empty;
-        }
-
-        private Rectangle GetItemRectangle(int index)
-        {
-            int pagesCount = (ParentInternal as TabControl)?.TabCount ?? 0;
-
-            if (index < 0 || index >= pagesCount)
-            {
-                return Rectangle.Empty;
-            }
-
-            RECT rectangle = new RECT();
-            User32.SendMessageW(Parent, (User32.WM)ComCtl32.TCM.GETITEMRECT, (IntPtr)index, ref rectangle);
-
-            return ParentInternal.RectangleToScreen(rectangle);
         }
 
         internal ToolTip ToolTip

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
@@ -11,7 +11,6 @@ using System.Drawing.Design;
 using System.Runtime.InteropServices;
 using System.Windows.Forms.Layout;
 using static Interop;
-using static Interop.User32;
 
 namespace System.Windows.Forms
 {
@@ -29,6 +28,7 @@ namespace System.Windows.Forms
     public class TabPage : Panel
     {
         private ImageList.Indexer _imageIndexer;
+        private ToolTip _toolTip;
         private string _toolTipText = string.Empty;
         private bool _enterFired = false;
         private bool _leaveFired = false;
@@ -491,6 +491,7 @@ namespace System.Windows.Forms
 
         internal override Rectangle GetToolNativeScreenRectangle()
         {
+            // A tooltip will be shown near a selected tab
             if (ParentInternal is TabControl tabControl)
             {
                 return GetItemRectangle(tabControl.SelectedIndex);
@@ -506,8 +507,8 @@ namespace System.Windows.Forms
                 return Rectangle.Empty;
             }
 
-            RECT rectangle = new RECT();
-            SendMessageW(Parent, (WindowMessage)ComCtl32.TCM.GETITEMRECT, (IntPtr)index, ref rectangle);
+            Rectangle rectangle = new Rectangle();
+            User32.SendMessageW(Parent, (User32.WindowMessage)ComCtl32.TCM.GETITEMRECT, (IntPtr)index, ref rectangle);
 
             return ParentInternal.RectangleToScreen(rectangle);
         }
@@ -521,11 +522,12 @@ namespace System.Windows.Forms
                 return;
             }
 
+            // Remove an old tooltip
             ToolTip.SetToolTip(this, null);
+
+            // Change a tooltip instance
             _toolTip = tooltip;
         }
-
-        ToolTip _toolTip;
 
         internal ToolTip ToolTip
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
@@ -367,7 +367,7 @@ namespace System.Windows.Forms
                 }
 
                 ToolTip.SetToolTip(this, value);
-                SetToolTipNative(ToolTip, ToolTipText);
+                SetToolTipNative(ToolTip);
 
                 if (value == _toolTipText)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
@@ -28,8 +28,12 @@ namespace System.Windows.Forms
     [DefaultProperty("Text")]
     public class TabPage : Panel
     {
-        private ImageList.Indexer _imageIndexer;
+        /// <summary>
+        ///  Internal property that has the default <see cref='ToolTip'/> instance if <see cref='ToolTipText'/> is set.
+        ///  This instance is replaced if an external ToolTip instance will be set.
+        /// </summary>
         private ToolTip _toolTip;
+        private ImageList.Indexer _imageIndexer;
         private string _toolTipText = string.Empty;
         private bool _enterFired = false;
         private bool _leaveFired = false;
@@ -596,6 +600,28 @@ namespace System.Windows.Forms
             else
             {
                 base.SetBoundsCore(x, y, width, height, specified);
+            }
+        }
+
+        protected override void SetToolTip(ToolTip toolTip, string toolTipText)
+        {
+            if (toolTip == null)
+            {
+                return;
+            }
+
+            // Check if there is an existing ToolTip object that is showing tooltips,
+            // if so - reset it to avoid showing several tooltips (old and new) at the same time.
+            if (ToolTip != toolTip)
+            {
+                ToolTip.SetToolTip(this, null);
+                ToolTip = toolTip;
+            }
+
+            // Show the same tooltip for the page's tab.
+            if (toolTipText != null && ToolTipText != toolTipText)
+            {
+                ToolTipText = toolTipText;
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -684,7 +684,7 @@ namespace System.Windows.Forms
 
         private void CheckNativeCompositeControls(Control associatedControl, string text)
         {
-            if (associatedControl is TabPage tabPage && this != tabPage.ToolTip)
+            if (associatedControl is TabPage tabPage)
             {
                 tabPage.SetToolTip(this, GetCaptionForTool(tabPage));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -720,6 +720,17 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
+        ///  Handles LostFocus event of a set control
+        /// </summary>
+        private void OnControlLostFocus(object sender, EventArgs e)
+        {
+            if (sender is IWin32Window window)
+            {
+                Hide(window);
+            }
+        }
+
+        /// <summary>
         ///  Fires the Draw event.
         /// </summary>
         private void OnDraw(DrawToolTipEventArgs e) => _onDraw?.Invoke(this, e);
@@ -1194,6 +1205,7 @@ namespace System.Windows.Forms
 
                 regions[i].HandleCreated -= new EventHandler(HandleCreated);
                 regions[i].HandleDestroyed -= new EventHandler(HandleDestroyed);
+                regions[i].LostFocus -= OnControlLostFocus;
 
                 KeyboardToolTipStateMachine.Instance.Unhook(regions[i], this);
             }
@@ -1241,7 +1253,6 @@ namespace System.Windows.Forms
         {
             TipInfo info = new TipInfo(caption, TipInfo.Type.Auto);
             SetToolTipInternal(control, info);
-            control.LostFocus += (object sender, EventArgs e) => Hide(control);
         }
 
         /// <summary>
@@ -1260,10 +1271,12 @@ namespace System.Windows.Forms
             if (exists && empty)
             {
                 _tools.Remove(control);
+                control.LostFocus -= OnControlLostFocus;
             }
             else if (!empty)
             {
                 _tools[control] = info;
+                control.LostFocus += OnControlLostFocus;
             }
 
             CheckNativeCompositeControls(control, info.Caption);
@@ -1302,6 +1315,7 @@ namespace System.Windows.Forms
                     }
 
                     _created.Remove(control);
+                    control.LostFocus -= OnControlLostFocus;
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -685,12 +685,10 @@ namespace System.Windows.Forms
 
         private void CheckNativeCompositeControls(Control associatedControl, string text)
         {
-            if (!(associatedControl is TabPage))
+            if (!(associatedControl is TabPage tabPage))
             {
                 return;
             }
-
-            TabPage tabPage = associatedControl as TabPage;
 
             if (tabPage.ToolTip != this)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -1235,6 +1235,7 @@ namespace System.Windows.Forms
                 {
                     ToolInfoWrapper<Control> toolInfo = GetTOOLINFO(control, info.Caption);
                     toolInfo.SendMessage(this, (User32.WM)TTM.SETTOOLINFOW);
+                    control?.SetToolTipInternal(this, GetToolTip(control));
                 }
                 else if (empty && exists && !DesignMode)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -690,10 +690,12 @@ namespace System.Windows.Forms
                 return;
             }
 
+            // Replace an old tooltip to a new tooltip if another tooltip was set.
+            // Need it to avoid showing several tooltips (old and new) in one moment.
             if (tabPage.ToolTip != this)
             {
-                tabPage.ToolTip.SetToolTip(tabPage, null); // Remove an old tooltip for the current page
-                tabPage.ToolTip = this; // Set a new tooltip instance
+                tabPage.ToolTip.SetToolTip(tabPage, null); // Reset the old tabPage tooltip before setting a new tooltip instance.
+                tabPage.ToolTip = this;
             }
 
             if (tabPage.ToolTipText != text && text != null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -684,18 +684,22 @@ namespace System.Windows.Forms
 
         private void CheckNativeCompositeControls(Control associatedControl, string text)
         {
-            if (associatedControl is TabPage tabPage)
+            if (!(associatedControl is TabPage))
             {
-                if (tabPage.ToolTip != this)
-                {
-                    tabPage.ToolTip.SetToolTip(tabPage, null); // Remove an old tooltip for the current page
-                    tabPage.ToolTip = this; // Set a new tooltip instance
-                }
+                return;
+            }
 
-                if (tabPage.ToolTipText != text && text != null)
-                {
-                    tabPage.ToolTipText = text; // Don't forget to change ToolTipText property
-                }
+            TabPage tabPage = associatedControl as TabPage;
+
+            if (tabPage.ToolTip != this)
+            {
+                tabPage.ToolTip.SetToolTip(tabPage, null); // Remove an old tooltip for the current page
+                tabPage.ToolTip = this; // Set a new tooltip instance
+            }
+
+            if (tabPage.ToolTipText != text && text != null)
+            {
+                tabPage.ToolTipText = text; // Don't forget to change ToolTipText property
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -1241,6 +1241,7 @@ namespace System.Windows.Forms
         {
             TipInfo info = new TipInfo(caption, TipInfo.Type.Auto);
             SetToolTipInternal(control, info);
+            control.LostFocus += (object sender, EventArgs e) => Hide(control);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -686,7 +686,16 @@ namespace System.Windows.Forms
         {
             if (associatedControl is TabPage tabPage)
             {
-                tabPage.SetToolTip(this, GetCaptionForTool(tabPage));
+                if (tabPage.ToolTip != this)
+                {
+                    tabPage.ToolTip.SetToolTip(tabPage, null); // Remove an old tooltip for the current page
+                    tabPage.ToolTip = this; // Set a new tooltip instance
+                }
+
+                if (tabPage.ToolTipText != text && text != null)
+                {
+                    tabPage.ToolTipText = text; // Don't forget to change ToolTipText property
+                }
             }
         }
 
@@ -1242,6 +1251,7 @@ namespace System.Windows.Forms
 
             bool exists = _tools.ContainsKey(control);
             bool empty = info == null || string.IsNullOrEmpty(info.Caption);
+
             if (exists && empty)
             {
                 _tools.Remove(control);
@@ -1250,6 +1260,8 @@ namespace System.Windows.Forms
             {
                 _tools[control] = info;
             }
+
+            CheckNativeCompositeControls(control, info.Caption);
 
             if (!empty && !exists)
             {
@@ -1260,8 +1272,6 @@ namespace System.Windows.Forms
                 {
                     HandleCreated(control, EventArgs.Empty);
                 }
-
-                CheckNativeCompositeControls(control, info.Caption);
             }
             else
             {
@@ -1275,7 +1285,6 @@ namespace System.Windows.Forms
                     toolInfo.SendMessage(this, (User32.WM)TTM.SETTOOLINFOW);
                     CheckNativeToolTip(control);
                     CheckCompositeControls(control);
-                    CheckNativeCompositeControls(control, toolInfo.Text);
                 }
                 else if (empty && exists && !DesignMode)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -10,6 +10,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using static Interop;
 using static Interop.ComCtl32;
@@ -1276,7 +1277,6 @@ namespace System.Windows.Forms
             else if (!empty)
             {
                 _tools[control] = info;
-                control.LostFocus += OnControlLostFocus;
             }
 
             CheckNativeCompositeControls(control, info.Caption);
@@ -1290,6 +1290,10 @@ namespace System.Windows.Forms
                 {
                     HandleCreated(control, EventArgs.Empty);
                 }
+
+                // !exists condition guarantees a single execution even when changing the text
+                // It isn't guarded by IsHandleCreated because often a tooltip is set when Handle isn't yet created.
+                control.LostFocus += OnControlLostFocus; // control have already added to _tools above
             }
             else
             {
@@ -1315,7 +1319,6 @@ namespace System.Windows.Forms
                     }
 
                     _created.Remove(control);
-                    control.LostFocus -= OnControlLostFocus;
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -682,6 +682,14 @@ namespace System.Windows.Forms
             }
         }
 
+        private void CheckNativeCompositeControls(Control associatedControl, string text)
+        {
+            if (associatedControl is TabPage tabPage && this != tabPage.ToolTip)
+            {
+                tabPage.SetToolTip(this, GetCaptionForTool(tabPage));
+            }
+        }
+
         private void CheckCompositeControls(Control associatedControl)
         {
             if (associatedControl is UpDownBase upDownBase)
@@ -1252,6 +1260,8 @@ namespace System.Windows.Forms
                 {
                     HandleCreated(control, EventArgs.Empty);
                 }
+
+                CheckNativeCompositeControls(control, info.Caption);
             }
             else
             {
@@ -1265,6 +1275,7 @@ namespace System.Windows.Forms
                     toolInfo.SendMessage(this, (User32.WM)TTM.SETTOOLINFOW);
                     CheckNativeToolTip(control);
                     CheckCompositeControls(control);
+                    CheckNativeCompositeControls(control, toolInfo.Text);
                 }
                 else if (empty && exists && !DesignMode)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -1701,14 +1701,16 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Called by ToolTip to poke in that Tooltip into this ComCtl so that the Native ChildToolTip is not exposed.
         /// </summary>
-        internal void SetToolTip(ToolTip toolTip, string toolTipText)
+        protected override void SetToolTip(ToolTip toolTip, string toolTipText)
         {
-            if (toolTip != null)
+            if (toolTip == null || !ShowNodeToolTips)
             {
-                User32.SendMessageW(toolTip, (User32.WM)TTM.SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
-                User32.SendMessageW(this, (User32.WM)TVM.SETTOOLTIPS, toolTip.Handle);
-                controlToolTipText = toolTipText;
+                return;
             }
+
+            User32.SendMessageW(toolTip, (User32.WM)TTM.SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
+            User32.SendMessageW(this, (User32.WM)TVM.SETTOOLTIPS, toolTip.Handle);
+            controlToolTipText = toolTipText;
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
@@ -978,10 +978,18 @@ namespace System.Windows.Forms
             }
         }
 
-        internal void SetToolTip(ToolTip toolTip, string caption)
+        /// <summary>
+        ///  This Function sets the ToolTip for this composite control.
+        /// </summary>
+        protected override void SetToolTip(ToolTip toolTip, string toolTipText)
         {
-            toolTip.SetToolTip(_upDownEdit, caption);
-            toolTip.SetToolTip(_upDownButtons, caption);
+            if (toolTip == null)
+            {
+                return;
+            }
+
+            toolTip.SetToolTip(upDownEdit, toolTipText);
+            toolTip.SetToolTip(upDownButtons, toolTipText);
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
@@ -988,8 +988,8 @@ namespace System.Windows.Forms
                 return;
             }
 
-            toolTip.SetToolTip(upDownEdit, toolTipText);
-            toolTip.SetToolTip(upDownButtons, toolTipText);
+            toolTip.SetToolTip(_upDownEdit, toolTipText);
+            toolTip.SetToolTip(_upDownButtons, toolTipText);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.Designer.cs
@@ -55,6 +55,7 @@ namespace WinformsControlsTest
             this.richTextBoxes = new System.Windows.Forms.Button();
             this.PictureBoxes = new System.Windows.Forms.Button();
             this.formBorderStyles = new System.Windows.Forms.Button();
+            this.tabControl = new System.Windows.Forms.Button();
             this.flowLayoutPanelUITypeEditors.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -252,6 +253,7 @@ namespace WinformsControlsTest
             this.flowLayoutPanelUITypeEditors.Controls.Add(this.richTextBoxes);
             this.flowLayoutPanelUITypeEditors.Controls.Add(this.PictureBoxes);
             this.flowLayoutPanelUITypeEditors.Controls.Add(this.formBorderStyles);
+            this.flowLayoutPanelUITypeEditors.Controls.Add(this.tabControl);
             this.flowLayoutPanelUITypeEditors.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanelUITypeEditors.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
             this.flowLayoutPanelUITypeEditors.Location = new System.Drawing.Point(8, 8);
@@ -309,6 +311,16 @@ namespace WinformsControlsTest
             this.formBorderStyles.UseVisualStyleBackColor = true;
             this.formBorderStyles.Click += new System.EventHandler(this.formBorderStyles_Click);
             // 
+            // tabControl
+            // 
+            this.tabControl.Location = new System.Drawing.Point(268, 293);
+            this.tabControl.Name = "tabControl";
+            this.tabControl.Size = new System.Drawing.Size(258, 23);
+            this.tabControl.TabIndex = 21;
+            this.tabControl.Text = "TabControl";
+            this.tabControl.UseVisualStyleBackColor = true;
+            this.tabControl.Click += new System.EventHandler(this.tabControlButton_Click);
+            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -350,6 +362,7 @@ namespace WinformsControlsTest
         private System.Windows.Forms.Button richTextBoxes;
         private System.Windows.Forms.Button PictureBoxes;
         private System.Windows.Forms.Button formBorderStyles;
+        private System.Windows.Forms.Button tabControl;
     }
 }
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
@@ -132,5 +132,10 @@ namespace WinformsControlsTest
         {
             new FormBorderStyles().Show();
         }
+
+        private void tabControlButton_Click(object sender, EventArgs e)
+        {
+            new TabControlTest().Show();
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TabControlTest.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TabControlTest.Designer.cs
@@ -36,7 +36,6 @@ namespace WinformsControlsTest
             tabControl1 = new TabControl();
             tabPage1 = new TabPage();
             tabPage2 = new TabPage();
-            toolTip = new ToolTip();
             button1 = new Button();
             tabControl1.SuspendLayout();
             SuspendLayout();
@@ -57,11 +56,6 @@ namespace WinformsControlsTest
             tabControl1.Size = new Size(200, 100);
             tabControl1.TabIndex = 0;
             tabControl1.ShowToolTips = true;
-            //
-            //tooltip
-            //
-            toolTip.AutoPopDelay = 1000;
-            toolTip.InitialDelay = 374;
             // 
             // tabPage1
             // 
@@ -91,8 +85,8 @@ namespace WinformsControlsTest
             AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             ClientSize = new System.Drawing.Size(343, 183);
-            Controls.Add(this.tabControl1);
-            Controls.Add(this.button1);
+            Controls.Add(tabControl1);
+            Controls.Add(button1);
             Name = "Form1";
             Text = "Form1";
             tabControl1.ResumeLayout(false);
@@ -103,6 +97,5 @@ namespace WinformsControlsTest
         private TabPage tabPage1;
         private TabPage tabPage2;
         private Button button1;
-        private ToolTip toolTip;
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TabControlTest.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TabControlTest.Designer.cs
@@ -1,0 +1,108 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace WinformsControlsTest
+{
+    partial class TabControlTest
+    {
+        /// <summary>
+        ///  Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        ///  Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        /// <summary>
+        ///  Required method for Designer support - do not modify
+        ///  the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            tabControl1 = new TabControl();
+            tabPage1 = new TabPage();
+            tabPage2 = new TabPage();
+            toolTip = new ToolTip();
+            button1 = new Button();
+            tabControl1.SuspendLayout();
+            SuspendLayout();
+            //
+            // setToolTipButton
+            //
+            button1.Location = new System.Drawing.Point(15, 140);
+            button1.Text = "Button";
+            button1.Click += ButtonClick;
+            // 
+            // tabControl1
+            // 
+            tabControl1.TabPages.Add(tabPage1);
+            tabControl1.TabPages.Add(tabPage2);
+            tabControl1.Location = new Point(15, 15);
+            tabControl1.Name = "tabControl1";
+            tabControl1.SelectedIndex = 0;
+            tabControl1.Size = new Size(200, 100);
+            tabControl1.TabIndex = 0;
+            tabControl1.ShowToolTips = true;
+            //
+            //tooltip
+            //
+            toolTip.AutoPopDelay = 1000;
+            toolTip.InitialDelay = 374;
+            // 
+            // tabPage1
+            // 
+            tabPage1.Location = new System.Drawing.Point(4, 22);
+            tabPage1.Name = "tabPage1";
+            tabPage1.Padding = new System.Windows.Forms.Padding(3);
+            tabPage1.Size = new System.Drawing.Size(20, 20);
+            tabPage1.TabIndex = 0;
+            tabPage1.Text = "tabPage1";
+            tabPage1.ToolTipText = "1_item";
+            tabPage1.BackColor = Color.Red;
+            //tabPage1.UseVisualStyleBackColor = true;
+            // 
+            // tabPage2
+            // 
+            tabPage2.Location = new System.Drawing.Point(4, 22);
+            tabPage2.Name = "tabPage2";
+            tabPage2.Padding = new System.Windows.Forms.Padding(3);
+            tabPage2.Size = new System.Drawing.Size(20, 20);
+            tabPage2.TabIndex = 0;
+            tabPage2.Text = "tabPage2";
+            tabPage2.ToolTipText = "2_item";
+            tabPage2.UseVisualStyleBackColor = true;
+            // 
+            // Form1
+            // 
+            AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(343, 183);
+            Controls.Add(this.tabControl1);
+            Controls.Add(this.button1);
+            Name = "Form1";
+            Text = "Form1";
+            tabControl1.ResumeLayout(false);
+            ResumeLayout(false);
+        }
+
+        private TabControl tabControl1;
+        private TabPage tabPage1;
+        private TabPage tabPage2;
+        private Button button1;
+        private ToolTip toolTip;
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TabControlTest.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TabControlTest.Designer.cs
@@ -38,18 +38,54 @@ namespace WinformsControlsTest
             tabPage2 = new TabPage();
             toolTip = new ToolTip();
             button1 = new Button();
+            button2 = new Button();
+            button3 = new Button();
+            internalButton = new Button();
+            _label = new Label();
             tabControl1.SuspendLayout();
             SuspendLayout();
             //
             // Set tooltip
             //
-            toolTip.SetToolTip(tabPage1, "Ultra super tabpage");
+            //toolTip.SetToolTip(tabPage1, "Ultra super tabpage");
+
+            //
+            // Label
+            //
+            _label.Location = new Point(15, 180);
+            _label.MaximumSize = new Size(150, 18);
+            _label.AutoSize = true;
+            _label.Text = "Some label as.dkgfhas.dfkgjs/dakfgj/sdfkgj/alsdkfjg asdlfmas/dlkmf/asdkmf/askldf/sakdfaskgn";
+            _label.AutoEllipsis = true;
+
             //
             // button1
             //
             button1.Location = new System.Drawing.Point(15, 140);
-            button1.Text = "Button";
+            button1.Text = "Button1";
             button1.Click += ButtonClick;
+            toolTip.SetToolTip(button1, "Button1");
+            // button2
+            //
+            button2.Location = new System.Drawing.Point(100, 140);
+            button2.Text = "Button2";
+            button2.Click += Button2Click;
+            toolTip.SetToolTip(button2, "Button2");
+            // button3
+            //
+            button3.Location = new System.Drawing.Point(185, 140);
+            button3.Text = "Button3";
+            toolTip.SetToolTip(button3, "Button3");
+            button3.Click += Button3Click;
+            //
+            // internalButton
+            //
+            tabPage1.Controls.Add(internalButton);
+            internalButton.Location = new System.Drawing.Point(15, 15);
+            internalButton.Size = new Size(100, 20);
+            internalButton.BackColor = Color.White;
+            internalButton.Text = "Internal button";
+            toolTip.SetToolTip(internalButton, "Internal button");
             // 
             // tabControl1
             // 
@@ -71,6 +107,8 @@ namespace WinformsControlsTest
             tabPage1.TabIndex = 0;
             tabPage1.Text = "tabPage1";
             //tabPage1.ToolTipText = "1_item";
+            toolTip.SetToolTip(tabPage1, "1_item");
+
             tabPage1.BackColor = Color.Red;
             // 
             // tabPage2
@@ -81,16 +119,21 @@ namespace WinformsControlsTest
             tabPage2.Size = new System.Drawing.Size(20, 20);
             tabPage2.TabIndex = 0;
             tabPage2.Text = "tabPage2";
-            tabPage2.ToolTipText = "2_item";
+            //tabPage2.ToolTipText = "2_item";
+            toolTip.SetToolTip(tabPage2, "2_item");
+
             tabPage2.UseVisualStyleBackColor = true;
             // 
             // Form1
             // 
             AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            ClientSize = new System.Drawing.Size(343, 183);
+            ClientSize = new System.Drawing.Size(343, 200);
             Controls.Add(tabControl1);
             Controls.Add(button1);
+            Controls.Add(button2);
+            Controls.Add(button3);
+            Controls.Add(_label);
             Name = "Form1";
             Text = "Form1";
             tabControl1.ResumeLayout(false);
@@ -101,6 +144,10 @@ namespace WinformsControlsTest
         private TabPage tabPage1;
         private TabPage tabPage2;
         private Button button1;
+        private Button button2;
+        private Button button3;
+        private Button internalButton;
         private ToolTip toolTip;
+        private Label _label;
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TabControlTest.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TabControlTest.Designer.cs
@@ -36,11 +36,16 @@ namespace WinformsControlsTest
             tabControl1 = new TabControl();
             tabPage1 = new TabPage();
             tabPage2 = new TabPage();
+            toolTip = new ToolTip();
             button1 = new Button();
             tabControl1.SuspendLayout();
             SuspendLayout();
             //
-            // setToolTipButton
+            // Set tooltip
+            //
+            toolTip.SetToolTip(tabPage1, "Ultra super tabpage");
+            //
+            // button1
             //
             button1.Location = new System.Drawing.Point(15, 140);
             button1.Text = "Button";
@@ -65,9 +70,8 @@ namespace WinformsControlsTest
             tabPage1.Size = new System.Drawing.Size(20, 20);
             tabPage1.TabIndex = 0;
             tabPage1.Text = "tabPage1";
-            tabPage1.ToolTipText = "1_item";
+            //tabPage1.ToolTipText = "1_item";
             tabPage1.BackColor = Color.Red;
-            //tabPage1.UseVisualStyleBackColor = true;
             // 
             // tabPage2
             // 
@@ -97,5 +101,6 @@ namespace WinformsControlsTest
         private TabPage tabPage1;
         private TabPage tabPage2;
         private Button button1;
+        private ToolTip toolTip;
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TabControlTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TabControlTest.cs
@@ -50,8 +50,6 @@ namespace WinformsControlsTest
             j++;
 
             new ToolTip().SetToolTip(_label, "");
-
-
         }
 
         private void Button3Click(object sender, EventArgs e)

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TabControlTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TabControlTest.cs
@@ -14,36 +14,7 @@ namespace WinformsControlsTest
             InitializeComponent();
         }
 
-        int i = -2;
-
         private void ButtonClick(object sender, EventArgs e)
-        {
-            switch (i)
-            {
-                case -2:
-                    tabPage1.ToolTipText = "TTT 1 set {}";
-                    break;
-                case -1:
-                    tabPage2.ToolTipText = "TTT 2 set {}";
-                    break;
-                case 0:
-                    toolTip.SetToolTip(tabPage1, "tabpage1");
-                    break;
-                case 1:
-                    toolTip.SetToolTip(tabPage2, "tabpage2");
-                    break;
-                case 2:
-                    tabPage1.ToolTipText = "page 1 - new text";
-                    break;
-                case 3:
-                    tabPage2.ToolTipText = "new text for page 2";
-                    break;
-                case 4:
-                    toolTip.SetToolTip(tabControl1, "TabControl tooltip");
-                    break;
-            }
-
-            i++;
-        }
+        { }
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TabControlTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TabControlTest.cs
@@ -16,28 +16,29 @@ namespace WinformsControlsTest
             //toolTip.SetToolTip(tabControl1, "TabControl");
         }
 
-        int i = 0;
+        int i = -1;
 
         private void ButtonClick(object sender, EventArgs e)
         {
             // It will be removed after testing
             switch (i)
             {
+                case -1:
+                    toolTip.SetToolTip(tabPage1, " \t  \r\n   ");
+                    break;
                 case 0:
-                    toolTip.SetToolTip(tabPage2, "This is page 1");
+                    toolTip.SetToolTip(tabPage2, "This is page 2");
                     break;
                 case 1:
-                    toolTip.SetToolTip(tabPage2, "This is page 1");
+                    toolTip.SetToolTip(tabPage1, "This is page 1");
                     break;
                 case 2:
-                    tabPage2.ToolTipText = "1) Some tt text";
+                    tabPage2.ToolTipText = "2) Some tt text";
                     break;
                 case 3:
-                    tabPage2.ToolTipText = "1) Some tt text";
+                    tabPage1.ToolTipText = "1) Some tt text";
                     break;
             }
-
-            toolTip.SetToolTip(tabPage1, " \t  \r\n   ");
 
             i++;
         }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TabControlTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TabControlTest.cs
@@ -14,7 +14,28 @@ namespace WinformsControlsTest
             InitializeComponent();
         }
 
+        int i = 0;
+
         private void ButtonClick(object sender, EventArgs e)
-        { }
+        {
+            // It will be removed after testing
+            switch (i)
+            {
+                case 0:
+                    toolTip.SetToolTip(tabPage2, "This is page 1");
+                    break;
+                case 1:
+                    toolTip.SetToolTip(tabPage2, "This is page 1");
+                    break;
+                case 2:
+                    tabPage2.ToolTipText = "1) Some tt text";
+                    break;
+                case 3:
+                    tabPage2.ToolTipText = "1) Some tt text";
+                    break;
+            }
+
+            i++;
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TabControlTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TabControlTest.cs
@@ -14,12 +14,18 @@ namespace WinformsControlsTest
             InitializeComponent();
         }
 
-        int i = 0;
+        int i = -2;
 
         private void ButtonClick(object sender, EventArgs e)
         {
             switch (i)
             {
+                case -2:
+                    tabPage1.ToolTipText = "TTT 1 set {}";
+                    break;
+                case -1:
+                    tabPage2.ToolTipText = "TTT 2 set {}";
+                    break;
                 case 0:
                     toolTip.SetToolTip(tabPage1, "tabpage1");
                     break;

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TabControlTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TabControlTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Globalization;
 using System.Windows.Forms;
 
 namespace WinformsControlsTest
@@ -12,6 +13,7 @@ namespace WinformsControlsTest
         public TabControlTest()
         {
             InitializeComponent();
+            //toolTip.SetToolTip(tabControl1, "TabControl");
         }
 
         int i = 0;
@@ -35,7 +37,35 @@ namespace WinformsControlsTest
                     break;
             }
 
+            toolTip.SetToolTip(tabPage1, " \t  \r\n   ");
+
             i++;
+        }
+
+        int j = 0;
+
+        private void Button2Click(object sender, EventArgs e)
+        {
+            new ToolTip().SetToolTip(internalButton, j.ToString());
+            j++;
+
+            new ToolTip().SetToolTip(_label, "");
+
+
+        }
+
+        private void Button3Click(object sender, EventArgs e)
+        {
+            new ToolTip().SetToolTip(_label, "New tooltip text");
+        }
+    }
+
+    public class MyLabel : Label
+    {
+        public MyLabel()
+        {
+            this.SetToolTip(new ToolTip(), "balas");
+            //new ToolTip().SetToolTip(this, "");
         }
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TabControlTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TabControlTest.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Windows.Forms;
+
+namespace WinformsControlsTest
+{
+    public partial class TabControlTest : Form
+    {
+        public TabControlTest()
+        {
+            InitializeComponent();
+        }
+
+        int i = 0;
+
+        private void ButtonClick(object sender, EventArgs e)
+        {
+            switch (i)
+            {
+                case 0:
+                    toolTip.SetToolTip(tabPage1, "tabpage1");
+                    break;
+                case 1:
+                    toolTip.SetToolTip(tabPage2, "tabpage2");
+                    break;
+                case 2:
+                    tabPage1.ToolTipText = "page 1 - new text";
+                    break;
+                case 3:
+                    tabPage2.ToolTipText = "new text for page 2";
+                    break;
+                case 4:
+                    toolTip.SetToolTip(tabControl1, "TabControl tooltip");
+                    break;
+            }
+
+            i++;
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPageTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPageTests.cs
@@ -3062,6 +3062,42 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(2, callCount);
         }
 
+        [WinFormsFact]
+        public void TabPage_ToolTipText_SetCorrectToolTip()
+        {
+            using TabPage tabPage = new TabPage();
+            tabPage.CreateControl();
+            string expected = "Some text";
+            tabPage.ToolTipText = expected;
+            string actual = tabPage.ToolTip.GetCaptionForTool(tabPage);
+            Assert.Equal(expected, actual);
+        }
+
+        [WinFormsFact]
+        public void TabPage_SetNewToolTip_SetCorrectToolTipText()
+        {
+            using TabPage tabPage = new TabPage();
+            tabPage.CreateControl();
+            string expected = "Some text";
+            using ToolTip toolTip = new ToolTip();
+            toolTip.SetToolTip(tabPage, expected);
+            string actual = tabPage.ToolTipText;
+            Assert.Equal(expected, actual);
+        }
+
+        [WinFormsFact]
+        public void TabPage_ToolTip_IsNotNull()
+        {
+            using TabPage tabPage = new TabPage();
+            Assert.NotNull(tabPage.ToolTip);
+
+            tabPage.ToolTip = new ToolTip();
+            Assert.NotNull(tabPage.ToolTip);
+
+            tabPage.ToolTip = null;
+            Assert.NotNull(tabPage.ToolTip);
+        }
+
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
         public void TabPage_ToolTipText_Set_GetReturnsExpected(string value, string expected)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #2717
Original bug: [604799](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/604799): [Accessibility] TabPage has no keyboard tooltip

## Proposed changes

- Add a virtual IsHoveredWithMouse property to change its value in inherited classes
- Change switch-case implementation in `KeyboardToolTipStateMachine.cs` due to extremely inconvenient use when debugging
- Implement keyboard tooltips for TabPages. Now a Tab and a Page have one tooltip
- Add a TabControl test app

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A user can get a tooltip using a keyboard 

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
- TabPages have no keyboard tooltips
- A TabPage tab has an incorrect tooltip text (TabControl text instead TabPage.ToolTipText property value)
- A user gets only a TabControl tooltip using a Tab-navigation
![Before](https://user-images.githubusercontent.com/49272759/72433043-9bbbd380-37a9-11ea-9fac-340f7fbbbef4.gif)

<!-- TODO -->

### After
- TabPages have keyboard tooltips
- TabPage tab has the same tooltip as a page. If set a new tooltip or change ToolTipText property value it will affect both tooltips. It is a simulation of that a tab tooltip and a page tooltip are one united tooltip
![Fixed](https://user-images.githubusercontent.com/49272759/72431933-f9025580-37a6-11ea-8beb-d03078f408c1.gif)

- A user can get TabControl tooltip if this TabControl has no pages
![image](https://user-images.githubusercontent.com/49272759/72432466-2ef40980-37a8-11ea-9e78-d7fd5b05d0d6.png)



<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- CTI
- Manual UI testing


## Test environment(s) <!-- Remove any that don't apply -->

- SDK Version: 5.0.100-alpha1-016143
- Microsoft Windows [Version 10.0.18363.592]


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2719)