### PR TITLE
Cleanup DataObject.FormatEnumerator and add DataObject FormatEnumerator tests

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Clipboard.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Clipboard.cs
@@ -22,51 +22,6 @@ namespace System.Windows.Forms
     /// </summary>
     public static class Clipboard
     {
-        internal static bool IsFormatValid(ReadOnlySpan<string> formats)
-        {
-            if (formats.Length <= 4)
-            {
-                for (int i = 0; i < formats.Length; i++)
-                {
-                    switch (formats[i])
-                    {
-                        case "Text":
-                        case "UnicodeText":
-                        case "System.String":
-                        case "Csv":
-                            break;
-                        default:
-                            return false;
-                    }
-                }
-                return true;
-            }
-
-            return false;
-        }
-
-        internal static bool IsFormatValid(FORMATETC[] formats)
-        {
-            Debug.Assert(formats != null, "Null returned from GetFormats");
-            if (formats.Length <= 4)
-            {
-                for (int i = 0; i < formats.Length; i++)
-                {
-                    short format = formats[i].cfFormat;
-                    if (format != (short)User32.CF.TEXT &&
-                        format != (short)User32.CF.UNICODETEXT &&
-                        format != DataFormats.GetFormat("System.String").Id &&
-                        format != DataFormats.GetFormat("Csv").Id)
-                    {
-                        return false;
-                    }
-                }
-                return true;
-            }
-
-            return false;
-        }
-
         /// <summary>
         ///  Places nonpersistent data on the system <see cref='Clipboard'/>.
         /// </summary>
@@ -113,12 +68,6 @@ namespace System.Windows.Forms
             if (!(data is IComDataObject))
             {
                 dataObject = new DataObject(data);
-            }
-
-            // Compute the format of the "data" passed in iff setText == true;
-            if (dataObject != null)
-            {
-                dataObject.RestrictedFormats = false;
             }
 
             HRESULT hr;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.FormatEnumerator.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.FormatEnumerator.cs
@@ -37,14 +37,6 @@ namespace System.Windows.Forms
                 current = 0;
                 if (formats != null)
                 {
-                    if (parent is DataObject dataObject && dataObject.RestrictedFormats)
-                    {
-                        if (!Clipboard.IsFormatValid(formats))
-                        {
-                            throw new Security.SecurityException(SR.ClipboardSecurityException);
-                        }
-                    }
-
                     for (int i = 0; i < formats.Length; i++)
                     {
                         FORMATETC currentFormat = formats[i];
@@ -71,14 +63,6 @@ namespace System.Windows.Forms
 
                 if (formats != null)
                 {
-                    if (parent is DataObject dataObject && dataObject.RestrictedFormats)
-                    {
-                        if (!Clipboard.IsFormatValid(formats))
-                        {
-                            throw new Security.SecurityException(SR.ClipboardSecurityException);
-                        }
-                    }
-
                     for (int i = 0; i < formats.Length; i++)
                     {
                         string format = formats[i];
@@ -110,10 +94,7 @@ namespace System.Windows.Forms
                             temp.tymed = TYMED.TYMED_HGLOBAL;
                         }
 
-                        if (temp.tymed != 0)
-                        {
-                            this.formats.Add(temp);
-                        }
+                        this.formats.Add(temp);
                     }
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.FormatEnumerator.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.FormatEnumerator.cs
@@ -4,10 +4,9 @@
 
 #nullable disable
 
-using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Globalization;
 using System.Runtime.InteropServices.ComTypes;
 using static Interop;
 
@@ -20,46 +19,27 @@ namespace System.Windows.Forms
         /// </summary>
         private class FormatEnumerator : IEnumFORMATETC
         {
-            internal IDataObject parent = null;
-            internal ArrayList formats = new ArrayList();
-            internal int current = 0;
+            private IDataObject _parent;
+            private readonly List<FORMATETC> _formats = new List<FORMATETC>();
+            private int _current = 0;
 
             public FormatEnumerator(IDataObject parent) : this(parent, parent.GetFormats())
             {
                 Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "FormatEnumerator: Constructed: " + parent.ToString());
             }
 
-            public FormatEnumerator(IDataObject parent, FORMATETC[] formats)
+            private FormatEnumerator(FormatEnumerator source)
             {
-                Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "FormatEnumerator: Constructed: " + parent.ToString() + ", FORMATETC[]" + formats.Length.ToString(CultureInfo.InvariantCulture));
-                this.formats.Clear();
-                this.parent = parent;
-                current = 0;
-                if (formats != null)
-                {
-                    for (int i = 0; i < formats.Length; i++)
-                    {
-                        FORMATETC currentFormat = formats[i];
-
-                        FORMATETC temp = new FORMATETC
-                        {
-                            cfFormat = currentFormat.cfFormat,
-                            dwAspect = currentFormat.dwAspect,
-                            ptd = currentFormat.ptd,
-                            lindex = currentFormat.lindex,
-                            tymed = currentFormat.tymed
-                        };
-                        this.formats.Add(temp);
-                    }
-                }
+                _parent = source._parent;
+                _current = 0;
+                _formats.AddRange(source._formats);
             }
 
             public FormatEnumerator(IDataObject parent, string[] formats)
             {
-                Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "FormatEnumerator: Constructed: " + parent.ToString() + ", string[]" + formats.Length.ToString(CultureInfo.InvariantCulture));
+                Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, $"FormatEnumerator: Constructed: {parent}, string[{(formats?.Length ?? 0)}]");
 
-                this.parent = parent;
-                this.formats.Clear();
+                _parent = parent;
 
                 if (formats != null)
                 {
@@ -94,7 +74,7 @@ namespace System.Windows.Forms
                             temp.tymed = TYMED.TYMED_HGLOBAL;
                         }
 
-                        this.formats.Add(temp);
+                        _formats.Add(temp);
                     }
                 }
             }
@@ -102,9 +82,9 @@ namespace System.Windows.Forms
             public int Next(int celt, FORMATETC[] rgelt, int[] pceltFetched)
             {
                 Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "FormatEnumerator: Next");
-                if (this.current < formats.Count && celt > 0)
+                if (_current < _formats.Count && celt > 0)
                 {
-                    FORMATETC current = (FORMATETC)formats[this.current];
+                    FORMATETC current = (FORMATETC)_formats[_current];
                     rgelt[0].cfFormat = current.cfFormat;
                     rgelt[0].tymed = current.tymed;
                     rgelt[0].dwAspect = DVASPECT.DVASPECT_CONTENT;
@@ -115,7 +95,7 @@ namespace System.Windows.Forms
                     {
                         pceltFetched[0] = 1;
                     }
-                    this.current++;
+                    _current++;
                 }
                 else
                 {
@@ -131,27 +111,25 @@ namespace System.Windows.Forms
             public int Skip(int celt)
             {
                 Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "FormatEnumerator: Skip");
-                if (current + celt >= formats.Count)
+                if (_current + celt >= _formats.Count)
                 {
                     return (int)HRESULT.S_FALSE;
                 }
-                current += celt;
+                _current += celt;
                 return (int)HRESULT.S_OK;
             }
 
             public int Reset()
             {
                 Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "FormatEnumerator: Reset");
-                current = 0;
+                _current = 0;
                 return (int)HRESULT.S_OK;
             }
 
             public void Clone(out IEnumFORMATETC ppenum)
             {
                 Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "FormatEnumerator: Clone");
-                FORMATETC[] temp = new FORMATETC[formats.Count];
-                formats.CopyTo(temp, 0);
-                ppenum = new FormatEnumerator(parent, temp);
+                ppenum = new FormatEnumerator(this);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
@@ -39,7 +39,6 @@ namespace System.Windows.Forms
             TYMED.TYMED_GDI};
 
         private readonly IDataObject innerData = null;
-        internal bool RestrictedFormats { get; set; }
 
         // We use this to identify that a stream is actually a serialized object.  On read,
         // we don't know if the contents of a stream were saved "raw" or if the stream is really


### PR DESCRIPTION
## Proposed Changes
- Cleanup DataObject.FormatEnumerator and add DataObject FormatEnumerator tests
- Remove dead CAS code

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3189)