### PR TITLE
Make default encoding retrieval resilient

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -2972,7 +2972,7 @@ namespace System.Windows.Forms
             else
             {
                 // Encode using the default code page.
-                encodedBytes = CodePagesEncodingProvider.Instance.GetEncoding(0).GetBytes(str);
+                encodedBytes = (CodePagesEncodingProvider.Instance.GetEncoding(0) ?? Encoding.UTF8).GetBytes(str);
             }
 
             editStream = new MemoryStream(encodedBytes.Length);
@@ -3005,7 +3005,7 @@ namespace System.Windows.Forms
                     editStream.Read(bytes, (int)streamStart, SZ_RTF_TAG.Length);
 
                     // Encode using the default encoding.
-                    string str = CodePagesEncodingProvider.Instance.GetEncoding(0).GetString(bytes);
+                    string str = (CodePagesEncodingProvider.Instance.GetEncoding(0) ?? Encoding.UTF8).GetString(bytes);
                     if (!SZ_RTF_TAG.Equals(str))
                     {
                         throw new ArgumentException(SR.InvalidFileFormat);
@@ -3098,7 +3098,7 @@ namespace System.Windows.Forms
                 else
                 {
                     // Convert from the current code page
-                    result = CodePagesEncodingProvider.Instance.GetEncoding(0).GetString(bytes, 0, bytes.Length);
+                    result = (CodePagesEncodingProvider.Instance.GetEncoding(0) ?? Encoding.UTF8).GetString(bytes, 0, bytes.Length);
                 }
 
                 // Trimming off a null char is usually a sign of incorrect marshalling.
@@ -3660,33 +3660,33 @@ namespace System.Windows.Forms
                     break;
 
                 case User32.WM.VSCROLL:
-                {
-                    base.WndProc(ref m);
-                    User32.SBV loWord = (User32.SBV)PARAM.LOWORD(m.WParam);
-                    if (loWord == User32.SBV.THUMBTRACK)
                     {
-                        OnVScroll(EventArgs.Empty);
+                        base.WndProc(ref m);
+                        User32.SBV loWord = (User32.SBV)PARAM.LOWORD(m.WParam);
+                        if (loWord == User32.SBV.THUMBTRACK)
+                        {
+                            OnVScroll(EventArgs.Empty);
+                        }
+                        else if (loWord == User32.SBV.THUMBPOSITION)
+                        {
+                            OnVScroll(EventArgs.Empty);
+                        }
+                        break;
                     }
-                    else if (loWord == User32.SBV.THUMBPOSITION)
-                    {
-                        OnVScroll(EventArgs.Empty);
-                    }
-                    break;
-                }
                 case User32.WM.HSCROLL:
-                {
-                    base.WndProc(ref m);
-                    User32.SBH loWord = (User32.SBH)PARAM.LOWORD(m.WParam);
-                    if (loWord == User32.SBH.THUMBTRACK)
                     {
-                        OnHScroll(EventArgs.Empty);
+                        base.WndProc(ref m);
+                        User32.SBH loWord = (User32.SBH)PARAM.LOWORD(m.WParam);
+                        if (loWord == User32.SBH.THUMBTRACK)
+                        {
+                            OnHScroll(EventArgs.Empty);
+                        }
+                        else if (loWord == User32.SBH.THUMBPOSITION)
+                        {
+                            OnHScroll(EventArgs.Empty);
+                        }
+                        break;
                     }
-                    else if (loWord == User32.SBH.THUMBPOSITION)
-                    {
-                        OnHScroll(EventArgs.Empty);
-                    }
-                    break;
-                }
                 default:
                     base.WndProc(ref m);
                     break;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
@@ -5101,7 +5101,7 @@ namespace System.Windows.Forms.Tests
 
             Span<byte> output = stackalloc byte[16];
 
-            int currentCodePage = CodePagesEncodingProvider.Instance.GetEncoding(0).CodePage;
+            int currentCodePage = (CodePagesEncodingProvider.Instance.GetEncoding(0) ?? Encoding.UTF8).CodePage;
 
             // The non-lossy conversion of nbsp only works single byte Windows code pages (e.g. not Japanese).
             if (currentCodePage >= 1250 && currentCodePage <= 1258)


### PR DESCRIPTION
Relates to #3032 and #3100

<!-- Please read CONTRIBUTING.md before submitting a pull request -->



## Proposed changes

- Make default encoding retrieval resilient in cases where user's encoding is not recognised by .NET's implementation, e.g. `codepage = 65001`. Refer to the [docs](https://docs.microsoft.com/dotnet/api/system.text.codepagesencodingprovider).

### Before:

Hundreds of tests failing with:

![image](https://user-images.githubusercontent.com/4403806/81523911-b2a6b700-9392-11ea-9706-11f60911827f.png)

```
************** Exception Text **************
System.NullReferenceException: Object reference not set to an instance of an object.
   at System.Windows.Forms.RichTextBox.StreamOut(SF flags) in C:\Development\winforms\src\System.Windows.Forms\src\System\Windows\Forms\RichTextBox.cs:line 3101
   at System.Windows.Forms.RichTextBox.get_Rtf() in C:\Development\winforms\src\System.Windows.Forms\src\System\Windows\Forms\RichTextBox.cs:line 686
   at System.Windows.Forms.RichTextBox.OnHandleDestroyed(EventArgs e) in C:\Development\winforms\src\System.Windows.Forms\src\System\Windows\Forms\RichTextBox.cs:line 2643
   at System.Windows.Forms.Control.WmDestroy(Message& m) in C:\Development\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 12038
   at System.Windows.Forms.Control.WndProc(Message& m) in C:\Development\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 13019
   at System.Windows.Forms.TextBoxBase.WndProc(Message& m) in C:\Development\winforms\src\System.Windows.Forms\src\System\Windows\Forms\TextBoxBase.cs:line 2207
   at System.Windows.Forms.RichTextBox.WndProc(Message& m) in C:\Development\winforms\src\System.Windows.Forms\src\System\Windows\Forms\RichTextBox.cs:line 3690
   at System.Windows.Forms.Control.ControlNativeWindow.OnMessage(Message& m) in C:\Development\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.ControlNativeWindow.cs:line 67
   at System.Windows.Forms.Control.ControlNativeWindow.WndProc(Message& m) in C:\Development\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.ControlNativeWindow.cs:line 119
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, WM msg, IntPtr wparam, IntPtr lparam) in C:\Development\winforms\src\System.Windows.Forms\src\System\Windows\Forms\NativeWindow.cs:line 372
```

<!-- We are in TELL-MODE the following section must be completed -->



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3210)