### PR TITLE
Fix skipping TableLayoutSettings_Serialize_InvalidStringConverter_DeserializeThrowsSerializationException

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHostTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHostTests.cs
@@ -1613,7 +1613,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(Color.FromArgb(unchecked((int)0xFF010203)), original.GetPixel(1, 2));
         }
 
-        [WinFormsFact(Skip = "Expected Exception is COMException - not TargetInvocationException")]
+        [WinFormsFact]
         public void AxHost_GetIPictureDispFromPicture_InvokeEnhancedMetafile_Roundtrips()
         {
             var original = new Metafile("bitmaps/milkmateya01.emf");
@@ -1632,8 +1632,7 @@ namespace System.Windows.Forms.Tests
             Ole32.IPictureDisp iPictureDisp = (Ole32.IPictureDisp)disp;
             Assert.NotNull(iPictureDisp);
             Assert.NotEqual(0, iPictureDisp.Handle);
-            TargetInvocationException ex = Assert.Throws<TargetInvocationException>(() => iPictureDisp.hPal);
-            Assert.IsType<COMException>(ex.InnerException);
+            Assert.Throws<COMException>(() => iPictureDisp.hPal);
             Assert.Equal(4, iPictureDisp.Type);
             Assert.Equal(19972, iPictureDisp.Width);
             Assert.Equal(28332, iPictureDisp.Height);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/TableLayoutSettingsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/TableLayoutSettingsTests.cs
@@ -1800,10 +1800,10 @@ namespace System.Windows.Forms.Layout.Tests
             }
         }
 
-        [WinFormsTheory (Skip = "Expected Exception has changed to System.Runtime.Serialization.SerializationException") ]
+        [WinFormsTheory]
         [InlineData(typeof(NullStringConverter))]
         [InlineData(typeof(EmptyStringConverter))]
-        public void TableLayoutSettings_Serialize_InvalidStringConverter_DeserializeThrowsTargetInvocationException(Type type)
+        public void TableLayoutSettings_Serialize_InvalidStringConverter_DeserializeThrowsSerializationException(Type type)
         {
             using var control = new TableLayoutPanel();
             TableLayoutSettings settings = control.LayoutSettings;
@@ -1814,8 +1814,7 @@ namespace System.Windows.Forms.Layout.Tests
                 formatter.Serialize(stream, settings);
                 stream.Seek(0, SeekOrigin.Begin);
 
-                TargetInvocationException ex = Assert.Throws<TargetInvocationException>(() => formatter.Deserialize(stream));
-                Assert.IsType<SerializationException>(ex.InnerException);
+                Assert.Throws<SerializationException>(() => formatter.Deserialize(stream));
             }
         }
 


### PR DESCRIPTION
Fixes #3046 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3217)