### PR TITLE
Enabling nrt for several safe files

### DIFF
--- a/src/System.Windows.Forms/src/System/Drawing/Design/UITypeEditorEditStyle.cs
+++ b/src/System.Windows.Forms/src/System/Drawing/Design/UITypeEditorEditStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Drawing.Design
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Resources/ResXNullRef.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXNullRef.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Resources
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleEvents.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleEvents.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleNavigation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleNavigation.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleRoles.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleRoles.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleSelection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleSelection.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleStates.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleStates.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AnchorStyles.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AnchorStyles.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Drawing.Design;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Appearance.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Appearance.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ArrangeDirection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ArrangeDirection.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 using static Interop;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ArrangeStartingPosition.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ArrangeStartingPosition.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ArrowDirection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ArrowDirection.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AssemblyAttributes.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AssemblyAttributes.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 // Always hard bind to System.dll and System.Drawing.dll
 
 using System.Runtime.CompilerServices;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AutoCompleteMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AutoCompleteMode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AutoCompleteSource.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AutoCompleteSource.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AutoScaleMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AutoScaleMode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AutoSizeMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AutoSizeMode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AutoValidate.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AutoValidate.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.ActiveXInvokeKind.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.ActiveXInvokeKind.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 using System.Globalization;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BatteryChargeStatus.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BatteryChargeStatus.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 namespace System.Windows.Forms
 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingCompleteContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingCompleteContext.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingCompleteState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingCompleteState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BootMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BootMode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Border3DSide.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Border3DSide.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 using static Interop;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Border3DStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Border3DStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 using static Interop;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BorderStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BorderStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BoundsSpecified.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BoundsSpecified.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBorderStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBorderStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CacheVirtualItemsEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CacheVirtualItemsEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class CacheVirtualItemsEventArgs : EventArgs

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CaptionButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CaptionButton.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CharacterCasing.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CharacterCasing.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CloseReason.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CloseReason.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColorDepth.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColorDepth.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum ColorDepth

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnClickEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnClickEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeaderAutoResizeStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeaderAutoResizeStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeaderStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeaderStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnStyle.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 namespace System.Windows.Forms
 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnWidthChangedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnWidthChangedEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class ColumnWidthChangedEventArgs : EventArgs

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnWidthChangingEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnWidthChangingEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBoxStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBoxStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContentsResizedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContentsResizedEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Drawing;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ExtendedStates.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ExtendedStates.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 namespace System.Windows.Forms
 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.MultithreadSafeCallScope.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.MultithreadSafeCallScope.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public partial class Control

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.PrintPaintEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.PrintPaintEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Drawing;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.States.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.States.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 namespace System.Windows.Forms
 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.UICuesStates.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.UICuesStates.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 namespace System.Windows.Forms
 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlStyles.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlStyles.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlUpdateMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlUpdateMode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAdvancedCellBorderStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAdvancedCellBorderStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum DataGridViewAdvancedCellBorderStyle

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAutoSizeColumnCriteriaInternal.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAutoSizeColumnCriteriaInternal.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 namespace System.Windows.Forms
 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAutoSizeColumnMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAutoSizeColumnMode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum DataGridViewAutoSizeColumnMode

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAutoSizeColumnsMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAutoSizeColumnsMode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum DataGridViewAutoSizeColumnsMode

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAutoSizeModeEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAutoSizeModeEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class DataGridViewAutoSizeModeEventArgs : EventArgs

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAutoSizeRowCriteriaInternal.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAutoSizeRowCriteriaInternal.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     [Flags]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAutoSizeRowMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAutoSizeRowMode.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 namespace System.Windows.Forms
 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAutoSizeRowsMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAutoSizeRowsMode.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 namespace System.Windows.Forms
 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAutoSizeRowsModeInternal.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAutoSizeRowsModeInternal.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 namespace System.Windows.Forms
 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBindingCompleteEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBindingCompleteEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellBorderStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellBorderStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum DataGridViewCellBorderStyle

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyleChangedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyleChangedEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     internal class DataGridViewCellStyleChangedEventArgs : EventArgs

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyleDifferences.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyleDifferences.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     internal enum DataGridViewCellStyleDifferences

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyleScopes.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyleScopes.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     [Flags]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewClipboardCopyMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewClipboardCopyMode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum DataGridViewClipboardCopyMode

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeadersHeightSizeMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeadersHeightSizeMode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum DataGridViewColumnHeadersHeightSizeMode

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnSortMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnSortMode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum DataGridViewColumnSortMode

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxDisplayStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxDisplayStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum DataGridViewComboBoxDisplayStyle

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewContentAlignment.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewContentAlignment.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum DataGridViewContentAlignment

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewDataErrorContexts.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewDataErrorContexts.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     [Flags]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewEditMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewEditMode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum DataGridViewEditMode

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewElementStates.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewElementStates.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewFreeDimension.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewFreeDimension.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     internal enum DataGridViewFreeDimension

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderBorderStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderBorderStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum DataGridViewHeaderBorderStyle

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHitTestCloseEdge.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHitTestCloseEdge.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     internal enum DataGridViewHitTestTypeCloseEdge

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHitTestType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHitTestType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewImageCellLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewImageCellLayout.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum DataGridViewImageCellLayout

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewPaintParts.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewPaintParts.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     [Flags]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeadersWidthSizeMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeadersWidthSizeMode.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 namespace System.Windows.Forms
 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeightInfoNeededEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeightInfoNeededEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeightInfoPushedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeightInfoPushedEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Diagnostics;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowsAddedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowsAddedEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class DataGridViewRowsAddedEventArgs : EventArgs

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowsRemovedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowsRemovedEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Globalization;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewSelectionMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewSelectionMode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum DataGridViewSelectionMode

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTriState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTriState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum DataGridViewTriState

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataSourceUpdateMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataSourceUpdateMode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateRangeEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateRangeEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePickerFormats.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePickerFormats.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Day.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Day.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Design/ToolStripDesignerAvailability.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Design/ToolStripDesignerAvailability.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.Design
 {
     [Flags]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DialogResult.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DialogResult.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DockStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DockStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Drawing.Design;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DockingBehavior.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DockingBehavior.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DragAction.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DragAction.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DragDropEffects.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DragDropEffects.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     [Flags]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DrawItemState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DrawItemState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DrawMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DrawMode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorBlinkStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorBlinkStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorIconAlignment.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorIconAlignment.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FixedPanel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FixedPanel.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FlatStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FlatStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FlowDirection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FlowDirection.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum FlowDirection

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FormBorderStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FormBorderStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FormClosedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FormClosedEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FormClosingEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FormClosingEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FormStartPosition.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FormStartPosition.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FormWindowState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FormWindowState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FrameStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FrameStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GDI/TextFormatFlags.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GDI/TextFormatFlags.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GetChildAtPointSkip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GetChildAtPointSkip.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop.User32;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GiveFeedbackEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GiveFeedbackEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GridItemType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GridItemType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum GridItemType

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HandledMouseEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HandledMouseEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class HandledMouseEventArgs : MouseEventArgs

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HelpEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HelpEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Drawing;
 using System.Runtime.InteropServices;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HelpNavigator.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HelpNavigator.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HorizontalAlignment.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HorizontalAlignment.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElementInsertionOrientation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElementInsertionOrientation.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 namespace System.Windows.Forms
 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ICommandExecutor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ICommandExecutor.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public interface ICommandExecutor

--- a/src/System.Windows.Forms/src/System/Windows/Forms/IMEMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/IMEMode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/IMessageFilter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/IMessageFilter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/IMessageModifyAndFilter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/IMessageModifyAndFilter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     // this is used by Application.cs to detect if we should respect changes to

--- a/src/System.Windows.Forms/src/System/Windows/Forms/IWin32window.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/IWin32window.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/IWindowTarget.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/IWindowTarget.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageLayout.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/InsertKeyMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/InsertKeyMode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/InvalidateEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/InvalidateEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Drawing;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ItemActivation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ItemActivation.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ItemBoundsPortion.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ItemBoundsPortion.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop.ComCtl32;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ItemChangedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ItemChangedEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class ItemChangedEventArgs : EventArgs

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ItemCheckEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ItemCheckEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/KeyEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/KeyEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/KeyPressEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/KeyPressEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LeftRightAlignment.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LeftRightAlignment.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkBehavior.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkBehavior.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum LinkBehavior

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum LinkState

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewAlignment.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewAlignment.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop.ComCtl32;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewHitTestLocation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewHitTestLocation.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop.ComCtl32;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItemState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItemState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MDILayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MDILayout.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MaskFormat.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MaskFormat.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MaskInputRejectedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MaskInputRejectedEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MenuGlyph.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MenuGlyph.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MergeAction.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MergeAction.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum MergeAction

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MessageBoxButtons.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MessageBoxButtons.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop.User32;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MessageBoxDefaultButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MessageBoxDefaultButton.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop.User32;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MessageBoxIcon.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MessageBoxIcon.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop.User32;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MessageBoxOptions.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MessageBoxOptions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop.User32;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MethodInvoker.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MethodInvoker.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarButtonType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarButtonType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public partial class MonthCalendar

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarChildType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarChildType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public partial class MonthCalendar

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MouseButtons.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MouseButtons.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MouseEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MouseEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Drawing;
 using System.Runtime.InteropServices;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NavigateEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NavigateEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NoneExcludedImageIndexConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NoneExcludedImageIndexConverter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Orientation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Orientation.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBoxSizeMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBoxSizeMode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PowerLineStatus.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PowerLineStatus.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum PowerLineStatus

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PowerState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PowerState.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 namespace System.Windows.Forms
 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PowerStatus.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PowerStatus.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PreProcessControlState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PreProcessControlState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum PreProcessControlState

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PreviewKeyDownEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PreviewKeyDownEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ProgressBarStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ProgressBarStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertySort.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertySort.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/QueryContinueDragEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/QueryContinueDragEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/QuestionEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/QuestionEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class QuestionEventArgs : EventArgs

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxFinds.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxFinds.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxLanguageOptions.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxLanguageOptions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxScrollBars.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxScrollBars.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxSelectionAttribute.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxSelectionAttribute.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxSelectionTypes.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxSelectionTypes.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxStreamType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxStreamType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxWordPunctuations.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxWordPunctuations.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RightToLeft.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RightToLeft.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RowStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RowStyle.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 namespace System.Windows.Forms
 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBars.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBars.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollButton.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollEventType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollEventType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 using static Interop;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollOrientation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollOrientation.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SearchDirectionHint.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SearchDirectionHint.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SecurityIDType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SecurityIDType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum SecurityIDType

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SelectionMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SelectionMode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Shortcut.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Shortcut.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SizeGripStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SizeGripStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SizeType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SizeType.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 namespace System.Windows.Forms
 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SortOrder.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SortOrder.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SplitterCancelEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SplitterCancelEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SplitterEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SplitterEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusBarPanelAutoSize.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusBarPanelAutoSize.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusBarPanelBorderStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusBarPanelBorderStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusBarPanelStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusBarPanelStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StructFormat.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StructFormat.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum StructFormat

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SystemParameter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SystemParameter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabAlignment.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabAlignment.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabAppearance.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabAppearance.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.State.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.State.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 namespace System.Windows.Forms
 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControlAction.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControlAction.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabDrawMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabDrawMode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabSizeMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabSizeMode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutPanelCellBorderStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutPanelCellBorderStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum TableLayoutPanelCellBorderStyle

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextDataFormat.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextDataFormat.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextImageRelation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextImageRelation.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TickStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TickStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownCloseReason.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownCloseReason.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum ToolStripDropDownCloseReason

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownClosedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownClosedEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class ToolStripDropDownClosedEventArgs : EventArgs

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownClosingEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownClosingEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownDirection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownDirection.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum ToolStripDropDownDirection

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripGripDisplayStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripGripDisplayStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum ToolStripGripDisplayStyle

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripGripStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripGripStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum ToolStripGripStyle

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemAlignment.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemAlignment.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemDisplayStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemDisplayStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemEventType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemEventType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemImageScaling.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemImageScaling.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum ToolStripItemImageScaling

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemOverflow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemOverflow.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemPlacement.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemPlacement.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemStates.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemStates.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     internal enum ToolStripItemStates

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripLayoutStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripLayoutStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum ToolStripLayoutStyle

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripLocationCancelEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripLocationCancelEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Drawing;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManagerRenderMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManagerRenderMode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPointType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPointType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     internal enum ToolStripPointType

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripRenderMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripRenderMode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripStatusLabelBorderSides.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripStatusLabelBorderSides.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Drawing.Design;
 using System.Runtime.InteropServices;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextDirection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextDirection.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum ToolStripTextDirection

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTipIcon.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTipIcon.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public enum ToolTipIcon

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewAction.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewAction.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewDrawMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewDrawMode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewHitTestLocation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewHitTestLocation.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 using static Interop;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UICues.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UICues.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UICuesEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UICuesEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UnhandledExceptionMode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UnhandledExceptionMode.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 namespace System.Windows.Forms
 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ValidationConstraints.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ValidationConstraints.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/View.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/View.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop.ComCtl32;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/BackgroundType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/BackgroundType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum BackgroundType

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/BooleanProperty.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/BooleanProperty.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop.UxTheme;
 
 namespace System.Windows.Forms.VisualStyles

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/BorderType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/BorderType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum BorderType

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/CheckBoxState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/CheckBoxState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum CheckBoxState

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/ColorProperty.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/ColorProperty.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop.UxTheme;
 
 namespace System.Windows.Forms.VisualStyles

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/ComboBoxState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/ComboBoxState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum ComboBoxState

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/ContentAlignment.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/ContentAlignment.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum ContentAlignment

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/EdgeEffects.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/EdgeEffects.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms.VisualStyles

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/EdgeStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/EdgeStyle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms.VisualStyles

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/Edges.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/Edges.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms.VisualStyles

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/EnumProperty.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/EnumProperty.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop.UxTheme;
 
 namespace System.Windows.Forms.VisualStyles

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/FilenameProperty.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/FilenameProperty.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop.UxTheme;
 
 namespace System.Windows.Forms.VisualStyles

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/FillType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/FillType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum FillType

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/FontProperty.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/FontProperty.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop.UxTheme;
 
 namespace System.Windows.Forms.VisualStyles

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/GlyphFontSizingType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/GlyphFontSizingType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum GlyphFontSizingType

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/GlyphType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/GlyphType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum GlyphType

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/GroupBoxState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/GroupBoxState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum GroupBoxState

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/HeaderItemState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/HeaderItemState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     // Used by some DataGridView classes.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/HitTestCode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/HitTestCode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum HitTestCode

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/HitTestOptions.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/HitTestOptions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     [Flags]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/HorizontalAlign.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/HorizontalAlign.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum HorizontalAlign

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/IconEffect.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/IconEffect.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum IconEffect

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/ImageOrientation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/ImageOrientation.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum ImageOrientation

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/ImageSelectType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/ImageSelectType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum ImageSelectType

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/IntegerProperty.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/IntegerProperty.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop.UxTheme;
 
 namespace System.Windows.Forms.VisualStyles

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/MarginProperty.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/MarginProperty.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop.UxTheme;
 
 namespace System.Windows.Forms.VisualStyles

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/OffsetType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/OffsetType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum OffsetType

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/PointProperty.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/PointProperty.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop.UxTheme;
 
 namespace System.Windows.Forms.VisualStyles

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/PushButtonState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/PushButtonState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum PushButtonState

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/RadioButtonState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/RadioButtonState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum RadioButtonState

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/ScrollBarArrowButtonState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/ScrollBarArrowButtonState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum ScrollBarArrowButtonState

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/ScrollBarSizeBoxState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/ScrollBarSizeBoxState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum ScrollBarSizeBoxState

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/ScrollBarState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/ScrollBarState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum ScrollBarState

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/SizingType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/SizingType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum SizingType

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/StringProperty.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/StringProperty.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop.UxTheme;
 
 namespace System.Windows.Forms.VisualStyles

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/TabItemState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/TabItemState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum TabItemState

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/TextBoxState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/TextBoxState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum TextBoxState

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/TextShadowType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/TextShadowType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum TextShadowType

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/ToolBarState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/ToolBarState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum ToolBarState

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/TrackBarThumbState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/TrackBarThumbState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum TrackBarThumbState

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/TrueSizeScalingType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/TrueSizeScalingType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum TrueSizeScalingType

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VerticalAlignment.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VerticalAlignment.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.VisualStyles
 {
     public enum VerticalAlignment

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms.VisualStyles

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserEncryptionLevel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserEncryptionLevel.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 namespace System.Windows.Forms
 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserProgressChangedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserProgressChangedEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserReadyState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserReadyState.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 using static Interop;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserRefreshOption.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserRefreshOption.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 namespace System.Windows.Forms
 {

--- a/src/System.Windows.Forms/src/misc/GDI/ApplyGraphicsProperties.cs
+++ b/src/System.Windows.Forms/src/misc/GDI/ApplyGraphicsProperties.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.Internal
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/misc/GDI/DeviceContextType.cs
+++ b/src/System.Windows.Forms/src/misc/GDI/DeviceContextType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.Internal
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/misc/GDI/GdiObjectType.cs
+++ b/src/System.Windows.Forms/src/misc/GDI/GdiObjectType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.Internal
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/misc/GDI/TextPaddingOptions.cs
+++ b/src/System.Windows.Forms/src/misc/GDI/TextPaddingOptions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.Internal
 {
     /// <summary>


### PR DESCRIPTION
Work for #1107.
Refers to #2702.

## Proposed changes
- Removed `#nullable disable` from some (not sure if all) safe (which wouldn't imply in API changes) files. These files have no warnings and no public reference members. They are mostly enum or simple event args files.

## Customer Impact

- None

## Regression? 

- No

## Risk

- None.

## Test methodology

- API diff must be empty


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2756)