### PR TITLE
removed DesignerCategory attribute from Form class

### DIFF
--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -206,17 +206,13 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>MaskDesignerDialog.resx</DependentUpon>
     </Compile>
-    <Compile Update="System\Windows\Forms\Design\MaskedTextBoxTextEditorDropDown.cs">
-      <SubType>UserControl</SubType>
-    </Compile>
+    <Compile Update="System\Windows\Forms\Design\MaskedTextBoxTextEditorDropDown.cs" />
     <Compile Update="Resources\LinkAreaEditor.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>LinkAreaEditor.resx</DependentUpon>
     </Compile>
-    <Compile Update="System\Windows\Forms\Design\FormatControl.cs">
-      <SubType>UserControl</SubType>
-    </Compile>
+    <Compile Update="System\Windows\Forms\Design\FormatControl.cs" />
     <Compile Update="System\Windows\Forms\Design\FormatStringDialog.cs" />
   </ItemGroup>
 </Project>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.cs
@@ -21,7 +21,6 @@ namespace System.Windows.Forms.Design
     [ComVisible(true)]
     [ClassInterface(ClassInterfaceType.AutoDispatch)]
     [ToolboxItem(false)]
-    [DesignerCategory("code")]
     public class ComponentEditorForm : Form
     {
         private readonly IComponent component;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -30,7 +30,7 @@ namespace System.Windows.Forms
     [Designer("System.Windows.Forms.Design.FormDocumentDesigner, " + AssemblyRef.SystemDesign, typeof(IRootDesigner))]
     [DefaultEvent(nameof(Load))]
     [InitializationEvent(nameof(Load))]
-    [DesignerCategory("code")]
+    [DesignerCategory("Form")]
     public partial class Form : ContainerControl
     {
 #if DEBUG


### PR DESCRIPTION
As @weltkante pointed out, DesignerCategory attribute is inheritable and if we have this attribute on Form class, we are enforsing this category on all user forms/controls and blocking designer. Thank you!
I'm removing this attribute in this change. 


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2895)