### PR TITLE
Use BOOL instead of bool in some DllImports in Interop

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MultilineStringEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MultilineStringEditor.cs
@@ -476,7 +476,7 @@ namespace System.ComponentModel.Design
             {
                 Debug.WriteLineIf(RichTextDbg.TraceVerbose, "IRichTextBoxOleCallback::GetNewStorage");
 
-                Ole32.ILockBytes pLockBytes = Ole32.CreateILockBytesOnHGlobal(IntPtr.Zero, true);
+                Ole32.ILockBytes pLockBytes = Ole32.CreateILockBytesOnHGlobal(IntPtr.Zero, BOOL.TRUE);
                 Debug.Assert(pLockBytes != null, "pLockBytes is NULL!");
 
                 storage = Ole32.StgCreateDocfileOnILockBytes(

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.DeleteDC.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.DeleteDC.cs
@@ -10,6 +10,6 @@ internal static partial class Interop
     internal static partial class Gdi32
     {
         [DllImport(Libraries.Gdi32, SetLastError = true, ExactSpelling = true)]
-        public static extern bool DeleteDC(IntPtr hDC);
+        public static extern BOOL DeleteDC(IntPtr hDC);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.ExtTextOutW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.ExtTextOutW.cs
@@ -10,6 +10,6 @@ internal static partial class Interop
     internal static partial class Gdi32
     {
         [DllImport(Libraries.Gdi32, ExactSpelling = false, CharSet = CharSet.Unicode)]
-        public unsafe static extern bool ExtTextOutW(IntPtr hdc, int x, int y, ETO options, ref RECT lprect, string lpString, int c, int* lpDx);
+        public unsafe static extern BOOL ExtTextOutW(IntPtr hdc, int x, int y, ETO options, ref RECT lprect, string lpString, int c, int* lpDx);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.OffsetViewportOrgEx.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.OffsetViewportOrgEx.cs
@@ -11,11 +11,11 @@ internal static partial class Interop
     internal static partial class Gdi32
     {
         [DllImport(Libraries.Gdi32, ExactSpelling = true)]
-        public static extern bool OffsetViewportOrgEx(IntPtr hdc, int x, int y, ref Point lppt);
+        public static extern BOOL OffsetViewportOrgEx(IntPtr hdc, int x, int y, ref Point lppt);
 
-        public static bool OffsetViewportOrgEx(HandleRef hdc, int x, int y, ref Point lppt)
+        public static BOOL OffsetViewportOrgEx(HandleRef hdc, int x, int y, ref Point lppt)
         {
-            bool result = OffsetViewportOrgEx(hdc.Handle, x, y, ref lppt);
+            BOOL result = OffsetViewportOrgEx(hdc.Handle, x, y, ref lppt);
             GC.KeepAlive(hdc.Wrapper);
             return result;
         }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.RestoreDC.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.RestoreDC.cs
@@ -10,11 +10,11 @@ internal static partial class Interop
     internal static partial class Gdi32
     {
         [DllImport(Libraries.Gdi32, ExactSpelling = true)]
-        public static extern bool RestoreDC(IntPtr hdc, int nSavedDC);
+        public static extern BOOL RestoreDC(IntPtr hdc, int nSavedDC);
 
-        public static bool RestoreDC(HandleRef hdc, int nSavedDC)
+        public static BOOL RestoreDC(HandleRef hdc, int nSavedDC)
         {
-            bool result = RestoreDC(hdc.Handle, nSavedDC);
+            BOOL result = RestoreDC(hdc.Handle, nSavedDC);
             GC.KeepAlive(hdc.Wrapper);
             return result;
         }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.ActivateActCtx.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.ActivateActCtx.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,6 +10,6 @@ internal partial class Interop
     internal partial class Kernel32
     {
         [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        public extern static bool ActivateActCtx(IntPtr hActCtx, out IntPtr lpCookie);
+        public extern static BOOL ActivateActCtx(IntPtr hActCtx, out IntPtr lpCookie);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.FreeLibrary.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.FreeLibrary.cs
@@ -10,6 +10,6 @@ internal partial class Interop
     internal partial class Kernel32
     {
         [DllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true)]
-        public static extern bool FreeLibrary(IntPtr hModule);
+        public static extern BOOL FreeLibrary(IntPtr hModule);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.CreateILockBytesOnHGlobal.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.CreateILockBytesOnHGlobal.cs
@@ -10,6 +10,6 @@ internal partial class Interop
     internal static partial class Ole32
     {
         [DllImport(Libraries.Ole32, PreserveSig = false)]
-        public static extern ILockBytes CreateILockBytesOnHGlobal(IntPtr hGlobal, bool fDeleteOnRelease);
+        public static extern ILockBytes CreateILockBytesOnHGlobal(IntPtr hGlobal, BOOL fDeleteOnRelease);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.SHGetPathFromIDListLongPath.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.SHGetPathFromIDListLongPath.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
     internal static partial class Shell32
     {
         [DllImport(Libraries.Shell32, ExactSpelling = true)]
-        private static extern bool SHGetPathFromIDListEx(IntPtr pidl, IntPtr pszPath, int cchPath, int flags);
+        private static extern BOOL SHGetPathFromIDListEx(IntPtr pidl, IntPtr pszPath, int cchPath, int flags);
 
         public static bool SHGetPathFromIDListLongPath(IntPtr pidl, out string path)
         {
@@ -54,7 +54,7 @@ internal static partial class Interop
             // this is much less overhead then looping and copying to intermediate buffers before creating a string.
             // Additionally, implementing this would allow us to short circuit the one caller (FolderBrowserDialog)
             // who doesn't care about the path, but just wants to know that we have an IShellFolder.
-            while (SHGetPathFromIDListEx(pidl, pszPath, length, 0) == false)
+            while (SHGetPathFromIDListEx(pidl, pszPath, length, 0).IsFalse())
             {
                 if (length >= Kernel32.MAX_UNICODESTRING_LEN
                     || *(char*)pszPath.ToPointer() == '\0')

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetClassInfoW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetClassInfoW.cs
@@ -10,6 +10,6 @@ internal static partial class Interop
     internal static partial class User32
     {
         [DllImport(Libraries.User32, CharSet = CharSet.Unicode, ExactSpelling = true)]
-        public static extern bool GetClassInfoW(HandleRef hInstance, string lpClassName, ref WNDCLASS lpWndClass);
+        public static extern BOOL GetClassInfoW(HandleRef hInstance, string lpClassName, ref WNDCLASS lpWndClass);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetCursorPos.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetCursorPos.cs
@@ -10,6 +10,6 @@ internal static partial class Interop
     internal static partial class User32
     {
         [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern bool SetCursorPos(int x, int y);
+        public static extern BOOL SetCursorPos(int x, int y);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ThemingScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ThemingScope.cs
@@ -35,7 +35,7 @@ namespace System.Windows.Forms
         /// </summary>
         public static IntPtr Activate(bool useVisualStyles)
         {
-            if (IsContextActiveButNotCreated(useVisualStyles) && Kernel32.ActivateActCtx(s_hActCtx, out IntPtr userCookie))
+            if (IsContextActiveButNotCreated(useVisualStyles) && Kernel32.ActivateActCtx(s_hActCtx, out IntPtr userCookie).IsTrue())
             {
                 return userCookie;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -174,7 +174,7 @@ namespace System.Windows.Forms
 
                 try
                 {
-                    iLockBytes = Ole32.CreateILockBytesOnHGlobal(hglobal, true);
+                    iLockBytes = Ole32.CreateILockBytesOnHGlobal(hglobal, BOOL.TRUE);
                     if (buffer == null)
                     {
                         storage = Ole32.StgCreateDocfileOnILockBytes(

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.MetafileDCWrapper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.MetafileDCWrapper.cs
@@ -72,7 +72,7 @@ namespace System.Windows.Forms
                     Gdi32.SelectObject(HDC, _hOriginalBmp);
                     success = Gdi32.DeleteObject(_hBitmap).IsTrue();
                     Debug.Assert(success, "DeleteObject() failed.");
-                    success = Gdi32.DeleteDC(HDC);
+                    success = Gdi32.DeleteDC(HDC).IsTrue();
                     Debug.Assert(success, "DeleteObject() failed.");
                 }
                 finally

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.WindowClass.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.WindowClass.cs
@@ -150,9 +150,8 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    // A system defined Window class was specified, get its info
-
-                    if (!User32.GetClassInfoW(NativeMethods.NullHandleRef, _className, ref windowClass))
+                    // A system defined Window class was specified, get its info.
+                    if (User32.GetClassInfoW(NativeMethods.NullHandleRef, _className, ref windowClass).IsFalse())
                     {
                         throw new Win32Exception(Marshal.GetLastWin32Error(), SR.InvalidWndClsName);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -3852,7 +3852,7 @@ namespace System.Windows.Forms
                     return HRESULT.E_FAIL;
                 }
 
-                Ole32.ILockBytes pLockBytes = Ole32.CreateILockBytesOnHGlobal(IntPtr.Zero, true);
+                Ole32.ILockBytes pLockBytes = Ole32.CreateILockBytesOnHGlobal(IntPtr.Zero, BOOL.TRUE);
                 Debug.Assert(pLockBytes != null, "pLockBytes is NULL!");
 
                 storage = Ole32.StgCreateDocfileOnILockBytes(


### PR DESCRIPTION
## Proposed changes

- Use BOOL instead of bool in some DllImports in Interop.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2833)