### PR TITLE
Remove invalid debug assert in GetSystemMetricsForDpi

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetSystemMetrics.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetSystemMetrics.cs
@@ -112,7 +112,6 @@ internal static partial class Interop
             }
             else
             {
-                Debug.Fail("GetSystemMetricsForDpi() is not available on this OS");
                 return GetSystemMetrics(nIndex);
             }
         }


### PR DESCRIPTION
We shouldn't have this throw an error because some machines run on windows 8, for example, which we support

Fixes #534
Contributes to #3121 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3219)