### PR TITLE
[Accessibility] Fixing a default accessible name of a list of a dropdown entry value in PropertyGridView

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6617,4 +6617,7 @@ Stack trace where the illegal operation occurred was:
   <data name="ErrorProviderDefaultAccessibleName" xml:space="preserve">
     <value>Error provider</value>
   </data>
+  <data name="PropertyGridEntryValuesListDefaultAccessibleName" xml:space="preserve">
+    <value>Available values</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -8101,6 +8101,11 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">Otevřít</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridEntryValuesListDefaultAccessibleName">
+        <source>Available values</source>
+        <target state="new">Available values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridExceptionInfo">
         <source>Error Information</source>
         <target state="translated">Informace o chybě</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -8101,6 +8101,11 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">Öffnen</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridEntryValuesListDefaultAccessibleName">
+        <source>Available values</source>
+        <target state="new">Available values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridExceptionInfo">
         <source>Error Information</source>
         <target state="translated">Fehlerinformation</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -8101,6 +8101,11 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">Abrir</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridEntryValuesListDefaultAccessibleName">
+        <source>Available values</source>
+        <target state="new">Available values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridExceptionInfo">
         <source>Error Information</source>
         <target state="translated">Información de error</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -8101,6 +8101,11 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">Ouvrir</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridEntryValuesListDefaultAccessibleName">
+        <source>Available values</source>
+        <target state="new">Available values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridExceptionInfo">
         <source>Error Information</source>
         <target state="translated">Informations sur l'erreur</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -8101,6 +8101,11 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">Apri</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridEntryValuesListDefaultAccessibleName">
+        <source>Available values</source>
+        <target state="new">Available values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridExceptionInfo">
         <source>Error Information</source>
         <target state="translated">Informazioni sull'errore</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -8101,6 +8101,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">開く</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridEntryValuesListDefaultAccessibleName">
+        <source>Available values</source>
+        <target state="new">Available values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridExceptionInfo">
         <source>Error Information</source>
         <target state="translated">エラー情報</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -8101,6 +8101,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">열기</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridEntryValuesListDefaultAccessibleName">
+        <source>Available values</source>
+        <target state="new">Available values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridExceptionInfo">
         <source>Error Information</source>
         <target state="translated">오류 정보</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -8101,6 +8101,11 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">Otwórz</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridEntryValuesListDefaultAccessibleName">
+        <source>Available values</source>
+        <target state="new">Available values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridExceptionInfo">
         <source>Error Information</source>
         <target state="translated">Informacje o błędzie</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -8101,6 +8101,11 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">Abrir</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridEntryValuesListDefaultAccessibleName">
+        <source>Available values</source>
+        <target state="new">Available values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridExceptionInfo">
         <source>Error Information</source>
         <target state="translated">Informações sobre o Erro</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -8102,6 +8102,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">Открыть</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridEntryValuesListDefaultAccessibleName">
+        <source>Available values</source>
+        <target state="new">Available values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridExceptionInfo">
         <source>Error Information</source>
         <target state="translated">Информация об ошибке</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -8101,6 +8101,11 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">Aç</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridEntryValuesListDefaultAccessibleName">
+        <source>Available values</source>
+        <target state="new">Available values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridExceptionInfo">
         <source>Error Information</source>
         <target state="translated">Hata Bilgileri</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -8101,6 +8101,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">打开</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridEntryValuesListDefaultAccessibleName">
+        <source>Available values</source>
+        <target state="new">Available values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridExceptionInfo">
         <source>Error Information</source>
         <target state="translated">错误信息</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -8101,6 +8101,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">開啟</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridEntryValuesListDefaultAccessibleName">
+        <source>Available values</source>
+        <target state="new">Available values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyGridExceptionInfo">
         <source>Error Information</source>
         <target state="translated">錯誤資訊</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -7229,6 +7229,12 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return base.FragmentNavigate(direction);
             }
 
+            public override string Name
+            {
+                get => base.Name ?? SR.PropertyGridEntryValuesListDefaultAccessibleName;
+                set => base.Name = value;
+            }
+
             /// <summary>
             ///  Return the element that is the root node of this fragment of UI.
             /// </summary>

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridViewAccessibleObjectTests.cs
@@ -263,5 +263,42 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             ControlAccessibleObject accessibleObject = (ControlAccessibleObject)propertyGrid.GridViewAccessibleObject;
             Assert.NotNull(accessibleObject.Parent);
         }
+
+        [Theory]
+        [InlineData("Some test text")]
+        [InlineData("")]
+        public void PropertyGridView_GridViewListBoxAccessibleObject_Name_ReturnsDeterminedName(string name)
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            Control.ControlAccessibleObject gridViewAccessibleObject = (Control.ControlAccessibleObject)propertyGrid.GridViewAccessibleObject;
+            PropertyGridView propertyGridView = (PropertyGridView)gridViewAccessibleObject.Owner;
+
+            propertyGridView.DropDownListBoxAccessibleObject.Name = name;
+            string listAccessibleName = propertyGridView.DropDownListBoxAccessibleObject.Name;
+            Assert.Equal(name, listAccessibleName);
+        }
+
+        [WinFormsFact]
+        public void PropertyGridView_GridViewListBoxAccessibleObject_ReturnsDefaultName()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            Control.ControlAccessibleObject gridViewAccessibleObject = (Control.ControlAccessibleObject)propertyGrid.GridViewAccessibleObject;
+            PropertyGridView propertyGridView = (PropertyGridView)gridViewAccessibleObject.Owner;
+
+            string listAccessibleName = propertyGridView.DropDownListBoxAccessibleObject.Name;
+            Assert.Equal(SR.PropertyGridEntryValuesListDefaultAccessibleName, listAccessibleName);
+        }
+
+        [WinFormsFact]
+        public void PropertyGridView_GridViewListBoxAccessibleObject_ReturnsDefaultName_IfBaseNameIsSetAsNull()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            Control.ControlAccessibleObject gridViewAccessibleObject = (Control.ControlAccessibleObject)propertyGrid.GridViewAccessibleObject;
+            PropertyGridView propertyGridView = (PropertyGridView)gridViewAccessibleObject.Owner;
+
+            propertyGridView.DropDownListBoxAccessibleObject.Name = null;
+            string listAccessibleName = propertyGridView.DropDownListBoxAccessibleObject.Name;
+            Assert.Equal(SR.PropertyGridEntryValuesListDefaultAccessibleName, listAccessibleName);
+        }
     }
 }


### PR DESCRIPTION
Fixes #2802

## Proposed changes

- Use a PropertyGrid entry name if a list AccessibleName isn't set

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A user can see a non-empty accessible name of a values list using Inspect 
(Does not affect Narrator announcing)
- Fixed MAS requirement:
![image](https://user-images.githubusercontent.com/49272759/74232511-02b1a700-4cda-11ea-85a2-1aa4f06b659f.png)

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
- An empty AccessibleName
![image](https://user-images.githubusercontent.com/49272759/74237738-4b229200-4ce5-11ea-80eb-5819be3450f5.png)

<!-- TODO -->

### After
- A non-empty AccessibleName (<del>"{Property name}"</del> -> "{Property name} property values")
![image](https://user-images.githubusercontent.com/49272759/74641239-02098c80-5182-11ea-99c4-88e32aab364e.png)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- CTI
- Unit testing

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Using Narrator, Accessibility Insights and Inspect
<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- .NET Core SDK: 5.0.0-alpha.1.20072.3
- Microsoft Windows [Version 10.0.18363.592]

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2843)