### PR TITLE
Provide internals test utilities

### DIFF
--- a/src/Common/tests/InternalUtilitiesForTests/src/ITestAccessor.cs
+++ b/src/Common/tests/InternalUtilitiesForTests/src/ITestAccessor.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System
+{
+    /// <summary>
+    ///  Interface for accessing internals from tests.
+    /// </summary>
+    /// <remarks>
+    ///  A non generic representation of the acessor functionality is needed to
+    ///  allow dynamically creating arbitrary <see cref="TestAccessor{T}"/> from
+    ///  helper methods.
+    /// </remarks>
+    public interface ITestAccessor
+    {
+        /// <summary>
+        ///  Gets a dynamic accessor to internals on the test object.
+        /// </summary>
+        /// <remarks>
+        ///  This does not work for ref structs as they are not yet accessible via reflection.
+        ///  See https://github.com/dotnet/runtime/issues/10057.
+        /// </remarks>
+        dynamic Dynamic { get; }
+
+        /// <summary>
+        ///  Creates a delegate for the given non-public method.
+        /// </summary>
+        /// <param name="methodName">
+        ///  The method name. If null, uses the name of the delegate for the method.
+        /// </param>
+        /// <remarks>
+        ///  This provides a way to access methods that take ref structs.
+        /// </remarks>
+        /// <example>
+        ///  <![CDATA[
+        ///   // For ref structs you have to define a delegate as ref struct types
+        ///   // cannot be used as generic arguments (e.g. to Func/Span)
+        ///
+        ///   private delegate int GetDirectoryNameOffset(ReadOnlySpan<char> path);
+        ///
+        ///   public int InternalGetDirectoryNameOffset(ReadOnlySpan<char> path)
+        ///   {
+        ///       var accessor = typeof(System.IO.Path).TestAccessor();
+        ///       return accessor.CreateDelegate<GetDirectoryNameOffset>()(@"C:\Foo");
+        ///   }
+        ///
+        ///   // Without ref structs you can just use Func/Action
+        ///   var accessor = typeof(Color).TestAccessor();
+        ///   bool result = accessor.CreateDelegate<Func<KnownColor, bool>>("IsKnownColorSystem")(KnownColor.Window);
+        ///  ]]>
+        /// </example>
+        TDelegate CreateDelegate<TDelegate>(string methodName = null)
+            where TDelegate : Delegate;
+    }
+}

--- a/src/Common/tests/InternalUtilitiesForTests/src/TestAccessor.cs
+++ b/src/Common/tests/InternalUtilitiesForTests/src/TestAccessor.cs
@@ -1,0 +1,172 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Dynamic;
+using System.Linq;
+using System.Reflection;
+
+namespace System
+{
+    /// <summary>
+    ///  Internals (including privates) access wrapper for tests.
+    /// </summary>
+    /// <typeparam name="T">The type of the class being accessed.</typeparam>
+    /// <remarks>
+    ///  Does not allow access to public members- use the object directly.
+    ///
+    ///  One should strive to *not* access internal state where otherwise avoidable.
+    ///  Ask yourself if you can test the contract of the object in question
+    ///  *without* manipulating internals directly. Often you can.
+    ///
+    ///  Where internals access is more useful are testing building blocks of more
+    ///  complicated objects, such as internal helper methods or classes.
+    ///
+    ///  This can be used to access private/internal objects as well via
+    /// </remarks>
+    /// <example>
+    ///  This class can also be derived from to create a strongly typed wrapper
+    ///  that can then be associated via an extension method for the given type
+    ///  to provide consistent discovery and access.
+    ///
+    ///  <![CDATA[
+    ///   public class GuidTestAccessor : TestAccessor<Guid>
+    ///   {
+    ///     public TestAccessor(Guid instance) : base(instance) {}
+    ///
+    ///     public int A => Dynamic._a;
+    ///   }
+    ///
+    ///   public static partial class TestAccessors
+    ///   {
+    ///       public static GuidTestAccessor TestAccessor(this Guid guid)
+    ///           => new GuidTestAccessor(guid);
+    ///   }
+    ///  ]]>
+    /// </example>
+    public class TestAccessor<T> : ITestAccessor
+    {
+        private static readonly Type s_type = typeof(T);
+        protected readonly T _instance;
+        private readonly DynamicWrapper _dynamicWrapper;
+
+        /// <param name="instance">The type instance, can be null for statics.</param>
+        public TestAccessor(T instance)
+        {
+            _instance = instance;
+            _dynamicWrapper = new DynamicWrapper(_instance);
+        }
+
+        /// <inheritdoc/>
+        public TDelegate CreateDelegate<TDelegate>(string methodName = null)
+            where TDelegate : Delegate
+        {
+            Type type = typeof(TDelegate);
+            Type[] types = type.GetMethod("Invoke").GetParameters().Select(pi => pi.ParameterType).ToArray();
+
+            // To make it easier to write a class wrapper with a number of delegates,
+            // we'll take the name from the delegate itself when unspecified.
+            if (methodName == null)
+                methodName = type.Name;
+
+            MethodInfo methodInfo = s_type.GetMethod(
+                methodName,
+                BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static,
+                binder: null,
+                types,
+                modifiers: null);
+
+            if (methodInfo == null)
+                throw new ArgumentException($"Could not find non public method {methodName}.");
+
+            return (TDelegate)methodInfo.CreateDelegate(type, methodInfo.IsStatic ? (object)null : _instance);
+        }
+
+        /// <inheritdoc/>
+        public dynamic Dynamic => _dynamicWrapper;
+
+        private class DynamicWrapper : DynamicObject
+        {
+            private readonly object _instance;
+
+            public DynamicWrapper(object instance)
+                => _instance = instance;
+
+            public override bool TryInvokeMember(InvokeMemberBinder binder, object[] args, out object result)
+            {
+                result = null;
+
+                MethodInfo methodInfo = null;
+
+                try
+                {
+                    methodInfo = s_type.GetMethod(
+                        binder.Name,
+                        BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
+                }
+                catch (AmbiguousMatchException)
+                {
+                    // More than one match for the name, specify the arguments
+                    methodInfo = s_type.GetMethod(
+                        binder.Name,
+                        BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static,
+                        binder: null,
+                        args.Select(a => a.GetType()).ToArray(),
+                        modifiers: null);
+                }
+
+                if (methodInfo == null)
+                    return false;
+
+                result = methodInfo.Invoke(_instance, args);
+                return true;
+            }
+
+            public override bool TrySetMember(SetMemberBinder binder, object value)
+            {
+                FieldInfo fieldInfo = GetFieldInfo(binder.Name);
+                if (fieldInfo != null)
+                {
+                    fieldInfo.SetValue(_instance, value);
+                    return true;
+                }
+
+                PropertyInfo propertyInfo = GetPropertyInfo(binder.Name);
+                if (propertyInfo == null)
+                    return false;
+
+                propertyInfo.SetValue(_instance, value);
+                return true;
+            }
+
+            public override bool TryGetMember(GetMemberBinder binder, out object result)
+            {
+                result = null;
+
+                FieldInfo fieldInfo = GetFieldInfo(binder.Name);
+                if (fieldInfo != null)
+                {
+                    result = fieldInfo.GetValue(_instance);
+                    return true;
+                }
+
+                PropertyInfo propertyInfo = GetPropertyInfo(binder.Name);
+                if (propertyInfo == null)
+                    return false;
+
+                result = propertyInfo.GetValue(_instance);
+                return true;
+            }
+
+            private PropertyInfo GetPropertyInfo(string propertyName)
+                => s_type.GetProperty(
+                    propertyName,
+                    BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic);
+
+            private FieldInfo GetFieldInfo(string fieldName)
+                => s_type.GetField(
+                    fieldName,
+                    BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic);
+        }
+    }
+}

--- a/src/Common/tests/InternalUtilitiesForTests/src/TestAccessors.cs
+++ b/src/Common/tests/InternalUtilitiesForTests/src/TestAccessors.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Forms;
+
+namespace System
+{
+    /// <summary>
+    ///  Extension methods for associating internals test accessors with
+    ///  types being tested.
+    /// </summary>
+    /// <remarks>
+    ///  In the System namespace for implicit discovery.
+    /// </remarks>
+    public static class TestAccessors
+    {
+        // Need to pass a null parameter when constructing a static instance
+        // of TestAccessor. As this is pretty common and never changes, caching
+        // the array here.
+        private static object[] s_nullObjectParam = { null };
+
+        /// <summary>
+        ///  Extension that creates a generic internals test accessor for a
+        ///  given instance or Type class (if only accessing statics).
+        /// </summary>
+        /// <param name="instanceOrType">
+        ///  Instance or Type class (if only accessing statics).
+        /// </param>
+        /// <example>
+        /// <![CDATA[
+        ///  Version version = new Version(4, 1);
+        ///  Assert.Equal(4, version.TestAccessor().Dynamic._Major));
+        ///
+        ///  // Or
+        ///
+        ///  dynamic accessor = version.TestAccessor().Dynamic;
+        ///  Assert.Equal(4, accessor._Major));
+        /// ]]>
+        /// </example>
+        public static ITestAccessor TestAccessor(this object instanceOrType)
+        {
+            if (instanceOrType is Type type)
+            {
+                return (ITestAccessor)Activator.CreateInstance(
+                    typeof(TestAccessor<>).MakeGenericType(type),
+                    s_nullObjectParam);
+            }
+            else
+            {
+                return (ITestAccessor)Activator.CreateInstance(
+                    typeof(TestAccessor<>).MakeGenericType(instanceOrType.GetType()),
+                    instanceOrType);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/EventHandlerService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/EventHandlerService.cs
@@ -91,10 +91,6 @@ namespace System.Windows.Forms.Design
                 _lastHandlerType = null;
                 OnEventHandlerChanged(EventArgs.Empty);
             }
-            else
-            {
-                Debug.Assert(_handlers.Count == 0, "Failed to locate handler to remove from list.");
-            }
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/EventHandlerService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/EventHandlerService.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 namespace System.Windows.Forms.Design
 {
@@ -16,8 +18,7 @@ namespace System.Windows.Forms.Design
         private Type _lastHandlerType;
         private EventHandler _changedEvent;
 
-        // The handler stack
-        private HandlerEntry _handlerHead;
+        private readonly LinkedList<object> _handlers = new LinkedList<object>();
 
         /// <summary>
         ///  Initializes a new instance of the EventHandlerService class.
@@ -59,19 +60,17 @@ namespace System.Windows.Forms.Design
                 return _lastHandler;
             }
 
-            Debug.Assert(_handlerHead != null, "Failed to locate handler to iterate from list.");
+            Debug.Assert(_handlers.Count > 0, "Should have handlers to look through.");
 
-            for (HandlerEntry entry = _handlerHead; entry != null; entry = entry.next)
+            object handler = _handlers.FirstOrDefault(h => handlerType.IsInstanceOfType(h));
+
+            if (handler != null)
             {
-                if (entry.handler != null && handlerType.IsInstanceOfType(entry.handler))
-                {
-                    _lastHandlerType = handlerType;
-                    _lastHandler = entry.handler;
-                    return entry.handler;
-                }
+                _lastHandler = handler;
+                _lastHandlerType = handlerType;
             }
 
-            return null;
+            return handler;
         }
 
         /// <summary>
@@ -84,19 +83,18 @@ namespace System.Windows.Forms.Design
                 throw new ArgumentNullException(nameof(handler));
             }
 
-            for (HandlerEntry entry = _handlerHead; entry != null; entry = entry.next)
+            var node = _handlers.Find(handler);
+            if (node != null)
             {
-                if (entry.handler == handler)
-                {
-                    _handlerHead = entry.next;
-                    _lastHandler = null;
-                    _lastHandlerType = null;
-                    OnEventHandlerChanged(EventArgs.Empty);
-                    return;
-                }
+                _handlers.Remove(node);
+                _lastHandler = null;
+                _lastHandlerType = null;
+                OnEventHandlerChanged(EventArgs.Empty);
             }
-
-            Debug.Assert(handler == null || _handlerHead == null, "Failed to locate handler to remove from list.");
+            else
+            {
+                Debug.Assert(_handlers.Count == 0, "Failed to locate handler to remove from list.");
+            }
         }
 
         /// <summary>
@@ -109,12 +107,9 @@ namespace System.Windows.Forms.Design
                 throw new ArgumentNullException(nameof(handler));
             }
 
-            _handlerHead = new HandlerEntry(handler, _handlerHead);
-
-            // Update the handlerType if the Handler pushed is the same type as the last one ....
-            // This is true when SplitContainer is on the form and Edit Properties pushed another handler.
+            _handlers.AddFirst(handler);
             _lastHandlerType = handler.GetType();
-            _lastHandler = _handlerHead.handler;
+            _lastHandler = handler;
 
             OnEventHandlerChanged(EventArgs.Empty);
         }
@@ -125,44 +120,6 @@ namespace System.Windows.Forms.Design
         private void OnEventHandlerChanged(EventArgs e)
         {
             _changedEvent?.Invoke(this, e);
-        }
-
-        /// <summary>
-        ///  Contains a single node of our handler stack.  We typically
-        ///  have very few handlers, and the handlers are long-living, so
-        ///  I just implemented this as a linked list.
-        /// </summary>
-        internal sealed class HandlerEntry
-        {
-            public object handler;
-            public HandlerEntry next;
-
-            /// <summary>
-            ///  Creates a new handler entry objet.
-            /// </summary>
-            public HandlerEntry(object handler, HandlerEntry next)
-            {
-                this.handler = handler;
-                this.next = next;
-            }
-        }
-
-        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
-
-        internal readonly struct TestAccessor
-        {
-            private readonly EventHandlerService _service;
-
-            public TestAccessor(EventHandlerService service)
-            {
-                _service = service;
-            }
-
-            public ref object LastHandler => ref _service._lastHandler;
-
-            public ref Type LastHandlerType => ref _service._lastHandlerType;
-
-            public ref HandlerEntry HandlerHead => ref _service._handlerHead;
         }
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/EventHandlerServiceTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/EventHandlerServiceTests.cs
@@ -35,9 +35,6 @@ namespace System.Windows.Forms.Design.Tests
             Assert.Null(service.GetHandler(typeof(object)));
         }
 
-        private class A { }
-        private class B : A { }
-
         [Fact]
         public void GetHandler_should_return_last_inserted_handler_of_type()
         {
@@ -181,5 +178,8 @@ namespace System.Windows.Forms.Design.Tests
 
             Assert.Equal(1, callCount);
         }
+
+        private class A { }
+        private class B : A { }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MaskedTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MaskedTextBox.cs
@@ -896,17 +896,8 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Determines if the control is in password protect mode.
         /// </summary>
-        internal override bool PasswordProtect
-        {
-            get
-            {
-                if (maskedTextProvider != null) // could be queried during object construction.
-                {
-                    return maskedTextProvider.IsPassword;
-                }
-                return base.PasswordProtect;
-            }
-        }
+        private protected override bool PasswordProtect
+            => maskedTextProvider?.IsPassword ?? base.PasswordProtect;
 
         /// <summary>
         ///  Specifies the prompt character to be used in the formatted string for unsupplied characters.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -805,8 +805,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Handles the WM_KEYDOWN message.
         /// </summary>
-        //added to handle keyboard events
-        //
+
         private void WmKeyDown(ref Message msg)
         {
             Keys keyData = (Keys)((int)msg.WParam | (int)ModifierKeys);
@@ -942,8 +941,6 @@ namespace System.Windows.Forms
                 case User32.WM.HSCROLL:
                     WmHScroll(ref m);
                     break;
-                //added case to handle keyboard events
-                //
                 case User32.WM.KEYDOWN:
                     WmKeyDown(ref m);
                     break;
@@ -984,20 +981,6 @@ namespace System.Windows.Forms
         private Color GetBackColor(bool isHighContract)
         {
             return (isHighContract && !ShouldSerializeBackColor()) ? SystemColors.ControlDark : BackColor;
-        }
-
-        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
-
-        internal readonly struct TestAccessor
-        {
-            private readonly PrintPreviewControl _control;
-
-            public TestAccessor(PrintPreviewControl control)
-            {
-                _control = control;
-            }
-
-            public Color GetBackColor(bool isHighContrast) => _control.GetBackColor(isHighContrast);
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -805,7 +805,6 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Handles the WM_KEYDOWN message.
         /// </summary>
-
         private void WmKeyDown(ref Message msg)
         {
             Keys keyData = (Keys)((int)msg.WParam | (int)ModifierKeys);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
@@ -289,7 +289,6 @@ namespace System.Windows.Forms
                 }
 
                 // Translate for Rtl if necessary
-
                 HorizontalAlignment align = RtlTranslateHorizontal(textAlign);
 
                 // WS_EX_RIGHT overrides the ES_XXXX alignment styles

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
@@ -88,8 +88,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Gets or sets a value indicating whether pressing ENTER
-        ///  in a multiline <see cref='TextBox'/>
+        ///  Gets or sets a value indicating whether pressing ENTER in a multiline <see cref='TextBox'/>
         ///  control creates a new line of text in the control or activates the default button
         ///  for the form.
         /// </summary>
@@ -102,7 +101,6 @@ namespace System.Windows.Forms
             {
                 return acceptsReturn;
             }
-
             set
             {
                 acceptsReturn = value;
@@ -141,8 +139,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  This is the AutoCompleteSource which can be one of the
-        ///  values from AutoCompleteSource enumeration.
+        ///  This is the AutoCompleteSource which can be one of the values from AutoCompleteSource enumeration.
         ///  This property in conjunction with AutoCompleteMode enables the AutoComplete feature for TextBox.
         /// </summary>
         [DefaultValue(AutoCompleteSource.None)]
@@ -237,8 +234,6 @@ namespace System.Windows.Forms
             {
                 if (characterCasing != value)
                 {
-                    //verify that 'value' is a valid enum type...
-                    //valid values are 0x0 to 0x2
                     if (!ClientUtils.IsEnumValid(value, (int)value, (int)CharacterCasing.Normal, (int)CharacterCasing.Lower))
                     {
                         throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(CharacterCasing));
@@ -269,13 +264,8 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Determines if the control is in password protect mode.
         /// </summary>
-        internal override bool PasswordProtect
-        {
-            get
-            {
-                return PasswordChar != '\0';
-            }
-        }
+        private protected override bool PasswordProtect
+            => PasswordChar != '\0';
 
         /// <summary>
         ///  Returns the parameters needed to create the handle. Inheriting classes
@@ -299,9 +289,12 @@ namespace System.Windows.Forms
                 }
 
                 // Translate for Rtl if necessary
-                //
+
                 HorizontalAlignment align = RtlTranslateHorizontal(textAlign);
-                cp.ExStyle &= ~(int)WS_EX.RIGHT;   // WS_EX_RIGHT overrides the ES_XXXX alignment styles
+
+                // WS_EX_RIGHT overrides the ES_XXXX alignment styles
+                cp.ExStyle &= ~(int)WS_EX.RIGHT;
+
                 switch (align)
                 {
                     case HorizontalAlignment.Left:
@@ -401,7 +394,6 @@ namespace System.Windows.Forms
             {
                 if (scrollBars != value)
                 {
-                    //valid values are 0x0 to 0x3
                     if (!ClientUtils.IsEnumValid(value, (int)value, (int)ScrollBars.None, (int)ScrollBars.Both))
                     {
                         throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ScrollBars));
@@ -435,8 +427,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Gets or sets
-        ///  the current text in the text box.
+        ///  Gets or sets the current text in the text box.
         /// </summary>
         public override string Text
         {
@@ -449,9 +440,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Gets or sets how text is
-        ///  aligned in a <see cref='TextBox'/>
-        ///  control.
+        ///  Gets or sets how text is aligned in a <see cref='TextBox'/> control.
         ///  Note: This code is duplicated in MaskedTextBox for simplicity.
         /// </summary>
         [Localizable(true)]
@@ -468,9 +457,6 @@ namespace System.Windows.Forms
             {
                 if (textAlign != value)
                 {
-                    //verify that 'value' is a valid enum type...
-
-                    //valid values are 0x0 to 0x2
                     if (!ClientUtils.IsEnumValid(value, (int)value, (int)HorizontalAlignment.Left, (int)HorizontalAlignment.Center))
                     {
                         throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(HorizontalAlignment));
@@ -522,7 +508,6 @@ namespace System.Windows.Forms
         public event EventHandler TextAlignChanged
         {
             add => Events.AddHandler(EVENT_TEXTALIGNCHANGED, value);
-
             remove => Events.RemoveHandler(EVENT_TEXTALIGNCHANGED, value);
         }
 
@@ -533,7 +518,7 @@ namespace System.Windows.Forms
                 // Reset this just in case, because the SHAutoComplete stuff
                 // will subclass this guys wndproc (and nativewindow can't know about it).
                 // so this will undo it, but on a dispose we'll be Destroying the window anyay.
-                //
+
                 ResetAutoComplete(true);
                 if (autoCompleteCustomSource != null)
                 {
@@ -575,6 +560,7 @@ namespace System.Windows.Forms
         protected unsafe override void OnBackColorChanged(EventArgs e)
         {
             base.OnBackColorChanged(e);
+
             // Force repainting of the entire window frame
             if (Application.RenderWithVisualStyles && IsHandleCreated && BorderStyle == BorderStyle.Fixed3D)
             {
@@ -591,7 +577,7 @@ namespace System.Windows.Forms
             base.OnFontChanged(e);
             if (AutoCompleteMode != AutoCompleteMode.None)
             {
-                //we always will recreate the handle when autocomplete mode is on
+                // Always recreate the handle when autocomplete mode is on
                 RecreateHandle();
             }
         }
@@ -706,7 +692,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Performs the actual select without doing arg checking.
         /// </summary>
-        internal override void SelectInternal(int start, int length, int textLen)
+        private protected override void SelectInternal(int start, int length, int textLen)
         {
             // If user set selection into text box, mark it so we don't
             // clobber it when we get focus.
@@ -727,9 +713,9 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Sets the AutoComplete mode in TextBox.
         /// </summary>
-        internal void SetAutoComplete(bool reset)
+        private void SetAutoComplete(bool reset)
         {
-            //Autocomplete Not Enabled for Password enabled and MultiLine Textboxes.
+            // Autocomplete Not Enabled for Password enabled and MultiLine Textboxes.
             if (Multiline || passwordChar != 0 || useSystemPasswordChar || AutoCompleteSource == AutoCompleteSource.None)
             {
                 return;
@@ -866,8 +852,6 @@ namespace System.Windows.Forms
             }
         }
 
-        //-------------------------------------------------------------------------------------------------
-
         /// <summary>
         ///  Draws the <see cref="PlaceholderText"/> in the client area of the <see cref="TextBox"/> using the default font and color.
         /// </summary>
@@ -939,11 +923,6 @@ namespace System.Windows.Forms
                         base.WndProc(ref m);
                     }
                     break;
-                //for readability ... so that we know whats happening ...
-                // case WM_LBUTTONUP is included here eventhough it just calls the base.
-                case User32.WM.LBUTTONUP:
-                    base.WndProc(ref m);
-                    break;
                 case User32.WM.PRINT:
                     WmPrint(ref m);
                     break;
@@ -962,24 +941,10 @@ namespace System.Windows.Forms
         }
 
         private bool ShouldRenderPlaceHolderText(in Message m) =>
-                    !string.IsNullOrEmpty(PlaceholderText) &&
-                    (m.Msg == (int)User32.WM.PAINT || m.Msg == (int)User32.WM.KILLFOCUS) &&
-                    !GetStyle(ControlStyles.UserPaint) &&
-                    !Focused &&
-                    TextLength == 0;
-
-        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
-
-        internal readonly struct TestAccessor
-        {
-            private readonly TextBox _textBox;
-
-            public TestAccessor(TextBox textBox)
-            {
-                _textBox = textBox;
-            }
-
-            public bool ShouldRenderPlaceHolderText(in Message m) => _textBox.ShouldRenderPlaceHolderText(m);
-        }
+            !string.IsNullOrEmpty(PlaceholderText) &&
+            (m.Msg == (int)User32.WM.PAINT || m.Msg == (int)User32.WM.KILLFOCUS) &&
+            !GetStyle(ControlStyles.UserPaint) &&
+            !Focused &&
+            TextLength == 0;
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -845,13 +845,7 @@ namespace System.Windows.Forms
         ///  MaskedTextBox and is false by default so RichTextBox that doesn't support Password doesn't
         ///  have to care about this.
         /// </summary>
-        virtual internal bool PasswordProtect
-        {
-            get
-            {
-                return false;
-            }
-        }
+        virtual private protected bool PasswordProtect => false;
 
         /// <summary>
         ///  Returns the preferred
@@ -1835,7 +1829,7 @@ namespace System.Windows.Forms
         ///  But if you do have it cached, please pass it in. This will avoid
         ///  the expensive call to the TextLength property.
         /// </summary>
-        internal virtual void SelectInternal(int start, int length, int textLen)
+        private protected virtual void SelectInternal(int start, int length, int textLen)
         {
             //if our handle is created - send message...
             if (IsHandleCreated)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -845,7 +845,7 @@ namespace System.Windows.Forms
         ///  MaskedTextBox and is false by default so RichTextBox that doesn't support Password doesn't
         ///  have to care about this.
         /// </summary>
-        virtual private protected bool PasswordProtect => false;
+        private protected virtual bool PasswordProtect => false;
 
         /// <summary>
         ///  Returns the preferred

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Printing/PrintPreviewControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Printing/PrintPreviewControlTests.cs
@@ -31,7 +31,7 @@ namespace System.Windows.Forms.Tests
                 control.BackColor = Color.FromArgb(customBackColorArgb);
             }
 
-            int actualBackColorArgb = control.GetTestAccessor().GetBackColor(isHighContrast).ToArgb();
+            int actualBackColorArgb = control.TestAccessor().Dynamic.GetBackColor(isHighContrast).ToArgb();
             Assert.Equal(expectedBackColorArgb, actualBackColorArgb);
 
             // Default AppWorkSpace color in HC theme does not allow to follow HC standards.

--- a/src/System.Windows.Forms/tests/UnitTests/TestAccessorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TestAccessorTests.cs
@@ -1,0 +1,219 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.CSharp.RuntimeBinder;
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    public class TestAccessorTests
+    {
+        [Fact]
+        public void TestAccessor_DynamicAccess_InstanceField()
+        {
+            var testClass = new PrivateTestClass();
+            dynamic access = testClass.TestAccessor().Dynamic;
+            access._integer = 5;
+            Assert.Equal(5, access._integer);
+        }
+
+        [Fact]
+        public void TestAccessor_DynamicAccess_StaticField()
+        {
+            // Don't need to create an instance to access a static, can
+            // use typeof instead
+            dynamic access = typeof(PrivateTestClass).TestAccessor().Dynamic;
+            access.s_integer = 16;
+            Assert.Equal(16, access.s_integer);
+
+            // Attempt using an instance as well
+            var testClass = new PrivateTestClass();
+            access = testClass.TestAccessor().Dynamic;
+            access.s_integer = 18;
+            Assert.Equal(18, access.s_integer);
+
+            // Try the static class version
+            access = typeof(PrivateStaticTestClass).TestAccessor().Dynamic;
+            access.s_integer = 21;
+            Assert.Equal(21, access.s_integer);
+        }
+
+        [Fact]
+        public void TestAccessor_DynamicAccess_ReadOnlyInstanceField()
+        {
+            var testClass = new PrivateTestClass();
+            dynamic access = testClass.TestAccessor().Dynamic;
+            access._readOnlyInteger = 7;
+            Assert.Equal(7, access._readOnlyInteger);
+        }
+
+        [Fact]
+        public void TestAccessor_DynamicAccess_ObjectInstanceField()
+        {
+            var testClass = new PrivateTestClass();
+            dynamic access = testClass.TestAccessor().Dynamic;
+            List<string> list = access._list;
+            Assert.NotNull(list);
+            Assert.Single(list);
+            Assert.Equal("42", list[0]);
+        }
+
+        [Fact]
+        public void TestAccessor_DynamicAccess_InstanceProperty()
+        {
+            var testClass = new PrivateTestClass();
+            dynamic access = testClass.TestAccessor().Dynamic;
+            access.Long = 1970;
+            Assert.Equal(1970, access.Long);
+        }
+
+        [Fact]
+        public void TestAccessor_DynamicAccess_StaticProperty()
+        {
+            var testClass = new PrivateTestClass();
+            dynamic access = testClass.TestAccessor().Dynamic;
+            access.Int = 1989;
+            Assert.Equal(1989, access.Int);
+
+            // Now try without an instance
+            access = typeof(PrivateTestClass).TestAccessor().Dynamic;
+            access.Int = 1988;
+            Assert.Equal(1988, access.Int);
+
+            // Try the static class version
+            access = typeof(PrivateStaticTestClass).TestAccessor().Dynamic;
+            access.Int = 1991;
+            Assert.Equal(1991, access.Int);
+        }
+
+        [Fact]
+        public void TestAccessor_DynamicAccess_PublicField()
+        {
+            var testClass = new PrivateTestClass();
+            dynamic access = testClass.TestAccessor().Dynamic;
+
+            // If the API is public we want to access "normally", so we prevent this.
+            Assert.Throws<RuntimeBinderException>(() => access.PublicField = 1918);
+        }
+
+        [Fact]
+        public void TestAccessor_DynamicAccess_PublicProperty()
+        {
+            var testClass = new PrivateTestClass();
+            dynamic access = testClass.TestAccessor().Dynamic;
+
+            // If the API is public we want to access "normally", so we prevent this.
+            Assert.Throws<RuntimeBinderException>(() => access.PublicProperty = "What?");
+        }
+
+        [Fact]
+        public void TestAccessor_DynamicAccess_InstanceMethod()
+        {
+            var testClass = new PrivateTestClass();
+            Assert.Equal(4, testClass.TestAccessor().Dynamic.ToStringLength(2001));
+            Assert.Equal(7, testClass.TestAccessor().Dynamic.ToStringLength("Flubber"));
+        }
+
+        [Fact]
+        public void TestAccessor_FuncDelegateAccess_InstanceMethod()
+        {
+            var testClass = new PrivateTestClass();
+            ITestAccessor accessor = testClass.TestAccessor();
+            Assert.Equal(4, accessor.CreateDelegate<Func<int, int>>("ToStringLength")(2001));
+            Assert.Equal(7, accessor.CreateDelegate<Func<string, int>>("ToStringLength")("Flubber"));
+        }
+
+        [Fact]
+        public void TestAccessor_NamedDelegateAccess_InstanceMethod()
+        {
+            var testClass = new PrivateTestClass();
+            ITestAccessor accessor = testClass.TestAccessor();
+            Assert.Equal(5, accessor.CreateDelegate<ToStringLength>()("25624"));
+        }
+
+        [Fact]
+        public void TestAccessor_DynamicAccess_StaticMethod()
+        {
+            var testClass = new PrivateTestClass();
+            Assert.Equal(2, testClass.TestAccessor().Dynamic.AddOne(1));
+
+            // Hit the static class version
+            Assert.Equal(3, typeof(PrivateStaticTestClass).TestAccessor().Dynamic.AddOne(2));
+        }
+
+        [Fact]
+        public void TestAccessor_FuncDelegateAccess_StaticMethod()
+        {
+            var testClass = new PrivateTestClass();
+            Assert.Equal(2000, testClass.TestAccessor().CreateDelegate<Func<int, int>>("AddOne")(1999));
+
+            // Hit the static class version
+            Assert.Equal(21, typeof(PrivateStaticTestClass).TestAccessor().CreateDelegate<Func<int, int>>("AddOne")(20));
+        }
+
+        [Fact]
+        public void TestAccessor_UpcastType()
+        {
+            A a = new B();
+            dynamic accessor = a.TestAccessor().Dynamic;
+            accessor._b = 3;
+            Assert.Equal(3, accessor._b);
+        }
+
+        // As you can't use a ref struct as a generic parameter to Action/Func, you
+        // need to use a defined delegate to access an internal method that takes
+        // or returns a ref struct (such as Spans).
+
+        public delegate int ToStringLength(ReadOnlySpan<char> value);
+
+#pragma warning disable IDE0044   // use readonly
+#pragma warning disable IDE0051   // unaccessed private
+#pragma warning disable IDE0052   // unaccessed private
+#pragma warning disable CS0169    // unused field
+
+        public class A
+        {
+            private int _a;
+        }
+
+        public class B : A
+        {
+            private int _b;
+        }
+
+        public class PrivateTestClass
+        {
+            private int _integer;
+            private readonly int _readOnlyInteger;
+            private List<string> _list = new List<string> { "42" };
+
+            private long Long { get; set; }
+
+            public float PublicField;
+            public string PublicProperty { get; set; }
+
+            // It is important that we have multiple methods with the same name for testing.
+            private int ToStringLength(int value) => ToStringLength(value.ToString());
+            private int ToStringLength(string value) => value.Length;
+            private int ToStringLength(ReadOnlySpan<char> value) => value.Length;
+
+            private static int s_integer;
+            private static int Int { get; set; }
+
+            private static int AddOne(int value) => value + 1;
+        }
+
+        public static class PrivateStaticTestClass
+        {
+            private static int s_integer;
+            private static int Int { get; set; }
+            private static int AddOne(int value) => value + 1;
+        }
+#pragma warning restore IDE0044
+#pragma warning restore IDE0051
+#pragma warning disable IDE0052
+#pragma warning restore CS0169
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/TestAccessorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TestAccessorTests.cs
@@ -154,12 +154,29 @@ namespace System.Windows.Forms.Tests
         }
 
         [Fact]
-        public void TestAccessor_UpcastType()
+        public void TestAccessor_DynamicAccess_UpcastType()
         {
             A a = new B();
             dynamic accessor = a.TestAccessor().Dynamic;
             accessor._b = 3;
             Assert.Equal(3, accessor._b);
+        }
+
+        [Fact]
+        public void TestAccessor_DynamicAccess_BaseClassField()
+        {
+            A a = new B();
+            dynamic accessor = a.TestAccessor().Dynamic;
+            accessor._a = 5;
+            Assert.Equal(5, accessor._a);
+        }
+
+        [Fact]
+        public void TestAccessor_DynamicAccess_BaseClassMethod()
+        {
+            A a = new B();
+            dynamic accessor = a.TestAccessor().Dynamic;
+            Assert.Equal(42, (int)accessor.AMethod());
         }
 
         // As you can't use a ref struct as a generic parameter to Action/Func, you
@@ -175,6 +192,7 @@ namespace System.Windows.Forms.Tests
 
         public class A
         {
+            private int AMethod() => 42;
             private int _a;
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.cs
@@ -377,7 +377,7 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(TextBox_ShouldRenderPlaceHolderText_TestData))]
         public void TextBox_ShouldRenderPlaceHolderText(TextBox textBox, Message m, bool expected)
         {
-            var result = textBox.GetTestAccessor().ShouldRenderPlaceHolderText(m);
+            bool result = textBox.TestAccessor().Dynamic.ShouldRenderPlaceHolderText(m);
             Assert.Equal(expected, result);
         }
 


### PR DESCRIPTION
Add internals accessor helpers

Introduces ITestAccessor and related classes to keep test specific code out of the shipping assemblies.

Allows easy dynamic access to private/internal fields and members and provides a pattern for writing typed accessors.

Also supports creating of delegates, which allows for access to members that utilize ref structs which are not yet supported in reflection.

Removes existing TestAccessor classes from the shipping code. Updates most of the internal virtual methods on TextBox to private protected to encapsulate. Various comment / line spacing fixes to TextBox.

There are three commits in this PR. The first two clean up tests and internal access for the EventHandlerService. I kept them separate as they don't depend on the new functionality as I removed all of the internals access there.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3225)