### PR TITLE
Add NIF and NIIF enums to Interop Shell32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.NIF.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.NIF.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal partial class Interop
+{
+    internal static partial class Shell32
+    {
+        [Flags]
+        public enum NIF : uint
+        {
+            MESSAGE = 0x00000001,
+            ICON = 0x00000002,
+            TIP = 0x00000004,
+            STATE = 0x00000008,
+            INFO = 0x00000010,
+            GUID = 0x00000020,
+            REALTIME = 0x00000040,
+            SHOWTIP = 0x00000080
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.NIIF.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.NIIF.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal partial class Interop
+{
+    internal static partial class Shell32
+    {
+        [Flags]
+        public enum NIIF : uint
+        {
+            NONE = 0x00000000,
+            INFO = 0x00000001,
+            WARNING = 0x00000002,
+            ERROR = 0x00000003,
+            USER = 0x00000004,
+            ICON_MASK = 0x0000000F,
+            NOSOUND = 0x00000010,
+            LARGE_ICON = 0x00000020,
+            RESPECT_QUIET_TIME = 0x00000080
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -102,14 +102,6 @@ namespace System.Windows.Forms
         MSAA_MENU_SIG = (unchecked((int)0xAA0DF00D));
 
         public const int
-        NIF_MESSAGE = 0x00000001,
-        NIF_ICON = 0x00000002,
-        NIF_INFO = 0x00000010,
-        NIF_TIP = 0x00000004,
-        NIIF_NONE = 0x00000000,
-        NIIF_INFO = 0x00000001,
-        NIIF_WARNING = 0x00000002,
-        NIIF_ERROR = 0x00000003,
         NIN_BALLOONSHOW = ((int)User32.WM.USER + 2),
         NIN_BALLOONHIDE = ((int)User32.WM.USER + 3),
         NIN_BALLOONTIMEOUT = ((int)User32.WM.USER + 4),
@@ -435,7 +427,7 @@ namespace System.Windows.Forms
             public int cbSize = Marshal.SizeOf<NOTIFYICONDATA>();
             public IntPtr hWnd;
             public int uID;
-            public int uFlags;
+            public Shell32.NIF uFlags;
             public int uCallbackMessage;
             public IntPtr hIcon;
             [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
@@ -447,7 +439,7 @@ namespace System.Windows.Forms
             public int uTimeoutOrVersion;
             [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 64)]
             public string szInfoTitle;
-            public int dwInfoFlags;
+            public Shell32.NIIF dwInfoFlags;
         }
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
@@ -597,23 +597,23 @@ namespace System.Windows.Forms
                 }
                 data.hWnd = window.Handle;
                 data.uID = id;
-                data.uFlags = NativeMethods.NIF_INFO;
+                data.uFlags = NIF.INFO;
                 data.uTimeoutOrVersion = timeout;
                 data.szInfoTitle = tipTitle;
                 data.szInfo = tipText;
                 switch (tipIcon)
                 {
                     case ToolTipIcon.Info:
-                        data.dwInfoFlags = NativeMethods.NIIF_INFO;
+                        data.dwInfoFlags = NIIF.INFO;
                         break;
                     case ToolTipIcon.Warning:
-                        data.dwInfoFlags = NativeMethods.NIIF_WARNING;
+                        data.dwInfoFlags = NIIF.WARNING;
                         break;
                     case ToolTipIcon.Error:
-                        data.dwInfoFlags = NativeMethods.NIIF_ERROR;
+                        data.dwInfoFlags = NIIF.ERROR;
                         break;
                     case ToolTipIcon.None:
-                        data.dwInfoFlags = NativeMethods.NIIF_NONE;
+                        data.dwInfoFlags = NIIF.NONE;
                         break;
                 }
                 UnsafeNativeMethods.Shell_NotifyIcon(NIM.MODIFY, data);
@@ -659,7 +659,7 @@ namespace System.Windows.Forms
                 NativeMethods.NOTIFYICONDATA data = new NativeMethods.NOTIFYICONDATA
                 {
                     uCallbackMessage = WM_TRAYMOUSEMESSAGE,
-                    uFlags = NativeMethods.NIF_MESSAGE
+                    uFlags = NIF.MESSAGE
                 };
                 if (showIconInTray)
                 {
@@ -674,10 +674,10 @@ namespace System.Windows.Forms
                 data.szTip = null;
                 if (icon != null)
                 {
-                    data.uFlags |= NativeMethods.NIF_ICON;
+                    data.uFlags |= NIF.ICON;
                     data.hIcon = icon.Handle;
                 }
-                data.uFlags |= NativeMethods.NIF_TIP;
+                data.uFlags |= NIF.TIP;
                 data.szTip = text;
 
                 if (showIconInTray && icon != null)


### PR DESCRIPTION
## Proposed changes

- Add NIF and NIIF enums to Interop Shell32.
- Remove NIF and NIIF constants and replace their usages with the above enum values.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2883)