### PR TITLE
Move GetWindowDC to Interop User32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetWindowDC.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetWindowDC.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        private static extern IntPtr GetWindowDC(IntPtr hWnd);
+
+        public static IntPtr GetWindowDC(HandleRef hWnd)
+        {
+            IntPtr result = GetWindowDC(hWnd.Handle);
+            GC.KeepAlive(hWnd.Wrapper);
+            return result;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -101,9 +101,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.Oleacc, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern int CreateStdAccessibleObject(HandleRef hWnd, int objID, ref Guid refiid, [In, Out, MarshalAs(UnmanagedType.Interface)] ref object pAcc);
 
-        [DllImport(ExternDll.User32, ExactSpelling = true)]
-        public static extern IntPtr GetWindowDC(HandleRef hWnd);
-
         //for RegionData
         [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern int GetRegionData(HandleRef hRgn, int size, IntPtr lpRgnData);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.cs
@@ -768,7 +768,7 @@ namespace System.Windows.Forms
                 // Using GetWindowDC instead of GetDCEx as GetDCEx seems to return a null handle and a last error of
                 // the operation succeeded.  We're not going to use the clipping rect anyways - so it's not
                 // that bigga deal.
-                IntPtr hdc = UnsafeNativeMethods.GetWindowDC(new HandleRef(this, m.HWnd));
+                IntPtr hdc = User32.GetWindowDC(new HandleRef(this, m.HWnd));
                 if (hdc == IntPtr.Zero)
                 {
                     throw new Win32Exception();


### PR DESCRIPTION
## Proposed changes

- Move GetWindowDC to Interop User32.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2954)