### PR TITLE
Remove unused FADF constants

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -34,10 +34,6 @@ namespace System.Windows.Forms
         DTN_CLOSEUP = ((0 - 760) + 7);
 
         public const int FRERR_BUFFERLENGTHZERO = 0x4001;
-        public const int FADF_BSTR = (0x100);
-        public const int FADF_UNKNOWN = (0x200);
-        public const int FADF_DISPATCH = (0x400);
-        public const int FADF_VARIANT = (unchecked((int)0x800));
 
         public const int
         GDI_ERROR = (unchecked((int)0xFFFFFFFF));


### PR DESCRIPTION
## Proposed changes

- Remove unused FADF constants.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2882)