### PR TITLE
Move IProvideClassInfo to Interop OleAut32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.IProvideClassInfo.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.IProvideClassInfo.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Oleaut32
+    {
+        [ComImport]
+        [Guid("B196B283-BAB4-101A-B69C-00AA00341D07")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        public interface IProvideClassInfo
+        {
+            [PreserveSig]
+            HRESULT GetClassInfo(out Oleaut32.ITypeInfo ppTI);
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -618,15 +618,6 @@ namespace System.Windows.Forms
                                 IntPtr piidSource);
         }
 
-        [ComImport]
-        [Guid("B196B283-BAB4-101A-B69C-00AA00341D07")]
-        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        public interface IProvideClassInfo
-        {
-            [PreserveSig]
-            HRESULT GetClassInfo(out Oleaut32.ITypeInfo ppTI);
-        }
-
         /// <summary>
         ///  This method takes a file URL and converts it to a local path.  The trick here is that
         ///  if there is a '#' in the path, everything after this is treated as a fragment.  So

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2TypeInfoProcessor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2TypeInfoProcessor.cs
@@ -66,12 +66,11 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             // typeinfo from the IDispatch. In the case of many OleAut32 operations, the CoClass
             // doesn't have the interface members on it, although in the shell it usually does, so
             // we need to re-order the lookup if we *actually* want the CoClass if it's available.
-
             for (int i = 0; pTypeInfo == null && i < 2; i++)
             {
                 if (wantCoClass == (i == 0))
                 {
-                    if (obj is NativeMethods.IProvideClassInfo pProvideClassInfo)
+                    if (obj is Oleaut32.IProvideClassInfo pProvideClassInfo)
                     {
                         pProvideClassInfo.GetClassInfo(out pTypeInfo);
                     }


### PR DESCRIPTION
## Proposed changes

- Move IProvideClassInfo to Interop OleAut32.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2905)