### PR TITLE
Enable PublicApiAnalyzers by default

### DIFF
--- a/eng/ApiCompatibility/PublicApiAnalyzer.props
+++ b/eng/ApiCompatibility/PublicApiAnalyzer.props
@@ -1,7 +1,8 @@
 <Project>
 
-  <PropertyGroup Condition="'$(UsePublicApiAnalyzers)' == 'true' And '$(Configuration)' == 'Release'">
-    <WarningsAsErrors>$(WarningsAsErrors);RS0016;RS0017;RS0022;RS0024;RS0025;RS0026;RS0027</WarningsAsErrors>
+  <PropertyGroup Condition="'$(UsePublicApiAnalyzers)' == 'true'">
+    <!-- https://github.com/dotnet/roslyn-analyzers/blob/master/src/PublicApiAnalyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.md -->
+    <WarningsAsErrors>$(WarningsAsErrors);RS0016;RS0017;RS0022;RS0024;RS0025;RS0026;RS0027;RS0036;RS0037</WarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/eng/ApiCompatibility/PublicApiAnalyzer.targets
+++ b/eng/ApiCompatibility/PublicApiAnalyzer.targets
@@ -1,6 +1,6 @@
 <Project>
 
-  <ItemGroup Condition="'$(UsePublicApiAnalyzers)' == 'true' And '$(Configuration)' == 'Release'">
+  <ItemGroup Condition="'$(UsePublicApiAnalyzers)' == 'true'">
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="$(MicrosoftCodeAnalysisPublicApiAnalyzers)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -855,11 +855,11 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-            ///  Retreives the current display rectangle. The display rectangle
+        ///  Retreives the current display rectangle. The display rectangle
         ///  is the virtual display area that is used to layout components.
         ///  The position and dimensions of the Form's display rectangle
         ///  change during autoScroll.
-            /// </summary>
+        /// </summary>
         public override Rectangle DisplayRectangle
         {
             get
@@ -3534,6 +3534,7 @@ namespace System.Windows.Forms
         }
 
 #if DEBUG
+#pragma warning disable RS0016 // Add public types and members to the declared API
         protected override void OnInvalidated(InvalidateEventArgs e)
         {
             base.OnInvalidated(e);
@@ -3561,6 +3562,7 @@ namespace System.Windows.Forms
                 Debug.WriteLineIf(!(ParentInternal is PropertyGrid), "Invalidate called on: " + name + new StackTrace().ToString());
             }
         }
+#pragma warning restore RS0016 // Add public types and members to the declared API
 #endif
 
         protected override void OnHandleCreated(EventArgs e)


### PR DESCRIPTION
Initially the analyzer was enabled in Release mode only. However most of development happens in Debug mode, resolving build breaking warnings will require additional cycles.

To streamline the process enable the analyzer by default.

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2787)