### PR TITLE
remove VS and roslyntools msbuild dependencies from our global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,10 +1,6 @@
 {
   "tools": {
     "dotnet": "5.0.100-alpha1-015536",
-    "vs": {
-      "version": "16.0"
-    },
-    "xcopy-msbuild": "16.0.0-rc1-alpha",
     "runtimes": {
       "dotnet": [
         "$(MicrosoftNETCoreAppPackageVersion)"


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #2729


## Proposed changes

- Remove the vs and xcopy-msbuild entries from our global.json
- This will make us build with dotnet instead of msbuild

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Customers will be able to build without having to install VS

## Regression? 

- Yes, we were able to do this before

## Risk

- None

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Built on a clean VM

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2730)