### PR TITLE
Add NIM enum to Interop Shell32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.NIM.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.NIM.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class Shell32
+    {
+        public enum NIM : uint
+        {
+            ADD = 0x00000000,
+            MODIFY = 0x00000001,
+            DELETE = 0x00000002,
+            SETFOCUS = 0x00000003,
+            SETVERSION = 0x00000004
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -103,11 +103,8 @@ namespace System.Windows.Forms
 
         MSAA_MENU_SIG = (unchecked((int)0xAA0DF00D));
 
-        public const int NIM_ADD = 0x00000000,
-        NIM_MODIFY = 0x00000001,
-        NIM_DELETE = 0x00000002,
+        public const int
         NIF_MESSAGE = 0x00000001,
-        NIM_SETVERSION = 0x00000004,
         NIF_ICON = 0x00000002,
         NIF_INFO = 0x00000010,
         NIF_TIP = 0x00000004,

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -3,11 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.ComTypes;
 using System.Text;
 using static Interop;
+using static Interop.Shell32;
 
 namespace System.Windows.Forms
 {
@@ -16,7 +15,7 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.User32)]
         public static extern int GetClassName(HandleRef hwnd, StringBuilder lpClassName, int nMaxCount);
 
-        [DllImport(ExternDll.Kernel32, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
+        [DllImport(ExternDll.Kernel32, CharSet = CharSet.Auto)]
         public static extern int GetLocaleInfo(uint Locale, int LCType, StringBuilder lpLCData, int cchData);
 
         [DllImport(ExternDll.Comdlg32, EntryPoint = "PrintDlg", SetLastError = true, CharSet = CharSet.Auto)]
@@ -49,7 +48,7 @@ namespace System.Windows.Forms
         public static extern HRESULT PrintDlgEx([In, Out] NativeMethods.PRINTDLGEX lppdex);
 
         [DllImport(ExternDll.Shell32, CharSet = CharSet.Auto)]
-        public static extern int Shell_NotifyIcon(int message, NativeMethods.NOTIFYICONDATA pnid);
+        public static extern int Shell_NotifyIcon(NIM dwMessage, NativeMethods.NOTIFYICONDATA lpData);
 
         [DllImport(ExternDll.Comdlg32, SetLastError = true, CharSet = CharSet.Auto)]
         public static extern bool GetOpenFileName([In, Out] NativeMethods.OPENFILENAME_I ofn);
@@ -125,7 +124,7 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.Oleacc, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern IntPtr LresultFromObject(ref Guid refiid, IntPtr wParam, IntPtr pAcc);
 
-        [DllImport(ExternDll.Oleacc, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
+        [DllImport(ExternDll.Oleacc, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern int CreateStdAccessibleObject(HandleRef hWnd, int objID, ref Guid refiid, [In, Out, MarshalAs(UnmanagedType.Interface)] ref object pAcc);
 
         [DllImport(ExternDll.User32, ExactSpelling = true)]
@@ -135,7 +134,7 @@ namespace System.Windows.Forms
         public static extern IntPtr CreateIC(string lpszDriverName, string lpszDeviceName, string lpszOutput, HandleRef /*DEVMODE*/ lpInitData);
 
         //for RegionData
-        [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
+        [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern int GetRegionData(HandleRef hRgn, int size, IntPtr lpRgnData);
 
         public unsafe static RECT[] GetRectsFromRegion(IntPtr hRgn)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using static Interop;
+using static Interop.Shell32;
 
 namespace System.Windows.Forms
 {
@@ -615,7 +616,7 @@ namespace System.Windows.Forms
                         data.dwInfoFlags = NativeMethods.NIIF_NONE;
                         break;
                 }
-                UnsafeNativeMethods.Shell_NotifyIcon(NativeMethods.NIM_MODIFY, data);
+                UnsafeNativeMethods.Shell_NotifyIcon(NIM.MODIFY, data);
             }
         }
 
@@ -683,17 +684,17 @@ namespace System.Windows.Forms
                 {
                     if (!added)
                     {
-                        UnsafeNativeMethods.Shell_NotifyIcon(NativeMethods.NIM_ADD, data);
+                        UnsafeNativeMethods.Shell_NotifyIcon(NIM.ADD, data);
                         added = true;
                     }
                     else
                     {
-                        UnsafeNativeMethods.Shell_NotifyIcon(NativeMethods.NIM_MODIFY, data);
+                        UnsafeNativeMethods.Shell_NotifyIcon(NIM.MODIFY, data);
                     }
                 }
                 else if (added)
                 {
-                    UnsafeNativeMethods.Shell_NotifyIcon(NativeMethods.NIM_DELETE, data);
+                    UnsafeNativeMethods.Shell_NotifyIcon(NIM.DELETE, data);
                     added = false;
                 }
             }


### PR DESCRIPTION
## Proposed changes

- Add NIM enum to Interop Shell32.
- Remove NIM constants and replace their usages with the above enum values.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2860)