### PR TITLE
Add DTS enum to Interop ComCtl32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.DTS.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.DTS.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        [Flags]
+        public enum DTS
+        {
+            SHORTDATEFORMAT = 0x0000,
+            UPDOWN = 0x0001,
+            SHOWNONE = 0x0002,
+            LONGDATEFORMAT = 0x0004,
+            TIMEFORMAT = 0x0009,
+            SHORTDATECENTURYFORMAT = 0x000C,
+            APPCANPARSE = 0x0010,
+            RIGHTALIGN = 0x0020
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -19,12 +19,6 @@ namespace System.Windows.Forms
         public const int CW_USEDEFAULT = (unchecked((int)0x80000000));
 
         public const int
-        DI_NORMAL = 0x0003,
-        DTS_UPDOWN = 0x0001,
-        DTS_SHOWNONE = 0x0002,
-        DTS_LONGDATEFORMAT = 0x0004,
-        DTS_TIMEFORMAT = 0x0009,
-        DTS_RIGHTALIGN = 0x0020,
         DTN_DATETIMECHANGE = ((0 - 760) + 1),
         DTN_USERSTRING = ((0 - 760) + 15),
         DTN_WMKEYDOWN = ((0 - 760) + 16),

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
@@ -51,7 +51,7 @@ namespace System.Windows.Forms
 
         private static readonly string DateTimePickerLocalizedControlTypeString = SR.DateTimePickerLocalizedControlType;
 
-        private const int TIMEFORMAT_NOUPDOWN = NativeMethods.DTS_TIMEFORMAT & (~NativeMethods.DTS_UPDOWN);
+        private const DTS TIMEFORMAT_NOUPDOWN = DTS.TIMEFORMAT & (~DTS.UPDOWN);
         private EventHandler onCloseUp;
         private EventHandler onDropDown;
         private EventHandler onValueChanged;
@@ -72,7 +72,7 @@ namespace System.Windows.Forms
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly DateTime MaxDateTime = new DateTime(9998, 12, 31);
 
-        private int style;
+        private DTS _style;
         private short prefHeightCache = -1;
 
         /// <summary>
@@ -450,17 +450,17 @@ namespace System.Windows.Forms
                 CreateParams cp = base.CreateParams;
                 cp.ClassName = WindowClasses.WC_DATETIMEPICK;
 
-                cp.Style |= style;
+                cp.Style |= (int)_style;
 
                 switch (format)
                 {
                     case DateTimePickerFormat.Long:
-                        cp.Style |= NativeMethods.DTS_LONGDATEFORMAT;
+                        cp.Style |= (int)DTS.LONGDATEFORMAT;
                         break;
                     case DateTimePickerFormat.Short:
                         break;
                     case DateTimePickerFormat.Time:
-                        cp.Style |= TIMEFORMAT_NOUPDOWN;
+                        cp.Style |= (int)TIMEFORMAT_NOUPDOWN;
                         break;
                     case DateTimePickerFormat.Custom:
                         break;
@@ -562,9 +562,9 @@ namespace System.Windows.Forms
         {
             get
             {
-                return ((style & NativeMethods.DTS_RIGHTALIGN) != 0)
-                ? LeftRightAlignment.Right
-                : LeftRightAlignment.Left;
+                return (_style & DTS.RIGHTALIGN) != 0
+                    ? LeftRightAlignment.Right
+                    : LeftRightAlignment.Left;
             }
 
             set
@@ -575,7 +575,7 @@ namespace System.Windows.Forms
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(LeftRightAlignment));
                 }
 
-                SetStyleBit((value == LeftRightAlignment.Right), NativeMethods.DTS_RIGHTALIGN);
+                SetStyleBit(value == LeftRightAlignment.Right, DTS.RIGHTALIGN);
             }
         }
 
@@ -909,14 +909,8 @@ namespace System.Windows.Forms
         ]
         public bool ShowCheckBox
         {
-            get
-            {
-                return (style & NativeMethods.DTS_SHOWNONE) != 0;
-            }
-            set
-            {
-                SetStyleBit(value, NativeMethods.DTS_SHOWNONE);
-            }
+            get => (_style & DTS.SHOWNONE) != 0;
+            set => SetStyleBit(value, DTS.SHOWNONE);
         }
 
         /// <summary>
@@ -930,15 +924,12 @@ namespace System.Windows.Forms
         ]
         public bool ShowUpDown
         {
-            get
-            {
-                return (style & NativeMethods.DTS_UPDOWN) != 0;
-            }
+            get => (_style & DTS.UPDOWN) != 0;
             set
             {
                 if (ShowUpDown != value)
                 {
-                    SetStyleBit(value, NativeMethods.DTS_UPDOWN);
+                    SetStyleBit(value, DTS.UPDOWN);
                 }
             }
         }
@@ -1414,20 +1405,20 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Turns on or off a given style bit
         /// </summary>
-        private void SetStyleBit(bool flag, int bit)
+        private void SetStyleBit(bool flag, DTS bit)
         {
-            if (((style & bit) != 0) == flag)
+            if (((_style & bit) != 0) == flag)
             {
                 return;
             }
 
             if (flag)
             {
-                style |= bit;
+                _style |= bit;
             }
             else
             {
-                style &= ~bit;
+                _style &= ~bit;
             }
 
             if (IsHandleCreated)


### PR DESCRIPTION
## Proposed changes

- Add DTS enum to Interop ComCtl32.
- Remove DTS constants and replace their usages with the above enum values.
- Remove unused DI_NORMAL constant.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2893)