### PR TITLE
Add SendDlgItemMessageW and COLOR enum to Interop User32

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.cs
@@ -12,6 +12,7 @@ using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using System.Windows.Forms.Design;
 using static Interop;
+using static Interop.User32;
 
 namespace System.Drawing.Design
 {
@@ -310,7 +311,7 @@ namespace System.Drawing.Design
                 Rectangle r = new Rectangle();
                 FillRectWithCellBounds(focus.X, focus.Y, ref r);
                 Invalidate(Rectangle.Inflate(r, 5, 5));
-                User32.NotifyWinEvent((uint)AccessibleEvents.Focus, new HandleRef(this, Handle), User32.OBJID.CLIENT, 1 + Get1DFrom2D(focus.X, focus.Y));
+                NotifyWinEvent((uint)AccessibleEvents.Focus, new HandleRef(this, Handle), OBJID.CLIENT, 1 + Get1DFrom2D(focus.X, focus.Y));
             }
 
             protected override bool IsInputKey(System.Windows.Forms.Keys keyData)
@@ -337,7 +338,7 @@ namespace System.Drawing.Design
                 colorUI.EditorService.CloseDropDown(); // It will be closed anyway as soon as it sees the WM_ACTIVATE
                 CustomColorDialog dialog = new CustomColorDialog();
 
-                IntPtr hwndFocus = User32.GetFocus();
+                IntPtr hwndFocus = GetFocus();
                 try
                 {
                     DialogResult result = dialog.ShowDialog();
@@ -586,7 +587,7 @@ namespace System.Drawing.Design
                 {
                     // Convert from screen to client coordinates
                     var pt = new Point(x, y);
-                    User32.ScreenToClient(new HandleRef(ColorPalette, ColorPalette.Handle), ref pt);
+                    ScreenToClient(new HandleRef(ColorPalette, ColorPalette.Handle), ref pt);
 
                     int cell = ColorPalette.GetCellFromLocationMouse(pt.X, pt.Y);
                     if (cell != -1)
@@ -621,7 +622,7 @@ namespace System.Drawing.Design
 
                             // Translate rect to screen coordinates
                             var pt = new Point(rect.X, rect.Y);
-                            User32.ClientToScreen(new HandleRef(parent.ColorPalette, parent.ColorPalette.Handle), ref pt);
+                            ClientToScreen(new HandleRef(parent.ColorPalette, parent.ColorPalette.Handle), ref pt);
 
                             return new Rectangle(pt.X, pt.Y, rect.Width, rect.Height);
                         }
@@ -1054,15 +1055,6 @@ namespace System.Drawing.Design
 
         private class CustomColorDialog : ColorDialog
         {
-            private const int COLOR_HUE = 703;
-            private const int COLOR_SAT = 704;
-            private const int COLOR_LUM = 705;
-            private const int COLOR_RED = 706;
-            private const int COLOR_GREEN = 707;
-            private const int COLOR_BLUE = 708;
-            private const int COLOR_ADD = 712;
-            private const int COLOR_MIX = 719;
-
             private IntPtr hInstance;
 
             public CustomColorDialog()
@@ -1107,44 +1099,44 @@ namespace System.Drawing.Design
 
             protected override IntPtr HookProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam)
             {
-                switch ((User32.WM)msg)
+                switch ((WM)msg)
                 {
-                    case User32.WM.INITDIALOG:
-                        UnsafeNativeMethods.SendDlgItemMessage(hwnd, COLOR_HUE, (int)User32.EM.SETMARGINS, (IntPtr)(User32.EC.LEFTMARGIN | User32.EC.RIGHTMARGIN), IntPtr.Zero);
-                        UnsafeNativeMethods.SendDlgItemMessage(hwnd, COLOR_SAT, (int)User32.EM.SETMARGINS, (IntPtr)(User32.EC.LEFTMARGIN | User32.EC.RIGHTMARGIN), IntPtr.Zero);
-                        UnsafeNativeMethods.SendDlgItemMessage(hwnd, COLOR_LUM, (int)User32.EM.SETMARGINS, (IntPtr)(User32.EC.LEFTMARGIN | User32.EC.RIGHTMARGIN), IntPtr.Zero);
-                        UnsafeNativeMethods.SendDlgItemMessage(hwnd, COLOR_RED, (int)User32.EM.SETMARGINS, (IntPtr)(User32.EC.LEFTMARGIN | User32.EC.RIGHTMARGIN), IntPtr.Zero);
-                        UnsafeNativeMethods.SendDlgItemMessage(hwnd, COLOR_GREEN, (int)User32.EM.SETMARGINS, (IntPtr)(User32.EC.LEFTMARGIN | User32.EC.RIGHTMARGIN), IntPtr.Zero);
-                        UnsafeNativeMethods.SendDlgItemMessage(hwnd, COLOR_BLUE, (int)User32.EM.SETMARGINS, (IntPtr)(User32.EC.LEFTMARGIN | User32.EC.RIGHTMARGIN), IntPtr.Zero);
-                        IntPtr hwndCtl = User32.GetDlgItem(hwnd, COLOR_MIX);
-                        User32.EnableWindow(hwndCtl, BOOL.FALSE);
-                        User32.SetWindowPos(
+                    case WM.INITDIALOG:
+                        SendDlgItemMessageW(hwnd, (DialogItemID)COLOR.HUE, (WM)EM.SETMARGINS, (IntPtr)(EC.LEFTMARGIN | EC.RIGHTMARGIN));
+                        SendDlgItemMessageW(hwnd, (DialogItemID)COLOR.SAT, (WM)EM.SETMARGINS, (IntPtr)(EC.LEFTMARGIN | EC.RIGHTMARGIN));
+                        SendDlgItemMessageW(hwnd, (DialogItemID)COLOR.LUM, (WM)EM.SETMARGINS, (IntPtr)(EC.LEFTMARGIN | EC.RIGHTMARGIN));
+                        SendDlgItemMessageW(hwnd, (DialogItemID)COLOR.RED, (WM)EM.SETMARGINS, (IntPtr)(EC.LEFTMARGIN | EC.RIGHTMARGIN));
+                        SendDlgItemMessageW(hwnd, (DialogItemID)COLOR.GREEN, (WM)EM.SETMARGINS, (IntPtr)(EC.LEFTMARGIN | EC.RIGHTMARGIN));
+                        SendDlgItemMessageW(hwnd, (DialogItemID)COLOR.BLUE, (WM)EM.SETMARGINS, (IntPtr)(EC.LEFTMARGIN | EC.RIGHTMARGIN));
+                        IntPtr hwndCtl = GetDlgItem(hwnd, (DialogItemID)COLOR.MIX);
+                        EnableWindow(hwndCtl, BOOL.FALSE);
+                        SetWindowPos(
                             hwndCtl,
-                            User32.HWND_TOP,
-                            flags: User32.SWP.HIDEWINDOW);
-                        hwndCtl = User32.GetDlgItem(hwnd, (int)User32.ID.OK);
-                        User32.EnableWindow(hwndCtl, BOOL.FALSE);
-                        User32.SetWindowPos(
+                            HWND_TOP,
+                            flags: SWP.HIDEWINDOW);
+                        hwndCtl = GetDlgItem(hwnd, (DialogItemID)ID.OK);
+                        EnableWindow(hwndCtl, BOOL.FALSE);
+                        SetWindowPos(
                             hwndCtl,
-                            User32.HWND_TOP,
-                            flags: User32.SWP.HIDEWINDOW);
-                        this.Color = Color.Empty;
+                            HWND_TOP,
+                            flags: SWP.HIDEWINDOW);
+                        Color = Color.Empty;
                         break;
 
-                    case User32.WM.COMMAND:
+                    case WM.COMMAND:
                         switch (PARAM.LOWORD(wParam))
                         {
-                            case COLOR_ADD:
+                            case (int)COLOR.ADD:
                                 byte red, green, blue;
                                 bool[] err = new bool[1];
-                                red = (byte)UnsafeNativeMethods.GetDlgItemInt(hwnd, COLOR_RED, err, false);
+                                red = (byte)UnsafeNativeMethods.GetDlgItemInt(hwnd, (int)COLOR.RED, err, false);
                                 Debug.Assert(!err[0], "Couldn't find dialog member COLOR_RED");
-                                green = (byte)UnsafeNativeMethods.GetDlgItemInt(hwnd, COLOR_GREEN, err, false);
+                                green = (byte)UnsafeNativeMethods.GetDlgItemInt(hwnd, (int)COLOR.GREEN, err, false);
                                 Debug.Assert(!err[0], "Couldn't find dialog member COLOR_GREEN");
-                                blue = (byte)UnsafeNativeMethods.GetDlgItemInt(hwnd, COLOR_BLUE, err, false);
+                                blue = (byte)UnsafeNativeMethods.GetDlgItemInt(hwnd, (int)COLOR.BLUE, err, false);
                                 Debug.Assert(!err[0], "Couldn't find dialog member COLOR_BLUE");
-                                this.Color = Color.FromArgb(red, green, blue);
-                                User32.PostMessageW(hwnd, User32.WM.COMMAND, PARAM.FromLowHigh((int)User32.ID.OK, 0), User32.GetDlgItem(hwnd, (int)User32.ID.OK));
+                                Color = Color.FromArgb(red, green, blue);
+                                PostMessageW(hwnd, WM.COMMAND, PARAM.FromLowHigh((int)ID.OK, 0), GetDlgItem(hwnd, (DialogItemID)ID.OK));
                                 break;
                         }
                         break;

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.COLOR.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.COLOR.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public enum COLOR
+        {
+            HUESCROLL = 700,
+            SATSCROLL = 701,
+            LUMSCROLL = 702,
+            HUE = 703,
+            SAT = 704,
+            LUM = 705,
+            RED = 706,
+            GREEN = 707,
+            BLUE = 708,
+            CURRENT = 709,
+            RAINBOW = 710,
+            SAVE = 711,
+            ADD = 712,
+            SOLID = 713,
+            TUNE = 714,
+            SCHEMES = 715,
+            ELEMENT = 716,
+            SAMPLES = 717,
+            PALETTE = 718,
+            MIX = 719,
+            BOX1 = 720,
+            CUSTOM1 = 721,
+            HUEACCEL = 723,
+            SATACCEL = 724,
+            LUMACCEL = 725,
+            REDACCEL = 726,
+            GREENACCEL = 727,
+            BLUEACCEL = 728,
+            SOLID_LEFT = 730,
+            SOLID_RIGHT = 731
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DialogItemID.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DialogItemID.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        // The values for this enum can be found in dlgs.h.
+        // Because it has many values, we only have the ones that we are currently using.
+        public enum DialogItemID : uint
+        {
+            stc4 = 0x0443,
+            cmb4 = 0x0473,
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SendDlgItemMessageW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SendDlgItemMessageW.cs
@@ -10,13 +10,6 @@ internal static partial class Interop
     internal static partial class User32
     {
         [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr GetDlgItem(IntPtr hWnd, DialogItemID nIDDlgItem);
-
-        public static IntPtr GetDlgItem(IHandle hWnd, DialogItemID nIDDlgItem)
-        {
-            IntPtr result = GetDlgItem(hWnd.Handle, nIDDlgItem);
-            GC.KeepAlive(hWnd);
-            return result;
-        }
+        public static extern IntPtr SendDlgItemMessageW(IntPtr hDlg, DialogItemID nIDDlgItem, WM Msg, IntPtr wParam = default, IntPtr lParam = default);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/UxTheme/Interop.TMT.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UxTheme/Interop.TMT.cs
@@ -8,10 +8,11 @@ internal static partial class Interop
 {
     public static partial class UxTheme
     {
+        // The values for this enum can be found in vssym32.h.
+        // Because it has many values, we only have the ones that we are currently using.
         [Flags]
         public enum TMT
         {
-            // This enum has many values, so we only add the ones that we are currently using.
             FLATMENUS = 1001,
             MINCOLORDEPTH = 1301,
 

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -16,10 +16,7 @@ namespace System.Windows.Forms
 
         public const int STATUS_PENDING = 0x103; //259 = STILL_ALIVE
 
-        public const int cmb4 = 0x0473;
-
-        public const int CW_USEDEFAULT = (unchecked((int)0x80000000)),
-        COLOR_WINDOW = 5;
+        public const int CW_USEDEFAULT = (unchecked((int)0x80000000));
 
         public const int
         DI_NORMAL = 0x0003,
@@ -153,8 +150,7 @@ namespace System.Windows.Forms
                                                     //public const int RECO_CUT   = 0x00000003; // cut to the clipboard
                                                     //public const int RECO_DRAG  = 0x00000004;    // drag
 
-        public const int stc4 = 0x0443,
-        STARTF_USESHOWWINDOW = 0x00000001,
+        public const int STARTF_USESHOWWINDOW = 0x00000001,
         SIZE_RESTORED = 0,
         SIZE_MAXIMIZED = 2,
         SORT_DEFAULT = 0x0,

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -131,12 +131,6 @@ namespace System.Windows.Forms
             return buffer;
         }
 
-        [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-        public extern static IntPtr SendDlgItemMessage(IntPtr hDlg, int nIDDlgItem, int Msg, IntPtr wParam, IntPtr lParam);
-
-        [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-        public extern static IntPtr SendDlgItemMessage(HandleRef hDlg, int nIDDlgItem, int Msg, IntPtr wParam, IntPtr lParam);
-
         [DllImport(ExternDll.Comdlg32, SetLastError = true, CharSet = CharSet.Auto)]
         public static extern bool GetSaveFileName([In, Out] NativeMethods.OPENFILENAME_I ofn);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -12418,7 +12418,7 @@ namespace System.Windows.Forms
             bool reflectCalled = false;
 
             int ctrlId = unchecked((int)(long)m.WParam);
-            IntPtr p = User32.GetDlgItem(m.HWnd, ctrlId);
+            IntPtr p = User32.GetDlgItem(m.HWnd, (User32.DialogItemID)ctrlId);
             if (p == IntPtr.Zero)
             {
                 // On 64-bit platforms wParam is already 64 bit but the control ID stored in it is only 32-bit
@@ -12710,7 +12710,7 @@ namespace System.Windows.Forms
                 case User32.WM.DESTROY:
                     break;
                 default:
-                    hWnd = User32.GetDlgItem(this, PARAM.HIWORD(m.WParam));
+                    hWnd = User32.GetDlgItem(this, (User32.DialogItemID)PARAM.HIWORD(m.WParam));
                     break;
             }
             if (hWnd == IntPtr.Zero || !ReflectMessage(hWnd, ref m))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FontDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FontDialog.cs
@@ -389,10 +389,10 @@ namespace System.Windows.Forms
                         var logFont = new User32.LOGFONTW();
                         User32.SendMessageW(hWnd, User32.WM.CHOOSEFONT_GETLOGFONT, IntPtr.Zero, ref logFont);
                         UpdateFont(ref logFont);
-                        int index = (int)UnsafeNativeMethods.SendDlgItemMessage(hWnd, 0x473, (int)User32.CB.GETCURSEL, IntPtr.Zero, IntPtr.Zero);
+                        int index = (int)User32.SendDlgItemMessageW(hWnd, User32.DialogItemID.cmb4, (User32.WM)User32.CB.GETCURSEL);
                         if (index != User32.CB_ERR)
                         {
-                            UpdateColor((int)UnsafeNativeMethods.SendDlgItemMessage(hWnd, 0x473, (int)User32.CB.GETITEMDATA, (IntPtr)index, IntPtr.Zero));
+                            UpdateColor((int)User32.SendDlgItemMessageW(hWnd, User32.DialogItemID.cmb4, (User32.WM)User32.CB.GETITEMDATA, (IntPtr)index));
                         }
                         if (NativeWindow.WndProcShouldBeDebuggable)
                         {
@@ -414,9 +414,9 @@ namespace System.Windows.Forms
                 case User32.WM.INITDIALOG:
                     if (!showColor)
                     {
-                        IntPtr hWndCtl = User32.GetDlgItem(hWnd, NativeMethods.cmb4);
+                        IntPtr hWndCtl = User32.GetDlgItem(hWnd, User32.DialogItemID.cmb4);
                         User32.ShowWindow(hWndCtl, User32.SW.HIDE);
-                        hWndCtl = User32.GetDlgItem(hWnd, NativeMethods.stc4);
+                        hWndCtl = User32.GetDlgItem(hWnd, User32.DialogItemID.stc4);
                         User32.ShowWindow(hWndCtl, User32.SW.HIDE);
                     }
                     break;


### PR DESCRIPTION
## Proposed changes

- Add SendDlgItemMessageW and COLOR enum to Interop User32.
- Remove SendDlgItemMessage from UnsafeNativeMethods.cs
- Remove COLOR constants and replace their usage with the above enum values.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2753)