### PR TITLE
Add GMR enum in Interop ComCtl32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.GMR.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.GMR.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        public enum GMR
+        {
+            VISIBLE = 0,
+            DAYSTATE = 1
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.MCHITTESTINFO.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.MCHITTESTINFO.cs
@@ -16,7 +16,7 @@ internal static partial class Interop
         {
             public uint cbSize;
             public Point pt;
-            public int uHit;
+            public MCHT uHit;
             public Kernel32.SYSTEMTIME st;
             public RECT rc;
             public int iOffset;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -40,8 +40,6 @@ namespace System.Windows.Forms
         public const int FADF_VARIANT = (unchecked((int)0x800));
 
         public const int
-        GMR_VISIBLE = 0,
-        GMR_DAYSTATE = 1,
         GDI_ERROR = (unchecked((int)0xFFFFFFFF)),
         GDTR_MIN = 0x0001,
         GDTR_MAX = 0x0002;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -1364,7 +1364,6 @@ namespace System.Windows.Forms
 
         // Return a localized string representation of the given DateTime value.
         // Used for throwing exceptions, etc.
-        //
         private static string FormatDate(DateTime value)
         {
             return value.ToString("d", CultureInfo.CurrentCulture);
@@ -1378,20 +1377,18 @@ namespace System.Windows.Forms
         {
             if (visible)
             {
-                return GetMonthRange(NativeMethods.GMR_VISIBLE);
+                return GetMonthRange(GMR.VISIBLE);
             }
-            else
-            {
-                return GetMonthRange(NativeMethods.GMR_DAYSTATE);
-            }
+
+            return GetMonthRange(GMR.DAYSTATE);
         }
 
         /// <summary>
         ///  Retrieves the enumeration value corresponding to the hit area.
         /// </summary>
-        private HitArea GetHitArea(int hit)
+        private HitArea GetHitArea(MCHT hit)
         {
-            switch ((MCHT)hit)
+            switch (hit)
             {
                 case MCHT.TITLEBK:
                     return HitArea.TitleBackground;
@@ -1507,7 +1504,7 @@ namespace System.Windows.Forms
             return minSize;
         }
 
-        private SelectionRange GetMonthRange(int flag)
+        private SelectionRange GetMonthRange(GMR flag)
         {
             Span<Kernel32.SYSTEMTIME> sa = stackalloc Kernel32.SYSTEMTIME[2];
             User32.SendMessageW(this, (User32.WM)MCM.GETMONTHRANGE, (IntPtr)flag, ref sa[0]);


### PR DESCRIPTION
## Proposed changes

- Add GMR enum in Interop ComCtl32.
- Remove GMR constants and replace their usage with the above enum values.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2834)