### PR TITLE
Fix NullReferenceExceptions in Control.ControlCollection with a null owner

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlCollection.cs
@@ -29,7 +29,7 @@ namespace System.Windows.Forms
 
             public ControlCollection(Control owner)
             {
-                Owner = owner;
+                Owner = owner ?? throw new ArgumentNullException(nameof(owner));
             }
 
             /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutControlCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutControlCollection.cs
@@ -16,9 +16,9 @@ namespace System.Windows.Forms
     [DesignerSerializer("System.Windows.Forms.Design.TableLayoutControlCollectionCodeDomSerializer, " + AssemblyRef.SystemDesign, "System.ComponentModel.Design.Serialization.CodeDomSerializer, " + AssemblyRef.SystemDesign)]
     public class TableLayoutControlCollection : Control.ControlCollection
     {
-        public TableLayoutControlCollection(TableLayoutPanel container) : base(container)
+        public TableLayoutControlCollection(TableLayoutPanel container) : base(container ?? throw new ArgumentNullException(nameof(container)))
         {
-            Container = container ?? throw new ArgumentNullException(nameof(container));
+            Container = container;
         }
 
         //the container of this TableLayoutControlCollection

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.ControlCollection.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.ControlCollection.cs
@@ -18,20 +18,20 @@ namespace System.Windows.Forms.Tests
 {
     public class ControlControlCollectionTests : IClassFixture<ThreadExceptionFixture>
     {
-        public static IEnumerable<object[]> Ctor_Control_TestData()
+        [WinFormsFact]
+        public void ControlCollection_Ctor_Control()
         {
-            yield return new object[] { null };
-            yield return new object[] { new Control() };
-        }
-
-        [WinFormsTheory]
-        [MemberData(nameof(Ctor_Control_TestData))]
-        public void Ctor_Control(Control owner)
-        {
+            using var owner = new Control();
             var collection = new Control.ControlCollection(owner);
             Assert.Empty(collection);
             Assert.False(collection.IsReadOnly);
             Assert.Same(owner, collection.Owner);
+        }
+
+        [WinFormsFact]
+        public void ControlCollection_Ctor_NullOwner_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("owner", () => new Control.ControlCollection(null));
         }
 
         [WinFormsFact]
@@ -1103,14 +1103,6 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ControlCollection_Add_NullOwner_ThrowsNullReferenceException()
-        {
-            var collection = new Control.ControlCollection(null);
-            using var control = new Control();
-            Assert.Throws<NullReferenceException>(() => collection.Add(control));
-        }
-
-        [WinFormsFact]
         public void ControlCollection_Add_TopLevelValue_ThrowsArgumentException()
         {
             using var owner = new Control();
@@ -1270,14 +1262,6 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ControlCollection_AddRange_NullOwner_ThrowsNullReferenceException()
-        {
-            using var control = new Control();
-            var collection = new Control.ControlCollection(null);
-            Assert.Throws<NullReferenceException>(() => collection.AddRange(new Control[] { control }));
-        }
-
-        [WinFormsFact]
         public void ControlCollection_Clear_Invoke_Success()
         {
             using var owner = new Control();
@@ -1326,13 +1310,6 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ControlCollection_Clear_NullOwner_ThrowsNullReferenceException()
-        {
-            var collection = new Control.ControlCollection(null);
-            Assert.Throws<NullReferenceException>(() => collection.Clear());
-        }
-
-        [WinFormsFact]
         public void ControlCollection_Clone_Invoke_Success()
         {
             using var owner = new Control();
@@ -1372,13 +1349,6 @@ namespace System.Windows.Forms.Tests
             {
                 owner.Layout -= parentHandler;
             }
-        }
-
-        [WinFormsFact]
-        public void ControlCollection_Clone_NullOwner_ThrowsNullReferenceException()
-        {
-            ICloneable collection = new Control.ControlCollection(null);
-            Assert.Throws<NullReferenceException>(() => collection.Clone());
         }
 
         [WinFormsFact]
@@ -2803,14 +2773,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(2, parentChangedCallCount);
             Assert.Equal(2, parentLayoutCallCount);
             Assert.Equal(1, callCount);
-        }
-
-        [WinFormsFact]
-        public void ControlCollection_Remove_InvokeNullOwner_ThrowsNullReferenceException()
-        {
-            var collection = new Control.ControlCollection(null);
-            using var value = new Control();
-            Assert.Throws<NullReferenceException>(() => collection.Remove(value));
         }
 
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.ControlCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.ControlCollectionTests.cs
@@ -16,20 +16,20 @@ namespace System.Windows.Forms.Tests
 
     public class TabControlControlCollectionTests : IClassFixture<ThreadExceptionFixture>
     {
-        public static IEnumerable<object[]> Ctor_TabControl_TestData()
+        [WinFormsFact]
+        public void TabControlControlCollection_Ctor_TabControl()
         {
-            yield return new object[] { null };
-            yield return new object[] { new TabControl() };
-        }
-
-        [WinFormsTheory]
-        [MemberData(nameof(Ctor_TabControl_TestData))]
-        public void TabControlControlCollection_Ctor_TabControl(TabControl owner)
-        {
+            using var owner = new TabControl();
             var collection = new TabControl.ControlCollection(owner);
             Assert.Empty(collection);
             Assert.False(collection.IsReadOnly);
             Assert.Same(owner, collection.Owner);
+        }
+
+        [WinFormsFact]
+        public void TabControlControlCollection_Ctor_NullOwner_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("owner", () => new TabControl.ControlCollection(null));
         }
 
         public static IEnumerable<object[]> Add_TestData()
@@ -887,14 +887,6 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void TabControlControlCollection_Add_NullOwner_ThrowsNullReferenceException()
-        {
-            var collection = new TabControl.ControlCollection(null);
-            using var value = new TabPage();
-            Assert.Throws<NullReferenceException>(() => collection.Add(value));
-        }
-
-        [WinFormsFact]
         public void TabControlControlCollection_Remove_InvokeValueWithoutHandleOwnerWithoutHandle_Success()
         {
             using var owner = new TabControl
@@ -1561,14 +1553,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(int.MaxValue, item.cchTextMax);
             Assert.Empty(new string(item.pszText));
             Assert.Equal(-1, item.iImage);
-        }
-
-        [WinFormsFact]
-        public void TabControlControlCollection_Remove_NullOwner_ThrowsNullReferenceException()
-        {
-            var collection = new TabControl.ControlCollection(null);
-            using var value = new Control();
-            Assert.Throws<NullReferenceException>(() => collection.Remove(value));
         }
 
         private class NullTextTabPage : TabPage

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPageTests.TabPageControlCollection.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPageTests.TabPageControlCollection.cs
@@ -10,20 +10,20 @@ namespace System.Windows.Forms.Tests
 {
     public class TabPageTabPageControlCollectionTests : IClassFixture<ThreadExceptionFixture>
     {
-        public static IEnumerable<object[]> Ctor_TabPage_TestData()
+        [WinFormsFact]
+        public void TabPageControlCollection_Ctor_TabPage()
         {
-            yield return new object[] { null };
-            yield return new object[] { new TabPage() };
-        }
-
-        [WinFormsTheory]
-        [MemberData(nameof(Ctor_TabPage_TestData))]
-        public void TabPageControlCollection_Ctor_TabPage(TabPage owner)
-        {
+            using var owner = new TabPage();
             var collection = new TabPage.TabPageControlCollection(owner);
             Assert.Empty(collection);
             Assert.False(collection.IsReadOnly);
             Assert.Same(owner, collection.Owner);
+        }
+
+        [WinFormsFact]
+        public void TabPageControlCollection_NullOwner_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("owner", () => new TabPage.TabPageControlCollection(null));
         }
 
         [WinFormsFact]


### PR DESCRIPTION
NREs are thrown when adding/using the collection, so just validate this upfront.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2819)