### PR TITLE
Don't force handle creation in TrackBar.OnHandleCreated

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -881,6 +881,12 @@ namespace System.Windows.Forms
         protected override void OnHandleCreated(EventArgs e)
         {
             base.OnHandleCreated(e);
+
+            if (!IsHandleCreated)
+            {
+                return;
+            }
+
             User32.SendMessageW(this, (User32.WindowMessage)TBM.SETRANGEMIN, PARAM.FromBool(false), (IntPtr)minimum);
             User32.SendMessageW(this, (User32.WindowMessage)TBM.SETRANGEMAX, PARAM.FromBool(false), (IntPtr)maximum);
             User32.SendMessageW(this, (User32.WindowMessage)TBM.SETTICFREQ, (IntPtr)tickFrequency);

--- a/src/System.Windows.Forms/tests/UnitTests/TrackBarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TrackBarTests.cs
@@ -2357,7 +2357,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, callCount);
         }
 
-        /*
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
         public void TrackBar_OnHandleCreated_Invoke_CallsHandleCreated(EventArgs eventArgs)
@@ -2383,7 +2382,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, callCount);
             Assert.False(control.IsHandleCreated);
         }
-        */
 
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]


### PR DESCRIPTION
## Proposed Changes
- Don't force handle creation in TrackBar.OnHandleCreated

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2740)