### PR TITLE
Move InvalidateRgn to Interop User32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Comdlg32/Interop.PrintDlg.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Comdlg32/Interop.PrintDlg.cs
@@ -9,10 +9,10 @@ internal partial class Interop
 {
     internal partial class Comdlg32
     {
-        [DllImport(ExternDll.Comdlg32, ExactSpelling = true, SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.Comdlg32, ExactSpelling = true, SetLastError = true, CharSet = CharSet.Unicode)]
         private static extern BOOL PrintDlgW(ref PRINTDLGW_32 lppd);
 
-        [DllImport(ExternDll.Comdlg32, ExactSpelling = true, SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.Comdlg32, ExactSpelling = true, SetLastError = true, CharSet = CharSet.Unicode)]
         private static extern BOOL PrintDlgW(ref PRINTDLGW_64 lppd);
 
         public static BOOL PrintDlg(ref PRINTDLGW lppd)

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.MultiByteToWideChar.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.MultiByteToWideChar.cs
@@ -14,7 +14,7 @@ internal partial class Interop
         //            of WCHARs in the string, while the size of the Out buffer equals the number of bytes. To avoid a buffer overrun, be sure to specify
         //            a buffer size appropriate for the data type the buffer receives. For more information, see Security Considerations: International Features.
         //            Always call these functions passing a null destination buffer to get its size and the create the buffer with the exact size.
-        [DllImport(ExternDll.Kernel32, ExactSpelling = true, CharSet = CharSet.Unicode, SetLastError = true)]
+        [DllImport(Libraries.Kernel32, ExactSpelling = true, CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern int MultiByteToWideChar(int CodePage, int dwFlags, byte[] lpMultiByteStr, int cchMultiByte, char[] lpWideCharStr, int cchWideChar);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.InvalidateRgn.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.InvalidateRgn.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        private static extern BOOL InvalidateRgn(IntPtr hWnd, IntPtr hrgn, BOOL erase);
+
+        public static BOOL InvalidateRgn(IHandle hWnd, HandleRef hrgn, BOOL erase)
+        {
+            BOOL result = InvalidateRgn(hWnd.Handle, hrgn.Handle, erase);
+            GC.KeepAlive(hWnd);
+            GC.KeepAlive(hrgn.Wrapper);
+            return result;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/SafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/SafeNativeMethods.cs
@@ -46,9 +46,6 @@ namespace System.Windows.Forms
         public static extern IntPtr /*HBITMAP*/ CreateBitmap(int nWidth, int nHeight, int nPlanes, int nBitsPerPixel, byte[] lpvBits);
 
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern bool InvalidateRgn(HandleRef hWnd, HandleRef hrgn, bool erase);
-
-        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern bool MessageBeep(int type);
 
         // Theming/Visual Styles

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -6287,9 +6287,10 @@ namespace System.Windows.Forms
                         // It's safe to invoke InvalidateRgn from a separate thread.
                         using (new MultithreadSafeCallScope())
                         {
-                            SafeNativeMethods.InvalidateRgn(new HandleRef(this, Handle),
-                                                            new HandleRef(region, regionHandle),
-                                                            !GetStyle(ControlStyles.Opaque));
+                            User32.InvalidateRgn(
+                                this,
+                                new HandleRef(region, regionHandle),
+                                (!GetStyle(ControlStyles.Opaque)).ToBOOL());
                         }
                     }
                 }


### PR DESCRIPTION
## Proposed changes

- Move InvalidateRgn to Interop User32.
- Replace some ExternDll usages with Libraries instead.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2987)