### PR TITLE
fix: Hide icon when `ShowIcon = false`

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -1928,7 +1928,7 @@ namespace System.Windows.Forms
             set
             {
                 formStateEx[FormStateExShowIcon] = value ? 1 : 0;
-                if (value)
+                if (!value)
                 {
                     UpdateStyles();
                 }
@@ -4250,7 +4250,7 @@ namespace System.Windows.Forms
         /// </summary>
         [Browsable(true)]
         [EditorBrowsable(EditorBrowsableState.Always)]
-            [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         protected virtual void OnDpiChanged(DpiChangedEventArgs e)
         {
             if (e.DeviceDpiNew != e.DeviceDpiOld)
@@ -5867,11 +5867,7 @@ namespace System.Windows.Forms
 
                 if (redrawFrame)
                 {
-                    User32.RedrawWindow(
-                    new HandleRef(this, Handle),
-                    null,
-                    IntPtr.Zero,
-                    User32.RDW.INVALIDATE | User32.RDW.FRAME);
+                    User32.RedrawWindow(new HandleRef(this, Handle), null, IntPtr.Zero, User32.RDW.INVALIDATE | User32.RDW.FRAME);
                 }
             }
         }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.Designer.cs
@@ -32,6 +32,7 @@ namespace WinformsControlsTest
         /// </summary>
         private void InitializeComponent()
         {
+            this.toggleIconButton = new System.Windows.Forms.Button();
             this.buttonsButton = new System.Windows.Forms.Button();
             this.calendar = new System.Windows.Forms.Button();
             this.treeViewButton = new System.Windows.Forms.Button();
@@ -57,6 +58,16 @@ namespace WinformsControlsTest
             this.formBorderStyles = new System.Windows.Forms.Button();
             this.flowLayoutPanelUITypeEditors.SuspendLayout();
             this.SuspendLayout();
+            // 
+            // toggleIconButton
+            // 
+            this.toggleIconButton.Location = new System.Drawing.Point(3, 3);
+            this.toggleIconButton.Name = "toggleIconButton";
+            this.toggleIconButton.Size = new System.Drawing.Size(259, 23);
+            this.toggleIconButton.TabIndex = 0;
+            this.toggleIconButton.Text = "Toggle form icon";
+            this.toggleIconButton.UseVisualStyleBackColor = true;
+            this.toggleIconButton.Click += new System.EventHandler(this.toggleIconButton_Click);
             // 
             // buttonsButton
             // 
@@ -230,6 +241,7 @@ namespace WinformsControlsTest
             // 
             // flowLayoutPanelUITypeEditors
             // 
+            this.flowLayoutPanelUITypeEditors.Controls.Add(this.toggleIconButton);
             this.flowLayoutPanelUITypeEditors.Controls.Add(this.buttonsButton);
             this.flowLayoutPanelUITypeEditors.Controls.Add(this.calendar);
             this.flowLayoutPanelUITypeEditors.Controls.Add(this.multipleControls);
@@ -313,9 +325,9 @@ namespace WinformsControlsTest
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(554, 335);
+            this.ClientSize = new System.Drawing.Size(554, 400);
             this.Controls.Add(this.flowLayoutPanelUITypeEditors);
-            this.MinimumSize = new System.Drawing.Size(570, 330);
+            this.MinimumSize = new System.Drawing.Size(570, 400);
             this.Name = "MainForm";
             this.Padding = new System.Windows.Forms.Padding(8);
             this.Text = "MenuForm";
@@ -326,6 +338,7 @@ namespace WinformsControlsTest
 
         #endregion
 
+        private System.Windows.Forms.Button toggleIconButton;
         private System.Windows.Forms.Button buttonsButton;
         private System.Windows.Forms.Button calendar;
         private System.Windows.Forms.Button treeViewButton;

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
@@ -21,6 +21,11 @@ namespace WinformsControlsTest
             flowLayoutPanelUITypeEditors.PerformLayout();
         }
 
+        private void toggleIconButton_Click(object sender, EventArgs e)
+        {
+            this.ShowIcon = !this.ShowIcon;
+        }
+
         private void button1_Click(object sender, EventArgs e)
         {
             new Buttons().Show();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
@@ -13,10 +13,10 @@ namespace System.Windows.Forms.Tests
 {
     public class FormTests : IClassFixture<ThreadExceptionFixture>
     {
-        [Fact]
+        [WinFormsFact]
         public void Form_Ctor_Default()
         {
-            var form = new Form();
+            using var form = new Form();
             Assert.False(form.Active);
             Assert.Null(form.ActiveMdiChild);
             Assert.False(form.AllowTransparency);
@@ -31,10 +31,10 @@ namespace System.Windows.Forms.Tests
             Assert.False(form.Visible);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void Form_AcceptButtonGetSet()
         {
-            var form = new Form();
+            using var form = new Form();
             var mock = new Mock<IButtonControl>(MockBehavior.Strict);
             mock.Setup(x => x.NotifyDefault(It.IsAny<bool>()));
 
@@ -43,11 +43,11 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(mock.Object, form.AcceptButton);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void Form_Active_Set_GetReturnsExpected(bool value)
         {
-            var form = new Form
+            using var form = new Form
             {
                 Active = value
             };
@@ -72,11 +72,11 @@ namespace System.Windows.Forms.Tests
             Assert.False(Form.ActiveForm.Active);
         }*/
 
-        [Fact]
+        [WinFormsFact]
         public void Form_ActiveMdiChildInternalGetSet()
         {
-            var form = new Form();
-            var child = new Form();
+            using var form = new Form();
+            using var child = new Form();
 
             form.ActiveMdiChildInternal = child;
 
@@ -84,11 +84,11 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(child, form.ActiveMdiChildInternal);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void Form_ActiveMdiChildGetSet()
         {
-            var form = new Form();
-            var child = new Form
+            using var form = new Form();
+            using var child = new Form
             {
                 Visible = true,
                 Enabled = true
@@ -100,11 +100,11 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(child, form.ActiveMdiChild);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void Form_ActiveMdiChildGetSetChildNotVisible()
         {
-            var form = new Form();
-            var child = new Form
+            using var form = new Form();
+            using var child = new Form
             {
                 Visible = false,
                 Enabled = true
@@ -115,11 +115,11 @@ namespace System.Windows.Forms.Tests
             Assert.Null(form.ActiveMdiChild);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void Form_ActiveMdiChildGetSetChildNotEnabled()
         {
-            var form = new Form();
-            var child = new Form
+            using var form = new Form();
+            using var child = new Form
             {
                 Visible = true,
                 Enabled = false


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3022


## Proposed changes

- Correct a regression introduced in #695 when a condition was flipped that stopped setting form's [extended style flag `WS_EX_DLGMODALFRAME`](https://docs.microsoft.com/en-us/windows/win32/winmsg/extended-window-styles).

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

Customers now able to hide form's icon at runtime by setting `myform.ShowIcon = false`.
Workarounds involve either 
* setting an icon on a form to a transparent blank icon, or 
* performing an interop call to hide the icon _before_ hiding the icon:
    ```cs
    if (myform.ShowIcon)
    {
        int extendedStyle = (int)User32.GetWindowLong(myform.Handle, User32.GWL.EXSTYLE);
        User32.SetWindowLong(myform.Handle, User32.GWL.EXSTYLE, (IntPtr)(extendedStyle | (int)User32.WS_EX.DLGMODALFRAME));
    }

    myform.ShowIcon =false;
    ```

## Regression? 

- Yes, introduced in .NET Core 3.0

## Risk

- Minimal

<!-- end TELL-MODE -->




## Test methodology <!-- How did you ensure quality? -->

- manual tests in the integration test app
- unit tests


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3040)