### PR TITLE
Fixing MCGRIDINFO definition

### DIFF
--- a/src/Common/tests/InternalUtilitiesForTests/src/ArchitectureDetection.cs
+++ b/src/Common/tests/InternalUtilitiesForTests/src/ArchitectureDetection.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System
+{
+    public static class ArchitectureDetection
+    {
+        public static bool Is32bit => IntPtr.Size == 4;
+        public static bool Is64bit => IntPtr.Size == 8;
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.MCGRIDINFO.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.MCGRIDINFO.cs
@@ -22,12 +22,12 @@ internal static partial class Interop
             public int iCalendar;
             public int iRow;
             public int iCol;
-            public bool bSelected;
+            public BOOL bSelected;
             public Kernel32.SYSTEMTIME stStart;
             public Kernel32.SYSTEMTIME stEnd;
             public RECT rc;
             public char* pszName;
-            public uint cchName;
+            public UIntPtr cchName;
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/Interop/ComCtl32/MCGRIDINFOTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/Interop/ComCtl32/MCGRIDINFOTests.cs
@@ -1,0 +1,115 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using Xunit;
+using static Interop.ComCtl32;
+
+namespace System.Windows.Forms.Primitives.Tests.Interop.ComCtl32
+{
+    public class MCGRIDINFOTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is32bit))]
+        public unsafe void MCGRIDINFO_x32_Size()
+        {
+            Assert.Equal(84, sizeof(MCGRIDINFO));
+        }
+
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is32bit))]
+        public unsafe void MCGRIDINFO_x32_Marshal_Size()
+        {
+            Assert.Equal(84, Marshal.SizeOf<MCGRIDINFO>());
+        }
+
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is32bit))]
+        public unsafe void MCGRIDINFO_x32_ensure_layout()
+        {
+            MCGRIDINFO sut = new MCGRIDINFO();
+            byte* addr = (byte*)&sut;
+
+            Assert.Equal(0, (byte*)&sut.cbSize - addr);          // 4, UINT
+            Assert.Equal(4, (byte*)&sut.dwPart - addr);          // 4, DWORD
+            Assert.Equal(8, (byte*)&sut.dwFlags - addr);         // 4, DWORD
+            Assert.Equal(12, (byte*)&sut.iCalendar - addr);      // 4, int
+            Assert.Equal(16, (byte*)&sut.iRow - addr);           // 4, int
+            Assert.Equal(20, (byte*)&sut.iCol - addr);           // 4, int
+            Assert.Equal(24, (byte*)&sut.bSelected - addr);      // 4, BOOL
+            Assert.Equal(28, (byte*)&sut.stStart - addr);        // 16, SYSTEMTIME
+            Assert.Equal(44, (byte*)&sut.stEnd - addr);          // 16, SYSTEMTIME
+            Assert.Equal(60, (byte*)&sut.rc - addr);             // 16, RECT
+            Assert.Equal(76, (byte*)&sut.pszName - addr);        // 4, PWSTR
+            Assert.Equal(80, (byte*)&sut.cchName - addr);        // 4, size_t
+        }
+
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is32bit))]
+        public void MCGRIDINFO_x32_Marshal_OffsetOf_IsCorrect()
+        {
+            Assert.Equal(0, (int)Marshal.OffsetOf<MCGRIDINFO>(nameof(MCGRIDINFO.cbSize)));            // 4, UINT
+            Assert.Equal(4, (int)Marshal.OffsetOf<MCGRIDINFO>(nameof(MCGRIDINFO.dwPart)));            // 4, DWORD
+            Assert.Equal(8, (int)Marshal.OffsetOf<MCGRIDINFO>(nameof(MCGRIDINFO.dwFlags)));           // 4, DWORD
+            Assert.Equal(12, (int)Marshal.OffsetOf<MCGRIDINFO>(nameof(MCGRIDINFO.iCalendar)));        // 4, int
+            Assert.Equal(16, (int)Marshal.OffsetOf<MCGRIDINFO>(nameof(MCGRIDINFO.iRow)));             // 4, int
+            Assert.Equal(20, (int)Marshal.OffsetOf<MCGRIDINFO>(nameof(MCGRIDINFO.iCol)));             // 4, int
+            Assert.Equal(24, (int)Marshal.OffsetOf<MCGRIDINFO>(nameof(MCGRIDINFO.bSelected)));        // 4, BOOL
+            Assert.Equal(28, (int)Marshal.OffsetOf<MCGRIDINFO>(nameof(MCGRIDINFO.stStart)));          // 16, SYSTEMTIME
+            Assert.Equal(44, (int)Marshal.OffsetOf<MCGRIDINFO>(nameof(MCGRIDINFO.stEnd)));            // 16, SYSTEMTIME
+            Assert.Equal(60, (int)Marshal.OffsetOf<MCGRIDINFO>(nameof(MCGRIDINFO.rc)));               // 16, RECT
+            Assert.Equal(76, (int)Marshal.OffsetOf<MCGRIDINFO>(nameof(MCGRIDINFO.pszName)));          // 8, PWSTR
+            Assert.Equal(80, (int)Marshal.OffsetOf<MCGRIDINFO>(nameof(MCGRIDINFO.cchName)));          // 8, size_t
+        }
+
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is64bit))]
+        public unsafe void MCGRIDINFO_x64_Size()
+        {
+            Assert.Equal(96, sizeof(MCGRIDINFO));
+        }
+
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is64bit))]
+        public void MCGRIDINFO_x64_Marshal_Size()
+        {
+            Assert.Equal(96, Marshal.SizeOf<MCGRIDINFO>());
+        }
+
+        private bool a = ArchitectureDetection.Is64bit;
+
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is64bit))]
+        public unsafe void MCGRIDINFO_x64_ensure_layout()
+        {
+            MCGRIDINFO sut = new MCGRIDINFO();
+            byte* addr = (byte*)&sut;
+
+            Assert.Equal(0, (byte*)&sut.cbSize - addr);          // 4, UINT
+            Assert.Equal(4, (byte*)&sut.dwPart - addr);          // 4, DWORD
+            Assert.Equal(8, (byte*)&sut.dwFlags - addr);         // 4, DWORD
+            Assert.Equal(12, (byte*)&sut.iCalendar - addr);      // 4, int
+            Assert.Equal(16, (byte*)&sut.iRow - addr);           // 4, int
+            Assert.Equal(20, (byte*)&sut.iCol - addr);           // 4, int
+            Assert.Equal(24, (byte*)&sut.bSelected - addr);      // 4, BOOL
+            Assert.Equal(28, (byte*)&sut.stStart - addr);        // 16, SYSTEMTIME
+            Assert.Equal(44, (byte*)&sut.stEnd - addr);          // 16, SYSTEMTIME
+            Assert.Equal(60, (byte*)&sut.rc - addr);             // 16, RECT
+            // 4 bytes alignment 76 -> 80
+            Assert.Equal(80, (byte*)&sut.pszName - addr);        // 8, PWSTR
+            Assert.Equal(88, (byte*)&sut.cchName - addr);        // 8, size_t
+        }
+
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is64bit))]
+        public void MCGRIDINFO_x64_Marshal_OffsetOf_IsCorrect()
+        {
+            Assert.Equal(0, (int)Marshal.OffsetOf<MCGRIDINFO>(nameof(MCGRIDINFO.cbSize)));            // 4, UINT
+            Assert.Equal(4, (int)Marshal.OffsetOf<MCGRIDINFO>(nameof(MCGRIDINFO.dwPart)));            // 4, DWORD
+            Assert.Equal(8, (int)Marshal.OffsetOf<MCGRIDINFO>(nameof(MCGRIDINFO.dwFlags)));           // 4, DWORD
+            Assert.Equal(12, (int)Marshal.OffsetOf<MCGRIDINFO>(nameof(MCGRIDINFO.iCalendar)));        // 4, int
+            Assert.Equal(16, (int)Marshal.OffsetOf<MCGRIDINFO>(nameof(MCGRIDINFO.iRow)));             // 4, int
+            Assert.Equal(20, (int)Marshal.OffsetOf<MCGRIDINFO>(nameof(MCGRIDINFO.iCol)));             // 4, int
+            Assert.Equal(24, (int)Marshal.OffsetOf<MCGRIDINFO>(nameof(MCGRIDINFO.bSelected)));        // 4, BOOL
+            Assert.Equal(28, (int)Marshal.OffsetOf<MCGRIDINFO>(nameof(MCGRIDINFO.stStart)));          // 16, SYSTEMTIME
+            Assert.Equal(44, (int)Marshal.OffsetOf<MCGRIDINFO>(nameof(MCGRIDINFO.stEnd)));            // 16, SYSTEMTIME
+            Assert.Equal(60, (int)Marshal.OffsetOf<MCGRIDINFO>(nameof(MCGRIDINFO.rc)));               // 16, RECT
+            // 4 bytes alignment 76 -> 80
+            Assert.Equal(80, (int)Marshal.OffsetOf<MCGRIDINFO>(nameof(MCGRIDINFO.pszName)));          // 8, PWSTR
+            Assert.Equal(88, (int)Marshal.OffsetOf<MCGRIDINFO>(nameof(MCGRIDINFO.cchName)));          // 8, size_t
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/Interop/Comdlg32/PRINTDLGWTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/Interop/Comdlg32/PRINTDLGWTests.cs
@@ -10,16 +10,13 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Comdlg32
 {
     public class PRINTDLGWTests : IClassFixture<ThreadExceptionFixture>
     {
-        public static bool Is32bit => IntPtr.Size == 4;
-        public static bool Is64bit => IntPtr.Size == 8;
-
-        [ConditionalFact(nameof(Is32bit))]
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is32bit))]
         public unsafe void PRINTDLGW_32_Size()
         {
             Assert.Equal(66, sizeof(PRINTDLGW_32));
         }
 
-        [ConditionalFact(nameof(Is32bit))]
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is32bit))]
         public unsafe void PRINTDLGW_32_ensure_layout()
         {
             PRINTDLGW_32 sut = new PRINTDLGW_32();
@@ -46,13 +43,13 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Comdlg32
             Assert.Equal(62, (byte*)&sut._hSetupTemplate - addr);       // 4, HGLOBAL
         }
 
-        [ConditionalFact(nameof(Is64bit))]
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is64bit))]
         public unsafe void PRINTDLGW_64_Size()
         {
             Assert.Equal(120, sizeof(PRINTDLGW_64));
         }
 
-        [ConditionalFact(nameof(Is64bit))]
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is64bit))]
         public unsafe void PRINTDLGW_64_ensure_layout()
         {
             PRINTDLGW_64 sut = new PRINTDLGW_64();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
@@ -520,7 +520,7 @@ namespace System.Windows.Forms
                         iCol = column,
                         iRow = row,
                         pszName = pName,
-                        cchName = (uint)name.Length - 1
+                        cchName = (UIntPtr)name.Length - 1
                     };
 
                     result = User32.SendMessageW(_owner, (User32.WM)MCM.GETCALENDARGRIDINFO, IntPtr.Zero, ref gridInfo) != IntPtr.Zero;


### PR DESCRIPTION
Fixes #2912 
Related issue #2475

`MonthCalendarAccessibleObject` gets incorrect `SYSTEMTIME `info when sending Windows messages due to incorrect `MCGRIDINFO `definition.

## Proposed changes

<!-- - Guard variables against incorrect values to avoid exceptions -->

- Edit MCGRIDINFO to avoid SYSTEMTIME value errors

## Customer Impact

- A user can use a correct MonthCalendar without exceptions

## Regression? 

- Yes, from PR #2090

## Risk

- Minimal

## Screenshots 

### Before
- Incorrect SYSTEMTIME value
![image](https://user-images.githubusercontent.com/49272759/75328598-4fc37a80-588f-11ea-8d66-b3ae2c0d2c6a.png)


### After

- Correct SYSTEMTIME value
![image](https://user-images.githubusercontent.com/49272759/75327702-e8f19180-588d-11ea-90ff-13f42117c7f2.png)


## Test methodology

- CTI
- Manual UI testing
- Unit testing

## Accessibility testing 
- Using Inspect and Narrator tools
 

## Test environment(s) 

- .NET Core SDK: 5.0.0-alpha.1.20072.3
- Microsoft Windows [Version 10.0.18363.592]



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2911)