### PR TITLE
make tests more robust

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
+++ b/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\..\..\System.Design\src\System.Design.Facade.csproj" />
     <ProjectReference Include="..\..\..\System.Drawing\src\System.Drawing.Facade.csproj" />
     <ProjectReference Include="..\..\..\System.Drawing.Design\src\System.Drawing.Design.Facade.csproj" />
+    <ProjectReference Include="..\..\..\System.Windows.Forms.Primitives\src\System.Windows.Forms.Primitives.csproj" />
     <ProjectReference Include="..\..\..\Common\tests\InternalUtilitiesForTests\InternalUtilitiesForTests.csproj" />
   </ItemGroup>
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -3642,8 +3642,7 @@ namespace System.Windows.Forms.Tests
             Assert.True(control.IsHandleCreated);
 
             Rectangle rect2 = control.GetItemRect(1);
-            Assert.True(rect2.X >= rect1.X + rect1.Width);
-            Assert.Equal(rect2.Y, rect1.Y);
+            Assert.True((rect2.X >= rect1.Right && rect2.Y == rect1.Y) || (rect2.X == rect1.X && rect2.Y >= rect1.Bottom));
             Assert.True(rect2.Width > 0);
             Assert.True(rect2.Height > 0);
             Assert.True(control.IsHandleCreated);
@@ -3677,8 +3676,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, createdCallCount);
 
             Rectangle rect2 = control.GetItemRect(1);
-            Assert.True(rect2.X >= rect1.X + rect1.Width);
-            Assert.Equal(rect2.Y, rect1.Y);
+            Assert.True((rect2.X >= rect1.Right && rect2.Y == rect1.Y) || (rect2.X == rect1.X && rect2.Y >= rect1.Bottom));
             Assert.True(rect2.Width > 0);
             Assert.True(rect2.Height > 0);
             Assert.True(control.IsHandleCreated);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendarTests.cs
@@ -583,16 +583,16 @@ namespace System.Windows.Forms.Tests
             {
                 CalendarDimensions = value
             };
-            Assert.True(calendar.CalendarDimensions.Width > 0 && calendar.CalendarDimensions.Width < 12);
-            Assert.True(calendar.CalendarDimensions.Height > 0 && calendar.CalendarDimensions.Height < 12);
-            Assert.NotEqual(value, calendar.CalendarDimensions);
+            Assert.True(calendar.CalendarDimensions.Width > 0 && calendar.CalendarDimensions.Width <= 12);
+            Assert.True(calendar.CalendarDimensions.Height > 0 && calendar.CalendarDimensions.Height <= 12);
             Assert.False(calendar.IsHandleCreated);
 
             // Set same.
+            var previousCalendarDimensions = calendar.CalendarDimensions;
             calendar.CalendarDimensions = value;
-            Assert.True(calendar.CalendarDimensions.Width > 0 && calendar.CalendarDimensions.Width < 12);
-            Assert.True(calendar.CalendarDimensions.Height > 0 && calendar.CalendarDimensions.Height < 12);
-            Assert.NotEqual(value, calendar.CalendarDimensions);
+            Assert.True(calendar.CalendarDimensions.Width > 0 && calendar.CalendarDimensions.Width <= 12);
+            Assert.True(calendar.CalendarDimensions.Height > 0 && calendar.CalendarDimensions.Height <= 12);
+            Assert.Equal(previousCalendarDimensions, calendar.CalendarDimensions);
             Assert.False(calendar.IsHandleCreated);
         }
 
@@ -641,19 +641,19 @@ namespace System.Windows.Forms.Tests
             calendar.HandleCreated += (sender, e) => createdCallCount++;
 
             calendar.CalendarDimensions = value;
-            Assert.True(calendar.CalendarDimensions.Width > 0 && calendar.CalendarDimensions.Width < 12);
-            Assert.True(calendar.CalendarDimensions.Height > 0 && calendar.CalendarDimensions.Height < 12);
-            Assert.NotEqual(value, calendar.CalendarDimensions);
+            Assert.True(calendar.CalendarDimensions.Width > 0 && calendar.CalendarDimensions.Width <= 12);
+            Assert.True(calendar.CalendarDimensions.Height > 0 && calendar.CalendarDimensions.Height <= 12);
             Assert.True(calendar.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
 
             // Set same.
+            var previousCalendarDimensions = calendar.CalendarDimensions;
             calendar.CalendarDimensions = value;
-            Assert.True(calendar.CalendarDimensions.Width > 0 && calendar.CalendarDimensions.Width < 12);
-            Assert.True(calendar.CalendarDimensions.Height > 0 && calendar.CalendarDimensions.Height < 12);
-            Assert.NotEqual(value, calendar.CalendarDimensions);
+            Assert.True(calendar.CalendarDimensions.Width > 0 && calendar.CalendarDimensions.Width <= 12);
+            Assert.True(calendar.CalendarDimensions.Height > 0 && calendar.CalendarDimensions.Height <= 12);
+            Assert.Equal(previousCalendarDimensions, calendar.CalendarDimensions);
             Assert.True(calendar.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
@@ -2335,7 +2335,7 @@ namespace System.Windows.Forms.Tests
             control.HandleCreated += (sender, e) => createdCallCount++;
 
             Size size = control.SingleMonthSize;
-            Assert.True(size.Width >= 176);
+            Assert.True(size.Width >= 169);
             Assert.True(size.Height >= 153);
             Assert.Equal(size, control.SingleMonthSize);
             Assert.True(control.IsHandleCreated);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripDropDownTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripDropDownTests.cs
@@ -139,7 +139,7 @@ namespace System.Windows.Forms.Tests
             Assert.IsType<ToolStripProfessionalRenderer>(control.Renderer);
             Assert.Equal(ToolStripRenderMode.ManagerRenderMode, control.RenderMode);
             Assert.True(control.ResizeRedraw);
-            Assert.Equal(2, control.Right);
+            Assert.Equal(SystemInformation.WorkingArea.X + 2, control.Right);
             Assert.Equal(RightToLeft.No, control.RightToLeft);
             Assert.True(control.ShowFocusCues);
             Assert.True(control.ShowItemToolTips);
@@ -1931,6 +1931,15 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(Location_Set_TestData))]
         public void ToolStripDropDown_Location_Set_GetReturnsExpected(Point value, Point expected, int expectedLocationChangedCallCount)
         {
+            if (value != Point.Empty)
+            {
+                expected.X = Math.Max(expected.X, SystemInformation.WorkingArea.X);
+                expected.Y = Math.Max(expected.Y, SystemInformation.WorkingArea.Y);
+
+                if (expectedLocationChangedCallCount == 0 && SystemInformation.WorkingArea.Location != Point.Empty)
+                    expectedLocationChangedCallCount = 1;
+            }
+
             using var control = new ToolStripDropDown();
             int moveCallCount = 0;
             int locationChangedCallCount = 0;


### PR DESCRIPTION
Fixes #3121

## Proposed changes
Make tests more robust against machine specific environments:
* taskbar not docked to the bottom
* having more than one monitor (or a real large monitor)
* having monitors with different DPI settings

## Customer Impact
- none outside of this repository, this only affects tests
- for developers on this repository, more people should be able to successfully run tests locally

## Regression? 
- arguably adding tests which are written against a specific machine are a regression ;-)

## Risk
- making tests slightly more tolerant may hide something, but its unlikely

## Test methodology
- running tests locally now succeeds
- manually debugging tests to make sure the changes are minimal invasive

## Test environment(s)
- a machine with two monitors having different DPIs
- secondary monitor placed to the right of the primary monitor
- task bar docket to the left on the primary monitor, to the right on secondary monitor


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3129)