### PR TITLE
Add ICON enum in Interop User32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.ICON.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.ICON.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public enum ICON
+        {
+            SMALL = 0,
+            BIG = 1
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -21,10 +21,6 @@ namespace System.Windows.Forms
         public const int
         HCF_HIGHCONTRASTON = 0x00000001;
 
-        public const int
-        ICON_SMALL = 0,
-        ICON_BIG = 1;
-
         public const int LANG_NEUTRAL = 0x00,
                          LOCALE_IFIRSTDAYOFWEEK = 0x0000100C;   /* first day of week specifier */
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -3168,7 +3168,7 @@ namespace System.Windows.Forms
                     Icon icon = Icon;
                     if (icon != null && TaskbarOwner.Handle != IntPtr.Zero)
                     {
-                        User32.SendMessageW(TaskbarOwner, User32.WM.SETICON, (IntPtr)NativeMethods.ICON_BIG, icon.Handle);
+                        User32.SendMessageW(TaskbarOwner, User32.WM.SETICON, (IntPtr)User32.ICON.BIG, icon.Handle);
                     }
                 }
 
@@ -5854,15 +5854,15 @@ namespace System.Windows.Forms
 
                     if (smallIcon != null)
                     {
-                        User32.SendMessageW(this, User32.WM.SETICON, (IntPtr)NativeMethods.ICON_SMALL, smallIcon.Handle);
+                        User32.SendMessageW(this, User32.WM.SETICON, (IntPtr)User32.ICON.SMALL, smallIcon.Handle);
                     }
 
-                    User32.SendMessageW(this, User32.WM.SETICON, (IntPtr)NativeMethods.ICON_BIG, icon.Handle);
+                    User32.SendMessageW(this, User32.WM.SETICON, (IntPtr)User32.ICON.BIG, icon.Handle);
                 }
                 else
                 {
-                    User32.SendMessageW(this, User32.WM.SETICON, (IntPtr)NativeMethods.ICON_SMALL, IntPtr.Zero);
-                    User32.SendMessageW(this, User32.WM.SETICON, (IntPtr)NativeMethods.ICON_BIG, IntPtr.Zero);
+                    User32.SendMessageW(this, User32.WM.SETICON, (IntPtr)User32.ICON.SMALL, IntPtr.Zero);
+                    User32.SendMessageW(this, User32.WM.SETICON, (IntPtr)User32.ICON.BIG, IntPtr.Zero);
                 }
 
                 if (redrawFrame)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MDIControlStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MDIControlStrip.cs
@@ -96,12 +96,11 @@ namespace System.Windows.Forms
 
         private Image GetTargetWindowIcon()
         {
-            Image systemIcon = null;
-            IntPtr hIcon = User32.SendMessageW(new HandleRef(this, Control.GetSafeHandle(target)), User32.WM.GETICON, (IntPtr)NativeMethods.ICON_SMALL, IntPtr.Zero);
-            Icon icon = (hIcon != IntPtr.Zero) ? Icon.FromHandle(hIcon) : Form.DefaultIcon;
+            IntPtr hIcon = User32.SendMessageW(new HandleRef(this, GetSafeHandle(target)), User32.WM.GETICON, (IntPtr)User32.ICON.SMALL, IntPtr.Zero);
+            Icon icon = hIcon != IntPtr.Zero ? Icon.FromHandle(hIcon) : Form.DefaultIcon;
             Icon smallIcon = new Icon(icon, SystemInformation.SmallIconSize);
 
-            systemIcon = smallIcon.ToBitmap();
+            Image systemIcon = smallIcon.ToBitmap();
             smallIcon.Dispose();
 
             return systemIcon;


### PR DESCRIPTION
## Proposed changes

- Add ICON enum in Interop User32.
- Remove ICON constants and replace their usages with the above enum values.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3004)