### PR TITLE
Remove Succeeded and Failed methods from NativeMethods.cs

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/ExternDll.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/ExternDll.cs
@@ -6,43 +6,12 @@ namespace System
 {
     internal static class ExternDll
     {
-        public const string Activeds = "activeds.dll";
-        public const string Comctl32 = "comctl32.dll";
         public const string Comdlg32 = "comdlg32.dll";
         public const string Gdi32 = "gdi32.dll";
-        public const string Gdiplus = "gdiplus.dll";
         public const string Hhctrl = "hhctrl.ocx";
         public const string Kernel32 = "kernel32.dll";
-        public const string Loadperf = "Loadperf.dll";
-        public const string Mscoree = "mscoree.dll";
-        public const string Clr = "clr.dll";
-        public const string Msi = "msi.dll";
-        public const string Mqrt = "mqrt.dll";
-        public const string Ntdll = "ntdll.dll";
-        public const string Ole32 = "ole32.dll";
         public const string Oleacc = "oleacc.dll";
-        public const string Oleaut32 = "oleaut32.dll";
-        public const string Olepro32 = "olepro32.dll";
-        public const string PerfCounter = "perfcounter.dll";
-        public const string Psapi = "psapi.dll";
         public const string Shell32 = "shell32.dll";
         public const string User32 = "user32.dll";
-        public const string Uxtheme = "uxtheme.dll";
-        public const string WinMM = "winmm.dll";
-        public const string Winspool = "winspool.drv";
-        public const string Wtsapi32 = "wtsapi32.dll";
-        public const string Version = "version.dll";
-        public const string Vsassert = "vsassert.dll";
-        public const string Fxassert = "Fxassert.dll";
-        public const string Crypt32 = "crypt32.dll";
-        public const string Wldp = "wldp.dll";
-
-        // system.data specific
-        internal const string Odbc32 = "odbc32.dll";
-        internal const string SNI = "System.Data.dll";
-
-        // system.data.oracleclient specific
-        internal const string OciDll = "oci.dll";
-        internal const string OraMtsDll = "oramts.dll";
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -195,16 +195,6 @@ namespace System.Windows.Forms
         HLP_NAVIGATOR = 3,
         HLP_OBJECT = 4;
 
-        public static bool Succeeded(int hr)
-        {
-            return (hr >= 0);
-        }
-
-        public static bool Failed(int hr)
-        {
-            return (hr < 0);
-        }
-
         public const int
         TV_FIRST = 0x1100,
         TTS_ALWAYSTIP = 0x01,
@@ -857,11 +847,11 @@ namespace System.Windows.Forms
             int GetGUID(int dwGuidKind, [In, Out] ref Guid pGuid);
 
             [PreserveSig]
-            int GetMultiTypeInfoCount([In, Out] ref int pcti);
+            HRESULT GetMultiTypeInfoCount([In, Out] ref int pcti);
 
             // we use arrays for most of these since we never use them anyway.
             [PreserveSig]
-            int GetInfoOfIndex(int iti, int dwFlags,
+            HRESULT GetInfoOfIndex(int iti, int dwFlags,
                                 [In, Out]
                                 ref UnsafeNativeMethods.ITypeInfo pTypeInfo,
                                 int pTIFlags,

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/SafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/SafeNativeMethods.cs
@@ -58,37 +58,37 @@ namespace System.Windows.Forms
         public static extern bool DrawEdge(HandleRef hDC, ref RECT rect, int edge, int flags);
 
         // Theming/Visual Styles
-        [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
-        public static extern int GetThemeBackgroundContentRect(HandleRef hTheme, HandleRef hdc, int iPartId, int iStateId, [In] NativeMethods.COMRECT pBoundingRect, [Out] NativeMethods.COMRECT pContentRect);
+        [DllImport(Libraries.UxTheme, CharSet = CharSet.Auto)]
+        public static extern HRESULT GetThemeBackgroundContentRect(HandleRef hTheme, HandleRef hdc, int iPartId, int iStateId, [In] NativeMethods.COMRECT pBoundingRect, [Out] NativeMethods.COMRECT pContentRect);
 
-        [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
-        public static extern int GetThemeBackgroundExtent(HandleRef hTheme, HandleRef hdc, int iPartId, int iStateId, [In] NativeMethods.COMRECT pContentRect, [Out] NativeMethods.COMRECT pExtentRect);
+        [DllImport(Libraries.UxTheme, CharSet = CharSet.Auto)]
+        public static extern HRESULT GetThemeBackgroundExtent(HandleRef hTheme, HandleRef hdc, int iPartId, int iStateId, [In] NativeMethods.COMRECT pContentRect, [Out] NativeMethods.COMRECT pExtentRect);
 
-        [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
-        public static extern int GetThemeBackgroundRegion(HandleRef hTheme, HandleRef hdc, int iPartId, int iStateId, [In] NativeMethods.COMRECT pRect, ref IntPtr pRegion);
+        [DllImport(Libraries.UxTheme, CharSet = CharSet.Auto)]
+        public static extern HRESULT GetThemeBackgroundRegion(HandleRef hTheme, HandleRef hdc, int iPartId, int iStateId, [In] NativeMethods.COMRECT pRect, ref IntPtr pRegion);
 
-        [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
-        public static extern int GetThemeFilename(HandleRef hTheme, int iPartId, int iStateId, int iPropId, StringBuilder pszThemeFilename, int cchMaxBuffChars);
+        [DllImport(Libraries.UxTheme, CharSet = CharSet.Auto)]
+        public static extern HRESULT GetThemeFilename(HandleRef hTheme, int iPartId, int iStateId, int iPropId, StringBuilder pszThemeFilename, int cchMaxBuffChars);
 
-        [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
-        public static extern int GetThemePartSize(HandleRef hTheme, HandleRef hdc, int iPartId, int iStateId, [In] NativeMethods.COMRECT prc, VisualStyles.ThemeSizeType eSize, out Size psz);
+        [DllImport(Libraries.UxTheme, CharSet = CharSet.Auto)]
+        public static extern HRESULT GetThemePartSize(HandleRef hTheme, HandleRef hdc, int iPartId, int iStateId, [In] NativeMethods.COMRECT prc, VisualStyles.ThemeSizeType eSize, out Size psz);
 
-        [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
-        public static extern int GetThemePosition(HandleRef hTheme, int iPartId, int iStateId, int iPropId, out Point pPoint);
+        [DllImport(Libraries.UxTheme, CharSet = CharSet.Auto)]
+        public static extern HRESULT GetThemePosition(HandleRef hTheme, int iPartId, int iStateId, int iPropId, out Point pPoint);
 
-        [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
-        public static extern int GetThemeMargins(HandleRef hTheme, HandleRef hDC, int iPartId, int iStateId, int iPropId, NativeMethods.COMRECT prc, ref MARGINS margins);
+        [DllImport(Libraries.UxTheme, CharSet = CharSet.Auto)]
+        public static extern HRESULT GetThemeMargins(HandleRef hTheme, HandleRef hDC, int iPartId, int iStateId, int iPropId, NativeMethods.COMRECT prc, ref MARGINS margins);
 
-        [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
-        public static extern int GetThemeString(HandleRef hTheme, int iPartId, int iStateId, int iPropId, StringBuilder pszBuff, int cchMaxBuffChars);
+        [DllImport(Libraries.UxTheme, CharSet = CharSet.Auto)]
+        public static extern HRESULT GetThemeString(HandleRef hTheme, int iPartId, int iStateId, int iPropId, StringBuilder pszBuff, int cchMaxBuffChars);
 
-        [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
-        public static extern int GetThemeTextExtent(HandleRef hTheme, HandleRef hdc, int iPartId, int iStateId, [MarshalAs(UnmanagedType.LPWStr)] string pszText, int iCharCount, int dwTextFlags, [In] NativeMethods.COMRECT pBoundingRect, [Out] NativeMethods.COMRECT pExtentRect);
+        [DllImport(Libraries.UxTheme, CharSet = CharSet.Auto)]
+        public static extern HRESULT GetThemeTextExtent(HandleRef hTheme, HandleRef hdc, int iPartId, int iStateId, [MarshalAs(UnmanagedType.LPWStr)] string pszText, int iCharCount, int dwTextFlags, [In] NativeMethods.COMRECT pBoundingRect, [Out] NativeMethods.COMRECT pExtentRect);
 
-        [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
-        public static extern int GetThemeTextMetrics(HandleRef hTheme, HandleRef hdc, int iPartId, int iStateId, ref VisualStyles.TextMetrics ptm);
+        [DllImport(Libraries.UxTheme, CharSet = CharSet.Auto)]
+        public static extern HRESULT GetThemeTextMetrics(HandleRef hTheme, HandleRef hdc, int iPartId, int iStateId, ref VisualStyles.TextMetrics ptm);
 
-        [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto)]
-        public static extern int HitTestThemeBackground(HandleRef hTheme, HandleRef hdc, int iPartId, int iStateId, int dwOptions, [In] NativeMethods.COMRECT pRect, HandleRef hrgn, Point ptTest, ref ushort pwHitTestCode);
+        [DllImport(Libraries.UxTheme, CharSet = CharSet.Auto)]
+        public static extern HRESULT HitTestThemeBackground(HandleRef hTheme, HandleRef hdc, int iPartId, int iStateId, int dwOptions, [In] NativeMethods.COMRECT pRect, HandleRef hrgn, Point ptTest, ref ushort pwHitTestCode);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -47,7 +47,7 @@ namespace System.Windows.Forms
         }
 
         [DllImport(ExternDll.Comdlg32, SetLastError = true, CharSet = CharSet.Auto)]
-        public static extern int PrintDlgEx([In, Out] NativeMethods.PRINTDLGEX lppdex);
+        public static extern HRESULT PrintDlgEx([In, Out] NativeMethods.PRINTDLGEX lppdex);
 
         [DllImport(ExternDll.Shell32, CharSet = CharSet.Auto)]
         public static extern int DragQueryFile(HandleRef hDrop, int iFile, StringBuilder lpszFile, int cch);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2TypeInfoProcessor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2TypeInfoProcessor.cs
@@ -100,7 +100,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
             if (obj is NativeMethods.IProvideMultipleClassInfo pCI)
             {
-                if (!NativeMethods.Succeeded(pCI.GetMultiTypeInfoCount(ref n)) || n == 0)
+                if (!pCI.GetMultiTypeInfoCount(ref n).Succeeded() || n == 0)
                 {
                     n = 0;
                 }
@@ -111,7 +111,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
                     for (int i = 0; i < n; i++)
                     {
-                        if (NativeMethods.Failed(pCI.GetInfoOfIndex(i, 1 /*MULTICLASSINFO_GETTYPEINFO*/, ref temp, 0, 0, IntPtr.Zero, IntPtr.Zero)))
+                        if (pCI.GetInfoOfIndex(i, 1 /*MULTICLASSINFO_GETTYPEINFO*/, ref temp, 0, 0, IntPtr.Zero, IntPtr.Zero).Failed())
                         {
                             continue;
                         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXFontMarshaler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXFontMarshaler.cs
@@ -55,7 +55,7 @@ namespace System.Windows.Forms
 
                 Marshal.Release(pFont);
 
-                if (NativeMethods.Failed(hr))
+                if (((HRESULT)hr).Failed())
                 {
                     Marshal.ThrowExceptionForHR(hr);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintDialog.cs
@@ -525,8 +525,8 @@ namespace System.Windows.Forms
                 // PrintDlgEx. So we have to strip them out.
                 data.Flags &= ~(PD.SHOWHELP | PD.NONETWORKBUTTON);
 
-                int hr = UnsafeNativeMethods.PrintDlgEx(data);
-                if (NativeMethods.Failed(hr) || data.dwResultAction == PD_RESULT.CANCEL)
+                HRESULT hr = UnsafeNativeMethods.PrintDlgEx(data);
+                if (hr.Failed() || data.dwResultAction == PD_RESULT.CANCEL)
                 {
                     return false;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
@@ -24,7 +24,7 @@ namespace System.Windows.Forms.VisualStyles
         private string _class;
         private int part;
         private int state;
-        private int lastHResult = 0;
+        private HRESULT lastHResult = 0;
         private static readonly int numberOfPossibleClasses = VisualStyleElement.Count; //used as size for themeHandles
 
         [ThreadStatic]
@@ -292,13 +292,13 @@ namespace System.Windows.Forms.VisualStyles
                     using (ThemeHandle hTheme = ThemeHandle.Create(_class, true, hWnd))
                     {
                         RECT rect  = bounds;
-                        lastHResult = (int)UxTheme.DrawThemeBackground(hTheme, hdc, part, state, ref rect, null);
+                        lastHResult = UxTheme.DrawThemeBackground(hTheme, hdc, part, state, ref rect, null);
                     }
                 }
                 else
                 {
                     RECT rect  = bounds;
-                    lastHResult = (int)UxTheme.DrawThemeBackground(this, hdc, part, state, ref rect, null);
+                    lastHResult = UxTheme.DrawThemeBackground(this, hdc, part, state, ref rect, null);
                 }
             }
         }
@@ -335,14 +335,14 @@ namespace System.Windows.Forms.VisualStyles
                     {
                         RECT rect = bounds;
                         RECT clipRect = clipRectangle;
-                        lastHResult = (int)UxTheme.DrawThemeBackground(hTheme, hdc, part, state, ref rect, &clipRect);
+                        lastHResult = UxTheme.DrawThemeBackground(hTheme, hdc, part, state, ref rect, &clipRect);
                     }
                 }
                 else
                 {
                     RECT rect = bounds;
                     RECT clipRect = clipRectangle;
-                    lastHResult = (int)UxTheme.DrawThemeBackground(this, hdc, part, state, ref rect, &clipRect);
+                    lastHResult = UxTheme.DrawThemeBackground(this, hdc, part, state, ref rect, &clipRect);
                 }
             }
         }
@@ -376,7 +376,7 @@ namespace System.Windows.Forms.VisualStyles
             var hdc = new HandleRef(wgr, wgr.WindowsGraphics.DeviceContext.Hdc);
             RECT destRect = bounds;
             var contentRect = new RECT();
-            lastHResult = (int)UxTheme.DrawThemeEdge(this, hdc, part, state, ref destRect, (User32.EDGE)style, (User32.BF)edges | (User32.BF)effects | User32.BF.ADJUST, ref contentRect);
+            lastHResult = UxTheme.DrawThemeEdge(this, hdc, part, state, ref destRect, (User32.EDGE)style, (User32.BF)edges | (User32.BF)effects | User32.BF.ADJUST, ref contentRect);
             return contentRect;
         }
 
@@ -461,7 +461,7 @@ namespace System.Windows.Forms.VisualStyles
                 using var wgr = new WindowsGraphicsWrapper(dc, AllGraphicsProperties);
                 var hdc = new HandleRef(wgr, wgr.WindowsGraphics.DeviceContext.Hdc);
                 RECT rc = bounds;
-                lastHResult = (int)UxTheme.DrawThemeParentBackground(childControl, hdc, ref rc);
+                lastHResult = UxTheme.DrawThemeParentBackground(childControl, hdc, ref rc);
             }
         }
 
@@ -502,7 +502,7 @@ namespace System.Windows.Forms.VisualStyles
                 var hdc = new HandleRef(wgr, wgr.WindowsGraphics.DeviceContext.Hdc);
                 uint disableFlag = drawDisabled ? 0x1u : 0u;
                 RECT rect = bounds;
-                lastHResult = (int)UxTheme.DrawThemeText(this, hdc, part, state, textToDraw, textToDraw.Length, (User32.DT)flags, disableFlag, ref rect);
+                lastHResult = UxTheme.DrawThemeText(this, hdc, part, state, textToDraw, textToDraw.Length, (User32.DT)flags, disableFlag, ref rect);
             }
         }
 
@@ -606,7 +606,7 @@ namespace System.Windows.Forms.VisualStyles
             }
 
             BOOL val = BOOL.FALSE;
-            lastHResult = (int)UxTheme.GetThemeBool(this, part, state, (int)prop, ref val);
+            lastHResult = UxTheme.GetThemeBool(this, part, state, (int)prop, ref val);
             return val.IsTrue();
         }
 
@@ -622,7 +622,7 @@ namespace System.Windows.Forms.VisualStyles
             }
 
             int color = 0;
-            lastHResult = (int)UxTheme.GetThemeColor(this, part, state, (int)prop, ref color);
+            lastHResult = UxTheme.GetThemeColor(this, part, state, (int)prop, ref color);
             return ColorTranslator.FromWin32(color);
         }
 
@@ -638,7 +638,7 @@ namespace System.Windows.Forms.VisualStyles
             }
 
             int val = 0;
-            lastHResult = (int)UxTheme.GetThemeEnumValue(this, part, state, (int)prop, ref val);
+            lastHResult = UxTheme.GetThemeEnumValue(this, part, state, (int)prop, ref val);
             return val;
         }
 
@@ -680,13 +680,13 @@ namespace System.Windows.Forms.VisualStyles
             using (WindowsGraphicsWrapper wgr = new WindowsGraphicsWrapper(dc, AllGraphicsProperties))
             {
                 HandleRef hdc = new HandleRef(wgr, wgr.WindowsGraphics.DeviceContext.Hdc);
-                lastHResult = (int)UxTheme.GetThemeFont(new HandleRef(this, Handle), hdc, part, state, (int)prop, ref logfont);
+                lastHResult = UxTheme.GetThemeFont(new HandleRef(this, Handle), hdc, part, state, (int)prop, ref logfont);
             }
 
             Font font = null;
 
             //check for a failed HR.
-            if (NativeMethods.Succeeded(lastHResult))
+            if (lastHResult.Succeeded())
             {
                 try
                 {
@@ -719,7 +719,7 @@ namespace System.Windows.Forms.VisualStyles
             }
 
             int val = 0;
-            lastHResult = (int)UxTheme.GetThemeInt(this, part, state, (int)prop, ref val);
+            lastHResult = UxTheme.GetThemeInt(this, part, state, (int)prop, ref val);
             return val;
         }
 
@@ -989,7 +989,7 @@ namespace System.Windows.Forms.VisualStyles
         {
             get
             {
-                return lastHResult;
+                return (int)lastHResult;
             }
         }
 


### PR DESCRIPTION
## Proposed changes

- Remove Succeeded and Failed methods from NativeMethods.cs
- Remove unused constants from ExternDll.cs
- Replace int with HRESULT return type.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2764)