### PR TITLE
Move GetDlgItem to Interop User32

### DIFF
--- a/src/System.Windows.Forms.Design.Editors/src/System/Drawing/Design/ColorEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/Drawing/Design/ColorEditor.cs
@@ -1116,13 +1116,13 @@ namespace System.Drawing.Design
                         UnsafeNativeMethods.SendDlgItemMessage(hwnd, COLOR_RED, (int)User32.EM.SETMARGINS, (IntPtr)(User32.EC.LEFTMARGIN | User32.EC.RIGHTMARGIN), IntPtr.Zero);
                         UnsafeNativeMethods.SendDlgItemMessage(hwnd, COLOR_GREEN, (int)User32.EM.SETMARGINS, (IntPtr)(User32.EC.LEFTMARGIN | User32.EC.RIGHTMARGIN), IntPtr.Zero);
                         UnsafeNativeMethods.SendDlgItemMessage(hwnd, COLOR_BLUE, (int)User32.EM.SETMARGINS, (IntPtr)(User32.EC.LEFTMARGIN | User32.EC.RIGHTMARGIN), IntPtr.Zero);
-                        IntPtr hwndCtl = UnsafeNativeMethods.GetDlgItem(hwnd, COLOR_MIX);
+                        IntPtr hwndCtl = User32.GetDlgItem(hwnd, COLOR_MIX);
                         User32.EnableWindow(hwndCtl, BOOL.FALSE);
                         User32.SetWindowPos(
                             hwndCtl,
                             User32.HWND_TOP,
                             flags: User32.SWP.HIDEWINDOW);
-                        hwndCtl = UnsafeNativeMethods.GetDlgItem(hwnd, (int)User32.ID.OK);
+                        hwndCtl = User32.GetDlgItem(hwnd, (int)User32.ID.OK);
                         User32.EnableWindow(hwndCtl, BOOL.FALSE);
                         User32.SetWindowPos(
                             hwndCtl,
@@ -1144,7 +1144,7 @@ namespace System.Drawing.Design
                                 blue = (byte)UnsafeNativeMethods.GetDlgItemInt(hwnd, COLOR_BLUE, err, false);
                                 Debug.Assert(!err[0], "Couldn't find dialog member COLOR_BLUE");
                                 this.Color = Color.FromArgb(red, green, blue);
-                                User32.PostMessageW(hwnd, User32.WindowMessage.WM_COMMAND, PARAM.FromLowHigh((int)User32.ID.OK, 0), UnsafeNativeMethods.GetDlgItem(hwnd, (int)User32.ID.OK));
+                                User32.PostMessageW(hwnd, User32.WindowMessage.WM_COMMAND, PARAM.FromLowHigh((int)User32.ID.OK, 0), User32.GetDlgItem(hwnd, (int)User32.ID.OK));
                                 break;
                         }
                         break;

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetDlgItem.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetDlgItem.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern IntPtr GetDlgItem(IntPtr hWnd, int nIDDlgItem);
+
+        public static IntPtr GetDlgItem(IHandle hWnd, int nIDDlgItem)
+        {
+            IntPtr result = GetDlgItem(hWnd.Handle, nIDDlgItem);
+            GC.KeepAlive(hWnd);
+            return result;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -277,12 +277,6 @@ namespace System.Windows.Forms
         public extern static IntPtr SendMessage(HandleRef hWnd, int Msg, IntPtr wParam, NativeMethods.ListViewCompareCallback pfnCompare);
 
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern IntPtr GetDlgItem(HandleRef hWnd, int nIDDlgItem);
-
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern IntPtr GetDlgItem(IntPtr hWnd, int nIDDlgItem);
-
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern int GetDlgItemInt(IntPtr hWnd, int nIDDlgItem, bool[] err, bool signed);
 
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -12415,7 +12415,7 @@ namespace System.Windows.Forms
             bool reflectCalled = false;
 
             int ctrlId = unchecked((int)(long)m.WParam);
-            IntPtr p = UnsafeNativeMethods.GetDlgItem(new HandleRef(null, m.HWnd), ctrlId);
+            IntPtr p = User32.GetDlgItem(m.HWnd, ctrlId);
             if (p == IntPtr.Zero)
             {
                 // On 64-bit platforms wParam is already 64 bit but the control ID stored in it is only 32-bit
@@ -12707,7 +12707,7 @@ namespace System.Windows.Forms
                 case WindowMessages.WM_DESTROY:
                     break;
                 default:
-                    hWnd = UnsafeNativeMethods.GetDlgItem(new HandleRef(this, Handle), PARAM.HIWORD(m.WParam));
+                    hWnd = User32.GetDlgItem(this, PARAM.HIWORD(m.WParam));
                     break;
             }
             if (hWnd == IntPtr.Zero || !ReflectMessage(hWnd, ref m))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FontDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FontDialog.cs
@@ -412,9 +412,9 @@ namespace System.Windows.Forms
                 case WindowMessages.WM_INITDIALOG:
                     if (!showColor)
                     {
-                        IntPtr hWndCtl = UnsafeNativeMethods.GetDlgItem(new HandleRef(null, hWnd), NativeMethods.cmb4);
+                        IntPtr hWndCtl = User32.GetDlgItem(hWnd, NativeMethods.cmb4);
                         User32.ShowWindow(hWndCtl, User32.SW.HIDE);
-                        hWndCtl = UnsafeNativeMethods.GetDlgItem(new HandleRef(null, hWnd), NativeMethods.stc4);
+                        hWndCtl = User32.GetDlgItem(hWnd, NativeMethods.stc4);
                         User32.ShowWindow(hWndCtl, User32.SW.HIDE);
                     }
                     break;


### PR DESCRIPTION
## Proposed changes

- Move GetDlgItem to Interop User32.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2743)