### PR TITLE
Move FOS to Interop Shell32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.FOS.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.FOS.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal partial class Interop
+{
+    internal static partial class Shell32
+    {
+        [Flags]
+        public enum FOS : uint
+        {
+            OVERWRITEPROMPT = 0x2,
+            STRICTFILETYPES = 0x4,
+            NOCHANGEDIR = 0x8,
+            PICKFOLDERS = 0x20,
+            FORCEFILESYSTEM = 0x40,     // Ensure that items returned are filesystem items.
+            ALLNONSTORAGEITEMS = 0x80,  // Allow choosing items that have no storage.
+            NOVALIDATE = 0x100,
+            ALLOWMULTISELECT = 0x200,
+            PATHMUSTEXIST = 0x800,
+            FILEMUSTEXIST = 0x1000,
+            CREATEPROMPT = 0x2000,
+            SHAREAWARE = 0x4000,
+            NOREADONLYRETURN = 0x8000,
+            NOTESTFILECREATE = 0x10000,
+            HIDEMRUPLACES = 0x20000,
+            HIDEPINNEDPLACES = 0x40000,
+            NODEREFERENCELINKS = 0x100000,
+            OKBUTTONNEEDSINTERACTION = 0x200000,
+            DONTADDTORECENT = 0x2000000,
+            FORCESHOWHIDDEN = 0x10000000,
+            DEFAULTNOMINIMODE = 0x20000000,
+            FORCEPREVIEWPANEON = 0x40000000,
+            SUPPORTSTREAMABLEITEMS = 0x80000000
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/FileDialog_Vista_Interop.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/FileDialog_Vista_Interop.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using System.Runtime.InteropServices;
+using static Interop.Shell32;
 
 namespace System.Windows.Forms
 {
@@ -414,31 +415,6 @@ namespace System.Windows.Forms
             public string pszName;
             [MarshalAs(UnmanagedType.LPWStr)]
             public string pszSpec;
-        }
-
-        [Flags]
-        public enum FOS : uint
-        {
-            FOS_OVERWRITEPROMPT = 0x00000002,
-            FOS_STRICTFILETYPES = 0x00000004,
-            FOS_NOCHANGEDIR = 0x00000008,
-            FOS_PICKFOLDERS = 0x00000020,
-            FOS_FORCEFILESYSTEM = 0x00000040, // Ensure that items returned are filesystem items.
-            FOS_ALLNONSTORAGEITEMS = 0x00000080, // Allow choosing items that have no storage.
-            FOS_NOVALIDATE = 0x00000100,
-            FOS_ALLOWMULTISELECT = 0x00000200,
-            FOS_PATHMUSTEXIST = 0x00000800,
-            FOS_FILEMUSTEXIST = 0x00001000,
-            FOS_CREATEPROMPT = 0x00002000,
-            FOS_SHAREAWARE = 0x00004000,
-            FOS_NOREADONLYRETURN = 0x00008000,
-            FOS_NOTESTFILECREATE = 0x00010000,
-            FOS_HIDEMRUPLACES = 0x00020000,
-            FOS_HIDEPINNEDPLACES = 0x00040000,
-            FOS_NODEREFERENCELINKS = 0x00100000,
-            FOS_DONTADDTORECENT = 0x02000000,
-            FOS_FORCESHOWHIDDEN = 0x10000000,
-            FOS_DEFAULTNOMINIMODE = 0x20000000
         }
 
         public enum CDCONTROLSTATE

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog_Vista.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog_Vista.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
 using static Interop;
+using static Interop.Shell32;
 
 namespace System.Windows.Forms
 {
@@ -93,18 +94,18 @@ namespace System.Windows.Forms
             _customPlaces.Apply(dialog);
         }
 
-        private FileDialogNative.FOS GetOptions()
+        private FOS GetOptions()
         {
-            const FileDialogNative.FOS BlittableOptions =
-                FileDialogNative.FOS.FOS_OVERWRITEPROMPT
-              | FileDialogNative.FOS.FOS_NOCHANGEDIR
-              | FileDialogNative.FOS.FOS_NOVALIDATE
-              | FileDialogNative.FOS.FOS_ALLOWMULTISELECT
-              | FileDialogNative.FOS.FOS_PATHMUSTEXIST
-              | FileDialogNative.FOS.FOS_FILEMUSTEXIST
-              | FileDialogNative.FOS.FOS_CREATEPROMPT
-              | FileDialogNative.FOS.FOS_NODEREFERENCELINKS
-            ;
+            const FOS BlittableOptions =
+                FOS.OVERWRITEPROMPT
+              | FOS.NOCHANGEDIR
+              | FOS.NOVALIDATE
+              | FOS.ALLOWMULTISELECT
+              | FOS.PATHMUSTEXIST
+              | FOS.FILEMUSTEXIST
+              | FOS.CREATEPROMPT
+              | FOS.NODEREFERENCELINKS;
+
             const int UnexpectedOptions =
                 (int)(Comdlg32.OFN.SHOWHELP // If ShowHelp is true, we don't use the Vista Dialog
                 | Comdlg32.OFN.ENABLEHOOK // These shouldn't be set in options (only set in the flags for the legacy dialog)
@@ -113,10 +114,10 @@ namespace System.Windows.Forms
 
             Debug.Assert((UnexpectedOptions & _options) == 0, "Unexpected FileDialog options");
 
-            FileDialogNative.FOS ret = (FileDialogNative.FOS)_options & BlittableOptions;
+            FOS ret = (FOS)_options & BlittableOptions;
 
             // Force no mini mode for the SaveFileDialog
-            ret |= FileDialogNative.FOS.FOS_DEFAULTNOMINIMODE;
+            ret |= FOS.DEFAULTNOMINIMODE;
 
             // Make sure that the Open dialog allows the user to specify
             // non-file system locations. This flag will cause the dialog to copy the resource
@@ -125,7 +126,7 @@ namespace System.Windows.Forms
             // An example of a non-file system location is a URL (http://), or a file stored on
             // a digital camera that is not mapped to a drive letter.
             // This reproduces the behavior of the "classic" Open and Save dialogs.
-            ret |= FileDialogNative.FOS.FOS_FORCEFILESYSTEM;
+            ret |= FOS.FORCEFILESYSTEM;
 
             return ret;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 using static Interop;
+using static Interop.Shell32;
 
 namespace System.Windows.Forms
 {
@@ -227,7 +228,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            dialog.SetOptions(FileDialogNative.FOS.FOS_PICKFOLDERS | FileDialogNative.FOS.FOS_FORCEFILESYSTEM | FileDialogNative.FOS.FOS_FILEMUSTEXIST);
+            dialog.SetOptions(FOS.PICKFOLDERS | FOS.FORCEFILESYSTEM | FOS.FILEMUSTEXIST);
 
             if (!string.IsNullOrEmpty(_selectedPath))
             {


### PR DESCRIPTION
## Proposed changes

- Move FOS to Interop Shell32.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2763)