### PR TITLE
Add reference to ToolStripDropDownMenu.ico

### DIFF
--- a/src/System.Windows.Forms/src/System.Windows.Forms.csproj
+++ b/src/System.Windows.Forms/src/System.Windows.Forms.csproj
@@ -554,6 +554,9 @@
     <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\ToolStripMenuItem.ico">
       <LogicalName>System.Windows.Forms.ToolStripMenuItem</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\ToolStripDropDownMenu.ico">
+      <LogicalName>System.Windows.Forms.ToolStripDropDownMenu</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\ToolStripDropDownButton.ico">
       <LogicalName>System.Windows.Forms.ToolStripDropDownButton</LogicalName>
     </EmbeddedResource>


### PR DESCRIPTION
#Fixes #2939
 
The [ToolStripDropDownMenu.ico file](https://github.com/dotnet/winforms/blob/b666dc7a94d8ac87a7d300cfb4fa86332fb79bae/src/System.Windows.Forms/src/Resources/System/Windows/Forms/ToolStrip/ToolStripDropDownMenu.ico) is already there, but the reference was missing.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2946)