### PR TITLE
Add HDN enum in Interop ComCtl32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.DTN.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.DTN.cs
@@ -16,9 +16,9 @@ internal static partial class Interop
             FORMATW = FIRST - 3,
             WMKEYDOWNW = FIRST - 4,
             USERSTRINGW = FIRST - 5,
-            DATETIMECHANGE = FIRST2 - 6,
             CLOSEUP = FIRST2,
             DROPDOWN = FIRST2 - 1,
+            DATETIMECHANGE = FIRST2 - 6
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.HDN.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.HDN.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        public enum HDN
+        {
+            FIRST = 0 - 300,
+            LAST = 0 - 399,
+            BEGINDRAG = FIRST - 10,
+            ENDDRAG = FIRST - 11,
+            FILTERCHANGE = FIRST - 12,
+            FILTERBTNCLICK = FIRST - 13,
+            BEGINFILTEREDIT = FIRST - 14,
+            ENDFILTEREDIT = FIRST - 15,
+            ITEMSTATEICONCLICK = FIRST - 16,
+            ITEMKEYDOWN = FIRST - 17,
+            DROPDOWN = FIRST - 18,
+            OVERFLOWCLICK = FIRST - 19,
+            ITEMCHANGINGW = FIRST - 20,
+            ITEMCHANGEDW = FIRST - 21,
+            ITEMCLICKW = FIRST - 22,
+            ITEMDBLCLICKW = FIRST - 23,
+            DIVIDERDBLCLICKW = FIRST - 25,
+            BEGINTRACKW = FIRST - 26,
+            ENDTRACKW = FIRST - 27,
+            TRACKW = FIRST - 28,
+            GETDISPINFOW = FIRST - 29
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -19,19 +19,7 @@ namespace System.Windows.Forms
         GDI_ERROR = (unchecked((int)0xFFFFFFFF));
 
         public const int
-        HCF_HIGHCONTRASTON = 0x00000001,
-        HDN_ITEMCHANGING = ((0 - 300) - 20),
-        HDN_ITEMCHANGED = ((0 - 300) - 21),
-        HDN_ITEMCLICK = ((0 - 300) - 22),
-        HDN_ITEMDBLCLICK = ((0 - 300) - 23),
-        HDN_DIVIDERDBLCLICK = ((0 - 300) - 25),
-        HDN_BEGINTDRAG = ((0 - 300) - 10),
-        HDN_BEGINTRACK = ((0 - 300) - 26),
-        HDN_ENDDRAG = ((0 - 300) - 11),
-        HDN_ENDTRACK = ((0 - 300) - 27),
-        HDN_TRACK = ((0 - 300) - 28),
-        HDN_GETDISPINFO = ((0 - 300) - 29);
-        // HOVER_DEFAULT = Do not use this value ever! It crashes entire servers.
+        HCF_HIGHCONTRASTON = 0x00000001;
 
         public const int
         ICON_SMALL = 0,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -5715,7 +5715,7 @@ namespace System.Windows.Forms
                 OnColumnClick(new ColumnClickEventArgs(columnIndex));
             }
 
-            if (nmhdr->code == NativeMethods.HDN_BEGINTRACK)
+            if (nmhdr->code == (int)HDN.BEGINTRACKW)
             {
                 listViewState[LISTVIEWSTATE_headerControlTracking] = true;
 
@@ -5737,7 +5737,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            if (nmhdr->code == NativeMethods.HDN_ITEMCHANGING)
+            if (nmhdr->code == (int)HDN.ITEMCHANGINGW)
             {
                 NMHEADERW* nmheader = (NMHEADERW*)m.LParam;
 
@@ -5772,7 +5772,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            if ((nmhdr->code == NativeMethods.HDN_ITEMCHANGED) &&
+            if ((nmhdr->code == (int)HDN.ITEMCHANGEDW) &&
                 !listViewState[LISTVIEWSTATE_headerControlTracking])
             {
                 NMHEADERW* nmheader = (NMHEADERW*)m.LParam;
@@ -5829,7 +5829,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            if (nmhdr->code == NativeMethods.HDN_ENDTRACK)
+            if (nmhdr->code == (int)HDN.ENDTRACKW)
             {
                 Debug.Assert(listViewState[LISTVIEWSTATE_headerControlTracking], "HDN_ENDTRACK and HDN_BEGINTRACK are out of sync...");
                 listViewState[LISTVIEWSTATE_headerControlTracking] = false;
@@ -5857,7 +5857,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            if (nmhdr->code == NativeMethods.HDN_ENDDRAG)
+            if (nmhdr->code == (int)HDN.ENDDRAG)
             {
                 NMHEADERW* header = (NMHEADERW*)m.LParam;
                 if (header->pitem != null)
@@ -5922,7 +5922,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            if (nmhdr->code == NativeMethods.HDN_DIVIDERDBLCLICK)
+            if (nmhdr->code == (int)HDN.DIVIDERDBLCLICKW)
             {
                 // We need to keep track that the user double clicked the column header divider
                 // so we know that the column header width is changing.


### PR DESCRIPTION
## Proposed changes

- Add HDN enum in Interop ComCtl32.
- Remove HDN constants and replaces their usages with the above enum values.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2976)