### PR TITLE
fix: `Application.ExecutablePath` returns dll instead of exe (#2801)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -340,26 +340,8 @@ namespace System.Windows.Forms
             {
                 if (executablePath == null)
                 {
-                    Assembly asm = Assembly.GetEntryAssembly();
-                    if (asm == null)
-                    {
-                        StringBuilder sb = UnsafeNativeMethods.GetModuleFileNameLongPath(NativeMethods.NullHandleRef);
-                        executablePath = Path.GetFullPath(sb.ToString());
-                    }
-                    else
-                    {
-                        string cb = asm.CodeBase;
-                        Uri codeBase = new Uri(cb);
-                        if (codeBase.IsFile)
-                        {
-                            executablePath = codeBase.LocalPath + Uri.UnescapeDataString(codeBase.Fragment);
-                            ;
-                        }
-                        else
-                        {
-                            executablePath = codeBase.ToString();
-                        }
-                    }
+                    StringBuilder sb = UnsafeNativeMethods.GetModuleFileNameLongPath(NativeMethods.NullHandleRef);
+                    executablePath = Path.GetFullPath(sb.ToString());
                 }
 
                 return executablePath;


### PR DESCRIPTION

Resolves #1143

For discussions and tests refer to https://github.com/dotnet/winforms/pull/2801
(cherry picked from commit 2af3af9589492d4c252af9a282a3e4cad293defa)



## Proposed changes

 In .NET artifacts are DLLs even for executable projects. With some automagic they get bundled into executables.
However `Assembly.GetEntryAssembly()` always returns the dll instead of the exe.

Following the guidance from the Runtime team retrieve the path to the executable via `GetModuleFileNameW` call.



<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Customers can now retrieve a path to the applications executable instead of the application's dll.

## Regression? 

- Yes

## Risk

- Small-medium due to possibly unaccounted use cases

<!-- end TELL-MODE -->




## Test methodology <!-- How did you ensure quality? -->

- Refer to https://github.com/dotnet/winforms/pull/2801

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2838)