### PR TITLE
Validate requested clipboard formats

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Clipboard.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Clipboard.cs
@@ -249,6 +249,11 @@ namespace System.Windows.Forms
 
         public static bool ContainsData(string format)
         {
+            if (string.IsNullOrWhiteSpace(format))
+            {
+                return false;
+            }
+
             IDataObject dataObject = Clipboard.GetDataObject();
             if (dataObject != null)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataFormats.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataFormats.cs
@@ -159,6 +159,11 @@ namespace System.Windows.Forms
         /// </summary>
         public static Format GetFormat(string format)
         {
+            if (string.IsNullOrWhiteSpace(format))
+            {
+                throw new ArgumentException(nameof(format));
+            }
+
             lock (s_internalSyncObject)
             {
                 EnsurePredefined();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataFormatsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataFormatsTests.cs
@@ -111,12 +111,23 @@ namespace System.Windows.Forms.Tests
         {
             yield return new object[] { null };
             yield return new object[] { string.Empty };
-            yield return new object[] { new string('a', 256) };
         }
 
         [Theory]
         [MemberData(nameof(GetFormat_InvalidString_TestData))]
-        public void DataFormats_GetFormat_NullOrEmptyString_ThrowsWin32Exception(string format)
+        public void DataFormats_GetFormat_NullOrEmptyString_ArgumentException(string format)
+        {
+            Assert.Throws<ArgumentException>(() => DataFormats.GetFormat(format));
+        }
+
+        public static IEnumerable<object[]> GetFormat_InvalidFormat_TestData()
+        {
+            yield return new object[] { new string('a', 256) };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetFormat_InvalidFormat_TestData))]
+        public void DataFormats_GetFormat_InvalidFormat_ThrowsWin32Exception(string format)
         {
             Assert.Throws<Win32Exception>(() => DataFormats.GetFormat(format));
         }


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Contributes to tests stability work.

## Proposed changes

Certain clipboard tests failed because they fed in `null` and empty string as formats. These would ultimately lead to failure when we attempted to register these formats with `RegisterClipboardFormatW` call.

```
[xUnit.net 00:00:09.54]     System.Windows.Forms.Tests.ClipboardTests.Clipboard_ContainsData_InvokeMultipleTimes_Success(format: "") [FAIL]
[xUnit.net 00:00:09.54]     System.Windows.Forms.Tests.ClipboardTests.Clipboard_ContainsData_InvokeMultipleTimes_Success(format: null) [FAIL]
  X System.Windows.Forms.Tests.ClipboardTests.Clipboard_ContainsData_InvokeMultipleTimes_Success(format: "") [3ms]
  Error Message:
   System.ComponentModel.Win32Exception : Clipboard format registration did not succeed.
  Stack Trace:
     at System.Windows.Forms.DataFormats.GetFormat(String format) in C:\Development\winforms\src\System.Windows.Forms\src\System\Windows\Forms\DataFormats.cs:line 188
   at System.Windows.Forms.DataObject.OleConverter.GetDataPresentInner(String format) in C:\Development\winforms\src\System.Windows.Forms\src\System\Windows\Forms\DataObject.cs:line 1764
   at System.Windows.Forms.DataObject.OleConverter.GetDataPresent(String format, Boolean autoConvert) in C:\Development\winforms\src\System.Windows.Forms\src\System\Windows\Forms\DataObject.cs:line 1782      
   at System.Windows.Forms.DataObject.GetDataPresent(String format, Boolean autoConvert) in C:\Development\winforms\src\System.Windows.Forms\src\System\Windows\Forms\DataObject.cs:line 229
   at System.Windows.Forms.Clipboard.ContainsData(String format) in C:\Development\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Clipboard.cs:line 255
   at System.Windows.Forms.Tests.ClipboardTests.Clipboard_ContainsData_InvokeMultipleTimes_Success(String format) in C:\Development\winforms\src\System.Windows.Forms\tests\UnitTests\System\Windows\Forms\ClipboardTests.cs:line 56

  X System.Windows.Forms.Tests.ClipboardTests.Clipboard_ContainsData_InvokeMultipleTimes_Success(format: null) [2ms]
  Error Message:
   System.ComponentModel.Win32Exception : Clipboard format registration did not succeed.
  Stack Trace:
     at System.Windows.Forms.DataFormats.GetFormat(String format) in C:\Development\winforms\src\System.Windows.Forms\src\System\Windows\Forms\DataFormats.cs:line 188
   at System.Windows.Forms.DataObject.OleConverter.GetDataPresentInner(String format) in C:\Development\winforms\src\System.Windows.Forms\src\System\Windows\Forms\DataObject.cs:line 1764
   at System.Windows.Forms.DataObject.OleConverter.GetDataPresent(String format, Boolean autoConvert) in C:\Development\winforms\src\System.Windows.Forms\src\System\Windows\Forms\DataObject.cs:line 1782      
   at System.Windows.Forms.DataObject.GetDataPresent(String format, Boolean autoConvert) in C:\Development\winforms\src\System.Windows.Forms\src\System\Windows\Forms\DataObject.cs:line 229
   at System.Windows.Forms.Clipboard.ContainsData(String format) in C:\Development\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Clipboard.cs:line 255
   at System.Windows.Forms.Tests.ClipboardTests.Clipboard_ContainsData_InvokeMultipleTimes_Success(String format) in C:\Development\winforms\src\System.Windows.Forms\tests\UnitTests\System\Windows\Forms\ClipboardTests.cs:line 56
                                                                                                                                                                                                                [xUnit.net 00:00:09.67]     System.Windows.Forms.Tests.ClipboardTests.Clipboard_GetDataObject_InvokeMultipleTimes_Success [FAIL]
```

Clamp down on this and ensure these formats are rejected up front.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Some customers may see it as a breaking changes, since instead of `Win32Exception` we'll now be throwing `ArgumentException` if `null`, empty string or whitespaces are passed in.

## Regression? 

- No

## Risk

- Minimal, handling of an edge-case scenario

<!-- end TELL-MODE -->




## Test methodology <!-- How did you ensure quality? -->

- existing `ClipboardTests` now succeed
- new tests to `DataFormatsTests`


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3115)