### PR TITLE
Cleanup Enum validation across winforms

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ByteViewer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ByteViewer.cs
@@ -669,7 +669,7 @@ namespace System.ComponentModel.Design
         /// </summary>
         public virtual void SetDisplayMode(DisplayMode mode)
         {
-            if (!ClientUtils.IsEnumValid(mode, (int)mode, (int)DisplayMode.Hexdump, (int)DisplayMode.Auto))
+            if (mode < DisplayMode.Hexdump || mode > DisplayMode.Auto)
             {
                 throw new InvalidEnumArgumentException("mode", (int)mode, typeof(DisplayMode));
             }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ClientUtils.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ClientUtils.cs
@@ -25,40 +25,10 @@ namespace System.Windows.Forms
                     || ex is AccessViolationException;
         }
 
-        // Sequential version
-        // assumes sequential enum members 0,1,2,3,4 -etc.
-        //
-        public static bool IsEnumValid(Enum enumValue, int value, int minValue, int maxValue)
-        {
-            bool valid = (value >= minValue) && (value <= maxValue);
-#if DEBUG
-            Debug_SequentialEnumIsDefinedCheck(enumValue, minValue, maxValue);
-#endif
-            return valid;
-        }
-
-        // Useful for sequential enum values which only use powers of two 0,1,2,4,8 etc: IsEnumValid(val, min, max, 1)
-        // Valid example: TextImageRelation 0,1,2,4,8 - only one bit can ever be on, and the value is between 0 and 8.
-        //
-        //   ClientUtils.IsEnumValid((int)(relation), /*min*/(int)TextImageRelation.None, (int)TextImageRelation.TextBeforeImage,1);
-        //
-        public static bool IsEnumValid(Enum enumValue, int value, int minValue, int maxValue, int maxNumberOfBitsOn)
-        {
-            System.Diagnostics.Debug.Assert(maxNumberOfBitsOn >= 0 && maxNumberOfBitsOn < 32, "expect this to be greater than zero and less than 32");
-
-            bool valid = (value >= minValue) && (value <= maxValue);
-            //Note: if it's 0, it'll have no bits on.  If it's a power of 2, it'll have 1.
-            valid = (valid && BitOperations.PopCount((uint)value) <= maxNumberOfBitsOn);
-#if DEBUG
-            Debug_NonSequentialEnumIsDefinedCheck(enumValue, minValue, maxValue, maxNumberOfBitsOn, valid);
-#endif
-            return valid;
-        }
-
         // Useful for enums that are a subset of a bitmask
         // Valid example: EdgeEffects  0, 0x800 (FillInterior), 0x1000 (Flat), 0x4000(Soft), 0x8000(Mono)
         //
-        //   ClientUtils.IsEnumValid((int)(effects), /*mask*/ FillInterior | Flat | Soft | Mono,
+        //   ClientUtils.IsEnumValid_Masked((int)(effects), /*mask*/ FillInterior | Flat | Soft | Mono,
         //          ,2);
         //
         public static bool IsEnumValid_Masked(Enum enumValue, int value, uint mask)
@@ -137,76 +107,6 @@ namespace System.Windows.Forms
             }
 
             return index + 1;
-        }
-
-#if DEBUG
-        [ThreadStatic]
-        private static Hashtable? enumValueInfo;
-        public const int MAXCACHE = 300;  // we think we're going to get O(100) of these, put in a tripwire if it gets larger.
-
-        private class SequentialEnumInfo
-        {
-            public SequentialEnumInfo(Type t)
-            {
-                int actualMinimum = int.MaxValue;
-                int actualMaximum = int.MinValue;
-                int countEnumVals = 0;
-
-                foreach (int iVal in Enum.GetValues(t))
-                {
-                    actualMinimum = Math.Min(actualMinimum, iVal);
-                    actualMaximum = Math.Max(actualMaximum, iVal);
-                    countEnumVals++;
-                }
-
-                if (countEnumVals - 1 != (actualMaximum - actualMinimum))
-                {
-                    Debug.Fail("this enum cannot be sequential.");
-                }
-                MinValue = actualMinimum;
-                MaxValue = actualMaximum;
-            }
-            public int MinValue;
-            public int MaxValue;
-        }
-
-        private static void Debug_SequentialEnumIsDefinedCheck(Enum value, int minVal, int maxVal)
-        {
-            Type t = value.GetType();
-
-            if (enumValueInfo is null)
-            {
-                enumValueInfo = new Hashtable();
-            }
-
-            SequentialEnumInfo? sequentialEnumInfo = null;
-
-            if (enumValueInfo.ContainsKey(t))
-            {
-                sequentialEnumInfo = enumValueInfo[t] as SequentialEnumInfo;
-            }
-            if (sequentialEnumInfo is null)
-            {
-                sequentialEnumInfo = new SequentialEnumInfo(t);
-
-                if (enumValueInfo.Count > MAXCACHE)
-                {
-                    // see comment next to MAXCACHE declaration.
-                    Debug.Fail("cache is too bloated, clearing out, we need to revisit this.");
-                    enumValueInfo.Clear();
-                }
-                enumValueInfo[t] = sequentialEnumInfo;
-            }
-            if (minVal != sequentialEnumInfo.MinValue)
-            {
-                // put string allocation in the IF block so the common case doesnt build up the string.
-                System.Diagnostics.Debug.Fail("Minimum passed in is not the actual minimum for the enum.  Consider changing the parameters or using a different function.");
-            }
-            if (maxVal != sequentialEnumInfo.MaxValue)
-            {
-                // put string allocation in the IF block so the common case doesnt build up the string.
-                Debug.Fail("Maximum passed in is not the actual maximum for the enum.  Consider changing the parameters or using a different function.");
-            }
         }
 
         private static void Debug_ValidateMask(Enum value, uint mask)

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ClientUtils.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ClientUtils.cs
@@ -42,32 +42,6 @@ namespace System.Windows.Forms
             return valid;
         }
 
-        // Useful for cases where you have discontiguous members of the enum.
-        // Valid example: AutoComplete source.
-        // if (!ClientUtils.IsEnumValid(value, AutoCompleteSource.None,
-        //                                            AutoCompleteSource.AllSystemSources
-        //                                            AutoCompleteSource.AllUrl,
-        //                                            AutoCompleteSource.CustomSource,
-        //                                            AutoCompleteSource.FileSystem,
-        //                                            AutoCompleteSource.FileSystemDirectories,
-        //                                            AutoCompleteSource.HistoryList,
-        //                                            AutoCompleteSource.ListItems,
-        //                                            AutoCompleteSource.RecentlyUsedList))
-        //
-        // PERF tip: put the default value in the enum towards the front of the argument list.
-        public static bool IsEnumValid_NotSequential(Enum enumValue, int value, params int[] enumValues)
-        {
-            Debug.Assert(Enum.GetValues(enumValue.GetType()).Length == enumValues.Length, "Not all the enum members were passed in.");
-            for (int i = 0; i < enumValues.Length; i++)
-            {
-                if (enumValues[i] == value)
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
         private enum CharType
         {
             None,
@@ -119,38 +93,6 @@ namespace System.Windows.Forms
             }
             System.Diagnostics.Debug.Assert(newmask == mask, "Mask not valid in IsEnumValid!");
         }
-
-        private static void Debug_NonSequentialEnumIsDefinedCheck(Enum value, int minVal, int maxVal, int maxBitsOn, bool isValid) {
-               Type t = value.GetType();
-               int actualMinimum = int.MaxValue;
-               int actualMaximum = int.MinValue;
-               int checkedValue = Convert.ToInt32(value, CultureInfo.InvariantCulture);
-               int maxBitsFound = 0;
-               bool foundValue = false;
-            foreach (int iVal in Enum.GetValues(t)){
-                actualMinimum = Math.Min(actualMinimum, iVal);
-                   actualMaximum = Math.Max(actualMaximum, iVal);
-                   maxBitsFound = Math.Max(maxBitsFound, BitOperations.PopCount((uint)iVal));
-                   if (checkedValue == iVal) {
-                       foundValue = true;
-                   }
-               }
-               if (minVal != actualMinimum) {
-                    // put string allocation in the IF block so the common case doesnt build up the string.
-                   System.Diagnostics.Debug.Fail( "Minimum passed in is not the actual minimum for the enum.  Consider changing the parameters or using a different function.");
-               }
-               if (maxVal != actualMaximum) {
-                    // put string allocation in the IF block so the common case doesnt build up the string.
-                   System.Diagnostics.Debug.Fail("Maximum passed in is not the actual maximum for the enum.  Consider changing the parameters or using a different function.");
-               }
-
-               if (maxBitsFound != maxBitsOn) {
-                   System.Diagnostics.Debug.Fail("Incorrect usage of IsEnumValid function. The bits set to 1 in this enum was found to be: " + maxBitsFound.ToString(CultureInfo.InvariantCulture) + "this does not match what's passed in: " + maxBitsOn.ToString(CultureInfo.InvariantCulture));
-               }
-               if (foundValue != isValid) {
-                    System.Diagnostics.Debug.Fail(string.Format(CultureInfo.InvariantCulture, "Returning {0} but we actually {1} found the value in the enum! Consider using a different overload to IsValidEnum.", isValid, ((foundValue) ? "have" : "have not")));
-               }
-           }
 #endif
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ClientUtils.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ClientUtils.cs
@@ -25,23 +25,6 @@ namespace System.Windows.Forms
                     || ex is AccessViolationException;
         }
 
-        // Useful for enums that are a subset of a bitmask
-        // Valid example: EdgeEffects  0, 0x800 (FillInterior), 0x1000 (Flat), 0x4000(Soft), 0x8000(Mono)
-        //
-        //   ClientUtils.IsEnumValid_Masked((int)(effects), /*mask*/ FillInterior | Flat | Soft | Mono,
-        //          ,2);
-        //
-        public static bool IsEnumValid_Masked(Enum enumValue, int value, uint mask)
-        {
-            bool valid = ((value & mask) == value);
-
-#if DEBUG
-            Debug_ValidateMask(enumValue, mask);
-#endif
-
-            return valid;
-        }
-
         private enum CharType
         {
             None,
@@ -82,17 +65,5 @@ namespace System.Windows.Forms
 
             return index + 1;
         }
-
-        private static void Debug_ValidateMask(Enum value, uint mask)
-        {
-            Type t = value.GetType();
-            uint newmask = 0;
-            foreach (int iVal in Enum.GetValues(t))
-            {
-                newmask |= (uint)iVal;
-            }
-            System.Diagnostics.Debug.Assert(newmask == mask, "Mask not valid in IsEnumValid!");
-        }
-#endif
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Button.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Button.cs
@@ -64,7 +64,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)AutoSizeMode.GrowAndShrink, (int)AutoSizeMode.GrowOnly))
+                if (value < AutoSizeMode.GrowAndShrink || value > AutoSizeMode.GrowOnly)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(AutoSizeMode));
                 }
@@ -177,7 +177,7 @@ namespace System.Windows.Forms
 
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)DialogResult.None, (int)DialogResult.No))
+                if (value < DialogResult.None || value > DialogResult.No)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DialogResult));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
@@ -8,6 +8,8 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Design;
+using System.Numerics;
+using System.Runtime.InteropServices;
 using System.Windows.Forms.ButtonInternal;
 using System.Windows.Forms.Layout;
 using static Interop;
@@ -276,15 +278,16 @@ namespace System.Windows.Forms
             }
             set
             {
+                if (value < FlatStyle.Flat || value > FlatStyle.System)
+                {
+                    throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(FlatStyle));
+                }
+
                 if (value == FlatStyle)
                 {
                     return;
                 }
 
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)FlatStyle.Flat, (int)FlatStyle.System))
-                {
-                    throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(FlatStyle));
-                }
                 _flatStyle = value;
                 LayoutTransaction.DoLayoutIf(AutoSize, ParentInternal, this, PropertyNames.FlatStyle);
                 Invalidate();
@@ -697,7 +700,7 @@ namespace System.Windows.Forms
             get => _textImageRelation;
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)TextImageRelation.Overlay, (int)TextImageRelation.TextBeforeImage, 1))
+                if (value < TextImageRelation.Overlay || value > TextImageRelation.TextBeforeImage || BitOperations.PopCount((uint)value) > 1)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(TextImageRelation));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckBox.cs
@@ -80,8 +80,7 @@ namespace System.Windows.Forms
 
             set
             {
-                //valid values are 0x0 to 0x1
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)Appearance.Normal, (int)Appearance.Button))
+                if (value < Appearance.Normal || value > Appearance.Button)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(Appearance));
                 }
@@ -209,7 +208,7 @@ namespace System.Windows.Forms
             set
             {
                 // valid values are 0-2 inclusive.
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)CheckState.Unchecked, (int)CheckState.Indeterminate))
+                if (value < CheckState.Unchecked || value > CheckState.Indeterminate)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(CheckState));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
@@ -229,8 +229,7 @@ namespace System.Windows.Forms
             get => base.SelectionMode;
             set
             {
-                //valid values are 0x0 to 0x3
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)SelectionMode.None, (int)SelectionMode.MultiExtended))
+                if (value < SelectionMode.None || value > SelectionMode.MultiExtended)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(SelectionMode));
                 }
@@ -904,7 +903,7 @@ namespace System.Windows.Forms
                 throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
             }
             // valid values are 0-2 inclusive.
-            if (!ClientUtils.IsEnumValid(value, (int)value, (int)CheckState.Unchecked, (int)CheckState.Indeterminate))
+            if (value < CheckState.Unchecked || value > CheckState.Indeterminate)
             {
                 throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(CheckState));
             }
@@ -1061,7 +1060,7 @@ namespace System.Windows.Forms
                 //validate the enum that's passed in here
                 //
                 // Valid values are 0-2 inclusive.
-                if (!ClientUtils.IsEnumValid(check, (int)check, (int)CheckState.Unchecked, (int)CheckState.Indeterminate))
+                if (check < CheckState.Unchecked || check > CheckState.Indeterminate)
                 {
                     throw new InvalidEnumArgumentException(nameof(check), (int)check, typeof(CheckState));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Clipboard.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Clipboard.cs
@@ -236,7 +236,7 @@ namespace System.Windows.Forms
 
         public static bool ContainsText(TextDataFormat format)
         {
-            if (!ClientUtils.IsEnumValid(format, (int)format, (int)TextDataFormat.Text, (int)TextDataFormat.CommaSeparatedValue))
+            if (format < TextDataFormat.Text || format > TextDataFormat.CommaSeparatedValue)
             {
                 throw new InvalidEnumArgumentException(nameof(format), (int)format, typeof(TextDataFormat));
             }
@@ -308,7 +308,7 @@ namespace System.Windows.Forms
 
         public static string GetText(TextDataFormat format)
         {
-            if (!ClientUtils.IsEnumValid(format, (int)format, (int)TextDataFormat.Text, (int)TextDataFormat.CommaSeparatedValue))
+            if (format < TextDataFormat.Text || format > TextDataFormat.CommaSeparatedValue)
             {
                 throw new InvalidEnumArgumentException(nameof(format), (int)format, typeof(TextDataFormat));
             }
@@ -419,7 +419,7 @@ namespace System.Windows.Forms
             {
                 throw new ArgumentNullException(nameof(text));
             }
-            if (!ClientUtils.IsEnumValid(format, (int)format, (int)TextDataFormat.Text, (int)TextDataFormat.CommaSeparatedValue))
+            if (format < TextDataFormat.Text || format > TextDataFormat.CommaSeparatedValue)
             {
                 throw new InvalidEnumArgumentException(nameof(format), (int)format, typeof(TextDataFormat));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
@@ -346,7 +346,7 @@ namespace System.Windows.Forms
             set
             {
                 // valid values are 0x0 to 0x2.
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)HorizontalAlignment.Left, (int)HorizontalAlignment.Center))
+                if (value < HorizontalAlignment.Left || value > HorizontalAlignment.Center)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(HorizontalAlignment));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -191,18 +191,20 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (!ClientUtils.IsEnumValid_NotSequential(value, (int)value,
-                                                    (int)AutoCompleteSource.None,
-                                                    (int)AutoCompleteSource.AllSystemSources,
-                                                    (int)AutoCompleteSource.AllUrl,
-                                                    (int)AutoCompleteSource.CustomSource,
-                                                    (int)AutoCompleteSource.FileSystem,
-                                                    (int)AutoCompleteSource.FileSystemDirectories,
-                                                    (int)AutoCompleteSource.HistoryList,
-                                                    (int)AutoCompleteSource.ListItems,
-                                                    (int)AutoCompleteSource.RecentlyUsedList))
+                switch (value)
                 {
-                    throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(AutoCompleteSource));
+                    case AutoCompleteSource.None:
+                    case AutoCompleteSource.AllSystemSources:
+                    case AutoCompleteSource.AllUrl:
+                    case AutoCompleteSource.CustomSource:
+                    case AutoCompleteSource.FileSystem:
+                    case AutoCompleteSource.FileSystemDirectories:
+                    case AutoCompleteSource.HistoryList:
+                    case AutoCompleteSource.ListItems:
+                    case AutoCompleteSource.RecentlyUsedList:
+                        break;
+                    default:
+                        throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(AutoCompleteSource));
                 }
 
                 if (DropDownStyle == ComboBoxStyle.DropDownList &&

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -150,8 +150,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                //valid values are 0x0 to 0x3
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)AutoCompleteMode.None, (int)AutoCompleteMode.SuggestAppend))
+                if (value < AutoCompleteMode.None || value > AutoCompleteMode.SuggestAppend)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(AutoCompleteMode));
                 }
@@ -455,8 +454,7 @@ namespace System.Windows.Forms
             {
                 if (DrawMode != value)
                 {
-                    //valid values are 0x0 to 0x2.
-                    if (!ClientUtils.IsEnumValid(value, (int)value, (int)DrawMode.Normal, (int)DrawMode.OwnerDrawVariable))
+                    if (value < DrawMode.Normal || value > DrawMode.OwnerDrawVariable)
                     {
                         throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DrawMode));
                     }
@@ -589,8 +587,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                //valid values are 0x0 to 0x3
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)FlatStyle.Flat, (int)FlatStyle.System))
+                if (value < FlatStyle.Flat || value > FlatStyle.System)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(FlatStyle));
                 }
@@ -1218,9 +1215,7 @@ namespace System.Windows.Forms
             {
                 if (DropDownStyle != value)
                 {
-                    // verify that 'value' is a valid enum type...
-                    //valid values are 0x0 to 0x2
-                    if (!ClientUtils.IsEnumValid(value, (int)value, (int)ComboBoxStyle.Simple, (int)ComboBoxStyle.DropDownList))
+                    if (value < ComboBoxStyle.Simple || value > ComboBoxStyle.DropDownList)
                     {
                         throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ComboBoxStyle));
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -160,7 +160,7 @@ namespace System.Windows.Forms
             get => _autoScaleMode;
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)AutoScaleMode.None, (int)AutoScaleMode.Inherit))
+                if (value < AutoScaleMode.None || value > AutoScaleMode.Inherit)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(AutoScaleMode));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.Ime.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.Ime.cs
@@ -239,8 +239,7 @@ namespace System.Windows.Forms
                 Debug.WriteLineIf(CompModSwitches.ImeMode.Level >= TraceLevel.Info, string.Format(CultureInfo.CurrentCulture, "Inside set_ImeModeBase({0}), this = {1}", value, this));
                 Debug.Indent();
 
-                //valid values are -1 to 0xb
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)ImeMode.Inherit, (int)ImeMode.OnHalf))
+                if (value < ImeMode.Inherit || value > ImeMode.OnHalf)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ImeMode));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -625,8 +625,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                //valid values are -1 to 0x40
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)AccessibleRole.Default, (int)AccessibleRole.OutlineButton))
+                if (value < AccessibleRole.Default || value > AccessibleRole.OutlineButton)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(AccessibleRole));
                 }
@@ -1018,7 +1017,7 @@ namespace System.Windows.Forms
                 if (BackgroundImageLayout != value)
                 {
                     // Valid values are 0x0 to 0x4
-                    if (!ClientUtils.IsEnumValid(value, (int)value, (int)ImageLayout.None, (int)ImageLayout.Zoom))
+                    if (value < ImageLayout.None || value > ImageLayout.Zoom)
                     {
                         throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ImageLayout));
                     }
@@ -3237,8 +3236,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                //valid values are 0x0 to 0x2.
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)RightToLeft.No, (int)RightToLeft.Inherit))
+                if (value < RightToLeft.No || value > RightToLeft.Inherit)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(RightToLeft));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -2346,7 +2346,6 @@ namespace System.Windows.Forms
 
         protected void AutoResizeRows(int rowIndexStart, int rowsCount, DataGridViewAutoSizeRowMode autoSizeRowMode, bool fixedWidth)
         {
-            // not using ClientUtils.IsEnumValid here because DataGridViewAutoSizeRowCriteriaInternal is a flags enum.
             if (((DataGridViewAutoSizeRowCriteriaInternal)autoSizeRowMode & InvalidDataGridViewAutoSizeRowCriteriaInternalMask) != 0)
             {
                 throw new InvalidEnumArgumentException(nameof(autoSizeRowMode), (int)autoSizeRowMode, typeof(DataGridViewAutoSizeRowMode));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -1133,7 +1133,7 @@ namespace System.Windows.Forms
             set
             {
                 // Sequential enum.  Valid values are 0x0 to 0x2
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)BorderStyle.None, (int)BorderStyle.Fixed3D))
+                if (value < BorderStyle.None || value > BorderStyle.Fixed3D)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(BorderStyle));
                 }
@@ -1290,7 +1290,7 @@ namespace System.Windows.Forms
             set
             {
                 // Sequential enum.  Valid values are 0x0 to 0xa
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)DataGridViewCellBorderStyle.Custom, (int)DataGridViewCellBorderStyle.SunkenHorizontal))
+                if (value < DataGridViewCellBorderStyle.Custom || value > DataGridViewCellBorderStyle.SunkenHorizontal)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DataGridViewCellBorderStyle));
                 }
@@ -1442,7 +1442,7 @@ namespace System.Windows.Forms
             set
             {
                 // Sequential enum.  Valid values are 0x0 to 0x3
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)DataGridViewClipboardCopyMode.Disable, (int)DataGridViewClipboardCopyMode.EnableAlwaysIncludeHeaderText))
+                if (value < DataGridViewClipboardCopyMode.Disable || value > DataGridViewClipboardCopyMode.EnableAlwaysIncludeHeaderText)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DataGridViewClipboardCopyMode));
                 }
@@ -1541,7 +1541,7 @@ namespace System.Windows.Forms
             set
             {
                 // Sequential enum.  Valid values are 0x0 to 0x4
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)DataGridViewHeaderBorderStyle.Custom, (int)DataGridViewHeaderBorderStyle.None))
+                if (value < DataGridViewHeaderBorderStyle.Custom || value > DataGridViewHeaderBorderStyle.None)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DataGridViewHeaderBorderStyle));
                 }
@@ -1710,7 +1710,7 @@ namespace System.Windows.Forms
             set
             {
                 // Sequential enum.  Valid values are 0x0 to 0x2
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)DataGridViewColumnHeadersHeightSizeMode.EnableResizing, (int)DataGridViewColumnHeadersHeightSizeMode.AutoSize))
+                if (value < DataGridViewColumnHeadersHeightSizeMode.EnableResizing || value > DataGridViewColumnHeadersHeightSizeMode.AutoSize)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DataGridViewColumnHeadersHeightSizeMode));
                 }
@@ -2277,7 +2277,7 @@ namespace System.Windows.Forms
             set
             {
                 // Sequential enum.  Valid values are 0x0 to 0x4
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)DataGridViewEditMode.EditOnEnter, (int)DataGridViewEditMode.EditProgrammatically))
+                if (value < DataGridViewEditMode.EditOnEnter || value > DataGridViewEditMode.EditProgrammatically)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DataGridViewEditMode));
                 }
@@ -3505,7 +3505,7 @@ namespace System.Windows.Forms
             set
             {
                 // Sequential enum.  Valid values are 0x0 to 0x4
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)DataGridViewHeaderBorderStyle.Custom, (int)DataGridViewHeaderBorderStyle.None))
+                if (value < DataGridViewHeaderBorderStyle.Custom || value > DataGridViewHeaderBorderStyle.None)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DataGridViewHeaderBorderStyle));
                 }
@@ -3720,7 +3720,7 @@ namespace System.Windows.Forms
             set
             {
                 // Sequential enum.  Valid values are 0x0 to 0x4
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)DataGridViewRowHeadersWidthSizeMode.EnableResizing, (int)DataGridViewRowHeadersWidthSizeMode.AutoSizeToFirstHeader))
+                if (value < DataGridViewRowHeadersWidthSizeMode.EnableResizing || value > DataGridViewRowHeadersWidthSizeMode.AutoSizeToFirstHeader)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DataGridViewRowHeadersWidthSizeMode));
                 }
@@ -3857,7 +3857,7 @@ namespace System.Windows.Forms
             set
             {
                 // Sequential enum.  Valid values are 0x0 to 0x3
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)ScrollBars.None, (int)ScrollBars.Both))
+                if (value < ScrollBars.None || value > ScrollBars.Both)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ScrollBars));
                 }
@@ -4007,7 +4007,7 @@ namespace System.Windows.Forms
             set
             {
                 // Sequential enum.  Valid values are 0x0 to 0x4
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)DataGridViewSelectionMode.CellSelect, (int)DataGridViewSelectionMode.ColumnHeaderSelect))
+                if (value < DataGridViewSelectionMode.CellSelect || value > DataGridViewSelectionMode.ColumnHeaderSelect)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DataGridViewSelectionMode));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAdvancedBorderStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAdvancedBorderStyle.cs
@@ -56,7 +56,7 @@ namespace System.Windows.Forms
             set
             {
                 // Sequential enum.  Valid values are 0x0 to 0x7
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)DataGridViewAdvancedCellBorderStyle.NotSet, (int)DataGridViewAdvancedCellBorderStyle.OutsetPartial))
+                if (value < DataGridViewAdvancedCellBorderStyle.NotSet || value > DataGridViewAdvancedCellBorderStyle.OutsetPartial)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DataGridViewAdvancedCellBorderStyle));
                 }
@@ -92,7 +92,7 @@ namespace System.Windows.Forms
             set
             {
                 // Sequential enum.  Valid values are 0x0 to 0x7
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)DataGridViewAdvancedCellBorderStyle.NotSet, (int)DataGridViewAdvancedCellBorderStyle.OutsetPartial))
+                if (value < DataGridViewAdvancedCellBorderStyle.NotSet || value > DataGridViewAdvancedCellBorderStyle.OutsetPartial)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DataGridViewAdvancedCellBorderStyle));
                 }
@@ -140,7 +140,7 @@ namespace System.Windows.Forms
             set
             {
                 // Sequential enum.  Valid values are 0x0 to 0x7
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)DataGridViewAdvancedCellBorderStyle.NotSet, (int)DataGridViewAdvancedCellBorderStyle.OutsetPartial))
+                if (value < DataGridViewAdvancedCellBorderStyle.NotSet || value > DataGridViewAdvancedCellBorderStyle.OutsetPartial)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DataGridViewAdvancedCellBorderStyle));
                 }
@@ -197,7 +197,7 @@ namespace System.Windows.Forms
             set
             {
                 // Sequential enum.  Valid values are 0x0 to 0x7
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)DataGridViewAdvancedCellBorderStyle.NotSet, (int)DataGridViewAdvancedCellBorderStyle.OutsetPartial))
+                if (value < DataGridViewAdvancedCellBorderStyle.NotSet || value > DataGridViewAdvancedCellBorderStyle.OutsetPartial)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DataGridViewAdvancedCellBorderStyle));
                 }
@@ -246,7 +246,7 @@ namespace System.Windows.Forms
             set
             {
                 // Sequential enum.  Valid values are 0x0 to 0x7
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)DataGridViewAdvancedCellBorderStyle.NotSet, (int)DataGridViewAdvancedCellBorderStyle.OutsetPartial))
+                if (value < DataGridViewAdvancedCellBorderStyle.NotSet || value > DataGridViewAdvancedCellBorderStyle.OutsetPartial)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DataGridViewAdvancedCellBorderStyle));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.cs
@@ -87,7 +87,7 @@ namespace System.Windows.Forms
             set
             {
                 // Sequential enum.  Valid values are 0x0 to 0x3
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)FlatStyle.Flat, (int)FlatStyle.System))
+                if (value < FlatStyle.Flat || value > FlatStyle.System)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(FlatStyle));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyle.cs
@@ -499,7 +499,7 @@ namespace System.Windows.Forms
             set
             {
                 // Sequential enum.  Valid values are 0x0 to 0x2
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)DataGridViewTriState.NotSet, (int)DataGridViewTriState.False))
+                if (value < DataGridViewTriState.NotSet || value > DataGridViewTriState.False)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DataGridViewTriState));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.cs
@@ -271,7 +271,7 @@ namespace System.Windows.Forms
             set
             {
                 // Sequential enum.  Valid values are 0x0 to 0x3
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)FlatStyle.Flat, (int)FlatStyle.System))
+                if (value < FlatStyle.Flat || value > FlatStyle.System)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(FlatStyle));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.cs
@@ -76,7 +76,7 @@ namespace System.Windows.Forms
             set
             {
                 // Sequential enum.  Valid values are 0x0 to 0x2
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)SortOrder.None, (int)SortOrder.Descending))
+                if (value < SortOrder.None || value > SortOrder.Descending)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(SortOrder));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
@@ -298,7 +298,7 @@ namespace System.Windows.Forms
             set
             {
                 // Sequential enum.  Valid values are 0x0 to 0x2
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)DataGridViewComboBoxDisplayStyle.ComboBox, (int)DataGridViewComboBoxDisplayStyle.Nothing))
+                if (value < DataGridViewComboBoxDisplayStyle.ComboBox || value > DataGridViewComboBoxDisplayStyle.Nothing)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DataGridViewComboBoxDisplayStyle));
                 }
@@ -470,7 +470,7 @@ namespace System.Windows.Forms
             set
             {
                 // Sequential enum.  Valid values are 0x0 to 0x3
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)FlatStyle.Flat, (int)FlatStyle.System))
+                if (value < FlatStyle.Flat || value > FlatStyle.System)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(FlatStyle));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewImageCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewImageCell.cs
@@ -142,7 +142,7 @@ namespace System.Windows.Forms
             set
             {
                 // Sequential enum.  Valid values are 0x0 to 0x3
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)DataGridViewImageCellLayout.NotSet, (int)DataGridViewImageCellLayout.Zoom))
+                if (value < DataGridViewImageCellLayout.NotSet || value > DataGridViewImageCellLayout.Zoom)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DataGridViewImageCellLayout));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.cs
@@ -136,7 +136,7 @@ namespace System.Windows.Forms
             set
             {
                 // Sequential enum.  Valid values are 0x0 to 0x3
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)LinkBehavior.SystemDefault, (int)LinkBehavior.NeverUnderline))
+                if (value < LinkBehavior.SystemDefault || value > LinkBehavior.NeverUnderline)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(LinkBehavior));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
 using System.IO;
+using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using System.Runtime.Serialization;
@@ -279,8 +280,7 @@ namespace System.Windows.Forms
 
         public virtual bool ContainsText(TextDataFormat format)
         {
-            //valid values are 0x0 to 0x4
-            if (!ClientUtils.IsEnumValid(format, (int)format, (int)TextDataFormat.Text, (int)TextDataFormat.CommaSeparatedValue))
+            if (format < TextDataFormat.Text || format > TextDataFormat.CommaSeparatedValue)
             {
                 throw new InvalidEnumArgumentException(nameof(format), (int)format, typeof(TextDataFormat));
             }
@@ -315,8 +315,7 @@ namespace System.Windows.Forms
 
         public virtual string GetText(TextDataFormat format)
         {
-            //valid values are 0x0 to 0x4
-            if (!ClientUtils.IsEnumValid(format, (int)format, (int)TextDataFormat.Text, (int)TextDataFormat.CommaSeparatedValue))
+            if (format < TextDataFormat.Text || format > TextDataFormat.CommaSeparatedValue)
             {
                 throw new InvalidEnumArgumentException(nameof(format), (int)format, typeof(TextDataFormat));
             }
@@ -379,8 +378,7 @@ namespace System.Windows.Forms
                 throw new ArgumentNullException(nameof(textData));
             }
 
-            //valid values are 0x0 to 0x4
-            if (!ClientUtils.IsEnumValid(format, (int)format, (int)TextDataFormat.Text, (int)TextDataFormat.CommaSeparatedValue))
+            if (format < TextDataFormat.Text || format > TextDataFormat.CommaSeparatedValue)
             {
                 throw new InvalidEnumArgumentException(nameof(format), (int)format, typeof(TextDataFormat));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
@@ -8,6 +8,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
+using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Windows.Forms.Layout;
 using Microsoft.Win32;
@@ -551,8 +552,7 @@ namespace System.Windows.Forms
 
             set
             {
-                //valid values are 0x0 to 0x1
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)LeftRightAlignment.Left, (int)LeftRightAlignment.Right))
+                if (value < LeftRightAlignment.Left || value > LeftRightAlignment.Right)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(LeftRightAlignment));
                 }
@@ -603,8 +603,7 @@ namespace System.Windows.Forms
 
             set
             {
-                //valid values are 0x1, 0x2,0x4,0x8. max number of bits on at a time is 1
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)DateTimePickerFormat.Long, (int)DateTimePickerFormat.Custom, /*maxNumberOfBitsOn*/1))
+                if (value < DateTimePickerFormat.Long || value > DateTimePickerFormat.Custom  || BitOperations.PopCount((uint)value) > 1)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DateTimePickerFormat));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
@@ -127,7 +127,7 @@ namespace System.Windows.Forms
             get => _blinkRate == 0 ? ErrorBlinkStyle.NeverBlink : _blinkStyle;
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)ErrorBlinkStyle.BlinkIfDifferentError, (int)ErrorBlinkStyle.NeverBlink))
+                if (value < ErrorBlinkStyle.BlinkIfDifferentError || value > ErrorBlinkStyle.NeverBlink)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ErrorBlinkStyle));
                 }
@@ -1429,7 +1429,7 @@ namespace System.Windows.Forms
                 get => _iconAlignment;
                 set
                 {
-                    if (!ClientUtils.IsEnumValid(value, (int)value, (int)ErrorIconAlignment.TopLeft, (int)ErrorIconAlignment.BottomRight))
+                    if (value < ErrorIconAlignment.TopLeft || value > ErrorIconAlignment.BottomRight)
                     {
                         throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ErrorIconAlignment));
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -551,7 +551,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)AutoSizeMode.GrowAndShrink, (int)AutoSizeMode.GrowOnly))
+                if (value < AutoSizeMode.GrowAndShrink || value > AutoSizeMode.GrowOnly)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(AutoSizeMode));
                 }
@@ -676,7 +676,7 @@ namespace System.Windows.Forms
             get => (FormBorderStyle)formState[FormStateBorderStyle];
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)FormBorderStyle.None, (int)FormBorderStyle.SizableToolWindow))
+                if (value < FormBorderStyle.None || value > FormBorderStyle.SizableToolWindow)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(FormBorderStyle));
                 }
@@ -994,8 +994,7 @@ namespace System.Windows.Forms
 
             set
             {
-                //valid values are 0x0 to 0x7
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)DialogResult.None, (int)DialogResult.No))
+                if (value < DialogResult.None || value > DialogResult.No)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DialogResult));
                 }
@@ -1994,10 +1993,7 @@ namespace System.Windows.Forms
             {
                 if (SizeGripStyle != value)
                 {
-                    //do some bounds checking here
-                    //
-                    //valid values are 0x0 to 0x2
-                    if (!ClientUtils.IsEnumValid(value, (int)value, (int)SizeGripStyle.Auto, (int)SizeGripStyle.Hide))
+                    if (value < SizeGripStyle.Auto || value > SizeGripStyle.Hide)
                     {
                         throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(SizeGripStyle));
                     }
@@ -2024,8 +2020,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                //valid values are 0x0 to 0x4
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)FormStartPosition.Manual, (int)FormStartPosition.CenterParent))
+                if (value < FormStartPosition.Manual || value > FormStartPosition.CenterParent)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(FormStartPosition));
                 }
@@ -2330,7 +2325,7 @@ namespace System.Windows.Forms
             get => (FormWindowState)formState[FormStateWindowState];
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)FormWindowState.Normal, (int)FormWindowState.Maximized))
+                if (value < FormWindowState.Normal || value > FormWindowState.Maximized)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(FormWindowState));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.cs
@@ -89,7 +89,7 @@ namespace System.Windows.Forms
             get => GetAutoSizeMode();
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)AutoSizeMode.GrowAndShrink, (int)AutoSizeMode.GrowOnly))
+                if (value < AutoSizeMode.GrowAndShrink || value > AutoSizeMode.GrowOnly)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(AutoSizeMode));
                 }
@@ -190,8 +190,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                //valid values are 0x0 to 0x3
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)FlatStyle.Flat, (int)FlatStyle.System))
+                if (value < FlatStyle.Flat || value > FlatStyle.System)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(FlatStyle));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HelpProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HelpProvider.cs
@@ -231,7 +231,7 @@ namespace System.Windows.Forms
             {
                 throw new ArgumentNullException(nameof(ctl));
             }
-            if (!ClientUtils.IsEnumValid(navigator, (int)navigator, (int)HelpNavigator.Topic, (int)HelpNavigator.TopicId))
+            if (navigator < HelpNavigator.Topic || navigator > HelpNavigator.TopicId)
             {
                 throw new InvalidEnumArgumentException(nameof(navigator), (int)navigator, typeof(HelpNavigator));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
@@ -96,16 +96,16 @@ namespace System.Windows.Forms
             get => _colorDepth;
             set
             {
-                // ColorDepth is not conitguous - list the members instead.
-                if (!ClientUtils.IsEnumValid_NotSequential(value,
-                                                     (int)value,
-                                                    (int)ColorDepth.Depth4Bit,
-                                                    (int)ColorDepth.Depth8Bit,
-                                                    (int)ColorDepth.Depth16Bit,
-                                                    (int)ColorDepth.Depth24Bit,
-                                                    (int)ColorDepth.Depth32Bit))
+                switch (value)
                 {
-                    throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ColorDepth));
+                    case ColorDepth.Depth4Bit:
+                    case ColorDepth.Depth8Bit:
+                    case ColorDepth.Depth16Bit:
+                    case ColorDepth.Depth24Bit:
+                    case ColorDepth.Depth32Bit:
+                        break;
+                    default:
+                        throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ColorDepth));
                 }
 
                 if (_colorDepth == value)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
@@ -213,7 +213,7 @@ namespace System.Windows.Forms
             get => (BorderStyle)_labelState[s_stateBorderStyle];
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)BorderStyle.None, (int)BorderStyle.Fixed3D))
+                if (value < BorderStyle.None || value > BorderStyle.Fixed3D)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(BorderStyle));
                 }
@@ -325,8 +325,7 @@ namespace System.Windows.Forms
             get => (FlatStyle)_labelState[s_stateFlatStyle];
             set
             {
-                //valid values are 0x0 to 0x3
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)FlatStyle.Flat, (int)FlatStyle.System))
+                if (value < FlatStyle.Flat || value > FlatStyle.System)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(FlatStyle));
                 }
@@ -593,7 +592,7 @@ namespace System.Windows.Forms
             get => _liveSetting;
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)AutomationLiveSetting.Off, (int)AutomationLiveSetting.Assertive))
+                if (value < AutomationLiveSetting.Off || value > AutomationLiveSetting.Assertive)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(AutomationLiveSetting));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/CommonProperties.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/CommonProperties.cs
@@ -562,7 +562,7 @@ namespace System.Windows.Forms.Layout
 
             // If we are anchored we return DefaultDock
             value = mode == DockAnchorMode.Dock ? value : DefaultDock;
-            Debug.Assert(ClientUtils.IsEnumValid(value, (int)value, (int)DockStyle.None, (int)DockStyle.Fill), "Illegal value returned form xGetDock.");
+            Debug.Assert(Enum.IsDefined(typeof(DockStyle), value), "Illegal value returned form xGetDock.");
 
             Debug.Assert(mode == DockAnchorMode.Dock || value == DefaultDock,
                 "xGetDock needs to return the DefaultDock style when not docked.");
@@ -595,7 +595,7 @@ namespace System.Windows.Forms.Layout
         internal static void xSetDock(IArrangedElement element, DockStyle value)
         {
             Debug.Assert(value != xGetDock(element), "PERF: Caller should guard against setting Dock to original value.");
-            Debug.Assert(ClientUtils.IsEnumValid(value, (int)value, (int)DockStyle.None, (int)DockStyle.Fill), "Illegal value passed to xSetDock.");
+            Debug.Assert(Enum.IsDefined(typeof(DockStyle), value), "Illegal value passed to xSetDock.");
 
             BitVector32 state = GetLayoutState(element);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DockAndAnchorLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DockAndAnchorLayout.cs
@@ -757,7 +757,7 @@ namespace System.Windows.Forms.Layout
 
             if (GetDock(element) != value)
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)DockStyle.None, (int)DockStyle.Fill))
+                if (value < DockStyle.None || value > DockStyle.Fill)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DockStyle));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/FlowLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/FlowLayout.cs
@@ -312,7 +312,7 @@ namespace System.Windows.Forms.Layout
 
         public static void SetFlowDirection(IArrangedElement container, FlowDirection value)
         {
-            if (!ClientUtils.IsEnumValid(value, (int)value, (int)FlowDirection.LeftToRight, (int)FlowDirection.BottomUp))
+            if (value < FlowDirection.LeftToRight || value > FlowDirection.BottomUp)
             {
                 throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(FlowDirection));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
@@ -271,8 +271,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                //valid values are 0x0 to 0x3
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)LinkBehavior.SystemDefault, (int)LinkBehavior.NeverUnderline))
+                if (value < LinkBehavior.SystemDefault || value > LinkBehavior.NeverUnderline)
                 {
                     throw new InvalidEnumArgumentException(nameof(LinkBehavior), (int)value, typeof(LinkBehavior));
                 }
@@ -895,8 +894,7 @@ namespace System.Windows.Forms
 
             set
             {
-                //valid values are 0x0 to 0x7
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)DialogResult.None, (int)DialogResult.No))
+                if (value < DialogResult.None || value > DialogResult.No)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DialogResult));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -231,7 +231,7 @@ namespace System.Windows.Forms
             get => borderStyle;
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)BorderStyle.None, (int)BorderStyle.Fixed3D))
+                if (value < BorderStyle.None || value > BorderStyle.Fixed3D)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(BorderStyle));
                 }
@@ -418,8 +418,7 @@ namespace System.Windows.Forms
 
             set
             {
-                //valid values are 0x0 to 0x2
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)DrawMode.Normal, (int)DrawMode.OwnerDrawVariable))
+                if (value < DrawMode.Normal || value > DrawMode.OwnerDrawVariable)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DrawMode));
                 }
@@ -1044,7 +1043,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)SelectionMode.None, (int)SelectionMode.MultiExtended))
+                if (value < SelectionMode.None || value > SelectionMode.MultiExtended)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(SelectionMode));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -280,16 +280,17 @@ namespace System.Windows.Forms
 
             set
             {
-                // using this as ListViewAlignment has discontiguous values.
-                if (!ClientUtils.IsEnumValid_NotSequential(value,
-                                                (int)value,
-                                                (int)ListViewAlignment.Default,
-                                                (int)ListViewAlignment.Top,
-                                                (int)ListViewAlignment.Left,
-                                                (int)ListViewAlignment.SnapToGrid))
+                switch (value)
                 {
-                    throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ListViewAlignment));
+                    case ListViewAlignment.Default:
+                    case ListViewAlignment.Top:
+                    case ListViewAlignment.Left:
+                    case ListViewAlignment.SnapToGrid:
+                        break;
+                    default:
+                        throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ListViewAlignment));
                 }
+
                 if (alignStyle != value)
                 {
                     alignStyle = value;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -245,8 +245,7 @@ namespace System.Windows.Forms
 
             set
             {
-                //valid values are 0x0 to 0x2
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)ItemActivation.Standard, (int)ItemActivation.TwoClick))
+                if (value < ItemActivation.Standard || value > ItemActivation.TwoClick)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ItemActivation));
                 }
@@ -441,7 +440,7 @@ namespace System.Windows.Forms
             get => borderStyle;
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)BorderStyle.None, (int)BorderStyle.Fixed3D))
+                if (value < BorderStyle.None || value > BorderStyle.Fixed3D)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(BorderStyle));
                 }
@@ -1053,8 +1052,7 @@ namespace System.Windows.Forms
             get { return headerStyle; }
             set
             {
-                //valid values are 0x0 to 0x2
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)ColumnHeaderStyle.None, (int)ColumnHeaderStyle.Clickable))
+                if (value < ColumnHeaderStyle.None || value > ColumnHeaderStyle.Clickable)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ColumnHeaderStyle));
                 }
@@ -1573,8 +1571,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                //valid values are 0x0 to 0x2
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)SortOrder.None, (int)SortOrder.Descending))
+                if (value < SortOrder.None || value > SortOrder.Descending)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(SortOrder));
                 }
@@ -1896,8 +1893,7 @@ namespace System.Windows.Forms
 
                 FlipViewToLargeIconAndSmallIcon = false;
 
-                //valid values are 0x0 to 0x4
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)View.LargeIcon, (int)View.Tile))
+                if (value < View.LargeIcon || value > View.Tile)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(View));
                 }
@@ -3630,8 +3626,7 @@ namespace System.Windows.Forms
             {
                 throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
             }
-            //valid values are 0x0 to 0x3
-            if (!ClientUtils.IsEnumValid(portion, (int)portion, (int)ItemBoundsPortion.Entire, (int)ItemBoundsPortion.ItemOnly))
+            if (portion < ItemBoundsPortion.Entire || portion > ItemBoundsPortion.ItemOnly)
             {
                 throw new InvalidEnumArgumentException(nameof(portion), (int)portion, typeof(ItemBoundsPortion));
             }
@@ -3706,8 +3701,7 @@ namespace System.Windows.Forms
             {
                 throw new ArgumentOutOfRangeException(nameof(subItemIndex), subItemIndex, string.Format(SR.InvalidArgument, nameof(subItemIndex), subItemIndex));
             }
-            //valid values are 0x0 to 0x3
-            if (!ClientUtils.IsEnumValid(portion, (int)portion, (int)ItemBoundsPortion.Entire, (int)ItemBoundsPortion.ItemOnly))
+            if (portion < ItemBoundsPortion.Entire || portion > ItemBoundsPortion.ItemOnly)
             {
                 throw new InvalidEnumArgumentException(nameof(portion), (int)portion, typeof(ItemBoundsPortion));
             }
@@ -5251,8 +5245,7 @@ namespace System.Windows.Forms
                 throw new ArgumentOutOfRangeException(nameof(columnIndex), columnIndex, string.Format(SR.InvalidArgument, nameof(columnIndex), columnIndex));
             }
 
-            //valid values are 0x0 to 0x2
-            if (!ClientUtils.IsEnumValid(headerAutoResize, (int)headerAutoResize, (int)ColumnHeaderAutoResizeStyle.None, (int)ColumnHeaderAutoResizeStyle.ColumnContent))
+            if (headerAutoResize < ColumnHeaderAutoResizeStyle.None || headerAutoResize > ColumnHeaderAutoResizeStyle.ColumnContent)
             {
                 throw new InvalidEnumArgumentException(nameof(headerAutoResize), (int)headerAutoResize, typeof(ColumnHeaderAutoResizeStyle));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
@@ -120,7 +120,7 @@ namespace System.Windows.Forms
             get => _headerAlignment;
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)HorizontalAlignment.Left, (int)HorizontalAlignment.Center))
+                if (value < HorizontalAlignment.Left || value > HorizontalAlignment.Center)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(HorizontalAlignment));
                 }
@@ -171,7 +171,7 @@ namespace System.Windows.Forms
             get => _footerAlignment;
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)HorizontalAlignment.Left, (int)HorizontalAlignment.Center))
+                if (value < HorizontalAlignment.Left || value > HorizontalAlignment.Center)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(HorizontalAlignment));
                 }
@@ -205,7 +205,7 @@ namespace System.Windows.Forms
             get => _collapsedState;
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)ListViewGroupCollapsedState.Default, (int)ListViewGroupCollapsedState.Collapsed))
+                if (value < ListViewGroupCollapsedState.Default || value > ListViewGroupCollapsedState.Collapsed)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ListViewGroupCollapsedState));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MaskedTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MaskedTextBox.cs
@@ -412,8 +412,7 @@ namespace System.Windows.Forms
 
             set
             {
-                //valid values are 0x0 to 0x3
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)MaskFormat.ExcludePromptAndLiterals, (int)MaskFormat.IncludePromptAndLiterals))
+                if (value < MaskFormat.ExcludePromptAndLiterals || value > MaskFormat.IncludePromptAndLiterals)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(MaskFormat));
                 }
@@ -531,8 +530,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                //valid values are 0x0 to 0x2
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)InsertKeyMode.Default, (int)InsertKeyMode.Overwrite))
+                if (value < InsertKeyMode.Default || value > InsertKeyMode.Overwrite)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(InsertKeyMode));
                 }
@@ -1262,8 +1260,7 @@ namespace System.Windows.Forms
                 if (textAlign != value)
                 {
                     //verify that 'value' is a valid enum type...
-                    //valid values are 0x0 to 0x2
-                    if (!ClientUtils.IsEnumValid(value, (int)value, (int)HorizontalAlignment.Left, (int)HorizontalAlignment.Center))
+                    if (value < HorizontalAlignment.Left || value > HorizontalAlignment.Center)
                     {
                         throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(HorizontalAlignment));
                     }
@@ -1325,8 +1322,7 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                //valid values are 0x0 to 0x3
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)MaskFormat.ExcludePromptAndLiterals, (int)MaskFormat.IncludePromptAndLiterals))
+                if (value < MaskFormat.ExcludePromptAndLiterals || value > MaskFormat.IncludePromptAndLiterals)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(MaskFormat));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MessageBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MessageBox.cs
@@ -340,7 +340,7 @@ namespace System.Windows.Forms
                                              MessageBoxButtons buttons, MessageBoxIcon icon, MessageBoxDefaultButton defaultButton,
                                              MessageBoxOptions options, bool showHelp)
         {
-            if (!ClientUtils.IsEnumValid(buttons, (int)buttons, (int)MessageBoxButtons.OK, (int)MessageBoxButtons.RetryCancel))
+            if (buttons < MessageBoxButtons.OK || buttons > MessageBoxButtons.RetryCancel)
             {
                 throw new InvalidEnumArgumentException(nameof(buttons), (int)buttons, typeof(MessageBoxButtons));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
@@ -120,8 +120,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                //valid values are 0x0 to 0x3
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)ToolTipIcon.None, (int)ToolTipIcon.Error))
+                if (value < ToolTipIcon.None || value > ToolTipIcon.Error)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ToolTipIcon));
                 }
@@ -568,8 +567,7 @@ namespace System.Windows.Forms
                 throw new ArgumentException(SR.NotifyIconEmptyOrNullTipText);
             }
 
-            //valid values are 0x0 to 0x3
-            if (!ClientUtils.IsEnumValid(tipIcon, (int)tipIcon, (int)ToolTipIcon.None, (int)ToolTipIcon.Error))
+            if (tipIcon < ToolTipIcon.None || tipIcon > ToolTipIcon.Error)
             {
                 throw new InvalidEnumArgumentException(nameof(tipIcon), (int)tipIcon, typeof(ToolTipIcon));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Panel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Panel.cs
@@ -71,7 +71,7 @@ namespace System.Windows.Forms
             get => GetAutoSizeMode();
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)AutoSizeMode.GrowAndShrink, (int)AutoSizeMode.GrowOnly))
+                if (value < AutoSizeMode.GrowAndShrink || value > AutoSizeMode.GrowOnly)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(AutoSizeMode));
                 }
@@ -108,7 +108,7 @@ namespace System.Windows.Forms
             {
                 if (_borderStyle != value)
                 {
-                    if (!ClientUtils.IsEnumValid(value, (int)value, (int)BorderStyle.None, (int)BorderStyle.Fixed3D))
+                    if (value < BorderStyle.None || value > BorderStyle.Fixed3D)
                     {
                         throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(BorderStyle));
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
@@ -134,7 +134,7 @@ namespace System.Windows.Forms
             get => _borderStyle;
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)BorderStyle.None, (int)BorderStyle.Fixed3D))
+                if (value < BorderStyle.None || value > BorderStyle.Fixed3D)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(BorderStyle));
                 }
@@ -803,7 +803,7 @@ namespace System.Windows.Forms
             get => _sizeMode;
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)PictureBoxSizeMode.Normal, (int)PictureBoxSizeMode.Zoom))
+                if (value < PictureBoxSizeMode.Normal || value > PictureBoxSizeMode.Zoom)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(PictureBoxSizeMode));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ProgressBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ProgressBar.cs
@@ -104,7 +104,7 @@ namespace System.Windows.Forms
             {
                 if (_style != value)
                 {
-                    if (!ClientUtils.IsEnumValid(value, (int)value, (int)ProgressBarStyle.Blocks, (int)ProgressBarStyle.Marquee))
+                    if (value < ProgressBarStyle.Blocks || value > ProgressBarStyle.Marquee)
                     {
                         throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ProgressBarStyle));
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -1040,8 +1040,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                //valid values are 0x0 to 0x3
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)PropertySort.NoSort, (int)PropertySort.CategorizedAlphabetical))
+                if (value < PropertySort.NoSort || value > PropertySort.CategorizedAlphabetical)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(PropertySort));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RadioButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RadioButton.cs
@@ -107,8 +107,7 @@ namespace System.Windows.Forms
             {
                 if (appearance != value)
                 {
-                    //valid values are 0x0 to 0x1
-                    if (!ClientUtils.IsEnumValid(value, (int)value, (int)Appearance.Normal, (int)Appearance.Button))
+                    if (value < Appearance.Normal || value > Appearance.Button)
                     {
                         throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(Appearance));
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -793,8 +793,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                //valid values are 0x0 to 0x2
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)HorizontalAlignment.Left, (int)HorizontalAlignment.Center))
+                if (value < HorizontalAlignment.Left || value > HorizontalAlignment.Center)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(HorizontalAlignment));
                 }
@@ -2399,8 +2398,7 @@ namespace System.Windows.Forms
         /// </summary>
         public void LoadFile(string path, RichTextBoxStreamType fileType)
         {
-            //valid values are 0x0 to 0x4
-            if (!ClientUtils.IsEnumValid(fileType, (int)fileType, (int)RichTextBoxStreamType.RichText, (int)RichTextBoxStreamType.UnicodePlainText))
+            if (fileType < RichTextBoxStreamType.RichText || fileType > RichTextBoxStreamType.UnicodePlainText)
             {
                 throw new InvalidEnumArgumentException(nameof(fileType), (int)fileType, typeof(RichTextBoxStreamType));
             }
@@ -2425,7 +2423,7 @@ namespace System.Windows.Forms
             {
                 throw new ArgumentNullException(nameof(data));
             }
-            if (!ClientUtils.IsEnumValid(fileType, (int)fileType, (int)RichTextBoxStreamType.RichText, (int)RichTextBoxStreamType.UnicodePlainText))
+            if (fileType < RichTextBoxStreamType.RichText || fileType > RichTextBoxStreamType.UnicodePlainText)
             {
                 throw new InvalidEnumArgumentException(nameof(fileType), (int)fileType, typeof(RichTextBoxStreamType));
             }
@@ -2717,8 +2715,7 @@ namespace System.Windows.Forms
         /// </summary>
         public void SaveFile(string path, RichTextBoxStreamType fileType)
         {
-            //valid values are 0x0 to 0x4
-            if (!ClientUtils.IsEnumValid(fileType, (int)fileType, (int)RichTextBoxStreamType.RichText, (int)RichTextBoxStreamType.UnicodePlainText))
+            if (fileType < RichTextBoxStreamType.RichText || fileType > RichTextBoxStreamType.UnicodePlainText)
             {
                 throw new InvalidEnumArgumentException(nameof(fileType), (int)fileType, typeof(RichTextBoxStreamType));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -722,19 +722,18 @@ namespace System.Windows.Forms
             }
             set
             {
-                // we could be more clever here, but it doesnt seem like this would get set enough
-                // to warrant a clever bitmask.
-                if (!ClientUtils.IsEnumValid_NotSequential(value,
-                    (int)value,
-                    (int)RichTextBoxScrollBars.Both,
-                    (int)RichTextBoxScrollBars.None,
-                    (int)RichTextBoxScrollBars.Horizontal,
-                    (int)RichTextBoxScrollBars.Vertical,
-                    (int)RichTextBoxScrollBars.ForcedHorizontal,
-                    (int)RichTextBoxScrollBars.ForcedVertical,
-                    (int)RichTextBoxScrollBars.ForcedBoth))
+                switch (value)
                 {
-                    throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(RichTextBoxScrollBars));
+                    case RichTextBoxScrollBars.Both:
+                    case RichTextBoxScrollBars.None:
+                    case RichTextBoxScrollBars.Horizontal:
+                    case RichTextBoxScrollBars.Vertical:
+                    case RichTextBoxScrollBars.ForcedHorizontal:
+                    case RichTextBoxScrollBars.ForcedVertical:
+                    case RichTextBoxScrollBars.ForcedBoth:
+                        break;
+                    default:
+                        throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(RichTextBoxScrollBars));
                 }
 
                 if (value != ScrollBars)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
@@ -249,7 +249,7 @@ namespace System.Windows.Forms
             get => _borderStyle;
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)BorderStyle.None, (int)BorderStyle.Fixed3D))
+                if (value < BorderStyle.None || value > BorderStyle.Fixed3D)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(BorderStyle));
                 }
@@ -361,8 +361,7 @@ namespace System.Windows.Forms
 
             set
             {
-                //valid values are 0x0 to 0x2
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)FixedPanel.None, (int)FixedPanel.Panel2))
+                if (value < FixedPanel.None || value > FixedPanel.Panel2)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(FixedPanel));
                 }
@@ -438,8 +437,7 @@ namespace System.Windows.Forms
             get { return _orientation; }
             set
             {
-                //valid values are 0x0 to 0x1
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)Orientation.Horizontal, (int)Orientation.Vertical))
+                if (value < Orientation.Horizontal || value > Orientation.Vertical)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(Orientation));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.cs
@@ -194,7 +194,7 @@ namespace System.Windows.Forms
             get => borderStyle;
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)BorderStyle.None, (int)BorderStyle.Fixed3D))
+                if (value < BorderStyle.None || value > BorderStyle.Fixed3D)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(BorderStyle));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -116,8 +116,7 @@ namespace System.Windows.Forms
             {
                 if (_alignment != value)
                 {
-                    //valid values are 0x0 to 0x3
-                    if (!ClientUtils.IsEnumValid(value, (int)value, (int)TabAlignment.Top, (int)TabAlignment.Right))
+                    if (value < TabAlignment.Top || value > TabAlignment.Right)
                     {
                         throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(TabAlignment));
                     }
@@ -161,8 +160,7 @@ namespace System.Windows.Forms
             {
                 if (_appearance != value)
                 {
-                    //valid values are 0x0 to 0x2
-                    if (!ClientUtils.IsEnumValid(value, (int)value, (int)TabAppearance.Normal, (int)TabAppearance.FlatButtons))
+                    if (value < TabAppearance.Normal || value > TabAppearance.FlatButtons)
                     {
                         throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(TabAppearance));
                     }
@@ -418,8 +416,7 @@ namespace System.Windows.Forms
 
             set
             {
-                //valid values are 0x0 to 0x1
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)TabDrawMode.Normal, (int)TabDrawMode.OwnerDrawFixed))
+                if (value < TabDrawMode.Normal || value > TabDrawMode.OwnerDrawFixed)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(TabDrawMode));
                 }
@@ -785,8 +782,7 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                //valid values are 0x0 to 0x2
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)TabSizeMode.Normal, (int)TabSizeMode.Fixed))
+                if (value < TabSizeMode.Normal || value > TabSizeMode.Fixed)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(TabSizeMode));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutSettings.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutSettings.cs
@@ -72,8 +72,7 @@ namespace System.Windows.Forms
             get { return _borderStyle; }
             set
             {
-                //valid values are 0x0 to 0x6
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)TableLayoutPanelCellBorderStyle.None, (int)TableLayoutPanelCellBorderStyle.OutsetPartial))
+                if (value < TableLayoutPanelCellBorderStyle.None || value > TableLayoutPanelCellBorderStyle.OutsetPartial)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidArgument, nameof(CellBorderStyle), value));
                 }
@@ -205,8 +204,7 @@ namespace System.Windows.Forms
 
             set
             {
-                //valid values are 0x0 to 0x2
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)TableLayoutPanelGrowStyle.FixedSize, (int)TableLayoutPanelGrowStyle.AddColumns))
+                if (value < TableLayoutPanelGrowStyle.FixedSize || value > TableLayoutPanelGrowStyle.AddColumns)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidArgument, nameof(GrowStyle), value));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogExpander.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogExpander.cs
@@ -189,11 +189,7 @@ namespace System.Windows.Forms
             get => _expanderPosition;
             set
             {
-                if (!ClientUtils.IsEnumValid(
-                    value,
-                    (int)value,
-                    (int)TaskDialogExpanderPosition.AfterText,
-                    (int)TaskDialogExpanderPosition.AfterFootnote))
+                if (value < TaskDialogExpanderPosition.AfterText || value > TaskDialogExpanderPosition.AfterFootnote)
                 {
                     throw new InvalidEnumArgumentException(
                         nameof(value),

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogProgressBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogProgressBar.cs
@@ -75,11 +75,7 @@ namespace System.Windows.Forms
             get => _state;
             set
             {
-                if (!ClientUtils.IsEnumValid(
-                    value,
-                    (int)value,
-                    (int)TaskDialogProgressBarState.Normal,
-                    (int)TaskDialogProgressBarState.None))
+                if (value < TaskDialogProgressBarState.Normal || value > TaskDialogProgressBarState.None)
                 {
                     throw new InvalidEnumArgumentException(
                         nameof(value),

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
@@ -122,7 +122,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)AutoCompleteMode.None, (int)AutoCompleteMode.SuggestAppend))
+                if (value < AutoCompleteMode.None || value > AutoCompleteMode.SuggestAppend)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(AutoCompleteMode));
                 }
@@ -232,7 +232,7 @@ namespace System.Windows.Forms
             {
                 if (characterCasing != value)
                 {
-                    if (!ClientUtils.IsEnumValid(value, (int)value, (int)CharacterCasing.Normal, (int)CharacterCasing.Lower))
+                    if (value < CharacterCasing.Normal || value > CharacterCasing.Lower)
                     {
                         throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(CharacterCasing));
                     }
@@ -391,7 +391,7 @@ namespace System.Windows.Forms
             {
                 if (scrollBars != value)
                 {
-                    if (!ClientUtils.IsEnumValid(value, (int)value, (int)ScrollBars.None, (int)ScrollBars.Both))
+                    if (value < ScrollBars.None || value > ScrollBars.Both)
                     {
                         throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ScrollBars));
                     }
@@ -454,7 +454,7 @@ namespace System.Windows.Forms
             {
                 if (textAlign != value)
                 {
-                    if (!ClientUtils.IsEnumValid(value, (int)value, (int)HorizontalAlignment.Left, (int)HorizontalAlignment.Center))
+                    if (value < HorizontalAlignment.Left || value > HorizontalAlignment.Center)
                     {
                         throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(HorizontalAlignment));
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -353,7 +353,7 @@ namespace System.Windows.Forms
             {
                 if (borderStyle != value)
                 {
-                    if (!ClientUtils.IsEnumValid(value, (int)value, (int)BorderStyle.None, (int)BorderStyle.Fixed3D))
+                    if (value < BorderStyle.None || value > BorderStyle.Fixed3D)
                     {
                         throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(BorderStyle));
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -876,8 +876,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                //valid values are 0x0 to 0x1
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)ToolStripGripStyle.Hidden, (int)ToolStripGripStyle.Visible))
+                if (value < ToolStripGripStyle.Hidden || value > ToolStripGripStyle.Visible)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ToolStripGripStyle));
                 }
@@ -1264,8 +1263,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                //valid values are 0x0 to 0x4
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)ToolStripLayoutStyle.StackWithOverflow, (int)ToolStripLayoutStyle.Table))
+                if (value < ToolStripLayoutStyle.StackWithOverflow || value > ToolStripLayoutStyle.Table)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ToolStripLayoutStyle));
                 }
@@ -1665,8 +1663,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                //valid values are 0x0 to 0x3
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)ToolStripRenderMode.Custom, (int)ToolStripRenderMode.ManagerRenderMode))
+                if (value < ToolStripRenderMode.Custom || value > ToolStripRenderMode.ManagerRenderMode)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ToolStripRenderMode));
                 }
@@ -1816,8 +1813,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                //valid values are 0x0 to 0x3
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)ToolStripTextDirection.Inherit, (int)ToolStripTextDirection.Vertical270))
+                if (value < ToolStripTextDirection.Inherit || value > ToolStripTextDirection.Vertical270)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ToolStripTextDirection));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -12,6 +12,7 @@ using System.Drawing;
 using System.Drawing.Design;
 using System.Drawing.Imaging;
 using System.Globalization;
+using System.Numerics;
 using System.Windows.Forms.Layout;
 using static Interop;
 using IComDataObject = System.Runtime.InteropServices.ComTypes.IDataObject;
@@ -272,7 +273,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)AccessibleRole.Default, (int)AccessibleRole.OutlineButton))
+                if (value < AccessibleRole.Default || value > AccessibleRole.OutlineButton)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(AccessibleRole));
                 }
@@ -292,7 +293,7 @@ namespace System.Windows.Forms
             get => _alignment;
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)ToolStripItemAlignment.Left, (int)ToolStripItemAlignment.Right))
+                if (value < ToolStripItemAlignment.Left || value > ToolStripItemAlignment.Right)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ToolStripItemAlignment));
                 }
@@ -440,7 +441,7 @@ namespace System.Windows.Forms
             {
                 if (BackgroundImageLayout != value)
                 {
-                    if (!ClientUtils.IsEnumValid(value, (int)value, (int)ImageLayout.None, (int)ImageLayout.Zoom))
+                    if (value < ImageLayout.None || value > ImageLayout.Zoom)
                     {
                         throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ImageLayout));
                     }
@@ -587,7 +588,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)DockStyle.None, (int)DockStyle.Fill))
+                if (value < DockStyle.None || value > DockStyle.Fill)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DockStyle));
                 }
@@ -663,7 +664,7 @@ namespace System.Windows.Forms
             {
                 if (_displayStyle != value)
                 {
-                    if (!ClientUtils.IsEnumValid(value, (int)value, (int)ToolStripItemDisplayStyle.None, (int)ToolStripItemDisplayStyle.ImageAndText))
+                    if (value < ToolStripItemDisplayStyle.None || value > ToolStripItemDisplayStyle.ImageAndText)
                     {
                         throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ToolStripItemDisplayStyle));
                     }
@@ -1166,7 +1167,7 @@ namespace System.Windows.Forms
             get => _imageScaling;
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)ToolStripItemImageScaling.None, (int)ToolStripItemImageScaling.SizeToFit))
+                if (value < ToolStripItemImageScaling.None || value > ToolStripItemImageScaling.SizeToFit)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ToolStripItemImageScaling));
                 }
@@ -1289,7 +1290,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)MergeAction.Append, (int)MergeAction.MatchOnly))
+                if (value < MergeAction.Append || value > MergeAction.MatchOnly)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(MergeAction));
                 }
@@ -1513,7 +1514,7 @@ namespace System.Windows.Forms
             get => _overflow;
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)ToolStripItemOverflow.Never, (int)ToolStripItemOverflow.AsNeeded))
+                if (value < ToolStripItemOverflow.Never || value > ToolStripItemOverflow.AsNeeded)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ToolStripGripStyle));
                 }
@@ -1695,7 +1696,7 @@ namespace System.Windows.Forms
 
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)RightToLeft.No, (int)RightToLeft.Inherit))
+                if (value < RightToLeft.No || value > RightToLeft.Inherit)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(RightToLeft));
                 }
@@ -1947,7 +1948,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)ToolStripTextDirection.Inherit, (int)ToolStripTextDirection.Vertical270))
+                if (value < ToolStripTextDirection.Inherit || value > ToolStripTextDirection.Vertical270)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ToolStripTextDirection));
                 }
@@ -1966,7 +1967,7 @@ namespace System.Windows.Forms
             get => _textImageRelation;
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)TextImageRelation.Overlay, (int)TextImageRelation.TextBeforeImage, 1))
+                if (value < TextImageRelation.Overlay || value > TextImageRelation.TextBeforeImage || BitOperations.PopCount((uint)value) > 1)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(TextImageRelation));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripLabel.cs
@@ -137,8 +137,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                //valid values are 0x0 to 0x3
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)LinkBehavior.SystemDefault, (int)LinkBehavior.NeverUnderline))
+                if (value < LinkBehavior.SystemDefault || value > LinkBehavior.NeverUnderline)
                 {
                     throw new InvalidEnumArgumentException(nameof(LinkBehavior), (int)value, typeof(LinkBehavior));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.cs
@@ -556,7 +556,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)ToolStripManagerRenderMode.Custom, (int)ToolStripManagerRenderMode.Professional))
+                if (value < ToolStripManagerRenderMode.Custom || value > ToolStripManagerRenderMode.Professional)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ToolStripManagerRenderMode));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.cs
@@ -410,8 +410,7 @@ namespace System.Windows.Forms
 
             set
             {
-                //valid values are 0x0 to 0x2
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)CheckState.Unchecked, (int)CheckState.Indeterminate))
+                if (value < CheckState.Unchecked || value > CheckState.Indeterminate)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(CheckState));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripRendererSwitcher.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripRendererSwitcher.cs
@@ -99,8 +99,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                //valid values are 0x0 to 0x3
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)ToolStripRenderMode.Custom, (int)ToolStripRenderMode.ManagerRenderMode))
+                if (value < ToolStripRenderMode.Custom || value > ToolStripRenderMode.ManagerRenderMode)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ToolStripRenderMode));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripStatusLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripStatusLabel.cs
@@ -96,21 +96,21 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (!ClientUtils.IsEnumValid_NotSequential(value,
-                                             (int)value,
-                                             (int)Border3DStyle.Adjust,
-                                             (int)Border3DStyle.Bump,
-                                             (int)Border3DStyle.Etched,
-                                             (int)Border3DStyle.Flat,
-                                             (int)Border3DStyle.Raised,
-                                             (int)Border3DStyle.RaisedInner,
-                                             (int)Border3DStyle.RaisedOuter,
-                                             (int)Border3DStyle.Sunken,
-                                             (int)Border3DStyle.SunkenInner,
-                                             (int)Border3DStyle.SunkenOuter
-                                                ))
+                switch (borderStyle)
                 {
-                    throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(Border3DStyle));
+                    case Border3DStyle.Adjust:
+                    case Border3DStyle.Bump:
+                    case Border3DStyle.Etched:
+                    case Border3DStyle.Flat:
+                    case Border3DStyle.Raised:
+                    case Border3DStyle.RaisedInner:
+                    case Border3DStyle.RaisedOuter:
+                    case Border3DStyle.Sunken:
+                    case Border3DStyle.SunkenInner:
+                    case Border3DStyle.SunkenOuter:
+                        break;
+                    default:
+                        throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(Border3DStyle));
                 }
 
                 if (borderStyle != value)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripStatusLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripStatusLabel.cs
@@ -197,7 +197,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)AutomationLiveSetting.Off, (int)AutomationLiveSetting.Assertive))
+                if (value < AutomationLiveSetting.Off || value > AutomationLiveSetting.Assertive)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(AutomationLiveSetting));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -434,7 +434,7 @@ namespace System.Windows.Forms
             {
                 if (_toolTipIcon != value)
                 {
-                    if (!ClientUtils.IsEnumValid(value, (int)value, (int)ToolTipIcon.None, (int)ToolTipIcon.Error))
+                    if (value < ToolTipIcon.None || value > ToolTipIcon.Error)
                     {
                         throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ToolTipIcon));
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -258,7 +258,7 @@ namespace System.Windows.Forms
             {
                 if (borderStyle != value)
                 {
-                    if (!ClientUtils.IsEnumValid(value, (int)value, (int)BorderStyle.None, (int)BorderStyle.Fixed3D))
+                    if (value < BorderStyle.None || value > BorderStyle.Fixed3D)
                     {
                         throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(BorderStyle));
                     }
@@ -957,8 +957,7 @@ namespace System.Windows.Forms
 
             set
             {
-                //valid values are 0x0 to 0x2
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)TreeViewDrawMode.Normal, (int)TreeViewDrawMode.OwnerDrawAll))
+                if (value < TreeViewDrawMode.Normal || value > TreeViewDrawMode.OwnerDrawAll)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(TreeViewDrawMode));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
@@ -189,7 +189,7 @@ namespace System.Windows.Forms
             get => _borderStyle;
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)BorderStyle.None, (int)BorderStyle.Fixed3D))
+                if (value < BorderStyle.None || value > BorderStyle.Fixed3D)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(BorderStyle));
                 }
@@ -407,7 +407,7 @@ namespace System.Windows.Forms
             get => _upDownEdit.TextAlign;
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)HorizontalAlignment.Left, (int)HorizontalAlignment.Center))
+                if (value < HorizontalAlignment.Left || value > HorizontalAlignment.Center)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(HorizontalAlignment));
                 }
@@ -430,7 +430,7 @@ namespace System.Windows.Forms
             get => _upDownAlign;
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)LeftRightAlignment.Left, (int)LeftRightAlignment.Right))
+                if (value < LeftRightAlignment.Left || value > LeftRightAlignment.Right)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(LeftRightAlignment));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UserControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UserControl.cs
@@ -79,7 +79,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (!ClientUtils.IsEnumValid(value, (int)value, (int)AutoSizeMode.GrowAndShrink, (int)AutoSizeMode.GrowOnly))
+                if (value < AutoSizeMode.GrowAndShrink || value > AutoSizeMode.GrowOnly)
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(AutoSizeMode));
                 }
@@ -143,8 +143,7 @@ namespace System.Windows.Forms
             {
                 if (borderStyle != value)
                 {
-                    //valid values are 0x0 to 0x2
-                    if (!ClientUtils.IsEnumValid(value, (int)value, (int)BorderStyle.None, (int)BorderStyle.Fixed3D))
+                    if (value < BorderStyle.None || value > BorderStyle.Fixed3D)
                     {
                         throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(BorderStyle));
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
@@ -307,8 +307,16 @@ namespace System.Windows.Forms.VisualStyles
             if (!ClientUtils.IsEnumValid_Masked(edges, (int)edges, (uint)(Edges.Left | Edges.Top | Edges.Right | Edges.Bottom | Edges.Diagonal)))
                 throw new InvalidEnumArgumentException(nameof(edges), (int)edges, typeof(Edges));
 
-            if (!ClientUtils.IsEnumValid_NotSequential(style, (int)style, (int)EdgeStyle.Raised, (int)EdgeStyle.Sunken, (int)EdgeStyle.Etched, (int)EdgeStyle.Bump))
-                throw new InvalidEnumArgumentException(nameof(style), (int)style, typeof(EdgeStyle));
+            switch (style)
+            {
+                case EdgeStyle.Raised:
+                case EdgeStyle.Sunken:
+                case EdgeStyle.Etched:
+                case EdgeStyle.Bump:
+                    break;
+                default:
+                    throw new InvalidEnumArgumentException(nameof(style), (int)style, typeof(EdgeStyle));
+            }
 
             if (!ClientUtils.IsEnumValid_Masked(effects, (int)effects, (uint)(EdgeEffects.FillInterior | EdgeEffects.Flat | EdgeEffects.Soft | EdgeEffects.Mono)))
                 throw new InvalidEnumArgumentException(nameof(effects), (int)effects, typeof(EdgeEffects));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
@@ -510,7 +510,7 @@ namespace System.Windows.Forms.VisualStyles
         /// </summary>
         public bool GetBoolean(BooleanProperty prop)
         {
-            if (!ClientUtils.IsEnumValid(prop, (int)prop, (int)BooleanProperty.Transparent, (int)BooleanProperty.SourceShrink))
+            if (prop < BooleanProperty.Transparent || prop > BooleanProperty.SourceShrink)
                 throw new InvalidEnumArgumentException(nameof(prop), (int)prop, typeof(BooleanProperty));
 
             BOOL val = BOOL.FALSE;
@@ -523,8 +523,7 @@ namespace System.Windows.Forms.VisualStyles
         /// </summary>
         public Color GetColor(ColorProperty prop)
         {
-            // Valid values are 0xed9 to 0xeef
-            if (!ClientUtils.IsEnumValid(prop, (int)prop, (int)ColorProperty.BorderColor, (int)ColorProperty.AccentColorHint))
+            if (prop < ColorProperty.BorderColor || prop > ColorProperty.AccentColorHint)
                 throw new InvalidEnumArgumentException(nameof(prop), (int)prop, typeof(ColorProperty));
 
             int color = 0;
@@ -537,8 +536,7 @@ namespace System.Windows.Forms.VisualStyles
         /// </summary>
         public int GetEnumValue(EnumProperty prop)
         {
-            // Valid values are 0xfa1 to 0xfaf
-            if (!ClientUtils.IsEnumValid(prop, (int)prop, (int)EnumProperty.BackgroundType, (int)EnumProperty.TrueSizeScalingType))
+            if (prop < EnumProperty.BackgroundType || prop > EnumProperty.TrueSizeScalingType)
                 throw new InvalidEnumArgumentException(nameof(prop), (int)prop, typeof(EnumProperty));
 
             int val = 0;
@@ -551,8 +549,7 @@ namespace System.Windows.Forms.VisualStyles
         /// </summary>
         public unsafe string GetFilename(FilenameProperty prop)
         {
-            // Valid values are 0xbb9 to 0xbc0
-            if (!ClientUtils.IsEnumValid(prop, (int)prop, (int)FilenameProperty.ImageFile, (int)FilenameProperty.GlyphImageFile))
+            if (prop < FilenameProperty.ImageFile || prop > FilenameProperty.GlyphImageFile)
                 throw new InvalidEnumArgumentException(nameof(prop), (int)prop, typeof(FilenameProperty));
 
             Span<char> filename = stackalloc char[512];
@@ -572,8 +569,14 @@ namespace System.Windows.Forms.VisualStyles
             if (dc is null)
                 throw new ArgumentNullException(nameof(dc));
 
-            if (!ClientUtils.IsEnumValid_NotSequential(prop, (int)prop, (int)FontProperty.TextFont, (int)FontProperty.GlyphFont))
-                throw new InvalidEnumArgumentException(nameof(prop), (int)prop, typeof(FontProperty));
+            switch (prop)
+            {
+                case FontProperty.TextFont:
+                case FontProperty.GlyphFont:
+                    break;
+                default:
+                    throw new InvalidEnumArgumentException(nameof(prop), (int)prop, typeof(FontProperty));
+            }
 
             using var hdc = new DeviceContextHdcScope(dc);
             _lastHResult = GetThemeFont(this, hdc, Part, State, (int)prop, out User32.LOGFONTW logfont);
@@ -605,8 +608,7 @@ namespace System.Windows.Forms.VisualStyles
         /// </summary>
         public int GetInteger(IntegerProperty prop)
         {
-            // Valid values are 0x961 to 0x978
-            if (!ClientUtils.IsEnumValid(prop, (int)prop, (int)IntegerProperty.ImageCount, (int)IntegerProperty.MinDpi5))
+            if (prop < IntegerProperty.ImageCount || prop > IntegerProperty.MinDpi5)
                 throw new InvalidEnumArgumentException(nameof(prop), (int)prop, typeof(IntegerProperty));
 
             int val = 0;
@@ -628,8 +630,7 @@ namespace System.Windows.Forms.VisualStyles
 
         internal unsafe Size GetPartSize(Gdi32.HDC dc, ThemeSizeType type, IntPtr hwnd = default)
         {
-            // Valid values are 0x0 to 0x2
-            if (!ClientUtils.IsEnumValid(type, (int)type, (int)ThemeSizeType.Minimum, (int)ThemeSizeType.Draw))
+            if (type < ThemeSizeType.Minimum || type > ThemeSizeType.Draw)
                 throw new InvalidEnumArgumentException(nameof(type), (int)type, typeof(ThemeSizeType));
 
             if (DpiHelper.IsPerMonitorV2Awareness && hwnd != IntPtr.Zero)
@@ -655,8 +656,7 @@ namespace System.Windows.Forms.VisualStyles
             if (dc is null)
                 throw new ArgumentNullException(nameof(dc));
 
-            // Valid values are 0x0 to 0x2
-            if (!ClientUtils.IsEnumValid(type, (int)type, (int)ThemeSizeType.Minimum, (int)ThemeSizeType.Draw))
+            if (type < ThemeSizeType.Minimum || type > ThemeSizeType.Draw)
                 throw new InvalidEnumArgumentException(nameof(type), (int)type, typeof(ThemeSizeType));
 
             using var hdc = new DeviceContextHdcScope(dc);
@@ -670,8 +670,7 @@ namespace System.Windows.Forms.VisualStyles
         /// </summary>
         public Point GetPoint(PointProperty prop)
         {
-            //valid values are 0xd49 to 0xd50
-            if (!ClientUtils.IsEnumValid(prop, (int)prop, (int)PointProperty.Offset, (int)PointProperty.MinSize5))
+            if (prop < PointProperty.Offset || prop > PointProperty.MinSize5)
                 throw new InvalidEnumArgumentException(nameof(prop), (int)prop, typeof(PointProperty));
 
             _lastHResult = GetThemePosition(this, Part, State, (int)prop, out Point point);
@@ -686,8 +685,7 @@ namespace System.Windows.Forms.VisualStyles
             if (dc is null)
                 throw new ArgumentNullException(nameof(dc));
 
-            // Valid values are 0xe11 to 0xe13
-            if (!ClientUtils.IsEnumValid(prop, (int)prop, (int)MarginProperty.SizingMargins, (int)MarginProperty.CaptionMargins))
+            if (prop < MarginProperty.SizingMargins || prop > MarginProperty.CaptionMargins)
                 throw new InvalidEnumArgumentException(nameof(prop), (int)prop, typeof(MarginProperty));
 
             using var hdc = new DeviceContextHdcScope(dc);
@@ -701,8 +699,7 @@ namespace System.Windows.Forms.VisualStyles
         /// </summary>
         public unsafe string GetString(StringProperty prop)
         {
-            // Valid values are 0xc81 to 0xc81
-            if (!ClientUtils.IsEnumValid(prop, (int)prop, (int)StringProperty.Text, (int)StringProperty.Text))
+            if (prop < StringProperty.Text || prop > StringProperty.Text)
                 throw new InvalidEnumArgumentException(nameof(prop), (int)prop, typeof(StringProperty));
 
             Span<char> aString = stackalloc char[512];

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
@@ -304,7 +304,8 @@ namespace System.Windows.Forms.VisualStyles
 
         internal Rectangle DrawEdge(Gdi32.HDC dc, Rectangle bounds, Edges edges, EdgeStyle style, EdgeEffects effects)
         {
-            if (!ClientUtils.IsEnumValid_Masked(edges, (int)edges, (uint)(Edges.Left | Edges.Top | Edges.Right | Edges.Bottom | Edges.Diagonal)))
+            const Edges AllEdges = Edges.Left | Edges.Top | Edges.Right | Edges.Bottom | Edges.Diagonal;
+            if ((edges & AllEdges) != edges)
                 throw new InvalidEnumArgumentException(nameof(edges), (int)edges, typeof(Edges));
 
             switch (style)
@@ -318,7 +319,8 @@ namespace System.Windows.Forms.VisualStyles
                     throw new InvalidEnumArgumentException(nameof(style), (int)style, typeof(EdgeStyle));
             }
 
-            if (!ClientUtils.IsEnumValid_Masked(effects, (int)effects, (uint)(EdgeEffects.FillInterior | EdgeEffects.Flat | EdgeEffects.Soft | EdgeEffects.Mono)))
+            const EdgeEffects AllEffects =EdgeEffects.FillInterior | EdgeEffects.Flat | EdgeEffects.Soft | EdgeEffects.Mono;
+            if ((effects & AllEffects) != effects)
                 throw new InvalidEnumArgumentException(nameof(effects), (int)effects, typeof(EdgeEffects));
 
             RECT destRect = bounds;

--- a/src/System.Windows.Forms/tests/TestUtilities/CommonTestHelper.cs
+++ b/src/System.Windows.Forms/tests/TestUtilities/CommonTestHelper.cs
@@ -19,18 +19,6 @@ namespace WinForms.Common.Tests
 {
     public static class CommonTestHelper
     {
-        // helper method to generate theory data from all values of an enum type
-        public static TheoryData<T> GetEnumTheoryData<T>() where T : Enum
-        {
-            var data = new TheoryData<T>();
-            foreach (T item in Enum.GetValues(typeof(T)))
-            {
-                data.Add(item);
-            }
-
-            return data;
-        }
-
         public static TheoryData GetEnumTypeTheoryData(Type enumType)
         {
             var data = new TheoryData<Enum>();
@@ -41,26 +29,27 @@ namespace WinForms.Common.Tests
             return data;
         }
 
-        // helper method to generate invalid theory data for an enum type
-        // This method assumes that int.MinValue and int.MaxValue are not in the enum
-        public static TheoryData<T> GetEnumTheoryDataInvalid<T>() where T : Enum
-        {
-            var data = new TheoryData<T>
-            {
-                // This boxing is necessary because you can't cast an int to a generic,
-                // even if the generic is guaranteed to be an enum
-                (T)(object)int.MinValue,
-                (T)(object)int.MaxValue
-            };
-            return data;
-        }
-
         public static TheoryData<Enum> GetEnumTypeTheoryDataInvalid(Type enumType)
         {
             var data = new TheoryData<Enum>();
-            IEnumerable<Enum> values = Enum.GetValues(enumType).Cast<Enum>().OrderBy(p => p);
+            Enum[] values = Enum.GetValues(enumType).Cast<Enum>().OrderBy(p => p).Distinct().ToArray();
 
-            // Assumes that the enum is sequential.
+            for (int i = 0; i < values.Length - 2; i++)
+            {
+                int currentVal = Convert.ToInt32(values[i]);
+                int nextVal = Convert.ToInt32(values[i + 1]);
+                if (nextVal != currentVal + 1)
+                {
+                    // Not sequential.
+                    data.Add((Enum)Enum.ToObject(enumType, currentVal + 1));
+
+                    if (nextVal - 1 != currentVal)
+                    {
+                        data.Add((Enum)Enum.ToObject(enumType, nextVal - 1));
+                    }
+                }
+            }
+
             data.Add((Enum)Enum.ToObject(enumType, Convert.ToInt32(values.Min()) - 1));
             data.Add((Enum)Enum.ToObject(enumType, Convert.ToInt32(values.Max()) + 1));
             return data;

--- a/src/System.Windows.Forms/tests/UnitTests/CheckedListBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/CheckedListBoxTests.cs
@@ -109,20 +109,12 @@ namespace System.Windows.Forms.Tests
             ArgumentException ex = Assert.Throws<ArgumentException>(() => box.SelectionMode = expected);
         }
 
-        /// <summary>
-        ///  Data for the SelectionModeGetSetInvalid test
-        /// </summary>
-        public static TheoryData<SelectionMode> SelectionModeGetSetInvalidData =>
-            CommonTestHelper.GetEnumTheoryDataInvalid<SelectionMode>();
-
         [WinFormsTheory]
-        [MemberData(nameof(SelectionModeGetSetInvalidData))]
-        public void CheckedListBox_CheckStateGetSetInvalid(SelectionMode expected)
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryDataInvalid), typeof(SelectionMode))]
+        public void CheckedListBox_SelectionMode_SetInvalidValue_ThrowsInvalidEnumArgumentException(SelectionMode value)
         {
-            using var box = new CheckedListBox();
-
-            InvalidEnumArgumentException ex = Assert.Throws<InvalidEnumArgumentException>(() => box.SelectionMode = expected);
-            Assert.Equal("value", ex.ParamName);
+            using var control = new CheckedListBox();
+            Assert.Throws<InvalidEnumArgumentException>("value", () => control.SelectionMode = value);
         }
 
         /// <summary>
@@ -276,39 +268,30 @@ namespace System.Windows.Forms.Tests
             Assert.Equal("index", ex.ParamName);
         }
 
-        /// <summary>
-        ///  Data for the SetItemCheckState test
-        /// </summary>
-        public static TheoryData<CheckState> SetItemCheckStateData =>
-            CommonTestHelper.GetEnumTheoryData<CheckState>();
-
         [WinFormsTheory]
-        [MemberData(nameof(SetItemCheckStateData))]
-        public void CheckedListBox_SetItemCheckState(CheckState expected)
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(CheckState))]
+        public void CheckedListBox_SetItemCheckState_Invoke_GetReturnsExpected(CheckState value)
         {
-            using var box = new CheckedListBox();
-            box.Items.Add(new CheckBox(), false);
+            using var control = new CheckedListBox();
+            control.Items.Add(new CheckBox(), false);
 
-            box.SetItemCheckState(0, expected);
+            control.SetItemCheckState(0, value);
+            Assert.Equal(value, control.GetItemCheckState(0));
+            Assert.False(control.IsHandleCreated);
 
-            Assert.Equal(expected, box.GetItemCheckState(0));
+            // Set same.
+            control.SetItemCheckState(0, value);
+            Assert.Equal(value, control.GetItemCheckState(0));
+            Assert.False(control.IsHandleCreated);
         }
 
-        /// <summary>
-        ///  Data for the SetItemCheckStateInvalid test
-        /// </summary>
-        public static TheoryData<CheckState> SetItemCheckStateInvalidData =>
-            CommonTestHelper.GetEnumTheoryDataInvalid<CheckState>();
-
         [WinFormsTheory]
-        [MemberData(nameof(SetItemCheckStateInvalidData))]
-        public void CheckedListBox_SetItemCheckStateInvalid(CheckState expected)
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryDataInvalid), typeof(CheckState))]
+        public void CheckedListBox_SetItemCheckState_InvokeInvalidValue_ThrowsInvalidEnumArgumentException(CheckState value)
         {
-            using var box = new CheckedListBox();
-            box.Items.Add(new CheckBox(), false);
-
-            InvalidEnumArgumentException ex = Assert.Throws<InvalidEnumArgumentException>(() => box.SetItemCheckState(0, expected));
-            Assert.Equal("value", ex.ParamName);
+            using var control = new CheckedListBox();
+            control.Items.Add(new CheckBox(), false);
+            Assert.Throws<InvalidEnumArgumentException>("value", () => control.SetItemCheckState(0, value));
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CheckBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CheckBoxTests.cs
@@ -145,38 +145,29 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.IsHandleCreated);
         }
 
-        /// <summary>
-        ///  Data for the AppearanceGetSet test
-        /// </summary>
-        public static TheoryData<Appearance> AppearanceGetSetData =>
-            CommonTestHelper.GetEnumTheoryData<Appearance>();
-
         [WinFormsTheory]
-        [MemberData(nameof(AppearanceGetSetData))]
-        public void CheckBox_AutoSizeModeGetSet(Appearance expected)
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(Appearance))]
+        public void CheckBox_Appearance_Set_GetReturnsExpected(Appearance value)
         {
-            using var box = new CheckBox
+            using var control = new CheckBox
             {
-                Appearance = expected
+                Appearance = value
             };
+            Assert.Equal(value, control.Appearance);
+            Assert.False(control.IsHandleCreated);
 
-            Assert.Equal(expected, box.Appearance);
+            // Set same.
+            control.Appearance = value;
+            Assert.Equal(value, control.Appearance);
+            Assert.False(control.IsHandleCreated);
         }
 
-        /// <summary>
-        ///  Data for the AppearanceGetSetInvalid test
-        /// </summary>
-        public static TheoryData<Appearance> AppearanceGetSetInvalidData =>
-            CommonTestHelper.GetEnumTheoryDataInvalid<Appearance>();
-
         [WinFormsTheory]
-        [MemberData(nameof(AppearanceGetSetInvalidData))]
-        public void CheckBox_AppearanceGetSetInvalid(Appearance expected)
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryDataInvalid), typeof(Appearance))]
+        public void CheckBox_Appearance_SetInvalidValue_ThrowsInvalidEnumArgumentException(Appearance value)
         {
-            using var box = new CheckBox();
-
-            InvalidEnumArgumentException ex = Assert.Throws<InvalidEnumArgumentException>(() => box.Appearance = expected);
-            Assert.Equal("value", ex.ParamName);
+            using var control = new CheckBox();
+            Assert.Throws<InvalidEnumArgumentException>("value", () => control.Appearance = value);
         }
 
         /// <summary>
@@ -197,40 +188,29 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, box.AutoCheck);
         }
 
-        /// <summary>
-        ///  Data for the ContentAlignmentGetSet test
-        /// </summary>
-        public static TheoryData<ContentAlignment> ContentAlignmentGetSetData =>
-            CommonTestHelper.GetEnumTheoryData<ContentAlignment>();
-
         [WinFormsTheory]
-        [MemberData(nameof(ContentAlignmentGetSetData))]
-        public void CheckBox_ContentAlignmentGetSet(ContentAlignment expected)
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(ContentAlignment))]
+        public void CheckBox_CheckAlign_Set_GetReturnsExpected(ContentAlignment value)
         {
-            using var box = new CheckBox
+            using var control = new CheckBox
             {
-                CheckAlign = expected,
-                TextAlign = expected
+                CheckAlign = value
             };
+            Assert.Equal(value, control.CheckAlign);
+            Assert.False(control.IsHandleCreated);
 
-            Assert.Equal(expected, box.CheckAlign);
-            Assert.Equal(expected, box.TextAlign);
+            // Set same.
+            control.CheckAlign = value;
+            Assert.Equal(value, control.CheckAlign);
+            Assert.False(control.IsHandleCreated);
         }
 
-        /// <summary>
-        ///  Data for the ContentAlignmentGetSetInvalid test
-        /// </summary>
-        public static TheoryData<ContentAlignment> ContentAlignmentGetSetInvalidData =>
-            CommonTestHelper.GetEnumTheoryDataInvalid<ContentAlignment>();
-
         [WinFormsTheory]
-        [MemberData(nameof(ContentAlignmentGetSetInvalidData))]
-        public void CheckBox_ContentAlignmentGetSetInvalid(ContentAlignment expected)
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryDataInvalid), typeof(ContentAlignment))]
+        public void CheckBox_CheckAlign_SetInvalidValue_ThrowsInvalidEnumArgumentException(ContentAlignment value)
         {
-            using var box = new CheckBox();
-
-            InvalidEnumArgumentException ex = Assert.Throws<InvalidEnumArgumentException>(() => box.CheckAlign = expected);
-            Assert.Equal("value", ex.ParamName);
+            using var control = new CheckBox();
+            Assert.Throws<InvalidEnumArgumentException>("value", () => control.CheckAlign = value);
         }
 
         [WinFormsTheory]
@@ -290,38 +270,56 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expectedCheckState, box.CheckState);
         }
 
-        /// <summary>
-        ///  Data for the CheckStateGetSet test
-        /// </summary>
-        public static TheoryData<CheckState> CheckStateGetSetData =>
-            CommonTestHelper.GetEnumTheoryData<CheckState>();
-
         [WinFormsTheory]
-        [MemberData(nameof(CheckStateGetSetData))]
-        public void CheckBox_CheckStateGetSet(CheckState expected)
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(CheckState))]
+        public void CheckBox_CheckState_Set_GetReturnsExpected(CheckState value)
         {
-            using var box = new CheckBox
+            using var control = new CheckBox
             {
-                CheckState = expected
+                CheckState = value
             };
+            Assert.Equal(value, control.CheckState);
+            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
+            //Assert.False(control.IsHandleCreated);
 
-            Assert.Equal(expected, box.CheckState);
+            // Set same.
+            control.CheckState = value;
+            Assert.Equal(value, control.CheckState);
+            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
+            //Assert.False(control.IsHandleCreated);
         }
 
-        /// <summary>
-        ///  Data for the CheckStateGetSetInvalid test
-        /// </summary>
-        public static TheoryData<CheckState> CheckStateGetSetInvalidData =>
-            CommonTestHelper.GetEnumTheoryDataInvalid<CheckState>();
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryDataInvalid), typeof(CheckState))]
+        public void CheckBox_CheckState_SetInvalidValue_ThrowsInvalidEnumArgumentException(CheckState value)
+        {
+            using var control = new CheckBox();
+            Assert.Throws<InvalidEnumArgumentException>("value", () => control.CheckState = value);
+        }
 
         [WinFormsTheory]
-        [MemberData(nameof(CheckStateGetSetInvalidData))]
-        public void CheckBox_CheckStateGetSetInvalid(CheckState expected)
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(ContentAlignment))]
+        public void CheckBox_TextAlign_Set_GetReturnsExpected(ContentAlignment value)
         {
-            using var box = new CheckBox();
+            using var control = new CheckBox
+            {
+                TextAlign = value
+            };
+            Assert.Equal(value, control.TextAlign);
+            Assert.False(control.IsHandleCreated);
 
-            InvalidEnumArgumentException ex = Assert.Throws<InvalidEnumArgumentException>(() => box.CheckState = expected);
-            Assert.Equal("value", ex.ParamName);
+            // Set same.
+            control.TextAlign = value;
+            Assert.Equal(value, control.TextAlign);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryDataInvalid), typeof(ContentAlignment))]
+        public void CheckBox_TextAlign_SetInvalidValue_ThrowsInvalidEnumArgumentException(ContentAlignment value)
+        {
+            using var control = new CheckBox();
+            Assert.Throws<InvalidEnumArgumentException>("value", () => control.TextAlign = value);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.cs
@@ -2099,38 +2099,26 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(AutoSizeMode.GrowOnly, control.GetAutoSizeMode());
         }
 
-        /// <summary>
-        ///  Data for the GetChildAtPointNull test
-        /// </summary>
-        public static TheoryData<GetChildAtPointSkip> GetChildAtPointNullData =>
-            CommonTestHelper.GetEnumTheoryData<GetChildAtPointSkip>();
-
         [WinFormsTheory]
-        [MemberData(nameof(GetChildAtPointNullData))]
-        public void Control_GetChildAtPointNull(GetChildAtPointSkip skip)
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(GetChildAtPointSkip))]
+        public void Control_GetChildAtPoint_Invoke_ReturnsExpected(GetChildAtPointSkip skipValue)
         {
-            using var cont = new Control();
+            using var control = new Control();
+            Assert.Null(control.GetChildAtPoint(new Point(5, 5), skipValue));
+            Assert.True(control.IsHandleCreated);
 
-            Control ret = cont.GetChildAtPoint(new Point(5, 5), skip);
-
-            Assert.Null(ret);
+            // Call again.
+            Assert.Null(control.GetChildAtPoint(new Point(5, 5), skipValue));
+            Assert.True(control.IsHandleCreated);
         }
 
-        /// <summary>
-        ///  Data for the GetChildAtPointInvalid test
-        /// </summary>
-        public static TheoryData<GetChildAtPointSkip> GetChildAtPointInvalidData =>
-            CommonTestHelper.GetEnumTheoryDataInvalid<GetChildAtPointSkip>();
-
         [WinFormsTheory]
-        [MemberData(nameof(GetChildAtPointInvalidData))]
-        public void Control_GetChildAtPointInvalid(GetChildAtPointSkip skip)
+        [InlineData((GetChildAtPointSkip)(-1))]
+        [InlineData((GetChildAtPointSkip)8)]
+        public void Control_GetChildAtPoint_InvokeInvalidSkipValue_ThrowsInvalidEnumArgumentException(GetChildAtPointSkip skipValue)
         {
-            using var cont = new Control();
-
-            // act & assert
-            InvalidEnumArgumentException ex = Assert.Throws<InvalidEnumArgumentException>(() => cont.GetChildAtPoint(new Point(5, 5), skip));
-            Assert.Equal("skipValue", ex.ParamName);
+            using var control = new Control();
+            Assert.Throws<InvalidEnumArgumentException>("skipValue", () => control.GetChildAtPoint(new Point(5, 5), skipValue));
         }
 
         [WinFormsFact]


### PR DESCRIPTION
## Proposed Changes
- In corefx (runtime), we decided to remove `ClientUtils.IsEnumValid` and friends because, frankly, they're just a bit unnecessary and a bit ugly
- Also improves performance by avoiding allocation an int[] array each time we set the value. Bleh
- Also adds support for non sequential enums to `GetEnumTheoryTypeTestDataInvalid`

Example regex

VSCode Search and Replace
```
if \(!ClientUtils.IsEnumValid\((.+?(?=,)), \(int\).+?(?=,), \(int\)(.+?(?=,)), \(int\)(.+?(?=\)))\)\)
```
Replace with
```
if ($1 < $2 || $1 > $3)
```
```