### PR TITLE
Dispose everything in DesignerSurface related tests

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignSurfaceTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignSurfaceTests.cs
@@ -13,7 +13,7 @@ namespace System.ComponentModel.Design.Tests
 {
     public class DesignSurfaceTests : IClassFixture<ThreadExceptionFixture>
     {
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_Ctor_Default()
         {
             using var surface = new SubDesignSurface();
@@ -51,7 +51,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { mockServiceProvider.Object };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(Ctor_IServiceProvider_TestData))]
         public void DesignSurface_Ctor_IServiceProvider(IServiceProvider parentProvider)
         {
@@ -74,7 +74,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<InvalidOperationException>(() => surface.View);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_Ctor_Type()
         {
             using var surface = new SubDesignSurface(typeof(RootDesignerComponent));
@@ -96,7 +96,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(RootComponentDesigner.View, surface.View);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_Ctor_IServiceProvider_Type_NullParentProvider()
         {
             using var surface = new SubDesignSurface(null, typeof(RootDesignerComponent));
@@ -118,7 +118,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(RootComponentDesigner.View, surface.View);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_Ctor_IServiceProvider_Type_CustomParentProvider()
         {
             var mockServiceProvider = new Mock<IServiceProvider>(MockBehavior.Strict);
@@ -165,7 +165,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(RootComponentDesigner.View, surface.View);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_Ctor_NullRootComponentType_ThrowsArgumentNullException()
         {
             var mockServiceProvider = new Mock<IServiceProvider>(MockBehavior.Strict);
@@ -173,7 +173,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<ArgumentNullException>("rootComponentType", () => new DesignSurface(mockServiceProvider.Object, (Type)null));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_ComponentContainer_GetDisposed_ThrowsObjectDisposedException()
         {
             using var surface = new DesignSurface();
@@ -181,7 +181,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<ObjectDisposedException>(() => surface.ComponentContainer);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void DesignSurface_DtelLoading_Set_GetReturnsExpected(bool value)
         {
@@ -200,7 +200,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(!value, surface.DtelLoading);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_ServiceContainer_Get_ReturnsSame()
         {
             using var surface = new SubDesignSurface();
@@ -209,7 +209,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(container, surface.ServiceContainer);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_ServiceContainer_GetISelectionService_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();
@@ -219,7 +219,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(0, service.SelectionCount);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_ServiceContainer_GetIExtenderProviderService_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();
@@ -227,7 +227,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.IsAssignableFrom<IExtenderProviderService>(container.GetService(typeof(IExtenderProviderService)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_ServiceContainer_GetIExtenderListService_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();
@@ -236,7 +236,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.IsAssignableFrom<IExtenderProviderService>(container.GetService(typeof(IExtenderListService)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_ServiceContainer_GetITypeDescriptorFilterService_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();
@@ -244,7 +244,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.IsAssignableFrom<ITypeDescriptorFilterService>(container.GetService(typeof(ITypeDescriptorFilterService)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_ServiceContainer_GetIReferenceService_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();
@@ -252,7 +252,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.IsAssignableFrom<IReferenceService>(container.GetService(typeof(IReferenceService)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_ServiceContainer_GetDesignSurfaceService_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();
@@ -260,7 +260,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(surface, container.GetService(typeof(DesignSurface)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_ServiceContainer_GetInstanceTypeService_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();
@@ -276,7 +276,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { typeof(IDesignerLoaderHost2) };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(ServiceContainer_FixedService_TestData))]
         public void DesignSurface_ServiceContainer_GetFixedService_ReturnsExpected(Type serviceType)
         {
@@ -285,7 +285,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(surface.Host, container.GetService(serviceType));
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(ServiceContainer_FixedService_TestData))]
         public void DesignSurface_ServiceContainer_RemoveFixedService_ThrowsInvalidOperationException(Type serviceType)
         {
@@ -294,7 +294,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<InvalidOperationException>(() => container.RemoveService(serviceType));
         }
 
-        [Theory]
+        [WinFormsTheory]
         [InlineData(typeof(ISelectionService))]
         [InlineData(typeof(IExtenderProviderService))]
         [InlineData(typeof(IExtenderListService))]
@@ -314,7 +314,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(container.GetService(serviceType));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_ServiceContainer_RemoveNullServiceType_ThrowsArgumentNullException()
         {
             using var surface = new SubDesignSurface();
@@ -322,7 +322,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<ArgumentNullException>("serviceType", () => container.RemoveService(null));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_ServiceContainer_GetDisposed_ThrowsObjectDisposedException()
         {
             using var surface = new SubDesignSurface();
@@ -330,7 +330,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<ObjectDisposedException>(() => surface.ServiceContainer);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [InlineData(typeof(NullSupportedTechnologiesRootDesignerComponent))]
         [InlineData(typeof(EmptySupportedTechnologiesRootDesignerComponent))]
         public void DesignSurface_View_GetWithInvalidSupportedTechnologies_ThrowsNotSupportedException(Type rootComponentType)
@@ -340,7 +340,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<NotSupportedException>(() => surface.View);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_View_GetDisposed_ThrowsObjectDisposedException()
         {
             using var surface = new DesignSurface();
@@ -348,7 +348,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<ObjectDisposedException>(() => surface.View);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_View_GetWithExceptionLoadErrors_ThrowsInvalidOperationException()
         {
             var exception = new Exception();
@@ -370,7 +370,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { new object[] { null } };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(View_GetLoadError_TestData))]
         public void DesignSurface_View_GetWithLoadErrors_ThrowsInvalidOperationException(object[] errorCollection)
         {
@@ -408,7 +408,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { mockServiceProvider.Object };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(BeginLoad_TestData))]
         public void DesignSurface_BeginLoad_Invoke_Success(IServiceProvider parentProvider)
         {
@@ -429,7 +429,7 @@ namespace System.ComponentModel.Design.Tests
             mockLoader.Verify(l => l.BeginLoad(host), Times.Once());
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_BeginLoad_ThrowsException_SetsLoadErrors()
         {
             var exception = new Exception();
@@ -448,7 +448,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(exception, Assert.Single(surface.LoadErrors));
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetNullOrEmptyStringTheoryData))]
         public void DesignSurface_BeginLoad_ThrowsExceptionWithoutMessage_SetsLoadErrors(string message)
         {
@@ -475,7 +475,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.False(surface.Host.Loading);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_BeginLoad_ThrowsTargetInvocationException_SetsLoadErrors()
         {
             var exception = new Exception();
@@ -494,7 +494,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.False(surface.Host.Loading);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_BeginLoad_InvokeWithLoading_CallsHandler()
         {
             var surface = new SubDesignSurface();
@@ -544,7 +544,7 @@ namespace System.ComponentModel.Design.Tests
             mockLoader.Verify(l => l.BeginLoad(host), Times.Exactly(2));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_BeginLoad_InvokeErrorWithUnloading_CallsHandler()
         {
             var surface = new SubDesignSurface();
@@ -607,7 +607,7 @@ namespace System.ComponentModel.Design.Tests
             mockLoader.Verify(l => l.BeginLoad(host), Times.Exactly(2));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_BeginLoad_InvokeDefaultIExtenderProvider_Success()
         {
             var mockExtenderProviderService = new Mock<IExtenderProviderService>(MockBehavior.Strict);
@@ -643,7 +643,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(mockExtenderProvider.Object, Assert.Single(defaultProviderService.GetExtenderProviders()));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_BeginLoad_InvokeValidIExtenderProvider_CallsAddExtenderProvider()
         {
             var mockExtenderProviderService = new Mock<IExtenderProviderService>(MockBehavior.Strict);
@@ -691,7 +691,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { new object() };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(BeginLoad_InvalidIExtenderProvider_TestData))]
         public void DesignSurface_BeginLoad_InvokeInvalidIExtenderProvider_Success(object service)
         {
@@ -728,7 +728,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Empty(defaultProviderService.GetExtenderProviders());
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_BeginLoad_InvokeWithoutIDesignerEventServiceWithActivated_CallsHandler()
         {
             var surface = new SubDesignSurface();
@@ -755,7 +755,7 @@ namespace System.ComponentModel.Design.Tests
             mockLoader.Verify(l => l.BeginLoad(host), Times.Exactly(2));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_BeginLoad_InvokeWithIDesignerEventServiceWithActivated_DoesNotCallHandler()
         {
             var mockDesignerEventService = new Mock<IDesignerEventService>(MockBehavior.Strict);
@@ -790,7 +790,7 @@ namespace System.ComponentModel.Design.Tests
             mockServiceProvider.Verify(p => p.GetService(typeof(IDesignerEventService)), Times.Once());
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_BeginLoad_DisposeInLoading_DoesCallFlush()
         {
             using var surface = new SubDesignSurface();
@@ -828,7 +828,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(0, flushedCallCount);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_BeginLoad_DisposeInBeginLoad_DoesCallFlush()
         {
             using var surface = new SubDesignSurface();
@@ -872,7 +872,7 @@ namespace System.ComponentModel.Design.Tests
             mockLoader.Verify(l => l.BeginLoad(host), Times.Once());
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_BeginLoad_DisposeInBeginLoadThrowsException_DoesCallFlush()
         {
             using var surface = new SubDesignSurface();
@@ -918,14 +918,14 @@ namespace System.ComponentModel.Design.Tests
             mockLoader.Verify(l => l.BeginLoad(host), Times.Once());
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_BeginLoad_NullLoader_ThrowsArgumentNullException()
         {
             using var surface = new DesignSurface();
             Assert.Throws<ArgumentNullException>("loader", () => surface.BeginLoad((DesignerLoader)null));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_BeginLoad_InvokeType_Success()
         {
             var surface = new SubDesignSurface();
@@ -940,14 +940,14 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(RootComponentDesigner.View, surface.View);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_BeginLoad_NullRootComponentType_ThrowsArgumentNullException()
         {
             using var surface = new DesignSurface();
             Assert.Throws<ArgumentNullException>("rootComponentType", () => surface.BeginLoad((Type)null));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_BeginLoad_AlreadyCalled_ThrowsInvalidOperationException()
         {
             var surface = new SubDesignSurface();
@@ -964,7 +964,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<InvalidOperationException>(() => surface.BeginLoad(otherMockLoader.Object));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_BeginLoad_Disposed_ThrowsObjectDisposedException()
         {
             using var surface = new DesignSurface();
@@ -974,7 +974,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<ObjectDisposedException>(() => surface.BeginLoad(mockLoader.Object));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_CreateDesigner_InvokeNoDesigner_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();
@@ -983,7 +983,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(surface.CreateDesigner(component, rootDesigner: false));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_CreateDesigner_InvokeIDesigner_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();
@@ -992,7 +992,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.IsType<ComponentDesigner>(surface.CreateDesigner(component, rootDesigner: false));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_CreateDesigner_InvokeIRootDesigner_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();
@@ -1001,7 +1001,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(surface.CreateDesigner(component, rootDesigner: false));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_CreateDesigner_NullComponent_ThrowsArgumentNullException()
         {
             using var surface = new SubDesignSurface();
@@ -1009,7 +1009,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<ArgumentNullException>("component", () => surface.CreateDesigner(null, false));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_CreateDesigner_Disposed_ThrowsObjectDisposedException()
         {
             using var surface = new SubDesignSurface();
@@ -1019,7 +1019,7 @@ namespace System.ComponentModel.Design.Tests
         }
 
 #pragma warning disable 0618
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_CreateComponent_IComponentWithPublicDefaultConstructor_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();
@@ -1027,7 +1027,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(instance.Container);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_CreateComponent_IComponentWithPrivateDefaultConstructor_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();
@@ -1035,7 +1035,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(instance.Container);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_CreateComponent_IComponentWithIContainerConstructor_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();
@@ -1043,7 +1043,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(surface.ComponentContainer, instance.Container);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [InlineData(typeof(ClassWithPublicConstructor))]
         [InlineData(typeof(ClassWithPrivateDefaultConstructor))]
         public void DesignSurface_CreateComponent_NonIComponent_ReturnsNull(Type type)
@@ -1052,7 +1052,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(surface.CreateComponent(type));
         }
 
-        [Theory]
+        [WinFormsTheory]
         [InlineData(typeof(ClassWithIContainerConstructor))]
         [InlineData(typeof(ClassWithNoMatchingConstructor))]
         [InlineData(typeof(ComponentWithPrivateIContainerConstructor))]
@@ -1063,7 +1063,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<MissingMethodException>(() => surface.CreateComponent(type));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_CreateComponent_NullType_ThrowsArgumentNullException()
         {
             using var surface = new SubDesignSurface();
@@ -1071,21 +1071,21 @@ namespace System.ComponentModel.Design.Tests
         }
 #pragma warning restore 0618
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_CreateInstance_NonIComponentWithPublicDefaultConstructor_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();
             Assert.IsType<ClassWithPublicConstructor>(surface.CreateInstance(typeof(ClassWithPublicConstructor)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_CreateInstance_NonIComponentWithPrivateDefaultConstructor_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();
             Assert.IsType<ClassWithPrivateDefaultConstructor>(surface.CreateInstance(typeof(ClassWithPrivateDefaultConstructor)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_CreateInstance_IComponentWithPublicDefaultConstructor_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();
@@ -1093,7 +1093,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(instance.Container);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_CreateInstance_IComponentWithPrivateDefaultConstructor_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();
@@ -1101,7 +1101,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(instance.Container);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_CreateInstance_IComponentWithIContainerConstructor_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();
@@ -1109,7 +1109,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(surface.ComponentContainer, instance.Container);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [InlineData(typeof(ClassWithIContainerConstructor))]
         [InlineData(typeof(ClassWithNoMatchingConstructor))]
         [InlineData(typeof(ComponentWithPrivateIContainerConstructor))]
@@ -1120,14 +1120,14 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<MissingMethodException>(() => surface.CreateInstance(type));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_CreateInstance_NullType_ThrowsArgumentNullException()
         {
             using var surface = new SubDesignSurface();
             Assert.Throws<ArgumentNullException>("type", () => surface.CreateInstance(null));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_CreateNestedContainer_InvokeObject_ReturnsExpected()
         {
             using var surface = new DesignSurface();
@@ -1137,7 +1137,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(ownerComponent, container.Owner);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringTheoryData))]
         public void DesignSurface_CreateNestedContainer_InvokeObjectString_ReturnsExpected(string containerName)
         {
@@ -1148,7 +1148,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(ownerComponent, container.Owner);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_CreateNestedContainer_NullOwningComponent_ThrowsArgumentNullException()
         {
             using var surface = new DesignSurface();
@@ -1156,7 +1156,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<ArgumentNullException>("owningComponent", () => surface.CreateNestedContainer(null, "name"));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_CreateNestedContainer_Disposed_ThrowsObjectDisposedException()
         {
             using var surface = new DesignSurface();
@@ -1164,7 +1164,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<ObjectDisposedException>(() => surface.CreateNestedContainer(null, "name"));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_Dispose_InvokeMultipleTimes_Success()
         {
             using var surface = new DesignSurface();
@@ -1172,7 +1172,7 @@ namespace System.ComponentModel.Design.Tests
             surface.Dispose();
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_Dispose_Invoke_RemovesDesignSurfaceService()
         {
             using var surface = new SubDesignSurface();
@@ -1183,7 +1183,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(container.GetService(typeof(DesignSurface)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_Dispose_InvokeHasLoader_ThrowsInvalidOperationException()
         {
             var surface = new SubDesignSurface();
@@ -1200,7 +1200,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.True(host.Loading);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_Dispose_InvokeHasHostWithTransactions_ThrowsInvalidOperationException()
         {
             var surface = new SubDesignSurface();
@@ -1225,7 +1225,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal("Transaction1", host.TransactionDescription);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void Dispose_InvokeWithDisposed_CallsHandler()
         {
             using var surface = new DesignSurface();
@@ -1254,7 +1254,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(2, callCount);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void DesignSurface_Dispose_InvokeDisposingMultipleTimes_Success(bool disposing)
         {
@@ -1263,7 +1263,7 @@ namespace System.ComponentModel.Design.Tests
             surface.Dispose(disposing);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_Dispose_InvokeDisposing_RemovesDesignSurfaceService()
         {
             using var surface = new SubDesignSurface();
@@ -1274,7 +1274,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(container.GetService(typeof(DesignSurface)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_Dispose_InvokeNotDisposing_DoesNotRemoveDesignSurfaceService()
         {
             using var surface = new SubDesignSurface();
@@ -1285,7 +1285,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(surface, container.GetService(typeof(DesignSurface)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_Dispose_InvokeDisposingHasLoader_ThrowsInvalidOperationException()
         {
             var surface = new SubDesignSurface();
@@ -1302,7 +1302,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.True(host.Loading);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_Dispose_InvokeNotDisposingHasLoader_Nop()
         {
             var surface = new SubDesignSurface();
@@ -1319,7 +1319,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.True(host.Loading);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_Dispose_InvokeDisposingHasHostWithTransactions_ThrowsInvalidOperationException()
         {
             var surface = new SubDesignSurface();
@@ -1344,7 +1344,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal("Transaction1", host.TransactionDescription);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_Dispose_InvokeNotDisposingHasHostWithTransactions_Nop()
         {
             var surface = new SubDesignSurface();
@@ -1369,7 +1369,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal("Transaction1", host.TransactionDescription);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [InlineData(true, 1)]
         [InlineData(false, 0)]
         public void Dispose_InvokeDisposingWithDisposed_CallsHandler(bool disposing, int expectedCallCount)
@@ -1400,7 +1400,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(expectedCallCount * 2, callCount);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_Flush_InvokeWithHostWithLoader_CallsLoaderFlush()
         {
             var surface = new SubDesignSurface();
@@ -1421,7 +1421,7 @@ namespace System.ComponentModel.Design.Tests
             mockLoader.Verify(l => l.Flush(), Times.Exactly(2));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_Flush_InvokeWithHostWithoutLoader_Nop()
         {
             using var surface = new DesignSurface();
@@ -1431,7 +1431,7 @@ namespace System.ComponentModel.Design.Tests
             surface.Flush();
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_Flush_InvokeDisposed_Nop()
         {
             using var surface = new DesignSurface();
@@ -1442,7 +1442,7 @@ namespace System.ComponentModel.Design.Tests
             surface.Flush();
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_Flush_InvokeWithFlushed_CallsHandler()
         {
             using var surface = new DesignSurface();
@@ -1467,7 +1467,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(3, callCount);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_GetService_InvokeWithServiceProvider_ReturnsExpected()
         {
             var service = new object();
@@ -1481,7 +1481,7 @@ namespace System.ComponentModel.Design.Tests
             mockServiceProvider.Verify(p => p.GetService(typeof(int)), Times.Once());
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_GetService_GetISelectionService_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();
@@ -1490,14 +1490,14 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(0, service.SelectionCount);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_GetService_GetIExtenderProviderService_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();
             Assert.IsAssignableFrom<IExtenderProviderService>(surface.GetService(typeof(IExtenderProviderService)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_GetService_GetIExtenderListService_ReturnsExpected()
         {
             using var surface = new DesignSurface();
@@ -1505,35 +1505,35 @@ namespace System.ComponentModel.Design.Tests
             Assert.IsAssignableFrom<IExtenderProviderService>(surface.GetService(typeof(IExtenderListService)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_GetService_GetITypeDescriptorFilterService_ReturnsExpected()
         {
             using var surface = new DesignSurface();
             Assert.IsAssignableFrom<ITypeDescriptorFilterService>(surface.GetService(typeof(ITypeDescriptorFilterService)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_GetService_GetIReferenceService_ReturnsExpected()
         {
             using var surface = new DesignSurface();
             Assert.IsAssignableFrom<IReferenceService>(surface.GetService(typeof(IReferenceService)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_GetService_GetDesignSurfaceService_ReturnsExpected()
         {
             using var surface = new DesignSurface();
             Assert.Same(surface, surface.GetService(typeof(DesignSurface)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_GetService_GetInstanceTypeService_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();
             Assert.Same(surface.ServiceContainer, surface.GetService(surface.ServiceContainer.GetType()));
         }
 
-        [Theory]
+        [WinFormsTheory]
         [InlineData(typeof(IServiceContainer))]
         [InlineData(typeof(ServiceContainer))]
         public void DesignSurface_GetService_IServiceContainer_ReturnsExpected(Type serviceType)
@@ -1542,7 +1542,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(surface.ServiceContainer, surface.GetService(serviceType));
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(ServiceContainer_FixedService_TestData))]
         public void DesignSurface_GetService_GetFixedService_ReturnsExpected(Type serviceType)
         {
@@ -1550,14 +1550,14 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(surface.Host, surface.GetService(serviceType));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignSurface_GetService_InvokeWithoutServiceProvider_ReturnsNull()
         {
             using var surface = new DesignSurface();
             Assert.Null(surface.GetService(typeof(int)));
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(ServiceContainer_FixedService_TestData))]
         public void DesignSurface_GetService_Disposed_ReturnsNull(Type serviceType)
         {
@@ -1566,7 +1566,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(surface.GetService(serviceType));
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
         public void DesignSurface_OnLoading_Invoke_Success(EventArgs eventArgs)
         {
@@ -1600,7 +1600,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { new LoadedEventArgs(false, null) };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(LoadedEventArgs_TestData))]
         public void DesignSurface_OnLoaded_Invoke_Success(LoadedEventArgs eventArgs)
         {
@@ -1628,7 +1628,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(1, callCount);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
         public void DesignSurface_OnUnloaded_Invoke_Success(EventArgs eventArgs)
         {
@@ -1656,7 +1656,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(1, callCount);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
         public void DesignSurface_OnUnloading_Invoke_Success(EventArgs eventArgs)
         {
@@ -1684,7 +1684,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(1, callCount);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
         public void DesignSurface_OnViewActivate_Invoke_Success(EventArgs eventArgs)
         {

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignSurfaceTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignSurfaceTests.cs
@@ -412,7 +412,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(BeginLoad_TestData))]
         public void DesignSurface_BeginLoad_Invoke_Success(IServiceProvider parentProvider)
         {
-            using var surface = new SubDesignSurface(parentProvider);
+            var surface = new SubDesignSurface(parentProvider);
             IDesignerLoaderHost2 host = surface.Host;
             var mockLoader = new Mock<DesignerLoader>(MockBehavior.Strict);
             mockLoader
@@ -620,7 +620,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(IDesignerEventService)))
                 .Returns(null)
                 .Verifiable();
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IExtenderListService defaultProviderService = (IExtenderListService)surface.GetService(typeof(IExtenderListService));
             IDesignerLoaderHost2 host = surface.Host;
 
@@ -659,7 +659,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(IDesignerEventService)))
                 .Returns(null)
                 .Verifiable();
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IExtenderListService defaultProviderService = (IExtenderListService)surface.GetService(typeof(IExtenderListService));
             surface.ServiceContainer.RemoveService(typeof(IExtenderProviderService));
             IDesignerLoaderHost2 host = surface.Host;
@@ -704,7 +704,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(IDesignerEventService)))
                 .Returns(null)
                 .Verifiable();
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IExtenderListService defaultProviderService = (IExtenderListService)surface.GetService(typeof(IExtenderListService));
             surface.ServiceContainer.RemoveService(typeof(IExtenderProviderService));
             IDesignerLoaderHost2 host = surface.Host;
@@ -731,7 +731,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_BeginLoad_InvokeWithoutIDesignerEventServiceWithActivated_CallsHandler()
         {
-            using var surface = new SubDesignSurface();
+            var surface = new SubDesignSurface();
             int callCount = 0;
             IDesignerLoaderHost2 host = surface.Host;
             host.Activated += (sender, e) =>
@@ -764,7 +764,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(IDesignerEventService)))
                 .Returns(mockDesignerEventService.Object)
                 .Verifiable();
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
             int callCount = 0;
             host.Activated += (sender, e) =>

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignSurfaceTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignSurfaceTests.cs
@@ -16,7 +16,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_Ctor_Default()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             Assert.NotNull(surface.ComponentContainer);
             Assert.Empty(surface.ComponentContainer.Components);
             Assert.False(surface.DtelLoading);
@@ -55,7 +55,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(Ctor_IServiceProvider_TestData))]
         public void DesignSurface_Ctor_IServiceProvider(IServiceProvider parentProvider)
         {
-            var surface = new SubDesignSurface(parentProvider);
+            using var surface = new SubDesignSurface(parentProvider);
             Assert.NotNull(surface.ComponentContainer);
             Assert.Empty(surface.ComponentContainer.Components);
             Assert.False(surface.DtelLoading);
@@ -77,7 +77,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_Ctor_Type()
         {
-            var surface = new SubDesignSurface(typeof(RootDesignerComponent));
+            using var surface = new SubDesignSurface(typeof(RootDesignerComponent));
             Assert.NotNull(surface.ComponentContainer);
             Assert.Single(surface.ComponentContainer.Components);
             Assert.False(surface.DtelLoading);
@@ -99,7 +99,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_Ctor_IServiceProvider_Type_NullParentProvider()
         {
-            var surface = new SubDesignSurface(null, typeof(RootDesignerComponent));
+            using var surface = new SubDesignSurface(null, typeof(RootDesignerComponent));
             Assert.NotNull(surface.ComponentContainer);
             Assert.Single(surface.ComponentContainer.Components);
             Assert.False(surface.DtelLoading);
@@ -146,7 +146,7 @@ namespace System.ComponentModel.Design.Tests
             mockServiceProvider
                 .Setup(p => p.GetService(typeof(ContainerFilterService)))
                 .Returns(null);
-            var surface = new SubDesignSurface(mockServiceProvider.Object, typeof(RootDesignerComponent));
+            using var surface = new SubDesignSurface(mockServiceProvider.Object, typeof(RootDesignerComponent));
             Assert.NotNull(surface.ComponentContainer);
             Assert.Single(surface.ComponentContainer.Components);
             Assert.False(surface.DtelLoading);
@@ -176,7 +176,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_ComponentContainer_GetDisposed_ThrowsObjectDisposedException()
         {
-            var surface = new DesignSurface();
+            using var surface = new DesignSurface();
             surface.Dispose();
             Assert.Throws<ObjectDisposedException>(() => surface.ComponentContainer);
         }
@@ -185,7 +185,7 @@ namespace System.ComponentModel.Design.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void DesignSurface_DtelLoading_Set_GetReturnsExpected(bool value)
         {
-            var surface = new DesignSurface()
+            using var surface = new DesignSurface()
             {
                 DtelLoading = value
             };
@@ -203,7 +203,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_ServiceContainer_Get_ReturnsSame()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             ServiceContainer container = surface.ServiceContainer;
             Assert.NotNull(container);
             Assert.Same(container, surface.ServiceContainer);
@@ -212,7 +212,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_ServiceContainer_GetISelectionService_ReturnsExpected()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             ServiceContainer container = surface.ServiceContainer;
             ISelectionService service = Assert.IsAssignableFrom<ISelectionService>(container.GetService(typeof(ISelectionService)));
             Assert.Null(service.PrimarySelection);
@@ -222,7 +222,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_ServiceContainer_GetIExtenderProviderService_ReturnsExpected()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             ServiceContainer container = surface.ServiceContainer;
             Assert.IsAssignableFrom<IExtenderProviderService>(container.GetService(typeof(IExtenderProviderService)));
         }
@@ -230,7 +230,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_ServiceContainer_GetIExtenderListService_ReturnsExpected()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             ServiceContainer container = surface.ServiceContainer;
             Assert.IsAssignableFrom<IExtenderListService>(container.GetService(typeof(IExtenderListService)));
             Assert.IsAssignableFrom<IExtenderProviderService>(container.GetService(typeof(IExtenderListService)));
@@ -239,7 +239,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_ServiceContainer_GetITypeDescriptorFilterService_ReturnsExpected()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             ServiceContainer container = surface.ServiceContainer;
             Assert.IsAssignableFrom<ITypeDescriptorFilterService>(container.GetService(typeof(ITypeDescriptorFilterService)));
         }
@@ -247,7 +247,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_ServiceContainer_GetIReferenceService_ReturnsExpected()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             ServiceContainer container = surface.ServiceContainer;
             Assert.IsAssignableFrom<IReferenceService>(container.GetService(typeof(IReferenceService)));
         }
@@ -255,7 +255,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_ServiceContainer_GetDesignSurfaceService_ReturnsExpected()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             ServiceContainer container = surface.ServiceContainer;
             Assert.Same(surface, container.GetService(typeof(DesignSurface)));
         }
@@ -263,7 +263,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_ServiceContainer_GetInstanceTypeService_ReturnsExpected()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             ServiceContainer container = surface.ServiceContainer;
             Assert.Same(container, container.GetService(container.GetType()));
         }
@@ -280,7 +280,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(ServiceContainer_FixedService_TestData))]
         public void DesignSurface_ServiceContainer_GetFixedService_ReturnsExpected(Type serviceType)
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             ServiceContainer container = surface.ServiceContainer;
             Assert.Same(surface.Host, container.GetService(serviceType));
         }
@@ -289,7 +289,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(ServiceContainer_FixedService_TestData))]
         public void DesignSurface_ServiceContainer_RemoveFixedService_ThrowsInvalidOperationException(Type serviceType)
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             ServiceContainer container = surface.ServiceContainer;
             Assert.Throws<InvalidOperationException>(() => container.RemoveService(serviceType));
         }
@@ -303,7 +303,7 @@ namespace System.ComponentModel.Design.Tests
         [InlineData(typeof(DesignSurface))]
         public void DesignSurface_ServiceContainer_RemoveNonFixedServiceType_ThrowsArgumentNullException(Type serviceType)
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             ServiceContainer container = surface.ServiceContainer;
             Assert.NotNull(container.GetService(serviceType));
             container.RemoveService(serviceType);
@@ -317,7 +317,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_ServiceContainer_RemoveNullServiceType_ThrowsArgumentNullException()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             ServiceContainer container = surface.ServiceContainer;
             Assert.Throws<ArgumentNullException>("serviceType", () => container.RemoveService(null));
         }
@@ -325,7 +325,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_ServiceContainer_GetDisposed_ThrowsObjectDisposedException()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             surface.Dispose();
             Assert.Throws<ObjectDisposedException>(() => surface.ServiceContainer);
         }
@@ -335,7 +335,7 @@ namespace System.ComponentModel.Design.Tests
         [InlineData(typeof(EmptySupportedTechnologiesRootDesignerComponent))]
         public void DesignSurface_View_GetWithInvalidSupportedTechnologies_ThrowsNotSupportedException(Type rootComponentType)
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             surface.BeginLoad(rootComponentType);
             Assert.Throws<NotSupportedException>(() => surface.View);
         }
@@ -343,7 +343,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_View_GetDisposed_ThrowsObjectDisposedException()
         {
-            var surface = new DesignSurface();
+            using var surface = new DesignSurface();
             surface.Dispose();
             Assert.Throws<ObjectDisposedException>(() => surface.View);
         }
@@ -412,7 +412,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(BeginLoad_TestData))]
         public void DesignSurface_BeginLoad_Invoke_Success(IServiceProvider parentProvider)
         {
-            var surface = new SubDesignSurface(parentProvider);
+            using var surface = new SubDesignSurface(parentProvider);
             IDesignerLoaderHost2 host = surface.Host;
             var mockLoader = new Mock<DesignerLoader>(MockBehavior.Strict);
             mockLoader
@@ -620,7 +620,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(IDesignerEventService)))
                 .Returns(null)
                 .Verifiable();
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IExtenderListService defaultProviderService = (IExtenderListService)surface.GetService(typeof(IExtenderListService));
             IDesignerLoaderHost2 host = surface.Host;
 
@@ -659,7 +659,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(IDesignerEventService)))
                 .Returns(null)
                 .Verifiable();
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IExtenderListService defaultProviderService = (IExtenderListService)surface.GetService(typeof(IExtenderListService));
             surface.ServiceContainer.RemoveService(typeof(IExtenderProviderService));
             IDesignerLoaderHost2 host = surface.Host;
@@ -704,7 +704,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(IDesignerEventService)))
                 .Returns(null)
                 .Verifiable();
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IExtenderListService defaultProviderService = (IExtenderListService)surface.GetService(typeof(IExtenderListService));
             surface.ServiceContainer.RemoveService(typeof(IExtenderProviderService));
             IDesignerLoaderHost2 host = surface.Host;
@@ -731,7 +731,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_BeginLoad_InvokeWithoutIDesignerEventServiceWithActivated_CallsHandler()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             int callCount = 0;
             IDesignerLoaderHost2 host = surface.Host;
             host.Activated += (sender, e) =>
@@ -764,7 +764,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(IDesignerEventService)))
                 .Returns(mockDesignerEventService.Object)
                 .Verifiable();
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
             int callCount = 0;
             host.Activated += (sender, e) =>
@@ -793,7 +793,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_BeginLoad_DisposeInLoading_DoesCallFlush()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             int loadingCallCount = 0;
             surface.Loading += (sender, e) =>
             {
@@ -831,7 +831,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_BeginLoad_DisposeInBeginLoad_DoesCallFlush()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             int loadingCallCount = 0;
             surface.Loading += (sender, e) =>
             {
@@ -875,7 +875,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_BeginLoad_DisposeInBeginLoadThrowsException_DoesCallFlush()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             int loadingCallCount = 0;
             surface.Loading += (sender, e) =>
             {
@@ -921,7 +921,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_BeginLoad_NullLoader_ThrowsArgumentNullException()
         {
-            var surface = new DesignSurface();
+            using var surface = new DesignSurface();
             Assert.Throws<ArgumentNullException>("loader", () => surface.BeginLoad((DesignerLoader)null));
         }
 
@@ -943,7 +943,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_BeginLoad_NullRootComponentType_ThrowsArgumentNullException()
         {
-            var surface = new DesignSurface();
+            using var surface = new DesignSurface();
             Assert.Throws<ArgumentNullException>("rootComponentType", () => surface.BeginLoad((Type)null));
         }
 
@@ -967,7 +967,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_BeginLoad_Disposed_ThrowsObjectDisposedException()
         {
-            var surface = new DesignSurface();
+            using var surface = new DesignSurface();
             surface.Dispose();
             var mockLoader = new Mock<DesignerLoader>(MockBehavior.Strict);
             Assert.Throws<ObjectDisposedException>(() => surface.BeginLoad(typeof(RootDesignerComponent)));
@@ -977,8 +977,8 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_CreateDesigner_InvokeNoDesigner_ReturnsExpected()
         {
-            var surface = new DesignSurface();
-            var component = new Component();
+            using var surface = new SubDesignSurface();
+            using var component = new Component();
             Assert.Null(surface.CreateDesigner(component, rootDesigner: true));
             Assert.Null(surface.CreateDesigner(component, rootDesigner: false));
         }
@@ -986,8 +986,8 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_CreateDesigner_InvokeIDesigner_ReturnsExpected()
         {
-            var surface = new DesignSurface();
-            var component = new DesignerComponent();
+            using var surface = new SubDesignSurface();
+            using var component = new DesignerComponent();
             Assert.Null(surface.CreateDesigner(component, rootDesigner: true));
             Assert.IsType<ComponentDesigner>(surface.CreateDesigner(component, rootDesigner: false));
         }
@@ -995,8 +995,8 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_CreateDesigner_InvokeIRootDesigner_ReturnsExpected()
         {
-            var surface = new DesignSurface();
-            var component = new RootDesignerComponent();
+            using var surface = new SubDesignSurface();
+            using var component = new RootDesignerComponent();
             Assert.IsType<RootComponentDesigner>(surface.CreateDesigner(component, rootDesigner: true));
             Assert.Null(surface.CreateDesigner(component, rootDesigner: false));
         }
@@ -1004,7 +1004,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_CreateDesigner_NullComponent_ThrowsArgumentNullException()
         {
-            var surface = new DesignSurface();
+            using var surface = new SubDesignSurface();
             Assert.Throws<ArgumentNullException>("component", () => surface.CreateDesigner(null, true));
             Assert.Throws<ArgumentNullException>("component", () => surface.CreateDesigner(null, false));
         }
@@ -1012,7 +1012,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_CreateDesigner_Disposed_ThrowsObjectDisposedException()
         {
-            var surface = new DesignSurface();
+            using var surface = new SubDesignSurface();
             surface.Dispose();
             Assert.Throws<ObjectDisposedException>(() => surface.CreateDesigner(new Component(), true));
             Assert.Throws<ObjectDisposedException>(() => surface.CreateDesigner(new Component(), false));
@@ -1022,7 +1022,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_CreateComponent_IComponentWithPublicDefaultConstructor_ReturnsExpected()
         {
-            var surface = new DesignSurface();
+            using var surface = new SubDesignSurface();
             ComponentWithPublicConstructor instance = Assert.IsType<ComponentWithPublicConstructor>(surface.CreateComponent(typeof(ComponentWithPublicConstructor)));
             Assert.Null(instance.Container);
         }
@@ -1030,7 +1030,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_CreateComponent_IComponentWithPrivateDefaultConstructor_ReturnsExpected()
         {
-            var surface = new DesignSurface();
+            using var surface = new SubDesignSurface();
             ComponentWithPrivateDefaultConstructor instance = Assert.IsType<ComponentWithPrivateDefaultConstructor>(surface.CreateComponent(typeof(ComponentWithPrivateDefaultConstructor)));
             Assert.Null(instance.Container);
         }
@@ -1038,7 +1038,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_CreateComponent_IComponentWithIContainerConstructor_ReturnsExpected()
         {
-            var surface = new DesignSurface();
+            using var surface = new SubDesignSurface();
             ComponentWithIContainerConstructor instance = Assert.IsType<ComponentWithIContainerConstructor>(surface.CreateComponent(typeof(ComponentWithIContainerConstructor)));
             Assert.Same(surface.ComponentContainer, instance.Container);
         }
@@ -1048,7 +1048,7 @@ namespace System.ComponentModel.Design.Tests
         [InlineData(typeof(ClassWithPrivateDefaultConstructor))]
         public void DesignSurface_CreateComponent_NonIComponent_ReturnsNull(Type type)
         {
-            var surface = new DesignSurface();
+            using var surface = new SubDesignSurface();
             Assert.Null(surface.CreateComponent(type));
         }
 
@@ -1059,14 +1059,14 @@ namespace System.ComponentModel.Design.Tests
         [InlineData(typeof(ComponentWithNoMatchingConstructor))]
         public void DesignSurface_CreateComponent_TypeWithNoMatchingConstructor_ThrowsMissingMethodException(Type type)
         {
-            var surface = new DesignSurface();
+            using var surface = new SubDesignSurface();
             Assert.Throws<MissingMethodException>(() => surface.CreateComponent(type));
         }
 
         [Fact]
         public void DesignSurface_CreateComponent_NullType_ThrowsArgumentNullException()
         {
-            var surface = new DesignSurface();
+            using var surface = new SubDesignSurface();
             Assert.Throws<ArgumentNullException>("type", () => surface.CreateComponent(null));
         }
 #pragma warning restore 0618
@@ -1074,21 +1074,21 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_CreateInstance_NonIComponentWithPublicDefaultConstructor_ReturnsExpected()
         {
-            var surface = new DesignSurface();
+            using var surface = new SubDesignSurface();
             Assert.IsType<ClassWithPublicConstructor>(surface.CreateInstance(typeof(ClassWithPublicConstructor)));
         }
 
         [Fact]
         public void DesignSurface_CreateInstance_NonIComponentWithPrivateDefaultConstructor_ReturnsExpected()
         {
-            var surface = new DesignSurface();
+            using var surface = new SubDesignSurface();
             Assert.IsType<ClassWithPrivateDefaultConstructor>(surface.CreateInstance(typeof(ClassWithPrivateDefaultConstructor)));
         }
 
         [Fact]
         public void DesignSurface_CreateInstance_IComponentWithPublicDefaultConstructor_ReturnsExpected()
         {
-            var surface = new DesignSurface();
+            using var surface = new SubDesignSurface();
             ComponentWithPublicConstructor instance = Assert.IsType<ComponentWithPublicConstructor>(surface.CreateInstance(typeof(ComponentWithPublicConstructor)));
             Assert.Null(instance.Container);
         }
@@ -1096,7 +1096,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_CreateInstance_IComponentWithPrivateDefaultConstructor_ReturnsExpected()
         {
-            var surface = new DesignSurface();
+            using var surface = new SubDesignSurface();
             ComponentWithPrivateDefaultConstructor instance = Assert.IsType<ComponentWithPrivateDefaultConstructor>(surface.CreateInstance(typeof(ComponentWithPrivateDefaultConstructor)));
             Assert.Null(instance.Container);
         }
@@ -1104,7 +1104,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_CreateInstance_IComponentWithIContainerConstructor_ReturnsExpected()
         {
-            var surface = new DesignSurface();
+            using var surface = new SubDesignSurface();
             ComponentWithIContainerConstructor instance = Assert.IsType<ComponentWithIContainerConstructor>(surface.CreateInstance(typeof(ComponentWithIContainerConstructor)));
             Assert.Same(surface.ComponentContainer, instance.Container);
         }
@@ -1116,23 +1116,23 @@ namespace System.ComponentModel.Design.Tests
         [InlineData(typeof(ComponentWithNoMatchingConstructor))]
         public void DesignSurface_CreateInstance_TypeWithNoMatchingConstructor_ThrowsMissingMethodException(Type type)
         {
-            var surface = new DesignSurface();
+            using var surface = new SubDesignSurface();
             Assert.Throws<MissingMethodException>(() => surface.CreateInstance(type));
         }
 
         [Fact]
         public void DesignSurface_CreateInstance_NullType_ThrowsArgumentNullException()
         {
-            var surface = new DesignSurface();
+            using var surface = new SubDesignSurface();
             Assert.Throws<ArgumentNullException>("type", () => surface.CreateInstance(null));
         }
 
         [Fact]
         public void DesignSurface_CreateNestedContainer_InvokeObject_ReturnsExpected()
         {
-            var surface = new DesignSurface();
-            var ownerComponent = new Component();
-            INestedContainer container = surface.CreateNestedContainer(ownerComponent);
+            using var surface = new DesignSurface();
+            using var ownerComponent = new Component();
+            using INestedContainer container = surface.CreateNestedContainer(ownerComponent);
             Assert.Empty(container.Components);
             Assert.Same(ownerComponent, container.Owner);
         }
@@ -1141,9 +1141,9 @@ namespace System.ComponentModel.Design.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetStringTheoryData))]
         public void DesignSurface_CreateNestedContainer_InvokeObjectString_ReturnsExpected(string containerName)
         {
-            var surface = new DesignSurface();
-            var ownerComponent = new Component();
-            INestedContainer container = surface.CreateNestedContainer(ownerComponent, containerName);
+            using var surface = new DesignSurface();
+            using var ownerComponent = new Component();
+            using INestedContainer container = surface.CreateNestedContainer(ownerComponent, containerName);
             Assert.Empty(container.Components);
             Assert.Same(ownerComponent, container.Owner);
         }
@@ -1151,7 +1151,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_CreateNestedContainer_NullOwningComponent_ThrowsArgumentNullException()
         {
-            var surface = new DesignSurface();
+            using var surface = new DesignSurface();
             Assert.Throws<ArgumentNullException>("owningComponent", () => surface.CreateNestedContainer(null));
             Assert.Throws<ArgumentNullException>("owningComponent", () => surface.CreateNestedContainer(null, "name"));
         }
@@ -1159,7 +1159,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_CreateNestedContainer_Disposed_ThrowsObjectDisposedException()
         {
-            var surface = new DesignSurface();
+            using var surface = new DesignSurface();
             surface.Dispose();
             Assert.Throws<ObjectDisposedException>(() => surface.CreateNestedContainer(null, "name"));
         }
@@ -1167,7 +1167,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_Dispose_InvokeMultipleTimes_Success()
         {
-            var surface = new DesignSurface();
+            using var surface = new DesignSurface();
             surface.Dispose();
             surface.Dispose();
         }
@@ -1175,7 +1175,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_Dispose_Invoke_RemovesDesignSurfaceService()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             ServiceContainer container = surface.ServiceContainer;
             Assert.Same(surface, container.GetService(typeof(DesignSurface)));
 
@@ -1228,7 +1228,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void Dispose_InvokeWithDisposed_CallsHandler()
         {
-            var surface = new DesignSurface();
+            using var surface = new DesignSurface();
             surface.Dispose();
 
             int callCount = 0;
@@ -1258,7 +1258,7 @@ namespace System.ComponentModel.Design.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void DesignSurface_Dispose_InvokeDisposingMultipleTimes_Success(bool disposing)
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             surface.Dispose(disposing);
             surface.Dispose(disposing);
         }
@@ -1266,7 +1266,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_Dispose_InvokeDisposing_RemovesDesignSurfaceService()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             ServiceContainer container = surface.ServiceContainer;
             Assert.Same(surface, container.GetService(typeof(DesignSurface)));
 
@@ -1277,7 +1277,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_Dispose_InvokeNotDisposing_DoesNotRemoveDesignSurfaceService()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             ServiceContainer container = surface.ServiceContainer;
             Assert.Same(surface, container.GetService(typeof(DesignSurface)));
 
@@ -1374,7 +1374,7 @@ namespace System.ComponentModel.Design.Tests
         [InlineData(false, 0)]
         public void Dispose_InvokeDisposingWithDisposed_CallsHandler(bool disposing, int expectedCallCount)
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             surface.Dispose();
 
             int callCount = 0;
@@ -1424,7 +1424,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_Flush_InvokeWithHostWithoutLoader_Nop()
         {
-            var surface = new DesignSurface();
+            using var surface = new DesignSurface();
             surface.Flush();
 
             // Flush again.
@@ -1434,7 +1434,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_Flush_InvokeDisposed_Nop()
         {
-            var surface = new DesignSurface();
+            using var surface = new DesignSurface();
             surface.Dispose();
             surface.Flush();
 
@@ -1445,7 +1445,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_Flush_InvokeWithFlushed_CallsHandler()
         {
-            var surface = new DesignSurface();
+            using var surface = new DesignSurface();
             int callCount = 0;
             surface.Flushed += (sender, e) =>
             {
@@ -1476,7 +1476,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(int)))
                 .Returns(service)
                 .Verifiable();
-            var surface = new DesignSurface(mockServiceProvider.Object);
+            using var surface = new DesignSurface(mockServiceProvider.Object);
             Assert.Same(service, surface.GetService(typeof(int)));
             mockServiceProvider.Verify(p => p.GetService(typeof(int)), Times.Once());
         }
@@ -1484,7 +1484,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_GetService_GetISelectionService_ReturnsExpected()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             ISelectionService service = Assert.IsAssignableFrom<ISelectionService>(surface.GetService(typeof(ISelectionService)));
             Assert.Null(service.PrimarySelection);
             Assert.Equal(0, service.SelectionCount);
@@ -1493,14 +1493,14 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_GetService_GetIExtenderProviderService_ReturnsExpected()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             Assert.IsAssignableFrom<IExtenderProviderService>(surface.GetService(typeof(IExtenderProviderService)));
         }
 
         [Fact]
         public void DesignSurface_GetService_GetIExtenderListService_ReturnsExpected()
         {
-            var surface = new DesignSurface();
+            using var surface = new DesignSurface();
             Assert.IsAssignableFrom<IExtenderListService>(surface.GetService(typeof(IExtenderListService)));
             Assert.IsAssignableFrom<IExtenderProviderService>(surface.GetService(typeof(IExtenderListService)));
         }
@@ -1508,28 +1508,28 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignSurface_GetService_GetITypeDescriptorFilterService_ReturnsExpected()
         {
-            var surface = new DesignSurface();
+            using var surface = new DesignSurface();
             Assert.IsAssignableFrom<ITypeDescriptorFilterService>(surface.GetService(typeof(ITypeDescriptorFilterService)));
         }
 
         [Fact]
         public void DesignSurface_GetService_GetIReferenceService_ReturnsExpected()
         {
-            var surface = new DesignSurface();
+            using var surface = new DesignSurface();
             Assert.IsAssignableFrom<IReferenceService>(surface.GetService(typeof(IReferenceService)));
         }
 
         [Fact]
         public void DesignSurface_GetService_GetDesignSurfaceService_ReturnsExpected()
         {
-            var surface = new DesignSurface();
+            using var surface = new DesignSurface();
             Assert.Same(surface, surface.GetService(typeof(DesignSurface)));
         }
 
         [Fact]
         public void DesignSurface_GetService_GetInstanceTypeService_ReturnsExpected()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             Assert.Same(surface.ServiceContainer, surface.GetService(surface.ServiceContainer.GetType()));
         }
 
@@ -1538,7 +1538,7 @@ namespace System.ComponentModel.Design.Tests
         [InlineData(typeof(ServiceContainer))]
         public void DesignSurface_GetService_IServiceContainer_ReturnsExpected(Type serviceType)
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             Assert.Same(surface.ServiceContainer, surface.GetService(serviceType));
         }
 
@@ -1546,14 +1546,14 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(ServiceContainer_FixedService_TestData))]
         public void DesignSurface_GetService_GetFixedService_ReturnsExpected(Type serviceType)
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             Assert.Same(surface.Host, surface.GetService(serviceType));
         }
 
         [Fact]
         public void DesignSurface_GetService_InvokeWithoutServiceProvider_ReturnsNull()
         {
-            var surface = new DesignSurface();
+            using var surface = new DesignSurface();
             Assert.Null(surface.GetService(typeof(int)));
         }
 
@@ -1561,7 +1561,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(ServiceContainer_FixedService_TestData))]
         public void DesignSurface_GetService_Disposed_ReturnsNull(Type serviceType)
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             surface.Dispose();
             Assert.Null(surface.GetService(serviceType));
         }
@@ -1570,7 +1570,7 @@ namespace System.ComponentModel.Design.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
         public void DesignSurface_OnLoading_Invoke_Success(EventArgs eventArgs)
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
 
             // No handler.
             surface.OnLoading(eventArgs);
@@ -1604,7 +1604,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(LoadedEventArgs_TestData))]
         public void DesignSurface_OnLoaded_Invoke_Success(LoadedEventArgs eventArgs)
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
 
             // No handler.
             surface.OnLoaded(eventArgs);
@@ -1632,7 +1632,7 @@ namespace System.ComponentModel.Design.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
         public void DesignSurface_OnUnloaded_Invoke_Success(EventArgs eventArgs)
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
 
             // No handler.
             surface.OnUnloaded(eventArgs);
@@ -1660,7 +1660,7 @@ namespace System.ComponentModel.Design.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
         public void DesignSurface_OnUnloading_Invoke_Success(EventArgs eventArgs)
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
 
             // No handler.
             surface.OnUnloading(eventArgs);
@@ -1688,7 +1688,7 @@ namespace System.ComponentModel.Design.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
         public void DesignSurface_OnViewActivate_Invoke_Success(EventArgs eventArgs)
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
 
             // No handler.
             surface.OnViewActivate(eventArgs);
@@ -1733,6 +1733,14 @@ namespace System.ComponentModel.Design.Tests
             public new ServiceContainer ServiceContainer => base.ServiceContainer;
 
             public IDesignerLoaderHost2 Host => Assert.IsAssignableFrom<IDesignerLoaderHost2>(ComponentContainer);
+
+#pragma warning disable 0618
+            public new IComponent CreateComponent(Type componentType) => base.CreateComponent(componentType);
+#pragma warning restore 0618
+
+            public new IDesigner CreateDesigner(IComponent component, bool rootDesigner) => base.CreateDesigner(component, rootDesigner);
+
+            public new object CreateInstance(Type type) => base.CreateInstance(type);
 
             public new void Dispose(bool disposing) => base.Dispose(disposing);
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerHostTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerHostTests.cs
@@ -479,7 +479,7 @@ namespace System.ComponentModel.Design.Tests
                 .Returns(mockExtenderProviderService.Object)
                 .Verifiable();
 
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
 
             host.Container.Add(component);
@@ -617,7 +617,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(INameCreationService)))
                 .Returns(mockNameCreationService.Object);
 
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
             using var component = new RootDesignerComponent();
 
@@ -673,7 +673,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(INameCreationService)))
                 .Returns(mockNameCreationService.Object);
 
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
 
             host.Container.Add(component);
@@ -708,7 +708,7 @@ namespace System.ComponentModel.Design.Tests
                 .Returns(mockNameCreationService.Object)
                 .Verifiable();
 
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
             using var component1 = new RootDesignerComponent();
             host.Container.Add(component1, name);
@@ -762,7 +762,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(INameCreationService)))
                 .Returns(null);
 
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
             using var component1 = new RootDesignerComponent();
             host.Container.Add(component1, "name1");
@@ -809,7 +809,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(INameCreationService)))
                 .Returns(null);
 
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
             using var component = new RootDesignerComponent();
             host.Container.Add(component, "name1");
@@ -854,7 +854,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(INameCreationService)))
                 .Returns(null);
 
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
             host.Container.Add(component, "name1");
             Assert.Equal("name1", component.Site.Name);
@@ -1043,7 +1043,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(object)))
                 .Returns(otherService);
 
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
             using var component = new RootDesignerComponent();
             host.Container.Add(component);
@@ -1076,7 +1076,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(IServiceContainer)))
                 .Returns(otherContainer);
 
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
             using var component = new RootDesignerComponent();
             host.Container.Add(component);
@@ -1106,7 +1106,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(object)))
                 .Returns(otherService);
 
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
             using var component = new RootDesignerComponent();
             host.Container.Add(component);
@@ -1140,7 +1140,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(object)))
                 .Returns(otherService);
 
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
             using var component = new RootDesignerComponent();
             host.Container.Add(component);
@@ -1178,7 +1178,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(IServiceContainer)))
                 .Returns(otherContainer);
 
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
             using var component = new RootDesignerComponent();
             host.Container.Add(component);
@@ -1213,7 +1213,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(object)))
                 .Returns(otherService);
 
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
             using var component = new RootDesignerComponent();
             host.Container.Add(component);
@@ -1409,7 +1409,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(INameCreationService)))
                 .Returns(mockNameCreationService.Object);
 
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
             using var component = new RootDesignerComponent();
             host.Container.Add(component, "oldName");
@@ -1452,7 +1452,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(int)))
                 .Returns(service);
 
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
             using var component = new RootDesignerComponent();
             host.Container.Add(component);
@@ -1477,7 +1477,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(int)))
                 .Returns(service);
 
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
             using var component = new RootDesignerComponent();
             host.Container.Add(component);
@@ -1518,7 +1518,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(int)))
                 .Returns(service);
 
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
             using var component = new RootDesignerComponent();
             host.Container.Add(component);
@@ -2291,7 +2291,7 @@ namespace System.ComponentModel.Design.Tests
             mockServiceProvider
                 .Setup(p => p.GetService(typeof(IDesignerEventService)))
                 .Returns(null);
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             surface.BeginLoad(loader);
 
             IDesignerLoaderHost2 host = surface.Host;
@@ -2303,7 +2303,7 @@ namespace System.ComponentModel.Design.Tests
         {
             var service = new object();
             var mockServiceProvider = new Mock<IServiceProvider>(MockBehavior.Strict);
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
             Assert.Null(host.GetService(typeof(IMultitargetHelperService)));
         }
@@ -2317,7 +2317,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(int)))
                 .Returns(service)
                 .Verifiable();
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
             Assert.Same(service, host.GetService(typeof(int)));
             mockServiceProvider.Verify(p => p.GetService(typeof(int)), Times.Once());
@@ -2442,7 +2442,7 @@ namespace System.ComponentModel.Design.Tests
             mockServiceProvider
                 .Setup(p => p.GetService(typeof(IDesignerEventService)))
                 .Returns(mockDesignerEventService.Object);
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
 
             int activatedCallCount = 0;
@@ -2665,7 +2665,7 @@ namespace System.ComponentModel.Design.Tests
                 .Returns(mockExtenderProviderService.Object)
                 .Verifiable();
 
-            using var surface = new SubDesignSurface(mockServiceProvider.Object);
+            var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
 
             host.Container.Add(component);

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerHostTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerHostTests.cs
@@ -90,7 +90,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignerHost_IsClosingTransaction_GetWithoutTransaction_ReturnsFalse()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             IDesignerHostTransactionState hostTransactionState = Assert.IsAssignableFrom<IDesignerHostTransactionState>(surface.Host);
             Assert.False(hostTransactionState.IsClosingTransaction);
         }
@@ -151,7 +151,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignerHost_Activate_Invoke_CallsViewActivated()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             int viewActivatedCallCount = 0;
             int activatedCallCount = 0;
             surface.ViewActivated += (sender, e) =>
@@ -170,7 +170,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignerHost_Activate_InvokeDisposed_Nop()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             int viewActivatedCallCount = 0;
             int activatedCallCount = 0;
             surface.ViewActivated += (sender, e) =>
@@ -256,12 +256,12 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(Add_ComponentParentProvider_TestData))]
         public void DesignerHost_Add_ComponentWithRootDesigner_Success(IServiceProvider parentProvider, string expectedName)
         {
-            var surface = new SubDesignSurface(parentProvider);
+            using var surface = new SubDesignSurface(parentProvider);
             IDesignerLoaderHost2 host = surface.Host;
-            var component1 = new RootDesignerComponent();
-            var component2 = new RootDesignerComponent();
-            var component3 = new DesignerComponent();
-            var component4 = new Component();
+            using var component1 = new RootDesignerComponent();
+            using var component2 = new RootDesignerComponent();
+            using var component3 = new DesignerComponent();
+            using var component4 = new Component();
 
             host.Container.Add(component1);
             Assert.Same(component1, Assert.Single(host.Container.Components));
@@ -311,12 +311,12 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(Add_InvalidNameCreationServiceParentProvider_TestData))]
         public void DesignerHost_Add_ComponentStringWithRootDesigner_Success(IServiceProvider parentProvider)
         {
-            var surface = new SubDesignSurface(parentProvider);
+            using var surface = new SubDesignSurface(parentProvider);
             IDesignerLoaderHost2 host = surface.Host;
-            var component1 = new RootDesignerComponent();
-            var component2 = new RootDesignerComponent();
-            var component3 = new DesignerComponent();
-            var component4 = new Component();
+            using var component1 = new RootDesignerComponent();
+            using var component2 = new RootDesignerComponent();
+            using var component3 = new DesignerComponent();
+            using var component4 = new Component();
 
             host.Container.Add(component1, "name1");
             Assert.Same(component1, Assert.Single(host.Container.Components));
@@ -408,7 +408,7 @@ namespace System.ComponentModel.Design.Tests
                 .Returns(mockExtenderProviderService.Object)
                 .Verifiable();
 
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             surface.ServiceContainer.RemoveService(typeof(IExtenderProviderService));
             IDesignerLoaderHost2 host = surface.Host;
 
@@ -479,7 +479,7 @@ namespace System.ComponentModel.Design.Tests
                 .Returns(mockExtenderProviderService.Object)
                 .Verifiable();
 
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
 
             host.Container.Add(component);
@@ -550,10 +550,10 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(InvalidIExtenderProviderService_TestData))]
         public void DesignerHost_Add_InvalidIExtenderProviderServiceWithoutDefault_CallsParentGetService(Mock<IServiceProvider> mockParentProvider)
         {
-            var surface = new SubDesignSurface(mockParentProvider?.Object);
+            using var surface = new SubDesignSurface(mockParentProvider?.Object);
             surface.ServiceContainer.RemoveService(typeof(IExtenderProviderService));
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootExtenderProviderDesignerComponent();
+            using var component = new RootExtenderProviderDesignerComponent();
 
             host.Container.Add(component);
             Assert.Same(component, Assert.Single(host.Container.Components));
@@ -564,9 +564,9 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(InvalidIExtenderProviderService_TestData))]
         public void DesignerHost_Add_InvalidIExtenderProviderServiceWithDefault_DoesNotCallParentGetService(Mock<IServiceProvider> mockParentProvider)
         {
-            var surface = new SubDesignSurface(mockParentProvider?.Object);
+            using var surface = new SubDesignSurface(mockParentProvider?.Object);
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootExtenderProviderDesignerComponent();
+            using var component = new RootExtenderProviderDesignerComponent();
 
             host.Container.Add(component);
             Assert.Same(component, Assert.Single(host.Container.Components));
@@ -578,7 +578,7 @@ namespace System.ComponentModel.Design.Tests
         {
             var surface = new SubDesignSurface();
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
 
             host.Container.Add(component);
             Assert.Same(component, Assert.Single(host.Container.Components));
@@ -617,9 +617,9 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(INameCreationService)))
                 .Returns(mockNameCreationService.Object);
 
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
 
             host.Container.Add(component);
             Assert.Equal("name", component.Site.Name);
@@ -633,7 +633,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignerHost_Add_ComponentWithNameCreationServiceWithCustomReflectionType_CallsCreateName()
         {
-            var component = new CustomTypeDescriptionProviderComponent();
+            using var component = new CustomTypeDescriptionProviderComponent();
             var mockCustomTypeDescriptor = new Mock<ICustomTypeDescriptor>(MockBehavior.Strict);
             mockCustomTypeDescriptor
                 .Setup(d => d.GetAttributes())
@@ -673,7 +673,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(INameCreationService)))
                 .Returns(mockNameCreationService.Object);
 
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
 
             host.Container.Add(component);
@@ -708,16 +708,16 @@ namespace System.ComponentModel.Design.Tests
                 .Returns(mockNameCreationService.Object)
                 .Verifiable();
 
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
-            var component1 = new RootDesignerComponent();
+            using var component1 = new RootDesignerComponent();
             host.Container.Add(component1, name);
             Assert.Same(name, component1.Site.Name);
             mockNameCreationService.Verify(s => s.ValidateName(name), Times.Once());
             mockServiceProvider.Verify(p => p.GetService(typeof(INameCreationService)), Times.Once());
 
             // Add another.
-            var component2 = new DesignerComponent();
+            using var component2 = new DesignerComponent();
             host.Container.Add(component2, "name2");
             Assert.Equal("name2", component2.Site.Name);
             mockNameCreationService.Verify(s => s.ValidateName("name2"), Times.Once());
@@ -762,9 +762,9 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(INameCreationService)))
                 .Returns(null);
 
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
-            var component1 = new RootDesignerComponent();
+            using var component1 = new RootDesignerComponent();
             host.Container.Add(component1, "name1");
             Assert.Equal("name1", component1.Site.Name);
             mockServiceProvider.Verify(p => p.GetService(typeof(TypeDescriptionProviderService)), Times.Once());
@@ -775,7 +775,7 @@ namespace System.ComponentModel.Design.Tests
             mockTypeDescriptionProvider.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
 
             // Add again.
-            var component2 = new DesignerComponent();
+            using var component2 = new DesignerComponent();
             host.Container.Add(component2, "name2");
             Assert.Equal("name2", component2.Site.Name);
             mockServiceProvider.Verify(p => p.GetService(typeof(TypeDescriptionProviderService)), Times.Once());
@@ -809,9 +809,9 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(INameCreationService)))
                 .Returns(null);
 
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component, "name1");
             Assert.Equal("name1", component.Site.Name);
             mockServiceProvider.Verify(p => p.GetService(typeof(TypeDescriptionProviderService)), Times.Once());
@@ -821,7 +821,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignerHost_Add_ComponentWithTypeDescriptionProviderServiceWithProjectTargetFrameworkAttribute_DoesNotAddProvider()
         {
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             ICustomTypeDescriptor descriptor = TypeDescriptor.GetProvider(typeof(RootDesignerComponent)).GetTypeDescriptor(typeof(RootDesignerComponent));
             var mockTypeDescriptionProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
             mockTypeDescriptionProvider
@@ -854,7 +854,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(INameCreationService)))
                 .Returns(null);
 
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
             host.Container.Add(component, "name1");
             Assert.Equal("name1", component.Site.Name);
@@ -869,12 +869,13 @@ namespace System.ComponentModel.Design.Tests
             IDesignerLoaderHost2 host = surface.Host;
             surface.BeginLoad(typeof(RootDesignerComponent));
 
-            var component = new DesignerComponent();
+            using var component = new DesignerComponent();
             host.Container.Add(component);
             int callCount = 0;
             component.Disposed += (sender, e) =>
             {
-                Assert.Throws<Exception>(() => host.Container.Add(new DesignerComponent()));
+                using var newComponent = new DesignerComponent();
+                Assert.Throws<Exception>(() => host.Container.Add(newComponent));
                 callCount++;
             };
             surface.Dispose();
@@ -889,7 +890,7 @@ namespace System.ComponentModel.Design.Tests
         {
             var surface = new SubDesignSurface();
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component);
 
             IDictionaryService service = Assert.IsAssignableFrom<IDictionaryService>(component.Site);
@@ -902,7 +903,7 @@ namespace System.ComponentModel.Design.Tests
         {
             var surface = new SubDesignSurface();
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component);
 
             IDictionaryService service = Assert.IsAssignableFrom<IDictionaryService>(component.Site);
@@ -921,7 +922,7 @@ namespace System.ComponentModel.Design.Tests
         {
             var surface = new SubDesignSurface();
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component);
 
             IDictionaryService service = Assert.IsAssignableFrom<IDictionaryService>(component.Site);
@@ -933,7 +934,7 @@ namespace System.ComponentModel.Design.Tests
         {
             var surface = new SubDesignSurface();
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component);
 
             IDictionaryService service = Assert.IsAssignableFrom<IDictionaryService>(component.Site);
@@ -951,7 +952,7 @@ namespace System.ComponentModel.Design.Tests
         {
             var surface = new SubDesignSurface();
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component);
 
             IDictionaryService service = Assert.IsAssignableFrom<IDictionaryService>(component.Site);
@@ -963,7 +964,7 @@ namespace System.ComponentModel.Design.Tests
         {
             var surface = new SubDesignSurface();
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component);
 
             IDictionaryService service = Assert.IsAssignableFrom<IDictionaryService>(component.Site);
@@ -981,7 +982,7 @@ namespace System.ComponentModel.Design.Tests
         {
             var surface = new SubDesignSurface();
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component);
             IDictionaryService service = Assert.IsAssignableFrom<IDictionaryService>(component.Site);
 
@@ -1017,7 +1018,7 @@ namespace System.ComponentModel.Design.Tests
         {
             var surface = new SubDesignSurface();
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component);
             IDictionaryService service = Assert.IsAssignableFrom<IDictionaryService>(component.Site);
             Assert.Throws<ArgumentNullException>("key", () => service.SetValue(null, new object()));
@@ -1042,9 +1043,9 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(object)))
                 .Returns(otherService);
 
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component);
             IServiceContainer container = Assert.IsAssignableFrom<IServiceContainer>(component.Site);
             container.AddService(typeof(object), service);
@@ -1075,9 +1076,9 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(IServiceContainer)))
                 .Returns(otherContainer);
 
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component);
             IServiceContainer container = Assert.IsAssignableFrom<IServiceContainer>(component.Site);
             container.AddService(typeof(object), service, true);
@@ -1105,9 +1106,9 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(object)))
                 .Returns(otherService);
 
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component);
             IServiceContainer container = Assert.IsAssignableFrom<IServiceContainer>(component.Site);
             container.AddService(typeof(object), service, false);
@@ -1139,9 +1140,9 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(object)))
                 .Returns(otherService);
 
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component);
             IServiceContainer container = Assert.IsAssignableFrom<IServiceContainer>(component.Site);
             container.AddService(typeof(object), callback);
@@ -1177,9 +1178,9 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(IServiceContainer)))
                 .Returns(otherContainer);
 
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component);
             IServiceContainer container = Assert.IsAssignableFrom<IServiceContainer>(component.Site);
             container.AddService(typeof(object), callback, true);
@@ -1212,9 +1213,9 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(object)))
                 .Returns(otherService);
 
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component);
             IServiceContainer container = Assert.IsAssignableFrom<IServiceContainer>(component.Site);
             container.AddService(typeof(object), callback, false);
@@ -1241,9 +1242,9 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(AddComponentISiteName_Set_TestData))]
         public void DesignerHost_AddComponentISiteName_SetRootComponent_GetReturnsExpected(IServiceProvider parentProvider, string oldName, string value, string expectedName)
         {
-            var surface = new SubDesignSurface(parentProvider);
+            using var surface = new SubDesignSurface(parentProvider);
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component, oldName);
             component.Site.Name = value;
             Assert.Same(expectedName, component.Site.Name);
@@ -1260,7 +1261,7 @@ namespace System.ComponentModel.Design.Tests
         {
             var surface = new SubDesignSurface();
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component, "name");
             component.Site.Name = "NAME";
             Assert.Equal("NAME", component.Site.Name);
@@ -1276,9 +1277,9 @@ namespace System.ComponentModel.Design.Tests
         {
             var surface = new SubDesignSurface();
             IDesignerLoaderHost2 host = surface.Host;
-            var component1 = new RootDesignerComponent();
-            var component2 = new RootDesignerComponent();
-            var component3 = new RootDesignerComponent();
+            using var component1 = new RootDesignerComponent();
+            using var component2 = new RootDesignerComponent();
+            using var component3 = new RootDesignerComponent();
             host.Container.Add(component1);
             host.Container.Add(component2, null);
             host.Container.Add(component3, "name3");
@@ -1326,7 +1327,7 @@ namespace System.ComponentModel.Design.Tests
         {
             var surface = new SubDesignSurface();
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
 
             host.EndLoad(oldRootComponentClassName, true, null);
             Assert.Equal(oldRootComponentClassName, host.RootComponentClassName);
@@ -1350,7 +1351,7 @@ namespace System.ComponentModel.Design.Tests
             var surface = new SubDesignSurface();
             IDesignerLoaderHost2 host = surface.Host;
             IComponentChangeService changeService = Assert.IsAssignableFrom<IComponentChangeService>(host);
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
 
             int callCount = 0;
             ComponentRenameEventHandler handler = (sender, e) =>
@@ -1408,9 +1409,9 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(INameCreationService)))
                 .Returns(mockNameCreationService.Object);
 
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component, "oldName");
             Assert.Equal("oldName", component.Site.Name);
             mockNameCreationService.Verify(s => s.ValidateName("oldName"), Times.Once());
@@ -1425,8 +1426,8 @@ namespace System.ComponentModel.Design.Tests
         {
             var surface = new SubDesignSurface();
             IDesignerLoaderHost2 host = surface.Host;
-            var component1 = new RootDesignerComponent();
-            var component2 = new RootDesignerComponent();
+            using var component1 = new RootDesignerComponent();
+            using var component2 = new RootDesignerComponent();
             host.Container.Add(component1, "name1");
             host.Container.Add(component2, "name2");
             Assert.Throws<Exception>(() => component1.Site.Name = "name2");
@@ -1451,9 +1452,9 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(int)))
                 .Returns(service);
 
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component);
             Assert.Same(service, component.Site.GetService(typeof(int)));
         }
@@ -1476,9 +1477,9 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(int)))
                 .Returns(service);
 
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component);
             INestedContainer nestedContainer = Assert.IsAssignableFrom<INestedContainer>(component.Site.GetService(typeof(INestedContainer)));
             Assert.Same(service, component.Site.GetService(typeof(int)));
@@ -1491,7 +1492,7 @@ namespace System.ComponentModel.Design.Tests
         {
             var surface = new SubDesignSurface();
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component);
             INestedContainer container = Assert.IsAssignableFrom<INestedContainer>(component.Site.GetService(typeof(INestedContainer)));
             Assert.Same(container, component.Site.GetService(typeof(INestedContainer)));
@@ -1517,9 +1518,9 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(int)))
                 .Returns(service);
 
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component);
             NestedContainer container = Assert.IsAssignableFrom<NestedContainer>(component.Site.GetService(typeof(INestedContainer)));
             var nestedComponent = new Component();
@@ -1532,7 +1533,7 @@ namespace System.ComponentModel.Design.Tests
         {
             var surface = new SubDesignSurface();
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component);
             Assert.Same(component.Site, component.Site.GetService(typeof(IDictionaryService)));
         }
@@ -1542,7 +1543,7 @@ namespace System.ComponentModel.Design.Tests
         {
             var surface = new SubDesignSurface();
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component);
             Assert.Same(surface.ServiceContainer, component.Site.GetService(typeof(IServiceContainer)));
         }
@@ -1552,7 +1553,7 @@ namespace System.ComponentModel.Design.Tests
         {
             var surface = new SubDesignSurface();
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component);
             Assert.Same(host, component.Site.GetService(typeof(IContainer)));
         }
@@ -1562,7 +1563,7 @@ namespace System.ComponentModel.Design.Tests
         {
             var surface = new SubDesignSurface();
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component);
             Assert.Throws<ArgumentNullException>("service", () => component.Site.GetService(null));
         }
@@ -1574,7 +1575,7 @@ namespace System.ComponentModel.Design.Tests
             IDesignerLoaderHost2 host = surface.Host;
             IComponentChangeService changeService = Assert.IsAssignableFrom<IComponentChangeService>(host);
 
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             int componentAddingCallCount = 0;
             ComponentEventHandler componentAddingHandler = (sender, e) =>
             {
@@ -1645,7 +1646,7 @@ namespace System.ComponentModel.Design.Tests
         {
             var surface = new SubDesignSurface();
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component, component.GetType().FullName);
             Assert.Equal(component.GetType().FullName, host.RootComponentClassName);
             Assert.Throws<Exception>(() => host.Container.Add(component));
@@ -1657,7 +1658,7 @@ namespace System.ComponentModel.Design.Tests
         {
             var surface = new SubDesignSurface();
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new NonInitializingDesignerComponent();
+            using var component = new NonInitializingDesignerComponent();
             Assert.Throws<InvalidOperationException>(() => host.Container.Add(component));
             Assert.Throws<InvalidOperationException>(() => host.Container.Add(component, "name"));
         }
@@ -1667,7 +1668,7 @@ namespace System.ComponentModel.Design.Tests
         {
             var surface = new SubDesignSurface();
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new ThrowingInitializingDesignerComponent();
+            using var component = new ThrowingInitializingDesignerComponent();
             Assert.Throws<DivideByZeroException>(() => host.Container.Add(component));
             Assert.Null(component.Container);
             Assert.Null(component.Site);
@@ -1682,7 +1683,7 @@ namespace System.ComponentModel.Design.Tests
         {
             var surface = new SubDesignSurface();
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new CheckoutExceptionThrowingInitializingDesignerComponent();
+            using var component = new CheckoutExceptionThrowingInitializingDesignerComponent();
             // CheckoutException does not bubble up in xunit.
             bool threwCheckoutException = false;
             try
@@ -1789,7 +1790,7 @@ namespace System.ComponentModel.Design.Tests
             IDesignerLoaderHost2 host = surface.Host;
             surface.BeginLoad(typeof(RootDesignerComponent));
 
-            var component = new ThrowingDesignerDisposeComponent();
+            using var component = new ThrowingDesignerDisposeComponent();
             host.Container.Add(component);
             Assert.Throws<InvalidOperationException>(() => surface.Dispose());
             Assert.False(surface.IsLoaded);
@@ -1804,7 +1805,7 @@ namespace System.ComponentModel.Design.Tests
             IDesignerLoaderHost2 host = surface.Host;
             surface.BeginLoad(typeof(RootDesignerComponent));
 
-            var component = new ThrowingDisposeDesignerComponent();
+            using var component = new ThrowingDisposeDesignerComponent();
             host.Container.Add(component);
             Assert.Throws<InvalidOperationException>(() => surface.Dispose());
             Assert.False(surface.IsLoaded);
@@ -2222,16 +2223,16 @@ namespace System.ComponentModel.Design.Tests
             mockServiceProvider
                 .Setup(p => p.GetService(typeof(ContainerFilterService)))
                 .Returns(mockFilterService.Object);
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             Assert.Same(collection, surface.ComponentContainer.Components);
         }
 
         [Fact]
         public void DesignerHost_GetDesigner_InvokeNonEmpty_ReturnsExpected()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             IDesignerHost host = surface.Host;
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component);
             Assert.IsType<RootDesigner>(host.GetDesigner(component));
             Assert.Null(host.GetDesigner(new Component()));
@@ -2241,7 +2242,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignerHost_GetDesigner_InvokeEmpty_ReturnsExpected()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             IDesignerHost host = surface.Host;
             Assert.Null(host.GetDesigner(new Component()));
             Assert.Null(host.GetDesigner(new RootDesignerComponent()));
@@ -2250,7 +2251,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignerHost_GetDesigner_NullComponent_ThrowsArgumentNullException()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             IDesignerHost host = surface.Host;
             Assert.Throws<ArgumentNullException>("component", () => host.GetDesigner(null));
         }
@@ -2290,7 +2291,7 @@ namespace System.ComponentModel.Design.Tests
             mockServiceProvider
                 .Setup(p => p.GetService(typeof(IDesignerEventService)))
                 .Returns(null);
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             surface.BeginLoad(loader);
 
             IDesignerLoaderHost2 host = surface.Host;
@@ -2302,7 +2303,7 @@ namespace System.ComponentModel.Design.Tests
         {
             var service = new object();
             var mockServiceProvider = new Mock<IServiceProvider>(MockBehavior.Strict);
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
             Assert.Null(host.GetService(typeof(IMultitargetHelperService)));
         }
@@ -2316,7 +2317,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(int)))
                 .Returns(service)
                 .Verifiable();
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
             Assert.Same(service, host.GetService(typeof(int)));
             mockServiceProvider.Verify(p => p.GetService(typeof(int)), Times.Once());
@@ -2375,7 +2376,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(ITypeResolutionService)))
                 .Returns(mockTypeResolutionService.Object)
                 .Verifiable();
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerHost host = surface.Host;
             Assert.Equal(expected, host.GetType(typeName));
             mockServiceProvider.Verify(p => p.GetService(typeof(ITypeResolutionService)), Times.Once());
@@ -2397,7 +2398,7 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(p => p.GetService(typeof(ITypeResolutionService)))
                 .Returns(service)
                 .Verifiable();
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerHost host = surface.Host;
             Assert.Equal(typeof(int), host.GetType(typeof(int).FullName));
             mockServiceProvider.Verify(p => p.GetService(typeof(ITypeResolutionService)), Times.Once());
@@ -2406,7 +2407,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignerHost_GetType_NullTypeName_ThrowsArgumentNullException()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             IDesignerHost host = surface.Host;
             Assert.Throws<ArgumentNullException>("typeName", () => host.GetType(null));
         }
@@ -2441,7 +2442,7 @@ namespace System.ComponentModel.Design.Tests
             mockServiceProvider
                 .Setup(p => p.GetService(typeof(IDesignerEventService)))
                 .Returns(mockDesignerEventService.Object);
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
 
             int activatedCallCount = 0;
@@ -2509,7 +2510,7 @@ namespace System.ComponentModel.Design.Tests
             IDesignerLoaderHost2 host = surface.Host;
 
             var rootComponent = new RootDesignerComponent();
-            var component = new DesignerComponent();
+            using var component = new DesignerComponent();
             host.Container.Add(rootComponent);
             host.Container.Add(component);
             host.Container.Remove(rootComponent);
@@ -2594,7 +2595,7 @@ namespace System.ComponentModel.Design.Tests
                 .Returns(mockExtenderProviderService.Object)
                 .Verifiable();
 
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             surface.ServiceContainer.RemoveService(typeof(IExtenderProviderService));
             IDesignerLoaderHost2 host = surface.Host;
 
@@ -2664,7 +2665,7 @@ namespace System.ComponentModel.Design.Tests
                 .Returns(mockExtenderProviderService.Object)
                 .Verifiable();
 
-            var surface = new SubDesignSurface(mockServiceProvider.Object);
+            using var surface = new SubDesignSurface(mockServiceProvider.Object);
             IDesignerLoaderHost2 host = surface.Host;
 
             host.Container.Add(component);
@@ -2692,10 +2693,10 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(InvalidIExtenderProviderService_TestData))]
         public void DesignerHost_Remove_InvalidIExtenderProviderServiceWithoutDefault_CallsParentGetService(Mock<IServiceProvider> mockParentProvider)
         {
-            var surface = new SubDesignSurface(mockParentProvider?.Object);
+            using var surface = new SubDesignSurface(mockParentProvider?.Object);
             surface.ServiceContainer.RemoveService(typeof(IExtenderProviderService));
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootExtenderProviderDesignerComponent();
+            using var component = new RootExtenderProviderDesignerComponent();
 
             host.Container.Add(component);
             Assert.Same(component, Assert.Single(host.Container.Components));
@@ -2710,9 +2711,9 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(InvalidIExtenderProviderService_TestData))]
         public void DesignerHost_Remove_InvalidIExtenderProviderServiceWithDefault_DoesNotCallParentGetService(Mock<IServiceProvider> mockParentProvider)
         {
-            var surface = new SubDesignSurface(mockParentProvider?.Object);
+            using var surface = new SubDesignSurface(mockParentProvider?.Object);
             IDesignerLoaderHost2 host = surface.Host;
-            var component = new RootExtenderProviderDesignerComponent();
+            using var component = new RootExtenderProviderDesignerComponent();
 
             host.Container.Add(component);
             Assert.Same(component, Assert.Single(host.Container.Components));
@@ -2726,13 +2727,13 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void Remove_ComponentNotInContainerNonEmpty_Nop()
         {
-            var surface1 = new SubDesignSurface();
-            var surface2 = new SubDesignSurface();
+            using var surface1 = new SubDesignSurface();
+            using var surface2 = new SubDesignSurface();
             IDesignerLoaderHost2 host1 = surface1.Host;
             IDesignerLoaderHost2 host2 = surface2.Host;
 
             var otherComponent = new RootDesignerComponent();
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host1.Container.Add(otherComponent);
             host2.Container.Add(component);
             host2.Container.Remove(otherComponent);
@@ -2744,8 +2745,8 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void Remove_ComponentNotInContainerEmpty_Nop()
         {
-            var surface1 = new SubDesignSurface();
-            var surface2 = new SubDesignSurface();
+            using var surface1 = new SubDesignSurface();
+            using var surface2 = new SubDesignSurface();
             IDesignerLoaderHost2 host1 = surface1.Host;
             IDesignerLoaderHost2 host2 = surface2.Host;
 
@@ -2764,8 +2765,8 @@ namespace System.ComponentModel.Design.Tests
             IDesignerLoaderHost2 host = surface.Host;
             IComponentChangeService changeService = Assert.IsAssignableFrom<IComponentChangeService>(host);
 
-            var component1 = new RootDesignerComponent();
-            var component2 = new DesignerComponent();
+            using var component1 = new RootDesignerComponent();
+            using var component2 = new DesignerComponent();
             int componentRemovingCallCount = 0;
             ComponentEventHandler componentRemovingHandler = (sender, e) =>
             {
@@ -2830,7 +2831,7 @@ namespace System.ComponentModel.Design.Tests
             IDesignerLoaderHost2 host = surface.Host;
             IComponentChangeService changeService = Assert.IsAssignableFrom<IComponentChangeService>(host);
 
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             int componentRemovingCallCount = 0;
             ComponentEventHandler componentRemovingHandler = (sender, e) =>
             {
@@ -2851,7 +2852,7 @@ namespace System.ComponentModel.Design.Tests
             var surface = new SubDesignSurface();
             IDesignerLoaderHost2 host = surface.Host;
 
-            var component = new RootDesignerComponent();
+            using var component = new RootDesignerComponent();
             host.Container.Add(component);
             IDictionaryService service = Assert.IsAssignableFrom<IDictionaryService>(component.Site);
             service.SetValue("key", "value");
@@ -3053,7 +3054,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignerHost_IReflect_UnderlyingSystemType_ReturnsExpected()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             IReflect reflect = Assert.IsAssignableFrom<IReflect>(surface.Host);
             Assert.Equal(typeof(IDesignerHost), reflect.UnderlyingSystemType);
         }
@@ -3061,7 +3062,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignerHost_IReflect_GetField_Success()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             IReflect reflect = Assert.IsAssignableFrom<IReflect>(surface.Host);
             Assert.Equal(typeof(IDesignerHost).GetField(nameof(IDesignerHost.Activate)), reflect.GetField(nameof(IDesignerHost.Activate), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public));
         }
@@ -3069,7 +3070,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignerHost_IReflect_GetFields_Success()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             IReflect reflect = Assert.IsAssignableFrom<IReflect>(surface.Host);
             Assert.Equal(typeof(IDesignerHost).GetFields(), reflect.GetFields(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public));
         }
@@ -3077,7 +3078,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignerHost_IReflect_GetMember_Success()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             IReflect reflect = Assert.IsAssignableFrom<IReflect>(surface.Host);
             Assert.Equal(typeof(IDesignerHost).GetMember(nameof(IDesignerHost.Container)), reflect.GetMember(nameof(IDesignerHost.Container), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public));
         }
@@ -3085,7 +3086,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignerHost_IReflect_GetMembers_Success()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             IReflect reflect = Assert.IsAssignableFrom<IReflect>(surface.Host);
             Assert.Equal(typeof(IDesignerHost).GetMembers(), reflect.GetMembers(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public));
         }
@@ -3093,7 +3094,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignerHost_IReflect_GetMethod_Success()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             IReflect reflect = Assert.IsAssignableFrom<IReflect>(surface.Host);
             Assert.Equal(typeof(IDesignerHost).GetMethod(nameof(IDesignerHost.Activate)), reflect.GetMethod(nameof(IDesignerHost.Activate), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public));
             Assert.Equal(typeof(IDesignerHost).GetMethod(nameof(IDesignerHost.Activate)), reflect.GetMethod(nameof(IDesignerHost.Activate), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public, null, Array.Empty<Type>(), Array.Empty<ParameterModifier>()));
@@ -3102,7 +3103,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignerHost_IReflect_GetMethods_Success()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             IReflect reflect = Assert.IsAssignableFrom<IReflect>(surface.Host);
             Assert.Equal(typeof(IDesignerHost).GetMethods(), reflect.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public));
         }
@@ -3110,7 +3111,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignerHost_IReflect_GetProperty_Success()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             IReflect reflect = Assert.IsAssignableFrom<IReflect>(surface.Host);
             Assert.Equal(typeof(IDesignerHost).GetProperty(nameof(IDesignerHost.Container)), reflect.GetProperty(nameof(IDesignerHost.Container), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public));
             Assert.Equal(typeof(IDesignerHost).GetProperty(nameof(IDesignerHost.Container)), reflect.GetProperty(nameof(IDesignerHost.Container), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public, null, typeof(IContainer), Array.Empty<Type>(), Array.Empty<ParameterModifier>()));
@@ -3119,7 +3120,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignerHost_IReflect_GetProperties_Success()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             IReflect reflect = Assert.IsAssignableFrom<IReflect>(surface.Host);
             Assert.Equal(typeof(IDesignerHost).GetProperties(), reflect.GetProperties(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public));
         }
@@ -3127,7 +3128,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void DesignerHost_IReflect_InvokeMember_ReturnsExpected()
         {
-            var surface = new SubDesignSurface();
+            using var surface = new SubDesignSurface();
             IReflect reflect = Assert.IsAssignableFrom<IReflect>(surface.Host);
             Assert.Equal(surface.Host.Container, reflect.InvokeMember(nameof(IDesignerHost.Container), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.GetProperty, null, surface.Host, Array.Empty<object>(), Array.Empty<ParameterModifier>(), null, Array.Empty<string>()));
         }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerHostTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerHostTests.cs
@@ -15,7 +15,7 @@ namespace System.ComponentModel.Design.Tests
 {
     public class DesignerHostTests : IClassFixture<ThreadExceptionFixture>
     {
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void DesignerHost_CanReloadWithErrors_Set_GetReturnsExpected(bool value)
         {
@@ -33,7 +33,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(!value, host.CanReloadWithErrors);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_Container_Get_ReturnsHost()
         {
             var surface = new SubDesignSurface();
@@ -41,7 +41,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(host, host.Container);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void DesignerHost_IgnoreErrorsDuringReload_Set_GetReturnsExpected(bool value)
         {
@@ -59,7 +59,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.False(host.IgnoreErrorsDuringReload);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void DesignerHost_IgnoreErrorsDuringReload_SetWithCanReloadWithErrors_GetReturnsExpected(bool value)
         {
@@ -79,7 +79,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(!value, host.IgnoreErrorsDuringReload);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_InTransaction_GetWithoutTransactions_ReturnsFalse()
         {
             var surface = new SubDesignSurface();
@@ -87,7 +87,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.False(host.InTransaction);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_IsClosingTransaction_GetWithoutTransaction_ReturnsFalse()
         {
             using var surface = new SubDesignSurface();
@@ -95,7 +95,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.False(hostTransactionState.IsClosingTransaction);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_Loading_GetWithoutComponent_ReturnsFalse()
         {
             var surface = new SubDesignSurface();
@@ -103,7 +103,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.False(host.Loading);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void DesignerHost_Loading_GetWithLoader_ReturnsExpected(bool loading)
         {
@@ -124,7 +124,7 @@ namespace System.ComponentModel.Design.Tests
             mockLoader.Verify(l => l.Loading, Times.Once());
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_RootComponent_GetWithoutComponent_ReturnsNull()
         {
             var surface = new SubDesignSurface();
@@ -132,7 +132,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(host.RootComponent);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_RootComponentClassName_GetWithoutComponent_ReturnsNull()
         {
             var surface = new SubDesignSurface();
@@ -140,7 +140,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(host.RootComponentClassName);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_TransactionDescription_GetWithoutTransactions_ReturnsNull()
         {
             var surface = new SubDesignSurface();
@@ -148,7 +148,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(host.TransactionDescription);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_Activate_Invoke_CallsViewActivated()
         {
             using var surface = new SubDesignSurface();
@@ -167,7 +167,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(0, activatedCallCount);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_Activate_InvokeDisposed_Nop()
         {
             using var surface = new SubDesignSurface();
@@ -252,7 +252,7 @@ namespace System.ComponentModel.Design.Tests
             }
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(Add_ComponentParentProvider_TestData))]
         public void DesignerHost_Add_ComponentWithRootDesigner_Success(IServiceProvider parentProvider, string expectedName)
         {
@@ -307,7 +307,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(expectedName, component4.Site.Name);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(Add_InvalidNameCreationServiceParentProvider_TestData))]
         public void DesignerHost_Add_ComponentStringWithRootDesigner_Success(IServiceProvider parentProvider)
         {
@@ -380,7 +380,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { notInheritedComponent, 1 };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(Add_IExtenderProviderServiceWithoutDefault_TestData))]
         public void DesignerHost_Add_IExtenderProviderServiceWithoutDefault_Success(Component component, int expectedCallCount)
         {
@@ -451,7 +451,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { notInheritedComponent };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(Add_IExtenderProviderServiceWithDefault_TestData))]
         public void DesignerHost_Add_IExtenderProviderServiceWithDefault_DoesNotCallGetService(Component component)
         {
@@ -546,7 +546,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { invalidMockServiceProvider };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(InvalidIExtenderProviderService_TestData))]
         public void DesignerHost_Add_InvalidIExtenderProviderServiceWithoutDefault_CallsParentGetService(Mock<IServiceProvider> mockParentProvider)
         {
@@ -560,7 +560,7 @@ namespace System.ComponentModel.Design.Tests
             mockParentProvider?.Verify(p => p.GetService(typeof(IExtenderProviderService)), Times.Once());
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(InvalidIExtenderProviderService_TestData))]
         public void DesignerHost_Add_InvalidIExtenderProviderServiceWithDefault_DoesNotCallParentGetService(Mock<IServiceProvider> mockParentProvider)
         {
@@ -573,7 +573,7 @@ namespace System.ComponentModel.Design.Tests
             mockParentProvider?.Verify(p => p.GetService(typeof(IExtenderProviderService)), Times.Never());
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_Add_SameComponent_Success()
         {
             var surface = new SubDesignSurface();
@@ -595,7 +595,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal("name", component.Site.Name);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_Add_ComponentWithNameCreationServiceWithoutName_CallsCreateName()
         {
             var mockNameCreationService = new Mock<INameCreationService>(MockBehavior.Strict);
@@ -630,7 +630,7 @@ namespace System.ComponentModel.Design.Tests
             mockNameCreationService.Verify(s => s.CreateName(host.Container, typeof(RootDesignerComponent)), Times.Once());
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_Add_ComponentWithNameCreationServiceWithCustomReflectionType_CallsCreateName()
         {
             using var component = new CustomTypeDescriptionProviderComponent();
@@ -685,7 +685,7 @@ namespace System.ComponentModel.Design.Tests
             mockNameCreationService.Verify(s => s.CreateName(host.Container, typeof(RootDesignerComponent)), Times.Once());
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringTheoryData))]
         public void DesignerHost_Add_ComponentWithNameCreationServiceWithName_CallsValidateName(string name)
         {
@@ -724,7 +724,7 @@ namespace System.ComponentModel.Design.Tests
             mockServiceProvider.Verify(p => p.GetService(typeof(INameCreationService)), Times.Exactly(2));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_Add_ComponentWithTypeDescriptionProviderServiceWithoutProjectTargetFrameworkAttribute_AddsProvider()
         {
             ICustomTypeDescriptor descriptor = TypeDescriptor.GetProvider(typeof(RootDesignerComponent)).GetTypeDescriptor(typeof(RootDesignerComponent));
@@ -786,7 +786,7 @@ namespace System.ComponentModel.Design.Tests
             mockTypeDescriptionProvider.Verify(p => p.IsSupportedType(typeof(int)), Times.Exactly(2));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_Add_ComponentWithNullTypeDescriptionProviderService_Success()
         {
             var mockTypeDescriptionProviderService = new Mock<TypeDescriptionProviderService>(MockBehavior.Strict);
@@ -818,7 +818,7 @@ namespace System.ComponentModel.Design.Tests
             mockTypeDescriptionProviderService.Verify(s => s.GetProvider(component), Times.Once());
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_Add_ComponentWithTypeDescriptionProviderServiceWithProjectTargetFrameworkAttribute_DoesNotAddProvider()
         {
             using var component = new RootDesignerComponent();
@@ -862,7 +862,7 @@ namespace System.ComponentModel.Design.Tests
             mockTypeDescriptionProviderService.Verify(s => s.GetProvider(component), Times.Never());
         }
 
-        [Fact(Skip = "Unstable test, see: https://github.com/dotnet/winforms/issues/1460")]
+        [WinFormsFact(Skip = "Unstable test, see: https://github.com/dotnet/winforms/issues/1460")]
         public void DesignerHost_Add_DuringUnload_ThrowsException()
         {
             var surface = new SubDesignSurface();
@@ -885,7 +885,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.False(host.Loading);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddComponentIDictionaryServiceGetKey_NoDictionary_ReturnsNull()
         {
             var surface = new SubDesignSurface();
@@ -898,7 +898,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(service.GetKey(new object()));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddComponentIDictionaryServiceGetKey_NoSuchKeyWithDictionary_ReturnsNull()
         {
             var surface = new SubDesignSurface();
@@ -917,7 +917,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(service.GetKey(new object()));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddComponentIDictionaryServiceGetValue_NoDictionary_ReturnsNull()
         {
             var surface = new SubDesignSurface();
@@ -929,7 +929,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(service.GetValue(new object()));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddComponentIDictionaryServiceGetValue_NoSuchValueWithDictionary_ReturnsNull()
         {
             var surface = new SubDesignSurface();
@@ -947,7 +947,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(service.GetValue(new object()));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddComponentIDictionaryServiceGetValue_NullValueNoDictionary_ReturnsNull()
         {
             var surface = new SubDesignSurface();
@@ -959,7 +959,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<ArgumentNullException>("key", () => service.GetValue(null));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddComponentIDictionaryServiceGetValue_NullValueWithDictionary_ThrowsArgumentNullException()
         {
             var surface = new SubDesignSurface();
@@ -977,7 +977,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<ArgumentNullException>("key", () => service.GetValue(null));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddComponentIDictionaryServiceSetValue_Invoke_GetKeyValueReturnsExpected()
         {
             var surface = new SubDesignSurface();
@@ -1013,7 +1013,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(service.GetValue(key1));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddComponentIDictionaryServiceSetValue_NullKey_ThrowsArgumentNullException()
         {
             var surface = new SubDesignSurface();
@@ -1024,7 +1024,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<ArgumentNullException>("key", () => service.SetValue(null, new object()));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddComponentIServiceContainerAddService_InvokeObject_ReturnsExpected()
         {
             var service = new object();
@@ -1053,7 +1053,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(otherService, surface.GetService(typeof(object)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddComponentIServiceContainerAddService_InvokeObjectPromote_ReturnsExpected()
         {
             var service = new object();
@@ -1087,7 +1087,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(service, otherContainer.GetService(typeof(object)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddComponentIServiceContainerAddService_InvokeObjectNoPromote_ReturnsExpected()
         {
             var service = new object();
@@ -1116,7 +1116,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(otherService, surface.GetService(typeof(object)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddComponentIServiceContainerAddService_InvokeServiceCreatorCallback_ReturnsExpected()
         {
             var service = new object();
@@ -1150,7 +1150,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(otherService, surface.GetService(typeof(object)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddComponentIServiceContainerAddService_InvokeServiceCreatorCallbackPromote_ReturnsExpected()
         {
             var service = new object();
@@ -1189,7 +1189,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(service, otherContainer.GetService(typeof(object)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddComponentIServiceContainerAddService_InvokeServiceCreatorCallbackNoPromote_ReturnsExpected()
         {
             var service = new object();
@@ -1238,7 +1238,7 @@ namespace System.ComponentModel.Design.Tests
             }
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(AddComponentISiteName_Set_TestData))]
         public void DesignerHost_AddComponentISiteName_SetRootComponent_GetReturnsExpected(IServiceProvider parentProvider, string oldName, string value, string expectedName)
         {
@@ -1256,7 +1256,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(expectedName, host.RootComponentClassName);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddComponentISiteName_SetDifferentCase_GetReturnsExpected()
         {
             var surface = new SubDesignSurface();
@@ -1271,7 +1271,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal("NAME", component.Site.Name);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringWithNullTheoryData))]
         public void DesignerHost_AddComponentISiteName_SetWithMultipleComponents_GetReturnsExpected(string value)
         {
@@ -1321,7 +1321,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { "namespace.oldName", "name", "oldName", "oldName", "oldName" };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(AddComponentISiteName_SetWithNamespaceInRootComponentClassName_TestData))]
         public void DesignerHost_AddComponentISiteName_SetWithNamespaceInRootComponentClassName_GetReturnsExpected(string oldRootComponentClassName, string oldName, string value, string expectedName, string expectedRootComponentClassName)
         {
@@ -1344,7 +1344,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(component, host.RootComponent);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringWithNullTheoryData))]
         public void DesignerHost_AddComponentISiteName_SetNameWithComponentRename_CallsHandler(string value)
         {
@@ -1381,7 +1381,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(1, callCount);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [InlineData(null, "", 1)]
         [InlineData("", "", 1)]
         [InlineData("newName", "newName", 1)]
@@ -1421,7 +1421,7 @@ namespace System.ComponentModel.Design.Tests
             mockNameCreationService.Verify(s => s.ValidateName(expectedName), Times.Exactly(expectedCallCount));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddComponentISiteName_SetSameAsOtherComponent_GetReturnsExpected()
         {
             var surface = new SubDesignSurface();
@@ -1434,7 +1434,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<Exception>(() => component1.Site.Name = "NAME2");
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddComponentISiteGetService_Invoke_ReturnsExpected()
         {
             var service = new object();
@@ -1459,7 +1459,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(service, component.Site.GetService(typeof(int)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddComponentISiteGetService_InvokeWithNestedContainer_ReturnsService()
         {
             var service = new object();
@@ -1487,7 +1487,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(nestedContainer, component.Site.GetService(typeof(INestedContainer)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddComponentISiteGetService_INestedContainer_ReturnsExpected()
         {
             var surface = new SubDesignSurface();
@@ -1500,7 +1500,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(component, container.Owner);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddComponentISiteGetServiceINestedContainerGetService_Invoke_ReturnsExpected()
         {
             var service = new object();
@@ -1528,7 +1528,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(service, nestedComponent.Site.GetService(typeof(int)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddComponentISiteGetService_IDictionaryService_ReturnsExpected()
         {
             var surface = new SubDesignSurface();
@@ -1538,7 +1538,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(component.Site, component.Site.GetService(typeof(IDictionaryService)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddComponentISiteGetService_IServiceContainerReturnsExpected()
         {
             var surface = new SubDesignSurface();
@@ -1548,7 +1548,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(surface.ServiceContainer, component.Site.GetService(typeof(IServiceContainer)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddComponentISiteGetService_IContainerReturnsExpected()
         {
             var surface = new SubDesignSurface();
@@ -1558,7 +1558,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(host, component.Site.GetService(typeof(IContainer)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddComponentISiteGetService_NullServiceType_ThrowsArgumentNullException()
         {
             var surface = new SubDesignSurface();
@@ -1568,7 +1568,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<ArgumentNullException>("service", () => component.Site.GetService(null));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_Add_IComponentWithComponentAddingAndAdded_CallsHandler()
         {
             var surface = new SubDesignSurface();
@@ -1615,7 +1615,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(1, componentAddedCallCount);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_Add_NullComponent_ThrowsArgumentNullException()
         {
             var surface = new SubDesignSurface();
@@ -1630,7 +1630,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { new DesignerComponent() };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(Add_NoRootDesigner_TestData))]
         public void DesignerHost_Add_NoRootDesigner_ThrowsException(IComponent component)
         {
@@ -1641,7 +1641,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Empty(host.Container.Components);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_Add_CyclicRootDesigner_ThrowsException()
         {
             var surface = new SubDesignSurface();
@@ -1653,7 +1653,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<Exception>(() => host.Container.Add(new RootDesignerComponent(), host.RootComponentClassName));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_Add_NonInitializingRootDesigner_ThrowsInvalidOperationException()
         {
             var surface = new SubDesignSurface();
@@ -1663,7 +1663,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<InvalidOperationException>(() => host.Container.Add(component, "name"));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_Add_ThrowingInitializingRootDesigner_RethrowsException()
         {
             var surface = new SubDesignSurface();
@@ -1678,7 +1678,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(component.Site);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_Add_CheckoutExceptionThrowingInitializingRootDesigner_RethrowsException()
         {
             var surface = new SubDesignSurface();
@@ -1703,7 +1703,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal("name", component.Site.Name);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddService_InvokeObject_GetServiceReturnsExpected()
         {
             var surface = new SubDesignSurface();
@@ -1716,7 +1716,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(service, host.GetService(typeof(object)));
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void DesignerHost_AddService_InvokeObjectBool_GetServiceReturnsExpected(bool promote)
         {
@@ -1730,7 +1730,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(service, host.GetService(typeof(object)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddService_InvokeCallback_GetServiceReturnsExpected()
         {
             var surface = new SubDesignSurface();
@@ -1744,7 +1744,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(service, host.GetService(typeof(object)));
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void DesignerHost_AddService_InvokeObjectCallback_GetServiceReturnsExpected(bool promote)
         {
@@ -1759,7 +1759,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(service, host.GetService(typeof(object)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_AddService_InvokeDisposed_ThrowsObjectDisposedException()
         {
             var surface = new SubDesignSurface();
@@ -1774,7 +1774,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<ObjectDisposedException>(() => host.AddService(typeof(object), callback, false));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_Dispose_Invoke_ThrowsInvalidOperationException()
         {
             var surface = new SubDesignSurface();
@@ -1783,7 +1783,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<InvalidOperationException>(() => disposable.Dispose());
         }
 
-        [Fact(Skip = "Unstable test, see: https://github.com/dotnet/winforms/issues/1460")]
+        [WinFormsFact(Skip = "Unstable test, see: https://github.com/dotnet/winforms/issues/1460")]
         public void DesignerHost_Add_DesignerDisposeThrowsDuringUnloadingDispose_ThrowsInvalidOperationException()
         {
             var surface = new SubDesignSurface();
@@ -1798,7 +1798,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.False(host.Loading);
         }
 
-        [Fact(Skip = "Unstable test, see: https://github.com/dotnet/winforms/issues/1151")]
+        [WinFormsFact(Skip = "Unstable test, see: https://github.com/dotnet/winforms/issues/1151")]
         public void DesignerHost_Add_ComponentDisposeThrowsDuringUnloadingDispose_ThrowsInvalidOperationException()
         {
             var surface = new SubDesignSurface();
@@ -1813,7 +1813,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.False(host.Loading);
         }
 
-        [Fact(Skip = "Unstable test, see: https://github.com/dotnet/winforms/issues/1460")]
+        [WinFormsFact(Skip = "Unstable test, see: https://github.com/dotnet/winforms/issues/1460")]
         public void DesignerHost_Add_RootDesignerDisposeThrowsDuringUnloadingDispose_ThrowsInvalidOperationException()
         {
             var surface = new SubDesignSurface();
@@ -1826,7 +1826,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.False(host.Loading);
         }
 
-        [Fact(Skip = "Unstable test, see: https://github.com/dotnet/winforms/issues/1460")]
+        [WinFormsFact(Skip = "Unstable test, see: https://github.com/dotnet/winforms/issues/1460")]
         public void DesignerHost_Add_RootComponentDisposeThrowsDuringUnloadingDispose_ThrowsInvalidOperationException()
         {
             var surface = new SubDesignSurface();
@@ -1838,7 +1838,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.False(host.Loading);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_CreateComponent_NullComponentType_ThrowsArgumentNullException()
         {
             var surface = new SubDesignSurface();
@@ -1846,7 +1846,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<ArgumentNullException>("componentType", () => host.CreateComponent(null));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_CreateTransaction_Invoke_ReturnsExpected()
         {
             var surface = new SubDesignSurface();
@@ -1868,7 +1868,7 @@ namespace System.ComponentModel.Design.Tests
             transaction2.Cancel();
         }
 
-        [Theory]
+        [WinFormsTheory]
         [InlineData(null, "No Description Available")]
         [InlineData("", "")]
         [InlineData("Description", "Description")]
@@ -1893,7 +1893,7 @@ namespace System.ComponentModel.Design.Tests
             transaction2.Cancel();
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_CreateTransaction_InvokeWithTransactionOpeningAndTransactionOpened_CallsHandlers()
         {
             var surface = new SubDesignSurface();
@@ -1939,7 +1939,7 @@ namespace System.ComponentModel.Design.Tests
             transaction1.Cancel();
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_CreateTransaction_Cancel_Success()
         {
             var surface = new SubDesignSurface();
@@ -1981,7 +1981,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(host.TransactionDescription);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_CreateTransaction_CancelWithTransactionClosingAndTransactionClosed_CallsHandlers()
         {
             var surface = new SubDesignSurface();
@@ -2042,7 +2042,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(2, closedCallCount);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_CreateTransaction_CancelNested_ThrowsInvalidOperationException()
         {
             var surface = new SubDesignSurface();
@@ -2052,7 +2052,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<InvalidOperationException>(() => transaction1.Cancel());
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_CreateTransaction_Commit_Success()
         {
             var surface = new SubDesignSurface();
@@ -2094,7 +2094,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(host.TransactionDescription);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_CreateTransaction_CommitWithTransactionClosingAndTransactionClosed_CallsHandlers()
         {
             var surface = new SubDesignSurface();
@@ -2155,7 +2155,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(2, closedCallCount);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_CreateTransaction_CommitNested_ThrowsInvalidOperationException()
         {
             var surface = new SubDesignSurface();
@@ -2197,7 +2197,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { "baseClassName", false, new object[] { null } };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(DesignerHost_EndLoad_TestData))]
         public void DesignerHost_EndLoad_NotCalledBeginLoad_Success(string baseClassName, bool successful, ICollection errorCollection)
         {
@@ -2211,7 +2211,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(baseClassName, host.RootComponentClassName);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_GetComponents_Invoke_ReturnsFiltered()
         {
             var collection = new ComponentCollection(new Component[] { new Component() });
@@ -2227,7 +2227,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(collection, surface.ComponentContainer.Components);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_GetDesigner_InvokeNonEmpty_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();
@@ -2239,7 +2239,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(host.GetDesigner(new RootDesignerComponent()));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_GetDesigner_InvokeEmpty_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();
@@ -2248,7 +2248,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(host.GetDesigner(new RootDesignerComponent()));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_GetDesigner_NullComponent_ThrowsArgumentNullException()
         {
             using var surface = new SubDesignSurface();
@@ -2283,7 +2283,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { mockInvalidServiceProviderLoader.Object, o };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(GetService_InvalidLoader_TestData))]
         public void DesignerHost_GetService_IMultitargetHelperServiceWithLoader_ReturnsExpected(DesignerLoader loader, object expected)
         {
@@ -2298,7 +2298,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(expected, host.GetService(typeof(IMultitargetHelperService)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_GetServiceIMultitargetHelperServiceWithoutLoader_ReturnsNull()
         {
             var service = new object();
@@ -2308,7 +2308,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(host.GetService(typeof(IMultitargetHelperService)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_GetService_InvokeWithServiceProvider_ReturnsExpected()
         {
             var service = new object();
@@ -2323,7 +2323,7 @@ namespace System.ComponentModel.Design.Tests
             mockServiceProvider.Verify(p => p.GetService(typeof(int)), Times.Once());
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_GetService_InvokeWithoutServiceProvider_ReturnsNull()
         {
             var surface = new SubDesignSurface();
@@ -2331,7 +2331,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(host.GetService(typeof(int)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_GetService_IContainer_ReturnsExpected()
         {
             var surface = new SubDesignSurface();
@@ -2339,7 +2339,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(host, host.GetService(typeof(IContainer)));
         }
 
-        [Theory]
+        [WinFormsTheory]
         [InlineData(typeof(IServiceContainer))]
         [InlineData(typeof(ServiceContainer))]
         public void DesignerHost_GetService_IServiceContainer_ReturnsExpected(Type serviceType)
@@ -2349,7 +2349,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(surface.ServiceContainer, host.GetService(serviceType));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_GetService_NullType_ThrowsArgumentNullException()
         {
             var surface = new SubDesignSurface();
@@ -2357,7 +2357,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<ArgumentNullException>("service", () => host.GetService(null));
         }
 
-        [Theory]
+        [WinFormsTheory]
         [InlineData("", null)]
         [InlineData("", typeof(int))]
         [InlineData("typeName", null)]
@@ -2389,7 +2389,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { new object() };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(GetType_InvalidTypeResolutionService_TestData))]
         public void DesignerHost_GetType_InvokeWithInvalidTypeResolutionService_ReturnsExpected(object service)
         {
@@ -2404,7 +2404,7 @@ namespace System.ComponentModel.Design.Tests
             mockServiceProvider.Verify(p => p.GetService(typeof(ITypeResolutionService)), Times.Once());
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_GetType_NullTypeName_ThrowsArgumentNullException()
         {
             using var surface = new SubDesignSurface();
@@ -2433,7 +2433,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { new ActiveDesignerEventArgs(null, null), 0, 0, 0 };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(ChangeActiveDesigner_TestData))]
         public void DesignerHost_ChangeActiveDesigner_Invoke_Success(ActiveDesignerEventArgs eventArgs, int expectedActivatedCallCount, int expectedDeactivatedCallCount, int expectedFlushCount)
         {
@@ -2503,7 +2503,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(expectedFlushCount, flushCallCount);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_Remove_Invoke_Success()
         {
             var surface = new SubDesignSurface();
@@ -2567,7 +2567,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { notInheritedComponent, 1, 1 };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(Remove_IExtenderProviderServiceWithoutDefault_TestData))]
         public void DesignerHost_Remove_IExtenderProviderServiceWithoutDefault_Success(Component component, int expectedAddCallCount, int expectedRemoveCallCount)
         {
@@ -2637,7 +2637,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { notInheritedComponent };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(Remove_IExtenderProviderServiceWithDefault_TestData))]
         public void DesignerHost_Remove_IExtenderProviderServiceWithDefault_Success(Component component)
         {
@@ -2689,7 +2689,7 @@ namespace System.ComponentModel.Design.Tests
             mockExtenderProviderService.Verify(s => s.RemoveExtenderProvider(component as IExtenderProvider), Times.Never());
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(InvalidIExtenderProviderService_TestData))]
         public void DesignerHost_Remove_InvalidIExtenderProviderServiceWithoutDefault_CallsParentGetService(Mock<IServiceProvider> mockParentProvider)
         {
@@ -2707,7 +2707,7 @@ namespace System.ComponentModel.Design.Tests
             mockParentProvider?.Verify(p => p.GetService(typeof(IExtenderProviderService)), Times.Exactly(2));
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(InvalidIExtenderProviderService_TestData))]
         public void DesignerHost_Remove_InvalidIExtenderProviderServiceWithDefault_DoesNotCallParentGetService(Mock<IServiceProvider> mockParentProvider)
         {
@@ -2724,7 +2724,7 @@ namespace System.ComponentModel.Design.Tests
             mockParentProvider?.Verify(p => p.GetService(typeof(IExtenderProviderService)), Times.Never());
         }
 
-        [Fact]
+        [WinFormsFact]
         public void Remove_ComponentNotInContainerNonEmpty_Nop()
         {
             using var surface1 = new SubDesignSurface();
@@ -2742,7 +2742,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(component, Assert.Single(host2.Container.Components));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void Remove_ComponentNotInContainerEmpty_Nop()
         {
             using var surface1 = new SubDesignSurface();
@@ -2758,7 +2758,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Empty(host2.Container.Components);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void Remove_InvokeWithComponentRemoved_CallsHandler()
         {
             var surface = new SubDesignSurface();
@@ -2824,7 +2824,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(1, componentRemovedCallCount);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_Remove_SetSiteToNullInComponentRemoving_Success()
         {
             var surface = new SubDesignSurface();
@@ -2846,7 +2846,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(component.Site);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_Remove_SiteHasDictionary_ClearsDictionary()
         {
             var surface = new SubDesignSurface();
@@ -2862,7 +2862,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(service.GetValue("key"));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_Remove_NullComponent_ThrowsArgumentNullException()
         {
             var surface = new SubDesignSurface();
@@ -2870,7 +2870,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<ArgumentNullException>("component", () => host.Container.Remove(null));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_RemoveService_Invoke_GetServiceReturnsExpected()
         {
             var surface = new SubDesignSurface();
@@ -2883,7 +2883,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(host.GetService(typeof(object)));
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void DesignerHost_RemoveService_InvokeBool_GetServiceReturnsExpected(bool promote)
         {
@@ -2897,7 +2897,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(host.GetService(typeof(object)));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_RemoveService_InvokeDisposed_ThrowsObjectDisposedException()
         {
             var surface = new SubDesignSurface();
@@ -2915,7 +2915,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { new object(), TypeDescriptor.GetProperties(typeof(string))[0] };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(OnComponentChanging_TestData))]
         public void DesignerHost_IComponentChangeServiceOnComponentChanging_Invoke_CallsComponentChanging(object component, MemberDescriptor member)
         {
@@ -2948,7 +2948,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(2, callCount);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(OnComponentChanging_TestData))]
         public void DesignerHost_IComponentChangeServiceOnComponentChanging_InvokeLoading_DoesNotCallHandler(object component, MemberDescriptor member)
         {
@@ -2985,7 +2985,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { new object(), TypeDescriptor.GetProperties(typeof(string))[0], new object(), new object() };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(OnComponentChanged_TestData))]
         public void DesignerHost_IComponentChangeServiceOnComponentChanged_Invoke_CallsComponentChanged(object component, MemberDescriptor member, object oldValue, object newValue)
         {
@@ -3020,7 +3020,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(2, callCount);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(OnComponentChanged_TestData))]
         public void DesignerHost_IComponentChangeServiceOnComponentChanged_InvokeLoading_DoesNotCallHandler(object component, MemberDescriptor member, object oldValue, object newValue)
         {
@@ -3051,7 +3051,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(0, callCount);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_IReflect_UnderlyingSystemType_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();
@@ -3059,7 +3059,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(typeof(IDesignerHost), reflect.UnderlyingSystemType);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_IReflect_GetField_Success()
         {
             using var surface = new SubDesignSurface();
@@ -3067,7 +3067,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(typeof(IDesignerHost).GetField(nameof(IDesignerHost.Activate)), reflect.GetField(nameof(IDesignerHost.Activate), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_IReflect_GetFields_Success()
         {
             using var surface = new SubDesignSurface();
@@ -3075,7 +3075,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(typeof(IDesignerHost).GetFields(), reflect.GetFields(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_IReflect_GetMember_Success()
         {
             using var surface = new SubDesignSurface();
@@ -3083,7 +3083,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(typeof(IDesignerHost).GetMember(nameof(IDesignerHost.Container)), reflect.GetMember(nameof(IDesignerHost.Container), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_IReflect_GetMembers_Success()
         {
             using var surface = new SubDesignSurface();
@@ -3091,7 +3091,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(typeof(IDesignerHost).GetMembers(), reflect.GetMembers(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_IReflect_GetMethod_Success()
         {
             using var surface = new SubDesignSurface();
@@ -3100,7 +3100,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(typeof(IDesignerHost).GetMethod(nameof(IDesignerHost.Activate)), reflect.GetMethod(nameof(IDesignerHost.Activate), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public, null, Array.Empty<Type>(), Array.Empty<ParameterModifier>()));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_IReflect_GetMethods_Success()
         {
             using var surface = new SubDesignSurface();
@@ -3108,7 +3108,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(typeof(IDesignerHost).GetMethods(), reflect.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_IReflect_GetProperty_Success()
         {
             using var surface = new SubDesignSurface();
@@ -3117,7 +3117,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(typeof(IDesignerHost).GetProperty(nameof(IDesignerHost.Container)), reflect.GetProperty(nameof(IDesignerHost.Container), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public, null, typeof(IContainer), Array.Empty<Type>(), Array.Empty<ParameterModifier>()));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_IReflect_GetProperties_Success()
         {
             using var surface = new SubDesignSurface();
@@ -3125,7 +3125,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(typeof(IDesignerHost).GetProperties(), reflect.GetProperties(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void DesignerHost_IReflect_InvokeMember_ReturnsExpected()
         {
             using var surface = new SubDesignSurface();

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/SiteNestedContainerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/SiteNestedContainerTests.cs
@@ -63,7 +63,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { CreateSite("ownerName"), "containerName", "componentName", "ownerName.containerName.componentName" };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(CreateNestedContainer_TestData))]
         public void SiteNestedContainer_Add_Component_Success(ISite ownerSite, string containerName, string componentName, string expectedFullName)
         {
@@ -150,7 +150,7 @@ namespace System.ComponentModel.Design.Tests
             }
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(Add_ComponentParentProvider_TestData))]
         public void SiteNestedContainer_Add_ComponentWithRootDesigner_Success(IServiceProvider parentProvider)
         {
@@ -207,7 +207,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(component4.Site.Name);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(Add_InvalidNameCreationServiceParentProvider_TestData))]
         public void SiteNestedContainer_Add_ComponentStringWithRootDesigner_Success(IServiceProvider parentProvider)
         {
@@ -282,7 +282,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { notInheritedComponent, 1 };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(Add_IExtenderProviderServiceWithoutDefault_TestData))]
         public void SiteNestedContainer_Add_IExtenderProviderServiceWithoutDefault_Success(Component component, int expectedCallCount)
         {
@@ -349,7 +349,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { notInheritedComponent, true };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(Add_IExtenderProviderServiceWithDefault_TestData))]
         public void SiteNestedContainer_Add_IExtenderProviderServiceWithDefault_DoesNotCallGetService(Component component, bool throws)
         {
@@ -443,7 +443,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { invalidMockServiceProvider };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(InvalidIExtenderProviderService_TestData))]
         public void SiteNestedContainer_Add_InvalidIExtenderProviderServiceWithoutDefault_CallsParentGetService(Mock<IServiceProvider> mockParentProvider)
         {
@@ -458,7 +458,7 @@ namespace System.ComponentModel.Design.Tests
             mockParentProvider?.Verify(p => p.GetService(typeof(IExtenderProviderService)), Times.Once());
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(InvalidIExtenderProviderService_TestData))]
         public void SiteNestedContainer_Add_InvalidIExtenderProviderServiceWithDefault_DoesNotCallParentGetService(Mock<IServiceProvider> mockParentProvider)
         {
@@ -472,7 +472,7 @@ namespace System.ComponentModel.Design.Tests
             mockParentProvider?.Verify(p => p.GetService(typeof(IExtenderProviderService)), Times.Never());
         }
 
-        [Fact]
+        [WinFormsFact]
         public void SiteNestedContainer_Add_IComponentWithComponentAddingAndAdded_CallsHandler()
         {
             using var surface = new SubDesignSurface();
@@ -521,7 +521,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(2, componentAddedCallCount);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void SiteNestedContainer_Add_NullComponent_ThrowsArgumentNullException()
         {
             using var surface = new DesignSurface();
@@ -536,7 +536,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { new DesignerComponent() };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(Add_NoRootDesigner_TestData))]
         public void SiteNestedContainer_Add_NoRootDesigner_ThrowsException(IComponent component)
         {
@@ -548,7 +548,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Empty(container.Components);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void SiteNestedContainer_Add_CyclicRootDesigner_ThrowsException()
         {
             using var surface = new SubDesignSurface();
@@ -562,7 +562,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<Exception>(() => container.Add(new RootDesignerComponent(), host.RootComponentClassName));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void SiteNestedContainer_Add_NonInitializingRootDesigner_ThrowsInvalidOperationException()
         {
             using var surface = new DesignSurface();
@@ -573,7 +573,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Throws<InvalidOperationException>(() => container.Add(component, "name"));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void SiteNestedContainer_Add_ThrowingInitializingRootDesigner_RethrowsException()
         {
             using var surface = new DesignSurface();
@@ -589,7 +589,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(component.Site);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void SiteNestedContainer_Add_CheckoutExceptionThrowingInitializingRootDesigner_RethrowsException()
         {
             using var surface = new DesignSurface();
@@ -635,7 +635,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(0, callCount);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void SiteNestedContainer_Remove_Invoke_Success()
         {
             using var surface = new SubDesignSurface();
@@ -695,7 +695,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { notInheritedComponent, 1, 1 };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(Remove_IExtenderProviderServiceWithoutDefault_TestData))]
         public void SiteNestedContainer_Remove_IExtenderProviderServiceWithoutDefault_Success(Component component, int expectedAddCallCount, int expectedRemoveCallCount)
         {
@@ -760,7 +760,7 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { notInheritedComponent };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(Remove_IExtenderProviderServiceWithDefault_TestData))]
         public void SiteNestedContainer_Remove_IExtenderProviderServiceWithDefault_Success(Component component)
         {
@@ -807,7 +807,7 @@ namespace System.ComponentModel.Design.Tests
             mockExtenderProviderService.Verify(s => s.RemoveExtenderProvider(component as IExtenderProvider), Times.Never());
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(InvalidIExtenderProviderService_TestData))]
         public void SiteNestedContainer_Remove_InvalidIExtenderProviderServiceWithoutDefault_CallsParentGetService(Mock<IServiceProvider> mockParentProvider)
         {
@@ -826,7 +826,7 @@ namespace System.ComponentModel.Design.Tests
             mockParentProvider?.Verify(p => p.GetService(typeof(IExtenderProviderService)), Times.Exactly(2));
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(InvalidIExtenderProviderService_TestData))]
         public void SiteNestedContainer_Remove_InvalidIExtenderProviderServiceWithDefault_DoesNotCallParentGetService(Mock<IServiceProvider> mockParentProvider)
         {
@@ -844,12 +844,14 @@ namespace System.ComponentModel.Design.Tests
             mockParentProvider?.Verify(p => p.GetService(typeof(IExtenderProviderService)), Times.Never());
         }
 
-        [Fact]
+        [WinFormsFact]
         public void SiteNestedContainer_Remove_ComponentNotInContainerNonEmpty_Nop()
         {
             using var surface = new DesignSurface();
-            using INestedContainer container1 = surface.CreateNestedContainer(new Component(), "containerName");
-            using INestedContainer container2 = surface.CreateNestedContainer(new Component(), "containerName");
+            using var component1 = new Component();
+            using INestedContainer container1 = surface.CreateNestedContainer(component1, "containerName");
+            using var component2 = new Component();
+            using INestedContainer container2 = surface.CreateNestedContainer(component2, "containerName");
 
             var otherComponent = new RootDesignerComponent();
             using var component = new RootDesignerComponent();
@@ -861,12 +863,14 @@ namespace System.ComponentModel.Design.Tests
             Assert.Same(component, Assert.Single(container2.Components));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void SiteNestedContainer_Remove_ComponentNotInContainerEmpty_Nop()
         {
             using var surface = new DesignSurface();
-            using INestedContainer container1 = surface.CreateNestedContainer(new Component(), "containerName");
-            using INestedContainer container2 = surface.CreateNestedContainer(new Component(), "containerName");
+            using var component1 = new Component();
+            using INestedContainer container1 = surface.CreateNestedContainer(component1, "containerName");
+            using var component2 = new Component();
+            using INestedContainer container2 = surface.CreateNestedContainer(component2, "containerName");
 
             var otherComponent = new RootDesignerComponent();
             container1.Add(otherComponent);
@@ -876,7 +880,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Empty(container2.Components);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void SiteNestedContainer_Remove_InvokeWithComponentRemoved_CallsHandler()
         {
             using var surface = new SubDesignSurface();
@@ -944,7 +948,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal(1, componentRemovedCallCount);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void SiteNestedContainer_Remove_SetSiteToNullInComponentRemoving_Success()
         {
             using var surface = new SubDesignSurface();
@@ -968,7 +972,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(component.Site);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void SiteNestedContainer_Remove_SiteHasDictionary_DoesNotClearDictionary()
         {
             using var surface = new SubDesignSurface();
@@ -985,7 +989,7 @@ namespace System.ComponentModel.Design.Tests
             Assert.Equal("value", service.GetValue("key"));
         }
 
-        [Fact]
+        [WinFormsFact]
         public void SiteNestedContainer_Remove_NullComponent_ThrowsArgumentNullException()
         {
             using var surface = new DesignSurface();

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/SiteNestedContainerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/SiteNestedContainerTests.cs
@@ -615,27 +615,25 @@ namespace System.ComponentModel.Design.Tests
             Assert.Null(component.Site.Name);
         }
 
-        // Commenting out failing test
-        // Tracked by https://github.com/dotnet/winforms/issues/1151
-        // [Fact]
-        // public void SiteNestedContainer_Add_Unloading_Nop()
-        // {
-        //     using var surface = new SubDesignSurface();
-        //     IDesignerLoaderHost2 host = surface.Host;
-        //     surface.BeginLoad(typeof(RootDesignerComponent));
-        //     using var owningComponent = new Component();
-        //     INestedContainer container = surface.CreateNestedContainer(owningComponent, "containerName");
+         [Fact(Skip = "Unstable test. See https://github.com/dotnet/winforms/issues/1151")]
+         public void SiteNestedContainer_Add_Unloading_Nop()
+         {
+            using var surface = new SubDesignSurface();
+            IDesignerLoaderHost2 host = surface.Host;
+            surface.BeginLoad(typeof(RootDesignerComponent));
+            using var owningComponent = new Component();
+            using INestedContainer container = surface.CreateNestedContainer(owningComponent, "containerName");
 
-        //     var component = new DisposingDesignerComponent();
-        //     container.Add(component);
-        //     int callCount = 0;
-        //     DisposingDesigner.Disposed += (sender, e) =>
-        //     {
-        //         callCount++;
-        //     };
-        //     surface.Dispose();
-        //     Assert.Equal(0, callCount);
-        // }
+            var component = new DisposingDesignerComponent();
+            container.Add(component);
+            int callCount = 0;
+            DisposingDesigner.Disposed += (sender, e) =>
+            {
+                callCount++;
+            };
+            surface.Dispose();
+            Assert.Equal(0, callCount);
+        }
 
         [Fact]
         public void SiteNestedContainer_Remove_Invoke_Success()


### PR DESCRIPTION

So I'm investigating #1460 and #1151. 

It seems like the failure in `DesignerHost_Add_ComponentDisposeThrowsDuringUnloadingDispose_ThrowsInvalidOperationException` and `DesignSurface_View_GetWithInvalidSupportedTechnologies_ThrowsNotSupportedException` etc. etc. are related to locking of `LicenseManager`. Not really sure how to fix this in the tests.

It seems like the failure in `DesignerHost_Add_DuringUnload_ThrowsException` and `SiteNestedContainer_Add_Unloading_Nop` are unrelated to this and instead related to `DesignSurface.CreateDesigner` returning null. See https://github.com/dotnet/winforms/issues/1460#issuecomment-515985498

Looking at the stack trace of the failure in #1560
```cs
  System.Exception : There is no designer for the class System.ComponentModel.Design.Tests.DesignerHostTests+DesignerComponent.
  Stack Trace:
    /_/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs(244,0): at System.ComponentModel.Design.DesignerHost.AddToContainerPostProcess(IComponent component, String name, IContainer containerToAddTo)
    /_/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs(151,0): at System.ComponentModel.Design.DesignerHost.PerformAdd(IComponent component, String name)
    /_/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs(141,0): at System.ComponentModel.Design.DesignerHost.Add(IComponent component, String name)
       at System.ComponentModel.Container.Add(IComponent component)
    /_/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerHostTests.cs(874,0): at System.ComponentModel.Design.Tests.DesignerHostTests.DesignerHost_Add_DuringUnload_ThrowsException()
```

For the record, the failing test is below, and we fail at `host.Container.Add`
```cs
public void DesignerHost_Add_DuringUnload_ThrowsException()
{
    using var surface = new SubDesignSurface();
    IDesignerLoaderHost2 host = surface.Host;
    surface.BeginLoad(typeof(RootDesignerComponent));

    using var component = new DesignerComponent();
    host.Container.Add(component);
    int callCount = 0;
    component.Disposed += (sender, e) =>
    {
        using var newComponent = new DesignerComponent();
        Assert.Throws<Exception>(() => host.Container.Add(newComponent));
        callCount++;
    };
    surface.Dispose();
    Assert.Equal(1, callCount);
    Assert.False(surface.IsLoaded);
    Assert.Empty(surface.LoadErrors);
    Assert.False(host.Loading);
}
```

I had a little theory that this could be because of the code in `AddToContainerPostProcess`. Basically, it seems like we are `_rootComponent == null`, even though I'm fairly sure we don't expect it to be. Problems happen because we look for `IRootDesigner`, which the components we're adding don't implement.
 
```cs
IDesigner designer;
// Is this the first component the loader has created?  If so, then it must be the root component (by definition) so we will expect there to be a root designer associated with the component.  Otherwise, we search for a normal designer, which can be optionally provided.
if (_rootComponent == null)
{
    designer = _surface.CreateDesigner(component, true) as IRootDesigner;
    if (designer == null)
    {
        Exception ex = new Exception(string.Format(SR.DesignerHostNoTopLevelDesigner, component.GetType().FullName))
        {
            HelpLink = SR.DesignerHostNoTopLevelDesigner
        };
        throw ex;
    }
}
```

I looked at the code and saw nothing was being disposed in any of the test code.

So in terms of the locking problem, I thought that this might be a problem because `LicenseManager` lock may have been held and not released because we didn't dispose of anything. However, this didn't seem to be the case.
- I don't really have much of an idea about how to fix these tests. It seems odd that they only failed in the tests that we disabled, and not be disabled again (I could repro a test failure in `DesignSurface_View_GetWithInvalidSupportedTechnologies_ThrowsNotSupportedException` but this test has been enabled for 9+ months on the CI)
- Maybe we could wrap each test in `RemoteExecutor.Invoke` but I am a bit reluctant to do this as it creates additional strains on test execution and seems a bit odd.

I then suspected that something was problematic in that we were not disposing of any components within the classes and this could cause `_rootComponent` to equal null somehow
- This didn't seem to be the case either.

All in all, I fell back stumped. However, its good practice to dispose of anything in test code, so I kept the changes here and am submitting them.

I'm not sure if this will fix anything, but ah well

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3221)