### PR TITLE
Add missing template identity version information

### DIFF
--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/template.json
@@ -6,8 +6,8 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a .NET Core Windows Forms (WinForms) Application",
   "groupIdentity": "Microsoft.Common.WinForms",
-  "precedence": "3000",
-  "identity": "Microsoft.Common.WinForms.5.0",
+  "precedence": "5000",
+  "identity": "Microsoft.Common.WinForms.CSharp.5.0",
   "shortName": "winforms",
   "tags": {
     "language": "C#",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/template.json
@@ -7,7 +7,7 @@
   "description": "A project for creating a .NET Core Windows Forms (WinForms) Application",
   "groupIdentity": "Microsoft.Common.WinForms",
   "precedence": "3000",
-  "identity": "Microsoft.Common.WinForms",
+  "identity": "Microsoft.Common.WinForms.5.0",
   "shortName": "winforms",
   "tags": {
     "language": "C#",
@@ -28,6 +28,14 @@
       "description": "The target framework for the project.",
       "datatype": "choice",
       "choices": [
+        {
+          "choice": "netcoreapp3.0",
+          "description": "Target netcoreapp3.0"
+        },
+        {
+          "choice": "netcoreapp3.1",
+          "description": "Target netcoreapp3.1"
+        },
         {
           "choice": "netcoreapp5.0",
           "description": "Target netcoreapp5.0"

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/template.json
@@ -7,7 +7,7 @@
   "description": "A project for creating a .NET Core Windows Forms (WinForms) Application",
   "groupIdentity": "Microsoft.Common.WinForms",
   "precedence": "3000",
-  "identity": "Microsoft.Common.WinForms.VisualBasic.3.0",
+  "identity": "Microsoft.Common.WinForms.VisualBasic.5.0",
   "shortName": "winforms",
   "tags": {
     "language": "VB",
@@ -28,6 +28,14 @@
       "description": "The target framework for the project.",
       "datatype": "choice",
       "choices": [
+        {
+          "choice": "netcoreapp3.0",
+          "description": "Target netcoreapp3.0"
+        },
+        {
+          "choice": "netcoreapp3.1",
+          "description": "Target netcoreapp3.1"
+        },
         {
           "choice": "netcoreapp5.0",
           "description": "Target netcoreapp5.0"

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a .NET Core Windows Forms (WinForms) Application",
   "groupIdentity": "Microsoft.Common.WinForms",
-  "precedence": "3000",
+  "precedence": "5000",
   "identity": "Microsoft.Common.WinForms.VisualBasic.5.0",
   "shortName": "winforms",
   "tags": {

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Core Windows Forms (WinForms)",
   "groupIdentity": "Microsoft.Common.WinForms.Library",
-  "precedence": "3000",
+  "precedence": "5000",
   "identity": "Microsoft.Common.WinForms.Library.CSharp.5.0",
   "shortName": "winformslib",
   "tags": {

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/template.json
@@ -7,7 +7,7 @@
   "description": "A project for creating a class library that targets .NET Core Windows Forms (WinForms)",
   "groupIdentity": "Microsoft.Common.WinForms.Library",
   "precedence": "3000",
-  "identity": "Microsoft.Common.WinForms.Library.CSharp.3.0",
+  "identity": "Microsoft.Common.WinForms.Library.CSharp.5.0",
   "shortName": "winformslib",
   "tags": {
     "language": "C#",
@@ -28,6 +28,14 @@
       "description": "The target framework for the project.",
       "datatype": "choice",
       "choices": [
+        {
+          "choice": "netcoreapp3.0",
+          "description": "Target netcoreapp3.0"
+        },
+        {
+          "choice": "netcoreapp3.1",
+          "description": "Target netcoreapp3.1"
+        },
         {
           "choice": "netcoreapp5.0",
           "description": "Target netcoreapp5.0"

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/template.json
@@ -7,7 +7,7 @@
   "description": "A project for creating a class library that targets .NET Core Windows Forms (WinForms)",
   "groupIdentity": "Microsoft.Common.WinForms.Library",
   "precedence": "3000",
-  "identity": "Microsoft.Common.WinForms.Library.VisualBasic.3.0",
+  "identity": "Microsoft.Common.WinForms.Library.VisualBasic.5.0",
   "shortName": "winformslib",
   "tags": {
     "language": "VB",
@@ -28,6 +28,14 @@
       "description": "The target framework for the project.",
       "datatype": "choice",
       "choices": [
+        {
+          "choice": "netcoreapp3.0",
+          "description": "Target netcoreapp3.0"
+        },
+        {
+          "choice": "netcoreapp3.1",
+          "description": "Target netcoreapp3.1"
+        },
         {
           "choice": "netcoreapp5.0",
           "description": "Target netcoreapp5.0"

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Core Windows Forms (WinForms)",
   "groupIdentity": "Microsoft.Common.WinForms.Library",
-  "precedence": "3000",
+  "precedence": "5000",
   "identity": "Microsoft.Common.WinForms.Library.VisualBasic.5.0",
   "shortName": "winformslib",
   "tags": {


### PR DESCRIPTION
Resolves #2981


## Proposed changes

- Fix the packages identities and add framework choices.


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

Given that the identity lacked the version, the new template package targeting netcoreapp5.0 would supersede and replace the ones targeting netcoreapp3.x.

This breaks developer's ability to create app targeting netcoreapp3.x from command line (via `dotnet new winforms`) and rom VS (because the VS Template Engine Host will only install the highest versioned package for any given identity).

## Regression? 

- Yes 

## Risk

- Low. The change is to “dotnet new” templates only. No changes to Windows Forms runtime. 

<!-- end TELL-MODE -->




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2922)