### PR TITLE
Read Name property instead of name field when serializing ColumnHeader.Name 

### DIFF
--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -217,8 +217,6 @@
     <Compile Update="System\Windows\Forms\Design\FormatControl.cs">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Update="System\Windows\Forms\Design\FormatStringDialog.cs">
-      <SubType>Form</SubType>
-    </Compile>
+    <Compile Update="System\Windows\Forms\Design\FormatStringDialog.cs" />
   </ItemGroup>
 </Project>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
@@ -16,12 +16,10 @@ namespace System.Windows.Forms
     /// <summary>
     ///  Displays a single column header in a <see cref='Forms.ListView'/> control.
     /// </summary>
-    [
-    ToolboxItem(false),
-    DesignTimeVisible(false),
-    DefaultProperty(nameof(Text)),
-    TypeConverter(typeof(ColumnHeaderConverter))
-    ]
+    [ToolboxItem(false)]
+    [DesignTimeVisible(false)]
+    [DefaultProperty(nameof(Text))]
+    [TypeConverter(typeof(ColumnHeaderConverter))]
     public class ColumnHeader : Component, ICloneable
     {
         // disable csharp compiler warning #0414: field assigned unused value
@@ -99,12 +97,10 @@ namespace System.Windows.Forms
             }
         }
 
-        [
-            Localizable(true),
-            RefreshProperties(RefreshProperties.Repaint),
-        SRCategory(nameof(SR.CatBehavior)),
-        SRDescription(nameof(SR.ColumnHeaderDisplayIndexDescr))
-        ]
+        [Localizable(true)]
+        [RefreshProperties(RefreshProperties.Repaint)]
+        [SRCategory(nameof(SR.CatBehavior))]
+        [SRDescription(nameof(SR.ColumnHeaderDisplayIndexDescr))]
         public int DisplayIndex
         {
             get
@@ -190,13 +186,11 @@ namespace System.Windows.Forms
             }
         }
 
-        [
-        DefaultValue(-1),
-        TypeConverter(typeof(ImageIndexConverter)),
-        Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor)),
-        RefreshProperties(RefreshProperties.Repaint),
-        DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)
-        ]
+        [DefaultValue(-1)]
+        [TypeConverter(typeof(ImageIndexConverter))]
+        [Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
+        [RefreshProperties(RefreshProperties.Repaint)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public int ImageIndex
         {
             get
@@ -236,13 +230,11 @@ namespace System.Windows.Forms
             }
         }
 
-        [
-        DefaultValue(""),
-        TypeConverter(typeof(ImageKeyConverter)),
-        Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor)),
-        RefreshProperties(RefreshProperties.Repaint),
-        DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)
-        ]
+        [DefaultValue("")]
+        [TypeConverter(typeof(ImageKeyConverter))]
+        [Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
+        [RefreshProperties(RefreshProperties.Repaint)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string ImageKey
         {
             get
@@ -278,10 +270,8 @@ namespace System.Windows.Forms
         /// <summary>
         ///  The Name of the column header
         /// </summary>
-        [
-        Browsable(false),
-        SRDescription(nameof(SR.ColumnHeaderNameDescr))
-        ]
+        [Browsable(false)]
+        [SRDescription(nameof(SR.ColumnHeaderNameDescr))]
         public string Name
         {
             get
@@ -308,15 +298,13 @@ namespace System.Windows.Forms
         /// <summary>
         ///  The text displayed in the column header
         /// </summary>
-        [
-        Localizable(true),
-        SRDescription(nameof(SR.ColumnCaption))
-        ]
+        [Localizable(true)]
+        [SRDescription(nameof(SR.ColumnCaption))]
         public string Text
         {
             get
             {
-                return (text ?? "ColumnHeader");
+                return text ?? nameof(ColumnHeader);
             }
             set
             {
@@ -338,11 +326,9 @@ namespace System.Windows.Forms
         /// <summary>
         ///  The horizontal alignment of the text contained in this column
         /// </summary>
-        [
-        SRDescription(nameof(SR.ColumnAlignment)),
-        Localizable(true),
-        DefaultValue(HorizontalAlignment.Left)
-        ]
+        [SRDescription(nameof(SR.ColumnAlignment))]
+        [Localizable(true)]
+        [DefaultValue(HorizontalAlignment.Left)]
         public HorizontalAlignment TextAlign
         {
             get
@@ -351,7 +337,7 @@ namespace System.Windows.Forms
                 {
                     textAlignInitialized = true;
                     // See below for an explanation of (Index != 0)
-                    //Added !IsMirrored
+                    // Added !IsMirrored
                     if ((Index != 0) && (listview.RightToLeft == RightToLeft.Yes) && !listview.IsMirrored)
                     {
                         textAlign = HorizontalAlignment.Right;
@@ -361,7 +347,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                //valid values are 0x0 to 0x2.
+                // valid values are 0x0 to 0x2.
                 if (!ClientUtils.IsEnumValid(value, (int)value, (int)HorizontalAlignment.Left, (int)HorizontalAlignment.Center))
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(HorizontalAlignment));
@@ -383,14 +369,12 @@ namespace System.Windows.Forms
             }
         }
 
-        [
-        SRCategory(nameof(SR.CatData)),
-        Localizable(false),
-        Bindable(true),
-        SRDescription(nameof(SR.ControlTagDescr)),
-        DefaultValue(null),
-        TypeConverter(typeof(StringConverter)),
-        ]
+        [SRCategory(nameof(SR.CatData))]
+        [Localizable(false)]
+        [Bindable(true)]
+        [SRDescription(nameof(SR.ControlTagDescr))]
+        [DefaultValue(null)]
+        [TypeConverter(typeof(StringConverter))]
         public object Tag
         {
             get
@@ -410,14 +394,13 @@ namespace System.Windows.Forms
                 return width;
             }
         }
+
         /// <summary>
         ///  The width of the column in pixels.
         /// </summary>
-        [
-        SRDescription(nameof(SR.ColumnWidth)),
-        Localizable(true),
-        DefaultValue(60)
-        ]
+        [SRDescription(nameof(SR.ColumnWidth))]
+        [Localizable(true)]
+        [DefaultValue(60)]
         public int Width
         {
             get
@@ -533,7 +516,7 @@ namespace System.Windows.Forms
 
         internal bool ShouldSerializeText()
         {
-            return (text != null);
+            return text != null;
         }
 
         /// <summary>
@@ -541,7 +524,7 @@ namespace System.Windows.Forms
         /// </summary>
         public override string ToString()
         {
-            return "ColumnHeader: Text: " + Text;
+            return $"{nameof(ColumnHeader)}: Text: {Text}";
         }
 
         internal class ColumnHeaderImageListIndexer : ImageList.Indexer

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
@@ -506,7 +506,7 @@ namespace System.Windows.Forms
 
         private bool ShouldSerializeName()
         {
-            return !string.IsNullOrEmpty(name);
+            return !string.IsNullOrEmpty(Name);
         }
 
         private bool ShouldSerializeDisplayIndex()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.cs
@@ -18,10 +18,10 @@ namespace System.Windows.Forms.Design
     /// <summary>
     ///  Provides a user interface for <see cref='WindowsFormsComponentEditor'/>.
     /// </summary>
-    [ComVisible(true),
-     ClassInterface(ClassInterfaceType.AutoDispatch)
-    ]
+    [ComVisible(true)]
+    [ClassInterface(ClassInterfaceType.AutoDispatch)]
     [ToolboxItem(false)]
+    [DesignerCategory("code")]
     public class ComponentEditorForm : Form
     {
         private readonly IComponent component;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -22,17 +22,15 @@ namespace System.Windows.Forms
     /// <summary>
     ///  Represents a window or dialog box that makes up an application's user interface.
     /// </summary>
-    [
-    ComVisible(true),
-    ClassInterface(ClassInterfaceType.AutoDispatch),
-    ToolboxItemFilter("System.Windows.Forms.Control.TopLevel"),
-    ToolboxItem(false),
-    DesignTimeVisible(false),
-    Designer("System.Windows.Forms.Design.FormDocumentDesigner, " + AssemblyRef.SystemDesign, typeof(IRootDesigner)),
-    DesignerCategory("Form"),
-    DefaultEvent(nameof(Load)),
-    InitializationEvent(nameof(Load)),
-    ]
+    [ComVisible(true)]
+    [ClassInterface(ClassInterfaceType.AutoDispatch)]
+    [ToolboxItemFilter("System.Windows.Forms.Control.TopLevel")]
+    [ToolboxItem(false)]
+    [DesignTimeVisible(false)]
+    [Designer("System.Windows.Forms.Design.FormDocumentDesigner, " + AssemblyRef.SystemDesign, typeof(IRootDesigner))]
+    [DefaultEvent(nameof(Load))]
+    [InitializationEvent(nameof(Load))]
+    [DesignerCategory("code")]
     public partial class Form : ContainerControl
     {
 #if DEBUG

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeaderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeaderTests.cs
@@ -913,6 +913,32 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
+        [InlineData("name", "name", true)]
+        [InlineData(null, "", false)]
+        public void ColumnHeader_Name_WithSite_ShouldSerializeValue_Success(string name, string resultingName, bool result)
+        {
+            PropertyDescriptor property = TypeDescriptor.GetProperties(typeof(ColumnHeader))[nameof(ColumnHeader.Name)];
+
+            // Get name from the Site
+            using ColumnHeader header = new ColumnHeader();
+            var mockSite = new Mock<ISite>(MockBehavior.Strict);
+            mockSite
+                .Setup(s => s.Name)
+                .Returns(name);
+            mockSite
+                .Setup(s => s.Component)
+                .Returns(header);
+            // Container is accessed when disposing the ColumnHeader component.
+            mockSite
+                .Setup(s => s.Container)
+                .Returns((IContainer)null);
+            header.Site = mockSite.Object;
+
+            Assert.Equal(resultingName, header.Name);
+            Assert.Equal(result, property.ShouldSerializeValue(header));
+        }
+
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringWithNullTheoryData))]
         public void ColumnHeader_Tag_Set_GetReturnsExpected(object value)
         {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #2867 


## Proposed changes

The `name` field is not set in this code, however it is read in ShouldSerializeName. Thus ShouldSerialize always returns `false` and ColumnHeader names are never serialized into `InitializeComponent` method. Thus `Name` property is always null at run time. However this property is used as a key  when accessing column display order. See issue for details. 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

listView1.Columns.IndexOfKey("columnHeader1") - always return `-1`

## Regression? 

- No

## Risk

-Winforms Core designer will be generating different code compared to the Framework designer.  

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

Unit test
 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2869)