### PR TITLE
fix: Fail roll forward .NET Core 3.x -> .NET 5.0

### DIFF
--- a/Winforms.sln
+++ b/Winforms.sln
@@ -122,6 +122,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Windows.Forms.Design.Editors.Facade3x", "src\System.Windows.Forms.Design.Editors\src\System.Windows.Forms.Design.Editors.Facade3x.csproj", "{E0681991-228A-420E-85D5-A9E796F0AAE0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -236,6 +238,10 @@ Global
 		{9BFDE7F2-C8F3-40D6-9A16-8DCD1A37E900}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9BFDE7F2-C8F3-40D6-9A16-8DCD1A37E900}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9BFDE7F2-C8F3-40D6-9A16-8DCD1A37E900}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E0681991-228A-420E-85D5-A9E796F0AAE0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E0681991-228A-420E-85D5-A9E796F0AAE0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E0681991-228A-420E-85D5-A9E796F0AAE0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E0681991-228A-420E-85D5-A9E796F0AAE0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -273,6 +279,7 @@ Global
 		{D49B43AE-F6CC-43BA-91B6-1B248F22BCDD} = {8F20A905-BD37-4D80-B8DF-FA45276FC23F}
 		{90B27178-F535-43F7-886E-0AB75203F246} = {77FEDB47-F7F6-490D-AF7C-ABB4A9E0B9D7}
 		{9BFDE7F2-C8F3-40D6-9A16-8DCD1A37E900} = {583F1292-AE8D-4511-B8D8-A81FE4642DDC}
+		{E0681991-228A-420E-85D5-A9E796F0AAE0} = {434C00C3-E498-4BA7-9764-9F0FC8CFE457}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7B1B0433-F612-4E5A-BE7E-FCF5B9F6E136}

--- a/eng/FacadeAssemblies.props
+++ b/eng/FacadeAssemblies.props
@@ -2,10 +2,17 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   
   <PropertyGroup>
-    <IsFacadeAssembly Condition="'$(IsFacadeAssembly)'=='' AND ($(MSBuildProjectName.EndsWith('.Facade')))">true</IsFacadeAssembly>
+    <!-- Facades for .NET Framework assemblies -->
+    <_IsFacadeAssemblyNetFx Condition="$(MSBuildProjectName.EndsWith('.Facade'))">true</_IsFacadeAssemblyNetFx>
+    <!-- Facades for .NET Core 3.x assemblies -->
+    <_IsFacadeAssemblyNetCore3x Condition="$(MSBuildProjectName.EndsWith('.Facade3x'))">true</_IsFacadeAssemblyNetCore3x>
+
+    <IsFacadeAssembly Condition="'$(IsFacadeAssembly)' == '' AND ('$(_IsFacadeAssemblyNetFx)' == 'true' OR '$(_IsFacadeAssemblyNetCore3x)' == 'true')">true</IsFacadeAssembly>
+    <IsFacadeAssemblyNetFx Condition="'$(IsFacadeAssembly)' == 'true' AND '$(_IsFacadeAssemblyNetFx)' == 'true'">true</IsFacadeAssemblyNetFx>
+    <IsFacadeAssemblyNetCore3x Condition="'$(IsFacadeAssembly)' == 'true' AND '$(_IsFacadeAssemblyNetCore3x)' == 'true'">true</IsFacadeAssemblyNetCore3x>
   </PropertyGroup>
   
-  <PropertyGroup Condition="'$(IsFacadeAssembly)'=='true'"> 
+  <PropertyGroup Condition="'$(IsFacadeAssembly)' == 'true'"> 
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <GenFacadesIgnoreMissingTypes>true</GenFacadesIgnoreMissingTypes>
 
@@ -15,16 +22,27 @@
     <MicrosoftTargetingPackNETFrameworkv472Package></MicrosoftTargetingPackNETFrameworkv472Package>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(IsFacadeAssembly)'=='true'">  
+  <ItemGroup Condition="'$(IsFacadeAssemblyNetFx)' == 'true'">  
     <!-- PrivateAssets="All": don't flow package references to callers -->
     <PackageReference Include="Microsoft.TargetingPack.NETFramework.v4.7.2" Version="$(MicrosoftTargetingPackNETFrameworkv472PackageVersion)" PrivateAssets="All" GeneratePathProperty="true" ExcludeAssets="All" NoWarn="NU1701" />
     <PackageReference Include="Microsoft.DotNet.GenFacades" Version="$(MicrosoftDotNetGenFacadesPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
-  
-  <Target Condition="'$(IsFacadeAssembly)'=='true'" Name="ResolveMatchingContract" BeforeTargets="ResolveAssemblyReferences">
-    <ItemGroup>
-      <ResolvedMatchingContract Include="$(PkgMicrosoft_TargetingPack_NETFramework_v4_7_2)\lib\*\$(AssemblyName).dll" />
 
+  <ItemGroup Condition="'$(IsFacadeAssemblyNetCore3x)' == 'true'">  
+    <!-- PrivateAssets="All": don't flow package references to callers -->
+    <PackageReference Include="Microsoft.WindowsDesktop.App.Ref" Version="$(MicrosoftWindowsDesktopAppRefv30PackageVersion)" PrivateAssets="All" GeneratePathProperty="true" ExcludeAssets="All" NoWarn="NU1701" />
+    <PackageReference Include="Microsoft.DotNet.GenFacades" Version="$(MicrosoftDotNetGenFacadesPackageVersion)" PrivateAssets="All" />
+  </ItemGroup>
+
+  <Target Name="ResolveMatchingContract" BeforeTargets="ResolveAssemblyReferences">
+    <ItemGroup Condition="'$(IsFacadeAssemblyNetFx)' == 'true'">
+      <ResolvedMatchingContract Include="$(PkgMicrosoft_TargetingPack_NETFramework_v4_7_2)\lib\*\$(AssemblyName).dll" />
+      <!-- in case we're regenerating a facade that is already referenced -->
+      <Reference Remove="@(Reference)"  Condition="'%(FileName)%(Extension)' == '$(AssemblyName).dll'" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(IsFacadeAssemblyNetCore3x)' == 'true'">
+      <ResolvedMatchingContract Include="$(PkgMicrosoft_WindowsDesktop_App_Ref)\ref\*\$(AssemblyName).dll" />
       <!-- in case we're regenerating a facade that is already referenced -->
       <Reference Remove="@(Reference)"  Condition="'%(FileName)%(Extension)' == '$(AssemblyName).dll'" />
     </ItemGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -61,6 +61,7 @@
   <PropertyGroup>
     <MoqPackageVersion>4.10.0</MoqPackageVersion>
     <MicrosoftTargetingPackNETFrameworkv472PackageVersion>1.0.0</MicrosoftTargetingPackNETFrameworkv472PackageVersion>
+    <MicrosoftWindowsDesktopAppRefv30PackageVersion>3.0.0</MicrosoftWindowsDesktopAppRefv30PackageVersion>
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
   </PropertyGroup>
 </Project>

--- a/pkg/Microsoft.Private.Winforms/FrameworkListFiles.props
+++ b/pkg/Microsoft.Private.Winforms/FrameworkListFiles.props
@@ -7,6 +7,7 @@
     <FrameworkListFileClass Include="System.Drawing.Design.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Drawing.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.Design.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="System.Windows.Forms.Design.Editors.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.Primitives.dll" Profile="WindowsForms" />
   </ItemGroup>

--- a/pkg/Microsoft.Private.Winforms/Microsoft.Private.Winforms.csproj
+++ b/pkg/Microsoft.Private.Winforms/Microsoft.Private.Winforms.csproj
@@ -79,9 +79,10 @@
 
     <!-- Reference and Source System.Windows.Forms.Design includes -->
     <ProjectReference Include="..\..\src\System.Windows.Forms.Design\src\System.Windows.Forms.Design.csproj" />
-    
-    <!-- Reference and Source System.Windows.Forms.Design.Editors includes -->
 
+    <!-- Facade for System.Windows.Forms.Design.Editors includes -->
+    <ProjectReference Include="..\..\src\System.Windows.Forms.Design.Editors\src\System.Windows.Forms.Design.Editors.Facade3x.csproj" />
+    
     <!-- Facade for Microsoft.VisualBasic include -->
     <ProjectReference Include="..\..\src\Microsoft.VisualBasic\src\Microsoft.VisualBasic.Facade.csproj" />
 

--- a/src/System.Windows.Forms.Design.Editors/Directory.Build.props
+++ b/src/System.Windows.Forms.Design.Editors/Directory.Build.props
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="..\..\Directory.Build.props" />
+  <PropertyGroup>
+	<StrongNameKeyId>Microsoft</StrongNameKeyId>
+  </PropertyGroup>
+</Project>

--- a/src/System.Windows.Forms.Design.Editors/src/System.Windows.Forms.Design.Editors.Facade3x.csproj
+++ b/src/System.Windows.Forms.Design.Editors/src/System.Windows.Forms.Design.Editors.Facade3x.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>System.Windows.Forms.Design.Editors</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\System.Windows.Forms.Design\src\System.Windows.Forms.Design.csproj" />
+    <ProjectReference Include="..\..\System.Windows.Forms\src\System.Windows.Forms.csproj" />
+  </ItemGroup>
+  
+</Project>


### PR DESCRIPTION
As part of consolidation initiative (refer to #2781) we have merged System.Windows.Forms.Design.Editors.dll into System.Windows.Forms.Design.dll.

However doing so we broke roll-forward upgrades for any app depending on types declared in System.Windows.Forms.Design.Editors.dll.



Resolves #2921.




## Proposed changes

- Create a facade assembly that forwards types from original assembly.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Customers can roll forward from .NET Core 3.x to .NET 5.0

## Regression? 

- Yes 

## Test methodology
* [Use the repro app](https://github.com/RussKie/Test-TypeForwards/commit/c5f76dca248dee7fd69d95fc9b5af0f76c32578e) or generate a new Windows Forms app targeting .NET Core 3.0 (or 3.1) and set it to rollforward:
  ```json
  {
    "sdk": {
      "rollForward": "major"
    }
  }
  ```
* Add the following line to `Form1`:
  ```cs
  AnchorEditor editor = new AnchorEditor();
  ```
* Ensure no .NET Core 3.x runtime is installed. Best to run a VM with only .NET5 Preview1 installed
* Run the app, observe the failure:
  ![image](https://user-images.githubusercontent.com/4403806/75743892-ba305b00-5d66-11ea-9601-d91ea8bb78de.png)
* Build the current commit with `pack` option:
  ```powershell
  PS> .\build.ps1 -pack
  ```
* Copy `System.Windows.Forms.Design.Editors.dll`
	- from .\artifacts\packages\Debug\NonShipping\Microsoft.Private.Winforms.5.0.0-dev.nupkg\lib\netcoreapp5.0 --> C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App\5.0.0-preview.2.20119.5
	- from .\artifacts\packages\Debug\NonShipping\Microsoft.Private.Winforms.5.0.0-dev.nupkg\ref\netcoreapp5.0 --> C:\Program Files\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\5.0.0-preview.2.20119.5\ref\netcoreapp5.0
* Update the WindowsDesktop manifest to include the new assembly:
  ```diff
  --- a/C:/Program Files/dotnet/shared/Microsoft.WindowsDesktop.App/5.0.0-preview.2.20119.5/Microsoft.WindowsDesktop.App.deps.json
  +++ b/C:/Program Files/dotnet/shared/Microsoft.WindowsDesktop.App/5.0.0-preview.2.20119.5/Microsoft.WindowsDesktop.App.deps.json
            "runtimes/win-x64/lib/netcoreapp5.0/System.Windows.Forms.Design.dll": {
              "assemblyVersion": "5.0.0.0",
              "fileVersion": "5.0.20.11805"
            },
  +         "runtimes/win-x64/lib/netcoreapp5.0/System.Windows.Forms.Design.Editors.dll": {
  +           "assemblyVersion": "5.0.0.0",
  +           "fileVersion": "5.0.20.11805"
  +         },
            "runtimes/win-x64/lib/netcoreapp5.0/System.Windows.Forms.Primitives.dll": {
              "assemblyVersion": "5.0.0.0",
              "fileVersion": "5.0.20.11805"
            },
  ```
* Re-run the app, observe the app start
  ![image](https://user-images.githubusercontent.com/4403806/75742168-eb0d9180-5d60-11ea-9b79-ad4ce33344e1.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2923)