### PR TITLE
fix: WebBrowser_AttachInterfaces_Invoke_Success fails if IE browser not installed

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/WebBrowserTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/WebBrowserTests.cs
@@ -4,6 +4,7 @@
 
 using System.ComponentModel;
 using System.Drawing;
+using System.Runtime.InteropServices;
 using WinForms.Common.Tests;
 using Xunit;
 
@@ -480,8 +481,25 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void WebBrowser_AttachInterfaces_Invoke_Success()
         {
-            Type t = Type.GetTypeFromCLSID(new Guid("0002DF01-0000-0000-C000-000000000046"));
-            var nativeActiveXObject = Activator.CreateInstance(t);
+            object nativeActiveXObject = null;
+
+            try
+            {
+                Type t = Type.GetTypeFromCLSID(new Guid("0002DF01-0000-0000-C000-000000000046"));
+                nativeActiveXObject = Activator.CreateInstance(t);
+            }
+            catch (COMException)
+            {
+                // Windows doesn't have IE browser capability installed,
+                // run 'Get-WindowsCapability -online' for more details
+                //
+                // xUnit doesn't support dynamic test skipping, https://github.com/xunit/xunit/issues/2073
+                // just return. The test will be marked as success, but it is better than just fail.
+                //
+                //Skip.If(true, "Windows doesn't have IE browser capability installed");
+                return;
+            }
+
             using var control = new SubWebBrowser();
             control.AttachInterfaces(nativeActiveXObject);
 


### PR DESCRIPTION
IE browser is now an optional Windows component, and it may not be present in all environments we run tests.

`Type.GetTypeFromCLSID` returns `System.__ComObject` regardless of whether the CLSID is valid. Which leaves us checking whether an IE browser is installed and handling the exception.
Further xUnit does not support dynamic skipping of tests https://github.com/xunit/xunit/issues/2073 that forces us to abandon the test if the IE browser is not detected, marking the test as success.

Relates to #2889 and dotnet/core-eng#9068


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2909)