### PR TITLE
Issue 2797 combo box selected item change forces handle creating

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -2799,6 +2799,11 @@ namespace System.Windows.Forms
             base.OnSelectedIndexChanged(e);
             ((EventHandler)Events[EVENT_SELECTEDINDEXCHANGED])?.Invoke(this, e);
 
+            if (!IsHandleCreated)
+            {
+                return;
+            }
+
             if (dropDownWillBeClosed)
             {
                 // This is after-closing selection - do not focus on the list item

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -952,6 +952,19 @@ namespace System.Windows.Forms.Tests
             Assert.False(exceptionThrown, "Getting accessible object for ComboBox item has thrown an exception.");
         }
 
+        [Fact]
+        public void ComboBox_SelectedIndexChanged_Doesnt_force_Handle_creating()
+        {
+            string[] items = new[] { "Item 1", "Item 2", "Item 3" };
+
+            var comboBox = new ComboBox();
+            Assert.False(comboBox.IsHandleCreated);
+
+            comboBox.Items.AddRange(items);
+            comboBox.SelectedItem = items[1];
+            Assert.False(comboBox.IsHandleCreated);
+        }
+
         public class HashNotImplementedObject
         {
             public override int GetHashCode()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #2797 
Relates to #3062


## Proposed changes

- Adding the test that reveals the issue with forcing control handle creation on changing SelectedItem and SelectedIndex of the ComboBox control.
- Adding the fix that prevents executing accessibility logic in case the control handle is not yet created and prevents preliminary handle creation (forcing handle creation) in this case.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Users will not experience side effects related to forcing preliminary handle creation.

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->
![Before](https://user-images.githubusercontent.com/23213980/79495280-0a206400-802d-11ea-965b-d90467d5caaf.gif)


### After

<!-- TODO -->
![After](https://user-images.githubusercontent.com/23213980/79495294-0d1b5480-802d-11ea-943e-f1c784a8d2a3.gif)



## Test methodology <!-- How did you ensure quality? -->

- Manual test.
- Unit test.
- Already tested and verified in 5.0 - no regression.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- <!-- use `dotnet --info` -->
Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.18363
 OS Platform: Windows
 RID:         win10-x64

.NET Core SDKs installed:
  3.1.100 [C:\Program Files\dotnet\sdk]
  3.1.200-preview-014883 [C:\Program Files\dotnet\sdk]
  3.1.201 [C:\Program Files\dotnet\sdk]

.NET Core runtimes installed:
  Microsoft.NETCore.App 3.1.3 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.WindowsDesktop.App 3.1.3 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3071)