### PR TITLE
Remove ExitInternal

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
@@ -913,7 +913,7 @@ namespace System.Windows.Forms
                             switch (result)
                             {
                                 case DialogResult.Abort:
-                                    ExitInternal();
+                                    Exit();
                                     Environment.Exit(0);
                                     break;
                                 case DialogResult.Yes:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -856,6 +856,10 @@ namespace System.Windows.Forms
                 if (s_exiting)
                 {
                     // Recursive call to Exit
+                    if (e != null)
+                    {
+                        e.Cancel = false;
+                    }
                     return;
                 }
                 s_exiting = true;
@@ -873,8 +877,8 @@ namespace System.Windows.Forms
                                 if (e != null)
                                 {
                                     e.Cancel = true;
-                                    return;
                                 }
+                                return;
                             }
                         }
 


### PR DESCRIPTION
There are no security checks in Core so ExitInternal is unnecessary (the security checks were already removed).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2942)