### PR TITLE
show file in code view 

### DIFF
--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -206,17 +206,13 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>MaskDesignerDialog.resx</DependentUpon>
     </Compile>
-    <Compile Update="System\Windows\Forms\Design\MaskedTextBoxTextEditorDropDown.cs">
-      <SubType>UserControl</SubType>
-    </Compile>
+    <Compile Update="System\Windows\Forms\Design\MaskedTextBoxTextEditorDropDown.cs" />
     <Compile Update="Resources\LinkAreaEditor.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>LinkAreaEditor.resx</DependentUpon>
     </Compile>
-    <Compile Update="System\Windows\Forms\Design\FormatControl.cs">
-      <SubType>UserControl</SubType>
-    </Compile>
+    <Compile Update="System\Windows\Forms\Design\FormatControl.cs" />
     <Compile Update="System\Windows\Forms\Design\FormatStringDialog.cs" />
   </ItemGroup>
 </Project>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UserControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UserControl.cs
@@ -18,14 +18,12 @@ namespace System.Windows.Forms
     ///  the standard positioning and mnemonic handling code that is necessary
     ///  in a user control.
     /// </summary>
-    [
-    ComVisible(true),
-    ClassInterface(ClassInterfaceType.AutoDispatch),
-    Designer("System.Windows.Forms.Design.UserControlDocumentDesigner, " + AssemblyRef.SystemDesign, typeof(IRootDesigner)),
-    Designer("System.Windows.Forms.Design.ControlDesigner, " + AssemblyRef.SystemDesign),
-    DesignerCategory("UserControl"),
-    DefaultEvent(nameof(Load))
-    ]
+    [ComVisible(true)]
+    [ClassInterface(ClassInterfaceType.AutoDispatch)]
+    [Designer("System.Windows.Forms.Design.UserControlDocumentDesigner, " + AssemblyRef.SystemDesign, typeof(IRootDesigner))]
+    [Designer("System.Windows.Forms.Design.ControlDesigner, " + AssemblyRef.SystemDesign)]
+    [DefaultEvent(nameof(Load))]
+    [DesignerCategory("code")]
     public class UserControl : ContainerControl
     {
         private static readonly object EVENT_LOAD = new object();


### PR DESCRIPTION
UserControl.cs has no content to show in the designer, thus setting the default editor to Code view.
FormatControl and MaskedTextBox.TextEdtorDropDown, would load in the designer eventually, thus not changing the files, only removing association with designer in the project.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2887)