### PR TITLE
Fixing 2947: Call to ParkingWindow.RemoveReflectChild() causes Cross-thread exception under load

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ParkingWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ParkingWindow.cs
@@ -78,14 +78,14 @@ namespace System.Windows.Forms
                 // messagepump is gone and then decide to clean them up.  We should clean
                 // up the parkingwindow in this case and a postmessage won't do it.
 
-                uint id = User32.GetWindowThreadProcessId(this, out _);
+                uint id = User32.GetWindowThreadProcessId(HandleInternal, out _);
                 ThreadContext context = ThreadContext.FromId(id);
 
                 // We only do this if the ThreadContext tells us that we are currently
                 // handling a window message.
                 if (context == null || !ReferenceEquals(context, ThreadContext.FromCurrent()))
                 {
-                    User32.PostMessageW(this, (User32.WM)WM_CHECKDESTROY);
+                    User32.PostMessageW(HandleInternal, (User32.WM)WM_CHECKDESTROY);
                 }
                 else
                 {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Application.ParkingWindowTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Application.ParkingWindowTests.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using Microsoft.DotNet.RemoteExecutor;
+using WinForms.Common.Tests;
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    public class ParkingWindowTests
+    {
+        [WinFormsFact]
+        public void ParkingWindow_DoesNotThrowOnGarbageCollecting()
+        {
+            using RemoteInvokeHandle invokerHandle = RemoteExecutor.Invoke(() =>
+            {
+                Control.CheckForIllegalCrossThreadCalls = true;
+
+                Form form = InitFormWithControlToGarbageCollect();
+
+                try
+                {
+                    // Force garbage collecting to access combobox from another (GC) thread.
+                    GC.Collect();
+
+                    GC.WaitForPendingFinalizers();
+                }
+                catch (Exception ex)
+                {
+                    Assert.True(ex == null, "Expected no exception, but got: " + ex.Message); // Actually need to check whether GC.Collect() does not throw exception.
+                }
+            });
+
+            // verify the remote process succeeded
+            Assert.Equal(0, invokerHandle.ExitCode);
+        }
+
+        private Form InitFormWithControlToGarbageCollect()
+        {
+            Form form = new Form();
+            ComboBox comboBox = new ComboBox();
+            comboBox.DropDownStyle = ComboBoxStyle.DropDown;
+
+            form.Controls.Add(comboBox);
+            form.Show();
+
+            // Park combobox handle in ParkingWindow.
+            comboBox.Parent = null;
+
+            // Recreate comobox handle to set parent to ParkingWindow.
+            comboBox.DropDownStyle = ComboBoxStyle.DropDownList;
+
+            // Lose the reference to combobox to allow Garbage collecting combobox.
+            comboBox = null;
+
+            return form;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #2947 


## Proposed changes

- Changing call to Handle with call to HandleInternal to prevent throwing an error when garbage collection is in progress.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Customers will not see an error in case garbage collector cleans up the references to WinForms controls which are not used anymore.
- The case is applicable on high load environments when running application may require garbage collector to clean up controls to free memory.

## Regression? 

- Yes

## Risk

- Low

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Cross-thread error on garbage collection.

### After

No error.


## Test methodology <!-- How did you ensure quality? -->

- Manual testing;
- Unit tests (to be implemented);
- UI tests.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

<!-- use `dotnet --info` -->
.NET Core SDK (reflecting any global.json):
 Version:   5.0.100-alpha.1.20073.10
 Commit:    29f4d693a9

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.18363
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\5.0.100-alpha1-05536\

Host (useful for support):
  Version: 5.0.0-alpha.1.20072.3
  Commit:  c3dc1fdfdc

.NET Core SDKs installed:
  3.0.101 [C:\Program Files\dotnet\sdk]
  3.1.200-preview-014883 [C:\Program Files\dotnet\sdk]
  5.0.100-alpha.1.20073.10 [C:\Program Files\dotnet\sdk]
  5.0.100-alpha1-05536 [C:\Program Files\dotnet\sdk]

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2951)