### PR TITLE
Fix DataObject.GetData issues

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.ReleaseStgMedium.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.ReleaseStgMedium.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+
+internal static partial class Interop
+{
+    internal static partial class Ole32
+    {
+        // Even though the windows headers indicate that STGMEDIUM is input only this is not true,
+        // ReleaseStgMedium will clear the fields it released. It is important for classic marshaling
+        // to *NOT* mark the argument as input parameter because otherwise .NET will not transfer
+        // ownership of the COM pointers correctly. This defeats the purpose of calling this method.
+        [DllImport(Libraries.Ole32, ExactSpelling = true)]
+        public static extern void ReleaseStgMedium(ref STGMEDIUM pmedium);
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.FormatEnumerator.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.FormatEnumerator.cs
@@ -94,10 +94,6 @@ namespace System.Windows.Forms
                         {
                             temp.tymed = TYMED.TYMED_GDI;
                         }
-                        else if (format.Equals(DataFormats.EnhancedMetafile))
-                        {
-                            temp.tymed = TYMED.TYMED_ENHMF;
-                        }
                         else if (format.Equals(DataFormats.Text)
                                  || format.Equals(DataFormats.UnicodeText)
                                  || format.Equals(DataFormats.StringFormat)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
@@ -87,6 +87,10 @@ namespace System.Windows.Forms
                         hglobal = Kernel32.GlobalAlloc(
                             Kernel32.GMEM.MOVEABLE | Kernel32.GMEM.DDESHARE | Kernel32.GMEM.ZEROINIT,
                             (uint)sstg.cbSize);
+                        // not throwing here because the other out of memory condition on GlobalAlloc
+                        // happens inside innerData.GetData and gets turned into a null return value
+                        if (hglobal == IntPtr.Zero)
+                            return null;
                         IntPtr ptr = Kernel32.GlobalLock(hglobal);
                         pStream.Read((byte*)ptr, (uint)sstg.cbSize, null);
                         Kernel32.GlobalUnlock(hglobal);
@@ -249,7 +253,7 @@ namespace System.Windows.Forms
                             // delete it while the object is still around.  So we have to do the really expensive
                             // thing of cloning the image so we can release the HBITMAP.
 
-                            // This bitmap is created by the com object which originally copied the bitmap to tbe
+                            // This bitmap is created by the com object which originally copied the bitmap to the
                             // clipboard. We call Add here, since DeleteObject calls Remove.
                             Image clipboardImage = Image.FromHbitmap(medium.unionmember);
                             if (clipboardImage != null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
@@ -36,8 +36,6 @@ namespace System.Windows.Forms
         new TYMED[] {
             TYMED.TYMED_HGLOBAL,
             TYMED.TYMED_ISTREAM,
-            TYMED.TYMED_ENHMF,
-            TYMED.TYMED_MFPICT,
             TYMED.TYMED_GDI};
 
         private readonly IDataObject innerData = null;

--- a/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
+++ b/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\..\..\System.Drawing.Design\src\System.Drawing.Design.Facade.csproj" />
     <ProjectReference Include="..\..\..\System.Windows.Forms.Primitives\src\System.Windows.Forms.Primitives.csproj" />
     <ProjectReference Include="..\..\..\Common\tests\InternalUtilitiesForTests\InternalUtilitiesForTests.csproj" />
+    <ProjectReference Include="..\..\..\System.Windows.Forms.Primitives\src\System.Windows.Forms.Primitives.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
@@ -1561,6 +1561,18 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<InvalidEnumArgumentException>("format", () => dataObject.SetText("text", format));
         }
 
+        [WinFormsFact]
+        public void DataObject_GetData_EnhancedMetafile_DoesNotTerminateProcess()
+        {
+            var data = new DataObject(new DataObjectIgnoringStorageMediumForEnhancedMetafile());
+
+            // Office ignores the storage medium in GetData(EnhancedMetafile) and always returns a handle,
+            // even when asked for a stream. This used to crash the process when DataObject interpreted the
+            // handle as a pointer to a COM IStream without checking the storage medium it retrieved.
+
+            Assert.Null(data.GetData(DataFormats.EnhancedMetafile));
+        }
+
         private sealed class DataObjectIgnoringStorageMediumForEnhancedMetafile : System.Runtime.InteropServices.ComTypes.IDataObject
         {
             public void GetData(ref FORMATETC format, out STGMEDIUM medium)
@@ -1591,18 +1603,6 @@ namespace System.Windows.Forms.Tests
             public int DAdvise(ref FORMATETC pFormatetc, ADVF advf, IAdviseSink adviseSink, out int connection) => throw new NotImplementedException();
             public void DUnadvise(int connection) => throw new NotImplementedException();
             public int EnumDAdvise(out IEnumSTATDATA enumAdvise) => throw new NotImplementedException();
-        }
-
-        [WinFormsFact]
-        public void DataObject_GetData_EnhancedMetafile_DoesNotTerminateProcess()
-        {
-            var data = new DataObject(new DataObjectIgnoringStorageMediumForEnhancedMetafile());
-
-            // Office ignores the storage medium in GetData(EnhancedMetafile) and always returns a handle,
-            // even when asked for a stream. This used to crash the process when DataObject interpreted the
-            // handle as a pointer to a COM IStream without checking the storage medium it retrieved.
-
-            Assert.Null(data.GetData(DataFormats.EnhancedMetafile));
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
@@ -1563,9 +1563,6 @@ namespace System.Windows.Forms.Tests
 
         private sealed class DataObjectIgnoringStorageMediumForEnhancedMetafile : System.Runtime.InteropServices.ComTypes.IDataObject
         {
-            private const int DV_E_FORMATETC = unchecked((int)0x80040064);
-            private const int CF_ENHMETAFILE = 14;
-
             public void GetData(ref FORMATETC format, out STGMEDIUM medium)
             {
                 Marshal.ThrowExceptionForHR(QueryGetData(ref format));
@@ -1581,8 +1578,8 @@ namespace System.Windows.Forms.Tests
             {
                 // do not check the requested storage medium, we always return a metafile handle, thats what Office does
 
-                if (format.cfFormat != CF_ENHMETAFILE || format.dwAspect != DVASPECT.DVASPECT_CONTENT || format.lindex != -1)
-                    return DV_E_FORMATETC;
+                if (format.cfFormat != (short)Interop.User32.CF.ENHMETAFILE || format.dwAspect != DVASPECT.DVASPECT_CONTENT || format.lindex != -1)
+                    return (int)Interop.HRESULT.DV_E_FORMATETC;
 
                 return 0;
             }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3025
Contributes to #1268

## Proposed changes

- use ReleaseStgMedium for ownership handling as suggested by win32 docs
- do not assume third party implementations of IDataObject.GetData return the medium which was asked for (Office sometimes ignores the medium the caller asks for and always returns the medium it happens to be using internally). Since Windows/OLE does not pose constraints on what the DataObject source returns WinForms needs to be robust and handle this case instead of crashing the whole process.
- clean up dead code related to metafiles, most code supporting them is already gone

## Customer Impact

- no more crashing when asking Office for "EnhancedMetafile"

## Regression? 

- Yes (earlier Desktop Framework versions which still supported metafiles did not crash; latest Desktop Framework however also crashes the whole process)

## Risk

- low
  * For the scenario crashing the process there is no risk, (almost) nothing is worse than crashing the process
  * Metafile support was already removed and did not work anyways. Removing dead code related to metafiles should not be a problem since it was not possible to retrieve them.

## Test methodology <!-- How did you ensure quality? -->

- Manual test of scenario #3025 by copy/pasting a metafile from Word to .NET Core, ensuring it no longer crashes the process and instead properly delivers no content as expected.
- Unit test which exercises the code path which was previously crashing


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3039)