### PR TITLE
fix: Hide icon when `ShowIcon = false`

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -2068,7 +2068,7 @@ namespace System.Windows.Forms
             set
             {
                 formStateEx[FormStateExShowIcon] = value ? 1 : 0;
-                if (value)
+                if (!value)
                 {
                     UpdateStyles();
                 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.Designer.cs
@@ -32,6 +32,7 @@ namespace WinformsControlsTest
         /// </summary>
         private void InitializeComponent()
         {
+            this.toggleIconButton = new System.Windows.Forms.Button();
             this.buttonsButton = new System.Windows.Forms.Button();
             this.calendar = new System.Windows.Forms.Button();
             this.treeViewButton = new System.Windows.Forms.Button();
@@ -56,6 +57,16 @@ namespace WinformsControlsTest
             this.formBorderStyles = new System.Windows.Forms.Button();
             this.flowLayoutPanelUITypeEditors.SuspendLayout();
             this.SuspendLayout();
+            // 
+            // toggleIconButton
+            // 
+            this.toggleIconButton.Location = new System.Drawing.Point(3, 3);
+            this.toggleIconButton.Name = "toggleIconButton";
+            this.toggleIconButton.Size = new System.Drawing.Size(259, 23);
+            this.toggleIconButton.TabIndex = 0;
+            this.toggleIconButton.Text = "Toggle form icon";
+            this.toggleIconButton.UseVisualStyleBackColor = true;
+            this.toggleIconButton.Click += new System.EventHandler(this.toggleIconButton_Click);
             // 
             // buttonsButton
             // 
@@ -219,6 +230,7 @@ namespace WinformsControlsTest
             // 
             // flowLayoutPanelUITypeEditors
             // 
+            this.flowLayoutPanelUITypeEditors.Controls.Add(this.toggleIconButton);
             this.flowLayoutPanelUITypeEditors.Controls.Add(this.buttonsButton);
             this.flowLayoutPanelUITypeEditors.Controls.Add(this.calendar);
             this.flowLayoutPanelUITypeEditors.Controls.Add(this.multipleControls);
@@ -301,9 +313,9 @@ namespace WinformsControlsTest
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(554, 335);
+            this.ClientSize = new System.Drawing.Size(554, 400);
             this.Controls.Add(this.flowLayoutPanelUITypeEditors);
-            this.MinimumSize = new System.Drawing.Size(570, 330);
+            this.MinimumSize = new System.Drawing.Size(570, 400);
             this.Name = "MainForm";
             this.Padding = new System.Windows.Forms.Padding(8);
             this.Text = "MenuForm";
@@ -314,6 +326,7 @@ namespace WinformsControlsTest
 
         #endregion
 
+        private System.Windows.Forms.Button toggleIconButton;
         private System.Windows.Forms.Button buttonsButton;
         private System.Windows.Forms.Button calendar;
         private System.Windows.Forms.Button treeViewButton;

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
@@ -19,6 +19,11 @@ namespace WinformsControlsTest
             InitializeComponent();
         }
 
+        private void toggleIconButton_Click(object sender, EventArgs e)
+        {
+            this.ShowIcon = !this.ShowIcon;
+        }
+
         private void button1_Click(object sender, EventArgs e)
         {
             new Buttons().Show();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
@@ -1,20 +1,23 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Xunit;
-using Moq;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.Drawing;
+using Moq;
+using Xunit;
 using WinForms.Common.Tests;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
     public class FormTests
     {
-        [Fact]
+        [WinFormsFact]
         public void Form_Ctor_Default()
         {
-            var form = new Form();
+            using var form = new Form();
             Assert.False(form.Active);
             Assert.Null(form.ActiveMdiChild);
             Assert.False(form.AllowTransparency);
@@ -29,10 +32,27 @@ namespace System.Windows.Forms.Tests
             Assert.False(form.Visible);
         }
 
-        [Fact]
+        [WinFormsFact]
+        public static void Form_Ctor_show_icon_by_default()
+        {
+            using var form = new Form();
+            Assert.True(form.Handle != IntPtr.Zero);
+
+            IntPtr hSmallIcon = User32.SendMessageW(form, User32.WM.GETICON, (IntPtr)User32.ICON.SMALL, IntPtr.Zero);
+            Assert.True(hSmallIcon != IntPtr.Zero);
+
+            IntPtr hLargeIcon = User32.SendMessageW(form, User32.WM.GETICON, (IntPtr)User32.ICON.BIG, IntPtr.Zero);
+            Assert.True(hLargeIcon != IntPtr.Zero);
+
+            // normal form doesn't have WS_EX.DLGMODALFRAME set, and show icon
+            User32.WS_EX extendedStyle = unchecked((User32.WS_EX)(long)User32.GetWindowLong(form, User32.GWL.EXSTYLE));
+            Assert.False(extendedStyle.HasFlag(User32.WS_EX.DLGMODALFRAME));
+        }
+
+        [WinFormsFact]
         public void Form_AcceptButtonGetSet()
         {
-            var form = new Form();
+            using var form = new Form();
             var mock = new Mock<IButtonControl>(MockBehavior.Strict);
             mock.Setup(x => x.NotifyDefault(It.IsAny<bool>()));
 
@@ -41,11 +61,11 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(mock.Object, form.AcceptButton);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void Form_Active_Set_GetReturnsExpected(bool value)
         {
-            var form = new Form
+            using var form = new Form
             {
                 Active = value
             };
@@ -70,11 +90,11 @@ namespace System.Windows.Forms.Tests
             Assert.False(Form.ActiveForm.Active);
         }*/
 
-        [Fact]
+        [WinFormsFact]
         public void Form_ActiveMdiChildInternalGetSet()
         {
-            var form = new Form();
-            var child = new Form();
+            using var form = new Form();
+            using var child = new Form();
 
             form.ActiveMdiChildInternal = child;
 
@@ -82,11 +102,11 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(child, form.ActiveMdiChildInternal);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void Form_ActiveMdiChildGetSet()
         {
-            var form = new Form();
-            var child = new Form
+            using var form = new Form();
+            using var child = new Form
             {
                 Visible = true,
                 Enabled = true
@@ -98,11 +118,11 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(child, form.ActiveMdiChild);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void Form_ActiveMdiChildGetSetChildNotVisible()
         {
-            var form = new Form();
-            var child = new Form
+            using var form = new Form();
+            using var child = new Form
             {
                 Visible = false,
                 Enabled = true
@@ -113,11 +133,11 @@ namespace System.Windows.Forms.Tests
             Assert.Null(form.ActiveMdiChild);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void Form_ActiveMdiChildGetSetChildNotEnabled()
         {
-            var form = new Form();
-            var child = new Form
+            using var form = new Form();
+            using var child = new Form
             {
                 Visible = true,
                 Enabled = false

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
@@ -9,6 +9,7 @@ using Moq;
 using Xunit;
 using WinForms.Common.Tests;
 using static Interop;
+using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms.Tests
 {
@@ -38,15 +39,15 @@ namespace System.Windows.Forms.Tests
             using var form = new Form();
             Assert.True(form.Handle != IntPtr.Zero);
 
-            IntPtr hSmallIcon = User32.SendMessageW(form, User32.WM.GETICON, (IntPtr)User32.ICON.SMALL, IntPtr.Zero);
+            IntPtr hSmallIcon = User32.SendMessageW(form, WindowMessages.WM_GETICON, (IntPtr)NativeMethods.ICON_SMALL, IntPtr.Zero);
             Assert.True(hSmallIcon != IntPtr.Zero);
 
-            IntPtr hLargeIcon = User32.SendMessageW(form, User32.WM.GETICON, (IntPtr)User32.ICON.BIG, IntPtr.Zero);
+            IntPtr hLargeIcon = User32.SendMessageW(form, WindowMessages.WM_GETICON, (IntPtr)NativeMethods.ICON_BIG, IntPtr.Zero);
             Assert.True(hLargeIcon != IntPtr.Zero);
 
             // normal form doesn't have WS_EX.DLGMODALFRAME set, and show icon
-            User32.WS_EX extendedStyle = unchecked((User32.WS_EX)(long)User32.GetWindowLong(form, User32.GWL.EXSTYLE));
-            Assert.False(extendedStyle.HasFlag(User32.WS_EX.DLGMODALFRAME));
+            int extendedStyle = unchecked((int)(long)UnsafeNativeMethods.GetWindowLong(new HandleRef(form, form.Handle), NativeMethods.GWL_EXSTYLE));
+            Assert.True((extendedStyle & NativeMethods.WS_EX_DLGMODALFRAME) == 0);
         }
 
         [WinFormsFact]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3022


## Proposed changes

- Correct a regression introduced in #695 when a condition was flipped that stopped setting form's [extended style flag `WS_EX_DLGMODALFRAME`](https://docs.microsoft.com/en-us/windows/win32/winmsg/extended-window-styles).

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

Customers now able to hide form's icon at runtime by setting `myform.ShowIcon = false`.
Workarounds involve either 
* setting an icon on a form to a transparent blank icon, or 
* performing an interop call to hide the icon _before_ hiding the icon:
    ```cs
    if (myform.ShowIcon)
    {
        int extendedStyle = (int)User32.GetWindowLong(myform.Handle, User32.GWL.EXSTYLE);
        User32.SetWindowLong(myform.Handle, User32.GWL.EXSTYLE, (IntPtr)(extendedStyle | (int)User32.WS_EX.DLGMODALFRAME));
    }

    myform.ShowIcon =false;
    ```

## Regression? 

- Yes, introduced in .NET Core 3.0

## Risk

- Minimal

<!-- end TELL-MODE -->




## Test methodology <!-- How did you ensure quality? -->

- manual tests in the integration test app
- unit tests


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3055)