### PR TITLE
Fix: Incorrect Editor for StringCollection

### DIFF
--- a/src/System.Windows.Forms/src/System/Drawing/Design/UITypeEditor.cs
+++ b/src/System.Windows.Forms/src/System/Drawing/Design/UITypeEditor.cs
@@ -6,6 +6,7 @@
 
 using System.Collections;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Drawing.Imaging;
 using System.IO;
@@ -32,9 +33,8 @@ namespace System.Drawing.Design
 
                 // System.Windows.Forms type Editors
                 [typeof(string[])] = "System.Windows.Forms.Design.StringArrayEditor, " + AssemblyRef.SystemDesign,
-
-                // System.Windows.Forms type Editors
                 [typeof(Collection<string>)] = "System.Windows.Forms.Design.StringCollectionEditor, " + AssemblyRef.SystemDesign,
+                [typeof(StringCollection)] = "System.Windows.Forms.Design.StringCollectionEditor, " + AssemblyRef.SystemDesign,
 
                 // System.Drawing.Design type Editors
                 [typeof(Bitmap)] = "System.Drawing.Design.BitmapEditor, " + AssemblyRef.SystemDrawingDesign,


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3049 


## Proposed changes

- Add a mapping for `StringCollection` in `UITypeEditor`so correct editor opens 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Customers will see the correct editor for an editor on type `StringCollection`

## Regression? 

- Yes

## Risk

- Low

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->
**Incorrect Editor:**
![image](https://user-images.githubusercontent.com/30007367/79895874-70560f80-83bc-11ea-9887-3f15537e421d.png)

### After

<!-- TODO -->
**Correct Editor shown:**
![image](https://user-images.githubusercontent.com/30007367/79896267-012ceb00-83bd-11ea-854c-05d6fb0dc41e.png)


## Test methodology <!-- How did you ensure quality? -->

- manual testing


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3120)