### PR TITLE
Implement Subtitle Property for ListViewGroup

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.LVGROUPW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.LVGROUPW.cs
@@ -22,6 +22,21 @@ internal static partial class Interop
             public LVGS stateMask;
             public LVGS state;
             public LVGA uAlign;
+
+            public char* pszSubtitle;
+            public uint cchSubtitle;
+            public char* pszTask;
+            public uint cchTask;
+            public char* pszDescriptionTop;
+            public uint cchDescriptionTop;
+            public char* pszDescriptionBottom;
+            public uint cchDescriptionBottom;
+            public int iTitleImage;
+            public int iExtendedImage;
+            public int iFirstItem;
+            public uint cItems;
+            public char* pszSubsetTitle;
+            public uint cchSubsetTitle;
         }
     }
 }

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+System.Windows.Forms.ListViewGroup.Subtitle.get -> string!
+System.Windows.Forms.ListViewGroup.Subtitle.set -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -5409,10 +5409,11 @@ namespace System.Windows.Forms
         {
             string header = group.Header;
             string footer = group.Footer;
+            string subtitle = group.Subtitle;
             var lvgroup = new LVGROUPW
             {
                 cbSize = (uint)sizeof(LVGROUPW),
-                mask = LVGF.HEADER | LVGF.FOOTER | LVGF.ALIGN | LVGF.STATE | additionalMask,
+                mask = LVGF.HEADER | LVGF.FOOTER | LVGF.ALIGN | LVGF.STATE | LVGF.SUBTITLE | additionalMask,
                 cchHeader = header.Length,
                 iGroupId = group.ID
             };
@@ -5439,6 +5440,7 @@ namespace System.Windows.Forms
                     break;
             }
 
+            fixed (char* pSubtitle = subtitle)
             fixed (char* pHeader = header)
             fixed (char* pFooter = footer)
             {
@@ -5457,6 +5459,8 @@ namespace System.Windows.Forms
                         break;
                 }
 
+                lvgroup.cchSubtitle = (uint)subtitle.Length;
+                lvgroup.pszSubtitle = pSubtitle;
                 lvgroup.pszHeader = pHeader;
                 return User32.SendMessageW(this, (User32.WM)msg, lParam, ref lvgroup);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
@@ -25,6 +25,7 @@ namespace System.Windows.Forms
         private string? _footer;
         private HorizontalAlignment _footerAlignment = HorizontalAlignment.Left;
         private ListViewGroupCollapsedState _collapsedState = ListViewGroupCollapsedState.Default;
+        private string? _subtitle;
 
         private ListView.ListViewItemCollection? _items;
 
@@ -179,6 +180,26 @@ namespace System.Windows.Forms
                 }
 
                 _collapsedState = value;
+                UpdateListView();
+            }
+        }
+
+        /// <summary>
+        ///  The text displayed in the group subtitle.
+        /// </summary>
+        [SRCategory(nameof(SR.CatAppearance))]
+        [AllowNull]
+        public string Subtitle
+        {
+            get => _subtitle ?? string.Empty;
+            set
+            {
+                if (_subtitle == value)
+                {
+                    return;
+                }
+
+                _subtitle = value;
                 UpdateListView();
             }
         }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #2655


## Proposed changes

- Add subtitle API to `ListViewGroup`

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Customers will have the ability to add subtitles to their ListViewGroups

## Regression? 

- No

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->
![image](https://user-images.githubusercontent.com/30007367/81241913-8240d080-8fc0-11ea-81b2-c2c56b30f54d.png)

### After

<!-- TODO -->
![image](https://user-images.githubusercontent.com/30007367/81241820-3ee66200-8fc0-11ea-8112-0c79af80c202.png)

## Test methodology <!-- How did you ensure quality? -->

- Unit testing
- Manual testing

## Note
- Correct me if I'm wrong, but for accessibility purposes I believe we'll need to expose the UIA Text Pattern

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3234)