### PR TITLE
Add MCN enum to Interop ComCtl32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.MCN.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.MCN.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        public enum MCN
+        {
+            FIRST = 0 - 746,
+            LAST = 0 - 752,
+            SELECT = FIRST,
+            GETDAYSTATE = FIRST - 1,
+            SELCHANGE = FIRST - 3,
+            VIEWCHANGE = FIRST - 4
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -67,11 +67,7 @@ namespace System.Windows.Forms
         }
 
         public const int
-        MDIS_ALLCHILDSTYLES = 0x0001,
-        MCN_VIEWCHANGE = (0 - 750), // MCN_SELECT -4  - give state of calendar view
-        MCN_SELCHANGE = ((0 - 750) + 1),
-        MCN_GETDAYSTATE = ((0 - 750) + 3),
-        MCN_SELECT = ((0 - 750) + 4);
+        MDIS_ALLCHILDSTYLES = 0x0001;
 
         public const int
         PATCOPY = 0x00F00021,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -2148,18 +2148,18 @@ namespace System.Windows.Forms
             if (m.HWnd == Handle)
             {
                 User32.NMHDR* nmhdr = (User32.NMHDR*)m.LParam;
-                switch (nmhdr->code)
+                switch ((MCN)nmhdr->code)
                 {
-                    case NativeMethods.MCN_SELECT:
+                    case MCN.SELECT:
                         WmDateSelected(ref m);
                         break;
-                    case NativeMethods.MCN_SELCHANGE:
+                    case MCN.SELCHANGE:
                         WmDateChanged(ref m);
                         break;
-                    case NativeMethods.MCN_GETDAYSTATE:
+                    case MCN.GETDAYSTATE:
                         WmDateBold(ref m);
                         break;
-                    case NativeMethods.MCN_VIEWCHANGE:
+                    case MCN.VIEWCHANGE:
                         WmCalViewChanged(ref m);
                         break;
                 }


### PR DESCRIPTION
## Proposed changes

- Add MCN enum to Interop ComCtl32.
- Remove MCN constants and replace their usages with MCN enum values.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2977)