### PR TITLE
Add MDITILE enum in Interop User32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.MDITILE.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.MDITILE.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [Flags]
+        public enum MDITILE : uint
+        {
+            VERTICAL = 0x0000,
+            HORIZONTAL = 0x0001,
+            SKIPDISABLED = 0x0002,
+            ZORDER = 0x0004
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -97,9 +97,6 @@ namespace System.Windows.Forms
         public const int MEMBERID_NIL = (-1),
         ERROR_INSUFFICIENT_BUFFER = 122, //https://msdn.microsoft.com/en-us/library/windows/desktop/ms681382(v=vs.85).aspx
         MDIS_ALLCHILDSTYLES = 0x0001,
-        MDITILE_VERTICAL = 0x0000,
-        MDITILE_HORIZONTAL = 0x0001,
-        MDITILE_SKIPDISABLED = 0x0002,
         MCN_VIEWCHANGE = (0 - 750), // MCN_SELECT -4  - give state of calendar view
         MCN_SELCHANGE = ((0 - 750) + 1),
         MCN_GETDAYSTATE = ((0 - 750) + 3),

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MDIClient.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MDIClient.cs
@@ -170,10 +170,10 @@ namespace System.Windows.Forms
                     User32.SendMessageW(this, User32.WM.MDICASCADE);
                     break;
                 case MdiLayout.TileVertical:
-                    User32.SendMessageW(this, User32.WM.MDITILE, (IntPtr)NativeMethods.MDITILE_VERTICAL);
+                    User32.SendMessageW(this, User32.WM.MDITILE, (IntPtr)User32.MDITILE.VERTICAL);
                     break;
                 case MdiLayout.TileHorizontal:
-                    User32.SendMessageW(this, User32.WM.MDITILE, (IntPtr)NativeMethods.MDITILE_HORIZONTAL);
+                    User32.SendMessageW(this, User32.WM.MDITILE, (IntPtr)User32.MDITILE.HORIZONTAL);
                     break;
                 case MdiLayout.ArrangeIcons:
                     User32.SendMessageW(this, User32.WM.MDIICONARRANGE);


### PR DESCRIPTION
## Proposed changes

- Add MDITILE enum in Interop User32.
- Remove MDITILE constants and replace their usages with the above enum values.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2839)