### PR TITLE
Adding unit tests for DataGridViewAccessibleObject

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
@@ -27,6 +27,8 @@ namespace System.Windows.Forms
                 this.owner = owner;
             }
 
+            internal override bool IsReadOnly => owner.ReadOnly;
+
             public override string Name
             {
                 get

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
@@ -2243,6 +2243,8 @@ namespace System.Windows.Forms
                 return patternId.Equals(UiaCore.UIA.LegacyIAccessiblePatternId);
             }
 
+            internal override bool IsReadOnly => owner.ReadOnly;
+
             internal override object GetPropertyValue(UiaCore.UIA propertyId)
             {
                 switch (propertyId)

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewAccessibleObjectTests.cs
@@ -40,36 +40,60 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
         }
 
         [WinFormsFact]
-        public void DataGridViewAccessibleObject_GetChildCount_ReturnsCorrectValue()
+        public void DataGridViewAccessibleObject_EmptyGrid_GetChildCount_ReturnsCorrectValue()
         {
             using DataGridView dataGridView = new DataGridView();
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
-
-            Assert.Equal(0, accessibleObject.GetChildCount()); // dataGridView doesn't have an item
-
-            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
-            Assert.Equal(2, accessibleObject.GetChildCount()); // ColumnHeaders and First Row
-
-            dataGridView.ColumnHeadersVisible = false;
-            Assert.Equal(1, accessibleObject.GetChildCount()); // First Row only
+            Assert.Equal(0, accessibleObject.GetChildCount()); // dataGridView doesn't have items
         }
 
         [WinFormsFact]
-        public void DataGridViewAccessibleObject_GetChild_ReturnsCorrectValue()
+        public void DataGridViewAccessibleObject_GridWithFirstRowOnly_GetChildCount_ReturnsCorrectValue()
         {
             using DataGridView dataGridView = new DataGridView();
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.ColumnHeadersVisible = false;
+            Assert.Equal(1, accessibleObject.GetChildCount()); // A first row only
+        }
 
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_GridWithColumnHeadersAndFirstRow_GetChildCount_ReturnsCorrectValue()
+        {
+            using DataGridView dataGridView = new DataGridView();
+            AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            Assert.Equal(2, accessibleObject.GetChildCount()); // Column headers and a first Row
+        }
+
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_EmptyGrid_GetChild_ReturnsCorrectValue()
+        {
+            using DataGridView dataGridView = new DataGridView();
+            AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
             Assert.Equal(0, accessibleObject.GetChildCount()); // dataGridView doesn't have an item
             Assert.Null(accessibleObject.GetChild(0)); // GetChild method should not throw an exception
+        }
 
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_GridWithFirstRowOnly_GetChild_ReturnsCorrectValue()
+        {
+            using DataGridView dataGridView = new DataGridView();
+            AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
             dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
-            Assert.NotNull(accessibleObject.GetChild(0)); // dataGridView ColumnHeaders
-            Assert.NotNull(accessibleObject.GetChild(1)); // dataGridView a new empty row
-
             dataGridView.ColumnHeadersVisible = false;
-            Assert.NotNull(accessibleObject.GetChild(0)); // dataGridView a new empty row.
+            Assert.NotNull(accessibleObject.GetChild(0)); // dataGridView a first empty row.
             Assert.Null(accessibleObject.GetChild(1)); // GetChild method should not throw an exception
+        }
+
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_GridWithColumnHeadersAndFirstRow_GetChild_ReturnsCorrectValue()
+        {
+            using DataGridView dataGridView = new DataGridView();
+            AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            Assert.NotNull(accessibleObject.GetChild(0)); // dataGridView column headers
+            Assert.NotNull(accessibleObject.GetChild(1)); // dataGridView a first empty row
         }
 
         [WinFormsFact]
@@ -234,23 +258,59 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void DataGridViewAccessibleObject_IsReadOnly_ReturnsCorrectValue(bool isReadOnly)
+        public void DataGridViewAccessibleObject_Cell_IsReadOnly_ReturnsCorrectValue(bool isReadOnly)
         {
             using DataGridView dataGridView = new DataGridView();
             dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
 
             dataGridView.Rows[0].Cells[0].ReadOnly = isReadOnly;
-            TestIsReadonly(dataGridView);
 
-            dataGridView.Rows[0].ReadOnly = isReadOnly;
-            TestIsReadonly(dataGridView);
+            Assert.Equal(dataGridView.ReadOnly, dataGridView.AccessibilityObject.IsReadOnly);
 
-            dataGridView.ReadOnly = isReadOnly;
-            TestIsReadonly(dataGridView);
+            foreach (DataGridViewRow row in dataGridView.Rows)
+            {
+                Assert.Equal(row.ReadOnly, row.AccessibilityObject.IsReadOnly);
+
+                foreach (DataGridViewCell cell in row.Cells)
+                {
+                    Assert.Equal(cell.ReadOnly, cell.AccessibilityObject.IsReadOnly);
+                }
+            }
         }
 
-        private void TestIsReadonly(DataGridView dataGridView)
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewAccessibleObject_Row_IsReadOnly_ReturnsCorrectValue(bool isReadOnly)
         {
+            using DataGridView dataGridView = new DataGridView();
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+
+            dataGridView.Rows[0].ReadOnly = isReadOnly;
+
+            Assert.Equal(dataGridView.ReadOnly, dataGridView.AccessibilityObject.IsReadOnly);
+
+            foreach (DataGridViewRow row in dataGridView.Rows)
+            {
+                Assert.Equal(row.ReadOnly, row.AccessibilityObject.IsReadOnly);
+
+                foreach (DataGridViewCell cell in row.Cells)
+                {
+                    Assert.Equal(cell.ReadOnly, cell.AccessibilityObject.IsReadOnly);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewAccessibleObject_Grid_IsReadOnly_ReturnsCorrectValue(bool isReadOnly)
+        {
+            using DataGridView dataGridView = new DataGridView();
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+
+            dataGridView.ReadOnly = isReadOnly;
+
             Assert.Equal(dataGridView.ReadOnly, dataGridView.AccessibilityObject.IsReadOnly);
 
             foreach (DataGridViewRow row in dataGridView.Rows)

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewAccessibleObjectTests.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
+using System.Drawing;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using Xunit;
 using static Interop;
 
@@ -10,20 +13,20 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
 {
     public class DataGridViewAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
     {
-        [Fact]
-        public void PropertyGridAccessibleObject_Ctor_Default()
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_Ctor_Default()
         {
-            DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new DataGridView();
 
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
             Assert.NotNull(accessibleObject);
             Assert.Equal(AccessibleRole.Table, accessibleObject.Role);
         }
 
-        [Fact]
-        public void DataGridViewAccessibleObject_ItemStatus()
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_ItemStatus_ReturnsAsSorted()
         {
-            DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new DataGridView();
             DataGridViewTextBoxColumn column = new DataGridViewTextBoxColumn();
             column.SortMode = DataGridViewColumnSortMode.Programmatic;
             column.HeaderText = "Some column";
@@ -34,6 +37,247 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             string itemStatus = dataGridView.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ItemStatusPropertyId)?.ToString();
             string expectedStatus = "Sorted ascending by Some column.";
             Assert.Equal(expectedStatus, itemStatus);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_GetChildCount_ReturnsCorrectValue()
+        {
+            using DataGridView dataGridView = new DataGridView();
+            AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
+
+            Assert.Equal(0, accessibleObject.GetChildCount()); // dataGridView doesn't have an item
+
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            Assert.Equal(2, accessibleObject.GetChildCount()); // ColumnHeaders and First Row
+
+            dataGridView.ColumnHeadersVisible = false;
+            Assert.Equal(1, accessibleObject.GetChildCount()); // First Row only
+        }
+
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_GetChild_ReturnsCorrectValue()
+        {
+            using DataGridView dataGridView = new DataGridView();
+            AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
+
+            Assert.Equal(0, accessibleObject.GetChildCount()); // dataGridView doesn't have an item
+            Assert.Null(accessibleObject.GetChild(0)); // GetChild method should not throw an exception
+
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            Assert.NotNull(accessibleObject.GetChild(0)); // dataGridView ColumnHeaders
+            Assert.NotNull(accessibleObject.GetChild(1)); // dataGridView a new empty row
+
+            dataGridView.ColumnHeadersVisible = false;
+            Assert.NotNull(accessibleObject.GetChild(0)); // dataGridView a new empty row.
+            Assert.Null(accessibleObject.GetChild(1)); // GetChild method should not throw an exception
+        }
+
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_Bounds_ReturnsCorrectValue()
+        {
+            using DataGridView dataGridView = new DataGridView();
+            dataGridView.Size = new Size(500, 300);
+            AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
+
+            int actualWidth = accessibleObject.Bounds.Width;
+            int expectedWidth = dataGridView.Size.Width;
+            Assert.Equal(expectedWidth, actualWidth);
+
+            int actualHeight = accessibleObject.Bounds.Height;
+            int expectedHeight = dataGridView.Size.Height;
+            Assert.Equal(expectedHeight, actualHeight);
+
+            Rectangle actualBounds = accessibleObject.Bounds;
+            actualBounds.Location = new Point(0, 0);
+            Rectangle expectedBounds = dataGridView.Bounds;
+            Assert.Equal(expectedBounds, actualBounds);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_ControlType_IsTable()
+        {
+            using DataGridView dataGridView = new DataGridView();
+            AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
+            object actual = accessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
+            UiaCore.UIA expected = UiaCore.UIA.TableControlTypeId;
+            Assert.Equal(expected, actual);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_GetFocused_ReturnsCorrectFocusedCell()
+        {
+            using DataGridView dataGridView = new DataGridView();
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.CreateControl();
+            User32.SetFocus(new HandleRef(dataGridView, dataGridView.Handle));
+
+            DataGridViewCell cell = dataGridView.Rows[0].Cells[0];
+            Assert.NotNull(cell);
+
+            dataGridView.CurrentCell = cell;
+            Assert.True(cell.Selected);
+
+            AccessibleObject focusedCell = dataGridView.AccessibilityObject.GetFocused();
+            Assert.NotNull(focusedCell);
+            Assert.Equal(cell.AccessibilityObject, focusedCell);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_GetItem_ReturnsCorrectValue()
+        {
+            using DataGridView dataGridView = new DataGridView();
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add();
+
+            for (int i = 0; i < dataGridView.Rows.Count; i++)
+            {
+                for (int j = 0; j < dataGridView.Rows[i].Cells.Count; j++)
+                {
+                    AccessibleObject expected = dataGridView.Rows[i].Cells[j].AccessibilityObject;
+                    AccessibleObject actual = (AccessibleObject)dataGridView.AccessibilityObject.GetItem(i, j);
+                    Assert.Equal(expected, actual);
+                }
+            }
+        }
+
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_ItemStatus_IsCorrectWhenSorted()
+        {
+            using DataGridView dataGridView = new DataGridView();
+            using DataGridViewTextBoxColumn column = new DataGridViewTextBoxColumn();
+            column.SortMode = DataGridViewColumnSortMode.Programmatic;
+            column.HeaderText = "Some column";
+
+            dataGridView.Columns.Add(column);
+            dataGridView.Sort(dataGridView.Columns[0], ListSortDirection.Ascending);
+
+            string actualStatus = dataGridView.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ItemStatusPropertyId)?.ToString();
+            string expectedStatus = "Sorted ascending by Some column.";
+            Assert.Equal(expectedStatus, actualStatus);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_State_IsFocusable()
+        {
+            using DataGridView dataGridView = new DataGridView();
+            AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
+            Assert.Equal(AccessibleStates.Focusable, accessibleObject.State & AccessibleStates.Focusable);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_Ctor_NullOwnerParameter_ThrowsArgumentNullException()
+        {
+            using DataGridView dataGridView = new DataGridView();
+            Type type = dataGridView.AccessibilityObject.GetType();
+            ConstructorInfo ctor = type.GetConstructor(new Type[] { typeof(DataGridView) });
+            Assert.NotNull(ctor);
+            Assert.Throws<TargetInvocationException>(() => ctor.Invoke(new object[] { null }));
+        }
+
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_FirstAndLastChildren_AreNotNull()
+        {
+            using DataGridView dataGridView = new DataGridView();
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
+
+            // ColumnHeaders
+            UiaCore.IRawElementProviderFragment firstChild = accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild);
+            Assert.NotNull(firstChild);
+
+            // New row
+            UiaCore.IRawElementProviderFragment lastChild = accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild);
+            Assert.NotNull(lastChild);
+        }
+
+        [Theory]
+        [InlineData((int)UiaCore.UIA.IsGridPatternAvailablePropertyId)]
+        [InlineData((int)UiaCore.UIA.IsTablePatternAvailablePropertyId)]
+        public void DataGridViewAccessibleObject_Pattern_IsAvailable(int propertyId)
+        {
+            using DataGridView dataGridView = new DataGridView();
+            AccessibleObject accessibilityObject = dataGridView.AccessibilityObject;
+            Assert.True((bool)accessibilityObject.GetPropertyValue((UiaCore.UIA)propertyId));
+        }
+
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_Cell_IsOffscreen_ReturnsCorrectValue()
+        {
+            using DataGridView dataGridView = new DataGridView();
+            AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
+            dataGridView.Size = new Size(200, 100);
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+
+            dataGridView.Rows.Add(); // 1
+            object isOffscreen = dataGridView.Rows[1].Cells[0].AccessibilityObject.GetPropertyValue(UiaCore.UIA.IsOffscreenPropertyId);
+            Assert.False((bool)isOffscreen); // Within the visible area
+
+            dataGridView.Rows.Add(); // 2
+            dataGridView.Rows.Add(); // 3
+            dataGridView.Rows.Add(); // 4
+            isOffscreen = dataGridView.Rows[4].Cells[0].AccessibilityObject.GetPropertyValue(UiaCore.UIA.IsOffscreenPropertyId);
+            Assert.True((bool)isOffscreen); // Out of the visible area
+        }
+
+        [Theory]
+        [InlineData((int)UiaCore.UIA.TablePatternId)]
+        [InlineData((int)UiaCore.UIA.GridPatternId)]
+        public void DataGridViewAccessibleObject_IsPatternSupported(int patternId)
+        {
+            using DataGridView dataGridView = new DataGridView();
+            AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
+            Assert.True(accessibleObject.IsPatternSupported((UiaCore.UIA)patternId));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewAccessibleObject_IsReadOnly_ReturnsCorrectValue(bool isReadOnly)
+        {
+            using DataGridView dataGridView = new DataGridView();
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+
+            dataGridView.Rows[0].Cells[0].ReadOnly = isReadOnly;
+            TestIsReadonly(dataGridView);
+
+            dataGridView.Rows[0].ReadOnly = isReadOnly;
+            TestIsReadonly(dataGridView);
+
+            dataGridView.ReadOnly = isReadOnly;
+            TestIsReadonly(dataGridView);
+        }
+
+        private void TestIsReadonly(DataGridView dataGridView)
+        {
+            Assert.Equal(dataGridView.ReadOnly, dataGridView.AccessibilityObject.IsReadOnly);
+
+            foreach (DataGridViewRow row in dataGridView.Rows)
+            {
+                Assert.Equal(row.ReadOnly, row.AccessibilityObject.IsReadOnly);
+
+                foreach (DataGridViewCell cell in row.Cells)
+                {
+                    Assert.Equal(cell.ReadOnly, cell.AccessibilityObject.IsReadOnly);
+                }
+            }
+        }
+
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_Owner_IsNotNull()
+        {
+            using DataGridView dataGridView = new DataGridView();
+            Control.ControlAccessibleObject accessibleObject = (Control.ControlAccessibleObject)dataGridView.AccessibilityObject;
+            Assert.NotNull(accessibleObject.Owner);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_Parent_IsNotNull()
+        {
+            using DataGridView dataGridView = new DataGridView();
+            AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
+            Assert.NotNull(accessibleObject.Parent);
         }
     }
 }


### PR DESCRIPTION
Fixes #1833

## Proposed changes

- Add unit tests
- Fix IsReadOnly property for DataGridViewAccessibleObject and DataGridViewRowAccessibleObject

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- No

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->

## Test environment(s) <!-- Remove any that don't apply -->

- SDK Version: 5.0.100-alpha1-016143
- Microsoft Windows [Version 10.0.18363.592]


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2871)