### PR TITLE
Fix facade reference and unskip unit test

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
+++ b/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
@@ -14,8 +14,14 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Windows.Forms.csproj" />
     <ProjectReference Include="..\..\..\System.Design\src\System.Design.Facade.csproj" />
+    <ProjectReference Include="..\..\..\System.Drawing\src\System.Drawing.Facade.csproj" />
     <ProjectReference Include="..\..\..\System.Drawing.Design\src\System.Drawing.Design.Facade.csproj" />
     <ProjectReference Include="..\..\..\Common\tests\InternalUtilitiesForTests\InternalUtilitiesForTests.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- workaround for https://github.com/dotnet/sdk/issues/3254 -->
+    <Reference Include="$(BaseOutputPath)..\System.Drawing.Facade\$(Configuration)\$(TargetFramework)\System.Drawing.dll" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/DesignerAttributeTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/DesignerAttributeTests.cs
@@ -19,9 +19,6 @@ namespace System.Windows.Forms.Design.Tests
         private readonly ITestOutputHelper _output;
 
         private static readonly ImmutableHashSet<string> SkipList = ImmutableHashSet.Create(new string[] {
-            // https://github.com/dotnet/winforms/issues/2413
-            "System.Drawing.Design.UITypeEditor, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
-
             // https://github.com/dotnet/winforms/issues/2412
             "System.Windows.Forms.Design.ControlBindingsConverter, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
 


### PR DESCRIPTION
Fixes #2413

## Proposed changes

Add reference to System.Drawing facade in order to be able to unit-test it. If you don't do this you inherit the System.Drawing from shared framework `Microsoft.NetCore.App` which does not contain the same redirects as the WinForms version, in particular the `UITypeEditor` redirect is missing.

## Open questions

* In the issue discussion it was noted that WinForms should not update the facade versions to 5.0 but instead keep them at 4.0 like the shared framework does.
  * The facades don't contain any code, they'll always be a redirect of the Desktop Version for compatibility and not get any new stuff
  * WinForms and the shared framework should agree about versioning, if the base framework doesn't level its facades for 5.0 neither should do WinForms for facades its replacing.

  The versioning problem does not prevent fixing the unit tests so it could be split off into a separate issue

* The PR contains a workaround for dotnet/sdk#3254 - will create a follow-up issue to track removal of the workaround unless something better can be figured out

## Customer Impact

as is the PR has no customer impact

once we roll back the 5.0 versioning of System.Drawing and other facades this change is visible to users who already compiled against a 5.0 preview

## Regression? 

unclear, probably not (the regression part of not redirecting UITypeEditor should already have been fixed, we just couldn't test it)

## Risk

low, as-is the PR only affects unit tests

once we roll back the 5.0 versioning of System.Drawing and other facades there may be some risk of breaking people who already have been compiling against earlier 5.0 previews and built nuget packages and stuff, but thats probably acceptable since its a preview?

## Test methodology

skipped unit test now passes, test is now able to confirm what already was present in the product


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3098)