### PR TITLE
Add ICM enum in Interop RichEdit

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ICM.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ICM.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal partial class Interop
+{
+    internal static partial class Richedit
+    {
+        public enum ICM
+        {
+            NOTOPEN = 0x0000,
+            LEVEL3 = 0x0001,
+            LEVEL2 = 0x0002,
+            LEVEL2_5 = 0x0003,
+            LEVEL2_SUI = 0x0004,
+            CTF = 0x0005
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -3533,8 +3533,8 @@ namespace System.Windows.Forms
             if (ImeMode == ImeMode.Hangul || ImeMode == ImeMode.HangulFull)
             {
                 // Is the IME CompositionWindow open?
-                int compMode = unchecked((int)(long)User32.SendMessageW(this, (User32.WM)RichEditMessages.EM_GETIMECOMPMODE));
-                if (RichTextBoxConstants.ICM_NOTOPEN != compMode)
+                ICM compMode = unchecked((ICM)(long)User32.SendMessageW(this, (User32.WM)RichEditMessages.EM_GETIMECOMPMODE));
+                if (compMode != ICM.NOTOPEN)
                 {
                     int textLength = User32.GetWindowTextLengthW(new HandleRef(this, Handle));
                     if (selStart == selEnd && textLength == MaxLength)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxConstants.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxConstants.cs
@@ -16,13 +16,6 @@ namespace System.Windows.Forms
 
         /* RichTextBox messages */
 
-        // Values for EM_GETIMECOMPMODE
-        internal const int ICM_NOTOPEN = 0x0000;
-        internal const int ICM_LEVEL3 = 0x0001;
-        internal const int ICM_LEVEL2 = 0x0002;
-        internal const int ICM_LEVEL2_5 = 0x0003;
-        internal const int ICM_LEVEL2_SUI = 0x0004;
-
         // New notifications
         internal const int EN_MSGFILTER = 0x0700;
         internal const int EN_REQUESTRESIZE = 0x0701;


### PR DESCRIPTION
## Proposed changes

- Add ICM enum in Interop RichEdit.
- Remove ICM constants and replace their usages with the above enum values.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3017)