### PR TITLE
Remove dead code in TaskDialogPage.Bind()

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogPage.cs
@@ -849,16 +849,10 @@ namespace System.Windows.Forms
                 TaskDialogRadioButton radioButton = radioButtons[i];
                 flags |= radioButton.Bind(this, RadioButtonStartID + i);
 
-                if (radioButton.IsCreated)
+                // Validate() will already have verified that no more than one radio button is checked.
+                if (radioButton.IsCreated && radioButton.Checked)
                 {
-                    if (radioButton.Checked && defaultRadioButtonID == 0)
-                    {
-                        defaultRadioButtonID = radioButton.RadioButtonID;
-                    }
-                    else if (radioButton.Checked)
-                    {
-                        radioButton.Checked = false;
-                    }
+                    defaultRadioButtonID = radioButton.RadioButtonID;
                 }
             }
 


### PR DESCRIPTION
## Proposed changes

- Remove code which would set `TaskDialogRadioButton.Checked` to `false` after binding it, in case another radio button was already checked.
This code (`radioButton.Checked = false;`) will never execute since `TaskDialogPage.Validate()` will already have ensured that only a single button is checked. Additionally, that code would actually throw if executed here as the button has already been bound.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- None; the condition (more than one radio button is checked) cannot be met in the current code.

## Regression? 

- No

## Risk

-

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

- Manual testing and code review

Thanks!

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3119)