### PR TITLE
Add WINDOW_SIZE enum in Interop User32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.WINDOW_SIZE.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.WINDOW_SIZE.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        // We named this enum WINDOW_SIZE instead of just SIZE to avoid possible future confusion with SIZE struct.
+        public enum WINDOW_SIZE
+        {
+            RESTORED = 0,
+            MINIMIZED = 1,
+            MAXIMIZED = 2,
+            MAXSHOW = 3,
+            MAXHIDE = 4
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -58,8 +58,6 @@ namespace System.Windows.Forms
         PATINVERT = 0x005A0049;
 
         public const int
-        SIZE_RESTORED = 0,
-        SIZE_MAXIMIZED = 2,
         SORT_DEFAULT = 0x0,
         SUBLANG_DEFAULT = 0x01;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -6478,7 +6478,7 @@ namespace System.Windows.Forms
                 if (MdiControlStrip == null && MdiParentInternal != null && MdiParentInternal.ActiveMdiChildInternal == this)
                 {
                     int wParam = m.WParam.ToInt32();
-                    MdiParentInternal.UpdateMdiControlStrip(wParam == NativeMethods.SIZE_MAXIMIZED);
+                    MdiParentInternal.UpdateMdiControlStrip(wParam == (int)User32.WINDOW_SIZE.MAXIMIZED);
                 }
             }
         }


### PR DESCRIPTION
## Proposed changes

- Add SIZE enum in Interop User32.
- Remove SIZE constants and replace their usages with the above enum values.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3006)