### PR TITLE
Cleanup CHARFORMATW

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.CFE.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.CFE.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal partial class Interop
+{
+    internal static partial class Richedit
+    {
+        [Flags]
+        public enum CFE : uint
+        {
+            BOLD = 0x00000001,
+            ITALIC = 0x00000002,
+            UNDERLINE = 0x00000004,
+            STRIKEOUT = 0x00000008,
+            PROTECTED = 0x00000010,
+            LINK = 0x00000020,
+            AUTOCOLOR = 0x40000000,
+            SUBSCRIPT = 0x00010000,
+            SUPERSCRIPT = 0x00020000,
+            SMALLCAPS = CFM.SMALLCAPS,
+            ALLCAPS = CFM.ALLCAPS,
+            HIDDEN = CFM.HIDDEN,
+            OUTLINE = CFM.OUTLINE,
+            SHADOW = CFM.SHADOW,
+            EMBOSS = CFM.EMBOSS,
+            IMPRINT = CFM.IMPRINT,
+            DISABLED = CFM.DISABLED,
+            REVISED = CFM.REVISED,
+            AUTOBACKCOLOR = CFM.BACKCOLOR,
+            FONTBOUND = 0x00100000,
+            LINKPROTECTED = 0x00800000,
+            EXTENDED = 0x02000000,
+            MATHNOBUILDUP = 0x08000000,
+            MATH = 0x10000000,
+            MATHORDINARY = 0x20000000,
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.CFM.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.CFM.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal partial class Interop
+{
+    internal static partial class Richedit
+    {
+        [Flags]
+        public enum CFM : uint
+        {
+            BOLD = 0x00000001,
+            ITALIC = 0x00000002,
+            UNDERLINE = 0x00000004,
+            STRIKEOUT = 0x00000008,
+            PROTECTED = 0x00000010,
+            LINK = 0x00000020,
+            SIZE = 0x80000000,
+            COLOR = 0x40000000,
+            FACE = 0x20000000,
+            OFFSET = 0x10000000,
+            CHARSET = 0x08000000,
+            SMALLCAPS = 0x00000040,
+            ALLCAPS = 0x00000080,
+            HIDDEN = 0x00000100,
+            OUTLINE = 0x00000200,
+            SHADOW = 0x00000400,
+            EMBOSS = 0x00000800,
+            IMPRINT = 0x00001000,
+            DISABLED = 0x00002000,
+            REVISED = 0x00004000,
+            REVAUTHOR = 0x00008000,
+            ANIMATION = 0x00040000,
+            STYLE = 0x00080000,
+            KERNING = 0x00100000,
+            SPACING = 0x00200000,
+            WEIGHT = 0x00400000,
+            UNDERLINETYPE = 0x00800000,
+            COOKIE = 0x01000000,
+            LCID = 0x02000000,
+            BACKCOLOR = 0x04000000,
+            SUBSCRIPT = CFE.SUBSCRIPT | CFE.SUPERSCRIPT,
+            SUPERSCRIPT = CFM.SUBSCRIPT,
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.CHARFORMATW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.CHARFORMATW.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+internal partial class Interop
+{
+    internal static partial class Richedit
+    {
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public unsafe struct CHARFORMATW
+        {
+            private const int LF_FACESIZE = 32;
+
+            public uint cbSize;
+            public CFM dwMask;
+            public CFE dwEffects;
+            public int yHeight;
+            public int yOffset;
+            public int crTextColor;
+            public byte bCharSet;
+            public byte bPitchAndFamily;
+
+            private fixed char _szFaceName[LF_FACESIZE];
+            private Span<char> szFaceName
+            {
+                get { fixed (char* c = _szFaceName) { return new Span<char>(c, LF_FACESIZE); } }
+            }
+
+            public ReadOnlySpan<char> FaceName
+            {
+                get => szFaceName.SliceAtFirstNull();
+                set => SpanHelpers.CopyAndTerminate(value, szFaceName);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.SCF.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.SCF.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal partial class Interop
+{
+    internal static partial class Richedit
+    {
+        [Flags]
+        public enum SCF : uint
+        {
+            SELECTION = 0x0001,
+            WORD = 0x0002,
+            DEFAULT = 0x0000,
+            ALL = 0x0004,
+            USEUIRULES = 0x0008,
+            ASSOCIATEFONT = 0x0010,
+            NOKBUPDATE = 0x0020,
+            ASSOCIATEFONT2 = 0x0040,
+            SMARTFONT = 0x0080,
+            CHARREPFROMLCID = 0x0100,
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -588,48 +588,6 @@ namespace System.Windows.Forms
             public IntPtr lpData = IntPtr.Zero;
         }
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-        public unsafe struct CHARFORMATW
-        {
-            private const int LF_FACESIZE = 32;
-
-            public int cbSize;
-            public Richedit.CFM dwMask;
-            public Richedit.CFE dwEffects;
-            public int yHeight;
-            public int yOffset;
-            public int crTextColor;
-            public byte bCharSet;
-            public byte bPitchAndFamily;
-
-            private fixed char _szFaceName[LF_FACESIZE];
-            private Span<char> szFaceName
-            {
-                get { fixed (char* c = _szFaceName) { return new Span<char>(c, LF_FACESIZE); } }
-            }
-
-            public ReadOnlySpan<char> FaceName
-            {
-                get => szFaceName.SliceAtFirstNull();
-                set => SpanHelpers.CopyAndTerminate(value, szFaceName);
-            }
-        }
-
-        [StructLayout(LayoutKind.Sequential, Pack = 4)]
-        public class CHARFORMATA
-        {
-            public int cbSize = Marshal.SizeOf<CHARFORMATA>();
-            public Richedit.CFM dwMask;
-            public Richedit.CFE dwEffects;
-            public int yHeight;
-            public int yOffset;
-            public int crTextColor;
-            public byte bCharSet;
-            public byte bPitchAndFamily;
-            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
-            public byte[] szFaceName = new byte[32];
-        }
-
         [StructLayout(LayoutKind.Sequential, Pack = 4)]
         public class CHARFORMAT2A
         {

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -594,8 +594,8 @@ namespace System.Windows.Forms
             private const int LF_FACESIZE = 32;
 
             public int cbSize;
-            public int dwMask;
-            public int dwEffects;
+            public Richedit.CFM dwMask;
+            public Richedit.CFE dwEffects;
             public int yHeight;
             public int yOffset;
             public int crTextColor;
@@ -619,8 +619,8 @@ namespace System.Windows.Forms
         public class CHARFORMATA
         {
             public int cbSize = Marshal.SizeOf<CHARFORMATA>();
-            public int dwMask;
-            public int dwEffects;
+            public Richedit.CFM dwMask;
+            public Richedit.CFE dwEffects;
             public int yHeight;
             public int yOffset;
             public int crTextColor;
@@ -634,8 +634,8 @@ namespace System.Windows.Forms
         public class CHARFORMAT2A
         {
             public int cbSize = Marshal.SizeOf<CHARFORMAT2A>();
-            public int dwMask = 0;
-            public int dwEffects = 0;
+            public Richedit.CFM dwMask;
+            public Richedit.CFE dwEffects;
             public int yHeight = 0;
             public int yOffset = 0;
             public int crTextColor = 0;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -144,13 +144,7 @@ namespace System.Windows.Forms
 
         // For RichTextBox
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-        public static extern IntPtr SendMessage(HandleRef hWnd, User32.WM msg, IntPtr wParam, [In, Out, MarshalAs(UnmanagedType.LPStruct)] NativeMethods.CHARFORMATA lParam);
-
-        [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
         public static extern IntPtr SendMessage(HandleRef hWnd, User32.WM msg, IntPtr wParam, [In, Out, MarshalAs(UnmanagedType.LPStruct)] NativeMethods.CHARFORMAT2A lParam);
-
-        [DllImport(ExternDll.User32, CharSet = CharSet.Unicode)]
-        public static extern IntPtr SendMessage(HandleRef hWnd, int msg, int wParam, ref NativeMethods.CHARFORMATW lParam);
 
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
         public static extern int SendMessage(HandleRef hWnd, int msg, int wParam, [Out, MarshalAs(UnmanagedType.IUnknown)]out object editOle);

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -144,10 +144,10 @@ namespace System.Windows.Forms
 
         // For RichTextBox
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-        public static extern IntPtr SendMessage(HandleRef hWnd, int msg, int wParam, [In, Out, MarshalAs(UnmanagedType.LPStruct)] NativeMethods.CHARFORMATA lParam);
+        public static extern IntPtr SendMessage(HandleRef hWnd, User32.WM msg, IntPtr wParam, [In, Out, MarshalAs(UnmanagedType.LPStruct)] NativeMethods.CHARFORMATA lParam);
 
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-        public static extern IntPtr SendMessage(HandleRef hWnd, int msg, int wParam, [In, Out, MarshalAs(UnmanagedType.LPStruct)] NativeMethods.CHARFORMAT2A lParam);
+        public static extern IntPtr SendMessage(HandleRef hWnd, User32.WM msg, IntPtr wParam, [In, Out, MarshalAs(UnmanagedType.LPStruct)] NativeMethods.CHARFORMAT2A lParam);
 
         [DllImport(ExternDll.User32, CharSet = CharSet.Unicode)]
         public static extern IntPtr SendMessage(HandleRef hWnd, int msg, int wParam, ref NativeMethods.CHARFORMATW lParam);

--- a/src/System.Windows.Forms.Primitives/tests/Interop/Richedit/CHARFORMATWTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/Interop/Richedit/CHARFORMATWTests.cs
@@ -3,21 +3,22 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using static Interop.Richedit;
 
-namespace System.Windows.Forms.Tests.InteropTests
+namespace System.Windows.Forms.Tests.Interop.Richedit
 {
     public class CHARFORMATWTests : IClassFixture<ThreadExceptionFixture>
     {
         [Fact]
         public unsafe void CharFormat_Size()
         {
-            Assert.Equal(92, sizeof(NativeMethods.CHARFORMATW));
+            Assert.Equal(92, sizeof(CHARFORMATW));
         }
 
         [Fact]
         public unsafe void CharFormat_FaceName()
         {
-            NativeMethods.CHARFORMATW charFormat = default;
+            CHARFORMATW charFormat = default;
             charFormat.FaceName = "TwoFace";
             Assert.Equal("TwoFace", charFormat.FaceName.ToString());
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -986,7 +986,7 @@ namespace System.Windows.Forms
                 ForceHandleCreate();
                 NativeMethods.CHARFORMATA cf = GetCharFormat(true);
                 // if the effects member contains valid info
-                if ((cf.dwMask & RichTextBoxConstants.CFM_OFFSET) != 0)
+                if ((cf.dwMask & CFM.OFFSET) != 0)
                 {
                     selCharOffset = cf.yOffset;
                 }
@@ -1009,7 +1009,7 @@ namespace System.Windows.Forms
                 ForceHandleCreate();
                 NativeMethods.CHARFORMATA cf = new NativeMethods.CHARFORMATA
                 {
-                    dwMask = RichTextBoxConstants.CFM_OFFSET,
+                    dwMask = CFM.OFFSET,
                     yOffset = Pixel2Twip(IntPtr.Zero, value, false)
                 };
 
@@ -1018,7 +1018,7 @@ namespace System.Windows.Forms
                 // we would cache property values until the handle is created - but for this property,
                 // it's far more simple to just create the handle.
                 //
-                UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), RichEditMessages.EM_SETCHARFORMAT, RichTextBoxConstants.SCF_SELECTION, cf);
+                UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), (User32.WM)RichEditMessages.EM_SETCHARFORMAT, (IntPtr)SCF.SELECTION, cf);
             }
         }
 
@@ -1041,7 +1041,7 @@ namespace System.Windows.Forms
                 ForceHandleCreate();
                 NativeMethods.CHARFORMATA cf = GetCharFormat(true);
                 // if the effects member contains valid info
-                if ((cf.dwMask & RichTextBoxConstants.CFM_COLOR) != 0)
+                if ((cf.dwMask & CFM.COLOR) != 0)
                 {
                     selColor = ColorTranslator.FromOle(cf.crTextColor);
                 }
@@ -1052,12 +1052,12 @@ namespace System.Windows.Forms
             {
                 ForceHandleCreate();
                 NativeMethods.CHARFORMATA cf = GetCharFormat(true);
-                cf.dwMask = RichTextBoxConstants.CFM_COLOR;
+                cf.dwMask = CFM.COLOR;
                 cf.dwEffects = 0;
                 cf.crTextColor = ColorTranslator.ToWin32(value);
 
                 // set the format information
-                UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), RichEditMessages.EM_SETCHARFORMAT, RichTextBoxConstants.SCF_SELECTION, cf);
+                UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), (User32.WM)RichEditMessages.EM_SETCHARFORMAT, (IntPtr)SCF.SELECTION, cf);
             }
         }
 
@@ -1080,11 +1080,11 @@ namespace System.Windows.Forms
                 {
                     NativeMethods.CHARFORMAT2A cf2 = GetCharFormat2(true);
                     // If the effects member contains valid info
-                    if ((cf2.dwEffects & RichTextBoxConstants.CFE_AUTOBACKCOLOR) != 0)
+                    if ((cf2.dwEffects & CFE.AUTOBACKCOLOR) != 0)
                     {
                         selColor = BackColor;
                     }
-                    else if ((cf2.dwMask & RichTextBoxConstants.CFM_BACKCOLOR) != 0)
+                    else if ((cf2.dwMask & CFM.BACKCOLOR) != 0)
                     {
                         selColor = ColorTranslator.FromOle(cf2.crBackColor);
                     }
@@ -1105,15 +1105,15 @@ namespace System.Windows.Forms
                     NativeMethods.CHARFORMAT2A cf2 = new NativeMethods.CHARFORMAT2A();
                     if (value == Color.Empty)
                     {
-                        cf2.dwEffects = RichTextBoxConstants.CFE_AUTOBACKCOLOR;
+                        cf2.dwEffects = CFE.AUTOBACKCOLOR;
                     }
                     else
                     {
-                        cf2.dwMask = RichTextBoxConstants.CFM_BACKCOLOR;
+                        cf2.dwMask = CFM.BACKCOLOR;
                         cf2.crBackColor = ColorTranslator.ToWin32(value);
                     }
 
-                    UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), RichEditMessages.EM_SETCHARFORMAT, RichTextBoxConstants.SCF_SELECTION, cf2);
+                    UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), (User32.WM)RichEditMessages.EM_SETCHARFORMAT, (IntPtr)SCF.SELECTION, cf2);
                 }
             }
         }
@@ -1287,12 +1287,12 @@ namespace System.Windows.Forms
             get
             {
                 ForceHandleCreate();
-                return GetCharFormat(RichTextBoxConstants.CFM_PROTECTED, RichTextBoxConstants.CFM_PROTECTED) == RichTextBoxSelectionAttribute.All;
+                return GetCharFormat(CFM.PROTECTED, CFE.PROTECTED) == RichTextBoxSelectionAttribute.All;
             }
             set
             {
                 ForceHandleCreate();
-                SetCharFormat(RichTextBoxConstants.CFM_PROTECTED, value ? RichTextBoxConstants.CFE_PROTECTED : 0, RichTextBoxSelectionAttribute.All);
+                SetCharFormat(CFM.PROTECTED, value ? CFE.PROTECTED : 0, RichTextBoxSelectionAttribute.All);
             }
         }
 
@@ -2337,33 +2337,33 @@ namespace System.Windows.Forms
         private bool InternalSetForeColor(Color value)
         {
             NativeMethods.CHARFORMATA cf = GetCharFormat(false);
-            if ((cf.dwMask & RichTextBoxConstants.CFM_COLOR) != 0
+            if ((cf.dwMask & CFM.COLOR) != 0
                 && ColorTranslator.ToWin32(value) == cf.crTextColor)
             {
                 return true;
             }
 
-            cf.dwMask = RichTextBoxConstants.CFM_COLOR;
+            cf.dwMask = CFM.COLOR;
             cf.dwEffects = 0;
             cf.crTextColor = ColorTranslator.ToWin32(value);
-            return SetCharFormat(RichTextBoxConstants.SCF_ALL, cf);
+            return SetCharFormat(SCF.ALL, cf);
         }
 
         private NativeMethods.CHARFORMATA GetCharFormat(bool fSelection)
         {
             NativeMethods.CHARFORMATA cf = new NativeMethods.CHARFORMATA();
-            UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), RichEditMessages.EM_GETCHARFORMAT, fSelection ? RichTextBoxConstants.SCF_SELECTION : RichTextBoxConstants.SCF_DEFAULT, cf);
+            UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), (User32.WM)RichEditMessages.EM_GETCHARFORMAT, fSelection ? (IntPtr)SCF.SELECTION : (IntPtr)SCF.DEFAULT, cf);
             return cf;
         }
 
         private NativeMethods.CHARFORMAT2A GetCharFormat2(bool fSelection)
         {
             NativeMethods.CHARFORMAT2A cf2 = new NativeMethods.CHARFORMAT2A();
-            UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), RichEditMessages.EM_GETCHARFORMAT, fSelection ? RichTextBoxConstants.SCF_SELECTION : RichTextBoxConstants.SCF_DEFAULT, cf2);
+            UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), (User32.WM)RichEditMessages.EM_GETCHARFORMAT, fSelection ? (IntPtr)SCF.SELECTION : (IntPtr)SCF.DEFAULT, cf2);
             return cf2;
         }
 
-        private RichTextBoxSelectionAttribute GetCharFormat(int mask, int effect)
+        private RichTextBoxSelectionAttribute GetCharFormat(CFM mask, CFE effect)
         {
             RichTextBoxSelectionAttribute charFormat = RichTextBoxSelectionAttribute.None;
 
@@ -2390,7 +2390,7 @@ namespace System.Windows.Forms
             ForceHandleCreate();
 
             NativeMethods.CHARFORMATA cf = GetCharFormat(selectionOnly);
-            if ((cf.dwMask & RichTextBoxConstants.CFM_FACE) == 0)
+            if ((cf.dwMask & CFM.FACE) == 0)
             {
                 return null;
             }
@@ -2403,7 +2403,7 @@ namespace System.Windows.Forms
             }
 
             float fontSize = 13;
-            if ((cf.dwMask & RichTextBoxConstants.CFM_SIZE) != 0)
+            if ((cf.dwMask & CFM.SIZE) != 0)
             {
                 fontSize = (float)cf.yHeight / (float)20.0;
                 if (fontSize == 0 && cf.yHeight > 0)
@@ -2413,22 +2413,22 @@ namespace System.Windows.Forms
             }
 
             FontStyle style = FontStyle.Regular;
-            if ((cf.dwMask & RichTextBoxConstants.CFM_BOLD) != 0 && (cf.dwEffects & RichTextBoxConstants.CFE_BOLD) != 0)
+            if ((cf.dwMask & CFM.BOLD) != 0 && (cf.dwEffects & CFE.BOLD) != 0)
             {
                 style |= FontStyle.Bold;
             }
 
-            if ((cf.dwMask & RichTextBoxConstants.CFM_ITALIC) != 0 && (cf.dwEffects & RichTextBoxConstants.CFE_ITALIC) != 0)
+            if ((cf.dwMask & CFM.ITALIC) != 0 && (cf.dwEffects & CFE.ITALIC) != 0)
             {
                 style |= FontStyle.Italic;
             }
 
-            if ((cf.dwMask & RichTextBoxConstants.CFM_STRIKEOUT) != 0 && (cf.dwEffects & RichTextBoxConstants.CFE_STRIKEOUT) != 0)
+            if ((cf.dwMask & CFM.STRIKEOUT) != 0 && (cf.dwEffects & CFE.STRIKEOUT) != 0)
             {
                 style |= FontStyle.Strikeout;
             }
 
-            if ((cf.dwMask & RichTextBoxConstants.CFM_UNDERLINE) != 0 && (cf.dwEffects & RichTextBoxConstants.CFE_UNDERLINE) != 0)
+            if ((cf.dwMask & CFM.UNDERLINE) != 0 && (cf.dwEffects & CFE.UNDERLINE) != 0)
             {
                 style |= FontStyle.Underline;
             }
@@ -2935,7 +2935,7 @@ namespace System.Windows.Forms
             }
         }
 
-        private bool SetCharFormat(int mask, int effect, RichTextBoxSelectionAttribute charFormat)
+        private bool SetCharFormat(CFM mask, CFE effect, RichTextBoxSelectionAttribute charFormat)
         {
             // check to see if the control has been created
             if (IsHandleCreated)
@@ -2958,43 +2958,43 @@ namespace System.Windows.Forms
                 }
 
                 // set the format information
-                return IntPtr.Zero != UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), RichEditMessages.EM_SETCHARFORMAT, RichTextBoxConstants.SCF_SELECTION, cf);
+                return IntPtr.Zero != UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), (User32.WM)RichEditMessages.EM_SETCHARFORMAT, (IntPtr)SCF.SELECTION, cf);
             }
             return false;
         }
 
-        private bool SetCharFormat(int charRange, NativeMethods.CHARFORMATA cf)
+        private bool SetCharFormat(SCF charRange, NativeMethods.CHARFORMATA cf)
         {
-            return IntPtr.Zero != UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), RichEditMessages.EM_SETCHARFORMAT, charRange, cf);
+            return IntPtr.Zero != UnsafeNativeMethods.SendMessage(new HandleRef(this, Handle), (User32.WM)RichEditMessages.EM_SETCHARFORMAT, (IntPtr)charRange, cf);
         }
 
         private unsafe void SetCharFormatFont(bool selectionOnly, Font value)
         {
             ForceHandleCreate();
 
-            int dwMask = RichTextBoxConstants.CFM_FACE | RichTextBoxConstants.CFM_SIZE | RichTextBoxConstants.CFM_BOLD |
-                RichTextBoxConstants.CFM_ITALIC | RichTextBoxConstants.CFM_STRIKEOUT | RichTextBoxConstants.CFM_UNDERLINE |
-                RichTextBoxConstants.CFM_CHARSET;
+            CFM dwMask = CFM.FACE | CFM.SIZE | CFM.BOLD |
+                CFM.ITALIC | CFM.STRIKEOUT | CFM.UNDERLINE |
+                CFM.CHARSET;
 
-            int dwEffects = 0;
+            CFE dwEffects = 0;
             if (value.Bold)
             {
-                dwEffects |= RichTextBoxConstants.CFE_BOLD;
+                dwEffects |= CFE.BOLD;
             }
 
             if (value.Italic)
             {
-                dwEffects |= RichTextBoxConstants.CFE_ITALIC;
+                dwEffects |= CFE.ITALIC;
             }
 
             if (value.Strikeout)
             {
-                dwEffects |= RichTextBoxConstants.CFE_STRIKEOUT;
+                dwEffects |= CFE.STRIKEOUT;
             }
 
             if (value.Underline)
             {
-                dwEffects |= RichTextBoxConstants.CFE_UNDERLINE;
+                dwEffects |= CFE.UNDERLINE;
             }
 
             User32.LOGFONTW logFont = User32.LOGFONTW.FromFont(value);
@@ -3012,7 +3012,7 @@ namespace System.Windows.Forms
             UnsafeNativeMethods.SendMessage(
                 new HandleRef(this, Handle),
                 RichEditMessages.EM_SETCHARFORMAT,
-                selectionOnly ? RichTextBoxConstants.SCF_SELECTION : RichTextBoxConstants.SCF_ALL,
+                selectionOnly ? (int)SCF.SELECTION : (int)SCF.ALL,
                 ref charFormat);
         }
 
@@ -3567,7 +3567,7 @@ namespace System.Windows.Forms
                                     // Allow change of protected style
                                     //
                                     NativeMethods.CHARFORMATA charFormat = Marshal.PtrToStructure<NativeMethods.CHARFORMATA>(enprotected.lParam);
-                                    if ((charFormat.dwMask & RichTextBoxConstants.CFM_PROTECTED) != 0)
+                                    if ((charFormat.dwMask & CFM.PROTECTED) != 0)
                                     {
                                         m.Result = IntPtr.Zero;
                                         return;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxConstants.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxConstants.cs
@@ -208,41 +208,6 @@ namespace System.Windows.Forms
 
         internal const int cchTextLimitDefault = 32767;
 
-        /* CHARFORMAT masks */
-        internal const int CFM_BOLD = 0x00000001;
-        internal const int CFM_ITALIC = 0x00000002;
-        internal const int CFM_UNDERLINE = 0x00000004;
-        internal const int CFM_STRIKEOUT = 0x00000008;
-        internal const int CFM_PROTECTED = 0x00000010;
-        internal const int CFM_LINK = 0x00000020;   /* Exchange hyperlink extension */
-        internal const int CFM_SIZE = unchecked((int)0x80000000);
-        internal const int CFM_COLOR = 0x40000000;
-        internal const int CFM_FACE = 0x20000000;
-        internal const int CFM_OFFSET = 0x10000000;
-        internal const int CFM_CHARSET = 0x08000000;
-
-        /* CHARFORMAT effects */
-        internal const int CFE_BOLD = 0x0001;
-        internal const int CFE_ITALIC = 0x0002;
-        internal const int CFE_UNDERLINE = 0x0004;
-        internal const int CFE_STRIKEOUT = 0x0008;
-        internal const int CFE_PROTECTED = 0x0010;
-        internal const int CFE_LINK = 0x0020;
-        internal const int CFE_AUTOCOLOR = 0x40000000;   /* NOTE: this corresponds to */
-                                                         /* CFM_COLOR, which controls it */
-        internal const int yHeightCharPtsMost = 1638;
-
-        /* EM_SETCHARFORMAT wparam masks */
-        internal const int SCF_SELECTION = 0x0001;
-        internal const int SCF_WORD = 0x0002;
-        internal const int SCF_DEFAULT = 0x0000;   // set the default charformat or paraformat
-        internal const int SCF_ALL = 0x0004;   // not valid with SCF_SELECTION or SCF_WORD
-        internal const int SCF_USEUIRULES = 0x0008;   // modifier for SCF_SELECTION; says that
-                                                      // the format came from a toolbar, etc. and
-                                                      // therefore UI formatting rules should be
-                                                      // used instead of strictly formatting the
-                                                      // selection.
-
         /* stream formats */
         internal const int SF_TEXT = 0x0001;
         internal const int SF_RTF = 0x0002;
@@ -262,58 +227,6 @@ namespace System.Windows.Forms
 
         /* all paragraph measurements are in twips */
         internal const int lDefaultTab = 720;
-
-        /* New masks and effects -- a parenthesized asterisk indicates that
-           the data is stored by RichEdit2.0, but not displayed */
-
-        internal const int CFM_SMALLCAPS = 0x0040;                   /* (*)  */
-        internal const int CFM_ALLCAPS = 0x0080;                   /* (*)  */
-        internal const int CFM_HIDDEN = 0x0100;                   /* (*)  */
-        internal const int CFM_OUTLINE = 0x0200;                   /* (*)  */
-        internal const int CFM_SHADOW = 0x0400;                   /* (*)  */
-        internal const int CFM_EMBOSS = 0x0800;                   /* (*)  */
-        internal const int CFM_IMPRINT = 0x1000;                   /* (*)  */
-        internal const int CFM_DISABLED = 0x2000;
-        internal const int CFM_REVISED = 0x4000;
-
-        internal const int CFM_BACKCOLOR = 0x04000000;
-        internal const int CFM_LCID = 0x02000000;
-        internal const int CFM_UNDERLINETYPE = 0x00800000;               /* (*)  */
-        internal const int CFM_WEIGHT = 0x00400000;
-        internal const int CFM_SPACING = 0x00200000;               /* (*)  */
-        internal const int CFM_KERNING = 0x00100000;               /* (*)  */
-        internal const int CFM_STYLE = 0x00080000;               /* (*)  */
-        internal const int CFM_ANIMATION = 0x00040000;               /* (*)  */
-        internal const int CFM_REVAUTHOR = 0x00008000;
-
-        internal const int CFE_SUBSCRIPT = 0x00010000;               /* Superscript and subscript are */
-        internal const int CFE_SUPERSCRIPT = 0x00020000;               /*  mutually exclusive                   */
-
-        internal const int CFM_SUBSCRIPT = (CFE_SUBSCRIPT | CFE_SUPERSCRIPT);
-        internal const int CFM_SUPERSCRIPT = CFM_SUBSCRIPT;
-
-        internal const int CFE_SMALLCAPS = CFM_SMALLCAPS;
-        internal const int CFE_ALLCAPS = CFM_ALLCAPS;
-        internal const int CFE_HIDDEN = CFM_HIDDEN;
-        internal const int CFE_OUTLINE = CFM_OUTLINE;
-        internal const int CFE_SHADOW = CFM_SHADOW;
-        internal const int CFE_EMBOSS = CFM_EMBOSS;
-        internal const int CFE_IMPRINT = CFM_IMPRINT;
-        internal const int CFE_DISABLED = CFM_DISABLED;
-        internal const int CFE_REVISED = CFM_REVISED;
-
-        /* NOTE: CFE_AUTOCOLOR and CFE_AUTOBACKCOLOR correspond to CFM_COLOR and
-           CFM_BACKCOLOR, respectively, which control them */
-        internal const int CFE_AUTOBACKCOLOR = CFM_BACKCOLOR;
-
-        /* Underline types */
-        internal const int CFU_CF1UNDERLINE = 0xFF; /* map charformat's bit underline to CF2.*/
-        internal const int CFU_INVERT = 0xFE; /* For IME composition fake a selection.*/
-        internal const int CFU_UNDERLINEDOTTED = 0x4;  /* (*) displayed as ordinary underline      */
-        internal const int CFU_UNDERLINEDOUBLE = 0x3;  /* (*) displayed as ordinary underline      */
-        internal const int CFU_UNDERLINEWORD = 0x2;  /* (*) displayed as ordinary underline      */
-        internal const int CFU_UNDERLINE = 0x1;
-        internal const int CFU_UNDERLINENONE = 0;
 
         /*
          *  PARAFORMAT numbering options (values for wNumbering):


### PR DESCRIPTION
## Proposed Changes
- Cleanup CHARFORMATW

- Only cleanup necessary is to move the file and use enums instead of `int` fields

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2777)