### PR TITLE
WIP: implement generic collections without signature changes

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ArraySubsetEnumerator.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ArraySubsetEnumerator.cs
@@ -5,17 +5,18 @@
 #nullable disable
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace System.Windows.Forms
 {
-    internal class ArraySubsetEnumerator : IEnumerator
+    internal class ArraySubsetEnumerator<T> : IEnumerator<T>
     {
-        private readonly object[] _array;
+        private readonly T[] _array;
         private readonly int _total;
         private int _current;
 
-        public ArraySubsetEnumerator(object[] array, int count)
+        public ArraySubsetEnumerator(T[] array, int count)
         {
             Debug.Assert(count == 0 || array != null, "if array is null, count should be 0");
             Debug.Assert(array == null || count <= array.Length, "Trying to enumerate more than the array contains");
@@ -23,6 +24,8 @@ namespace System.Windows.Forms
             _total = count;
             _current = -1;
         }
+
+        void IDisposable.Dispose() { }
 
         public bool MoveNext()
         {
@@ -37,6 +40,8 @@ namespace System.Windows.Forms
 
         public void Reset() => _current = -1;
 
-        public object Current => _current == -1 ? null : _array[_current];
+        public T Current => _current == -1 ? default : _array[_current];
+
+        object IEnumerator.Current => Current;
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AutoCompleteStringCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AutoCompleteStringCollection.cs
@@ -5,14 +5,16 @@
 #nullable disable
 
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 
 namespace System.Windows.Forms
 {
     /// <summary>
     ///  Represents a collection of strings.
     /// </summary>
-    public class AutoCompleteStringCollection : IList
+    public class AutoCompleteStringCollection : IList, IList<string>
     {
         CollectionChangeEventHandler onCollectionChanged;
         private readonly ArrayList data = new ArrayList();
@@ -87,6 +89,8 @@ namespace System.Windows.Forms
             OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Add, value));
             return index;
         }
+
+        void ICollection<string>.Add(string value) => Add(value);
 
         /// <summary>
         ///  Copies the elements of a string array to the end of the <see cref='AutoCompleteStringCollection'/>.
@@ -175,10 +179,18 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Removes a specific string from the <see cref='AutoCompleteStringCollection'/> .
         /// </summary>
-        public void Remove(string value)
+        public void Remove(string value) => TryRemove(value);
+
+        bool ICollection<string>.Remove(string value) => TryRemove(value);
+
+        private bool TryRemove(string value)
         {
+            if (!data.Contains(value))
+                return false;
+
             data.Remove(value);
             OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Remove, value));
+            return true;
         }
 
         /// <summary>
@@ -241,6 +253,11 @@ namespace System.Windows.Forms
         public IEnumerator GetEnumerator()
         {
             return data.GetEnumerator();
+        }
+
+        IEnumerator<string> IEnumerable<string>.GetEnumerator()
+        {
+            return data.Cast<string>().GetEnumerator();
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingsCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingsCollection.cs
@@ -6,6 +6,8 @@
 
 using System.ComponentModel;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace System.Windows.Forms
 {
@@ -13,7 +15,7 @@ namespace System.Windows.Forms
     ///  Represents a collection of data bindings on a control.
     /// </summary>
     [DefaultEvent(nameof(CollectionChanged))]
-    public class BindingsCollection : BaseCollection
+    public class BindingsCollection : BaseCollection, IReadOnlyList<Binding>
     {
         private ArrayList _list;
         private CollectionChangeEventHandler _onCollectionChanging;
@@ -121,5 +123,13 @@ namespace System.Windows.Forms
         protected virtual void RemoveCore(Binding dataBinding) => List.Remove(dataBinding);
 
         internal protected bool ShouldSerializeMyAll() => Count > 0;
+
+        IEnumerator<Binding> IEnumerable<Binding>.GetEnumerator()
+        {
+            if (_list is null)
+                return Enumerable.Empty<Binding>().GetEnumerator();
+            else
+                return _list.Cast<Binding>().GetEnumerator();
+        }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
@@ -1093,7 +1094,7 @@ namespace System.Windows.Forms
             }
         }
 
-        public class CheckedIndexCollection : IList
+        public class CheckedIndexCollection : IList, IList<int>
         {
             private readonly CheckedListBox owner;
 
@@ -1171,7 +1172,23 @@ namespace System.Windows.Forms
                 }
             }
 
+            int IList<int>.this[int index]
+            {
+                get => this[index];
+                set => throw new NotSupportedException(SR.CheckedListBoxCheckedIndexCollectionIsReadOnly);
+            }
+
+            void ICollection<int>.Add(int value)
+            {
+                throw new NotSupportedException(SR.CheckedListBoxCheckedIndexCollectionIsReadOnly);
+            }
+
             int IList.Add(object value)
+            {
+                throw new NotSupportedException(SR.CheckedListBoxCheckedIndexCollectionIsReadOnly);
+            }
+
+            void ICollection<int>.Clear()
             {
                 throw new NotSupportedException(SR.CheckedListBoxCheckedIndexCollectionIsReadOnly);
             }
@@ -1181,12 +1198,27 @@ namespace System.Windows.Forms
                 throw new NotSupportedException(SR.CheckedListBoxCheckedIndexCollectionIsReadOnly);
             }
 
+            void IList<int>.Insert(int index, int value)
+            {
+                throw new NotSupportedException(SR.CheckedListBoxCheckedIndexCollectionIsReadOnly);
+            }
+
             void IList.Insert(int index, object value)
             {
                 throw new NotSupportedException(SR.CheckedListBoxCheckedIndexCollectionIsReadOnly);
             }
 
+            bool ICollection<int>.Remove(int value)
+            {
+                throw new NotSupportedException(SR.CheckedListBoxCheckedIndexCollectionIsReadOnly);
+            }
+
             void IList.Remove(object value)
+            {
+                throw new NotSupportedException(SR.CheckedListBoxCheckedIndexCollectionIsReadOnly);
+            }
+
+            void IList<int>.RemoveAt(int index)
             {
                 throw new NotSupportedException(SR.CheckedListBoxCheckedIndexCollectionIsReadOnly);
             }
@@ -1222,6 +1254,8 @@ namespace System.Windows.Forms
                 }
             }
 
+            void ICollection<int>.CopyTo(int[] array, int index) => CopyTo(array, index);
+
             /// <summary>
             ///  This is the item array that stores our data.  We share this backing store
             ///  with the main object collection.
@@ -1234,11 +1268,15 @@ namespace System.Windows.Forms
                 }
             }
 
-            public IEnumerator GetEnumerator()
+            public IEnumerator GetEnumerator() => GetEnumeratorCore();
+
+            IEnumerator<int> IEnumerable<int>.GetEnumerator() => GetEnumeratorCore();
+
+            private IEnumerator<int> GetEnumeratorCore()
             {
                 int[] indices = new int[Count];
                 CopyTo(indices, 0);
-                return indices.GetEnumerator();
+                return WindowsFormsUtils.GetArrayEnumerator(indices);
             }
 
             public int IndexOf(int index)
@@ -1264,7 +1302,7 @@ namespace System.Windows.Forms
             }
         }
 
-        public class CheckedItemCollection : IList
+        public class CheckedItemCollection : IList, IList<object>
         {
             internal static int CheckedItemMask = ItemArray.CreateMask();
             internal static int IndeterminateItemMask = ItemArray.CreateMask();
@@ -1364,7 +1402,17 @@ namespace System.Windows.Forms
                 return InnerArray.IndexOfIdentifier(item, AnyMask);
             }
 
+            void ICollection<object>.Add(object value)
+            {
+                throw new NotSupportedException(SR.CheckedListBoxCheckedItemCollectionIsReadOnly);
+            }
+
             int IList.Add(object value)
+            {
+                throw new NotSupportedException(SR.CheckedListBoxCheckedItemCollectionIsReadOnly);
+            }
+
+            void ICollection<object>.Clear()
             {
                 throw new NotSupportedException(SR.CheckedListBoxCheckedItemCollectionIsReadOnly);
             }
@@ -1374,12 +1422,27 @@ namespace System.Windows.Forms
                 throw new NotSupportedException(SR.CheckedListBoxCheckedItemCollectionIsReadOnly);
             }
 
+            void IList<object>.Insert(int index, object value)
+            {
+                throw new NotSupportedException(SR.CheckedListBoxCheckedItemCollectionIsReadOnly);
+            }
+
             void IList.Insert(int index, object value)
             {
                 throw new NotSupportedException(SR.CheckedListBoxCheckedItemCollectionIsReadOnly);
             }
 
+            bool ICollection<object>.Remove(object value)
+            {
+                throw new NotSupportedException(SR.CheckedListBoxCheckedItemCollectionIsReadOnly);
+            }
+
             void IList.Remove(object value)
+            {
+                throw new NotSupportedException(SR.CheckedListBoxCheckedItemCollectionIsReadOnly);
+            }
+
+            void IList<object>.RemoveAt(int index)
             {
                 throw new NotSupportedException(SR.CheckedListBoxCheckedItemCollectionIsReadOnly);
             }
@@ -1397,6 +1460,8 @@ namespace System.Windows.Forms
                     dest.SetValue(InnerArray.GetItem(i, AnyMask), i + index);
                 }
             }
+
+            void ICollection<object>.CopyTo(object[] dest, int index) => CopyTo(dest, index);
 
             /// <summary>
             ///  This method returns if the actual item index is checked.  The index is the index to the MAIN
@@ -1419,7 +1484,11 @@ namespace System.Windows.Forms
                 return CheckState.Unchecked;
             }
 
-            public IEnumerator GetEnumerator()
+            public IEnumerator GetEnumerator() => GetEnumeratorCore();
+
+            IEnumerator<object> IEnumerable<object>.GetEnumerator() => GetEnumeratorCore();
+
+            private IEnumerator<object> GetEnumeratorCore()
             {
                 return InnerArray.GetEnumerator(AnyMask, true);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
@@ -4081,7 +4082,7 @@ namespace System.Windows.Forms
             }
         }
 
-        private sealed class ItemComparer : IComparer
+        private sealed class ItemComparer : IComparer, IComparer<object>
         {
             private readonly ComboBox comboBox;
 
@@ -4115,18 +4116,18 @@ namespace System.Windows.Forms
         }
 
         [ListBindable(false)]
-        public class ObjectCollection : IList
+        public class ObjectCollection : IList, IList<object>
         {
             private readonly ComboBox owner;
-            private ArrayList innerList;
-            private IComparer comparer;
+            private List<object> innerList;
+            private ItemComparer comparer;
 
             public ObjectCollection(ComboBox owner)
             {
                 this.owner = owner;
             }
 
-            private IComparer Comparer
+            private ItemComparer Comparer
             {
                 get
                 {
@@ -4138,13 +4139,13 @@ namespace System.Windows.Forms
                 }
             }
 
-            private ArrayList InnerList
+            private List<object> InnerList
             {
                 get
                 {
                     if (innerList == null)
                     {
-                        innerList = new ArrayList();
+                        innerList = new List<object>();
                     }
                     return innerList;
                 }
@@ -4212,6 +4213,8 @@ namespace System.Windows.Forms
                 }
                 return index;
             }
+
+            void ICollection<object>.Add(object item) => Add(item);
 
             private int AddInternal(object item)
             {
@@ -4367,13 +4370,17 @@ namespace System.Windows.Forms
 
             void ICollection.CopyTo(Array destination, int index)
             {
-                InnerList.CopyTo(destination, index);
+                ((ICollection)InnerList).CopyTo(destination, index);
             }
 
             /// <summary>
             ///  Returns an enumerator for the ComboBox Items collection.
             /// </summary>
-            public IEnumerator GetEnumerator()
+            public IEnumerator GetEnumerator() => GetEnumeratorCore();
+
+            IEnumerator<object> IEnumerable<object>.GetEnumerator() => GetEnumeratorCore();
+
+            private IEnumerator<object> GetEnumeratorCore()
             {
                 return InnerList.GetEnumerator();
             }
@@ -4482,12 +4489,22 @@ namespace System.Windows.Forms
             /// </summary>
             public void Remove(object value)
             {
-                int index = InnerList.IndexOf(value);
+                TryRemove(value);
+            }
 
-                if (index != -1)
-                {
-                    RemoveAt(index);
-                }
+            bool ICollection<object>.Remove(object value)
+            {
+                return TryRemove(value);
+            }
+
+            private bool TryRemove(object value)
+            {
+                int index = InnerList.IndexOf(value);
+                if (index < 0)
+                    return false;
+
+                RemoveAt(index);
+                return true;
             }
 
             internal void SetItemInternal(int index, object value)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellCollection.cs
@@ -5,8 +5,10 @@
 #nullable disable
 
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Linq;
 
 namespace System.Windows.Forms
 {
@@ -15,7 +17,7 @@ namespace System.Windows.Forms
     ///  control.
     /// </summary>
     [ListBindable(false)]
-    public class DataGridViewCellCollection : BaseCollection, IList
+    public class DataGridViewCellCollection : BaseCollection, IList, IList<DataGridViewCell>
     {
         CollectionChangeEventHandler onCollectionChanged;
         readonly ArrayList items = new ArrayList();
@@ -25,6 +27,8 @@ namespace System.Windows.Forms
         {
             return Add((DataGridViewCell)value);
         }
+
+        void ICollection<DataGridViewCell>.Add(DataGridViewCell dataGridViewCell) => Add(dataGridViewCell);
 
         void IList.Clear()
         {
@@ -95,6 +99,11 @@ namespace System.Windows.Forms
         IEnumerator IEnumerable.GetEnumerator()
         {
             return items.GetEnumerator();
+        }
+
+        IEnumerator<DataGridViewCell> IEnumerable<DataGridViewCell>.GetEnumerator()
+        {
+            return items.Cast<DataGridViewCell>().GetEnumerator();
         }
 
         public DataGridViewCellCollection(DataGridViewRow dataGridViewRow)
@@ -373,6 +382,14 @@ namespace System.Windows.Forms
             {
                 RemoveAt(cellIndex);
             }
+        }
+
+        bool ICollection<DataGridViewCell>.Remove(DataGridViewCell cell)
+        {
+            var wasContained = Contains(cell);
+            Remove(cell);
+            var isContained = Contains(cell);
+            return wasContained && !isContained;
         }
 
         public virtual void RemoveAt(int index)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellLinkedList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellLinkedList.cs
@@ -6,19 +6,25 @@
 
 using System.Diagnostics;
 using System.Collections;
+using System.Collections.Generic;
 
 namespace System.Windows.Forms
 {
     /// <summary>
     ///  Represents a linked list of <see cref='DataGridViewCell'/> objects
     /// </summary>
-    internal class DataGridViewCellLinkedList : IEnumerable
+    internal class DataGridViewCellLinkedList : IReadOnlyList<DataGridViewCell>
     {
         private DataGridViewCellLinkedListElement lastAccessedElement;
         private DataGridViewCellLinkedListElement headElement;
         private int count, lastAccessedIndex;
 
         IEnumerator IEnumerable.GetEnumerator()
+        {
+            return new DataGridViewCellLinkedListEnumerator(headElement);
+        }
+
+        IEnumerator<DataGridViewCell> IEnumerable<DataGridViewCell>.GetEnumerator()
         {
             return new DataGridViewCellLinkedListEnumerator(headElement);
         }
@@ -189,7 +195,7 @@ namespace System.Windows.Forms
     /// <summary>
     ///  Represents an emunerator of elements in a <see cref='DataGridViewCellLinkedList'/>  linked list.
     /// </summary>
-    internal class DataGridViewCellLinkedListEnumerator : IEnumerator
+    internal class DataGridViewCellLinkedListEnumerator : IEnumerator<DataGridViewCell>
     {
         private readonly DataGridViewCellLinkedListElement headElement;
         private DataGridViewCellLinkedListElement current;
@@ -201,7 +207,13 @@ namespace System.Windows.Forms
             reset = true;
         }
 
-        object IEnumerator.Current
+        void IDisposable.Dispose() { }
+
+        object IEnumerator.Current => Current;
+
+        DataGridViewCell IEnumerator<DataGridViewCell>.Current => Current;
+
+        private DataGridViewCell Current
         {
             get
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnCollection.cs
@@ -5,10 +5,12 @@
 #nullable disable
 
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
+using System.Linq;
 
 namespace System.Windows.Forms
 {
@@ -17,7 +19,7 @@ namespace System.Windows.Forms
     ///  <see cref='DataGridView'/> control.
     /// </summary>
     [ListBindable(false)]
-    public class DataGridViewColumnCollection : BaseCollection, IList
+    public class DataGridViewColumnCollection : BaseCollection, IList, IList<DataGridViewColumn>
     {
         private CollectionChangeEventHandler onCollectionChanged;
         private readonly ArrayList items = new ArrayList();
@@ -46,9 +48,20 @@ namespace System.Windows.Forms
             set { throw new NotSupportedException(); }
         }
 
+        DataGridViewColumn IList<DataGridViewColumn>.this[int index]
+        {
+            get { return this[index]; }
+            set { throw new NotSupportedException(); }
+        }
+
         int IList.Add(object value)
         {
             return Add((DataGridViewColumn)value);
+        }
+
+        void ICollection<DataGridViewColumn>.Add(DataGridViewColumn value)
+        {
+            Add(value);
         }
 
         void IList.Clear()
@@ -74,6 +87,14 @@ namespace System.Windows.Forms
         void IList.Remove(object value)
         {
             Remove((DataGridViewColumn)value);
+        }
+
+        bool ICollection<DataGridViewColumn>.Remove(DataGridViewColumn value)
+        {
+            var wasContained = Contains(value);
+            Remove(value);
+            var isContained = Contains(value);
+            return wasContained && !isContained;
         }
 
         void IList.RemoveAt(int index)
@@ -117,6 +138,11 @@ namespace System.Windows.Forms
         IEnumerator IEnumerable.GetEnumerator()
         {
             return items.GetEnumerator();
+        }
+
+        IEnumerator<DataGridViewColumn> IEnumerable<DataGridViewColumn>.GetEnumerator()
+        {
+            return items.Cast<DataGridViewColumn>().GetEnumerator();
         }
 
         public DataGridViewColumnCollection(DataGridView dataGridView)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewIntLinkedList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewIntLinkedList.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace System.Windows.Forms
@@ -12,13 +13,18 @@ namespace System.Windows.Forms
     /// <summary>
     ///  Represents a linked list of integers
     /// </summary>
-    internal class DataGridViewIntLinkedList : IEnumerable
+    internal class DataGridViewIntLinkedList : IReadOnlyList<int>
     {
         private DataGridViewIntLinkedListElement lastAccessedElement;
         private DataGridViewIntLinkedListElement headElement;
         private int count, lastAccessedIndex;
 
         IEnumerator IEnumerable.GetEnumerator()
+        {
+            return new DataGridViewIntLinkedListEnumerator(headElement);
+        }
+
+        IEnumerator<int> IEnumerable<int>.GetEnumerator()
         {
             return new DataGridViewIntLinkedListEnumerator(headElement);
         }
@@ -205,7 +211,7 @@ namespace System.Windows.Forms
     /// <summary>
     ///  Represents an emunerator of elements in a <see cref='DataGridViewIntLinkedList'/>  linked list.
     /// </summary>
-    internal class DataGridViewIntLinkedListEnumerator : IEnumerator
+    internal class DataGridViewIntLinkedListEnumerator : IEnumerator<int>
     {
         private readonly DataGridViewIntLinkedListElement headElement;
         private DataGridViewIntLinkedListElement current;
@@ -217,7 +223,13 @@ namespace System.Windows.Forms
             reset = true;
         }
 
-        object IEnumerator.Current
+        void IDisposable.Dispose() { }
+
+        object IEnumerator.Current => Current;
+
+        int IEnumerator<int>.Current => Current;
+
+        private int Current
         {
             get
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewSelectedCellCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewSelectedCellCollection.cs
@@ -5,8 +5,10 @@
 #nullable disable
 
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Linq;
 
 namespace System.Windows.Forms
 {
@@ -15,7 +17,7 @@ namespace System.Windows.Forms
     ///  control.
     /// </summary>
     [ListBindable(false)]
-    public class DataGridViewSelectedCellCollection : BaseCollection, IList
+    public class DataGridViewSelectedCellCollection : BaseCollection, IList, IList<DataGridViewCell>
     {
         readonly ArrayList items = new ArrayList();
 
@@ -24,7 +26,17 @@ namespace System.Windows.Forms
             throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
         }
 
+        void ICollection<DataGridViewCell>.Add(DataGridViewCell value)
+        {
+            throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
+        }
+
         void IList.Clear()
+        {
+            throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
+        }
+
+        void ICollection<DataGridViewCell>.Clear()
         {
             throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
         }
@@ -39,7 +51,17 @@ namespace System.Windows.Forms
             return items.IndexOf(value);
         }
 
+        int IList<DataGridViewCell>.IndexOf(DataGridViewCell value)
+        {
+            return items.IndexOf(value);
+        }
+
         void IList.Insert(int index, object value)
+        {
+            throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
+        }
+
+        void IList<DataGridViewCell>.Insert(int index, DataGridViewCell value)
         {
             throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
         }
@@ -49,7 +71,17 @@ namespace System.Windows.Forms
             throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
         }
 
+        bool ICollection<DataGridViewCell>.Remove(DataGridViewCell value)
+        {
+            throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
+        }
+
         void IList.RemoveAt(int index)
+        {
+            throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
+        }
+
+        void IList<DataGridViewCell>.RemoveAt(int index)
         {
             throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
         }
@@ -67,6 +99,12 @@ namespace System.Windows.Forms
         object IList.this[int index]
         {
             get { return items[index]; }
+            set { throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection); }
+        }
+
+        DataGridViewCell IList<DataGridViewCell>.this[int index]
+        {
+            get { return this[index]; }
             set { throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection); }
         }
 
@@ -93,6 +131,11 @@ namespace System.Windows.Forms
         IEnumerator IEnumerable.GetEnumerator()
         {
             return items.GetEnumerator();
+        }
+
+        IEnumerator<DataGridViewCell> IEnumerable<DataGridViewCell>.GetEnumerator()
+        {
+            return items.Cast<DataGridViewCell>().GetEnumerator();
         }
 
         internal DataGridViewSelectedCellCollection()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewSelectedColumnCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewSelectedColumnCollection.cs
@@ -5,12 +5,14 @@
 #nullable disable
 
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 
 namespace System.Windows.Forms
 {
     [ListBindable(false)]
-    public class DataGridViewSelectedColumnCollection : BaseCollection, IList
+    public class DataGridViewSelectedColumnCollection : BaseCollection, IList, IList<DataGridViewColumn>
     {
         readonly ArrayList items = new ArrayList();
 
@@ -19,7 +21,17 @@ namespace System.Windows.Forms
             throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
         }
 
+        void ICollection<DataGridViewColumn>.Add(DataGridViewColumn item)
+        {
+            throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
+        }
+
         void IList.Clear()
+        {
+            throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
+        }
+
+        void ICollection<DataGridViewColumn>.Clear()
         {
             throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
         }
@@ -34,7 +46,17 @@ namespace System.Windows.Forms
             return items.IndexOf(value);
         }
 
+        int IList<DataGridViewColumn>.IndexOf(DataGridViewColumn value)
+        {
+            return items.IndexOf(value);
+        }
+
         void IList.Insert(int index, object value)
+        {
+            throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
+        }
+
+        void IList<DataGridViewColumn>.Insert(int index, DataGridViewColumn value)
         {
             throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
         }
@@ -44,7 +66,17 @@ namespace System.Windows.Forms
             throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
         }
 
+        bool ICollection<DataGridViewColumn>.Remove(DataGridViewColumn value)
+        {
+            throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
+        }
+
         void IList.RemoveAt(int index)
+        {
+            throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
+        }
+
+        void IList<DataGridViewColumn>.RemoveAt(int index)
         {
             throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
         }
@@ -62,6 +94,12 @@ namespace System.Windows.Forms
         object IList.this[int index]
         {
             get { return items[index]; }
+            set { throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection); }
+        }
+
+        DataGridViewColumn IList<DataGridViewColumn>.this[int index]
+        {
+            get { return this[index]; }
             set { throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection); }
         }
 
@@ -88,6 +126,11 @@ namespace System.Windows.Forms
         IEnumerator IEnumerable.GetEnumerator()
         {
             return items.GetEnumerator();
+        }
+
+        IEnumerator<DataGridViewColumn> IEnumerable<DataGridViewColumn>.GetEnumerator()
+        {
+            return items.Cast<DataGridViewColumn>().GetEnumerator();
         }
 
         internal DataGridViewSelectedColumnCollection()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewSelectedRowCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewSelectedRowCollection.cs
@@ -5,7 +5,9 @@
 #nullable disable
 
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 
 namespace System.Windows.Forms
 {
@@ -14,11 +16,21 @@ namespace System.Windows.Forms
     ///  control.
     /// </summary>
     [ListBindable(false)]
-    public class DataGridViewSelectedRowCollection : BaseCollection, IList
+    public class DataGridViewSelectedRowCollection : BaseCollection, IList, IList<DataGridViewRow>
     {
         readonly ArrayList items = new ArrayList();
 
+        void ICollection<DataGridViewRow>.Add(DataGridViewRow value)
+        {
+            throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
+        }
+
         int IList.Add(object value)
+        {
+            throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
+        }
+
+        void ICollection<DataGridViewRow>.Clear()
         {
             throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
         }
@@ -38,7 +50,17 @@ namespace System.Windows.Forms
             return items.IndexOf(value);
         }
 
+        int IList<DataGridViewRow>.IndexOf(DataGridViewRow value)
+        {
+            return items.IndexOf(value);
+        }
+
         void IList.Insert(int index, object value)
+        {
+            throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
+        }
+
+        void IList<DataGridViewRow>.Insert(int index, DataGridViewRow value)
         {
             throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
         }
@@ -48,7 +70,17 @@ namespace System.Windows.Forms
             throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
         }
 
+        bool ICollection<DataGridViewRow>.Remove(DataGridViewRow item)
+        {
+            throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
+        }
+
         void IList.RemoveAt(int index)
+        {
+            throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
+        }
+
+        void IList<DataGridViewRow>.RemoveAt(int index)
         {
             throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection);
         }
@@ -66,6 +98,12 @@ namespace System.Windows.Forms
         object IList.this[int index]
         {
             get { return items[index]; }
+            set { throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection); }
+        }
+
+        DataGridViewRow IList<DataGridViewRow>.this[int index]
+        {
+            get { return this[index]; }
             set { throw new NotSupportedException(SR.DataGridView_ReadOnlyCollection); }
         }
 
@@ -92,6 +130,11 @@ namespace System.Windows.Forms
         IEnumerator IEnumerable.GetEnumerator()
         {
             return items.GetEnumerator();
+        }
+
+        IEnumerator<DataGridViewRow> IEnumerable<DataGridViewRow>.GetEnumerator()
+        {
+            return items.Cast<DataGridViewRow>().GetEnumerator();
         }
 
         internal DataGridViewSelectedRowCollection()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.cs
@@ -5,11 +5,13 @@
 #nullable disable
 
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Design;
 using System.Globalization;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Forms.Layout;
 using static Interop;
@@ -573,7 +575,7 @@ namespace System.Windows.Forms
         ///  Encapsulates a collection of objects for use by the <see cref='DomainUpDown'/>
         ///  class.
         /// </summary>
-        public class DomainUpDownItemCollection : ArrayList
+        public class DomainUpDownItemCollection : ArrayList, IList<object>
         {
             readonly DomainUpDown owner;
 
@@ -622,6 +624,8 @@ namespace System.Windows.Forms
                 return ret;
             }
 
+            void ICollection<object>.Add(object item) => Add(item);
+
             /// <summary>
             /// </summary>
             public override void Remove(object item)
@@ -636,6 +640,12 @@ namespace System.Windows.Forms
                 {
                     RemoveAt(index);
                 }
+            }
+
+            bool ICollection<object>.Remove(object item)
+            {
+                Remove(item); // throws on failure
+                return true;
             }
 
             /// <summary>
@@ -668,6 +678,10 @@ namespace System.Windows.Forms
                     owner.SortDomainItems();
                 }
             }
+
+            void ICollection<object>.CopyTo(object[] array, int arrayIndex) => CopyTo(array, arrayIndex);
+
+            IEnumerator<object> IEnumerable<object>.GetEnumerator() => this.Cast<object>().GetEnumerator();
         } // end class DomainUpDownItemCollection
 
         private sealed class DomainUpDownItemCompare : IComparer

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FormCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FormCollection.cs
@@ -5,6 +5,8 @@
 #nullable disable
 
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace System.Windows.Forms
 {
@@ -12,7 +14,7 @@ namespace System.Windows.Forms
     ///  This is a read only collection of Forms exposed as a static property of the
     ///  Application class. This is used to store all the currently loaded forms in an app.
     /// </summary>
-    public class FormCollection : ReadOnlyCollectionBase
+    public class FormCollection : ReadOnlyCollectionBase, IReadOnlyList<Form>
     {
         internal static object CollectionSyncRoot = new object();
 
@@ -92,5 +94,7 @@ namespace System.Windows.Forms
                 InnerList.Remove(form);
             }
         }
+
+        IEnumerator<Form> IEnumerable<Form>.GetEnumerator() => this.Cast<Form>().GetEnumerator();
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GridItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GridItemCollection.cs
@@ -5,13 +5,14 @@
 #nullable disable
 
 using System.Collections;
+using System.Collections.Generic;
 
 namespace System.Windows.Forms
 {
     /// <summary>
     ///  A read-only collection of GridItem objects
     /// </summary>
-    public class GridItemCollection : ICollection
+    public class GridItemCollection : ICollection, IReadOnlyList<GridItem>
     {
         public static GridItemCollection Empty = new GridItemCollection(Array.Empty<GridItem>());
 
@@ -64,5 +65,7 @@ namespace System.Windows.Forms
         ///  Creates and retrieves a new enumerator for this collection.
         /// </summary>
         public IEnumerator GetEnumerator() => _entries.GetEnumerator();
+
+        IEnumerator<GridItem> IEnumerable<GridItem>.GetEnumerator() => WindowsFormsUtils.GetArrayEnumerator(_entries);
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElementCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElementCollection.cs
@@ -5,12 +5,13 @@
 #nullable disable
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using static Interop.Mshtml;
 
 namespace System.Windows.Forms
 {
-    public sealed class HtmlElementCollection : ICollection
+    public sealed class HtmlElementCollection : ICollection, IReadOnlyList<HtmlElement>
     {
         private readonly IHTMLElementCollection htmlElementCollection;
         private readonly HtmlElement[] elementsArray;
@@ -178,12 +179,16 @@ namespace System.Windows.Forms
             }
         }
 
-        public IEnumerator GetEnumerator()
+        public IEnumerator GetEnumerator() => GetEnumeratorCore();
+
+        IEnumerator<HtmlElement> IEnumerable<HtmlElement>.GetEnumerator() => GetEnumeratorCore();
+
+        private IEnumerator<HtmlElement> GetEnumeratorCore()
         {
             HtmlElement[] htmlElements = new HtmlElement[Count];
             ((ICollection)this).CopyTo(htmlElements, 0);
 
-            return htmlElements.GetEnumerator();
+            return WindowsFormsUtils.GetArrayEnumerator(htmlElements);
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlWindowCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlWindowCollection.cs
@@ -5,13 +5,14 @@
 #nullable disable
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using static Interop.Mshtml;
 
 namespace System.Windows.Forms
 {
-    public class HtmlWindowCollection : ICollection
+    public class HtmlWindowCollection : ICollection, IReadOnlyList<HtmlWindow>
     {
         private readonly IHTMLFramesCollection2 htmlFramesCollection2;
         private readonly HtmlShimManager shimManager;
@@ -101,12 +102,16 @@ namespace System.Windows.Forms
             }
         }
 
-        public IEnumerator GetEnumerator()
+        public IEnumerator GetEnumerator() => GetEnumeratorCore();
+
+        IEnumerator<HtmlWindow> IEnumerable<HtmlWindow>.GetEnumerator() => GetEnumeratorCore();
+
+        private IEnumerator<HtmlWindow> GetEnumeratorCore()
         {
             HtmlWindow[] htmlWindows = new HtmlWindow[Count];
             ((ICollection)this).CopyTo(htmlWindows, 0);
 
-            return htmlWindows.GetEnumerator();
+            return WindowsFormsUtils.GetArrayEnumerator(htmlWindows);
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
@@ -1053,7 +1054,7 @@ namespace System.Windows.Forms
 
         // Everything other than set_All, Add, and Clear will force handle creation.
         [Editor("System.Windows.Forms.Design.ImageCollectionEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
-        public sealed class ImageCollection : IList
+        public sealed class ImageCollection : IList, IList<Image>
         {
             private readonly ImageList owner;
             private readonly ArrayList imageInfoCollection = new ArrayList();
@@ -1614,12 +1615,19 @@ namespace System.Windows.Forms
                 throw new NotSupportedException();
             }
 
+            void IList<Image>.Insert(int index, Image value) => throw new NotSupportedException();
+
             /// <summary>
             ///  Determines if the index is valid for the collection.
             /// </summary>
             private bool IsValidIndex(int index)
             {
                 return ((index >= 0) && (index < Count));
+            }
+
+            void ICollection<Image>.CopyTo(Image[] dest, int index)
+            {
+                ((ICollection)this).CopyTo(dest, index);
             }
 
             void ICollection.CopyTo(Array dest, int index)
@@ -1631,7 +1639,11 @@ namespace System.Windows.Forms
                 }
             }
 
-            public IEnumerator GetEnumerator()
+            public IEnumerator GetEnumerator() => GetEnumeratorCore();
+
+            IEnumerator<Image> IEnumerable<Image>.GetEnumerator() => GetEnumeratorCore();
+
+            private IEnumerator<Image> GetEnumeratorCore()
             {
                 // Forces handle creation
 
@@ -1642,11 +1654,16 @@ namespace System.Windows.Forms
                     images[i] = owner.GetBitmap(i);
                 }
 
-                return images.GetEnumerator();
+                return WindowsFormsUtils.GetArrayEnumerator(images);
             }
 
             [EditorBrowsable(EditorBrowsableState.Never)]
             public void Remove(Image image)
+            {
+                throw new NotSupportedException();
+            }
+
+            bool ICollection<Image>.Remove(Image image)
             {
                 throw new NotSupportedException();
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/InputLanguageCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/InputLanguageCollection.cs
@@ -5,13 +5,15 @@
 #nullable disable
 
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace System.Windows.Forms
 {
     /// <summary>
     ///  A collection that stores <see cref='InputLanguage'/> objects.
     /// </summary>
-    public class InputLanguageCollection : ReadOnlyCollectionBase
+    public class InputLanguageCollection : ReadOnlyCollectionBase, IReadOnlyList<InputLanguage>
     {
         /// <summary>
         ///  Initializes a new instance of <see cref='InputLanguageCollection'/> containing any array of <see cref='InputLanguage'/> objects.
@@ -58,5 +60,7 @@ namespace System.Windows.Forms
         {
             return InnerList.IndexOf(value);
         }
+
+        IEnumerator<InputLanguage> IEnumerable<InputLanguage>.GetEnumerator() => InnerList.Cast<InputLanguage>().GetEnumerator();
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -2738,7 +2738,7 @@ namespace System.Windows.Forms
             ///  Retrieves an enumerator that will enumerate based on
             ///  the given mask.
             /// </summary>
-            public IEnumerator GetEnumerator(int stateMask)
+            public IEnumerator<object> GetEnumerator(int stateMask)
             {
                 return GetEnumerator(stateMask, false);
             }
@@ -2747,7 +2747,7 @@ namespace System.Windows.Forms
             ///  Retrieves an enumerator that will enumerate based on
             ///  the given mask.
             /// </summary>
-            public IEnumerator GetEnumerator(int stateMask, bool anyBit)
+            public IEnumerator<object> GetEnumerator(int stateMask, bool anyBit)
             {
                 return new EntryEnumerator(this, stateMask, anyBit);
             }
@@ -2981,7 +2981,7 @@ namespace System.Windows.Forms
             ///  EntryEnumerator is an enumerator that will enumerate over
             ///  a given state mask.
             /// </summary>
-            private class EntryEnumerator : IEnumerator
+            private class EntryEnumerator : IEnumerator<object>
             {
                 private readonly ItemArray items;
                 private readonly bool anyBit;
@@ -3000,6 +3000,8 @@ namespace System.Windows.Forms
                     version = items.version;
                     current = -1;
                 }
+
+                void IDisposable.Dispose() { }
 
                 /// <summary>
                 ///  Moves to the next element, or returns false if at the end.
@@ -3055,7 +3057,7 @@ namespace System.Windows.Forms
                 /// <summary>
                 ///  Retrieves the current value in the enumerator.
                 /// </summary>
-                object IEnumerator.Current
+                public object Current
                 {
                     get
                     {
@@ -3075,7 +3077,7 @@ namespace System.Windows.Forms
             ///  A collection that stores objects.
         /// </summary>
         [ListBindable(false)]
-        public class ObjectCollection : IList
+        public class ObjectCollection : IList, IList<object>
         {
             private readonly ListBox owner;
             private ItemArray items;
@@ -3252,6 +3254,8 @@ namespace System.Windows.Forms
                 return Add(item);
             }
 
+            void ICollection<object>.Add(object item) => Add(item);
+
             public void AddRange(ObjectCollection value)
             {
                 owner.CheckNoDataSource();
@@ -3372,7 +3376,11 @@ namespace System.Windows.Forms
             /// <summary>
             ///  Returns an enumerator for the ListBox Items collection.
             /// </summary>
-            public IEnumerator GetEnumerator()
+            public IEnumerator GetEnumerator() => GetEnumeratorCore();
+
+            IEnumerator<object> IEnumerable<object>.GetEnumerator() => GetEnumeratorCore();
+
+            private IEnumerator<object> GetEnumeratorCore()
             {
                 return InnerArray.GetEnumerator(0);
             }
@@ -3456,14 +3464,18 @@ namespace System.Windows.Forms
             ///  Removes the given item from the ListBox, provided that it is
             ///  actually in the list.
             /// </summary>
-            public void Remove(object value)
+            public void Remove(object value) => TryRemove(value);
+
+            bool ICollection<object>.Remove(object value) => TryRemove(value);
+
+            private bool TryRemove(object value)
             {
                 int index = InnerArray.IndexOf(value, 0);
+                if (index < 0)
+                    return false;
 
-                if (index != -1)
-                {
-                    RemoveAt(index);
-                }
+                RemoveAt(index);
+                return true;
             }
 
             /// <summary>
@@ -3538,7 +3550,7 @@ namespace System.Windows.Forms
 
         //******************************************************************************************
         // IntegerCollection
-        public class IntegerCollection : IList
+        public class IntegerCollection : IList, IList<int>
         {
             private readonly ListBox owner;
             private int[] innerArray;
@@ -3584,6 +3596,8 @@ namespace System.Windows.Forms
                     return false;
                 }
             }
+
+            bool ICollection<int>.IsReadOnly => false;
 
             bool IList.IsReadOnly
             {
@@ -3681,6 +3695,8 @@ namespace System.Windows.Forms
                 return index;
             }
 
+            void ICollection<int>.Add(int item) => Add(item);
+
             int IList.Add(object item)
             {
                 if (!(item is int))
@@ -3761,6 +3777,8 @@ namespace System.Windows.Forms
                 throw new NotSupportedException(SR.ListBoxCantInsertIntoIntegerCollection);
             }
 
+            void IList<int>.Insert(int index, int item) => throw new NotSupportedException(SR.ListBoxCantInsertIntoIntegerCollection);
+
             void IList.Remove(object value)
             {
                 if (!(value is int))
@@ -3779,14 +3797,18 @@ namespace System.Windows.Forms
             ///  Removes the given item from the array.  If
             ///  the item is not in the array, this does nothing.
             /// </summary>
-            public void Remove(int item)
+            public void Remove(int item) => TryRemove(item);
+
+            bool ICollection<int>.Remove(int item) => TryRemove(item);
+
+            private bool TryRemove(int item)
             {
                 int index = IndexOf(item);
+                if (index < 0)
+                    return false;
 
-                if (index != -1)
-                {
-                    RemoveAt(index);
-                }
+                RemoveAt(index);
+                return true;
             }
 
             /// <summary>
@@ -3854,16 +3876,20 @@ namespace System.Windows.Forms
                 }
             }
 
+            void ICollection<int>.CopyTo(int[] destination, int index) => CopyTo(destination, index);
+
             IEnumerator IEnumerable.GetEnumerator()
             {
                 return new CustomTabOffsetsEnumerator(this);
             }
 
+            IEnumerator<int> IEnumerable<int>.GetEnumerator() => new CustomTabOffsetsEnumerator(this);
+
             /// <summary>
             ///  EntryEnumerator is an enumerator that will enumerate over
             ///  a given state mask.
             /// </summary>
-            private class CustomTabOffsetsEnumerator : IEnumerator
+            private class CustomTabOffsetsEnumerator : IEnumerator<int>
             {
                 private readonly IntegerCollection items;
                 private int current;
@@ -3876,6 +3902,8 @@ namespace System.Windows.Forms
                     this.items = items;
                     current = -1;
                 }
+
+                void IDisposable.Dispose() { }
 
                 /// <summary>
                 ///  Moves to the next element, or returns false if at the end.
@@ -3905,7 +3933,7 @@ namespace System.Windows.Forms
                 /// <summary>
                 ///  Retrieves the current value in the enumerator.
                 /// </summary>
-                object IEnumerator.Current
+                private int Current
                 {
                     get
                     {
@@ -3917,13 +3945,17 @@ namespace System.Windows.Forms
                         return items[current];
                     }
                 }
+
+                object IEnumerator.Current => Current;
+
+                int IEnumerator<int>.Current => Current;
             }
         }
 
         //******************************************************************************************
 
         // SelectedIndices
-        public class SelectedIndexCollection : IList
+        public class SelectedIndexCollection : IList, IList<int>
         {
             private readonly ListBox owner;
 
@@ -4037,7 +4069,17 @@ namespace System.Windows.Forms
                 throw new NotSupportedException(SR.ListBoxSelectedIndexCollectionIsReadOnly);
             }
 
+            void IList<int>.Insert(int index, int value)
+            {
+                throw new NotSupportedException(SR.ListBoxSelectedIndexCollectionIsReadOnly);
+            }
+
             void IList.Remove(object value)
+            {
+                throw new NotSupportedException(SR.ListBoxSelectedIndexCollectionIsReadOnly);
+            }
+
+            void IList<int>.RemoveAt(int index)
             {
                 throw new NotSupportedException(SR.ListBoxSelectedIndexCollectionIsReadOnly);
             }
@@ -4057,6 +4099,12 @@ namespace System.Windows.Forms
                     object identifier = InnerArray.GetEntryObject(index, SelectedObjectCollection.SelectedObjectMask);
                     return InnerArray.IndexOfIdentifier(identifier, 0);
                 }
+            }
+
+            int IList<int>.this[int index]
+            {
+                get => this[index];
+                set => throw new NotSupportedException(SR.ListBoxSelectedIndexCollectionIsReadOnly);
             }
 
             object IList.this[int index]
@@ -4093,6 +4141,8 @@ namespace System.Windows.Forms
                 }
             }
 
+            void ICollection<int>.CopyTo(int[] destination, int index) => CopyTo(destination, index);
+
             public void Clear()
             {
                 if (owner != null)
@@ -4116,7 +4166,11 @@ namespace System.Windows.Forms
                 }
             }
 
-            public void Remove(int index)
+            public void Remove(int index) => TryRemove(index);
+
+            bool ICollection<int>.Remove(int index) => TryRemove(index);
+
+            private bool TryRemove(int index)
             {
                 if (owner != null)
                 {
@@ -4126,12 +4180,19 @@ namespace System.Windows.Forms
                         if (index != -1 && Contains(index))
                         {
                             owner.SetSelected(index, false);
+                            return true;
                         }
                     }
                 }
+
+                return false;
             }
 
-            public IEnumerator GetEnumerator()
+            public IEnumerator GetEnumerator() => GetEnumeratorCore();
+
+            IEnumerator<int> IEnumerable<int>.GetEnumerator() => GetEnumeratorCore();
+
+            private IEnumerator<int> GetEnumeratorCore()
             {
                 return new SelectedIndexEnumerator(this);
             }
@@ -4140,7 +4201,7 @@ namespace System.Windows.Forms
             ///  EntryEnumerator is an enumerator that will enumerate over
             ///  a given state mask.
             /// </summary>
-            private class SelectedIndexEnumerator : IEnumerator
+            private class SelectedIndexEnumerator : IEnumerator<int>
             {
                 private readonly SelectedIndexCollection items;
                 private int current;
@@ -4153,6 +4214,8 @@ namespace System.Windows.Forms
                     this.items = items;
                     current = -1;
                 }
+
+                void IDisposable.Dispose() { }
 
                 /// <summary>
                 ///  Moves to the next element, or returns false if at the end.
@@ -4182,7 +4245,7 @@ namespace System.Windows.Forms
                 /// <summary>
                 ///  Retrieves the current value in the enumerator.
                 /// </summary>
-                object IEnumerator.Current
+                private int Current
                 {
                     get
                     {
@@ -4194,11 +4257,15 @@ namespace System.Windows.Forms
                         return items[current];
                     }
                 }
+
+                int IEnumerator<int>.Current => Current;
+
+                object IEnumerator.Current => Current;
             }
         }
 
         // Should be "ObjectCollection", except we already have one of those.
-        public class SelectedObjectCollection : IList
+        public class SelectedObjectCollection : IList, IList<object>
         {
             // This is the bitmask used within ItemArray to identify selected objects.
             internal static int SelectedObjectMask = ItemArray.CreateMask();
@@ -4344,7 +4411,17 @@ namespace System.Windows.Forms
                 throw new NotSupportedException(SR.ListBoxSelectedObjectCollectionIsReadOnly);
             }
 
+            void ICollection<object>.Add(object value)
+            {
+                throw new NotSupportedException(SR.ListBoxSelectedObjectCollectionIsReadOnly);
+            }
+
             void IList.Clear()
+            {
+                throw new NotSupportedException(SR.ListBoxSelectedObjectCollectionIsReadOnly);
+            }
+
+            void ICollection<object>.Clear()
             {
                 throw new NotSupportedException(SR.ListBoxSelectedObjectCollectionIsReadOnly);
             }
@@ -4354,12 +4431,27 @@ namespace System.Windows.Forms
                 throw new NotSupportedException(SR.ListBoxSelectedObjectCollectionIsReadOnly);
             }
 
+            void IList<object>.Insert(int index, object value)
+            {
+                throw new NotSupportedException(SR.ListBoxSelectedObjectCollectionIsReadOnly);
+            }
+
             void IList.Remove(object value)
             {
                 throw new NotSupportedException(SR.ListBoxSelectedObjectCollectionIsReadOnly);
             }
 
+            bool ICollection<object>.Remove(object value)
+            {
+                throw new NotSupportedException(SR.ListBoxSelectedObjectCollectionIsReadOnly);
+            }
+
             void IList.RemoveAt(int index)
+            {
+                throw new NotSupportedException(SR.ListBoxSelectedObjectCollectionIsReadOnly);
+            }
+
+            void IList<object>.RemoveAt(int index)
             {
                 throw new NotSupportedException(SR.ListBoxSelectedObjectCollectionIsReadOnly);
             }
@@ -4392,6 +4484,8 @@ namespace System.Windows.Forms
                 }
             }
 
+            void ICollection<object>.CopyTo(object[] destination, int index) => CopyTo(destination, index);
+
             public void CopyTo(Array destination, int index)
             {
                 int cnt = InnerArray.GetCount(SelectedObjectMask);
@@ -4401,7 +4495,11 @@ namespace System.Windows.Forms
                 }
             }
 
-            public IEnumerator GetEnumerator()
+            public IEnumerator GetEnumerator() => GetEnumeratorCore();
+
+            IEnumerator<object> IEnumerable<object>.GetEnumerator() => GetEnumeratorCore();
+
+            private IEnumerator<object> GetEnumeratorCore()
             {
                 return InnerArray.GetEnumerator(SelectedObjectMask);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -12,6 +12,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Design;
 using System.Globalization;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Forms.Layout;
 using System.Windows.Forms.VisualStyles;
@@ -6559,7 +6560,7 @@ namespace System.Windows.Forms
         //end subhag
 
         [ListBindable(false)]
-        public class CheckedIndexCollection : IList
+        public class CheckedIndexCollection : IList, IList<int>
         {
             private readonly ListView owner;
 
@@ -6646,6 +6647,12 @@ namespace System.Windows.Forms
                     // Should never get to this point.
                     throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
                 }
+            }
+
+            int IList<int>.this[int index]
+            {
+                get => this[index];
+                set => throw new NotSupportedException();
             }
 
             object IList.this[int index]
@@ -6741,7 +6748,17 @@ namespace System.Windows.Forms
                 }
             }
 
+            void ICollection<int>.Add(int value)
+            {
+                throw new NotSupportedException();
+            }
+
             int IList.Add(object value)
+            {
+                throw new NotSupportedException();
+            }
+
+            void ICollection<int>.Clear()
             {
                 throw new NotSupportedException();
             }
@@ -6751,7 +6768,17 @@ namespace System.Windows.Forms
                 throw new NotSupportedException();
             }
 
+            void IList<int>.Insert(int index, int value)
+            {
+                throw new NotSupportedException();
+            }
+
             void IList.Insert(int index, object value)
+            {
+                throw new NotSupportedException();
+            }
+
+            bool ICollection<int>.Remove(int value)
             {
                 throw new NotSupportedException();
             }
@@ -6761,9 +6788,19 @@ namespace System.Windows.Forms
                 throw new NotSupportedException();
             }
 
+            void IList<int>.RemoveAt(int index)
+            {
+                throw new NotSupportedException();
+            }
+
             void IList.RemoveAt(int index)
             {
                 throw new NotSupportedException();
+            }
+
+            void ICollection<int>.CopyTo(int[] dest, int index)
+            {
+                ((ICollection)this).CopyTo(dest, index);
             }
 
             void ICollection.CopyTo(Array dest, int index)
@@ -6774,22 +6811,24 @@ namespace System.Windows.Forms
                 }
             }
 
-            public IEnumerator GetEnumerator()
+            public IEnumerator GetEnumerator() => GetEnumeratorCore();
+            IEnumerator<int> IEnumerable<int>.GetEnumerator() => GetEnumeratorCore();
+            internal IEnumerator<int> GetEnumeratorCore()
             {
                 int[] indices = IndicesArray;
                 if (indices != null)
                 {
-                    return indices.GetEnumerator();
+                    return WindowsFormsUtils.GetArrayEnumerator(indices);
                 }
                 else
                 {
-                    return Array.Empty<int>().GetEnumerator();
+                    return Enumerable.Empty<int>().GetEnumerator();
                 }
             }
         }
 
         [ListBindable(false)]
-        public class CheckedListViewItemCollection : IList
+        public class CheckedListViewItemCollection : IList, IList<ListViewItem>
         {
             private readonly ListView owner;
 
@@ -6853,6 +6892,12 @@ namespace System.Windows.Forms
                     int itemIndex = owner.CheckedIndices[index];
                     return owner.Items[itemIndex];
                 }
+            }
+
+            ListViewItem IList<ListViewItem>.this[int index]
+            {
+                get => this[index];
+                set => throw new NotSupportedException();
             }
 
             object IList.this[int index]
@@ -7070,7 +7115,17 @@ namespace System.Windows.Forms
                 throw new NotSupportedException();
             }
 
+            void ICollection<ListViewItem>.Add(ListViewItem value)
+            {
+                throw new NotSupportedException();
+            }
+
             void IList.Clear()
+            {
+                throw new NotSupportedException();
+            }
+
+            void ICollection<ListViewItem>.Clear()
             {
                 throw new NotSupportedException();
             }
@@ -7080,12 +7135,27 @@ namespace System.Windows.Forms
                 throw new NotSupportedException();
             }
 
+            void IList<ListViewItem>.Insert(int index, ListViewItem value)
+            {
+                throw new NotSupportedException();
+            }
+
             void IList.Remove(object value)
             {
                 throw new NotSupportedException();
             }
 
+            bool ICollection<ListViewItem>.Remove(ListViewItem item)
+            {
+                throw new NotSupportedException();
+            }
+
             void IList.RemoveAt(int index)
+            {
+                throw new NotSupportedException();
+            }
+
+            void IList<ListViewItem>.RemoveAt(int index)
             {
                 throw new NotSupportedException();
             }
@@ -7103,7 +7173,11 @@ namespace System.Windows.Forms
                 }
             }
 
-            public IEnumerator GetEnumerator()
+            void ICollection<ListViewItem>.CopyTo(ListViewItem[] dest, int index) => CopyTo(dest, index);
+
+            public IEnumerator GetEnumerator() => GetEnumeratorCore();
+            IEnumerator<ListViewItem> IEnumerable<ListViewItem>.GetEnumerator() => GetEnumeratorCore();
+            private IEnumerator<ListViewItem> GetEnumeratorCore()
             {
                 if (owner.VirtualMode)
                 {
@@ -7113,17 +7187,17 @@ namespace System.Windows.Forms
                 ListViewItem[] items = ItemArray;
                 if (items != null)
                 {
-                    return items.GetEnumerator();
+                    return WindowsFormsUtils.GetArrayEnumerator(items);
                 }
                 else
                 {
-                    return Array.Empty<ListViewItem>().GetEnumerator();
+                    return Enumerable.Empty<ListViewItem>().GetEnumerator();
                 }
             }
         }
 
         [ListBindable(false)]
-        public class SelectedIndexCollection : IList
+        public class SelectedIndexCollection : IList, IList<int>
         {
             private readonly ListView owner;
 
@@ -7227,6 +7301,12 @@ namespace System.Windows.Forms
                 }
             }
 
+            int IList<int>.this[int index]
+            {
+                get => this[index];
+                set => throw new NotSupportedException();
+            }
+
             object IList.this[int index]
             {
                 get
@@ -7325,12 +7405,22 @@ namespace System.Windows.Forms
                 }
             }
 
+            void ICollection<int>.Add(int value)
+            {
+                Add(value);
+            }
+
             void IList.Clear()
             {
                 Clear();
             }
 
             void IList.Insert(int index, object value)
+            {
+                throw new NotSupportedException();
+            }
+
+            void IList<int>.Insert(int index, int value)
             {
                 throw new NotSupportedException();
             }
@@ -7347,7 +7437,19 @@ namespace System.Windows.Forms
                 }
             }
 
+            bool ICollection<int>.Remove(int itemIndex)
+            {
+                var result = Contains(itemIndex);
+                Remove(itemIndex);
+                return result;
+            }
+
             void IList.RemoveAt(int index)
+            {
+                throw new NotSupportedException();
+            }
+
+            void IList<int>.RemoveAt(int index)
             {
                 throw new NotSupportedException();
             }
@@ -7401,16 +7503,22 @@ namespace System.Windows.Forms
                 }
             }
 
-            public IEnumerator GetEnumerator()
+            void ICollection<int>.CopyTo(int[] dest, int index) => CopyTo(dest, index);
+
+            public IEnumerator GetEnumerator() => GetEnumeratorCore();
+
+            IEnumerator<int> IEnumerable<int>.GetEnumerator() => GetEnumeratorCore();
+
+            private IEnumerator<int> GetEnumeratorCore()
             {
                 int[] indices = IndicesArray;
                 if (indices != null)
                 {
-                    return indices.GetEnumerator();
+                    return WindowsFormsUtils.GetArrayEnumerator(indices);
                 }
                 else
                 {
-                    return Array.Empty<int>().GetEnumerator();
+                    return Enumerable.Empty<int>().GetEnumerator();
                 }
             }
 
@@ -7439,7 +7547,7 @@ namespace System.Windows.Forms
         }
 
         [ListBindable(false)]
-        public class SelectedListViewItemCollection : IList
+        public class SelectedListViewItemCollection : IList, IList<ListViewItem>
         {
             private readonly ListView owner;
 
@@ -7599,6 +7707,16 @@ namespace System.Windows.Forms
                 }
             }
 
+            ListViewItem IList<ListViewItem>.this[int index]
+            {
+                get => this[index];
+                set
+                {
+                    // SelectedListViewItemCollection is read-only
+                    throw new NotSupportedException();
+                }
+            }
+
             object IList.this[int index]
             {
                 get
@@ -7655,7 +7773,19 @@ namespace System.Windows.Forms
                 throw new NotSupportedException();
             }
 
+            void ICollection<ListViewItem>.Add(ListViewItem value)
+            {
+                // SelectedListViewItemCollection is read-only
+                throw new NotSupportedException();
+            }
+
             void IList.Insert(int index, object value)
+            {
+                // SelectedListViewItemCollection is read-only
+                throw new NotSupportedException();
+            }
+
+            void IList<ListViewItem>.Insert(int index, ListViewItem value)
             {
                 // SelectedListViewItemCollection is read-only
                 throw new NotSupportedException();
@@ -7675,7 +7805,19 @@ namespace System.Windows.Forms
                 throw new NotSupportedException();
             }
 
+            bool ICollection<ListViewItem>.Remove(ListViewItem item)
+            {
+                // SelectedListViewItemCollection is read-only
+                throw new NotSupportedException();
+            }
+
             void IList.RemoveAt(int index)
+            {
+                // SelectedListViewItemCollection is read-only
+                throw new NotSupportedException();
+            }
+
+            void IList<ListViewItem>.RemoveAt(int index)
             {
                 // SelectedListViewItemCollection is read-only
                 throw new NotSupportedException();
@@ -7751,7 +7893,13 @@ namespace System.Windows.Forms
                 }
             }
 
-            public IEnumerator GetEnumerator()
+            void ICollection<ListViewItem>.CopyTo(ListViewItem[] dest, int index) => CopyTo(dest, index);
+
+            public IEnumerator GetEnumerator() => GetEnumeratorCore();
+
+            IEnumerator<ListViewItem> IEnumerable<ListViewItem>.GetEnumerator() => GetEnumeratorCore();
+
+            private IEnumerator<ListViewItem> GetEnumeratorCore()
             {
                 if (owner.VirtualMode)
                 {
@@ -7761,11 +7909,11 @@ namespace System.Windows.Forms
                 ListViewItem[] items = SelectedItemArray;
                 if (items != null)
                 {
-                    return items.GetEnumerator();
+                    return WindowsFormsUtils.GetArrayEnumerator(items);
                 }
                 else
                 {
-                    return Array.Empty<ListViewItem>().GetEnumerator();
+                    return Enumerable.Empty<ListViewItem>().GetEnumerator();
                 }
             }
 
@@ -7846,7 +7994,7 @@ namespace System.Windows.Forms
         }
 
         [ListBindable(false)]
-        public class ColumnHeaderCollection : IList
+        public class ColumnHeaderCollection : IList, IList<ColumnHeader>
         {
             private readonly ListView owner;
 
@@ -7882,6 +8030,12 @@ namespace System.Windows.Forms
                 {
                     throw new NotSupportedException();
                 }
+            }
+
+            ColumnHeader IList<ColumnHeader>.this[int index]
+            {
+                get => this[index];
+                set => throw new NotSupportedException();
             }
 
             /// <summary>
@@ -8153,6 +8307,8 @@ namespace System.Windows.Forms
                 }
             }
 
+            void ICollection<ColumnHeader>.Add(ColumnHeader value) => Add(value);
+
             /// <summary>
             ///  Removes all columns from the list view.
             /// </summary>
@@ -8214,6 +8370,14 @@ namespace System.Windows.Forms
             }
 
             void ICollection.CopyTo(Array dest, int index)
+            {
+                if (Count > 0)
+                {
+                    System.Array.Copy(owner.columnHeaders, 0, dest, index, Count);
+                }
+            }
+
+            void ICollection<ColumnHeader>.CopyTo(ColumnHeader[] dest, int index)
             {
                 if (Count > 0)
                 {
@@ -8420,6 +8584,17 @@ namespace System.Windows.Forms
                 }
             }
 
+            bool ICollection<ColumnHeader>.Remove(ColumnHeader item)
+            {
+                if (item is null)
+                    return false;
+
+                var wasContained = Contains(item);
+                Remove(item);
+                var isContained = Contains(item);
+                return wasContained && !isContained;
+            }
+
             void IList.Remove(object value)
             {
                 if (value is ColumnHeader)
@@ -8428,15 +8603,19 @@ namespace System.Windows.Forms
                 }
             }
 
-            public IEnumerator GetEnumerator()
+            public IEnumerator GetEnumerator() => GetEnumeratorCore();
+
+            IEnumerator<ColumnHeader> IEnumerable<ColumnHeader>.GetEnumerator() => GetEnumeratorCore();
+
+            private IEnumerator<ColumnHeader> GetEnumeratorCore()
             {
                 if (owner.columnHeaders != null)
                 {
-                    return owner.columnHeaders.GetEnumerator();
+                    return WindowsFormsUtils.GetArrayEnumerator(owner.columnHeaders);
                 }
                 else
                 {
-                    return Array.Empty<ColumnHeader>().GetEnumerator();
+                    return Enumerable.Empty<ColumnHeader>().GetEnumerator();
                 }
             }
         }
@@ -8445,7 +8624,7 @@ namespace System.Windows.Forms
         ///  Represents the collection of items in a ListView or ListViewGroup
         /// </summary>
         [ListBindable(false)]
-        public class ListViewItemCollection : IList
+        public class ListViewItemCollection : IList, IList<ListViewItem>
         {
             ///  A caching mechanism for key accessor
             ///  We use an index here rather than control so that we don't have lifetime
@@ -8463,7 +8642,7 @@ namespace System.Windows.Forms
                 void Clear();
                 bool Contains(ListViewItem item);
                 void CopyTo(Array dest, int index);
-                IEnumerator GetEnumerator();
+                IEnumerator<ListViewItem> GetEnumerator();
                 int IndexOf(ListViewItem item);
                 ListViewItem Insert(int index, ListViewItem item);
                 void Remove(ListViewItem item);
@@ -8655,6 +8834,8 @@ namespace System.Windows.Forms
                 return value;
             }
 
+            void ICollection<ListViewItem>.Add(ListViewItem item) => Add(item);
+
             // <-- NEW ADD OVERLOADS IN WHIDBEY
 
             /// <summary>
@@ -8761,6 +8942,8 @@ namespace System.Windows.Forms
                 InnerList.CopyTo(dest, index);
             }
 
+            void ICollection<ListViewItem>.CopyTo(ListViewItem[] array, int arrayIndex) => CopyTo(array, arrayIndex);
+
             /// <summary>
             ///  Searches for Controls by their Name property, builds up an array
             ///  of all the controls that match.
@@ -8812,7 +8995,11 @@ namespace System.Windows.Forms
                 return foundItems;
             }
 
-            public IEnumerator GetEnumerator()
+            public IEnumerator GetEnumerator() => GetEnumeratorCore();
+
+            IEnumerator<ListViewItem> IEnumerable<ListViewItem>.GetEnumerator() => GetEnumeratorCore();
+
+            private IEnumerator<ListViewItem> GetEnumeratorCore()
             {
                 if (InnerList.OwnerIsVirtualListView && !InnerList.OwnerIsDesignMode)
                 {
@@ -8887,6 +9074,8 @@ namespace System.Windows.Forms
             {
                 return (index >= 0) && (index < Count);
             }
+
+            void IList<ListViewItem>.Insert(int index, ListViewItem item) => Insert(index, item);
 
             public ListViewItem Insert(int index, ListViewItem item)
             {
@@ -8988,6 +9177,17 @@ namespace System.Windows.Forms
                 }
 
                 Remove((ListViewItem)item);
+            }
+
+            bool ICollection<ListViewItem>.Remove(ListViewItem item)
+            {
+                if (item is null)
+                    return false;
+
+                var wasContained = Contains(item);
+                Remove(item);
+                var isContained = Contains(item);
+                return wasContained && !isContained;
             }
         }
 
@@ -9444,12 +9644,12 @@ namespace System.Windows.Forms
                 }
             }
 
-            public IEnumerator GetEnumerator()
+            public IEnumerator<ListViewItem> GetEnumerator()
             {
                 ListViewItem[] items = new ListViewItem[owner.itemCount];
                 CopyTo(items, 0);
 
-                return items.GetEnumerator();
+                return WindowsFormsUtils.GetArrayEnumerator(items);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupItemCollection.cs
@@ -5,13 +5,15 @@
 #nullable disable
 
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace System.Windows.Forms
 {
     internal class ListViewGroupItemCollection : ListView.ListViewItemCollection.IInnerList
     {
         private readonly ListViewGroup _group;
-        private ArrayList _items;
+        private List<ListViewItem> _items;
 
         public ListViewGroupItemCollection(ListViewGroup group)
         {
@@ -20,7 +22,7 @@ namespace System.Windows.Forms
 
         public int Count => Items.Count;
 
-        private ArrayList Items => _items ?? (_items = new ArrayList());
+        private List<ListViewItem> Items => _items ?? (_items = new List<ListViewItem>());
 
         public bool OwnerIsVirtualListView => _group.ListView != null && _group.ListView.VirtualMode;
 
@@ -83,9 +85,9 @@ namespace System.Windows.Forms
 
         public bool Contains(ListViewItem item) => Items.Contains(item);
 
-        public void CopyTo(Array dest, int index) => Items.CopyTo(dest, index);
+        public void CopyTo(Array dest, int index) => ((ICollection)Items).CopyTo(dest, index);
 
-        public IEnumerator GetEnumerator() => Items.GetEnumerator();
+        public IEnumerator<ListViewItem> GetEnumerator() => Items.GetEnumerator();
 
         public int IndexOf(ListViewItem item) => Items.IndexOf(item);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;
@@ -13,6 +14,7 @@ using System.Drawing.Design;
 using System.Drawing.Imaging;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Windows.Forms.ComponentModel.Com2Interop;
@@ -5165,7 +5167,7 @@ namespace System.Windows.Forms
             }
         }
 
-        public class PropertyTabCollection : ICollection
+        public class PropertyTabCollection : ICollection, IReadOnlyList<PropertyTab>
         {
             internal static PropertyTabCollection Empty = new PropertyTabCollection(null);
 
@@ -5267,14 +5269,18 @@ namespace System.Windows.Forms
             /// <summary>
             ///  Creates and retrieves a new enumerator for this collection.
             /// </summary>
-            public IEnumerator GetEnumerator()
+            public IEnumerator GetEnumerator() => GetEnumeratorCore();
+
+            IEnumerator<PropertyTab> IEnumerable<PropertyTab>.GetEnumerator() => GetEnumeratorCore();
+
+            private IEnumerator<PropertyTab> GetEnumeratorCore()
             {
                 if (owner == null)
                 {
-                    return Array.Empty<PropertyTab>().GetEnumerator();
+                    return Enumerable.Empty<PropertyTab>().GetEnumerator();
                 }
 
-                return owner.viewTabs.GetEnumerator();
+                return WindowsFormsUtils.GetArrayEnumerator(owner.viewTabs);
             }
 
             public void RemoveTabType(Type propertyTabType)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabPageCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabPageCollection.cs
@@ -1,17 +1,19 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 #nullable disable
 
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 
 namespace System.Windows.Forms
 {
     public partial class TabControl
     {
-        public class TabPageCollection : IList
+        public class TabPageCollection : IList, IList<TabPage>
         {
             private readonly TabControl _owner;
 
@@ -330,6 +332,9 @@ namespace System.Windows.Forms
             }
 
             public virtual void Clear() => _owner.RemoveAll();
+
+            void ICollection<TabPage>.CopyTo(TabPage[] dest, int index) => ((ICollection)this).CopyTo(dest, index);
+
             void ICollection.CopyTo(Array dest, int index)
             {
                 if (Count > 0)
@@ -338,25 +343,33 @@ namespace System.Windows.Forms
                 }
             }
 
-            public IEnumerator GetEnumerator()
+            public IEnumerator GetEnumerator() => GetEnumeratorCore();
+
+            IEnumerator<TabPage> IEnumerable<TabPage>.GetEnumerator() => GetEnumeratorCore();
+
+            private IEnumerator<TabPage> GetEnumeratorCore()
             {
                 TabPage[] tabPages = _owner.GetTabPages();
                 if (tabPages == null)
                 {
-                    return Array.Empty<TabPage>().GetEnumerator();
+                    return Enumerable.Empty<TabPage>().GetEnumerator();
                 }
 
-                return tabPages.GetEnumerator();
+                return WindowsFormsUtils.GetArrayEnumerator(tabPages);
             }
 
-            public void Remove(TabPage value)
+            public void Remove(TabPage value) => TryRemove(value);
+
+            bool ICollection<TabPage>.Remove(TabPage value) => TryRemove(value);
+
+            private bool TryRemove(TabPage value)
             {
                 if (value == null)
                 {
                     throw new ArgumentNullException(nameof(value));
                 }
 
-                _owner.Controls.Remove(value);
+                return ((ICollection<Control>)_owner.Controls).Remove(value);
             }
 
             void IList.Remove(object value)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeCollection.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing.Design;
@@ -14,7 +15,7 @@ namespace System.Windows.Forms
     [
     Editor("System.Windows.Forms.Design.TreeNodeCollectionEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))
     ]
-    public class TreeNodeCollection : IList
+    public class TreeNodeCollection : IList, IList<TreeNode>
     {
         private readonly TreeNode owner;
 
@@ -379,6 +380,8 @@ namespace System.Windows.Forms
             return node.index;
         }
 
+        void ICollection<TreeNode>.Add(TreeNode node) => Add(node);
+
         int IList.Add(object node)
         {
             if (node == null)
@@ -632,9 +635,17 @@ namespace System.Windows.Forms
             }
         }
 
-        public void Remove(TreeNode node)
+        void ICollection<TreeNode>.CopyTo(TreeNode[] array, int arrayIndex) => CopyTo(array, arrayIndex);
+
+        public void Remove(TreeNode node) => TryRemove(node);
+
+        bool ICollection<TreeNode>.Remove(TreeNode node) => TryRemove(node);
+
+        private bool TryRemove(TreeNode node)
         {
+            var result = (node.parent == this.owner);
             node.Remove();
+            return result;
         }
 
         void IList.Remove(object node)
@@ -662,9 +673,13 @@ namespace System.Windows.Forms
             }
         }
 
-        public IEnumerator GetEnumerator()
+        public IEnumerator GetEnumerator() => GetEnumeratorCore();
+
+        IEnumerator<TreeNode> IEnumerable<TreeNode>.GetEnumerator() => GetEnumeratorCore();
+
+        private IEnumerator<TreeNode> GetEnumeratorCore()
         {
-            return new ArraySubsetEnumerator(owner.children, owner.childCount);
+            return new ArraySubsetEnumerator<TreeNode>(owner.children, owner.childCount);
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WinFormsUtils.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WinFormsUtils.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
@@ -385,6 +386,11 @@ namespace System.Windows.Forms
                 }
                 return (remainder >= minValAfterShift && remainder <= maxValAfterShift);
             }
+        }
+
+        public static IEnumerator<T> GetArrayEnumerator<T>(T[] array)
+        {
+            return ((IEnumerable<T>)array).GetEnumerator();
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BindingsCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BindingsCollectionTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -15,7 +15,7 @@ namespace System.Windows.Forms.Tests
         public void Ctor_Default()
         {
             var collection = new SubBindingsCollection();
-            Assert.Equal(0, collection.Count);
+            Assert.Empty(collection);
             Assert.Empty(collection.List);
             Assert.False(collection.ShouldSerializeMyAll());
         }
@@ -27,7 +27,7 @@ namespace System.Windows.Forms.Tests
             var binding = new Binding(null, new object(), "member");
             collection.Add(binding);
 
-            Assert.Equal(1, collection.Count);
+            Assert.Single(collection);
             Assert.Same(binding, collection[0]);
             Assert.True(collection.ShouldSerializeMyAll());
         }
@@ -62,7 +62,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(binding);
             Assert.Equal(1, changingCallCount);
             Assert.Equal(1, changedCallCount);
-            Assert.Equal(1, collection.Count);
+            Assert.Single(collection);
 
             // Add again.
             collection.Add(binding);
@@ -93,7 +93,7 @@ namespace System.Windows.Forms.Tests
             var binding = new Binding(null, new object(), "member");
             collection.AddCore(binding);
 
-            Assert.Equal(1, collection.Count);
+            Assert.Single(collection);
             Assert.Same(binding, collection[0]);
             Assert.True(collection.ShouldSerializeMyAll());
         }
@@ -128,7 +128,7 @@ namespace System.Windows.Forms.Tests
             collection.AddCore(binding);
             Assert.Equal(0, changingCallCount);
             Assert.Equal(0, changedCallCount);
-            Assert.Equal(1, collection.Count);
+            Assert.Single(collection);
 
             // Add again.
             collection.AddCore(binding);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeaderCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeaderCollectionTests.cs
@@ -536,6 +536,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [Fact]
+        [Diagnostics.CodeAnalysis.SuppressMessage("Assertions", "xUnit2017:Do not use Contains() to check if a value exists in a collection", Justification = "We are testing the Contains method itself")]
         public void ColumnHeaderCollection_Contains_Invoke_ReturnsExpected()
         {
             var listView = new ListView();
@@ -549,6 +550,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [Fact]
+        [Diagnostics.CodeAnalysis.SuppressMessage("Assertions", "xUnit2017:Do not use Contains() to check if a value exists in a collection", Justification = "We are testing the Contains method itself")]
         public void ColumnHeaderCollection_Contains_Empty_ReturnsFalse()
         {
             var listView = new ListView();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.ControlCollection.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.ControlCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1352,6 +1352,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
+        [Diagnostics.CodeAnalysis.SuppressMessage("Assertions", "xUnit2017:Do not use Contains() to check if a value exists in a collection", Justification = "We are testing the Contains method itself")]
         public void ControlCollection_Contains_Invoke_ReturnsExpected()
         {
             using var owner = new Control();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowTests.cs
@@ -1663,7 +1663,7 @@ namespace System.Windows.Forms.Tests
 
             // Set different.
             row.Selected = false;
-            Assert.False((dataGridView.SelectedRows).Contains(row));
+            Assert.DoesNotContain(row, dataGridView.SelectedRows);
             Assert.False(row.Selected);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSelectedCellCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSelectedCellCollectionTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -102,6 +102,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
+        [Diagnostics.CodeAnalysis.SuppressMessage("Assertions", "xUnit2017:Do not use Contains() to check if a value exists in a collection", Justification = "We are testing the Contains method itself")]
         public void DataGridViewSelectedCellCollection_Contains_InvokeNotEmpty_ReturnsExpected()
         {
             using var control = new DataGridView
@@ -130,6 +131,7 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [MemberData(nameof(Contains_TestData))]
+        [Diagnostics.CodeAnalysis.SuppressMessage("Assertions", "xUnit2017:Do not use Contains() to check if a value exists in a collection", Justification = "We are testing the Contains method itself")]
         public void DataGridViewSelectedCellCollection_Contains_InvokeEmpty_ReturnsFalse(DataGridViewCell dataGridViewCell)
         {
             using var control = new DataGridView();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSelectedColumnCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSelectedColumnCollectionTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -114,6 +114,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
+        [Diagnostics.CodeAnalysis.SuppressMessage("Assertions", "xUnit2017:Do not use Contains() to check if a value exists in a collection", Justification = "We are testing the Contains method itself")]
         public void DataGridViewSelectedColumnCollection_Contains_InvokeNotEmpty_ReturnsExpected()
         {
             using var control = new DataGridView
@@ -146,6 +147,7 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [MemberData(nameof(Contains_TestData))]
+        [Diagnostics.CodeAnalysis.SuppressMessage("Assertions", "xUnit2017:Do not use Contains() to check if a value exists in a collection", Justification = "We are testing the Contains method itself")]
         public void DataGridViewSelectedColumnCollection_Contains_InvokeEmpty_ReturnsFalse(DataGridViewColumn dataGridViewColumn)
         {
             using var control = new DataGridView();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSelectedRowCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSelectedRowCollectionTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -99,6 +99,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
+        [Diagnostics.CodeAnalysis.SuppressMessage("Assertions", "xUnit2017:Do not use Contains() to check if a value exists in a collection", Justification = "We are testing the Contains method itself")]
         public void DataGridViewSelectedRowCollection_Contains_InvokeNotEmpty_ReturnsExpected()
         {
             using var control = new DataGridView
@@ -126,6 +127,7 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [MemberData(nameof(Contains_TestData))]
+        [Diagnostics.CodeAnalysis.SuppressMessage("Assertions", "xUnit2017:Do not use Contains() to check if a value exists in a collection", Justification = "We are testing the Contains method itself")]
         public void DataGridViewSelectedRowCollection_Contains_InvokeEmpty_ReturnsFalse(DataGridViewRow dataGridViewRow)
         {
             using var control = new DataGridView();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupCollectionTests.cs
@@ -644,6 +644,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [Fact]
+        [Diagnostics.CodeAnalysis.SuppressMessage("Assertions", "xUnit2017:Do not use Contains() to check if a value exists in a collection", Justification = "We are testing the Contains method itself")]
         public void ListViewGroupCollection_Contains_Invoke_ReturnsExpected()
         {
             var listView = new ListView();
@@ -657,6 +658,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [Fact]
+        [Diagnostics.CodeAnalysis.SuppressMessage("Assertions", "xUnit2017:Do not use Contains() to check if a value exists in a collection", Justification = "We are testing the Contains method itself")]
         public void ListViewGroupCollection_Contains_Empty_ReturnsFalse()
         {
             var listView = new ListView();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewSubItemCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewSubItemCollectionTests.cs
@@ -453,6 +453,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [Fact]
+        [Diagnostics.CodeAnalysis.SuppressMessage("Assertions", "xUnit2017:Do not use Contains() to check if a value exists in a collection", Justification = "We are testing the Contains method itself")]
         public void ListViewSubItemCollection_Contains_Invoke_ReturnsExpected()
         {
             var item = new ListViewItem();
@@ -466,6 +467,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [Fact]
+        [Diagnostics.CodeAnalysis.SuppressMessage("Assertions", "xUnit2017:Do not use Contains() to check if a value exists in a collection", Justification = "We are testing the Contains method itself")]
         public void ListViewSubItemCollection_Contains_Empty_ReturnsFalse()
         {
             var item = new ListViewItem();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabPageCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabPageCollectionTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1457,6 +1457,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
+        [Diagnostics.CodeAnalysis.SuppressMessage("Assertions", "xUnit2017:Do not use Contains() to check if a value exists in a collection", Justification = "We are testing the Contains method itself")]
         public void TabPageCollection_Contains_Invoke_ReturnsExpected()
         {
             using var owner = new TabControl();
@@ -1472,6 +1473,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
+        [Diagnostics.CodeAnalysis.SuppressMessage("Assertions", "xUnit2017:Do not use Contains() to check if a value exists in a collection", Justification = "We are testing the Contains method itself")]
         public void TabPageCollection_Contains_InvokeEmpty_ReturnsExpected()
         {
             using var owner = new TabControl();


### PR DESCRIPTION
Contributes to #2644
Alternative implementation to PR #2749

This is a WIP PR for exploring the impact #2644 may have and whether its worth taking the breaking change. This PR attempts to make no breaking change to public signatures except implementing additional interfaces.

This will allow LINQ support and other extension methods pick up the member type of the list, but the major downside of not allowing breaking changes is that plain `foreach` loops will not pick up nullability annotations because they need the return type of `GetEnumerator` adjusted, which is a breaking change (see PR #2749 for an implementation attempt)

Notes:
- As far as placement of new code goes I tried to orient myself on the corresponding `IList` methods (where available), this makes for weird placement since not all `IList<T>` methods are together, but considering I don't really want to reorder the existing methods (unless asked to) I figured it'd be the best solution to minimize diffs for now.
- There are plenty of odd design decisions in the original collections subclassing hierarchy which makes updating them harder.
- Existing `Remove` implementations don't tell the caller whether they removed something, but `IList<T>` requires this in its API. In some places where collections can be subclassed it is not easily possible to obtain this information, which leads to a bit weird looking implementation. Depending on how much you want to assume about subclass behavior these could be simplified.
- There are bugs in some existing collection classes where they don't check in `Remove` implementations whether the item to be removed is actually part of the collection. They run logic which severs the item and partially disconnects it from its true owner, but without notifying that owner. I did not fix these bugs yet (some are marked with comments though), I'm going to create a separate issue for this problem (so it doesn't have to wait for this issue/PR, which probably will take a while to dicscuss and resolve all points).
- xunit apparently doesn't support non-generic lists, so when you start implementing the generic list interface all kinds of collection-tests stop compiling because some analyzer wants you to use `Assert.Contains` or `Assert.DoesNotContain`. Minor inconvenience which is easily fixed.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/2999)