### PR TITLE
Add GetUserObjectInformationW, UOI and USEROBJECTFLAGS in Interop User32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetUserObjectInformationW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetUserObjectInformationW.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
+        public static extern BOOL GetUserObjectInformationW(IntPtr hObj, UOI nIndex, ref USEROBJECTFLAGS pvBuffer, int nLength, ref int lpnLengthNeeded);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.UOI.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.UOI.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public enum UOI
+        {
+            FLAGS = 1,
+            NAME = 2,
+            TYPE = 3,
+            USER_SID = 4,
+            HEAPSIZE = 5,
+            IO = 6,
+            TIMERPROC_EXCEPTION_SUPPRESSION = 7
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.USEROBJECTFLAGS.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.USEROBJECTFLAGS.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public struct USEROBJECTFLAGS
+        {
+            public BOOL fInherit;
+            public BOOL fReserved;
+            public uint dwFlags;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.WSF.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.WSF.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public enum WSF
+        {
+            VISIBLE = 0x0001
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -182,10 +182,6 @@ namespace System.Windows.Forms
         TB_BOTTOM = 7,
         TB_ENDTRACK = 8;
 
-        public const int UOI_FLAGS = 1;
-
-        public const int WSF_VISIBLE = 0x0001;
-
         public const int WHEEL_DELTA = 120;
 
         public static int START_PAGE_GENERAL = unchecked((int)0xffffffff);
@@ -201,13 +197,6 @@ namespace System.Windows.Forms
         public const string uuid_IAccessible = "{618736E0-3C3D-11CF-810C-00AA00389B71}";
 
         public const string WinFormFrameworkId = "WinForm";
-
-        public struct USEROBJECTFLAGS
-        {
-            public int fInherit;
-            public int fReserved;
-            public int dwFlags;
-        }
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
         public class HH_AKLINK

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -245,9 +245,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern int GetDlgItemInt(IntPtr hWnd, int nIDDlgItem, bool[] err, bool signed);
 
-        [DllImport(ExternDll.User32, SetLastError = true)]
-        public static extern bool GetUserObjectInformation(HandleRef hObj, int nIndex, ref NativeMethods.USEROBJECTFLAGS pvBuffer, int nLength, ref int lpnLengthNeeded);
-
         [DllImport(ExternDll.Oleacc, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern IntPtr LresultFromObject(ref Guid refiid, IntPtr wParam, HandleRef pAcc);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SystemInformation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SystemInformation.cs
@@ -643,10 +643,10 @@ namespace System.Windows.Forms
 
                     int lengthNeeded = 0;
 
-                    NativeMethods.USEROBJECTFLAGS flags = new NativeMethods.USEROBJECTFLAGS();
-                    if (UnsafeNativeMethods.GetUserObjectInformation(new HandleRef(null, hwinsta), NativeMethods.UOI_FLAGS, ref flags, sizeof(NativeMethods.USEROBJECTFLAGS), ref lengthNeeded))
+                    USEROBJECTFLAGS flags = default;
+                    if (GetUserObjectInformationW(hwinsta, UOI.FLAGS, ref flags, sizeof(USEROBJECTFLAGS), ref lengthNeeded).IsTrue())
                     {
-                        if ((flags.dwFlags & NativeMethods.WSF_VISIBLE) == 0)
+                        if ((flags.dwFlags & (int)WSF.VISIBLE) == 0)
                         {
                             s_isUserInteractive = false;
                         }


### PR DESCRIPTION
## Proposed changes

- Add GetUserObjectInformationW, UOI and USEROBJECTFLAGS in Interop User32.
- Remove corresponding method, enum and constant from NativeMethods.cs and UnsafeNativeMethods.cs  and replace their usages.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2770)