### PR TITLE
Move ScrollWindow to Interop User32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.ScrollWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.ScrollWindow.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        private static extern BOOL ScrollWindow(IntPtr hWnd, int nXAmount, int nYAmount, ref RECT rectScrollRegion, ref RECT rectClip);
+
+        public static BOOL ScrollWindow(IHandle hWnd, int nXAmount, int nYAmount, ref RECT rectScrollRegion, ref RECT rectClip)
+        {
+            BOOL result = ScrollWindow(hWnd.Handle, nXAmount, nYAmount, ref rectScrollRegion, ref rectClip);
+            GC.KeepAlive(hWnd);
+            return result;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/SafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/SafeNativeMethods.cs
@@ -52,9 +52,6 @@ namespace System.Windows.Forms
         public static extern bool MessageBeep(int type);
 
         [DllImport(ExternDll.User32, ExactSpelling = true)]
-        public static extern bool ScrollWindow(HandleRef hWnd, int nXAmount, int nYAmount, ref RECT rectScrollRegion, ref RECT rectClip);
-
-        [DllImport(ExternDll.User32, ExactSpelling = true)]
         public static extern bool DrawEdge(HandleRef hDC, ref RECT rect, int edge, int flags);
 
         // Theming/Visual Styles

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -25615,7 +25615,8 @@ namespace System.Windows.Forms
                 for (int r = 0; r < rects.Length; r++)
                 {
                     scroll = rects[r];
-                    SafeNativeMethods.ScrollWindow(new HandleRef(this, Handle),
+                    User32.ScrollWindow(
+                        this,
                         change,
                         0,
                         ref scroll,
@@ -25726,7 +25727,7 @@ namespace System.Windows.Forms
             UpdateMouseEnteredCell(null /*HitTestInfo*/, null /*MouseEventArgs*/);
 
             RECT scrollArea = rowsRect;
-            SafeNativeMethods.ScrollWindow(new HandleRef(this, Handle), 0, deltaY, ref scrollArea, ref scrollArea);
+            User32.ScrollWindow(this, 0, deltaY, ref scrollArea, ref scrollArea);
             if (invalidateTopOfRowHeaders)
             {
                 rowsRect.X = layout.Inside.X;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -774,11 +774,12 @@ namespace System.Windows.Forms
             }
 
             RECT scroll = ClientRectangle;
-            SafeNativeMethods.ScrollWindow(new HandleRef(this, Handle),
-                                 current.X - position.X,
-                                 current.Y - position.Y,
-                                 ref scroll,
-                                 ref scroll);
+            User32.ScrollWindow(
+                this,
+                current.X - position.X,
+                current.Y - position.Y,
+                ref scroll,
+                ref scroll);
 
             User32.SetScrollPos(this, User32.SB.HORZ, position.X, BOOL.TRUE);
             User32.SetScrollPos(this, User32.SB.VERT, position.Y, BOOL.TRUE);


### PR DESCRIPTION
## Proposed changes

- Move ScrollWindow to Interop User32.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2766)