### PR TITLE
Add GDTR enum to Interop ComCtl32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.GDTR.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.GDTR.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        [Flags]
+        public enum GDTR : uint
+        {
+            MIN = 0x0001,
+            MAX = 0x0002
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -40,9 +40,7 @@ namespace System.Windows.Forms
         public const int FADF_VARIANT = (unchecked((int)0x800));
 
         public const int
-        GDI_ERROR = (unchecked((int)0xFFFFFFFF)),
-        GDTR_MIN = 0x0001,
-        GDTR_MAX = 0x0002;
+        GDI_ERROR = (unchecked((int)0xFFFFFFFF));
 
         public const int
         HCF_HIGHCONTRASTON = 0x00000001,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
@@ -1433,7 +1433,7 @@ namespace System.Windows.Forms
                 Span<Kernel32.SYSTEMTIME> sa = stackalloc Kernel32.SYSTEMTIME[2];
                 sa[0] = DateTimeToSysTime(min);
                 sa[1] = DateTimeToSysTime(max);
-                int flags = NativeMethods.GDTR_MIN | NativeMethods.GDTR_MAX;
+                GDTR flags = GDTR.MIN | GDTR.MAX;
                 User32.SendMessageW(this, (User32.WM)DTM.SETRANGE, (IntPtr)flags, ref sa[0]);
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -1798,8 +1798,8 @@ namespace System.Windows.Forms
                 Span<Kernel32.SYSTEMTIME> sa = stackalloc Kernel32.SYSTEMTIME[2];
                 sa[0] = DateTimePicker.DateTimeToSysTime(minDate);
                 sa[1] = DateTimePicker.DateTimeToSysTime(maxDate);
-                int flag = NativeMethods.GDTR_MIN | NativeMethods.GDTR_MAX;
-                if ((int)User32.SendMessageW(this, (User32.WM)MCM.SETRANGE, (IntPtr)flag, ref sa[0]) == 0)
+                GDTR flags = GDTR.MIN | GDTR.MAX;
+                if ((int)User32.SendMessageW(this, (User32.WM)MCM.SETRANGE, (IntPtr)flags, ref sa[0]) == 0)
                 {
                     throw new InvalidOperationException(string.Format(SR.MonthCalendarRange, minDate.ToShortDateString(), maxDate.ToShortDateString()));
                 }


### PR DESCRIPTION
## Proposed changes

- Add GDTR enum to Interop ComCtl32.
- Remove GDTR constants and replace their usages with the above enum values.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2876)