### PR TITLE
Adding PropertyGridViewAccessibleObject unit tests

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridAccessibleObjectTests.cs
@@ -2,20 +2,54 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Windows.Forms.PropertyGridInternal;
 using Xunit;
+using static Interop;
 
 namespace System.Windows.Forms.Tests.AccessibleObjects
 {
     public class PropertyGridAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
     {
-        [Fact]
+        [WinFormsFact]
         public void PropertyGridAccessibleObject_Ctor_Default()
         {
-            PropertyGrid propertyGrid = new PropertyGrid();
-
-            var accessibleObject = new PropertyGridAccessibleObject(propertyGrid);
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            PropertyGridAccessibleObject accessibleObject = new PropertyGridAccessibleObject(propertyGrid);
             Assert.NotNull(accessibleObject.Owner);
             Assert.Equal(propertyGrid, accessibleObject.Owner);
+        }
+
+        [Theory]
+        [InlineData((int)UiaCore.UIA.TableItemPatternId)]
+        [InlineData((int)UiaCore.UIA.GridItemPatternId)]
+        public void GridEntryAccessibleObject_SupportsPattern(int pattern)
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            using ComboBox comboBox = new ComboBox();
+            propertyGrid.SelectedObject = comboBox;
+            GridEntry defaultGridEntry = propertyGrid.GetDefaultGridEntry();
+            GridEntry parentGridEntry = defaultGridEntry.ParentGridEntry; // Category which has item pattern.
+            AccessibleObject accessibleObject = parentGridEntry.AccessibilityObject;
+            Assert.True(accessibleObject.IsPatternSupported((UiaCore.UIA)pattern));
+        }
+
+        [Theory]
+        [InlineData((int)UiaCore.UIA.GridPatternId)]
+        [InlineData((int)UiaCore.UIA.TablePatternId)]
+        public void PropertyGridAccessibleObject_SupportsPattern(int pattern)
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            using ComboBox comboBox = new ComboBox();
+            propertyGrid.SelectedObject = comboBox;
+            PropertyGridAccessibleObject propertyGridAccessibleObject = new PropertyGridAccessibleObject(propertyGrid);
+
+            // First child should be PropertyGrid toolbox.
+            AccessibleObject firstChild = (AccessibleObject)propertyGridAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild);
+
+            // Second child entry should be PropertyGridView.
+            AccessibleObject gridViewChild = (AccessibleObject)firstChild.FragmentNavigate(UiaCore.NavigateDirection.NextSibling);
+
+            Assert.True(gridViewChild.IsPatternSupported((UiaCore.UIA)pattern));
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridViewAccessibleObjectTests.cs
@@ -2,46 +2,266 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
+using System.Reflection;
+using System.Windows.Forms.PropertyGridInternal;
 using Xunit;
+using static System.Windows.Forms.Control;
+using static System.Windows.Forms.PropertyGridInternal.PropertyGridView;
 using static Interop;
 
 namespace System.Windows.Forms.Tests.AccessibleObjects
 {
     public class PropertyGridViewAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
     {
-        [Theory]
-        [InlineData((int)UiaCore.UIA.GridPatternId)]
-        [InlineData((int)UiaCore.UIA.TablePatternId)]
-        public void PropertyGridAccessibleObject_Supports_TablePattern(int pattern)
+        [WinFormsFact]
+        public void PropertyGridViewAccessibleObject_Ctor_Default()
         {
-            PropertyGrid propertyGrid = new PropertyGrid();
-            ComboBox comboBox = new ComboBox();
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            AccessibleObject accessibleObject = propertyGrid.GridViewAccessibleObject;
+            Assert.NotNull(accessibleObject);
+
+            using PropertyGridView propertyGridView = new PropertyGridView(null, propertyGrid);
+            accessibleObject = new PropertyGridViewAccessibleObject(propertyGridView, propertyGrid);
+            Assert.NotNull(accessibleObject);
+        }
+
+        [WinFormsFact]
+        public void PropertyGridViewAccessibleObject_Ctor_NullOwner_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new PropertyGridViewAccessibleObject(null, null));
+        }
+
+        [WinFormsFact]
+        public void PropertyGridViewAccessibleObject_GetFocused_ReturnsCorrectValue()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            using ComboBox comboBox = new ComboBox();
+            propertyGrid.SelectedObject = comboBox;
+            GridEntry entry = (GridEntry)((GridEntry)propertyGrid.GetPropEntries()[0]).Children[2];
+            entry.Focus = true;
+            entry.Select();
+            Assert.Equal(entry, propertyGrid.SelectedGridItem);
+
+            AccessibleObject focusedEntry = propertyGrid.GridViewAccessibleObject.GetFocused();
+            Assert.Equal(entry.AccessibilityObject, focusedEntry);
+        }
+
+        [WinFormsFact]
+        public void PropertyGridViewAccessibleObject_GetSelected_ReturnsCorrectValue()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            using ComboBox comboBox = new ComboBox();
+            propertyGrid.SelectedObject = comboBox;
+            GridEntry entry = (GridEntry)((GridEntry)propertyGrid.GetPropEntries()[0]).Children[2];
+            entry.Focus = true;
+            entry.Select();
+            Assert.Equal(entry, propertyGrid.SelectedGridItem);
+
+            AccessibleObject focusedEntry = propertyGrid.GridViewAccessibleObject.GetSelected();
+            Assert.Equal(entry.AccessibilityObject, focusedEntry);
+        }
+
+        [WinFormsFact]
+        public void PropertyGridViewAccessibleObject_GetChildCount_ReturnsCorrectValue()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            AccessibleObject accessibleObject = propertyGrid.GridViewAccessibleObject;
+
+            Assert.Equal(0, accessibleObject.GetChildCount()); // propertyGrid doesn't have an item
+
+            using ComboBox comboBox = new ComboBox();
             propertyGrid.SelectedObject = comboBox;
 
-            var propertyGridAccessibleObject = new PropertyGridAccessibleObject(propertyGrid);
+            int count = 0;
 
-            // First child should be PropertyGrid toolbox.
-            var firstChild = propertyGridAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            foreach (GridEntry category in propertyGrid.GetPropEntries())
+            {
+                count++;
 
-            // Second child entry should be PropertyGridView.
-            var gridViewChild = firstChild.FragmentNavigate(UiaCore.NavigateDirection.NextSibling) as AccessibleObject;
+                foreach (GridEntry entry in category.Children)
+                {
+                    count++;
+                }
+            }
 
-            Assert.True(gridViewChild.IsPatternSupported(((UiaCore.UIA)pattern)));
+            Assert.Equal(count, accessibleObject.GetChildCount()); // Properties
+        }
+
+        [WinFormsFact]
+        public void PropertyGridViewAccessibleObject_GetChild_ReturnsCorrectValue()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            AccessibleObject accessibleObject = propertyGrid.GridViewAccessibleObject;
+
+            Assert.Equal(0, accessibleObject.GetChildCount()); // propertyGrid doesn't have items
+            Assert.Null(accessibleObject.GetChild(0)); // GetChild method should not throw an exception
+
+            using ComboBox comboBox = new ComboBox();
+            propertyGrid.SelectedObject = comboBox;
+
+            Assert.True(accessibleObject.GetChild(0) is GridEntry.GridEntryAccessibleObject); // "Accessibility" category entry
+            Assert.True(accessibleObject.GetChild(1) is GridEntry.GridEntryAccessibleObject); // "AccessibleDescriptor" entry
+            Assert.True(accessibleObject.GetChild(2) is GridEntry.GridEntryAccessibleObject); // "AccessibleName" entry
+            Assert.True(accessibleObject.GetChild(3) is GridEntry.GridEntryAccessibleObject); // "AccessibleRole" entry
+            Assert.True(accessibleObject.GetChild(4) is GridEntry.GridEntryAccessibleObject); // "Appereance" category entry
+        }
+
+        [WinFormsFact]
+        public void PropertyGridViewAccessibleObject_Bounds_InsidePropertyGridBounds()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            propertyGrid.CreateControl();
+            propertyGrid.Size = new Size(300, 500);
+            using ComboBox comboBox = new ComboBox();
+            propertyGrid.SelectedObject = comboBox;
+            AccessibleObject accessibleObject = propertyGrid.GridViewAccessibleObject;
+
+            Rectangle gridViewBounds = propertyGrid.RectangleToClient(accessibleObject.Bounds);
+            Rectangle propertyGridBounds = propertyGrid.Bounds;
+            Assert.True(propertyGridBounds.Contains(gridViewBounds));
+        }
+
+        [WinFormsFact]
+        public void PropertyGridViewAccessibleObject_ControlType_IsTable()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            AccessibleObject accessibleObject = propertyGrid.GridViewAccessibleObject;
+            object actual = accessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
+            UiaCore.UIA expected = UiaCore.UIA.TableControlTypeId;
+            Assert.Equal(expected, actual);
+        }
+
+        [WinFormsFact]
+        public void PropertyGridViewAccessibleObject_GetItem_ReturnsCorrectValue()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            propertyGrid.CreateControl();
+            using ComboBox comboBox = new ComboBox();
+            propertyGrid.SelectedObject = comboBox;
+            AccessibleObject accessibleObject = propertyGrid.GridViewAccessibleObject;
+
+            int i = 0;
+
+            foreach (GridEntry category in propertyGrid.GetPropEntries())
+            {
+                AccessibleObject categoryAccessibilityObject = category.AccessibilityObject;
+                AccessibleObject categoryItem = (AccessibleObject)accessibleObject.GetItem(i, 1);
+                Assert.Equal(categoryAccessibilityObject, categoryItem);
+                i++;
+
+                foreach (GridEntry entry in category.Children)
+                {
+                    AccessibleObject entryAccessibilityObject = entry.AccessibilityObject;
+                    AccessibleObject entryItem = (AccessibleObject)accessibleObject.GetItem(i, 1);
+                    Assert.Equal(categoryAccessibilityObject, categoryItem);
+                    i++;
+                }
+            }
+        }
+
+        [WinFormsFact]
+        public void PropertyGridViewAccessibleObject_State_IsFocusable()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            propertyGrid.CreateControl();
+            using ComboBox comboBox = new ComboBox();
+            propertyGrid.SelectedObject = comboBox;
+            AccessibleObject accessibleObject = propertyGrid.GridViewAccessibleObject;
+            Assert.Equal(AccessibleStates.Focusable, accessibleObject.State & AccessibleStates.Focusable);
+        }
+
+        [WinFormsFact]
+        public void PropertyGridViewAccessibleObject_Ctor_NullOwnerParameter_ThrowsArgumentNullException()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            AccessibleObject accessibleObject = propertyGrid.GridViewAccessibleObject;
+            Type type = accessibleObject.GetType();
+            ConstructorInfo ctor = type.GetConstructor(new Type[] { typeof(PropertyGridView), typeof(PropertyGrid) });
+            Assert.NotNull(ctor);
+            Assert.Throws<TargetInvocationException>(() => ctor.Invoke(new object[] { null, null }));
         }
 
         [Theory]
-        [InlineData((int)UiaCore.UIA.GridItemPatternId)]
-        [InlineData((int)UiaCore.UIA.TableItemPatternId)]
-        public void PropertyGridViewAccessibleObject_Supports_TablePattern(int pattern)
+        [InlineData((int)UiaCore.UIA.IsGridPatternAvailablePropertyId)]
+        [InlineData((int)UiaCore.UIA.IsTablePatternAvailablePropertyId)]
+        public void PropertyGridViewAccessibleObject_Pattern_IsAvailable(int propertyId)
         {
-            PropertyGrid propertyGrid = new PropertyGrid();
-            ComboBox comboBox = new ComboBox();
-            propertyGrid.SelectedObject = comboBox;
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            AccessibleObject accessibleObject = propertyGrid.GridViewAccessibleObject;
+            Assert.True((bool)accessibleObject.GetPropertyValue((UiaCore.UIA)propertyId));
+        }
 
-            var defaultGridEntry = propertyGrid.GetDefaultGridEntry();
-            var parentGridEntry = defaultGridEntry.ParentGridEntry; // Category which has item pattern.
-            var accessibleObject = parentGridEntry.AccessibilityObject;
-            Assert.True(accessibleObject.IsPatternSupported((UiaCore.UIA)pattern));
+        [Theory]
+        [InlineData((int)UiaCore.UIA.TablePatternId)]
+        [InlineData((int)UiaCore.UIA.GridPatternId)]
+        public void PropertyGridViewAccessibleObject_IsPatternSupported(int patternId)
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            AccessibleObject accessibleObject = propertyGrid.GridViewAccessibleObject;
+            Assert.True(accessibleObject.IsPatternSupported((UiaCore.UIA)patternId));
+        }
+
+        [WinFormsFact]
+        public void PropertyGridViewAccessibleObject_Entry_IsOffscreen_ReturnsCorrectValue()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            propertyGrid.Size = new Size(300, 500);
+            propertyGrid.Location = new Point(0, 0);
+            propertyGrid.CreateControl();
+            using ComboBox comboBox = new ComboBox();
+            propertyGrid.SelectedObject = comboBox;
+            ControlAccessibleObject accessibleObject = (ControlAccessibleObject)propertyGrid.GridViewAccessibleObject;
+            PropertyGridView propertyGridView = (PropertyGridView)accessibleObject.Owner;
+
+            Rectangle gridViewRectangle = accessibleObject.Bounds;
+
+            int ROWLABEL = 1;
+            int ROWVALUE = 2;
+
+            foreach (GridEntry category in propertyGrid.GetPropEntries())
+            {
+                AccessibleObject categoryAccessibilityObject = category.AccessibilityObject;
+                int row = propertyGridView.GetRowFromGridEntry(category);
+                Rectangle rect = propertyGridView.GetRectangle(row, ROWVALUE | ROWLABEL);
+                rect = propertyGridView.RectangleToScreen(rect);
+
+                bool visible = rect.Height > 0 &&
+                             ((rect.Y > gridViewRectangle.Y + 1 && rect.Y < gridViewRectangle.Bottom - 1) ||
+                              (rect.Y < gridViewRectangle.Bottom - 1 && rect.Bottom > gridViewRectangle.Y + 1)); // +-1 are borders
+
+                Assert.Equal(!visible, (bool)categoryAccessibilityObject.GetPropertyValue(UiaCore.UIA.IsOffscreenPropertyId));
+
+                foreach (GridEntry entry in category.Children)
+                {
+                    AccessibleObject entryAccessibilityObject = entry.AccessibilityObject;
+                    row = propertyGridView.GetRowFromGridEntry(entry);
+                    rect = propertyGridView.GetRectangle(row, ROWVALUE | ROWLABEL);
+                    rect = propertyGridView.RectangleToScreen(rect);
+
+                    visible = rect.Height > 0 &&
+                             ((rect.Y > gridViewRectangle.Y + 1 && rect.Y < gridViewRectangle.Bottom - 1) ||
+                              (rect.Y < gridViewRectangle.Bottom - 1 && rect.Bottom > gridViewRectangle.Y + 1)); // +-1 are borders
+
+                    Assert.Equal(!visible, (bool)entryAccessibilityObject.GetPropertyValue(UiaCore.UIA.IsOffscreenPropertyId));
+                }
+            }
+        }
+
+        [WinFormsFact]
+        public void PropertyGridViewAccessibleObject_Owner_IsNotNull()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            ControlAccessibleObject accessibleObject = (ControlAccessibleObject)propertyGrid.GridViewAccessibleObject;
+            Assert.NotNull(accessibleObject.Owner);
+        }
+
+        [WinFormsFact]
+        public void PropertyGridViewAccessibleObject_Parent_IsNotNull()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            ControlAccessibleObject accessibleObject = (ControlAccessibleObject)propertyGrid.GridViewAccessibleObject;
+            Assert.NotNull(accessibleObject.Parent);
         }
     }
 }


### PR DESCRIPTION
Fixes #1832

## Proposed changes

- Add unit tests for PropertyGridViewAccessibleObject
- Move PropertyGrid tests to PropertyGridAccessibleObjectTests class

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- No

## Regression? 

- No

## Risk

- Minimal

## Test environment(s) <!-- Remove any that don't apply -->

- SDK Version: 5.0.100-alpha1-016143
- Microsoft Windows [Version 10.0.18363.592]


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2875)