### PR TITLE
Fixing issue 3099 property descriptor grid entry accessible collapsed is incorrect

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
@@ -1290,7 +1290,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                         return UiaCore.ExpandCollapseState.Collapsed;
                     }
 
-                    if (_owningPropertyDescriptorGridEntry == propertyGridView.SelectedGridEntry && propertyGridView.DropDownVisible)
+                    if (_owningPropertyDescriptorGridEntry == propertyGridView.SelectedGridEntry &&
+                        ((_owningPropertyDescriptorGridEntry != null && _owningPropertyDescriptorGridEntry.InternalExpanded)
+                         || propertyGridView.DropDownVisible))
                     {
                         return UiaCore.ExpandCollapseState.Expanded;
                     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntryAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntryAccessibleObjectTests.cs
@@ -15,7 +15,7 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
         [WinFormsFact]
         public void PropertyDescriptorGridEntryAccessibleObject_Ctor_Default()
         {
-            var propertyGrid = new PropertyGrid();
+            using var propertyGrid = new PropertyGrid();
             var propertyDescriptorGridEntryTestEntity = new PropertyDescriptorGridEntryTestEntity(propertyGrid, null, false);
             var propertyDescriptorGridEntryAccessibleObject = propertyDescriptorGridEntryTestEntity.TestPropertyDescriptorGridEntryAccessibleObject;
 
@@ -31,7 +31,7 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
         [WinFormsFact]
         public void PropertyDescriptorGridEntryAccessibleObject_ExpandCollapseState_collapsed_by_default()
         {
-            var propertyGrid = new PropertyGrid();
+            using var propertyGrid = new PropertyGrid();
             var propertyDescriptorGridEntryTestEntity = new PropertyDescriptorGridEntryTestEntity(propertyGrid, null, false);
             var propertyDescriptorGridEntryAccessibleObject = propertyDescriptorGridEntryTestEntity.TestPropertyDescriptorGridEntryAccessibleObject;
 
@@ -42,8 +42,8 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
         [WinFormsFact]
         public void PropertyDescriptorGridEntryAccessibleObject_ExpandCollapseState_reflects_ExpandablePropertyState()
         {
-            Form form = new Form();
-            PropertyGrid propertyGrid = new PropertyGrid();
+            using Form form = new Form();
+            using PropertyGrid propertyGrid = new PropertyGrid();
             var testEntity = new TestEntity();
             testEntity.FontProperty = new Font(FontFamily.GenericSansSerif, 1);
             propertyGrid.SelectedObject = testEntity;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntryAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntryAccessibleObjectTests.cs
@@ -1,0 +1,107 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.PropertyGridInternal.Tests
+{
+    public class PropertyDescriptorGridEntryAccessibleObjectTests
+    {
+        [WinFormsFact]
+        public void PropertyDescriptorGridEntryAccessibleObject_Ctor_Default()
+        {
+            var propertyGrid = new PropertyGrid();
+            var propertyDescriptorGridEntryTestEntity = new PropertyDescriptorGridEntryTestEntity(propertyGrid, null, false);
+            var propertyDescriptorGridEntryAccessibleObject = propertyDescriptorGridEntryTestEntity.PropertyDescriptorGridEntryAccessibleObject;
+
+            Assert.NotNull(propertyDescriptorGridEntryAccessibleObject);
+
+            TypeInfo propertyDescriptorGridEntryAccessibleObjectTypeInfo = propertyDescriptorGridEntryAccessibleObject.GetType().GetTypeInfo();
+            FieldInfo owningPropertyDescriptorGridEntryField = propertyDescriptorGridEntryAccessibleObjectTypeInfo.GetDeclaredField("_owningPropertyDescriptorGridEntry");
+            var owningGridEntry = owningPropertyDescriptorGridEntryField.GetValue(propertyDescriptorGridEntryAccessibleObject);
+
+            Assert.Equal(propertyDescriptorGridEntryTestEntity, owningGridEntry);
+        }
+
+        [WinFormsFact]
+        public void PropertyDescriptorGridEntryAccessibleObject_ExpandCollapseState_collapsed_by_default()
+        {
+            var propertyGrid = new PropertyGrid();
+            var propertyDescriptorGridEntryTestEntity = new PropertyDescriptorGridEntryTestEntity(propertyGrid, null, false);
+            var propertyDescriptorGridEntryAccessibleObject = propertyDescriptorGridEntryTestEntity.PropertyDescriptorGridEntryAccessibleObject;
+
+            var expandCollapseState = propertyDescriptorGridEntryAccessibleObject.ExpandCollapseState;
+            Assert.Equal(UiaCore.ExpandCollapseState.Collapsed, expandCollapseState);
+        }
+
+        [WinFormsFact]
+        public void PropertyDescriptorGridEntryAccessibleObject_ExpandCollapseState_reflects_ExpandablePropertyState()
+        {
+            Form form = new Form();
+            PropertyGrid propertyGrid = new PropertyGrid();
+            var testEntity = new TestEntity();
+            testEntity.FontProperty = new Font(FontFamily.GenericSansSerif, 1);
+            propertyGrid.SelectedObject = testEntity;
+
+            form.Controls.Add(propertyGrid);
+
+            Type propertyGridType = typeof(PropertyGrid);
+            FieldInfo[] fields = propertyGridType.GetFields(
+                BindingFlags.NonPublic |
+                BindingFlags.Instance);
+            FieldInfo gridViewField = fields.First(f => f.Name == "gridView");
+            PropertyGridView propertyGridView = gridViewField.GetValue(propertyGrid) as PropertyGridView;
+            Type propertyGridViewType = typeof(PropertyGridView);
+            FieldInfo[] propertyGridViewFields = propertyGridViewType.GetFields(
+                BindingFlags.NonPublic |
+                BindingFlags.Instance);
+
+            int firstPropertyIndex = 1; // Index 0 corresponds to the category grid entry.
+            PropertyDescriptorGridEntry gridEntry = (PropertyDescriptorGridEntry)propertyGridView.AccessibilityGetGridEntries()[firstPropertyIndex];
+
+            FieldInfo selectedGridEntryField = propertyGridViewFields.First(f => f.Name == "selectedGridEntry");
+            var selectedGridEntry = selectedGridEntryField.GetValue(propertyGridView) as PropertyDescriptorGridEntry;
+            Assert.Equal(gridEntry.PropertyName, selectedGridEntry.PropertyName);
+
+            AccessibleObject selectedGridEntryAccessibleObject = gridEntry.AccessibilityObject;
+
+            gridEntry.InternalExpanded = false;
+            Assert.Equal(UiaCore.ExpandCollapseState.Collapsed, selectedGridEntryAccessibleObject.ExpandCollapseState);
+
+            gridEntry.InternalExpanded = true;
+            Assert.Equal(UiaCore.ExpandCollapseState.Expanded, selectedGridEntryAccessibleObject.ExpandCollapseState);
+        }
+
+        internal class PropertyDescriptorGridEntryTestEntity : PropertyDescriptorGridEntry
+        {
+            private PropertyDescriptorGridEntryAccessibleObject _accessibleObject { get; set; }
+
+            internal PropertyDescriptorGridEntryTestEntity(PropertyGrid ownerGrid, GridEntry peParent, bool hide)
+                : base(ownerGrid, peParent, hide)
+            {
+                _accessibleObject = new PropertyDescriptorGridEntryAccessibleObject(this);
+            }
+
+            public GridEntryAccessibleObject PropertyDescriptorGridEntryAccessibleObject
+            {
+                get
+                {
+                    return _accessibleObject;
+                }
+            }
+        }
+
+        internal class TestEntity
+        {
+            public Font FontProperty
+            {
+                get; set;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntryAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntryAccessibleObjectTests.cs
@@ -17,7 +17,7 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
         {
             var propertyGrid = new PropertyGrid();
             var propertyDescriptorGridEntryTestEntity = new PropertyDescriptorGridEntryTestEntity(propertyGrid, null, false);
-            var propertyDescriptorGridEntryAccessibleObject = propertyDescriptorGridEntryTestEntity.PropertyDescriptorGridEntryAccessibleObject;
+            var propertyDescriptorGridEntryAccessibleObject = propertyDescriptorGridEntryTestEntity.TestPropertyDescriptorGridEntryAccessibleObject;
 
             Assert.NotNull(propertyDescriptorGridEntryAccessibleObject);
 
@@ -33,7 +33,7 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
         {
             var propertyGrid = new PropertyGrid();
             var propertyDescriptorGridEntryTestEntity = new PropertyDescriptorGridEntryTestEntity(propertyGrid, null, false);
-            var propertyDescriptorGridEntryAccessibleObject = propertyDescriptorGridEntryTestEntity.PropertyDescriptorGridEntryAccessibleObject;
+            var propertyDescriptorGridEntryAccessibleObject = propertyDescriptorGridEntryTestEntity.TestPropertyDescriptorGridEntryAccessibleObject;
 
             var expandCollapseState = propertyDescriptorGridEntryAccessibleObject.ExpandCollapseState;
             Assert.Equal(UiaCore.ExpandCollapseState.Collapsed, expandCollapseState);
@@ -87,7 +87,7 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
                 _accessibleObject = new PropertyDescriptorGridEntryAccessibleObject(this);
             }
 
-            public GridEntryAccessibleObject PropertyDescriptorGridEntryAccessibleObject
+            public GridEntryAccessibleObject TestPropertyDescriptorGridEntryAccessibleObject
             {
                 get
                 {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3099


## Proposed changes

- Adding the test to reveal the issue with providing incorrect Collapsed/expanded accessible status for PropertyDescriptorGridEntries (like for expandable Font property).
- Fixing the issue with providing incorrect Collapsed/expanded accessible status for PropertyDescriptorGridEntries - with the fix if property row is expanded then Expanded accessible state is provided.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Screen reader users will be able to distinguish the state of expandable PropertyGrid entries (like Font).
- There will be no inaccuracy when providing accessible collapsed/expanded state for PropertyGrid entries.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->
![Before](https://user-images.githubusercontent.com/23213980/79867699-6dbcdf80-83e7-11ea-96de-b5f2a91d5a4d.png)

### After

<!-- TODO -->
![After](https://user-images.githubusercontent.com/23213980/79867706-71506680-83e7-11ea-9cc5-77df54dc0e6f.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual testing.
- Unit tests.
- Automation.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

<!-- use `dotnet --info` -->
C:\Users\v-milipi>dotnet --info
.NET Core SDK (reflecting any global.json):
 Version:   5.0.100-alpha.1.20073.10
 Commit:    29f4d693a9

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.18363
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\5.0.100-alpha1-05536\

Host (useful for support):
  Version: 5.0.0-alpha.1.20072.3
  Commit:  c3dc1fdfdc


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3109)