### PR TITLE
Add RECO enum to Interop Richedit

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MultilineStringEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MultilineStringEditor.cs
@@ -542,14 +542,13 @@ namespace System.ComponentModel.Design
                 return HRESULT.S_OK;
             }
 
-            public HRESULT QueryAcceptData(IComDataObject lpdataobj, IntPtr lpcfFormat, uint reco, BOOL fReally, IntPtr hMetaPict)
+            public HRESULT QueryAcceptData(IComDataObject lpdataobj, IntPtr lpcfFormat, Richedit.RECO reco, BOOL fReally, IntPtr hMetaPict)
             {
                 Debug.WriteLineIf(RichTextDbg.TraceVerbose, "IRichTextBoxOleCallback::QueryAcceptData(reco=" + reco + ")");
-                if (reco == NativeMethods.RECO_PASTE)
+                if (reco == Richedit.RECO.PASTE)
                 {
                     DataObject dataObj = new DataObject(lpdataobj);
-                    if (dataObj != null &&
-                        (dataObj.GetDataPresent(DataFormats.Text) || dataObj.GetDataPresent(DataFormats.UnicodeText)))
+                    if (dataObj.GetDataPresent(DataFormats.Text) || dataObj.GetDataPresent(DataFormats.UnicodeText))
                     {
                         return HRESULT.S_OK;
                     }
@@ -566,7 +565,7 @@ namespace System.ComponentModel.Design
                 return HRESULT.E_NOTIMPL;
             }
 
-            public HRESULT GetClipboardData(ref Richedit.CHARRANGE lpchrg, uint reco, IntPtr lplpdataobj)
+            public HRESULT GetClipboardData(ref Richedit.CHARRANGE lpchrg, Richedit.RECO reco, IntPtr lplpdataobj)
             {
                 Debug.WriteLineIf(RichTextDbg.TraceVerbose, "IRichTextBoxOleCallback::GetClipboardData");
                 return HRESULT.E_NOTIMPL;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.IRichEditOleCallback.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.IRichEditOleCallback.cs
@@ -31,13 +31,13 @@ internal partial class Interop
             HRESULT DeleteObject(IntPtr lpoleobj);
 
             [PreserveSig]
-            HRESULT QueryAcceptData(IDataObject lpdataobj, /* CLIPFORMAT* */ IntPtr lpcfFormat, uint reco, BOOL fReally, IntPtr hMetaPict);
+            HRESULT QueryAcceptData(IDataObject lpdataobj, /* CLIPFORMAT* */ IntPtr lpcfFormat, RECO reco, BOOL fReally, IntPtr hMetaPict);
 
             [PreserveSig]
             HRESULT ContextSensitiveHelp(BOOL fEnterMode);
 
             [PreserveSig]
-            HRESULT GetClipboardData(ref CHARRANGE lpchrg, uint reco, IntPtr lplpdataobj);
+            HRESULT GetClipboardData(ref CHARRANGE lpchrg, RECO reco, IntPtr lplpdataobj);
 
             [PreserveSig]
             HRESULT GetDragDropEffect(

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.RECO.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.RECO.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal partial class Interop
+{
+    internal static partial class Richedit
+    {
+        public enum RECO : uint
+        {
+            PASTE = 0x00000000,
+            DROP = 0x00000001,
+            COPY = 0x00000002,
+            CUT = 0x00000003,
+            DRAG = 0x00000004
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -138,12 +138,6 @@ namespace System.Windows.Forms
         PATCOPY = 0x00F00021,
         PATINVERT = 0x005A0049;
 
-        public const int RECO_PASTE = 0x00000000;   // paste from clipboard
-        public const int RECO_DROP = 0x00000001;    // drop
-                                                    //public const int RECO_COPY  = 0x00000002;    // copy to the clipboard
-                                                    //public const int RECO_CUT   = 0x00000003; // cut to the clipboard
-                                                    //public const int RECO_DRAG  = 0x00000004;    // drag
-
         public const int
         SIZE_RESTORED = 0,
         SIZE_MAXIMIZED = 2,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -3892,11 +3892,11 @@ namespace System.Windows.Forms
                 return HRESULT.S_OK;
             }
 
-            public HRESULT QueryAcceptData(IComDataObject lpdataobj, IntPtr lpcfFormat, uint reco, BOOL fReally, IntPtr hMetaPict)
+            public HRESULT QueryAcceptData(IComDataObject lpdataobj, IntPtr lpcfFormat, RECO reco, BOOL fReally, IntPtr hMetaPict)
             {
                 Debug.WriteLineIf(RichTextDbg.TraceVerbose, "IRichEditOleCallback::QueryAcceptData(reco=" + reco + ")");
 
-                if (reco == NativeMethods.RECO_DROP)
+                if (reco == RECO.DROP)
                 {
                     if (owner.AllowDrop || owner.EnableAutoDragDrop)
                     {
@@ -3998,7 +3998,7 @@ namespace System.Windows.Forms
                 return HRESULT.E_NOTIMPL;
             }
 
-            public HRESULT GetClipboardData(ref Richedit.CHARRANGE lpchrg, uint reco, IntPtr lplpdataobj)
+            public HRESULT GetClipboardData(ref Richedit.CHARRANGE lpchrg, RECO reco, IntPtr lplpdataobj)
             {
                 Debug.WriteLineIf(RichTextDbg.TraceVerbose, "IRichEditOleCallback::GetClipboardData");
                 return HRESULT.E_NOTIMPL;


### PR DESCRIPTION
## Proposed changes

- Add RECO enum to Interop Richedit.
- Remove RECO constants and replace their usages with the above enum values.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2837)