### PR TITLE
Fix flaky test

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WebBrowserTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WebBrowserTests.cs
@@ -955,7 +955,7 @@ namespace System.Windows.Forms.Tests
             await Task.Run(() => control.Navigate(file.Path));
             Assert.True(await source.Task);
 
-            Assert.Contains("HTML", control.DocumentType);
+            Assert.NotEmpty(control.DocumentType);
             Assert.DoesNotContain('\0', control.DocumentType);
         }
 


### PR DESCRIPTION
The test may intermittently fail in internal CI agents. Presumably due to either no IE installer or a different version of IE, that yeilds `DocumentType` as "HTM File" instead of "HTML Document".

Fixes: https://github.com/dotnet/winforms/pull/2962#discussion_r394735398




## Proposed changes

- Assert that `DocumentType` is set without asserting the string itself, as we don't control the content



<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2995)