### PR TITLE
Consolidate CHARFORMATW and CHARFORMAT2W

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.CHARFORMAT2W.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.CHARFORMAT2W.cs
@@ -11,7 +11,7 @@ internal partial class Interop
     internal static partial class Richedit
     {
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-        public unsafe struct CHARFORMATW
+        public unsafe struct CHARFORMAT2W
         {
             private const int LF_FACESIZE = 32;
 
@@ -24,7 +24,22 @@ internal partial class Interop
             public byte bCharSet;
             public byte bPitchAndFamily;
 
-            private fixed char _szFaceName[LF_FACESIZE];
+            public fixed char _szFaceName[LF_FACESIZE];
+
+            public ushort wWeight;
+            public short sSpacing;
+            public int crBackColor;
+            public int lcid;
+            public uint dwCookie;
+            public short sStyle;
+            public ushort wKerning;
+            public byte bUnderlineType;
+            public byte bAnimation;
+            public byte bRevAuthor;
+
+            // Only available in RichEdit 8.0
+            // public byte bUnderlineColor
+
             private Span<char> szFaceName
             {
                 get { fixed (char* c = _szFaceName) { return new Span<char>(c, LF_FACESIZE); } }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -256,31 +256,6 @@ namespace System.Windows.Forms
             }
         }
 
-        [StructLayout(LayoutKind.Sequential, Pack = 4)]
-        public class CHARFORMAT2A
-        {
-            public int cbSize = Marshal.SizeOf<CHARFORMAT2A>();
-            public Richedit.CFM dwMask;
-            public Richedit.CFE dwEffects;
-            public int yHeight = 0;
-            public int yOffset = 0;
-            public int crTextColor = 0;
-            public byte bCharSet = 0;
-            public byte bPitchAndFamily = 0;
-            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
-            public byte[] szFaceName = new byte[32];
-            public short wWeight = 0;
-            public short sSpacing = 0;
-            public int crBackColor = 0;
-            public int lcid = 0;
-            public int dwReserved = 0;
-            public short sStyle = 0;
-            public short wKerning = 0;
-            public byte bUnderlineType = 0;
-            public byte bAnimation = 0;
-            public byte bRevAuthor = 0;
-        }
-
         [StructLayout(LayoutKind.Sequential)]
         public class ENLINK
         {

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -70,10 +70,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.Kernel32, CharSet = CharSet.Auto)]
         public static extern void GetTempFileName(string tempDirName, string prefixName, int unique, StringBuilder sb);
 
-        // For RichTextBox
-        [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-        public static extern IntPtr SendMessage(HandleRef hWnd, User32.WM msg, IntPtr wParam, [In, Out, MarshalAs(UnmanagedType.LPStruct)] NativeMethods.CHARFORMAT2A lParam);
-
         [DllImport(Libraries.Oleacc, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern int CreateStdAccessibleObject(HandleRef hWnd, int objID, ref Guid refiid, [In, Out, MarshalAs(UnmanagedType.Interface)] ref object pAcc);
     }

--- a/src/System.Windows.Forms.Primitives/tests/Interop/Richedit/CHARFORMAT2WTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/Interop/Richedit/CHARFORMAT2WTests.cs
@@ -7,18 +7,18 @@ using static Interop.Richedit;
 
 namespace System.Windows.Forms.Tests.Interop.Richedit
 {
-    public class CHARFORMATWTests : IClassFixture<ThreadExceptionFixture>
+    public class CHARFORMAT2WTests : IClassFixture<ThreadExceptionFixture>
     {
         [Fact]
         public unsafe void CharFormat_Size()
         {
-            Assert.Equal(92, sizeof(CHARFORMATW));
+            Assert.Equal(116, sizeof(CHARFORMAT2W));
         }
 
         [Fact]
         public unsafe void CharFormat_FaceName()
         {
-            CHARFORMATW charFormat = default;
+            CHARFORMAT2W charFormat = default;
             charFormat.FaceName = "TwoFace";
             Assert.Equal("TwoFace", charFormat.FaceName.ToString());
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.cs
@@ -12756,6 +12756,54 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
+        public void Control_WndProc_InvokeImeNotifyCallCountWithoutHandle_Success()
+        {
+            using (new NoAssertContext())
+            {
+                using var control = new SubControl();
+                int imeModeChangedCallCount = 0;
+                control.ImeModeChanged += (sender, e) => imeModeChangedCallCount++;
+                var m = new Message
+                {
+                    Msg = (int)User32.WM.IME_NOTIFY,
+                    Result = (IntPtr)250
+                };
+                control.WndProc(ref m);
+                Assert.Equal(IntPtr.Zero, m.Result);
+                Assert.Equal(0, imeModeChangedCallCount);
+                Assert.False(control.IsHandleCreated);
+            }
+        }
+
+        [WinFormsFact]
+        public void Control_WndProc_InvokeImeNotifyCallCountWithHandle_Success()
+        {
+            using var control = new SubControl();
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            int invalidatedCallCount = 0;
+            control.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            control.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            control.HandleCreated += (sender, e) => createdCallCount++;
+
+            int imeModeChangedCallCount = 0;
+            control.ImeModeChanged += (sender, e) => imeModeChangedCallCount++;
+            var m = new Message
+            {
+                Msg = (int)User32.WM.IME_NOTIFY,
+                Result = (IntPtr)250
+            };
+            control.WndProc(ref m);
+            Assert.Equal(IntPtr.Zero, m.Result);
+            Assert.Equal(0, imeModeChangedCallCount);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+        }
+
+        [WinFormsFact]
         public void Control_WndProc_InvokeKillFocusWithoutHandle_Success()
         {
             using (new NoAssertContext())


### PR DESCRIPTION
## Proposed Changes
- Consolidate CHARFORMATW and CHARFORMAT2W

We only need one definition of `CHARFORMATW`, and that is the one with the most functionality, i.e. `CHARFORMAT2W`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3089)