### PR TITLE
Add DLGC enum to Interop User32

### DIFF
--- a/src/System.Windows.Forms.Design.Editors/src/System/ComponentModel/Design/ObjectSelectorEditor.cs
+++ b/src/System.Windows.Forms.Design.Editors/src/System/ComponentModel/Design/ObjectSelectorEditor.cs
@@ -308,7 +308,7 @@ namespace System.ComponentModel.Design
                 switch ((User32.WM)m.Msg)
                 {
                     case User32.WM.GETDLGCODE:
-                        m.Result = (IntPtr)((long)m.Result | NativeMethods.DLGC_WANTALLKEYS);
+                        m.Result = (IntPtr)((long)m.Result | (int)User32.DLGC.WANTALLKEYS);
                         return;
                     case User32.WM.MOUSEMOVE:
                         if (clickSeen)

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DLGC.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DLGC.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [Flags]
+        public enum DLGC : uint
+        {
+            WANTARROWS = 0x0001,
+            WANTTAB = 0x0002,
+            WANTALLKEYS = 0x0004,
+            WANTMESSAGE = 0x0004,       // Pass message to control.
+            HASSETSEL = 0x0008,         // Understands EM_SETSEL message.
+            DEFPUSHBUTTON = 0x0010,
+            UNDEFPUSHBUTTON = 0x0020,
+            RADIOBUTTON = 0x0040,
+            WANTCHARS = 0x0080,
+            STATIC = 0x0100,
+            BUTTON = 0x2000,
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -29,12 +29,6 @@ namespace System.Windows.Forms
 
         public const int
         DI_NORMAL = 0x0003,
-        DLGC_WANTARROWS = 0x0001,
-        DLGC_WANTTAB = 0x0002,
-        DLGC_WANTALLKEYS = 0x0004,
-        DLGC_WANTCHARS = 0x0080,
-        DLGC_WANTMESSAGE = 0x0004,      /* Pass message to control          */
-        DLGC_HASSETSEL = 0x0008,      /* Understands EM_SETSEL message    */
         DTS_UPDOWN = 0x0001,
         DTS_SHOWNONE = 0x0002,
         DTS_LONGDATEFORMAT = 0x0004,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -6712,11 +6712,11 @@ namespace System.Windows.Forms
             int mask = 0;
             if (charCode == (char)(int)Keys.Tab)
             {
-                mask = NativeMethods.DLGC_WANTCHARS | NativeMethods.DLGC_WANTALLKEYS | NativeMethods.DLGC_WANTTAB;
+                mask = (int)(User32.DLGC.WANTCHARS | User32.DLGC.WANTALLKEYS | User32.DLGC.WANTTAB);
             }
             else
             {
-                mask = NativeMethods.DLGC_WANTCHARS | NativeMethods.DLGC_WANTALLKEYS;
+                mask = (int)(User32.DLGC.WANTCHARS | User32.DLGC.WANTALLKEYS);
             }
             return (unchecked((int)(long)User32.SendMessageW(this, User32.WM.GETDLGCODE)) & mask) != 0;
         }
@@ -6740,23 +6740,23 @@ namespace System.Windows.Forms
                 return false;
             }
 
-            int mask = NativeMethods.DLGC_WANTALLKEYS;
+            User32.DLGC mask = User32.DLGC.WANTALLKEYS;
             switch (keyData & Keys.KeyCode)
             {
                 case Keys.Tab:
-                    mask = NativeMethods.DLGC_WANTALLKEYS | NativeMethods.DLGC_WANTTAB;
+                    mask = User32.DLGC.WANTALLKEYS | User32.DLGC.WANTTAB;
                     break;
                 case Keys.Left:
                 case Keys.Right:
                 case Keys.Up:
                 case Keys.Down:
-                    mask = NativeMethods.DLGC_WANTALLKEYS | NativeMethods.DLGC_WANTARROWS;
+                    mask = User32.DLGC.WANTALLKEYS | User32.DLGC.WANTARROWS;
                     break;
             }
 
             if (IsHandleCreated)
             {
-                return (unchecked((int)(long)User32.SendMessageW(this, User32.WM.GETDLGCODE)) & mask) != 0;
+                return (unchecked((int)(long)User32.SendMessageW(this, User32.WM.GETDLGCODE)) & (int)mask) != 0;
             }
             else
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -29084,12 +29084,12 @@ namespace System.Windows.Forms
         /// </summary>
         private void WmGetDlgCode(ref Message m)
         {
-            m.Result = (IntPtr)((long)m.Result | NativeMethods.DLGC_WANTARROWS | NativeMethods.DLGC_WANTCHARS);
+            m.Result = (IntPtr)((long)m.Result | (int)User32.DLGC.WANTARROWS | (int)User32.DLGC.WANTCHARS);
 
             Keys modifierKeys = ModifierKeys;
             if (GetTabKeyEffective((modifierKeys & Keys.Shift) == Keys.Shift, (modifierKeys & Keys.Control) == Keys.Control))
             {
-                m.Result = (IntPtr)((long)m.Result | NativeMethods.DLGC_WANTTAB);
+                m.Result = (IntPtr)((long)m.Result | (int)User32.DLGC.WANTTAB);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -2403,7 +2403,7 @@ namespace System.Windows.Forms
         private void WmGetDlgCode(ref Message m)
         {
             // The MonthCalendar does its own handling of arrow keys
-            m.Result = (IntPtr)NativeMethods.DLGC_WANTARROWS;
+            m.Result = (IntPtr)User32.DLGC.WANTARROWS;
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -6039,7 +6039,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 case (int)User32.WM.GETDLGCODE:
 
-                    int flags = NativeMethods.DLGC_WANTCHARS | NativeMethods.DLGC_WANTARROWS;
+                    int flags = (int)(User32.DLGC.WANTCHARS | User32.DLGC.WANTARROWS);
 
                     if (selectedGridEntry != null)
                     {
@@ -6050,7 +6050,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                             //
                             if (edit.Visible)
                             {
-                                flags |= NativeMethods.DLGC_WANTTAB;
+                                flags |= (int)User32.DLGC.WANTTAB;
                             }
                         }
                     }
@@ -7707,10 +7707,10 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     case User32.WM.GETDLGCODE:
 
-                        m.Result = (IntPtr)((long)m.Result | NativeMethods.DLGC_WANTARROWS | NativeMethods.DLGC_WANTCHARS);
+                        m.Result = (IntPtr)((long)m.Result | (int)User32.DLGC.WANTARROWS | (int)User32.DLGC.WANTCHARS);
                         if (psheet.NeedsCommit || WantsTab((ModifierKeys & Keys.Shift) == 0))
                         {
-                            m.Result = (IntPtr)((long)m.Result | NativeMethods.DLGC_WANTALLKEYS | NativeMethods.DLGC_WANTTAB);
+                            m.Result = (IntPtr)((long)m.Result | (int)User32.DLGC.WANTALLKEYS | (int)User32.DLGC.WANTTAB);
                         }
                         return;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -3790,7 +3790,7 @@ namespace System.Windows.Forms
 
                 case User32.WM.GETDLGCODE:
                     base.WndProc(ref m);
-                    m.Result = (IntPtr)((AcceptsTab) ? unchecked((int)(long)m.Result) | NativeMethods.DLGC_WANTTAB : unchecked((int)(long)m.Result) & ~NativeMethods.DLGC_WANTTAB);
+                    m.Result = (IntPtr)(AcceptsTab ? unchecked((int)(long)m.Result) | (int)User32.DLGC.WANTTAB : unchecked((int)(long)m.Result) & ~(int)User32.DLGC.WANTTAB);
                     break;
 
                 case User32.WM.GETOBJECT:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -2179,12 +2179,12 @@ namespace System.Windows.Forms
             if (AcceptsTab)
             {
                 Debug.WriteLineIf(Control.s_controlKeyboardRouting.TraceVerbose, "TextBox wants tabs");
-                m.Result = (IntPtr)(unchecked((int)(long)m.Result) | NativeMethods.DLGC_WANTTAB);
+                m.Result = (IntPtr)(unchecked((int)(long)m.Result) | (int)DLGC.WANTTAB);
             }
             else
             {
                 Debug.WriteLineIf(Control.s_controlKeyboardRouting.TraceVerbose, "TextBox doesn't want tabs");
-                m.Result = (IntPtr)(unchecked((int)(long)m.Result) & ~(NativeMethods.DLGC_WANTTAB | NativeMethods.DLGC_WANTALLKEYS));
+                m.Result = (IntPtr)(unchecked((int)(long)m.Result) & ~(int)(DLGC.WANTTAB | DLGC.WANTALLKEYS));
             }
         }
 


### PR DESCRIPTION
## Proposed changes

- Add DLGC enum to Interop User32.
- Remove DLGC constants and replace their usage with the above enum values.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2772)