### PR TITLE
Fix ILegacyIAccessibleProvider.GetSelection return type

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.ILegacyIAccessibleProvider.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.ILegacyIAccessibleProvider.cs
@@ -39,7 +39,8 @@ internal static partial class Interop
 
             string? KeyboardShortcut { get; }
 
-            object[]? /* IRawElementProviderSimple[] */ GetSelection();
+            [return: MarshalAs(UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_UNKNOWN)]
+            IRawElementProviderSimple[] GetSelection();
 
             string? DefaultAction { get; }
         }

--- a/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.IRawElementProviderHwndOverride.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.IRawElementProviderHwndOverride.cs
@@ -16,7 +16,7 @@ internal static partial class Interop
         [ComImport]
         [Guid("1d5df27c-8947-4425-b8d9-79787bb460b8")]
         [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        public interface IRawElementProviderHwndOverride : IRawElementProviderSimple
+        public interface IRawElementProviderHwndOverride
         {
             /// <summary>
             ///  Request a provider for the specified component. The returned provider can supply additional

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -833,12 +833,12 @@ namespace System.Windows.Forms
 
         UiaCore.IRawElementProviderSimple[] UiaCore.ILegacyIAccessibleProvider.GetSelection()
         {
-            if (!(GetSelected() is UiaCore.IRawElementProviderSimple selected))
+            if (GetSelected() is UiaCore.IRawElementProviderSimple selected)
             {
-                return Array.Empty<UiaCore.IRawElementProviderSimple>();
+                return new UiaCore.IRawElementProviderSimple[] { selected };
             }
 
-            return new UiaCore.IRawElementProviderSimple[] { selected };
+            return Array.Empty<UiaCore.IRawElementProviderSimple>();
         }
 
         void UiaCore.ILegacyIAccessibleProvider.Select(int flagsSelect) => Select((AccessibleSelection)flagsSelect);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -831,14 +831,14 @@ namespace System.Windows.Forms
 
         IAccessible? UiaCore.ILegacyIAccessibleProvider.GetIAccessible() => AsIAccessible(this);
 
-        object[]? UiaCore.ILegacyIAccessibleProvider.GetSelection()
+        UiaCore.IRawElementProviderSimple[] UiaCore.ILegacyIAccessibleProvider.GetSelection()
         {
-            if (GetSelected() is UiaCore.IRawElementProviderSimple selected)
+            if (!(GetSelected() is UiaCore.IRawElementProviderSimple selected))
             {
-                return new UiaCore.IRawElementProviderSimple[] { selected };
+                return Array.Empty<UiaCore.IRawElementProviderSimple>();
             }
 
-            return null;
+            return new UiaCore.IRawElementProviderSimple[] { selected };
         }
 
         void UiaCore.ILegacyIAccessibleProvider.Select(int flagsSelect) => Select((AccessibleSelection)flagsSelect);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/InternalAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/InternalAccessibleObject.cs
@@ -400,20 +400,16 @@ namespace System.Windows.Forms
 
         int ILegacyIAccessibleProvider.ChildId => publicILegacyIAccessibleProvider.ChildId;
 
-        void ILegacyIAccessibleProvider.DoDefaultAction()
-            => publicILegacyIAccessibleProvider.DoDefaultAction();
+        void ILegacyIAccessibleProvider.DoDefaultAction() => publicILegacyIAccessibleProvider.DoDefaultAction();
 
         IAccessible? ILegacyIAccessibleProvider.GetIAccessible()
             => publicILegacyIAccessibleProvider.GetIAccessible();
 
-        object[]? ILegacyIAccessibleProvider.GetSelection()
-            => AsArrayOfNativeAccessibles(publicILegacyIAccessibleProvider.GetSelection());
+        IRawElementProviderSimple[] ILegacyIAccessibleProvider.GetSelection() => publicILegacyIAccessibleProvider.GetSelection();
 
-        void ILegacyIAccessibleProvider.Select(int flagsSelect)
-            => publicILegacyIAccessibleProvider.Select(flagsSelect);
+        void ILegacyIAccessibleProvider.Select(int flagsSelect) => publicILegacyIAccessibleProvider.Select(flagsSelect);
 
-        void ILegacyIAccessibleProvider.SetValue(string szValue)
-            => publicILegacyIAccessibleProvider.SetValue(szValue);
+        void ILegacyIAccessibleProvider.SetValue(string szValue) => publicILegacyIAccessibleProvider.SetValue(szValue);
 
         void IInvokeProvider.Invoke() => publicIInvokeProvider.Invoke();
 


### PR DESCRIPTION
## Proposed Changes
Running the following test 

```cs
[WinFormsFact]
public void AccesibleObject_ILegacyIAccessibleProviderGetSelection_Invoke_ReturnsExpected()
{
    var o = new AccessibleObject();
    Test_ILegacyIAccessibleProviderGetSelection(o);
}

[DllImport(NativeTests, ExactSpelling = true)]
private static extern void Test_ILegacyIAccessibleProviderGetSelection(
    [MarshalAs(UnmanagedType.IUnknown)] object pUnk);
```

```cpp
#define TEST extern "C" __declspec(dllexport)

TEST void WINAPI Test_ILegacyIAccessibleProviderGetSelection(IUnknown* pUnknown)
{
    HRESULT hr;
    ILegacyIAccessibleProvider* pLegacyIAccessibleProvider;

    hr = pUnknown->QueryInterface(IID_ILegacyIAccessibleProvider, (void**)&pLegacyIAccessibleProvider);
    assert(hr == S_OK);

#if false
    SAFEARRAY *result = (SAFEARRAY*)(long)0xdeadbeef;
    hr = pLegacyIAccessibleProvider->GetSelection(&result);
    assert(hr == S_OK);
    assert(result->cbElements == 1);
    assert(static_cast<IRawElementProviderSimple*>(result->pvData) == NULL);
    SafeArrayDestroy(result);
#endif

    // Negative tests
    hr = pLegacyIAccessibleProvider->GetSelection(NULL);
    assert(hr == S_OK);

    return S_OK;
});
}
```

I get an assertion failure in
```cs
hr = pLegacyIAccessibleProvider->GetSelection(&result);
assert(hr == S_OK);
```

Instead of `S_OK`, I get `COR_E_SAFEARRAYTYPEMISMATCH` (0x80131533) returned as the HRESULT.

Taking a look at the native definition, we seem to be returning `object[]` instead of an interface array. So I think we end up marshalling an array of variants (?) definitely not the interface! 

From https://github.com/tpn/winsdk-10/blob/master/Include/10.0.10240.0/um/UIAutomationCore.idl#L845
```cpp
HRESULT GetSelection (
    [out, retval] SAFEARRAY(IRawElementProviderSimple *) * pvarSelectedChildren );
```

The fix is to correct the return value.

## Discussion
Following on from https://github.com/dotnet/runtime/issues/35855, should we create our own `SAFEARRAY` type and somehow pass this in as a pointer?


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3231)