### PR TITLE
Fix: StringCollectionEditor Unable to Create Instance of Type System.String

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.cs
@@ -121,7 +121,9 @@ namespace System.ComponentModel.Design
                 }
             }
 
-            return TypeDescriptor.CreateInstance(host, itemType, null, null);
+            return itemType?.UnderlyingSystemType == typeof(string)
+                ? string.Empty
+                : TypeDescriptor.CreateInstance(host, itemType, null, null);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/CollectionEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/CollectionEditorTests.cs
@@ -344,11 +344,18 @@ namespace System.ComponentModel.Design.Tests
             mockComponentInitializer.Verify(d => d.InitializeNewComponent(null), Times.Once());
         }
 
-        [Fact]
-        public void CollectionEditor_CreateInstance_InvokeWithoutContext_ReturnsExpected()
+        public static IEnumerable<object[]> CreateInstance_InvokeWithoutContext_TestData()
+        {
+            yield return new object[] { typeof(int), 0  };
+            yield return new object[] { typeof(string), string.Empty };
+        }
+
+        [Theory]
+        [MemberData(nameof(CreateInstance_InvokeWithoutContext_TestData))]
+        public void CollectionEditor_CreateInstance_InvokeWithoutContext_ReturnsExpected(Type type, object expected)
         {
             var editor = new SubCollectionEditor(null);
-            Assert.Equal(0, editor.CreateInstance(typeof(int)));
+            Assert.Equal(expected, editor.CreateInstance(type));
         }
 
         [Fact]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Relates to issue mentioned in comments of #3049


## Proposed changes

- Explicit checks if `itemType` is of type `string` so user will still be able to create instances of a `string` if we don't have a mapping for the editor on the collection of `string` that the user is trying to invoke

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Customers will no longer see an error message when trying to create instances of `string` with an editor on a collection of `string` we don't have a mapping to


## Regression? 

- No

## Risk

- Low

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

**Error Message:**
![image](https://user-images.githubusercontent.com/30007367/79897115-16564980-83be-11ea-9464-fc23430b0bda.png)

### After

**Fixed error for the case we don't have mapping for an editor on the collection of string user is trying to invoke:**
![image](https://user-images.githubusercontent.com/30007367/79896737-96c87a80-83bd-11ea-9f7d-d5c60691eb2d.png)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Did some manual testing, but will need to be tested further


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3111)