### PR TITLE
Remove unnecessary coherency attributes and prepare for strict coherency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -15,53 +15,53 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
       <Sha>c409bd0d3d80d6c674bb99b3ec0b2c15a891112c</Sha>
     </Dependency>
     <!-- CoreFX via Core Setup -->
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-preview.4.20220.15" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-preview.4.20220.15">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>c409bd0d3d80d6c674bb99b3ec0b2c15a891112c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-preview.4.20220.15" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-preview.4.20220.15">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>c409bd0d3d80d6c674bb99b3ec0b2c15a891112c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-preview.4.20220.15" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-preview.4.20220.15">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>c409bd0d3d80d6c674bb99b3ec0b2c15a891112c</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="5.0.0-preview.4.20220.15" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.CodeDom" Version="5.0.0-preview.4.20220.15">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>c409bd0d3d80d6c674bb99b3ec0b2c15a891112c</Sha>
     </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-preview.4.20220.15" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-preview.4.20220.15">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>c409bd0d3d80d6c674bb99b3ec0b2c15a891112c</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="5.0.0-preview.4.20220.15" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Drawing.Common" Version="5.0.0-preview.4.20220.15">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>c409bd0d3d80d6c674bb99b3ec0b2c15a891112c</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="5.0.0-preview.4.20220.15" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Resources.Extensions" Version="5.0.0-preview.4.20220.15">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>c409bd0d3d80d6c674bb99b3ec0b2c15a891112c</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-preview.4.20220.15" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-preview.4.20220.15">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>c409bd0d3d80d6c674bb99b3ec0b2c15a891112c</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="5.0.0-preview.4.20220.15" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Security.Permissions" Version="5.0.0-preview.4.20220.15">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>c409bd0d3d80d6c674bb99b3ec0b2c15a891112c</Sha>
     </Dependency>
-    <Dependency Name="System.Windows.Extensions" Version="5.0.0-preview.4.20220.15" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Windows.Extensions" Version="5.0.0-preview.4.20220.15">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>c409bd0d3d80d6c674bb99b3ec0b2c15a891112c</Sha>
     </Dependency>
     <!-- CoreCLR via Core Setup -->
-    <Dependency Name="Microsoft.NET.Sdk.IL" Version="5.0.0-preview.4.20220.15" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="Microsoft.NET.Sdk.IL" Version="5.0.0-preview.4.20220.15">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>c409bd0d3d80d6c674bb99b3ec0b2c15a891112c</Sha>
       <SourceBuildId>5596</SourceBuildId>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.ILAsm" Version="5.0.0-preview.4.20220.15" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="Microsoft.NETCore.ILAsm" Version="5.0.0-preview.4.20220.15">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>c409bd0d3d80d6c674bb99b3ec0b2c15a891112c</Sha>
       <SourceBuildId>5596</SourceBuildId>
@@ -87,11 +87,11 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>bce0a98620c1c5a110b2bba9912f3d5929069c6b</Sha>
     </Dependency>
-    <Dependency Name="runtime.win-x64.Microsoft.NETCore.ILAsm" Version="5.0.0-preview.4.20220.15" CoherentParentDependency="Microsoft.NetCore.ILAsm">
+    <Dependency Name="runtime.win-x64.Microsoft.NETCore.ILAsm" Version="5.0.0-preview.4.20220.15">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>c409bd0d3d80d6c674bb99b3ec0b2c15a891112c</Sha>
     </Dependency>
-    <Dependency Name="runtime.win-x86.Microsoft.NETCore.ILAsm" Version="5.0.0-preview.4.20220.15" CoherentParentDependency="Microsoft.NetCore.ILAsm">
+    <Dependency Name="runtime.win-x86.Microsoft.NETCore.ILAsm" Version="5.0.0-preview.4.20220.15">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>c409bd0d3d80d6c674bb99b3ec0b2c15a891112c</Sha>
     </Dependency>


### PR DESCRIPTION
Remove the unnecessary coherency attributes. These coherency attributes
are not needed because the packages are produced in the same build as
the CPD parent.

This also prepares this repo for 'strict' coherency
https://github.com/dotnet/arcade/issues/5195. Strict coherency is
significantly simpler and resolves a few cases where legacy CPD can
downgrade dependencies in incremental servicing. It looks in the CPD
parent's version.details.xml file to find the the CPD dependency, then
updates to that version. In winforms case, the CPD's dependencies are not
dependended on within runtime's own build, and the CPD attribute should be removed.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3113)