### PR TITLE
Add NIN enum to Interop Shell32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.NIN.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.NIN.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using static Interop.User32;
+
+internal partial class Interop
+{
+    internal static partial class Shell32
+    {
+        private const int NINF_KEY = 0x1;
+
+        public enum NIN
+        {
+            SELECT = (int)(WM.USER + 0),
+            KEYSELECT = (int)(SELECT | NINF_KEY),
+            BALLOONSHOW = (int)(WM.USER + 2),
+            BALLOONHIDE = (int)(WM.USER + 3),
+            BALLOONTIMEOUT = (int)(WM.USER + 4),
+            BALLOONUSERCLICK = (int)(WM.USER + 5),
+            POPUPOPEN = (int)(WM.USER + 6),
+            POPUPCLOSE = (int)(WM.USER + 7)
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -90,12 +90,6 @@ namespace System.Windows.Forms
         MCN_SELECT = ((0 - 750) + 4);
 
         public const int
-        NIN_BALLOONSHOW = ((int)User32.WM.USER + 2),
-        NIN_BALLOONHIDE = ((int)User32.WM.USER + 3),
-        NIN_BALLOONTIMEOUT = ((int)User32.WM.USER + 4),
-        NIN_BALLOONUSERCLICK = ((int)User32.WM.USER + 5);
-
-        public const int
         PATCOPY = 0x00F00021,
         PATINVERT = 0x005A0049;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
@@ -784,16 +784,16 @@ namespace System.Windows.Forms
                             }
                             WmMouseUp(ref msg, MouseButtons.Right);
                             break;
-                        case NativeMethods.NIN_BALLOONSHOW:
+                        case (int)NIN.BALLOONSHOW:
                             OnBalloonTipShown();
                             break;
-                        case NativeMethods.NIN_BALLOONHIDE:
+                        case (int)NIN.BALLOONHIDE:
                             OnBalloonTipClosed();
                             break;
-                        case NativeMethods.NIN_BALLOONTIMEOUT:
+                        case (int)NIN.BALLOONTIMEOUT:
                             OnBalloonTipClosed();
                             break;
-                        case NativeMethods.NIN_BALLOONUSERCLICK:
+                        case (int)NIN.BALLOONUSERCLICK:
                             OnBalloonTipClicked();
                             break;
                     }


### PR DESCRIPTION
## Proposed changes

- Add NIN enum to Interop Shell32.
- Remove NIN constants and replace their usages with the above enum values.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2929)