### PR TITLE
Add HT enum in Interop User32

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
@@ -935,11 +935,11 @@ namespace System.Windows.Forms.Design.Behavior
                         pt.Offset(pt1.X, pt1.Y);
                         if (_behaviorService.PropagateHitTest(pt) && !ProcessingDrag)
                         {
-                            m.Result = (IntPtr)(NativeMethods.HTTRANSPARENT);
+                            m.Result = (IntPtr)User32.HT.TRANSPARENT;
                         }
                         else
                         {
-                            m.Result = (IntPtr)(NativeMethods.HTCLIENT);
+                            m.Result = (IntPtr)User32.HT.CLIENT;
                         }
                         break;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
@@ -545,7 +545,7 @@ namespace System.Windows.Forms.Design
                     IntPtr hwnd = User32.WindowFromPoint(p);
                     if (hwnd != IntPtr.Zero)
                     {
-                        User32.SendMessageW(hwnd, User32.WM.SETCURSOR, hwnd, (IntPtr)NativeMethods.HTCLIENT);
+                        User32.SendMessageW(hwnd, User32.WM.SETCURSOR, hwnd, (IntPtr)User32.HT.CLIENT);
                     }
                     else
                     {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripAdornerWindowService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripAdornerWindowService.cs
@@ -290,7 +290,7 @@ namespace System.Windows.Forms.Design
                 switch ((User32.WM)m.Msg)
                 {
                     case User32.WM.NCHITTEST:
-                        m.Result = (IntPtr)(NativeMethods.HTTRANSPARENT);
+                        m.Result = (IntPtr)User32.HT.TRANSPARENT;
                         break;
                     default:
                         base.WndProc(ref m);

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.HT.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.HT.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public enum HT
+        {
+            ERROR = -2,
+            TRANSPARENT = -1,
+            NOWHERE = 0,
+            CLIENT = 1,
+            CAPTION = 2,
+            SYSMENU = 3,
+            GROWBOX = 4,
+            SIZE = GROWBOX,
+            MENU = 5,
+            HSCROLL = 6,
+            VSCROLL = 7,
+            MINBUTTON = 8,
+            MAXBUTTON = 9,
+            LEFT = 10,
+            RIGHT = 11,
+            TOP = 12,
+            TOPLEFT = 13,
+            TOPRIGHT = 14,
+            BOTTOM = 15,
+            BOTTOMLEFT = 16,
+            BOTTOMRIGHT = 17,
+            BORDER = 18,
+            REDUCE = MINBUTTON,
+            ZOOM = MAXBUTTON,
+            SIZEFIRST = LEFT,
+            SIZELAST = BOTTOMRIGHT,
+            OBJECT = 19,
+            CLOSE = 20,
+            HELP = 21
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -45,14 +45,6 @@ namespace System.Windows.Forms
         GDTR_MAX = 0x0002;
 
         public const int
-        HTTRANSPARENT = (-1),
-        HTNOWHERE = 0,
-        HTCLIENT = 1,
-        HTLEFT = 10,
-        HTBOTTOM = 15,
-        HTBOTTOMLEFT = 16,
-        HTBOTTOMRIGHT = 17,
-        HTBORDER = 18,
         HCF_HIGHCONTRASTON = 0x00000001,
         HDN_ITEMCHANGING = ((0 - 300) - 20),
         HDN_ITEMCHANGED = ((0 - 300) - 21),

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -2002,7 +2002,7 @@ namespace System.Windows.Forms
                     break;
 
                 case WM.SETCURSOR:
-                    if (Cursor != DefaultCursor && childEdit != null && m.HWnd == childEdit.Handle && PARAM.LOWORD(m.LParam) == NativeMethods.HTCLIENT)
+                    if (Cursor != DefaultCursor && childEdit != null && m.HWnd == childEdit.Handle && PARAM.LOWORD(m.LParam) == (int)HT.CLIENT)
                     {
                         Cursor.Current = Cursor;
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -1775,7 +1775,7 @@ namespace System.Windows.Forms
                     User32.GetWindowRect(this, ref r);
                     if ((r.left <= p.X && p.X < r.right && r.top <= p.Y && p.Y < r.bottom) || User32.GetCapture() == Handle)
                     {
-                        User32.SendMessageW(this, User32.WM.SETCURSOR, Handle, (IntPtr)NativeMethods.HTCLIENT);
+                        User32.SendMessageW(this, User32.WM.SETCURSOR, Handle, (IntPtr)User32.HT.CLIENT);
                     }
                 }
 
@@ -12611,7 +12611,7 @@ namespace System.Windows.Forms
             // Accessing through the Handle property has side effects that break this
             // logic. You must use InternalHandle.
             //
-            if (m.WParam == InternalHandle && PARAM.LOWORD(m.LParam) == NativeMethods.HTCLIENT)
+            if (m.WParam == InternalHandle && PARAM.LOWORD(m.LParam) == (int)User32.HT.CLIENT)
             {
                 Cursor.Current = Cursor;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -6479,7 +6479,7 @@ namespace System.Windows.Forms
                     pt.Y >= (clientSize.Height - SizeGripSize) &&
                     clientSize.Height >= SizeGripSize)
                 {
-                    m.Result = IsMirrored ? (IntPtr)NativeMethods.HTBOTTOMLEFT : (IntPtr)NativeMethods.HTBOTTOMRIGHT;
+                    m.Result = (IntPtr)(IsMirrored ? User32.HT.BOTTOMLEFT : User32.HT.BOTTOMRIGHT);
                     return;
                 }
             }
@@ -6492,10 +6492,10 @@ namespace System.Windows.Forms
             if (AutoSizeMode == AutoSizeMode.GrowAndShrink)
             {
                 int result = unchecked((int)(long)m.Result);
-                if (result >= NativeMethods.HTLEFT &&
-                    result <= NativeMethods.HTBOTTOMRIGHT)
+                if (result >= (int)User32.HT.LEFT &&
+                    result <= (int)User32.HT.BOTTOMRIGHT)
                 {
-                    m.Result = (IntPtr)NativeMethods.HTBORDER;
+                    m.Result = (IntPtr)User32.HT.BORDER;
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
@@ -1686,7 +1686,7 @@ namespace System.Windows.Forms
                     //
                     Rectangle rectInScreen = RectangleToScreen(new Rectangle(0, 0, Width, Height));
                     Point pt = new Point(unchecked((int)(long)m.LParam));
-                    m.Result = (IntPtr)((rectInScreen.Contains(pt) ? NativeMethods.HTCLIENT : NativeMethods.HTNOWHERE));
+                    m.Result = (IntPtr)(rectInScreen.Contains(pt) ? User32.HT.CLIENT : User32.HT.NOWHERE);
                     break;
 
                 default:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
@@ -425,7 +425,7 @@ namespace System.Windows.Forms
                         User32.GetWindowRect(this, ref r);
                         if ((r.left <= p.X && p.X < r.right && r.top <= p.Y && p.Y < r.bottom) || User32.GetCapture() == Handle)
                         {
-                            User32.SendMessageW(this, User32.WM.SETCURSOR, Handle, (IntPtr)NativeMethods.HTCLIENT);
+                            User32.SendMessageW(this, User32.WM.SETCURSOR, Handle, (IntPtr)User32.HT.CLIENT);
                         }
                     }
                 }
@@ -2052,7 +2052,7 @@ namespace System.Windows.Forms
             // Accessing through the Handle property has side effects that break this
             // logic. You must use InternalHandle.
             //
-            if (m.WParam == InternalHandle && PARAM.LOWORD(m.LParam) == NativeMethods.HTCLIENT)
+            if (m.WParam == InternalHandle && PARAM.LOWORD(m.LParam) == (int)User32.HT.CLIENT)
             {
                 if (OverrideCursor != null)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridToolTip.cs
@@ -191,7 +191,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     // thru to controls underneath. This is due to a combination of old app-specific code in comctl32,
                     // functional changes between v5 and v6, and the specfic way the property grid drives its tooltip.
                     // Workaround is to just force HTTRANSPARENT all the time.
-                    msg.Result = (IntPtr)NativeMethods.HTTRANSPARENT;
+                    msg.Result = (IntPtr)User32.HT.TRANSPARENT;
                     return;
             }
             base.WndProc(ref msg);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
@@ -582,7 +582,7 @@ namespace System.Windows.Forms
                         User32.GetWindowRect(this, ref r);
                         if ((r.left <= p.X && p.X < r.right && r.top <= p.Y && p.Y < r.bottom) || User32.GetCapture() == Handle)
                         {
-                            User32.SendMessageW(this, User32.WM.SETCURSOR, Handle, (IntPtr)NativeMethods.HTCLIENT);
+                            User32.SendMessageW(this, User32.WM.SETCURSOR, Handle, (IntPtr)User32.HT.CLIENT);
                         }
                     }
                 }
@@ -2416,17 +2416,9 @@ namespace System.Windows.Forms
         {
             // Accessing through the Handle property has side effects that break this
             // logic. You must use InternalHandle.
-            //
-            if (m.WParam == InternalHandle && ((int)m.LParam & 0x0000FFFF) == NativeMethods.HTCLIENT)
+            if (m.WParam == InternalHandle && ((int)m.LParam & 0x0000FFFF) == (int)User32.HT.CLIENT)
             {
-                if (OverrideCursor != null)
-                {
-                    Cursor.Current = OverrideCursor;
-                }
-                else
-                {
-                    Cursor.Current = Cursor;
-                }
+                Cursor.Current = OverrideCursor ?? Cursor;
             }
             else
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusStrip.cs
@@ -645,7 +645,7 @@ namespace System.Windows.Forms
                         {
                             if ((deltaRightEdge + deltaBottomEdge) < 2)
                             {
-                                m.Result = (IntPtr)NativeMethods.HTBOTTOMRIGHT;
+                                m.Result = (IntPtr)User32.HT.BOTTOMRIGHT;
                                 return;
                             }
                         }
@@ -681,7 +681,7 @@ namespace System.Windows.Forms
 
                     if (ClientRectangle.Contains(PointToClient(new Point(x, y))))
                     {
-                        m.Result = (IntPtr)NativeMethods.HTBOTTOMLEFT;
+                        m.Result = (IntPtr)User32.HT.BOTTOMLEFT;
                         return;
                     }
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.cs
@@ -945,8 +945,9 @@ namespace System.Windows.Forms
                 {
                     if (m.Msg == (int)User32.WM.NCHITTEST)
                     {
-                        m.Result = (IntPtr)NativeMethods.HTTRANSPARENT;
+                        m.Result = (IntPtr)User32.HT.TRANSPARENT;
                     }
+
                     base.WndProc(ref m);
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/HitTestCode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/HitTestCode.cs
@@ -2,29 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using static Interop.User32;
+
 namespace System.Windows.Forms.VisualStyles
 {
     public enum HitTestCode
     {
-        Nowhere = 0,
-        Client = 1,
-        Left = 10,
-        Right = 11,
-        Top = 12,
-        Bottom = 15,
-        TopLeft = 13,
-        TopRight = 14,
-        BottomLeft = 16,
-        BottomRight = 17
-        //      #define HTNOWHERE           0
-        //      #define HTCLIENT            1
-        //      #define HTLEFT              10
-        //      #define HTRIGHT             11
-        //      #define HTTOP               12
-        //      #define HTTOPLEFT           13
-        //      #define HTTOPRIGHT          14
-        //      #define HTBOTTOM            15
-        //      #define HTBOTTOMLEFT        16
-        //      #define HTBOTTOMRIGHT       17
+        Nowhere = HT.NOWHERE,
+        Client = HT.CLIENT,
+        Left = HT.LEFT,
+        Right = HT.RIGHT,
+        Top = HT.TOP,
+        Bottom = HT.BOTTOM,
+        TopLeft = HT.TOPLEFT,
+        TopRight = HT.TOPRIGHT,
+        BottomLeft = HT.BOTTOMLEFT,
+        BottomRight = HT.BOTTOMRIGHT
     }
 }


### PR DESCRIPTION
## Proposed changes

- Add HT enum in Interop User32.
- Remove HT constants and replace their usages with the above enum values.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2836)