### PR TITLE
Adding UIA accessibility support for PictureBox control

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -5,3 +5,4 @@ System.Windows.Forms.ListViewGroup.TitleImageKey.get -> string!
 System.Windows.Forms.ListViewGroup.TitleImageKey.set -> void
 ~System.Windows.Forms.ListView.GroupImageList.get -> System.Windows.Forms.ImageList
 ~System.Windows.Forms.ListView.GroupImageList.set -> void
+~override System.Windows.Forms.PictureBox.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.PictureBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.PictureBoxAccessibleObject.cs
@@ -10,7 +10,7 @@ namespace System.Windows.Forms
     {
         internal class PictureBoxAccessibleObject : ControlAccessibleObject
         {
-            internal PictureBoxAccessibleObject(PictureBox owner) : base(owner)
+            public PictureBoxAccessibleObject(PictureBox owner) : base(owner)
             {
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.PictureBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.PictureBoxAccessibleObject.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.InteropServices;
 using static Interop;
 
 namespace System.Windows.Forms
@@ -28,14 +27,6 @@ namespace System.Windows.Forms
                         => true,
                     _ => base.GetPropertyValue(propertyID)
                 };
-
-            internal override bool IsPatternSupported(UiaCore.UIA patternId)
-                => patternId switch
-                {
-                var p when
-                    p == UiaCore.UIA.LegacyIAccessiblePatternId => true,
-                _ => base.IsPatternSupported(patternId)
-    };
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.PictureBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.PictureBoxAccessibleObject.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System.Runtime.InteropServices;
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    public partial class PictureBox
+    {
+        [ComVisible(true)]
+        internal class PictureBoxAccessibleObject : ControlAccessibleObject
+        {
+            internal PictureBoxAccessibleObject(PictureBox owner) : base(owner)
+            {
+            }
+
+            private PictureBox OwningPictureBox => Owner as PictureBox;
+
+            internal override object GetPropertyValue(UiaCore.UIA propertyID)
+                => propertyID switch
+                {
+                    UiaCore.UIA.NamePropertyId
+                        => Name,
+                    UiaCore.UIA.ControlTypePropertyId
+                        => UiaCore.UIA.PaneControlTypeId,
+                    UiaCore.UIA.AutomationIdPropertyId
+                        => OwningPictureBox.IsHandleCreated ? OwningPictureBox.Name : string.Empty,
+                    UiaCore.UIA.IsKeyboardFocusablePropertyId
+                        => true,
+                    _ => base.GetPropertyValue(propertyID)
+                };
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.PictureBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.PictureBoxAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 using static Interop;
 
@@ -11,16 +9,13 @@ namespace System.Windows.Forms
 {
     public partial class PictureBox
     {
-        [ComVisible(true)]
         internal class PictureBoxAccessibleObject : ControlAccessibleObject
         {
             internal PictureBoxAccessibleObject(PictureBox owner) : base(owner)
             {
             }
 
-            private PictureBox OwningPictureBox => Owner as PictureBox;
-
-            internal override object GetPropertyValue(UiaCore.UIA propertyID)
+            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
                     UiaCore.UIA.NamePropertyId
@@ -28,11 +23,19 @@ namespace System.Windows.Forms
                     UiaCore.UIA.ControlTypePropertyId
                         => UiaCore.UIA.PaneControlTypeId,
                     UiaCore.UIA.AutomationIdPropertyId
-                        => OwningPictureBox.IsHandleCreated ? OwningPictureBox.Name : string.Empty,
+                        => Owner.Name,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId
                         => true,
                     _ => base.GetPropertyValue(propertyID)
                 };
+
+            internal override bool IsPatternSupported(UiaCore.UIA patternId)
+                => patternId switch
+                {
+                var p when
+                    p == UiaCore.UIA.LegacyIAccessiblePatternId => true,
+                _ => base.IsPatternSupported(patternId)
+    };
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
@@ -837,6 +837,8 @@ namespace System.Windows.Forms
             remove => Events.RemoveHandler(EVENT_SIZEMODECHANGED, value);
         }
 
+        internal override bool SupportsUiaProviders => true;
+
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public new bool TabStop

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
@@ -27,7 +27,7 @@ namespace System.Windows.Forms
     [Docking(DockingBehavior.Ask)]
     [Designer("System.Windows.Forms.Design.PictureBoxDesigner, " + AssemblyRef.SystemDesign)]
     [SRDescription(nameof(SR.DescriptionPictureBox))]
-    public class PictureBox : Control, ISupportInitialize
+    public partial class PictureBox : Control, ISupportInitialize
     {
         /// <summary>
         ///  The type of border this control will have.
@@ -968,6 +968,9 @@ namespace System.Windows.Forms
                 }
             }
         }
+
+        protected override AccessibleObject CreateAccessibilityInstance()
+            => new PictureBoxAccessibleObject(this);
 
         protected override void Dispose(bool disposing)
         {

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PictureBox.PictureBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PictureBox.PictureBoxAccessibleObjectTests.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using Xunit;
 using static Interop.UiaCore;
 
 namespace System.Windows.Forms.Tests
 {
-    public class PictureBoxAccessibleObjectTests
+    public class PictureBox_PictureBoxAccessibleObjectTests
     {
         [WinFormsFact]
         public void PictureBoxAccessibleObject_Ctor_NullControl_ThrowsArgumentNullException()
@@ -43,22 +42,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(AccessibleRole.PushButton, pictureBoxAccessibleObject.Role);
         }
 
-        public static IEnumerable<object[]> GetPropertyValue_TestData()
-        {
-            foreach (bool isHandleCreated in new bool[] { true, false })
-            {
-                yield return new object[] { UIA.NamePropertyId, isHandleCreated, "TestName" };
-                yield return new object[] { UIA.ControlTypePropertyId, isHandleCreated, UIA.PaneControlTypeId };
-                yield return new object[] { UIA.IsKeyboardFocusablePropertyId, isHandleCreated, true };
-            }
-
-            yield return new object[] { UIA.AutomationIdPropertyId, true, "PictureBox1" };
-            yield return new object[] { UIA.AutomationIdPropertyId, false, "PictureBox1" };
-        }
-
         [WinFormsTheory]
-        [MemberData(nameof(GetPropertyValue_TestData))]
-        internal void PictureBoxAccessibleObject_GetPropertyValue_returns_correct_values(UIA propertyID, bool isHandleCreated, object expected)
+        [InlineData(UIA.NamePropertyId, "TestName")]
+        [InlineData(UIA.ControlTypePropertyId, UIA.PaneControlTypeId)]
+        [InlineData(UIA.IsKeyboardFocusablePropertyId, true)]
+        [InlineData(UIA.AutomationIdPropertyId, "PictureBox1")]
+        internal void PictureBoxAccessibleObject_GetPropertyValue_returns_correct_values(UIA propertyID, object expected)
         {
             using var pictureBox = new PictureBox
             {
@@ -70,17 +59,11 @@ namespace System.Windows.Forms.Tests
 
             // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
             Assert.True(pictureBox.IsHandleCreated);
-
-            if (isHandleCreated)
-            {
-                Assert.NotEqual(IntPtr.Zero, pictureBox.Handle);
-            }
-
             object value = pictureBoxAccessibleObject.GetPropertyValue(propertyID);
             Assert.Equal(expected, value);
 
             // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            // Assert.Equal(isHandleCreated, pictureBox.IsHandleCreated);
+            Assert.True(pictureBox.IsHandleCreated);
         }
 
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PictureBox.PictureBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PictureBox.PictureBoxAccessibleObjectTests.cs
@@ -19,35 +19,80 @@ namespace System.Windows.Forms.Tests
         public void PictureBoxAccessibleObject_Ctor_Default()
         {
             using var pictureBox = new PictureBox();
+            Assert.False(pictureBox.IsHandleCreated);
             var pictureBoxAccessibleObject = new PictureBox.PictureBoxAccessibleObject(pictureBox);
 
             Assert.NotNull(pictureBoxAccessibleObject.Owner);
-            Assert.Equal(AccessibleRole.Client, pictureBoxAccessibleObject.Role);
+            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
+            Assert.True(pictureBox.IsHandleCreated);
         }
 
         [WinFormsFact]
-        public void PictureBoxAccessibleObject_Property_returns_correct_value()
+        public void PictureBoxAccessibleObject_Description_ReturnsExpected()
         {
             using var pictureBox = new PictureBox
             {
-                Name = "PictureBox1",
-                AccessibleName = "TestName",
                 AccessibleDescription = "TestDescription",
+            };
+
+            Assert.False(pictureBox.IsHandleCreated);
+            var pictureBoxAccessibleObject = new PictureBox.PictureBoxAccessibleObject(pictureBox);
+
+            Assert.Equal("TestDescription", pictureBoxAccessibleObject.Description);
+            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
+            Assert.True(pictureBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void PictureBoxAccessibleObject_Name_ReturnsExpected()
+        {
+            using var pictureBox = new PictureBox
+            {
+                AccessibleName = "TestName"
+            };
+
+            Assert.False(pictureBox.IsHandleCreated);
+            var pictureBoxAccessibleObject = new PictureBox.PictureBoxAccessibleObject(pictureBox);
+
+            Assert.Equal("TestName", pictureBoxAccessibleObject.Name);
+            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
+            Assert.True(pictureBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void PictureBoxAccessibleObject_CustomRole_ReturnsExpected()
+        {
+            using var pictureBox = new PictureBox
+            {
                 AccessibleRole = AccessibleRole.PushButton
             };
 
+            Assert.False(pictureBox.IsHandleCreated);
             var pictureBoxAccessibleObject = new PictureBox.PictureBoxAccessibleObject(pictureBox);
-            Assert.Equal("TestName", pictureBoxAccessibleObject.Name);
-            Assert.Equal("TestDescription", pictureBoxAccessibleObject.Description);
+
             Assert.Equal(AccessibleRole.PushButton, pictureBoxAccessibleObject.Role);
+            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
+            Assert.True(pictureBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void PictureBoxAccessibleObject_DefaultRole_ReturnsExpected()
+        {
+            using var pictureBox = new PictureBox();
+            Assert.False(pictureBox.IsHandleCreated);
+            var pictureBoxAccessibleObject = new PictureBox.PictureBoxAccessibleObject(pictureBox);
+            Assert.Equal(AccessibleRole.Client, pictureBoxAccessibleObject.Role);
+
+            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
+            Assert.True(pictureBox.IsHandleCreated);
         }
 
         [WinFormsTheory]
-        [InlineData(UIA.NamePropertyId, "TestName")]
-        [InlineData(UIA.ControlTypePropertyId, UIA.PaneControlTypeId)]
-        [InlineData(UIA.IsKeyboardFocusablePropertyId, true)]
-        [InlineData(UIA.AutomationIdPropertyId, "PictureBox1")]
-        internal void PictureBoxAccessibleObject_GetPropertyValue_returns_correct_values(UIA propertyID, object expected)
+        [InlineData((int)UIA.NamePropertyId, "TestName")]
+        [InlineData((int)UIA.ControlTypePropertyId, UIA.PaneControlTypeId)]
+        [InlineData((int)UIA.IsKeyboardFocusablePropertyId, true)]
+        [InlineData((int)UIA.AutomationIdPropertyId, "PictureBox1")]
+        public void PictureBoxAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected(int propertyID, object expected)
         {
             using var pictureBox = new PictureBox
             {
@@ -55,27 +100,25 @@ namespace System.Windows.Forms.Tests
                 AccessibleName = "TestName"
             };
 
+            Assert.False(pictureBox.IsHandleCreated);
             var pictureBoxAccessibleObject = new PictureBox.PictureBoxAccessibleObject(pictureBox);
+            object value = pictureBoxAccessibleObject.GetPropertyValue((UIA)propertyID);
 
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(pictureBox.IsHandleCreated);
-            object value = pictureBoxAccessibleObject.GetPropertyValue(propertyID);
             Assert.Equal(expected, value);
-
             // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
             Assert.True(pictureBox.IsHandleCreated);
         }
 
         [WinFormsFact]
-        internal void PictureBoxAccessibleObject_IsPatternSupported_returns_correct_value()
+        public void PictureBoxAccessibleObject_IsPatternSupported_Invoke_ReturnsTrue_ForLegacyIAccessiblePatternId()
         {
-            using var pictureBox = new PictureBox
-            {
-                Name = "PictureBox1"
-            };
-
+            using var pictureBox = new PictureBox();
+            Assert.False(pictureBox.IsHandleCreated);
             var pictureBoxAccessibleObject = new PictureBox.PictureBoxAccessibleObject(pictureBox);
+
             Assert.True(pictureBoxAccessibleObject.IsPatternSupported(UIA.LegacyIAccessiblePatternId));
+            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
+            Assert.True(pictureBox.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PictureBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PictureBoxAccessibleObjectTests.cs
@@ -1,0 +1,99 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+using static Interop.UiaCore;
+
+namespace System.Windows.Forms.Tests
+{
+    public class PictureBoxAccessibleObjectTests
+    {
+        [WinFormsFact]
+        public void PictureBoxAccessibleObject_Ctor_NullControl_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("ownerControl", () => new PictureBox.PictureBoxAccessibleObject(null));
+        }
+
+        [WinFormsFact]
+        public void PictureBoxAccessibleObject_Ctor_Default()
+        {
+            using var pictureBox = new PictureBox();
+            var pictureBoxAccessibleObject = new PictureBox.PictureBoxAccessibleObject(pictureBox);
+
+            Assert.NotNull(pictureBoxAccessibleObject.Owner);
+            Assert.Equal(AccessibleRole.Client, pictureBoxAccessibleObject.Role);
+        }
+
+        [WinFormsFact]
+        public void PictureBoxAccessibleObject_Property_returns_correct_value()
+        {
+            using var pictureBox = new PictureBox
+            {
+                Name = "PictureBox1",
+                AccessibleName = "TestName",
+                AccessibleDescription = "TestDescription",
+                AccessibleRole = AccessibleRole.PushButton
+            };
+
+            var pictureBoxAccessibleObject = new PictureBox.PictureBoxAccessibleObject(pictureBox);
+            Assert.Equal("TestName", pictureBoxAccessibleObject.Name);
+            Assert.Equal("TestDescription", pictureBoxAccessibleObject.Description);
+            Assert.Equal(AccessibleRole.PushButton, pictureBoxAccessibleObject.Role);
+        }
+
+        public static IEnumerable<object[]> GetPropertyValue_TestData()
+        {
+            foreach (bool isHandleCreated in new bool[] { true, false })
+            {
+                yield return new object[] { UIA.NamePropertyId, isHandleCreated, "TestName" };
+                yield return new object[] { UIA.ControlTypePropertyId, isHandleCreated, UIA.PaneControlTypeId };
+                yield return new object[] { UIA.IsKeyboardFocusablePropertyId, isHandleCreated, true };
+            }
+
+            yield return new object[] { UIA.AutomationIdPropertyId, true, "PictureBox1" };
+            yield return new object[] { UIA.AutomationIdPropertyId, false, "PictureBox1" };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(GetPropertyValue_TestData))]
+        internal void PictureBoxAccessibleObject_GetPropertyValue_returns_correct_values(UIA propertyID, bool isHandleCreated, object expected)
+        {
+            using var pictureBox = new PictureBox
+            {
+                Name = "PictureBox1",
+                AccessibleName = "TestName"
+            };
+
+            var pictureBoxAccessibleObject = new PictureBox.PictureBoxAccessibleObject(pictureBox);
+
+            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
+            Assert.True(pictureBox.IsHandleCreated);
+
+            if (isHandleCreated)
+            {
+                Assert.NotEqual(IntPtr.Zero, pictureBox.Handle);
+            }
+
+            object value = pictureBoxAccessibleObject.GetPropertyValue(propertyID);
+            Assert.Equal(expected, value);
+
+            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
+            // Assert.Equal(isHandleCreated, pictureBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        internal void PictureBoxAccessibleObject_IsPatternSupported_returns_correct_value()
+        {
+            using var pictureBox = new PictureBox
+            {
+                Name = "PictureBox1"
+            };
+
+            var pictureBoxAccessibleObject = new PictureBox.PictureBoxAccessibleObject(pictureBox);
+            Assert.True(pictureBoxAccessibleObject.IsPatternSupported(UIA.LegacyIAccessiblePatternId));
+        }
+    }
+}
+


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3232 


## Proposed changes

- Adding UIA accessibility support for PictureBox control.
- Moving PictureBox accessible object implementation to a separate file.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Improving development experience for ListView control accessibility.
- Prerequisite for #2164.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/23213980/81228245-6b1cd580-8ff6-11ea-8de5-c1f75b62c77e.png)

### After

<!-- TODO -->
![image](https://user-images.githubusercontent.com/23213980/81229228-21cd8580-8ff8-11ea-84dc-45248cea61d0.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual testing;
- Unit tests (to be implemented);
- UI automation.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->

- Inspect;
- Accessibility Insights;
- Narrator and other accessibility client apps.
 

## Test environment(s) <!-- Remove any that don't apply -->

<!-- use `dotnet --info` -->
.NET Core 5.0
Version: 5.0.100-alpha.1.20073.10
Commit: 29f4d693a9
Runtime Environment:
OS Name: Windows
OS Version: 10.0.18363
OS Platform: Windows
RID: win10-x64
Base Path: C:\Program Files\dotnet\sdk\5.0.100-alpha1-05536
Host (useful for support):
Version: 5.0.0-alpha.1.20072.3
Commit: c3dc1fdfdc

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3233)