### PR TITLE
Add CDCS, FDEOR, FDESRV, SIATTRIBFLAGS and SIGDN enums in Interop Shell32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.CDCS.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.CDCS.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal partial class Interop
+{
+    internal static partial class Shell32
+    {
+        public enum CDCS : uint
+        {
+            INACTIVE = 0,
+            ENABLED = 0x1,
+            VISIBLE = 0x2,
+            ENABLEDVISIBLE = 0x3
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.FDEOR.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.FDEOR.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal partial class Interop
+{
+    internal static partial class Shell32
+    {
+        public enum FDEOR : uint
+        {
+            DEFAULT = 0,
+            ACCEPT = 1,
+            REFUSE = 2
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.FDESVR.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.FDESVR.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal partial class Interop
+{
+    internal static partial class Shell32
+    {
+        public enum FDESVR : uint
+        {
+            DEFAULT = 0,
+            ACCEPT = 1,
+            REFUSE = 2
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.SIATTRIBFLAGS.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.SIATTRIBFLAGS.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal partial class Interop
+{
+    internal static partial class Shell32
+    {
+        public enum SIATTRIBFLAGS : uint
+        {
+            AND = 0x1,
+            OR = 0x2,
+            APPCOMPAT = 0x3,
+            MASK = 0x3,
+            ALLITEMS = 0x4000
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.SIGDN.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.SIGDN.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal partial class Interop
+{
+    internal static partial class Shell32
+    {
+        public enum SIGDN
+        {
+            NORMALDISPLAY = 0,
+            PARENTRELATIVEPARSING = unchecked((int)0x80018001),
+            DESKTOPABSOLUTEPARSING = unchecked((int)0x80028000),
+            PARENTRELATIVEEDITING = unchecked((int)0x80031001),
+            DESKTOPABSOLUTEEDITING = unchecked((int)0x8004c000),
+            FILESYSPATH = unchecked((int)0x80058000),
+            URL = unchecked((int)0x80068000),
+            PARENTRELATIVEFORADDRESSBAR = unchecked((int)0x8007c001),
+            PARENTRELATIVE = unchecked((int)0x80080001),
+            PARENTRELATIVEFORUI = unchecked((int)0x80094001)
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/FileDialog_Vista_Interop.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/FileDialog_Vista_Interop.cs
@@ -90,24 +90,6 @@ namespace System.Windows.Forms
             int Show([In] IntPtr parent);
         }
 
-        public enum SIATTRIBFLAGS
-        {
-            /// <summary>
-            ///  Multiple items and the attributes together.
-            /// </summary>
-            SIATTRIBFLAGS_AND = 0x00000001,
-
-            /// <summary>
-            ///  Multiple items or the attributes together.
-            /// </summary>
-            SIATTRIBFLAGS_OR = 0x00000002,
-
-            /// <summary>
-            ///  Call GetAttributes directly on the ShellFolder for multiple attributes
-            /// </summary>
-            SIATTRIBFLAGS_APPCOMPAT = 0x00000003
-        }
-
         [ComImport]
         [Guid(IIDGuid.IShellItemArray)]
         [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
@@ -338,11 +320,11 @@ namespace System.Windows.Forms
 
             void OnSelectionChange([In, MarshalAs(UnmanagedType.Interface)] IFileDialog pfd);
 
-            void OnShareViolation([In, MarshalAs(UnmanagedType.Interface)] IFileDialog pfd, [In, MarshalAs(UnmanagedType.Interface)] IShellItem psi, out FDE_SHAREVIOLATION_RESPONSE pResponse);
+            void OnShareViolation([In, MarshalAs(UnmanagedType.Interface)] IFileDialog pfd, [In, MarshalAs(UnmanagedType.Interface)] IShellItem psi, out FDESVR pResponse);
 
             void OnTypeChange([In, MarshalAs(UnmanagedType.Interface)] IFileDialog pfd);
 
-            void OnOverwrite([In, MarshalAs(UnmanagedType.Interface)] IFileDialog pfd, [In, MarshalAs(UnmanagedType.Interface)] IShellItem psi, out FDE_OVERWRITE_RESPONSE pResponse);
+            void OnOverwrite([In, MarshalAs(UnmanagedType.Interface)] IFileDialog pfd, [In, MarshalAs(UnmanagedType.Interface)] IShellItem psi, out FDEOR pResponse);
         }
 
         [ComImport,
@@ -361,8 +343,8 @@ namespace System.Windows.Forms
             void AddSeparator([In] int dwIDCtl);
             void AddText([In] int dwIDCtl, [In, MarshalAs(UnmanagedType.LPWStr)] string pszText);
             void SetControlLabel([In] int dwIDCtl, [In, MarshalAs(UnmanagedType.LPWStr)] string pszLabel);
-            void GetControlState([In] int dwIDCtl, [Out] out CDCONTROLSTATE pdwState);
-            void SetControlState([In] int dwIDCtl, [In] CDCONTROLSTATE dwState);
+            void GetControlState([In] int dwIDCtl, [Out] out CDCS pdwState);
+            void SetControlState([In] int dwIDCtl, [In] CDCS dwState);
             void GetEditBoxText([In] int dwIDCtl, [Out] IntPtr ppszText);
             void SetEditBoxText([In] int dwIDCtl, [In, MarshalAs(UnmanagedType.LPWStr)] string pszText);
             void GetCheckButtonState([In] int dwIDCtl, [Out] out bool pbChecked);
@@ -370,8 +352,8 @@ namespace System.Windows.Forms
             void AddControlItem([In] int dwIDCtl, [In] int dwIDItem, [In, MarshalAs(UnmanagedType.LPWStr)] string pszLabel);
             void RemoveControlItem([In] int dwIDCtl, [In] int dwIDItem);
             void RemoveAllControlItems([In] int dwIDCtl);
-            void GetControlItemState([In] int dwIDCtl, [In] int dwIDItem, [Out] out CDCONTROLSTATE pdwState);
-            void SetControlItemState([In] int dwIDCtl, [In] int dwIDItem, [In] CDCONTROLSTATE dwState);
+            void GetControlItemState([In] int dwIDCtl, [In] int dwIDItem, [Out] out CDCS pdwState);
+            void SetControlItemState([In] int dwIDCtl, [In] int dwIDItem, [In] CDCS dwState);
             void GetSelectedControlItem([In] int dwIDCtl, [Out] out int pdwIDItem);
             void SetSelectedControlItem([In] int dwIDCtl, [In] int dwIDItem); // Not valid for OpenDropDown
             void StartVisualGroup([In] int dwIDCtl, [In, MarshalAs(UnmanagedType.LPWStr)] string pszLabel);
@@ -395,19 +377,6 @@ namespace System.Windows.Forms
             void Compare([In, MarshalAs(UnmanagedType.Interface)] IShellItem psi, [In] uint hint, out int piOrder);
         }
 
-        public enum SIGDN : uint
-        {
-            SIGDN_NORMALDISPLAY = 0x00000000,           // SHGDN_NORMAL
-            SIGDN_PARENTRELATIVEPARSING = 0x80018001,   // SHGDN_INFOLDER | SHGDN_FORPARSING
-            SIGDN_DESKTOPABSOLUTEPARSING = 0x80028000,  // SHGDN_FORPARSING
-            SIGDN_PARENTRELATIVEEDITING = 0x80031001,   // SHGDN_INFOLDER | SHGDN_FOREDITING
-            SIGDN_DESKTOPABSOLUTEEDITING = 0x8004c000,  // SHGDN_FORPARSING | SHGDN_FORADDRESSBAR
-            SIGDN_FILESYSPATH = 0x80058000,             // SHGDN_FORPARSING
-            SIGDN_URL = 0x80068000,                     // SHGDN_FORPARSING
-            SIGDN_PARENTRELATIVEFORADDRESSBAR = 0x8007c001,     // SHGDN_INFOLDER | SHGDN_FORPARSING | SHGDN_FORADDRESSBAR
-            SIGDN_PARENTRELATIVE = 0x80080001           // SHGDN_INFOLDER
-        }
-
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto, Pack = 4)]
         public struct COMDLG_FILTERSPEC
         {
@@ -415,27 +384,6 @@ namespace System.Windows.Forms
             public string pszName;
             [MarshalAs(UnmanagedType.LPWStr)]
             public string pszSpec;
-        }
-
-        public enum CDCONTROLSTATE
-        {
-            CDCS_INACTIVE = 0x00000000,
-            CDCS_ENABLED = 0x00000001,
-            CDCS_VISIBLE = 0x00000002
-        }
-
-        public enum FDE_SHAREVIOLATION_RESPONSE
-        {
-            FDESVR_DEFAULT = 0x00000000,
-            FDESVR_ACCEPT = 0x00000001,
-            FDESVR_REFUSE = 0x00000002
-        }
-
-        public enum FDE_OVERWRITE_RESPONSE
-        {
-            FDEOR_DEFAULT = 0x00000000,
-            FDEOR_ACCEPT = 0x00000001,
-            FDEOR_REFUSE = 0x00000002
         }
 
         [DllImport(ExternDll.Shell32, CharSet = CharSet.Unicode)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog_Vista.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog_Vista.cs
@@ -219,18 +219,18 @@ namespace System.Windows.Forms
             {
             }
 
-            public void OnShareViolation(FileDialogNative.IFileDialog pfd, FileDialogNative.IShellItem psi, out FileDialogNative.FDE_SHAREVIOLATION_RESPONSE pResponse)
+            public void OnShareViolation(FileDialogNative.IFileDialog pfd, FileDialogNative.IShellItem psi, out FDESVR pResponse)
             {
-                pResponse = FileDialogNative.FDE_SHAREVIOLATION_RESPONSE.FDESVR_DEFAULT;
+                pResponse = FDESVR.DEFAULT;
             }
 
             public void OnTypeChange(FileDialogNative.IFileDialog pfd)
             {
             }
 
-            public void OnOverwrite(FileDialogNative.IFileDialog pfd, FileDialogNative.IShellItem psi, out FileDialogNative.FDE_OVERWRITE_RESPONSE pResponse)
+            public void OnOverwrite(FileDialogNative.IFileDialog pfd, FileDialogNative.IShellItem psi, out FDEOR pResponse)
             {
-                pResponse = FileDialogNative.FDE_OVERWRITE_RESPONSE.FDEOR_DEFAULT;
+                pResponse = FDEOR.DEFAULT;
             }
         }
 
@@ -273,7 +273,7 @@ namespace System.Windows.Forms
 
         private protected static string GetFilePathFromShellItem(FileDialogNative.IShellItem item)
         {
-            item.GetDisplayName(FileDialogNative.SIGDN.SIGDN_DESKTOPABSOLUTEPARSING, out string filename);
+            item.GetDisplayName(SIGDN.DESKTOPABSOLUTEPARSING, out string filename);
             return filename;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
@@ -249,15 +249,15 @@ namespace System.Windows.Forms
         private void GetResult(FileDialogNative.IFileDialog dialog)
         {
             dialog.GetResult(out FileDialogNative.IShellItem item);
-            item.GetDisplayName(FileDialogNative.SIGDN.SIGDN_FILESYSPATH, out _selectedPath);
+            item.GetDisplayName(SIGDN.FILESYSPATH, out _selectedPath);
         }
 
         private unsafe bool RunDialogOld(IntPtr hWndOwner)
         {
-            Shell32.SHGetSpecialFolderLocation(hWndOwner, (int)_rootFolder, out CoTaskMemSafeHandle listHandle);
+            SHGetSpecialFolderLocation(hWndOwner, (int)_rootFolder, out CoTaskMemSafeHandle listHandle);
             if (listHandle.IsInvalid)
             {
-                Shell32.SHGetSpecialFolderLocation(hWndOwner, (int)Environment.SpecialFolder.Desktop, out listHandle);
+                SHGetSpecialFolderLocation(hWndOwner, (int)Environment.SpecialFolder.Desktop, out listHandle);
                 if (listHandle.IsInvalid)
                 {
                     throw new InvalidOperationException(SR.FolderBrowserDialogNoRootFolder);
@@ -266,10 +266,10 @@ namespace System.Windows.Forms
 
             using (listHandle)
             {
-                uint mergedOptions = Shell32.BrowseInfoFlags.BIF_NEWDIALOGSTYLE;
+                uint mergedOptions = BrowseInfoFlags.BIF_NEWDIALOGSTYLE;
                 if (!ShowNewFolderButton)
                 {
-                    mergedOptions |= Shell32.BrowseInfoFlags.BIF_NONEWFOLDERBUTTON;
+                    mergedOptions |= BrowseInfoFlags.BIF_NONEWFOLDERBUTTON;
                 }
 
                 // The SHBrowserForFolder dialog is OLE/COM based, and documented as only being safe to use under the STA
@@ -281,13 +281,13 @@ namespace System.Windows.Forms
                     throw new Threading.ThreadStateException(string.Format(SR.DebuggingExceptionOnly, SR.ThreadMustBeSTA));
                 }
 
-                var callback = new Shell32.BrowseCallbackProc(FolderBrowserDialog_BrowseCallbackProc);
+                var callback = new BrowseCallbackProc(FolderBrowserDialog_BrowseCallbackProc);
                 char[] displayName = ArrayPool<char>.Shared.Rent(Kernel32.MAX_PATH + 1);
                 try
                 {
                     fixed (char* pDisplayName = displayName)
                     {
-                        var bi = new Shell32.BROWSEINFO
+                        var bi = new BROWSEINFO
                         {
                             pidlRoot = listHandle,
                             hwndOwner = hWndOwner,
@@ -300,7 +300,7 @@ namespace System.Windows.Forms
                         };
 
                         // Show the dialog
-                        using (CoTaskMemSafeHandle browseHandle = Shell32.SHBrowseForFolderW(ref bi))
+                        using (CoTaskMemSafeHandle browseHandle = SHBrowseForFolderW(ref bi))
                         {
                             if (browseHandle.IsInvalid)
                             {
@@ -308,7 +308,7 @@ namespace System.Windows.Forms
                             }
 
                             // Retrieve the path from the IDList.
-                            Shell32.SHGetPathFromIDListLongPath(browseHandle.DangerousGetHandle(), out _selectedPath);
+                            SHGetPathFromIDListLongPath(browseHandle.DangerousGetHandle(), out _selectedPath);
                             GC.KeepAlive(callback);
                             return true;
                         }
@@ -343,7 +343,7 @@ namespace System.Windows.Forms
                     if (selectedPidl != IntPtr.Zero)
                     {
                         // Try to retrieve the path from the IDList
-                        bool isFileSystemFolder = Shell32.SHGetPathFromIDListLongPath(selectedPidl, out _);
+                        bool isFileSystemFolder = SHGetPathFromIDListLongPath(selectedPidl, out _);
                         User32.SendMessageW(hwnd, (User32.WM)BFFM.ENABLEOK, IntPtr.Zero, PARAM.FromBool(isFileSystemFolder));
                     }
                     break;


### PR DESCRIPTION
## Proposed changes

- Add CDCS, FDEOR, FDESRV, SIATTRIBFLAGS and SIGDN enums in Interop Shell32.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2810)