### PR TITLE
Moving GroupBox accessible object to a separate file

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.GroupBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.GroupBoxAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 using static Interop;
 
@@ -17,8 +15,6 @@ namespace System.Windows.Forms
             internal GroupBoxAccessibleObject(GroupBox owner) : base(owner)
             {
             }
-
-            private GroupBox OwningGroupBox => Owner as GroupBox;
 
             public override AccessibleRole Role
             {
@@ -34,7 +30,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            internal override object GetPropertyValue(UiaCore.UIA propertyID)
+            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
                     UiaCore.UIA.NamePropertyId
@@ -42,7 +38,7 @@ namespace System.Windows.Forms
                     UiaCore.UIA.ControlTypePropertyId
                         => UiaCore.UIA.GroupControlTypeId,
                     UiaCore.UIA.AutomationIdPropertyId
-                        => OwningGroupBox.IsHandleCreated ? OwningGroupBox.Name : string.Empty,
+                        => Owner.Name,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId
                         => true,
                     _ => base.GetPropertyValue(propertyID)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.GroupBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.GroupBoxAccessibleObject.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System.Runtime.InteropServices;
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    public partial class GroupBox
+    {
+        [ComVisible(true)]
+        internal class GroupBoxAccessibleObject : ControlAccessibleObject
+        {
+            internal GroupBoxAccessibleObject(GroupBox owner) : base(owner)
+            {
+            }
+
+            private GroupBox OwningGroupBox => Owner as GroupBox;
+
+            public override AccessibleRole Role
+            {
+                get
+                {
+                    AccessibleRole role = Owner.AccessibleRole;
+                    if (role != AccessibleRole.Default)
+                    {
+                        return role;
+                    }
+
+                    return AccessibleRole.Grouping;
+                }
+            }
+
+            internal override object GetPropertyValue(UiaCore.UIA propertyID)
+                => propertyID switch
+                {
+                    UiaCore.UIA.NamePropertyId
+                        => Name,
+                    UiaCore.UIA.ControlTypePropertyId
+                        => UiaCore.UIA.GroupControlTypeId,
+                    UiaCore.UIA.AutomationIdPropertyId
+                        => OwningGroupBox.IsHandleCreated ? OwningGroupBox.Name : string.Empty,
+                    UiaCore.UIA.IsKeyboardFocusablePropertyId
+                        => true,
+                    _ => base.GetPropertyValue(propertyID)
+                };
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.cs
@@ -25,7 +25,7 @@ namespace System.Windows.Forms
     [DefaultProperty(nameof(Text))]
     [Designer("System.Windows.Forms.Design.GroupBoxDesigner, " + AssemblyRef.SystemDesign)]
     [SRDescription(nameof(SR.DescriptionGroupBox))]
-    public class GroupBox : Control
+    public partial class GroupBox : Control
     {
         int fontHeight = -1;
         Font cachedFont;
@@ -752,42 +752,6 @@ namespace System.Windows.Forms
         protected override AccessibleObject CreateAccessibilityInstance()
         {
             return new GroupBoxAccessibleObject(this);
-        }
-
-        [ComVisible(true)]
-        internal class GroupBoxAccessibleObject : ControlAccessibleObject
-        {
-            internal GroupBoxAccessibleObject(GroupBox owner) : base(owner)
-            {
-            }
-
-            public override AccessibleRole Role
-            {
-                get
-                {
-                    AccessibleRole role = Owner.AccessibleRole;
-                    if (role != AccessibleRole.Default)
-                    {
-                        return role;
-                    }
-                    return AccessibleRole.Grouping;
-                }
-            }
-
-            internal override bool IsIAccessibleExSupported() => true;
-
-            internal override object GetPropertyValue(UiaCore.UIA propertyID)
-            {
-                switch (propertyID)
-                {
-                    case UiaCore.UIA.ControlTypePropertyId:
-                        return UiaCore.UIA.GroupControlTypeId;
-                    case UiaCore.UIA.IsKeyboardFocusablePropertyId:
-                        return true;
-                }
-
-                return base.GetPropertyValue(propertyID);
-            }
         }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3229 


## Proposed changes

- Moving GroupBox accessible object to a separate file.
- Minor refactoring and code style changes.
- No functional changes.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Improving development experience for GroupBox control accessibility.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->
![image](https://user-images.githubusercontent.com/23213980/81226520-a7026b80-8ff3-11ea-9749-1514b125b424.png)


### After

<!-- TODO -->
![image](https://user-images.githubusercontent.com/23213980/81226420-80443500-8ff3-11ea-935a-4d2e20eafdef.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual testing.
- Separated accessible object should be covered by unit test.
- UI automation.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->

- Inspect too.
- Accessibility client apps.
 

## Test environment(s) <!-- Remove any that don't apply -->

<!-- use `dotnet --info` -->
.NET Core 5.0
Version: 5.0.100-alpha.1.20073.10
Commit: 29f4d693a9
Runtime Environment:
OS Name: Windows
OS Version: 10.0.18363
OS Platform: Windows
RID: win10-x64
Base Path: C:\Program Files\dotnet\sdk\5.0.100-alpha1-05536
Host (useful for support):
Version: 5.0.0-alpha.1.20072.3
Commit: c3dc1fdfdc

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3230)