### PR TITLE
WIP: Fixing `MonthCalendar. Narrator read only first month in container`

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
@@ -363,7 +363,7 @@ namespace System.Windows.Forms
             {
                 if (columnIndex < 0 ||
                     columnIndex >= MAX_DAYS ||
-                    columnIndex >= ColumnCount /*|| parentAccessibleObject == null*/)
+                    columnIndex >= ColumnCount)
                 {
                     return null;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
@@ -363,7 +363,7 @@ namespace System.Windows.Forms
             {
                 if (columnIndex < 0 ||
                     columnIndex >= MAX_DAYS ||
-                    columnIndex >= ColumnCount)
+                    columnIndex >= ColumnCount /*|| parentAccessibleObject == null*/)
                 {
                     return null;
                 }
@@ -501,6 +501,16 @@ namespace System.Windows.Forms
                 gridInfo.dwFlags &= ~MCGIF.NAME;
 
                 return User32.SendMessageW(_owner, (User32.WM)MCM.GETCALENDARGRIDINFO, IntPtr.Zero, ref gridInfo) != IntPtr.Zero;
+            }
+
+            public int GetCalendarCount()
+            {
+                // Do not use this if gridInfo.dwFlags contains MCGIF_NAME;
+                // use GetCalendarGridInfoText() instead.
+
+                int calendarCount = (int) User32.SendMessageW(_owner, (User32.WM)MCM.GETCALENDARCOUNT, IntPtr.Zero, IntPtr.Zero);
+
+                return calendarCount;
             }
 
             private unsafe bool GetCalendarGridInfoText(MCGIP dwPart, int calendarIndex, int row, int column, out string text)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
@@ -503,12 +503,9 @@ namespace System.Windows.Forms
                 return User32.SendMessageW(_owner, (User32.WM)MCM.GETCALENDARGRIDINFO, IntPtr.Zero, ref gridInfo) != IntPtr.Zero;
             }
 
-            public int GetCalendarCount()
+            private int GetCalendarCount()
             {
-                // Do not use this if gridInfo.dwFlags contains MCGIF_NAME;
-                // use GetCalendarGridInfoText() instead.
-
-                int calendarCount = (int) User32.SendMessageW(_owner, (User32.WM)MCM.GETCALENDARCOUNT, IntPtr.Zero, IntPtr.Zero);
+                int calendarCount = (int) User32.SendMessageW(_owner, (User32.WM)MCM.GETCALENDARCOUNT);
 
                 return calendarCount;
             }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/MonthCalendarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/MonthCalendarAccessibleObjectTests.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Windows.Forms.Tests.AccessibleObjects
+{
+    public class MonthCalendarAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsFact]
+        public void MonthCalendarAccessibleObject_CalendarCountIsCorrect_IfCalendarContainerIsBig ()
+        {
+            var calendar = new MonthCalendar();
+            calendar.Size = new System.Drawing.Size(1000, 500);
+            MonthCalendar.MonthCalendarAccessibleObject accessibleObject = Assert.IsType<MonthCalendar.MonthCalendarAccessibleObject>(calendar.AccessibilityObject);
+            int childCalendarCount = accessibleObject.GetCalendarCount();
+            Assert.Equal(12, childCalendarCount);
+
+            //TO DO: написать тест (на размер календаря 1000х500 приходится 27 чайлд компанентов[3 кнопки и 24 элемента(по 2 на каждый месяц)])
+            //почему-то, при наведении на любой месяц, в фокус попадают элементы первого месяца
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/MonthCalendarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/MonthCalendarAccessibleObjectTests.cs
@@ -16,7 +16,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
         [WinFormsFact]
         public void MonthCalendarAccessibleObject_CalendarCountIsCorrect_IfCalendarContainerIsBig ()
         {
-            var calendar = new MonthCalendar();
+            using var calendar = new MonthCalendar();
             calendar.Size = new System.Drawing.Size(1000, 500);
             MonthCalendar.MonthCalendarAccessibleObject accessibleObject = Assert.IsType<MonthCalendar.MonthCalendarAccessibleObject>(calendar.AccessibilityObject);
             int childCalendarCount = accessibleObject.GetCalendarCount();

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/MonthCalendarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/MonthCalendarAccessibleObjectTests.cs
@@ -21,9 +21,6 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             MonthCalendar.MonthCalendarAccessibleObject accessibleObject = Assert.IsType<MonthCalendar.MonthCalendarAccessibleObject>(calendar.AccessibilityObject);
             int childCalendarCount = accessibleObject.GetCalendarCount();
             Assert.Equal(12, childCalendarCount);
-
-            //TO DO: написать тест (на размер календаря 1000х500 приходится 27 чайлд компанентов[3 кнопки и 24 элемента(по 2 на каждый месяц)])
-            //почему-то, при наведении на любой месяц, в фокус попадают элементы первого месяца
         }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3019

## Proposed changes

- Added GetCalendarCount method to MonthCalendar accessible object
- Added unit test for this issue

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

Work in progress, TODO: add customer impact.

## Regression? 

- No

## Risk

- Low

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Work in progress, TODO: add before.

### After

Work in progress, TODO: add after.


## Test methodology <!-- How did you ensure quality? -->

-  Added unit test

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

Work in progress, TODO: add accessibility testing.
<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- DotNet version: 5.0.0-preview.4.20180.8


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3030)