### PR TITLE
Add NFR enum to Interop User32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.NFR.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.NFR.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public enum NFR
+        {
+            ANSI = 1,
+            UNICODE = 2
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -101,9 +101,7 @@ namespace System.Windows.Forms
         NIN_BALLOONSHOW = ((int)User32.WM.USER + 2),
         NIN_BALLOONHIDE = ((int)User32.WM.USER + 3),
         NIN_BALLOONTIMEOUT = ((int)User32.WM.USER + 4),
-        NIN_BALLOONUSERCLICK = ((int)User32.WM.USER + 5),
-        NFR_ANSI = 1,
-        NFR_UNICODE = 2;
+        NIN_BALLOONUSERCLICK = ((int)User32.WM.USER + 5);
 
         public const int
         PATCOPY = 0x00F00021,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -13171,7 +13171,7 @@ namespace System.Windows.Forms
                     break;
 
                 case User32.WM.REFLECT | User32.WM.NOTIFYFORMAT:
-                    m.Result = (IntPtr)(NativeMethods.NFR_UNICODE);
+                    m.Result = (IntPtr)User32.NFR.UNICODE;
                     break;
 
                 case User32.WM.SHOWWINDOW:


### PR DESCRIPTION
## Proposed changes

- Add NFR enum to Interop User32.
- Remove NFR constants and replace their usages with the above enum values.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2894)