### PR TITLE
Fix RichTextBox Rtf encoding

### DIFF
--- a/build-local.ps1
+++ b/build-local.ps1
@@ -242,7 +242,10 @@ try {
     # Detect the require version of NETCoreApp and see if we have it already
     [xml]$versionsProps = Get-Content -Raw -Path ./eng/Versions.props
     $value = $versionsProps.Project.PropertyGroup | Where-Object { $_['MicrosoftNETCoreAppRuntimewinx64PackageVersion'] -ne $null }
-    $netCoreAppVersion = $value.InnerText
+    if (!$value) {
+        throw "Unable to find Project.PropertyGroup.MicrosoftNETCoreAppRuntimewinx64PackageVersion element"
+    }
+    $netCoreAppVersion = $value.MicrosoftNETCoreAppRuntimewinx64PackageVersion
     $localNETCoreAppLocation = [System.IO.Path]::Combine($localSharedPath, 'Microsoft.NETCore.App', $netCoreAppVersion);
     $systemNETCoreAppLocation = [string][System.IO.Path]::Combine($(Get-SystemDotnetPath), 'shared\Microsoft.NETCore.App', $netCoreAppVersion);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -3084,7 +3084,7 @@ namespace System.Windows.Forms
                 str = str.Substring(0, nullTerminatedLength);
             }
 
-            // get the string into a byte array
+            // Get the string into a byte array
             byte[] encodedBytes;
             if ((flags & RichTextBoxConstants.SF_UNICODE) != 0)
             {
@@ -3092,8 +3092,10 @@ namespace System.Windows.Forms
             }
             else
             {
-                encodedBytes = Encoding.Default.GetBytes(str);
+                // Encode using the default code page.
+                encodedBytes = CodePagesEncodingProvider.Instance.GetEncoding(0).GetBytes(str);
             }
+
             editStream = new MemoryStream(encodedBytes.Length);
             editStream.Write(encodedBytes, 0, encodedBytes.Length);
             editStream.Position = 0;
@@ -3116,14 +3118,16 @@ namespace System.Windows.Forms
                 Debug.Assert(data != null, "StreamIn passed a null stream");
 
                 // If SF_RTF is requested then check for the RTF tag at the start
-                // of the file.  We don't load if the tag is not there
-                //
+                // of the file.  We don't load if the tag is not there.
+
                 if ((flags & RichTextBoxConstants.SF_RTF) != 0)
                 {
                     long streamStart = editStream.Position;
                     byte[] bytes = new byte[SZ_RTF_TAG.Length];
                     editStream.Read(bytes, (int)streamStart, SZ_RTF_TAG.Length);
-                    string str = Encoding.Default.GetString(bytes);
+
+                    // Encode using the default encoding.
+                    string str = CodePagesEncodingProvider.Instance.GetEncoding(0).GetString(bytes);
                     if (!SZ_RTF_TAG.Equals(str))
                     {
                         throw new ArgumentException(SR.InvalidFileFormat);
@@ -3134,6 +3138,7 @@ namespace System.Windows.Forms
                 }
 
                 int cookieVal = 0;
+
                 // set up structure to do stream operation
                 NativeMethods.EDITSTREAM es = new NativeMethods.EDITSTREAM();
                 if ((flags & RichTextBoxConstants.SF_UNICODE) != 0)
@@ -3223,9 +3228,10 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    result = Encoding.Default.GetString(bytes, 0, bytes.Length);
+                    // Convert from the current code page
+                    result = CodePagesEncodingProvider.Instance.GetEncoding(0).GetString(bytes, 0, bytes.Length);
                 }
-                // workaround ??? for
+
 
                 if (!string.IsNullOrEmpty(result) && (result[result.Length - 1] == '\0'))
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -3093,7 +3093,7 @@ namespace System.Windows.Forms
             else
             {
                 // Encode using the default code page.
-                encodedBytes = CodePagesEncodingProvider.Instance.GetEncoding(0).GetBytes(str);
+                encodedBytes = (CodePagesEncodingProvider.Instance.GetEncoding(0) ?? Encoding.UTF8).GetBytes(str);
             }
 
             editStream = new MemoryStream(encodedBytes.Length);
@@ -3127,7 +3127,7 @@ namespace System.Windows.Forms
                     editStream.Read(bytes, (int)streamStart, SZ_RTF_TAG.Length);
 
                     // Encode using the default encoding.
-                    string str = CodePagesEncodingProvider.Instance.GetEncoding(0).GetString(bytes);
+                    string str = (CodePagesEncodingProvider.Instance.GetEncoding(0) ?? Encoding.UTF8).GetString(bytes);
                     if (!SZ_RTF_TAG.Equals(str))
                     {
                         throw new ArgumentException(SR.InvalidFileFormat);
@@ -3229,7 +3229,7 @@ namespace System.Windows.Forms
                 else
                 {
                     // Convert from the current code page
-                    result = CodePagesEncodingProvider.Instance.GetEncoding(0).GetString(bytes, 0, bytes.Length);
+                    result = (CodePagesEncodingProvider.Instance.GetEncoding(0) ?? Encoding.UTF8).GetString(bytes, 0, bytes.Length);
                 }
 
 

--- a/src/System.Windows.Forms/tests/UnitTests/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/RichTextBoxTests.cs
@@ -44,7 +44,7 @@ namespace System.Windows.Forms.Tests
 
             Span<byte> output = stackalloc byte[16];
 
-            int currentCodePage = CodePagesEncodingProvider.Instance.GetEncoding(0).CodePage;
+            int currentCodePage = (CodePagesEncodingProvider.Instance.GetEncoding(0) ?? Encoding.UTF8).CodePage;
 
             // The non-lossy conversion of nbsp only works single byte Windows code pages (e.g. not Japanese).
             if (currentCodePage >= 1250 && currentCodePage <= 1258)

--- a/src/System.Windows.Forms/tests/UnitTests/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/RichTextBoxTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 namespace System.Windows.Forms.Tests
 {
     using System.Drawing;
+    using System.Text;
 
     public class RichTextBoxTests
     {
@@ -22,6 +23,34 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(int.MaxValue, rtb.MaxLength);
             Assert.True(rtb.Multiline);
             Assert.False(rtb.AutoSize);
+        }
+
+        [WinFormsFact]
+        public void RichTextBox_SetAnsiRtf_DoesNotCorrupt()
+        {
+            // RichTextBox.Rtf treats input as code page specific (i.e. not Unicode). To see
+            // that we're actually using the code page we'll set the text to 0xA0 (160 / nbsp) to see
+            // that we can get it back out. If the encoding is not done in the codepage we'll likely
+            // get multiple ASCII bytes back out. UTF-8, for example, encodes the .NET UTF-16 0x00A0 (160)
+            // to 0xC2 0xA0.
+
+            // Ultimately we should really update RichTextBox to always stream data in Unicode as
+            // we're hard-coded to load 4.1 (see RichTextBox.CreateParams).
+
+            using var control = new RichTextBox();
+
+            Span<char> input = stackalloc char[] { (char)0xA0 };
+            control.Rtf = $"{{\\rtf1\\ansi {input[0]}}}";
+
+            Span<byte> output = stackalloc byte[16];
+
+            int currentCodePage = CodePagesEncodingProvider.Instance.GetEncoding(0).CodePage;
+
+            // The non-lossy conversion of nbsp only works single byte Windows code pages (e.g. not Japanese).
+            if (currentCodePage >= 1250 && currentCodePage <= 1258)
+            {
+                Assert.Equal(input[0], control.Text[0]);
+            }
         }
     }
 }


### PR DESCRIPTION

Fixes #3032

Cherry-picked from 9729e9cd6d4289150969bc3b481518b71f37a086

<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

- .NET Core Encoding.Default gets UTF-8, not the default code page. Change our code to get the code page as we're sending data to the control as ASCII.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Customers who may have relied on the original behaviour of RTB to have ASCII as the default code page will be able to continue porting their apps to .NET Core 3.1.

## Regression? 

- Yes

## Risk

- Limited to RTB use in .NET Core 3.1

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

After assigning to `richTextBox.Rtf` some rtf code with nonbreaking space (160 char code), RichTextBox converts it to `\'c2\~` insted of `\~`.
![Snipaste_2020-04-02_15-01-27](https://user-images.githubusercontent.com/17767561/78247868-4bc0f300-74f4-11ea-9805-b74f9484ebcc.png)





###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3141)