### PR TITLE
WIP: Fixing issue 2704: Cannot find the RichEdit control of the "Text" property in UIA structure of a PropertyGrid control

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6644,4 +6644,7 @@ Stack trace where the illegal operation occurred was:
   <data name="TreeNodeCircularReference" xml:space="preserve">
     <value>A circular reference has been made. A TreeNode cannot be added as a descendant of itself.</value>
   </data>
+  <data name="PropertyGridViewDropDownControlHolderAccessibleName" xml:space="preserve">
+    <value>Drop down control holder</value>
+  </data>  
 </root>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -8251,6 +8251,11 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">Barva ohraničení oblasti mřížky</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewDropDownControlHolderAccessibleName">
+        <source>Drop down control holder</source>
+        <target state="new">Drop down control holder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridViewEditorCreatedInvalidObject">
         <source>Editor created an object that is not valid.  The created object must be of type '{0}'.</source>
         <target state="translated">Editor vytvořil objekt, který není platný. Vytvořený objekt musí být typu {0}.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -8251,6 +8251,11 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">Die Farbe des Rahmens, der den Rasterbereich umgibt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewDropDownControlHolderAccessibleName">
+        <source>Drop down control holder</source>
+        <target state="new">Drop down control holder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridViewEditorCreatedInvalidObject">
         <source>Editor created an object that is not valid.  The created object must be of type '{0}'.</source>
         <target state="translated">Der Editor hat ein ungültiges Objekt erstellt. Der erstellte Objekt muss den Typ {0} haben.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -8251,6 +8251,11 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">Color del borde que rodea el área de la cuadrícula.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewDropDownControlHolderAccessibleName">
+        <source>Drop down control holder</source>
+        <target state="new">Drop down control holder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridViewEditorCreatedInvalidObject">
         <source>Editor created an object that is not valid.  The created object must be of type '{0}'.</source>
         <target state="translated">El editor creó un objeto no válido. El objeto creado debe ser de tipo '{0}'.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -8251,6 +8251,11 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">Couleur des bordures de la grille.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewDropDownControlHolderAccessibleName">
+        <source>Drop down control holder</source>
+        <target state="new">Drop down control holder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridViewEditorCreatedInvalidObject">
         <source>Editor created an object that is not valid.  The created object must be of type '{0}'.</source>
         <target state="translated">L'Éditeur a créé un objet non valide. L'objet créé doit être de type '{0}'.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -8251,6 +8251,11 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">Colore del bordo che delimita l'area della griglia.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewDropDownControlHolderAccessibleName">
+        <source>Drop down control holder</source>
+        <target state="new">Drop down control holder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridViewEditorCreatedInvalidObject">
         <source>Editor created an object that is not valid.  The created object must be of type '{0}'.</source>
         <target state="translated">Oggetto non valido creato dall'editor. L'oggetto creato deve essere di tipo '{0}'.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -8251,6 +8251,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">グリッド領域を囲む境界線の色。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewDropDownControlHolderAccessibleName">
+        <source>Drop down control holder</source>
+        <target state="new">Drop down control holder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridViewEditorCreatedInvalidObject">
         <source>Editor created an object that is not valid.  The created object must be of type '{0}'.</source>
         <target state="translated">エディターで有効ではないオブジェクトが作成されました。  作成されるオブジェクトは型 '{0}' でなければなりません。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -8251,6 +8251,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">표 영역 주위의 테두리 색입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewDropDownControlHolderAccessibleName">
+        <source>Drop down control holder</source>
+        <target state="new">Drop down control holder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridViewEditorCreatedInvalidObject">
         <source>Editor created an object that is not valid.  The created object must be of type '{0}'.</source>
         <target state="translated">편집기에서 잘못된 개체를 만들었습니다. 만들어진 개체는 '{0}' 형식이어야 합니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -8251,6 +8251,11 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">Kolor obramowania otaczającego obszar siatki.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewDropDownControlHolderAccessibleName">
+        <source>Drop down control holder</source>
+        <target state="new">Drop down control holder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridViewEditorCreatedInvalidObject">
         <source>Editor created an object that is not valid.  The created object must be of type '{0}'.</source>
         <target state="translated">Edytor utworzył nieprawidłowy obiekt. Utworzony obiekt musi być typu „{0}”.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -8251,6 +8251,11 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">A cor da borda ao redor da área da grade.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewDropDownControlHolderAccessibleName">
+        <source>Drop down control holder</source>
+        <target state="new">Drop down control holder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridViewEditorCreatedInvalidObject">
         <source>Editor created an object that is not valid.  The created object must be of type '{0}'.</source>
         <target state="translated">O editor criou um objeto que não é válido. O objeto criado deve ser do tipo '{0}'.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -8252,6 +8252,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">Цвет границы вокруг области таблицы.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewDropDownControlHolderAccessibleName">
+        <source>Drop down control holder</source>
+        <target state="new">Drop down control holder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridViewEditorCreatedInvalidObject">
         <source>Editor created an object that is not valid.  The created object must be of type '{0}'.</source>
         <target state="translated">Элемент Editor создал недействительный объект.  Созданный объект должен быть типа '{0}'.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -8251,6 +8251,11 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">Kılavuz alanını çevreleyen kenarlığın rengi.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewDropDownControlHolderAccessibleName">
+        <source>Drop down control holder</source>
+        <target state="new">Drop down control holder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridViewEditorCreatedInvalidObject">
         <source>Editor created an object that is not valid.  The created object must be of type '{0}'.</source>
         <target state="translated">Düzenleyici geçerli olmayan bir nesne oluşturdu. Oluşturulan nesnenin '{0}' türünde olması gerekir.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -8251,6 +8251,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">网格区域周围的边框的颜色。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewDropDownControlHolderAccessibleName">
+        <source>Drop down control holder</source>
+        <target state="new">Drop down control holder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridViewEditorCreatedInvalidObject">
         <source>Editor created an object that is not valid.  The created object must be of type '{0}'.</source>
         <target state="translated">编辑器创建了一个无效对象。  创建的对象必须是“{0}”类型。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -8251,6 +8251,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">圍繞方格區域的框線色彩。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewDropDownControlHolderAccessibleName">
+        <source>Drop down control holder</source>
+        <target state="new">Drop down control holder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridViewEditorCreatedInvalidObject">
         <source>Editor created an object that is not valid.  The created object must be of type '{0}'.</source>
         <target state="translated">編輯器建立了無效的物件。建立的物件必須屬於類型 '{0}'。</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
@@ -1205,6 +1205,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                         return propertyGridView.DropDownListBoxAccessibleObject;
                     }
 
+                    if (propertyGridView.DropDownVisible && propertyGridView.DropDownControlHolder != null)
+                    {
+                        return propertyGridView.DropDownControlHolder.AccessibilityObject;
+                    }
+
                     return propertyGridView.EditAccessibleObject;
                 }
 


### PR DESCRIPTION
Adding PropertyGrid DropDown control holder and its child edit control to the UIA hierarchy of the PropertyGrid.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #2704 


## Proposed changes

- Adding accessible object for PropertyGrid's DropDownControlHolder;
- Implementing accessible navigation to find DropDownControlHolder pane and its child edit control in UIA hierarchy in PropertyGrid.
- Adding resource to announce DropDownControlHolder pane accessible name to inform users that the currently edited RichEdit control or another edit control is hosted in PropertyGrid's DropDown control holder.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Customers will be able to distinguish the dropped down control from another form controls if using Narrator or another screen reader.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/23213980/73003863-605b7d80-3e17-11ea-92af-f66d92fec2a1.png)

### After

<!-- TODO -->
![image](https://user-images.githubusercontent.com/23213980/73004026-ae708100-3e17-11ea-845d-448e48585d7d.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual testing;
- Unit tests (to be implemented);
- UI tests.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

<!-- use `dotnet --info` -->

.NET Core SDK (reflecting any global.json):
 Version:   5.0.100-alpha1-015763
 Commit:    0d0c902b77

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.18363
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\5.0.100-alpha1-015763\

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2758)