### PR TITLE
Move EndDialog to Interop User32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EndDialog.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EndDialog.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern BOOL EndDialog(IntPtr hDlg, IntPtr nResult);
+
+        public static BOOL EndDialog(HandleRef hDlg, IntPtr nResult)
+        {
+            BOOL result = EndDialog(hDlg.Handle, nResult);
+            GC.KeepAlive(hDlg.Wrapper);
+            return result;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -54,9 +54,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.Comdlg32, SetLastError = true, CharSet = CharSet.Auto)]
         public static extern bool GetOpenFileName([In, Out] NativeMethods.OPENFILENAME_I ofn);
 
-        [DllImport(ExternDll.User32, ExactSpelling = true)]
-        public static extern bool EndDialog(HandleRef hWnd, IntPtr result);
-
         [DllImport(ExternDll.Kernel32, ExactSpelling = true, CharSet = CharSet.Unicode)]
         public static extern int WideCharToMultiByte(int codePage, int flags, [MarshalAs(UnmanagedType.LPWStr)]string wideStr, int chars, [In, Out]byte[] pOutBytes, int bufferBytes, IntPtr defaultChar, IntPtr pDefaultUsed);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
@@ -10,7 +10,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
-using static System.Windows.Forms.UnsafeNativeMethods;
 using static Interop;
 
 namespace System.Windows.Forms
@@ -553,7 +552,7 @@ namespace System.Windows.Forms
                 {
                     if (_dialogHWnd != IntPtr.Zero)
                     {
-                        UnsafeNativeMethods.EndDialog(new HandleRef(this, _dialogHWnd), IntPtr.Zero);
+                        User32.EndDialog(new HandleRef(this, _dialogHWnd), IntPtr.Zero);
                     }
 
                     throw;


### PR DESCRIPTION
## Proposed changes

- Move EndDialog to Interop User32.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2850)