### PR TITLE
Move ERROR_INSUFFICIENT_BUFFER to Interop ERROR class

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Interop.ERROR.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Interop.ERROR.cs
@@ -1,13 +1,15 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 internal partial class Interop
 {
+    // https://docs.microsoft.com/windows/win32/debug/system-error-codes--0-499-
     internal static class ERROR
     {
         public const int ACCESS_DENIED = 0x0005;
         public const int INVALID_HANDLE = 0x0006;
         public const int INVALID_PARAMETER = 0x0057;
+        public const int INSUFFICIENT_BUFFER = 0x007A;
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -94,8 +94,7 @@ namespace System.Windows.Forms
             return ((0xFFFF & lgid) | (((0x000f) & sort) << 16));
         }
 
-        public const int MEMBERID_NIL = (-1),
-        ERROR_INSUFFICIENT_BUFFER = 122, //https://msdn.microsoft.com/en-us/library/windows/desktop/ms681382(v=vs.85).aspx
+        public const int
         MDIS_ALLCHILDSTYLES = 0x0001,
         MCN_VIEWCHANGE = (0 - 750), // MCN_SELECT -4  - give state of calendar view
         MCN_SELCHANGE = ((0 - 750) + 1),

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -83,7 +83,7 @@ namespace System.Windows.Forms
             // Iterating by allocating chunk of memory each time we find the length is not sufficient.
             // Performance should not be an issue for current MAX_PATH length due to this change.
             while (((length = GetModuleFileName(hModule, buffer, buffer.Capacity)) == buffer.Capacity)
-                && Marshal.GetLastWin32Error() == NativeMethods.ERROR_INSUFFICIENT_BUFFER
+                && Marshal.GetLastWin32Error() == ERROR.INSUFFICIENT_BUFFER
                 && buffer.Capacity < Kernel32.MAX_UNICODESTRING_LEN)
             {
                 noOfTimes += 2; // Increasing buffer size by 520 in each iteration.


### PR DESCRIPTION
## Proposed changes

- Move ERROR_INSUFFICIENT_BUFFER to Interop ERROR class.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2846)