### PR TITLE
Single instance

### DIFF
--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft.VisualBasic.Forms.vbproj
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft.VisualBasic.Forms.vbproj
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <!--
     https://github.com/dotnet/winforms/issues/2107#issuecomment-559289716
     https://github.com/microsoft/msbuild/issues/4923#issuecomment-554265394
@@ -9,11 +9,15 @@
     <AssemblyName>Microsoft.VisualBasic.Forms</AssemblyName>
     <Deterministic>true</Deterministic>
     <RootNamespace></RootNamespace>
-    <LangVersion>15.0</LangVersion>
+    <LangVersion>16</LangVersion>
     <VBRuntime>None</VBRuntime>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <UsePublicApiAnalyzers>true</UsePublicApiAnalyzers>
   </PropertyGroup>
+    
+  <ItemGroup>
+    <PackageReference Include="System.IO.Pipes.AccessControl" Version="4.5.1" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\System.Windows.Forms\src\System.Windows.Forms.csproj" />

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/NamedPipeXMLData.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/NamedPipeXMLData.vb
@@ -1,0 +1,23 @@
+﻿Imports System.Xml.Serialization
+
+Public Class NamedPipeXMLData
+    Private _commandLineArguments As New List(Of String)
+
+    Sub New()
+
+    End Sub
+
+    ''' <summary>
+    '''     A list of command line arguments.
+    ''' </summary>
+    <XmlElement("CommandLineArguments")>
+    Public Property CommandLineArguments As List(Of String)
+        Get
+            Return _commandLineArguments
+        End Get
+        Set(value As List(Of String))
+            _commandLineArguments = value
+        End Set
+    End Property
+
+End Class

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/NamedPipeXMLData.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/NamedPipeXMLData.vb
@@ -7,11 +7,13 @@ Namespace Microsoft.VisualBasic.ApplicationServices
 
         End Sub
 
+#Disable Warning RS0016 ' Add public types and members to the declared API
         ''' <summary>
         '''     A list of command line arguments.
         ''' </summary>
         <XmlElement("CommandLineArguments")>
         Public Property CommandLineArguments As New List(Of String)
+#Enable Warning RS0016 ' Add public types and members to the declared API
     End Class
 
 End Namespace

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/NamedPipeXMLData.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/NamedPipeXMLData.vb
@@ -1,19 +1,15 @@
-﻿Imports System.Xml.Serialization
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Runtime.Serialization
 
 Namespace Microsoft.VisualBasic.ApplicationServices
 
-    Public Class NamedPipeXMLData
-        Sub New()
-
-        End Sub
-
-#Disable Warning RS0016 ' Add public types and members to the declared API
-        ''' <summary>
-        '''     A list of command line arguments.
-        ''' </summary>
-        <XmlElement("CommandLineArguments")>
-        Public Property CommandLineArguments As New List(Of String)
-#Enable Warning RS0016 ' Add public types and members to the declared API
+    <DataContract>
+    Friend NotInheritable Class NamedPipeXmlData
+        <DataMember>
+        Public Property CommandLineArguments As String()
     End Class
 
 End Namespace

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/NamedPipeXMLData.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/NamedPipeXMLData.vb
@@ -7,9 +7,9 @@ Imports System.Runtime.Serialization
 Namespace Microsoft.VisualBasic.ApplicationServices
 
     <DataContract>
-    Friend NotInheritable Class NamedPipeXmlData
+    Friend Structure NamedPipeXmlData
         <DataMember>
         Public Property CommandLineArguments As String()
-    End Class
+    End Structure
 
 End Namespace

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/NamedPipeXMLData.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/NamedPipeXMLData.vb
@@ -1,23 +1,27 @@
 ﻿Imports System.Xml.Serialization
 
-Public Class NamedPipeXMLData
-    Private _commandLineArguments As New List(Of String)
+Namespace Microsoft.VisualBasic.ApplicationServices
 
-    Sub New()
+    Friend Class NamedPipeXMLData
+        Private _commandLineArguments As New List(Of String)
 
-    End Sub
+        Sub New()
 
-    ''' <summary>
-    '''     A list of command line arguments.
-    ''' </summary>
-    <XmlElement("CommandLineArguments")>
-    Public Property CommandLineArguments As List(Of String)
-        Get
-            Return _commandLineArguments
-        End Get
-        Set(value As List(Of String))
-            _commandLineArguments = value
-        End Set
-    End Property
+        End Sub
 
-End Class
+        ''' <summary>
+        '''     A list of command line arguments.
+        ''' </summary>
+        <XmlElement("CommandLineArguments")>
+        Friend Property CommandLineArguments As List(Of String)
+            Get
+                Return _commandLineArguments
+            End Get
+            Set(value As List(Of String))
+                _commandLineArguments = value
+            End Set
+        End Property
+
+    End Class
+
+End Namespace

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/NamedPipeXMLData.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/NamedPipeXMLData.vb
@@ -2,9 +2,7 @@
 
 Namespace Microsoft.VisualBasic.ApplicationServices
 
-    Friend Class NamedPipeXMLData
-        Private _commandLineArguments As New List(Of String)
-
+    Public Class NamedPipeXMLData
         Sub New()
 
         End Sub
@@ -13,15 +11,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
         '''     A list of command line arguments.
         ''' </summary>
         <XmlElement("CommandLineArguments")>
-        Friend Property CommandLineArguments As List(Of String)
-            Get
-                Return _commandLineArguments
-            End Get
-            Set(value As List(Of String))
-                _commandLineArguments = value
-            End Set
-        End Property
-
+        Public Property CommandLineArguments As New List(Of String)
     End Class
 
 End Namespace

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
@@ -942,12 +942,6 @@ Namespace Microsoft.VisualBasic.ApplicationServices
                                     OnStartupNextInstance(remoteEventArgs)
                                 End Sub)
                 ' Create a new pipe for next connection
-                _namedPipeServerStream = TryNamedPipeServerCreateServer()
-                If _namedPipeServerStream IsNot Nothing AndAlso _namedPipeServerStream.CanRead Then
-                    ' We are the first instance with the named pipe server listening and allow the form to load
-                    ' Begin async wait for connections
-                    _namedPipeServerStream.BeginWaitForConnection(AddressOf NamedPipeServerConnectionCallback, _namedPipeServerStream)
-                End If
             Catch ex As ObjectDisposedException
                 ' EndWaitForConnection will throw exception when someone closes the pipe before connection made
                 ' In that case we don't create any more pipes and just return
@@ -957,8 +951,18 @@ Namespace Microsoft.VisualBasic.ApplicationServices
                 ' ignored
             Finally
                 ' Close the original pipe (we will create a new one each time)
-                _namedPipeServerStream.Dispose()
-                ' ignored
+                If _namedPipeServerStream IsNot Nothing Then
+                    _namedPipeServerStream.Dispose()
+                End If
+            End Try
+            Try
+                _namedPipeServerStream = TryNamedPipeServerCreateServer()
+                If _namedPipeServerStream IsNot Nothing AndAlso _namedPipeServerStream.CanRead Then
+                    ' We are the first instance with the named pipe server listening and allow the form to load
+                    ' Begin async wait for connections
+                    _namedPipeServerStream.BeginWaitForConnection(AddressOf NamedPipeServerConnectionCallback, _namedPipeServerStream)
+                End If
+            Catch ex As Exception
             End Try
         End Sub
 

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
@@ -305,7 +305,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
                 DoApplicationModel() 'This isn't a Single-Instance application
                 Return
             End If
-            'This is a Single-Instance application
+            ' This is a Single-Instance application
             ' Must pass the calling assembly from here so we can get the running app. Otherwise, can break single instance.
             Dim ApplicationInstanceID As String = GetApplicationInstanceID(Assembly.GetCallingAssembly)
             _namedPipeID = ApplicationInstanceID & "NamedPipe"

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
@@ -898,8 +898,12 @@ Namespace Microsoft.VisualBasic.ApplicationServices
             Permissions.Assert()
 
             Dim Guid As Guid = GetTypeLibGuidForAssembly(Entry)
+            If Guid = Nothing Then
+                Return Entry.ManifestModule.ModuleVersionId.ToString
+            End If
             Dim Version As String = Entry.GetName.Version.ToString
             Dim VersionParts As String() = Version.Split(CType(".", Char()))
+            Dim SemiUniqueApplicationID As String = Guid.ToString + VersionParts(0) + "." + VersionParts(1)
             PermissionSet.RevertAssert()
 
             'Note: We used to make the terminal server session ID part of the key.  It turns out to be unnecessary and the call to
@@ -909,7 +913,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
             'any other global system object named "FOO" whether it be in session 2 running as  or session n running as whoever.
             'So it isn't necessary to make the session id part of the unique name that identifies a
 
-            Return Guid.ToString + VersionParts(0) + "." + VersionParts(1)  'Re: version parts, we have the major, minor, build, revision.  We key off major+minor.
+            Return SemiUniqueApplicationID  'Re: version parts, we have the major, minor, build, revision.  We key off major+minor.
         End Function
 
         Private Function GetTypeLibGuidForAssembly(_assembly As Assembly) As Guid
@@ -918,8 +922,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
                 Dim attribute As GuidAttribute = CType(CustomAttributes(0), GuidAttribute)
                 Return New Guid(attribute.Value)
             End If
-            Dim Hash As Integer = _assembly.GetHashCode
-            Return New Guid($"{(Hex(Hash) & "0000000").Substring(0, 8)}-0852-4dbc-8021-36955cd24ce3")
+            Return Nothing
         End Function
 
         ''' <summary>

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
@@ -698,6 +698,15 @@ Namespace Microsoft.VisualBasic.ApplicationServices
 
         <EditorBrowsable(EditorBrowsableState.Advanced)>
         Protected Property IsSingleInstance() As Boolean
+            Get
+                Return _isSingleInstance
+            End Get
+            Set(value As Boolean)
+                If value Then
+                    _isSingleInstance = value
+                End If
+            End Set
+        End Property
 
         ''' <summary>
         ''' Validates that the value being passed as an AuthenticationMode enum is a legal value
@@ -851,6 +860,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
         Private m_NetworkAvailChangeLock As New Object 'sync object
         Private m_SaveMySettingsOnExit As Boolean 'Informs My.Settings whether to save the settings on exit or not
 
+        Private _isSingleInstance As Boolean
         Private _mutexSingleInstance As Mutex
         Private _namedPipeID As String
         Private _namedPipeServerStream As NamedPipeServerStream

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
@@ -362,6 +362,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
                 End Try
                 Exit Sub
             End If
+            _mutexSingleInstance.WaitOne()
             ' We are not the first instance, send the named pipe message with our payload and stop loading
             Dim _NamedPipeXmlData As New NamedPipeXMLData With
                 {
@@ -369,6 +370,9 @@ Namespace Microsoft.VisualBasic.ApplicationServices
                 }
             ' Notify first instance by sending args
             NamedPipeClientSendOptions(_NamedPipeXmlData)
+            _mutexSingleInstance.ReleaseMutex()
+            _mutexSingleInstance.Dispose()
+            _mutexSingleInstance = Nothing
             If _namedPipeServerStream IsNot Nothing Then
                 _namedPipeServerStream.Dispose()
             End If

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
@@ -941,6 +941,13 @@ Namespace Microsoft.VisualBasic.ApplicationServices
                 MainForm.Invoke(Sub()
                                     OnStartupNextInstance(remoteEventArgs)
                                 End Sub)
+                ' Create a new pipe for next connection
+                _namedPipeServerStream = TryNamedPipeServerCreateServer()
+                If _namedPipeServerStream IsNot Nothing AndAlso _namedPipeServerStream.CanRead Then
+                    ' We are the first instance with the named pipe server listening and allow the form to load
+                    ' Begin async wait for connections
+                    _namedPipeServerStream.BeginWaitForConnection(AddressOf NamedPipeServerConnectionCallback, _namedPipeServerStream)
+                End If
             Catch ex As ObjectDisposedException
                 ' EndWaitForConnection will throw exception when someone closes the pipe before connection made
                 ' In that case we don't create any more pipes and just return
@@ -953,9 +960,6 @@ Namespace Microsoft.VisualBasic.ApplicationServices
                 _namedPipeServerStream.Dispose()
                 ' ignored
             End Try
-
-            ' Create a new pipe for next connection
-            _namedPipeServerStream = TryNamedPipeServerCreateServer()
         End Sub
 
         ''' <summary>

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
@@ -162,38 +162,6 @@ Namespace Microsoft.VisualBasic.ApplicationServices
     End Class
 
     ''' <summary>
-    ''' Exception for when we launch a Single-Instance application and it can't connect with the
-    ''' original instance.
-    ''' </summary>
-    ''' <remarks></remarks>
-    <EditorBrowsableAttribute(EditorBrowsableState.Never)>
-    <Serializable()>
-    Public Class CantGetSingleInstanceMutexException : Inherits Exception
-        ''' <summary>
-        '''  Creates a new exception
-        ''' </summary>
-        ''' <remarks></remarks>
-        Public Sub New()
-            MyBase.New(SR.AppModel_SingleInstanceMutexTimeout)
-        End Sub
-
-        Public Sub New(message As String)
-            MyBase.New(message)
-        End Sub
-
-        Public Sub New(message As String, innerException As Exception)
-            MyBase.New(message, innerException)
-        End Sub
-
-        ' De-serialization constructor must be defined since we are serializable
-        <System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)>
-        Protected Sub New(info As SerializationInfo, context As System.Runtime.Serialization.StreamingContext)
-            MyBase.New(info, context)
-        End Sub
-
-    End Class
-
-    ''' <summary>
     ''' Provides the infrastructure for the VB Windows Forms application model
     ''' </summary>
     ''' <remarks>Don't put access on this definition.</remarks>

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
@@ -177,7 +177,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
             MyBase.New(SR.AppModel_SingleInstanceMutexTimeout)
         End Sub
 
-        Public Sub New(ByVal message As String)
+        Public Sub New(message As String)
             MyBase.New(message)
         End Sub
 
@@ -187,7 +187,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
 
         ' De-serialization constructor must be defined since we are serializable
         <System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)>
-        Protected Sub New(ByVal info As SerializationInfo, ByVal context As System.Runtime.Serialization.StreamingContext)
+        Protected Sub New(info As SerializationInfo, context As System.Runtime.Serialization.StreamingContext)
             MyBase.New(info, context)
         End Sub
 
@@ -530,8 +530,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
             If eventArgs Is Nothing Then
                 Throw New ArgumentNullException(NameOf(eventArgs))
             End If
-            ' Review is the next statement needed
-            ' RaiseEvent StartupNextInstance(Me, eventArgs)
+            RaiseEvent StartupNextInstance(Me, eventArgs)
             ' Activate the original instance
             Call New UIPermission(UIPermissionWindow.SafeSubWindows Or UIPermissionWindow.SafeTopLevelWindows).Assert()
             If eventArgs.BringToForeground = True AndAlso Me.MainForm IsNot Nothing Then

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
@@ -163,6 +163,33 @@ Namespace Microsoft.VisualBasic.ApplicationServices
     End Class
 
     ''' <summary>
+    ''' Exception for when we launch a single-instance application and it can't connect with the
+    ''' original instance.
+    ''' </summary>
+    <EditorBrowsable(EditorBrowsableState.Never)>
+    <Serializable()>
+    Public Class CantStartSingleInstanceException : Inherits Exception
+
+        Public Sub New()
+            MyBase.New(SR.AppModel_SingleInstanceCantConnect)
+        End Sub
+
+        Public Sub New(message As String)
+            MyBase.New(message)
+        End Sub
+
+        Public Sub New(ByVal message As String, ByVal inner As Exception)
+            MyBase.New(message, inner)
+        End Sub
+
+        ' De-serialization constructor must be defined since we are serializable
+        <EditorBrowsable(EditorBrowsableState.Advanced)>
+        Protected Sub New(ByVal info As SerializationInfo, ByVal context As System.Runtime.Serialization.StreamingContext)
+            MyBase.New(info, context)
+        End Sub
+    End Class
+
+    ''' <summary>
     ''' Provides the infrastructure for the VB Windows Forms application model
     ''' </summary>
     ''' <remarks>Don't put access on this definition.</remarks>
@@ -246,38 +273,6 @@ Namespace Microsoft.VisualBasic.ApplicationServices
                 End If
             End RaiseEvent
         End Event
-
-        ''' <summary>
-        ''' Exception for when we launch a single-instance application and it can't connect with the
-        ''' original instance.
-        ''' </summary>
-        ''' <remarks></remarks>
-        <System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)>
-        <System.Serializable()>
-        Public Class CantStartSingleInstanceException : Inherits System.Exception
-
-            ''' <summary>
-            '''  Creates a new exception
-            ''' </summary>
-            ''' <remarks></remarks>
-            Public Sub New()
-                MyBase.New(SR.AppModel_SingleInstanceCantConnect)
-            End Sub
-
-            Public Sub New(ByVal message As String)
-                MyBase.New(message)
-            End Sub
-
-            Public Sub New(ByVal message As String, ByVal inner As System.Exception)
-                MyBase.New(message, inner)
-            End Sub
-
-            ' De-serialization constructor must be defined since we are serializable
-            <System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)>
-            Protected Sub New(ByVal info As System.Runtime.Serialization.SerializationInfo, ByVal context As System.Runtime.Serialization.StreamingContext)
-                MyBase.New(info, context)
-            End Sub
-        End Class
 
         ''' <summary>
         ''' Constructs the application Shutdown/Startup model object

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
@@ -311,7 +311,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
                 If FirstInstance() Then
                     ' Create a new pipe - it will return immediately and async wait for connections
                     NamedPipeServerCreateServer()
-
+                    DoApplicationModel()
                 Else
                     ' We are not the first instance, send the named pipe message with our payload and stop loading
                     Dim _NamedPipeXmlData = New NamedPipeXMLData With
@@ -899,8 +899,13 @@ Namespace Microsoft.VisualBasic.ApplicationServices
         End Function
 
         Private Function GetTypeLibGuidForAssembly(_assembly As Assembly) As Guid
-            Dim attribute As GuidAttribute = CType(_assembly.GetCustomAttributes(GetType(GuidAttribute), True)(0), GuidAttribute)
-            Return New Guid(attribute.Value)
+            Dim CustomAttributes As Object() = _assembly.GetCustomAttributes(GetType(GuidAttribute), True)
+            If CustomAttributes.Any Then
+                Dim attribute As GuidAttribute = CType(CustomAttributes(0), GuidAttribute)
+                Return New Guid(attribute.Value)
+            End If
+            Dim Hash As Integer = _assembly.GetHashCode
+            Return New Guid($"{(Hex(Hash) & "0000000").Substring(0, 8)}-0852-4dbc-8021-36955cd24ce3")
         End Function
 
         ''' <summary>

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
@@ -323,7 +323,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
                     End Try
                 Else
                     ' We are not the first instance, send the named pipe message with our payload and stop loading
-                    Dim _NamedPipeXmlData = New NamedPipeXMLData With
+                    Dim _NamedPipeXmlData As New NamedPipeXMLData With
                         {
                         .CommandLineArguments = Environment.GetCommandLineArgs().ToList()
                         }
@@ -944,11 +944,11 @@ Namespace Microsoft.VisualBasic.ApplicationServices
         ''' <param name="namedPipePayload"></param>
         Private Sub NamedPipeClientSendOptions(namedPipePayload As NamedPipeXMLData)
             Try
-                Using _namedPipeClientStream = New NamedPipeClientStream(".", m_NamedPipeID, PipeDirection.Out)
+                Using _namedPipeClientStream As New NamedPipeClientStream(".", m_NamedPipeID, PipeDirection.Out)
                     _namedPipeClientStream.Connect(3000)
                     ' Maximum wait 3 seconds
 
-                    Dim _xmlSerializer = New XmlSerializer(GetType(NamedPipeXMLData))
+                    Dim _xmlSerializer As New XmlSerializer(GetType(NamedPipeXMLData))
                     _xmlSerializer.Serialize(_namedPipeClientStream, namedPipePayload)
                 End Using
             Catch ex As Exception
@@ -995,13 +995,13 @@ Namespace Microsoft.VisualBasic.ApplicationServices
         Private Sub NamedPipeServerCreateServer()
             ' Create a new pipe accessible by local authenticated users, disallow network
             'var sidAuthUsers = new SecurityIdentifier(WellKnownSidType.AuthenticatedUserSid, null);
-            Dim sidNetworkService = New SecurityIdentifier(WellKnownSidType.NetworkServiceSid, Nothing)
-            Dim sidWorld = New SecurityIdentifier(WellKnownSidType.WorldSid, Nothing)
+            Dim sidNetworkService As New SecurityIdentifier(WellKnownSidType.NetworkServiceSid, Nothing)
+            Dim sidWorld As New SecurityIdentifier(WellKnownSidType.WorldSid, Nothing)
 
-            Dim _pipeSecurity = New PipeSecurity
+            Dim _pipeSecurity As New PipeSecurity
 
             ' Deny network access to the pipe
-            Dim accessRule = New PipeAccessRule(sidNetworkService, PipeAccessRights.ReadWrite, AccessControlType.Deny)
+            Dim accessRule As New PipeAccessRule(sidNetworkService, PipeAccessRights.ReadWrite, AccessControlType.Deny)
             _pipeSecurity.AddAccessRule(accessRule)
 
             ' Allow Everyone to read/write

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
@@ -948,9 +948,9 @@ Namespace Microsoft.VisualBasic.ApplicationServices
                 Dim _xmlSerializer As New XmlSerializer(GetType(NamedPipeXMLData))
                 Dim _namedPipeXmlData As NamedPipeXMLData = CType(_xmlSerializer.Deserialize(_namedPipeServerStream), NamedPipeXMLData)
                 Dim remoteEventArgs As New StartupNextInstanceEventArgs(New ReadOnlyCollection(Of String)(_namedPipeXmlData.CommandLineArguments), bringToForegroundFlag:=True)
-                _namedPipeServerStream.Close()
-                _namedPipeServerStream.Dispose()
-                TryNamedPipeServerCreateServer()
+                _namedPipeServerStream.Disconnect()
+                _namedPipeServerStream.BeginWaitForConnection(AddressOf NamedPipeServerConnectionCallback, _namedPipeServerStream)
+
                 _mutexSingleInstance.ReleaseMutex()
                 MainForm.Invoke(Sub()
                                     OnStartupNextInstance(remoteEventArgs)

--- a/src/Microsoft.VisualBasic.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualBasic.Forms/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,4 @@
+NamedPipeXMLData
+NamedPipeXMLData.CommandLineArguments() -> System.Collections.Generic.List(Of String)
+NamedPipeXMLData.CommandLineArguments(value As System.Collections.Generic.List(Of String)) -> Void
+NamedPipeXMLData.New() -> Void

--- a/src/Microsoft.VisualBasic.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualBasic.Forms/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,8 @@
+Microsoft.VisualBasic.ApplicationServices.CantGetSingleInstanceExceptionMutex
+Microsoft.VisualBasic.ApplicationServices.CantGetSingleInstanceExceptionMutex.New() -> Void
+Microsoft.VisualBasic.ApplicationServices.CantGetSingleInstanceExceptionMutex.New(info As System.Runtime.Serialization.SerializationInfo, context As System.Runtime.Serialization.StreamingContext) -> Void
+Microsoft.VisualBasic.ApplicationServices.CantGetSingleInstanceExceptionMutex.New(message As String) -> Void
+Microsoft.VisualBasic.ApplicationServices.CantGetSingleInstanceExceptionMutex.New(message As String, inner As System.Exception) -> Void
 Microsoft.VisualBasic.ApplicationServices.NamedPipeXMLData
 Microsoft.VisualBasic.ApplicationServices.NamedPipeXMLData.CommandLineArguments(AutoPropertyValue As System.Collections.Generic.List(Of String)) -> Void
 Microsoft.VisualBasic.ApplicationServices.NamedPipeXMLData.New() -> Void

--- a/src/Microsoft.VisualBasic.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualBasic.Forms/src/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
-Microsoft.VisualBasic.ApplicationServices.CantGetSingleInstanceMutexException
-Microsoft.VisualBasic.ApplicationServices.CantGetSingleInstanceMutexException.New() -> Void
-Microsoft.VisualBasic.ApplicationServices.CantGetSingleInstanceMutexException.New(info As System.Runtime.Serialization.SerializationInfo, context As System.Runtime.Serialization.StreamingContext) -> Void
-Microsoft.VisualBasic.ApplicationServices.CantGetSingleInstanceMutexException.New(message As String) -> Void
-Microsoft.VisualBasic.ApplicationServices.CantGetSingleInstanceMutexException.New(message As String, innerException As System.Exception) -> Void
 Overridable Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase.GetApplicationInstanceID(Entry As System.Reflection.Assembly) -> String

--- a/src/Microsoft.VisualBasic.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualBasic.Forms/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
+Microsoft.VisualBasic.ApplicationServices.NamedPipeXMLData
+Microsoft.VisualBasic.ApplicationServices.NamedPipeXMLData.CommandLineArguments(AutoPropertyValue As System.Collections.Generic.List(Of String)) -> Void
+Microsoft.VisualBasic.ApplicationServices.NamedPipeXMLData.New() -> Void
 Overridable Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase.GetApplicationInstanceID(Entry As System.Reflection.Assembly) -> String

--- a/src/Microsoft.VisualBasic.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualBasic.Forms/src/PublicAPI.Unshipped.txt
@@ -1,6 +1,6 @@
-Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase.CantStartSingleInstanceException
-Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase.CantStartSingleInstanceException.New() -> Void
-Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase.CantStartSingleInstanceException.New(info As System.Runtime.Serialization.SerializationInfo, context As System.Runtime.Serialization.StreamingContext) -> Void
-Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase.CantStartSingleInstanceException.New(message As String) -> Void
-Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase.CantStartSingleInstanceException.New(message As String, inner As System.Exception) -> Void
+Microsoft.VisualBasic.ApplicationServices.CantStartSingleInstanceException
+Microsoft.VisualBasic.ApplicationServices.CantStartSingleInstanceException.New() -> Void
+Microsoft.VisualBasic.ApplicationServices.CantStartSingleInstanceException.New(info As System.Runtime.Serialization.SerializationInfo, context As System.Runtime.Serialization.StreamingContext) -> Void
+Microsoft.VisualBasic.ApplicationServices.CantStartSingleInstanceException.New(message As String) -> Void
+Microsoft.VisualBasic.ApplicationServices.CantStartSingleInstanceException.New(message As String, inner As System.Exception) -> Void
 Overridable Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase.GetApplicationInstanceID(Entry As System.Reflection.Assembly) -> String

--- a/src/Microsoft.VisualBasic.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualBasic.Forms/src/PublicAPI.Unshipped.txt
@@ -1,9 +1,7 @@
-Microsoft.VisualBasic.ApplicationServices.CantGetSingleInstanceExceptionMutex
-Microsoft.VisualBasic.ApplicationServices.CantGetSingleInstanceExceptionMutex.New() -> Void
-Microsoft.VisualBasic.ApplicationServices.CantGetSingleInstanceExceptionMutex.New(info As System.Runtime.Serialization.SerializationInfo, context As System.Runtime.Serialization.StreamingContext) -> Void
-Microsoft.VisualBasic.ApplicationServices.CantGetSingleInstanceExceptionMutex.New(message As String) -> Void
-Microsoft.VisualBasic.ApplicationServices.CantGetSingleInstanceExceptionMutex.New(message As String, inner As System.Exception) -> Void
-Microsoft.VisualBasic.ApplicationServices.NamedPipeXMLData
-Microsoft.VisualBasic.ApplicationServices.NamedPipeXMLData.CommandLineArguments(AutoPropertyValue As System.Collections.Generic.List(Of String)) -> Void
-Microsoft.VisualBasic.ApplicationServices.NamedPipeXMLData.New() -> Void
+Microsoft.VisualBasic.ApplicationServices.CantGetSingleInstanceMutexException
+Microsoft.VisualBasic.ApplicationServices.CantGetSingleInstanceMutexException.New() -> Void
+Microsoft.VisualBasic.ApplicationServices.CantGetSingleInstanceMutexException.New(info As System.Runtime.Serialization.SerializationInfo, context As System.Runtime.Serialization.StreamingContext) -> Void
+Microsoft.VisualBasic.ApplicationServices.CantGetSingleInstanceMutexException.New(message As String) -> Void
+Microsoft.VisualBasic.ApplicationServices.CantGetSingleInstanceMutexException.New(message As String, innerException As System.Exception) -> Void
+Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase.IsSingleInstance(AutoPropertyValue As Boolean) -> Void
 Overridable Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase.GetApplicationInstanceID(Entry As System.Reflection.Assembly) -> String

--- a/src/Microsoft.VisualBasic.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualBasic.Forms/src/PublicAPI.Unshipped.txt
@@ -3,5 +3,4 @@ Microsoft.VisualBasic.ApplicationServices.CantGetSingleInstanceMutexException.Ne
 Microsoft.VisualBasic.ApplicationServices.CantGetSingleInstanceMutexException.New(info As System.Runtime.Serialization.SerializationInfo, context As System.Runtime.Serialization.StreamingContext) -> Void
 Microsoft.VisualBasic.ApplicationServices.CantGetSingleInstanceMutexException.New(message As String) -> Void
 Microsoft.VisualBasic.ApplicationServices.CantGetSingleInstanceMutexException.New(message As String, innerException As System.Exception) -> Void
-Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase.IsSingleInstance(AutoPropertyValue As Boolean) -> Void
 Overridable Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase.GetApplicationInstanceID(Entry As System.Reflection.Assembly) -> String

--- a/src/Microsoft.VisualBasic.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualBasic.Forms/src/PublicAPI.Unshipped.txt
@@ -2,3 +2,4 @@ NamedPipeXMLData
 NamedPipeXMLData.CommandLineArguments() -> System.Collections.Generic.List(Of String)
 NamedPipeXMLData.CommandLineArguments(value As System.Collections.Generic.List(Of String)) -> Void
 NamedPipeXMLData.New() -> Void
+Overridable Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase.GetApplicationInstanceID(Entry As System.Reflection.Assembly) -> String

--- a/src/Microsoft.VisualBasic.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualBasic.Forms/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
+Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase.CantStartSingleInstanceException
+Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase.CantStartSingleInstanceException.New() -> Void
+Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase.CantStartSingleInstanceException.New(info As System.Runtime.Serialization.SerializationInfo, context As System.Runtime.Serialization.StreamingContext) -> Void
+Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase.CantStartSingleInstanceException.New(message As String) -> Void
+Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase.CantStartSingleInstanceException.New(message As String, inner As System.Exception) -> Void
 Overridable Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase.GetApplicationInstanceID(Entry As System.Reflection.Assembly) -> String

--- a/src/Microsoft.VisualBasic.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualBasic.Forms/src/PublicAPI.Unshipped.txt
@@ -1,5 +1,1 @@
-NamedPipeXMLData
-NamedPipeXMLData.CommandLineArguments() -> System.Collections.Generic.List(Of String)
-NamedPipeXMLData.CommandLineArguments(value As System.Collections.Generic.List(Of String)) -> Void
-NamedPipeXMLData.New() -> Void
 Overridable Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase.GetApplicationInstanceID(Entry As System.Reflection.Assembly) -> String

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/SR.resx
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/SR.resx
@@ -112,10 +112,10 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=42.42.42.42, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=42.42.42.42, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ID53" xml:space="preserve">
     <value>File not found.</value>
@@ -218,8 +218,5 @@
   </data>
   <data name="EnvVarNotFound_Name" xml:space="preserve">
     <value>Environment variable is not defined: '{0}'.</value>
-  </data>
-  <data name="AppModel_SingleInstanceMutexTimeout" xml:space="preserve">
-    <value>Single Instance Mutex Timeout</value>
   </data>
 </root>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/SR.resx
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/SR.resx
@@ -1,4 +1,5 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
   <!-- 
     Microsoft ResX Schema 
     
@@ -217,5 +218,8 @@
   </data>
   <data name="EnvVarNotFound_Name" xml:space="preserve">
     <value>Environment variable is not defined: '{0}'.</value>
+  </data>
+  <data name="AppModel_SingleInstanceMutexTimeout" xml:space="preserve">
+    <value>Single Instance Mutex Timeout</value>
   </data>
 </root>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/SR.resx
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/SR.resx
@@ -219,7 +219,7 @@
   <data name="EnvVarNotFound_Name" xml:space="preserve">
     <value>Environment variable is not defined: '{0}'.</value>
   </data>
-  <data name="AppModel_SingleInstanceMutexTimeout" xml:space="preserve">
-    <value>Can't start Single Instance, MutexTimeout</value>
+  <data name="AppModel_SingleInstanceCantConnect" xml:space="preserve">
+    <value>This single-instance application could not connect to the original instance.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/SR.resx
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/SR.resx
@@ -219,4 +219,7 @@
   <data name="EnvVarNotFound_Name" xml:space="preserve">
     <value>Environment variable is not defined: '{0}'.</value>
   </data>
+  <data name="AppModel_SingleInstanceMutexTimeout" xml:space="preserve">
+    <value>Can't start Single Instance, MutexTimeout</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.cs.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Nebyl zadán formulář spuštění.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Single Instance Mutex Timeout</source>
-        <target state="new">Single Instance Mutex Timeout</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">Formulář úvodní obrazovky a hlavní formulář nemohou být stejné.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Nebyl zadán formulář spuštění.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Can't start Single Instance, MutexTimeout</source>
+        <target state="new">Can't start Single Instance, MutexTimeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">Formulář úvodní obrazovky a hlavní formulář nemohou být stejné.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Nebyl zadán formulář spuštění.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Single Instance Mutex Timeout</source>
+        <target state="new">Single Instance Mutex Timeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">Formulář úvodní obrazovky a hlavní formulář nemohou být stejné.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.cs.xlf
@@ -7,9 +7,9 @@
         <target state="translated">Nebyl zadán formulář spuštění.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Can't start Single Instance, MutexTimeout</source>
-        <target state="new">Can't start Single Instance, MutexTimeout</target>
+      <trans-unit id="AppModel_SingleInstanceCantConnect">
+        <source>This single-instance application could not connect to the original instance.</source>
+        <target state="new">This single-instance application could not connect to the original instance.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Es wurde kein Startformular angegeben.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Single Instance Mutex Timeout</source>
+        <target state="new">Single Instance Mutex Timeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">Das Formular für den Begrüßungsbildschirm und das Hauptformular dürfen nicht identisch sein.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.de.xlf
@@ -7,9 +7,9 @@
         <target state="translated">Es wurde kein Startformular angegeben.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Can't start Single Instance, MutexTimeout</source>
-        <target state="new">Can't start Single Instance, MutexTimeout</target>
+      <trans-unit id="AppModel_SingleInstanceCantConnect">
+        <source>This single-instance application could not connect to the original instance.</source>
+        <target state="new">This single-instance application could not connect to the original instance.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Es wurde kein Startformular angegeben.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Can't start Single Instance, MutexTimeout</source>
+        <target state="new">Can't start Single Instance, MutexTimeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">Das Formular für den Begrüßungsbildschirm und das Hauptformular dürfen nicht identisch sein.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.de.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Es wurde kein Startformular angegeben.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Single Instance Mutex Timeout</source>
-        <target state="new">Single Instance Mutex Timeout</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">Das Formular für den Begrüßungsbildschirm und das Hauptformular dürfen nicht identisch sein.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.es.xlf
@@ -7,9 +7,9 @@
         <target state="translated">No se ha especificado un formulario de inicio.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Can't start Single Instance, MutexTimeout</source>
-        <target state="new">Can't start Single Instance, MutexTimeout</target>
+      <trans-unit id="AppModel_SingleInstanceCantConnect">
+        <source>This single-instance application could not connect to the original instance.</source>
+        <target state="new">This single-instance application could not connect to the original instance.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.es.xlf
@@ -7,11 +7,6 @@
         <target state="translated">No se ha especificado un formulario de inicio.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Single Instance Mutex Timeout</source>
-        <target state="new">Single Instance Mutex Timeout</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">La pantalla de presentación y el formulario principal no pueden ser el mismo formulario.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">No se ha especificado un formulario de inicio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Single Instance Mutex Timeout</source>
+        <target state="new">Single Instance Mutex Timeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">La pantalla de presentación y el formulario principal no pueden ser el mismo formulario.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">No se ha especificado un formulario de inicio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Can't start Single Instance, MutexTimeout</source>
+        <target state="new">Can't start Single Instance, MutexTimeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">La pantalla de presentación y el formulario principal no pueden ser el mismo formulario.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Un formulaire de démarrage n'a pas été spécifié.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Can't start Single Instance, MutexTimeout</source>
+        <target state="new">Can't start Single Instance, MutexTimeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">L'écran de démarrage et le formulaire principal ne peuvent pas être le même formulaire.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.fr.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Un formulaire de démarrage n'a pas été spécifié.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Single Instance Mutex Timeout</source>
-        <target state="new">Single Instance Mutex Timeout</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">L'écran de démarrage et le formulaire principal ne peuvent pas être le même formulaire.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.fr.xlf
@@ -7,9 +7,9 @@
         <target state="translated">Un formulaire de démarrage n'a pas été spécifié.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Can't start Single Instance, MutexTimeout</source>
-        <target state="new">Can't start Single Instance, MutexTimeout</target>
+      <trans-unit id="AppModel_SingleInstanceCantConnect">
+        <source>This single-instance application could not connect to the original instance.</source>
+        <target state="new">This single-instance application could not connect to the original instance.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Un formulaire de démarrage n'a pas été spécifié.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Single Instance Mutex Timeout</source>
+        <target state="new">Single Instance Mutex Timeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">L'écran de démarrage et le formulaire principal ne peuvent pas être le même formulaire.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.it.xlf
@@ -7,9 +7,9 @@
         <target state="translated">Non è stato specificato un form di avvio.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Can't start Single Instance, MutexTimeout</source>
-        <target state="new">Can't start Single Instance, MutexTimeout</target>
+      <trans-unit id="AppModel_SingleInstanceCantConnect">
+        <source>This single-instance application could not connect to the original instance.</source>
+        <target state="new">This single-instance application could not connect to the original instance.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Non è stato specificato un form di avvio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Single Instance Mutex Timeout</source>
+        <target state="new">Single Instance Mutex Timeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">La schermata iniziale e il form principale non possono avere lo stesso formato.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Non è stato specificato un form di avvio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Can't start Single Instance, MutexTimeout</source>
+        <target state="new">Can't start Single Instance, MutexTimeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">La schermata iniziale e il form principale non possono avere lo stesso formato.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.it.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Non è stato specificato un form di avvio.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Single Instance Mutex Timeout</source>
-        <target state="new">Single Instance Mutex Timeout</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">La schermata iniziale e il form principale non possono avere lo stesso formato.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.ja.xlf
@@ -7,9 +7,9 @@
         <target state="translated">スタートアップ フォームが指定されていません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Can't start Single Instance, MutexTimeout</source>
-        <target state="new">Can't start Single Instance, MutexTimeout</target>
+      <trans-unit id="AppModel_SingleInstanceCantConnect">
+        <source>This single-instance application could not connect to the original instance.</source>
+        <target state="new">This single-instance application could not connect to the original instance.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">スタートアップ フォームが指定されていません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Can't start Single Instance, MutexTimeout</source>
+        <target state="new">Can't start Single Instance, MutexTimeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">スプラッシュ スクリーンとメイン フォームは同じフォームであることはできません。</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">スタートアップ フォームが指定されていません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Single Instance Mutex Timeout</source>
+        <target state="new">Single Instance Mutex Timeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">スプラッシュ スクリーンとメイン フォームは同じフォームであることはできません。</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.ja.xlf
@@ -7,11 +7,6 @@
         <target state="translated">スタートアップ フォームが指定されていません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Single Instance Mutex Timeout</source>
-        <target state="new">Single Instance Mutex Timeout</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">スプラッシュ スクリーンとメイン フォームは同じフォームであることはできません。</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">시작 폼이 지정되지 않았습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Single Instance Mutex Timeout</source>
+        <target state="new">Single Instance Mutex Timeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">시작 화면과 기본 폼은 같은 폼일 수 없습니다.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">시작 폼이 지정되지 않았습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Can't start Single Instance, MutexTimeout</source>
+        <target state="new">Can't start Single Instance, MutexTimeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">시작 화면과 기본 폼은 같은 폼일 수 없습니다.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.ko.xlf
@@ -7,9 +7,9 @@
         <target state="translated">시작 폼이 지정되지 않았습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Can't start Single Instance, MutexTimeout</source>
-        <target state="new">Can't start Single Instance, MutexTimeout</target>
+      <trans-unit id="AppModel_SingleInstanceCantConnect">
+        <source>This single-instance application could not connect to the original instance.</source>
+        <target state="new">This single-instance application could not connect to the original instance.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.ko.xlf
@@ -7,11 +7,6 @@
         <target state="translated">시작 폼이 지정되지 않았습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Single Instance Mutex Timeout</source>
-        <target state="new">Single Instance Mutex Timeout</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">시작 화면과 기본 폼은 같은 폼일 수 없습니다.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Formularz początkowy nie został określony.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Can't start Single Instance, MutexTimeout</source>
+        <target state="new">Can't start Single Instance, MutexTimeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">Ekran powitalny i ekran główny nie mogą być tym samym formularzem.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Formularz początkowy nie został określony.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Single Instance Mutex Timeout</source>
+        <target state="new">Single Instance Mutex Timeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">Ekran powitalny i ekran główny nie mogą być tym samym formularzem.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.pl.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Formularz początkowy nie został określony.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Single Instance Mutex Timeout</source>
-        <target state="new">Single Instance Mutex Timeout</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">Ekran powitalny i ekran główny nie mogą być tym samym formularzem.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.pl.xlf
@@ -7,9 +7,9 @@
         <target state="translated">Formularz początkowy nie został określony.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Can't start Single Instance, MutexTimeout</source>
-        <target state="new">Can't start Single Instance, MutexTimeout</target>
+      <trans-unit id="AppModel_SingleInstanceCantConnect">
+        <source>This single-instance application could not connect to the original instance.</source>
+        <target state="new">This single-instance application could not connect to the original instance.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Não foi especificado um formulário de inicialização.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Can't start Single Instance, MutexTimeout</source>
+        <target state="new">Can't start Single Instance, MutexTimeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">Tela inicial e formulário principal não podem ser o mesmo formulário.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Não foi especificado um formulário de inicialização.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Single Instance Mutex Timeout</source>
+        <target state="new">Single Instance Mutex Timeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">Tela inicial e formulário principal não podem ser o mesmo formulário.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Não foi especificado um formulário de inicialização.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Single Instance Mutex Timeout</source>
-        <target state="new">Single Instance Mutex Timeout</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">Tela inicial e formulário principal não podem ser o mesmo formulário.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -7,9 +7,9 @@
         <target state="translated">Não foi especificado um formulário de inicialização.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Can't start Single Instance, MutexTimeout</source>
-        <target state="new">Can't start Single Instance, MutexTimeout</target>
+      <trans-unit id="AppModel_SingleInstanceCantConnect">
+        <source>This single-instance application could not connect to the original instance.</source>
+        <target state="new">This single-instance application could not connect to the original instance.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Форма запуска не указана.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Single Instance Mutex Timeout</source>
+        <target state="new">Single Instance Mutex Timeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">Заставка и главная форма не могут быть одной и той же формой.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.ru.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Форма запуска не указана.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Single Instance Mutex Timeout</source>
-        <target state="new">Single Instance Mutex Timeout</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">Заставка и главная форма не могут быть одной и той же формой.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.ru.xlf
@@ -7,9 +7,9 @@
         <target state="translated">Форма запуска не указана.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Can't start Single Instance, MutexTimeout</source>
-        <target state="new">Can't start Single Instance, MutexTimeout</target>
+      <trans-unit id="AppModel_SingleInstanceCantConnect">
+        <source>This single-instance application could not connect to the original instance.</source>
+        <target state="new">This single-instance application could not connect to the original instance.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Форма запуска не указана.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Can't start Single Instance, MutexTimeout</source>
+        <target state="new">Can't start Single Instance, MutexTimeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">Заставка и главная форма не могут быть одной и той же формой.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Başlangıç formu belirtilmedi.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Can't start Single Instance, MutexTimeout</source>
+        <target state="new">Can't start Single Instance, MutexTimeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">Giriş ekranı ve ana form aynı form olamaz.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Başlangıç formu belirtilmedi.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Single Instance Mutex Timeout</source>
+        <target state="new">Single Instance Mutex Timeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">Giriş ekranı ve ana form aynı form olamaz.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.tr.xlf
@@ -7,9 +7,9 @@
         <target state="translated">Başlangıç formu belirtilmedi.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Can't start Single Instance, MutexTimeout</source>
-        <target state="new">Can't start Single Instance, MutexTimeout</target>
+      <trans-unit id="AppModel_SingleInstanceCantConnect">
+        <source>This single-instance application could not connect to the original instance.</source>
+        <target state="new">This single-instance application could not connect to the original instance.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.tr.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Başlangıç formu belirtilmedi.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Single Instance Mutex Timeout</source>
-        <target state="new">Single Instance Mutex Timeout</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">Giriş ekranı ve ana form aynı form olamaz.</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -7,9 +7,9 @@
         <target state="translated">未指定启动窗体。</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Can't start Single Instance, MutexTimeout</source>
-        <target state="new">Can't start Single Instance, MutexTimeout</target>
+      <trans-unit id="AppModel_SingleInstanceCantConnect">
+        <source>This single-instance application could not connect to the original instance.</source>
+        <target state="new">This single-instance application could not connect to the original instance.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">未指定启动窗体。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Single Instance Mutex Timeout</source>
+        <target state="new">Single Instance Mutex Timeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">初始屏幕和主窗体不能是同一个窗体。</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -7,11 +7,6 @@
         <target state="translated">未指定启动窗体。</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Single Instance Mutex Timeout</source>
-        <target state="new">Single Instance Mutex Timeout</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">初始屏幕和主窗体不能是同一个窗体。</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">未指定启动窗体。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Can't start Single Instance, MutexTimeout</source>
+        <target state="new">Can't start Single Instance, MutexTimeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">初始屏幕和主窗体不能是同一个窗体。</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">尚未指定啟動表單。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Can't start Single Instance, MutexTimeout</source>
+        <target state="new">Can't start Single Instance, MutexTimeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">啟動顯示畫面和主要表單不能是同樣的表單。</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">尚未指定啟動表單。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
+        <source>Single Instance Mutex Timeout</source>
+        <target state="new">Single Instance Mutex Timeout</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">啟動顯示畫面和主要表單不能是同樣的表單。</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -7,11 +7,6 @@
         <target state="translated">尚未指定啟動表單。</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Single Instance Mutex Timeout</source>
-        <target state="new">Single Instance Mutex Timeout</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">
         <source>Splash screen and main form cannot be the same form.</source>
         <target state="translated">啟動顯示畫面和主要表單不能是同樣的表單。</target>

--- a/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/Microsoft.VisualBasic.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -7,9 +7,9 @@
         <target state="translated">尚未指定啟動表單。</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppModel_SingleInstanceMutexTimeout">
-        <source>Can't start Single Instance, MutexTimeout</source>
-        <target state="new">Can't start Single Instance, MutexTimeout</target>
+      <trans-unit id="AppModel_SingleInstanceCantConnect">
+        <source>This single-instance application could not connect to the original instance.</source>
+        <target state="new">This single-instance application could not connect to the original instance.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppModel_SplashAndMainFormTheSame">

--- a/src/Microsoft.VisualBasic/tests/IntegrationTests/Microsoft.VisualBasic.IntegrationTests/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBaseTests.cs
+++ b/src/Microsoft.VisualBasic/tests/IntegrationTests/Microsoft.VisualBasic.IntegrationTests/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBaseTests.cs
@@ -53,5 +53,13 @@ namespace Microsoft.VisualBasic.IntegrationTests
             // Exception.ToString() called to verify message is constructed successfully.
             _ = Assert.Throws<NoStartupFormException>(() => application.Run(new string[0])).ToString();
         }
+
+        [Fact]
+        public void Run_CantStartSingleInstanceException()
+        {
+            var e = new CantStartSingleInstanceException();
+            // Exception.ToString() called to verify message is constructed successfully.
+            _ = e.ToString();
+        }
     }
 }

--- a/src/Microsoft.VisualBasic/tests/IntegrationTests/Microsoft.VisualBasic.IntegrationTests/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBaseTests.cs
+++ b/src/Microsoft.VisualBasic/tests/IntegrationTests/Microsoft.VisualBasic.IntegrationTests/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBaseTests.cs
@@ -18,10 +18,26 @@ namespace Microsoft.VisualBasic.IntegrationTests
             string exePath = TestHelpers.GetExePath("VisualBasicRuntimeTest");
             var startInfo = new ProcessStartInfo { FileName = exePath, Arguments = "WindowsFormsApplicationBase.Run" };
             var process = TestHelpers.StartProcess(startInfo);
+            var process1 = TestHelpers.StartProcess(startInfo);
+            Assert.False(process1.HasExited);
+            TestHelpers.EndProcess(process, timeout: 1000);
+            Assert.True(process.HasExited);
+            TestHelpers.EndProcess(process1, timeout: 1000);
+            Assert.True(process1.HasExited);
+        }
+
+        [Fact]
+        public void RunSingleInstance()
+        {
+            string exePath = TestHelpers.GetExePath("VisualBasicRuntimeTest");
+            var startInfo = new ProcessStartInfo { FileName = exePath, Arguments = "WindowsFormsApplicationBase.RunSingleInstance" };
+            var process = TestHelpers.StartProcess(startInfo);
+            var process1 = TestHelpers.StartProcess(startInfo);
+            System.Threading.Thread.Sleep(1000);
+            Assert.True(process1.HasExited);
             TestHelpers.EndProcess(process, timeout: 1000);
             Assert.True(process.HasExited);
         }
-
         [Fact]
         public void Run_NoStartupFormException()
         {

--- a/src/Microsoft.VisualBasic/tests/IntegrationTests/Microsoft.VisualBasic.IntegrationTests/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBaseTests.cs
+++ b/src/Microsoft.VisualBasic/tests/IntegrationTests/Microsoft.VisualBasic.IntegrationTests/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBaseTests.cs
@@ -45,6 +45,7 @@ namespace Microsoft.VisualBasic.IntegrationTests
             TestHelpers.EndProcess(ProcessList[0], timeout: 1000);
             Assert.True(ProcessList[0].HasExited, "First Instance didn't exit");
         }
+
         [Fact]
         public void Run_NoStartupFormException()
         {

--- a/src/Microsoft.VisualBasic/tests/IntegrationTests/Microsoft.VisualBasic.IntegrationTests/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBaseTests.cs
+++ b/src/Microsoft.VisualBasic/tests/IntegrationTests/Microsoft.VisualBasic.IntegrationTests/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBaseTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Windows.Forms.IntegrationTests.Common;
 using Microsoft.VisualBasic.ApplicationServices;
@@ -31,12 +32,18 @@ namespace Microsoft.VisualBasic.IntegrationTests
         {
             string exePath = TestHelpers.GetExePath("VisualBasicRuntimeTest");
             var startInfo = new ProcessStartInfo { FileName = exePath, Arguments = "WindowsFormsApplicationBase.RunSingleInstance" };
-            var process = TestHelpers.StartProcess(startInfo);
-            var process1 = TestHelpers.StartProcess(startInfo);
+            List<Process> ProcessList = new List<Process>();
+            for (int i = 0; i <= 9; i++)
+            {
+                ProcessList.Add(TestHelpers.StartProcess(startInfo));
+            }
             System.Threading.Thread.Sleep(1000);
-            Assert.True(process1.HasExited);
-            TestHelpers.EndProcess(process, timeout: 1000);
-            Assert.True(process.HasExited);
+            for (int i = 1; i <= 9; i++)
+            {
+            Assert.True(ProcessList[i].HasExited, $"Instance {i} didn't exit");
+            }
+            TestHelpers.EndProcess(ProcessList[0], timeout: 1000);
+            Assert.True(ProcessList[0].HasExited, "First Instance didn't exit");
         }
         [Fact]
         public void Run_NoStartupFormException()

--- a/src/Microsoft.VisualBasic/tests/IntegrationTests/VisualBasicRuntimeTest/Program.cs
+++ b/src/Microsoft.VisualBasic/tests/IntegrationTests/VisualBasicRuntimeTest/Program.cs
@@ -108,14 +108,7 @@ namespace VisualBasicRuntimeTest
 
             application.StartupNextInstance += (object sender, StartupNextInstanceEventArgs e) =>
             {
-                var forms = application.OpenForms;
-                valid = forms.Count == 1 &&
-                    forms[0] == mainForm &&
-                    application.ApplicationContext.MainForm == mainForm;
-                if (!valid)
-                {
-                    mainForm.Close();
-                }
+                // this needs testing
             };
 
             mainForm.Load += (object sender, EventArgs e) =>

--- a/src/Microsoft.VisualBasic/tests/IntegrationTests/VisualBasicRuntimeTest/Program.cs
+++ b/src/Microsoft.VisualBasic/tests/IntegrationTests/VisualBasicRuntimeTest/Program.cs
@@ -40,10 +40,10 @@ namespace VisualBasicRuntimeTest
                         Interaction_MsgBox(useVbHost: true);
                         break;
                     case "WindowsFormsApplicationBase.Run":
-                        WindowsFormsApplicationBase_Run();
+                        WindowsFormsApplicationBase_Run(useSingleInstance: false);
                         break;
                     case "WindowsFormsApplicationBase.RunSingleInstance":
-                        WindowsFormsApplicationBase_RunSingleInstance();
+                        WindowsFormsApplicationBase_Run(useSingleInstance: true);
                         break;
                     case "ProgressDialog.ShowProgressDialog":
                         ProgressDialog_ShowProgressDialog();
@@ -75,10 +75,10 @@ namespace VisualBasicRuntimeTest
             Interaction.MsgBox(Prompt: "Message", Buttons: MsgBoxStyle.OkCancel, Title: "Title");
         }
 
-        private static void WindowsFormsApplicationBase_Run()
+        private static void WindowsFormsApplicationBase_Run(bool useSingleInstance )
         {
             var mainForm = new Form();
-            var application = new WindowsApplication(mainForm, false);
+            var application = new WindowsApplication(mainForm, useSingleInstance);
             bool valid = false;
 
             mainForm.Load += (object sender, EventArgs e) =>
@@ -99,37 +99,6 @@ namespace VisualBasicRuntimeTest
                 throw new InvalidOperationException();
             }
         }
-        private static void WindowsFormsApplicationBase_RunSingleInstance()
-        {
-            var mainForm = new Form();
-            var application = new WindowsApplication(mainForm, true);
-
-            bool valid = false;
-
-            application.StartupNextInstance += (object sender, StartupNextInstanceEventArgs e) =>
-            {
-                // this needs testing
-            };
-
-            mainForm.Load += (object sender, EventArgs e) =>
-            {
-                var forms = application.OpenForms;
-                valid = forms.Count == 1 &&
-                    forms[0] == mainForm &&
-                    application.ApplicationContext.MainForm == mainForm;
-                if (!valid)
-                {
-                    mainForm.Close();
-                }
-            };
-
-            application.Run(new string[0]);
-            if (!valid)
-            {
-                throw new InvalidOperationException();
-            }
-        }
-
         private static void ProgressDialog_ShowProgressDialog()
         {
             var dialogType = typeof(ApplicationBase).Assembly.GetType("Microsoft.VisualBasic.MyServices.Internal.ProgressDialog");

--- a/src/Microsoft.VisualBasic/tests/IntegrationTests/VisualBasicRuntimeTest/Program.cs
+++ b/src/Microsoft.VisualBasic/tests/IntegrationTests/VisualBasicRuntimeTest/Program.cs
@@ -130,7 +130,6 @@ namespace VisualBasicRuntimeTest
             }
         }
 
-
         private static void ProgressDialog_ShowProgressDialog()
         {
             var dialogType = typeof(ApplicationBase).Assembly.GetType("Microsoft.VisualBasic.MyServices.Internal.ProgressDialog");


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #2056

## Proposed changes
Use NamedPipes to support VB Single Instance

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
VB needs to support Single Instance applications, this supports existing Framework features including passing command line arguments from additional launches back to first instance.

## Regression? 
- Yes I am fixing a regression

## Risk
No automated tests are included until design review (it was tested manually). Also I only write tests in VB and all the tests here are written in C#.
<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->
Manual not ready to Merge. The logic is from Reference Source and Microsoft NamedPipes documentation examples.

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft.WindowsDesktop.App 5.0.0-preview.1.20127.5 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3050)