### PR TITLE
Add TTS enum in Interop ComCtl32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TTS.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TTS.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        [Flags]
+        public enum TTS : int
+        {
+            ALWAYSTIP = 0x01,
+            NOPREFIX = 0x02,
+            NOANIMATE = 0x10,
+            NOFADE = 0x20,
+            BALLOON = 0x40,
+            CLOSE = 0x80,
+            USEVISUALSTYLE = 0x100
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -117,16 +117,6 @@ namespace System.Windows.Forms
         HLP_OBJECT = 4;
 
         public const int
-        TV_FIRST = 0x1100,
-        TTS_ALWAYSTIP = 0x01,
-        TTS_NOPREFIX = 0x02,
-        TTS_NOANIMATE = 0x10,
-        TTS_NOFADE = 0x20,
-        TTS_BALLOON = 0x40,
-        //TTI_NONE                =0,
-        //TTI_INFO                =1,
-        TTI_WARNING = 2,
-        //TTI_ERROR               =3,
         TB_LINEUP = 0,
         TB_LINEDOWN = 1,
         TB_PAGEUP = 2,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
@@ -930,7 +930,7 @@ namespace System.Windows.Forms
                     {
                         Parent = Handle,
                         ClassName = ComCtl32.WindowClasses.TOOLTIPS_CLASS,
-                        Style = NativeMethods.TTS_ALWAYSTIP
+                        Style = (int)ComCtl32.TTS.ALWAYSTIP
                     };
                     _tipWindow = new NativeWindow();
                     _tipWindow.CreateHandle(cparams);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridToolTip.cs
@@ -101,7 +101,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     Parent = IntPtr.Zero,
                     ClassName = ComCtl32.WindowClasses.TOOLTIPS_CLASS
                 };
-                cp.Style |= (NativeMethods.TTS_ALWAYSTIP | NativeMethods.TTS_NOPREFIX);
+                cp.Style |= (int)(ComCtl32.TTS.ALWAYSTIP | ComCtl32.TTS.NOPREFIX);
                 cp.ExStyle = 0;
                 cp.Caption = ToolTip;
                 return cp;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -209,23 +209,23 @@ namespace System.Windows.Forms
                 cp.ClassName = WindowClasses.TOOLTIPS_CLASS;
                 if (_showAlways)
                 {
-                    cp.Style = NativeMethods.TTS_ALWAYSTIP;
+                    cp.Style = (int)TTS.ALWAYSTIP;
                 }
                 if (_isBalloon)
                 {
-                    cp.Style |= NativeMethods.TTS_BALLOON;
+                    cp.Style |= (int)TTS.BALLOON;
                 }
                 if (!_stripAmpersands)
                 {
-                    cp.Style |= NativeMethods.TTS_NOPREFIX;
+                    cp.Style |= (int)TTS.NOPREFIX;
                 }
                 if (!_useAnimation)
                 {
-                    cp.Style |= NativeMethods.TTS_NOANIMATE;
+                    cp.Style |= (int)TTS.NOANIMATE;
                 }
                 if (!_useFading)
                 {
-                    cp.Style |= NativeMethods.TTS_NOFADE;
+                    cp.Style |= (int)TTS.NOFADE;
                 }
                 cp.ExStyle = 0;
                 cp.Caption = null;


### PR DESCRIPTION
## Proposed changes

- Add TTS enum in Interop ComCtl32.
- Remove TTS constants and replace their usages with the above enum values.
- Remove unused TV and TTI constants.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2904)