### PR TITLE
Add LVN and LV_VIEW enums in Interop ComCtl32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.LVIF.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.LVIF.cs
@@ -37,7 +37,7 @@ internal static partial class Interop
             INDENT = 0x00000010,
 
             /// <summary>
-            /// The control will not generate <see cref="System.Windows.Forms.NativeMethods.LVN_GETDISPINFO"/>
+            /// The control will not generate <see cref="LVN.GETDISPINFO"/>
             /// to retrieve text information if it receives an <see cref="LVM.GETITEMW"/> message.
             /// Instead, the <c>pszText</c> member will contain <c>LPSTR_TEXTCALLBACK</c>.
             /// </summary>
@@ -58,7 +58,7 @@ internal static partial class Interop
             /// <summary>
             /// The operating system should store the requested list item information
             /// and not ask for it again. This flag is used only with the
-            /// <see cref="System.Windows.Forms.NativeMethods.LVN_GETDISPINFO"/> notification code.
+            /// <see cref="LVN.GETDISPINFO"/> notification code.
             /// </summary>
             DI_SETITEM = 0x00001000,
 

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.LVN.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.LVN.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        public enum LVN
+        {
+            FIRST = 0 - 100,
+            LAST = 0 - 199,
+            ITEMCHANGING = FIRST - 0,
+            ITEMCHANGED = FIRST - 1,
+            INSERTITEM = FIRST - 2,
+            DELETEITEM = FIRST - 3,
+            DELETEALLITEMS = FIRST - 4,
+            BEGINLABELEDITW = FIRST - 75,
+            ENDLABELEDITW = FIRST - 76,
+            COLUMNCLICK = FIRST - 8,
+            BEGINDRAG = FIRST - 9,
+            BEGINRDRAG = FIRST - 11,
+            ODCACHEHINT = FIRST - 13,
+            ODFINDITEMW = FIRST - 79,
+            ITEMACTIVATE = FIRST - 14,
+            ODSTATECHANGED = FIRST - 15,
+            ODFINDITEM = ODFINDITEMW,
+            HOTTRACK = FIRST - 21,
+            GETDISPINFOW = FIRST - 77,
+            SETDISPINFOW = FIRST - 78,
+            BEGINLABELEDIT = BEGINLABELEDITW,
+            ENDLABELEDIT = ENDLABELEDITW,
+            GETDISPINFO = GETDISPINFOW,
+            SETDISPINFO = SETDISPINFOW,
+            KEYDOWN = FIRST - 55,
+            MARQUEEBEGIN = FIRST - 56,
+            GETINFOTIPW = FIRST - 58,
+            GETINFOTIP = GETINFOTIPW,
+            INCREMENTALSEARCHW = FIRST - 63,
+            INCREMENTALSEARCH = INCREMENTALSEARCHW,
+            COLUMNDROPDOWN = FIRST - 64,
+            COLUMNOVERFLOWCLICK = FIRST - 66,
+            BEGINSCROLL = FIRST - 80,
+            ENDSCROLL = FIRST - 81,
+            LINKCLICK = FIRST - 84,
+            GETEMPTYMARKUP = FIRST - 87
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.LV_VIEW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.LV_VIEW.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        public enum LV_VIEW : uint
+        {
+            ICON = 0x0000,
+            DETAILS = 0x0001,
+            SMALLICON = 0x0002,
+            LIST = 0x0003,
+            TILE = 0x0004,
+            MAX = 0x0004
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -78,24 +78,6 @@ namespace System.Windows.Forms
         ICON_SMALL = 0,
         ICON_BIG = 1;
 
-        public const int
-        LV_VIEW_TILE = 0x0004,
-        LVN_ITEMCHANGING = ((0 - 100) - 0),
-        LVN_ITEMCHANGED = ((0 - 100) - 1),
-        LVN_BEGINLABELEDIT = ((0 - 100) - 75),
-        LVN_ENDLABELEDIT = ((0 - 100) - 76),
-        LVN_COLUMNCLICK = ((0 - 100) - 8),
-        LVN_BEGINDRAG = ((0 - 100) - 9),
-        LVN_BEGINRDRAG = ((0 - 100) - 11),
-        LVN_ODFINDITEM = ((0 - 100) - 79),
-        LVN_ITEMACTIVATE = ((0 - 100) - 14),
-        LVN_GETDISPINFO = ((0 - 100) - 77),
-        LVN_ODCACHEHINT = ((0 - 100) - 13),
-        LVN_ODSTATECHANGED = ((0 - 100) - 15),
-        LVN_SETDISPINFO = ((0 - 100) - 78),
-        LVN_GETINFOTIP = ((0 - 100) - 58),
-        LVN_KEYDOWN = ((0 - 100) - 55);
-
         public const int LANG_NEUTRAL = 0x00,
                          LOCALE_IFIRSTDAYOFWEEK = 0x0000100C;   /* first day of week specifier */
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -3232,7 +3232,7 @@ namespace System.Windows.Forms
             {
                 fixed (char* pText = text)
                 {
-                    var lvFindInfo = new ComCtl32.LVFINDINFOW();
+                    var lvFindInfo = new LVFINDINFOW();
                     if (isTextSearch)
                     {
                         lvFindInfo.flags = LVFI.STRING;
@@ -5644,7 +5644,7 @@ namespace System.Windows.Forms
             User32.NMHDR* nmhdr = (User32.NMHDR*)m.LParam;
 
             // column header custom draw message handling
-            if (nmhdr->code == (int)ComCtl32.NM.CUSTOMDRAW && OwnerDraw)
+            if (nmhdr->code == (int)NM.CUSTOMDRAW && OwnerDraw)
             {
                 try
                 {
@@ -5698,7 +5698,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            if (nmhdr->code == (int)ComCtl32.NM.RELEASEDCAPTURE && listViewState[LISTVIEWSTATE_columnClicked])
+            if (nmhdr->code == (int)NM.RELEASEDCAPTURE && listViewState[LISTVIEWSTATE_columnClicked])
             {
                 listViewState[LISTVIEWSTATE_columnClicked] = false;
                 OnColumnClick(new ColumnClickEventArgs(columnIndex));
@@ -6021,11 +6021,11 @@ namespace System.Windows.Forms
 
             switch (nmhdr->code)
             {
-                case (int)ComCtl32.NM.CUSTOMDRAW:
+                case (int)NM.CUSTOMDRAW:
                     CustomDraw(ref m);
                     break;
 
-                case NativeMethods.LVN_BEGINLABELEDIT:
+                case (int)LVN.BEGINLABELEDIT:
                     {
                         NMLVDISPINFO* dispInfo = (NMLVDISPINFO*)m.LParam;
                         LabelEditEventArgs e = new LabelEditEventArgs(dispInfo->item.iItem);
@@ -6035,7 +6035,7 @@ namespace System.Windows.Forms
                         break;
                     }
 
-                case NativeMethods.LVN_COLUMNCLICK:
+                case (int)LVN.COLUMNCLICK:
                     {
                         NMLISTVIEW* nmlv = (NMLISTVIEW*)m.LParam;
                         listViewState[LISTVIEWSTATE_columnClicked] = true;
@@ -6043,7 +6043,7 @@ namespace System.Windows.Forms
                         break;
                     }
 
-                case NativeMethods.LVN_ENDLABELEDIT:
+                case (int)LVN.ENDLABELEDIT:
                     {
                         listViewState[LISTVIEWSTATE_inLabelEdit] = false;
                         NMLVDISPINFO* dispInfo = (NMLVDISPINFO*)m.LParam;
@@ -6062,11 +6062,11 @@ namespace System.Windows.Forms
                         break;
                     }
 
-                case NativeMethods.LVN_ITEMACTIVATE:
+                case (int)LVN.ITEMACTIVATE:
                     OnItemActivate(EventArgs.Empty);
                     break;
 
-                case NativeMethods.LVN_BEGINDRAG:
+                case (int)LVN.BEGINDRAG:
                     {
                         // The items collection was modified while dragging that means that
                         // we can't reliably give the user the item on which the dragging
@@ -6081,7 +6081,7 @@ namespace System.Windows.Forms
                         break;
                     }
 
-                case NativeMethods.LVN_BEGINRDRAG:
+                case (int)LVN.BEGINRDRAG:
                     {
                         // The items collection was modified while dragging. That means that
                         // we can't reliably give the user the item on which the dragging
@@ -6096,7 +6096,7 @@ namespace System.Windows.Forms
                         break;
                     }
 
-                case NativeMethods.LVN_ITEMCHANGING:
+                case (int)LVN.ITEMCHANGING:
                     {
                         NMLISTVIEW* nmlv = (NMLISTVIEW*)m.LParam;
                         if ((nmlv->uChanged & LVIF.STATE) != 0)
@@ -6116,7 +6116,7 @@ namespace System.Windows.Forms
                         break;
                     }
 
-                case NativeMethods.LVN_ITEMCHANGED:
+                case (int)LVN.ITEMCHANGED:
                     {
                         NMLISTVIEW* nmlv = (NMLISTVIEW*)m.LParam;
                         // Check for state changes to the selected state...
@@ -6185,15 +6185,15 @@ namespace System.Windows.Forms
                         break;
                     }
 
-                case (int)ComCtl32.NM.CLICK:
+                case (int)NM.CLICK:
                     WmNmClick(ref m);
                     // FALL THROUGH //
-                    goto case (int)ComCtl32.NM.RCLICK;
+                    goto case (int)NM.RCLICK;
 
-                case (int)ComCtl32.NM.RCLICK:
+                case (int)NM.RCLICK:
                     int displayIndex = GetIndexOfClickedItem();
 
-                    MouseButtons button = nmhdr->code == (int)ComCtl32.NM.CLICK ? MouseButtons.Left : MouseButtons.Right;
+                    MouseButtons button = nmhdr->code == (int)NM.CLICK ? MouseButtons.Left : MouseButtons.Right;
                     Point pos = Cursor.Position;
                     pos = PointToClient(pos);
 
@@ -6209,12 +6209,12 @@ namespace System.Windows.Forms
                     }
                     break;
 
-                case (int)ComCtl32.NM.DBLCLK:
+                case (int)NM.DBLCLK:
                     WmNmDblClick(ref m);
                     // FALL THROUGH //
-                    goto case (int)ComCtl32.NM.RDBLCLK;
+                    goto case (int)NM.RDBLCLK;
 
-                case (int)ComCtl32.NM.RDBLCLK:
+                case (int)NM.RDBLCLK:
                     int index = GetIndexOfClickedItem();
                     if (index != -1)
                     {
@@ -6229,7 +6229,7 @@ namespace System.Windows.Forms
                     Capture = true;
                     break;
 
-                case NativeMethods.LVN_KEYDOWN:
+                case (int)LVN.KEYDOWN:
                     if (CheckBoxes)
                     {
                         NMLVKEYDOWN* lvkd = (NMLVKEYDOWN*)m.LParam;
@@ -6254,14 +6254,14 @@ namespace System.Windows.Forms
                     }
                     break;
 
-                case NativeMethods.LVN_ODCACHEHINT:
+                case (int)LVN.ODCACHEHINT:
                     // tell the user to prepare the cache:
                     NMLVCACHEHINT* cacheHint = (NMLVCACHEHINT*)m.LParam;
                     OnCacheVirtualItems(new CacheVirtualItemsEventArgs(cacheHint->iFrom, cacheHint->iTo));
                     break;
 
                 default:
-                    if (nmhdr->code == NativeMethods.LVN_GETDISPINFO)
+                    if (nmhdr->code == (int)LVN.GETDISPINFO)
                     {
                         // we use the LVN_GETDISPINFO message only in virtual mode
                         if (VirtualMode && m.LParam != IntPtr.Zero)
@@ -6315,7 +6315,7 @@ namespace System.Windows.Forms
                             }
                         }
                     }
-                    else if (nmhdr->code == NativeMethods.LVN_ODSTATECHANGED)
+                    else if (nmhdr->code == (int)LVN.ODSTATECHANGED)
                     {
                         if (VirtualMode && m.LParam != IntPtr.Zero)
                         {
@@ -6330,7 +6330,7 @@ namespace System.Windows.Forms
                             }
                         }
                     }
-                    else if (nmhdr->code == NativeMethods.LVN_GETINFOTIP)
+                    else if (nmhdr->code == (int)LVN.GETINFOTIP)
                     {
                         if (ShowItemToolTips && m.LParam != IntPtr.Zero)
                         {
@@ -6348,7 +6348,7 @@ namespace System.Windows.Forms
                             }
                         }
                     }
-                    else if (nmhdr->code == NativeMethods.LVN_ODFINDITEM)
+                    else if (nmhdr->code == (int)LVN.ODFINDITEM)
                     {
                         if (VirtualMode)
                         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/View.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/View.cs
@@ -14,7 +14,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Each item appears as a full-sized icon with a label below it.
         /// </summary>
-        LargeIcon = (int)LVS.ICON,
+        LargeIcon = (int)LV_VIEW.ICON,
 
         /// <summary>
         ///  Each item appears on a seperate line with further
@@ -25,23 +25,23 @@ namespace System.Windows.Forms
         ///  column displays a header which can display a caption for the
         ///  column. The user can resize each column at runtime.
         /// </summary>
-        Details = (int)LVS.REPORT,
+        Details = (int)LV_VIEW.DETAILS,
 
         /// <summary>
         ///  Each item appears as a small icon with a label to its right.
         /// </summary>
-        SmallIcon = (int)LVS.SMALLICON,
+        SmallIcon = (int)LV_VIEW.SMALLICON,
 
         /// <summary>
         ///  Each item
         ///  appears as a small icon with a label to its right.
         ///  Items are arranged in columns with no column headers.
         /// </summary>
-        List = (int)LVS.LIST,
+        List = (int)LV_VIEW.LIST,
 
         /// <summary>
         ///  Tile view.
         /// </summary>
-        Tile = NativeMethods.LV_VIEW_TILE,
+        Tile = (int)LV_VIEW.TILE,
     }
 }


### PR DESCRIPTION
## Proposed changes

- Add LVN and LV_VIEW enums in Interop ComCtl32
- Remove corresponding constants and replace their usages with the above enum values.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2767)