### PR TITLE
Add missing ProgressBar AccessibleName

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -4703,6 +4703,9 @@ Stack trace where the illegal operation occurred was:
   <data name="ProfessionalColorsToolStripPanelGradientEndDescr" xml:space="preserve">
     <value>End color of the gradient used in the ToolStripPanel.</value>
   </data>
+  <data name="ProgressBarDefaultAccessibleName" xml:space="preserve">
+    <value>ProgressBar</value>
+  </data>
   <data name="ProgressBarIncrementMarqueeException" xml:space="preserve">
     <value>Increment should not be called if the style is Marquee.</value>
   </data>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -7911,6 +7911,11 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">Koncová barva přechodu použitá v ovládacím prvku ToolStripPanel</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProgressBarDefaultAccessibleName">
+        <source>ProgressBar</source>
+        <target state="new">ProgressBar</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProgressBarIncrementMarqueeException">
         <source>Increment should not be called if the style is Marquee.</source>
         <target state="translated">Pokud je nastaven styl Marquee, neměla by být volána metoda Increment.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -7911,6 +7911,11 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">Die im ToolStripPanel verwendete Endfarbe des Farbverlaufs.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProgressBarDefaultAccessibleName">
+        <source>ProgressBar</source>
+        <target state="new">ProgressBar</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProgressBarIncrementMarqueeException">
         <source>Increment should not be called if the style is Marquee.</source>
         <target state="translated">"Increment" darf nicht aufgerufen werden, wenn "Marquee" als Stil verwendet wird.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -7911,6 +7911,11 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">Color final del gradiente que se utiliza en ToolStripPanel.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProgressBarDefaultAccessibleName">
+        <source>ProgressBar</source>
+        <target state="new">ProgressBar</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProgressBarIncrementMarqueeException">
         <source>Increment should not be called if the style is Marquee.</source>
         <target state="translated">No se debería llamar a Increment si el estilo es de marquesina.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -7911,6 +7911,11 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">Couleur de fin du dégradé utilisé dans le ToolStripPanel.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProgressBarDefaultAccessibleName">
+        <source>ProgressBar</source>
+        <target state="new">ProgressBar</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProgressBarIncrementMarqueeException">
         <source>Increment should not be called if the style is Marquee.</source>
         <target state="translated">L'incrément ne doit pas être appelé si le style est Texte défilant.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -7911,6 +7911,11 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">Colore finale della sfumatura da utilizzare in ToolStripPanel.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProgressBarDefaultAccessibleName">
+        <source>ProgressBar</source>
+        <target state="new">ProgressBar</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProgressBarIncrementMarqueeException">
         <source>Increment should not be called if the style is Marquee.</source>
         <target state="translated">Non chiamare Increment se lo stile è Marquee.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -7911,6 +7911,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">ToolStripPanel で使用されるグラデーションの終わりの色です。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProgressBarDefaultAccessibleName">
+        <source>ProgressBar</source>
+        <target state="new">ProgressBar</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProgressBarIncrementMarqueeException">
         <source>Increment should not be called if the style is Marquee.</source>
         <target state="translated">スタイルに Marquee が指定されている場合、インクリメントを呼び出さないでください。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -7911,6 +7911,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">ToolStripPanel에 사용하는 그라데이션의 끝 색입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProgressBarDefaultAccessibleName">
+        <source>ProgressBar</source>
+        <target state="new">ProgressBar</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProgressBarIncrementMarqueeException">
         <source>Increment should not be called if the style is Marquee.</source>
         <target state="translated">스타일이 움직이는 텍스트인 경우 Increment를 호출하면 안 됩니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -7911,6 +7911,11 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">Końcowy kolor gradientu używany w elemencie ToolStripPanel.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProgressBarDefaultAccessibleName">
+        <source>ProgressBar</source>
+        <target state="new">ProgressBar</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProgressBarIncrementMarqueeException">
         <source>Increment should not be called if the style is Marquee.</source>
         <target state="translated">Element Increment nie powinien zostać wywołany, jeżeli styl jest ustawiony na Marquee.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -7911,6 +7911,11 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">A cor final do gradiente usada em ToolStripPanel.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProgressBarDefaultAccessibleName">
+        <source>ProgressBar</source>
+        <target state="new">ProgressBar</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProgressBarIncrementMarqueeException">
         <source>Increment should not be called if the style is Marquee.</source>
         <target state="translated">Increment não deverá ser chamado se o estilo for Marquee.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -7912,6 +7912,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">Последний цвет градиента, используемый в ToolStripPanel.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProgressBarDefaultAccessibleName">
+        <source>ProgressBar</source>
+        <target state="new">ProgressBar</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProgressBarIncrementMarqueeException">
         <source>Increment should not be called if the style is Marquee.</source>
         <target state="translated">Нельзя вызывать Increment при использовании стиля Marquee.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -7911,6 +7911,11 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">ToolStripPanel'de kullanılan geçişin bitiş rengi.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProgressBarDefaultAccessibleName">
+        <source>ProgressBar</source>
+        <target state="new">ProgressBar</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProgressBarIncrementMarqueeException">
         <source>Increment should not be called if the style is Marquee.</source>
         <target state="translated">Stil Marquee ise Increment çağrılmamalıdır.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -7911,6 +7911,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">在 ToolStripPanel 中使用的渐变的结束颜色。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProgressBarDefaultAccessibleName">
+        <source>ProgressBar</source>
+        <target state="new">ProgressBar</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProgressBarIncrementMarqueeException">
         <source>Increment should not be called if the style is Marquee.</source>
         <target state="translated">如果样式为“Marquee”，则不应调用 Increment。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -7911,6 +7911,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">ToolStripPanel 中所使用漸層的結束色彩。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProgressBarDefaultAccessibleName">
+        <source>ProgressBar</source>
+        <target state="new">ProgressBar</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProgressBarIncrementMarqueeException">
         <source>Increment should not be called if the style is Marquee.</source>
         <target state="translated">使用跑馬燈樣式時不能呼叫 Increment。</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ProgressBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ProgressBar.cs
@@ -716,6 +716,12 @@ namespace System.Windows.Forms
             {
             }
 
+            public override string Name
+            {
+                get => base.Name ?? SR.ProgressBarDefaultAccessibleName;
+                set => base.Name = value;
+            }
+
             private ProgressBar OwningProgressBar => Owner as ProgressBar;
 
             internal override bool IsIAccessibleExSupported() => true;

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ProgressBarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ProgressBarAccessibleObjectTests.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Accessibility;
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    public class ProgressBarAccessibleObject : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsFact]
+        public void ProgressBarAccessibilityObject_Properties_ReturnsExpected()
+        {
+            using var ownerControl = new ProgressBar
+            {
+                Value = 5,
+            };
+            Control.ControlAccessibleObject accessibilityObject = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(ownerControl.AccessibilityObject);
+            Assert.Equal(ownerControl.ClientSize, accessibilityObject.Bounds.Size);
+            Assert.Null(accessibilityObject.DefaultAction);
+            Assert.Null(accessibilityObject.Description);
+            Assert.Equal(ownerControl.Handle, accessibilityObject.Handle);
+            Assert.Null(accessibilityObject.Help);
+            Assert.Null(accessibilityObject.KeyboardShortcut);
+            Assert.Equal(SR.ProgressBarDefaultAccessibleName, accessibilityObject.Name);
+            Assert.Equal(AccessibleRole.ProgressBar, accessibilityObject.Role);
+            Assert.Same(ownerControl, accessibilityObject.Owner);
+            Assert.NotNull(accessibilityObject.Parent);
+            Assert.Equal(AccessibleStates.ReadOnly | AccessibleStates.Focusable, accessibilityObject.State);
+            Assert.Equal("5%", accessibilityObject.Value);
+        }
+
+        [WinFormsTheory]
+        [InlineData("100%")]
+        [InlineData("0%")]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("INVALID")]
+        public void ProgressBarAccessibilityObject_Value_Set_GetReturnsExpected(string value)
+        {
+            using var ownerControl = new ProgressBar();
+            Control.ControlAccessibleObject accessibilityObject = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(ownerControl.AccessibilityObject);
+            accessibilityObject.Value = value;
+            Assert.Equal("0%", accessibilityObject.Value);
+            Assert.Equal(0, ownerControl.Value);
+
+            // Set same.
+            accessibilityObject.Value = value;
+            Assert.Equal("0%", accessibilityObject.Value);
+            Assert.Equal(0, ownerControl.Value);
+        }
+
+        [WinFormsFact]
+        public void ProgressBarAccessibilityObject_GetChildCount_ReturnsExpected()
+        {
+            using var ownerControl = new ProgressBar
+            {
+                Value = 5
+            };
+            Control.ControlAccessibleObject accessibilityObject = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(ownerControl.AccessibilityObject);
+            IAccessible iAccessible = accessibilityObject;
+            Assert.Equal(0, iAccessible.accChildCount);
+            Assert.Equal(-1, accessibilityObject.GetChildCount());
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes
- Fix missing name: The Name property of a focusable element must not be null. [Section 508 502.3.1](https://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-ict-refresh/final-rule/single-file-version#502-interoperability-assistive-technology)

![image](https://user-images.githubusercontent.com/1275900/74041638-ef42cb00-49bd-11ea-993a-e130c20c152a.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2821)