### PR TITLE
Implement Collapsible/Collapsed for ListViewGroup

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,12 @@
+System.Windows.Forms.ListViewGroupCollapsedState.Default = 0 -> System.Windows.Forms.ListViewGroupCollapsedState
 System.Windows.Forms.VisualStyles.FontProperty.TextFont = 210 -> System.Windows.Forms.VisualStyles.FontProperty
+System.Windows.Forms.ListView.GroupCollapsedStateChanged -> System.EventHandler<System.Windows.Forms.ListViewGroupEventArgs>
+System.Windows.Forms.ListViewGroup.CollapsedState.get -> System.Windows.Forms.ListViewGroupCollapsedState
+System.Windows.Forms.ListViewGroup.CollapsedState.set -> void
+System.Windows.Forms.ListViewGroupCollapsedState
+System.Windows.Forms.ListViewGroupCollapsedState.Collapsed = 2 -> System.Windows.Forms.ListViewGroupCollapsedState
+System.Windows.Forms.ListViewGroupCollapsedState.Expanded = 1 -> System.Windows.Forms.ListViewGroupCollapsedState
+System.Windows.Forms.ListViewGroupEventArgs
+System.Windows.Forms.ListViewGroupEventArgs.GroupIndex.get -> int
+System.Windows.Forms.ListViewGroupEventArgs.ListViewGroupEventArgs(int groupIndex) -> void
+~virtual System.Windows.Forms.ListView.OnGroupCollapsedStateChanged(System.Windows.Forms.ListViewGroupEventArgs e) -> void

--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6707,4 +6707,7 @@ Stack trace where the illegal operation occurred was:
   <data name="WindowSubclassHandlerWndProcIsNotExceptedOne" xml:space="preserve">
     <value>The current window procedure is not the expected one.</value>
   </data>
+  <data name="ListViewGroupCollapsedStateChangedDescr" xml:space="preserve">
+    <value>Event raised when the CollapsedState property of a ListViewGroup changes.</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -6356,6 +6356,11 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">Zobrazí čáry mřížky kolem položek a podpoložek (SubItems). Projeví se pouze v zobrazení Details.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupCollapsedStateChangedDescr">
+        <source>Event raised when the CollapsedState property of a ListViewGroup changes.</source>
+        <target state="new">Event raised when the CollapsedState property of a ListViewGroup changes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupCollectionBadListViewGroup">
         <source>Parameter must be of type ListViewGroup.</source>
         <target state="translated">Parametr musí být typu ListViewGroup.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -6356,6 +6356,11 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">Zeigt Rasterlinien um Elemente und SubItems an (nur in der Details-Ansicht).</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupCollapsedStateChangedDescr">
+        <source>Event raised when the CollapsedState property of a ListViewGroup changes.</source>
+        <target state="new">Event raised when the CollapsedState property of a ListViewGroup changes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupCollectionBadListViewGroup">
         <source>Parameter must be of type ListViewGroup.</source>
         <target state="translated">Der Parametertyp muss ListViewGroup sein.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -6356,6 +6356,11 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">Muestra las líneas de la cuadrícula alrededor de los elementos y subelementos. Sólo se muestra en la vista de detalles.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupCollapsedStateChangedDescr">
+        <source>Event raised when the CollapsedState property of a ListViewGroup changes.</source>
+        <target state="new">Event raised when the CollapsedState property of a ListViewGroup changes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupCollectionBadListViewGroup">
         <source>Parameter must be of type ListViewGroup.</source>
         <target state="translated">El parámetro debe ser de tipo ListViewGroup.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -6356,6 +6356,11 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">Affiche un quadrillage autour des éléments et des SubItems. Affichage uniquement en mode Détails.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupCollapsedStateChangedDescr">
+        <source>Event raised when the CollapsedState property of a ListViewGroup changes.</source>
+        <target state="new">Event raised when the CollapsedState property of a ListViewGroup changes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupCollectionBadListViewGroup">
         <source>Parameter must be of type ListViewGroup.</source>
         <target state="translated">Le paramètre doit être de type ListViewGroup.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -6356,6 +6356,11 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">Visualizza linee della griglia attorno agli elementi e agli elementi secondari. Solo in visualizzazione Dettagli.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupCollapsedStateChangedDescr">
+        <source>Event raised when the CollapsedState property of a ListViewGroup changes.</source>
+        <target state="new">Event raised when the CollapsedState property of a ListViewGroup changes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupCollectionBadListViewGroup">
         <source>Parameter must be of type ListViewGroup.</source>
         <target state="translated">Il parametro deve essere di tipo ListViewGroup.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -6356,6 +6356,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">アイテムとサブアイテムの周りのグリッド線を表示します。詳細ビューでのみ表示されます。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupCollapsedStateChangedDescr">
+        <source>Event raised when the CollapsedState property of a ListViewGroup changes.</source>
+        <target state="new">Event raised when the CollapsedState property of a ListViewGroup changes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupCollectionBadListViewGroup">
         <source>Parameter must be of type ListViewGroup.</source>
         <target state="translated">パラメーターは、型 ListViewGroup でなければなりません。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -6356,6 +6356,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">항목과 하위 항목 주위에 모눈선을 표시합니다. 자세히 보기에서만 표시됩니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupCollapsedStateChangedDescr">
+        <source>Event raised when the CollapsedState property of a ListViewGroup changes.</source>
+        <target state="new">Event raised when the CollapsedState property of a ListViewGroup changes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupCollectionBadListViewGroup">
         <source>Parameter must be of type ListViewGroup.</source>
         <target state="translated">매개 변수는 ListViewGroup 형식이어야 합니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -6356,6 +6356,11 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">Wyświetla linie siatki wokół elementów i podelementów. Pokazywany tylko w widoku Details.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupCollapsedStateChangedDescr">
+        <source>Event raised when the CollapsedState property of a ListViewGroup changes.</source>
+        <target state="new">Event raised when the CollapsedState property of a ListViewGroup changes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupCollectionBadListViewGroup">
         <source>Parameter must be of type ListViewGroup.</source>
         <target state="translated">Parametr musi być typu ListViewGroup.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -6356,6 +6356,11 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">Exibe linhas de grade ao redor de itens e SubItems. Mostradas somente na exibição Detalhes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupCollapsedStateChangedDescr">
+        <source>Event raised when the CollapsedState property of a ListViewGroup changes.</source>
+        <target state="new">Event raised when the CollapsedState property of a ListViewGroup changes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupCollectionBadListViewGroup">
         <source>Parameter must be of type ListViewGroup.</source>
         <target state="translated">O parâmetro deve ser do tipo ListViewGroup.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -6357,6 +6357,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">Отображает линии сетки вокруг элементов и подэлементов. Действует только в представлении Details.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupCollapsedStateChangedDescr">
+        <source>Event raised when the CollapsedState property of a ListViewGroup changes.</source>
+        <target state="new">Event raised when the CollapsedState property of a ListViewGroup changes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupCollectionBadListViewGroup">
         <source>Parameter must be of type ListViewGroup.</source>
         <target state="translated">Параметр должен иметь тип ListViewGroup.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -6356,6 +6356,11 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">Öğelerin ve SubItem'ların etrafında kılavuz çizgileri görüntüler. Yalnızca Ayrıntı görünümünde gösterilir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupCollapsedStateChangedDescr">
+        <source>Event raised when the CollapsedState property of a ListViewGroup changes.</source>
+        <target state="new">Event raised when the CollapsedState property of a ListViewGroup changes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupCollectionBadListViewGroup">
         <source>Parameter must be of type ListViewGroup.</source>
         <target state="translated">Parametre ListViewGroup türünde olmalıdır.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -6356,6 +6356,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">在项和子项周围显示网格线。仅在“详细信息”视图中显示。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupCollapsedStateChangedDescr">
+        <source>Event raised when the CollapsedState property of a ListViewGroup changes.</source>
+        <target state="new">Event raised when the CollapsedState property of a ListViewGroup changes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupCollectionBadListViewGroup">
         <source>Parameter must be of type ListViewGroup.</source>
         <target state="translated">参数的类型必须是 ListViewGroup。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -6356,6 +6356,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">顯示項目與子項目周圍的格線。只有在詳細資料檢視中才顯示。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupCollapsedStateChangedDescr">
+        <source>Event raised when the CollapsedState property of a ListViewGroup changes.</source>
+        <target state="new">Event raised when the CollapsedState property of a ListViewGroup changes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupCollectionBadListViewGroup">
         <source>Parameter must be of type ListViewGroup.</source>
         <target state="translated">參數的類型必須為 ListViewGroup。</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -23,6 +24,7 @@ namespace System.Windows.Forms
         private HorizontalAlignment _headerAlignment = HorizontalAlignment.Left;
         private string? _footer;
         private HorizontalAlignment _footerAlignment = HorizontalAlignment.Left;
+        private ListViewGroupCollapsedState _collapsedState = ListViewGroupCollapsedState.Default;
 
         private ListView.ListViewItemCollection? _items;
 
@@ -157,6 +159,26 @@ namespace System.Windows.Forms
                 }
 
                 _footerAlignment = value;
+                UpdateListView();
+            }
+        }
+
+        /// <summary>
+        ///  Controls which <see cref="ListViewGroupCollapsedState"/> the group will appear as.
+        /// </summary>
+        [DefaultValue(ListViewGroupCollapsedState.Default)]
+        [SRCategory(nameof(SR.CatAppearance))]
+        public ListViewGroupCollapsedState CollapsedState
+        {
+            get => _collapsedState;
+            set
+            {
+                if (_collapsedState == value)
+                {
+                    return;
+                }
+
+                _collapsedState = value;
                 UpdateListView();
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupCollapsedState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupCollapsedState.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms
+{
+    /// <summary>
+    ///  Specifies the appearance of a <see cref="ListViewGroup"/>.
+    /// </summary>
+    public enum ListViewGroupCollapsedState
+    {
+        /// <summary>
+        ///  Non-collapsible group, expanded.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        ///  Collapsible group, expanded.
+        /// </summary>
+        Expanded,
+
+        /// <summary>
+        ///  Collapsible group, collapsed.
+        /// </summary>
+        Collapsed
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupEventArgs.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms
+{
+    /// <summary>
+    ///  Provides data for the <see cref='ListView.OnGroupCollapsedStateChanged'/> event.
+    /// </summary>
+    public class ListViewGroupEventArgs : EventArgs
+    {
+        /// <summary>
+        ///  Initializes a new instances of the <see cref="ListViewGroupEventArgs"/> class.
+        /// </summary>
+        /// <param name="groupIndex">The index of the <see cref="ListViewGroup"/> associated with the event.</param>
+        public ListViewGroupEventArgs(int groupIndex)
+        {
+            GroupIndex = groupIndex;
+        }
+
+        /// <summary>
+        ///  Gets the index of the <see cref="ListViewGroup"/> associated with the event.
+        /// </summary>
+        public int GroupIndex { get; }
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.Designer.cs
@@ -57,7 +57,8 @@ namespace WinformsControlsTest
             this.columnHeader2.ImageIndex = 1;
             // 
             // listView1
-            // 
+            //
+            this.listView1.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
             this.listView1.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.columnHeader1,
             this.columnHeader2});

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.cs
@@ -23,7 +23,7 @@ namespace WinformsControlsTest
             int i = random.Next(100, 300);
 
             Debug.WriteLine(listView1.TileSize);
-            listView1.TileSize = new Size(50, 50);
+            listView1.TileSize = new Size(200, 50);
             listView1.Items[0].ImageIndex = 0;
             listView1.Items[1].ImageIndex = 1;
             listView1.Items[2].ImageIndex = 2;
@@ -36,6 +36,8 @@ namespace WinformsControlsTest
                 var index = listView1.InsertionMark.NearestIndex(pos);
                 Console.WriteLine($"nearest index: {index}");
             };
+
+            AddCollapsibleGroupToListView();
         }
 
         private void CreateMyListView()
@@ -138,6 +140,42 @@ namespace WinformsControlsTest
             // Change a ListViewGroup's header.
             listView2.Groups[0].HeaderAlignment = HorizontalAlignment.Center;
             listView2.Groups[0].Header = "NewText";
+        }
+
+        private void AddCollapsibleGroupToListView()
+        {
+            var lvgroup1 = new ListViewGroup
+            {
+                Header = "CollapsibleGroup1",
+                CollapsedState = ListViewGroupCollapsedState.Expanded
+            };
+
+            listView1.Groups.Add(lvgroup1);
+            listView1.Items.Add(new ListViewItem
+            {
+                Text = "Item",
+                Group = lvgroup1
+            });
+
+            var lvgroup2 = new ListViewGroup
+            {
+                Header = "CollapsibleGroup2",
+                CollapsedState = ListViewGroupCollapsedState.Collapsed
+            };
+
+            listView1.Groups.Add(lvgroup2);
+            listView1.Items.Add(new ListViewItem
+            {
+                Text = "Item",
+                Group = lvgroup2
+            });
+
+            listView1.GroupCollapsedStateChanged += listView1_GroupCollapsedStateChanged;
+        }
+
+        private void listView1_GroupCollapsedStateChanged(object sender, ListViewGroupEventArgs e)
+        {
+            MessageBox.Show("CollapsedState changed at group with index " + e.GroupIndex);
         }
 
         private void listView2_Click(object sender, System.EventArgs e)

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.resx
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.resx
@@ -326,7 +326,7 @@
     <value>-4, 0</value>
   </data>
   <data name="listView1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>439, 212</value>
+    <value>439, 200</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
     <value>800, 408</value>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupEventArgsTests.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    // NB: doesn't require thread affinity
+    public class ListViewGroupEventArgsTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void Ctor_Int(int groupIndex)
+        {
+            var args = new ListViewGroupEventArgs(groupIndex);
+            Assert.Equal(groupIndex, args.GroupIndex);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3067 


## Proposed changes

- Add CollapsedState API to `ListViewGroup`

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Customers will have the ability to make their ListViewGroups collapsible and collapse/expand items in the group

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/30007367/80523089-62673800-8942-11ea-92a6-4b0e887ef200.png)

<!-- TODO -->

### After

![collapse2](https://user-images.githubusercontent.com/30007367/80524343-4e243a80-8944-11ea-8749-4529c305ae1c.gif)
<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Unit testing

## TODOs  <!-- Remove this section if PR does not change UI -->

- [ ]  Accessibility Improvements

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->

## Notes
- The user can either collapse item(s) through single click on chevron or double click on group header

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3155)