### PR TITLE
Move LresultFromObject to Interop Oleacc

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -1754,7 +1754,7 @@ namespace System.Windows.Forms.Design
                                 punkAcc = Marshal.GetIUnknownForObject(iacc);
                                 try
                                 {
-                                    m.Result = UnsafeNativeMethods.LresultFromObject(ref IID_IAccessible, m.WParam, punkAcc);
+                                    m.Result = Oleacc.LresultFromObject(ref IID_IAccessible, m.WParam, punkAcc);
                                 }
                                 finally
                                 {

--- a/src/System.Windows.Forms.Primitives/src/Interop/Interop.Libraries.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Interop.Libraries.cs
@@ -4,7 +4,7 @@
 
 internal static partial class Interop
 {
-    public static partial class Libraries
+    public static class Libraries
     {
         public const string Comctl32 = "comctl32.dll";
         public const string Comdlg32 = "comdlg32.dll";
@@ -13,6 +13,7 @@ internal static partial class Interop
         public const string Kernel32 = "kernel32.dll";
         public const string NtDll = "ntdll.dll";
         public const string Ole32 = "ole32.dll";
+        public const string Oleacc = "oleacc.dll";
         public const string Oleaut32 = "oleaut32.dll";
         public const string Powrprof = "Powrprof.dll";
         public const string RichEdit41 = "MsftEdit.DLL";

--- a/src/System.Windows.Forms.Primitives/src/Interop/Oleacc/Interop.LresultFromObject.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Oleacc/Interop.LresultFromObject.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Oleacc
+    {
+        [DllImport(Libraries.Oleacc, ExactSpelling = true)]
+        public static extern IntPtr LresultFromObject(ref Guid refiid, IntPtr wParam, IntPtr pAcc);
+
+        public static IntPtr LresultFromObject(ref Guid refiid, IntPtr wParam, HandleRef pAcc)
+        {
+            IntPtr result = LresultFromObject(ref refiid, wParam, pAcc.Handle);
+            GC.KeepAlive(pAcc.Wrapper);
+            return result;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/ExternDll.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/ExternDll.cs
@@ -10,7 +10,6 @@ namespace System
         public const string Gdi32 = "gdi32.dll";
         public const string Hhctrl = "hhctrl.ocx";
         public const string Kernel32 = "kernel32.dll";
-        public const string Oleacc = "oleacc.dll";
         public const string Shell32 = "shell32.dll";
         public const string User32 = "user32.dll";
     }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -92,13 +92,7 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern int GetDlgItemInt(IntPtr hWnd, int nIDDlgItem, bool[] err, bool signed);
 
-        [DllImport(ExternDll.Oleacc, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern IntPtr LresultFromObject(ref Guid refiid, IntPtr wParam, HandleRef pAcc);
-
-        [DllImport(ExternDll.Oleacc, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern IntPtr LresultFromObject(ref Guid refiid, IntPtr wParam, IntPtr pAcc);
-
-        [DllImport(ExternDll.Oleacc, ExactSpelling = true, CharSet = CharSet.Auto)]
+        [DllImport(Libraries.Oleacc, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern int CreateStdAccessibleObject(HandleRef hWnd, int objID, ref Guid refiid, [In, Out, MarshalAs(UnmanagedType.Interface)] ref object pAcc);
 
         //for RegionData

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -4096,7 +4096,7 @@ namespace System.Windows.Forms
 
                         try
                         {
-                            m.Result = UnsafeNativeMethods.LresultFromObject(ref IID_IAccessible, m.WParam, new HandleRef(this, punkAcc));
+                            m.Result = Oleacc.LresultFromObject(ref IID_IAccessible, m.WParam, new HandleRef(this, punkAcc));
                         }
                         finally
                         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -11945,7 +11945,7 @@ namespace System.Windows.Forms
 
                         try
                         {
-                            m.Result = UnsafeNativeMethods.LresultFromObject(ref IID_IAccessible, m.WParam, new HandleRef(ctrlAccessibleObject, punkAcc));
+                            m.Result = Oleacc.LresultFromObject(ref IID_IAccessible, m.WParam, new HandleRef(ctrlAccessibleObject, punkAcc));
                             Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, "LresultFromObject returned " + m.Result.ToString());
                         }
                         finally


### PR DESCRIPTION
## Proposed changes

- Move LresultFromObject to Interop Oleacc.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2955)