### PR TITLE
Add CreateICW to Interop Gdi32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.CreateICW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.CreateICW.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Gdi32
+    {
+        [DllImport(Libraries.Gdi32, ExactSpelling = true, SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern unsafe IntPtr CreateICW(char* lpszDriverName, char* lpszDeviceName, char* lpszOutput, IntPtr /*DEVMODE*/ lpInitData);
+
+        public static unsafe IntPtr CreateICW(string lpszDriverName, string lpszDeviceName, string lpszOutput, IntPtr /*DEVMODE*/ lpInitData)
+        {
+            fixed (char* driverName = lpszDriverName)
+            fixed (char* deviceName = lpszDeviceName)
+            fixed (char* output = lpszOutput)
+            {
+                return CreateICW(driverName, deviceName, output, lpInitData);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.PatBlt.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.PatBlt.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [DllImport(ExternDll.Gdi32, ExactSpelling = true)]
+        [DllImport(Libraries.Gdi32, ExactSpelling = true)]
         public static extern BOOL PatBlt(IntPtr hdc, int x, int y, int w, int h, ROP rop);
 
         public static BOOL PatBlt(HandleRef hdc, int x, int y, int w, int h, ROP rop)

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -130,9 +130,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.User32, ExactSpelling = true)]
         public static extern IntPtr GetWindowDC(HandleRef hWnd);
 
-        [DllImport(ExternDll.Gdi32, SetLastError = true, CharSet = CharSet.Unicode)]
-        public static extern IntPtr CreateIC(string lpszDriverName, string lpszDeviceName, string lpszOutput, HandleRef /*DEVMODE*/ lpInitData);
-
         //for RegionData
         [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern int GetRegionData(HandleRef hRgn, int size, IntPtr lpRgnData);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -707,7 +707,7 @@ namespace System.Windows.Forms
                     }
                     else if (IsHandleCreated)
                     {
-                        IntPtr hDC = UnsafeNativeMethods.CreateIC("DISPLAY", null, null, new HandleRef(null, IntPtr.Zero));
+                        IntPtr hDC = Gdi32.CreateICW("DISPLAY", null, null, IntPtr.Zero);
                         try
                         {
                             User32.SendMessageW(this, (User32.WM)RichEditMessages.EM_SETTARGETDEVICE, hDC, (IntPtr)Pixel2Twip(hDC, value, true));

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
@@ -848,7 +848,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void RichTextBox_RightMargin_GetWithHandle_ReturnsExpecte()
+        public void RichTextBox_RightMargin_GetWithHandle_ReturnsExpected()
         {
             using var control = new RichTextBox();
             Assert.NotEqual(IntPtr.Zero, control.Handle);


### PR DESCRIPTION
## Proposed changes

- Add CreateICW to Interop Gdi32.
- Remove CreateIC from UnsafeNativeMethods and replace its usages.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2881)