### PR TITLE
Add Microsoft.DotNet.CMake.Sdk to global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -12,11 +12,13 @@
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20256.5",
+    "Microsoft.DotNet.CMake.Sdk": "5.0.0-beta.20256.5",
     "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20256.5",
     "FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
     "Microsoft.NET.Sdk.IL": "5.0.0-preview.5.20260.5"
   },
   "native-tools": {
+    "cmake": "3.14.2",
     "dotnet-api-docs_netcoreapp3.0": "0.0.0.1"
   }
 }


### PR DESCRIPTION
We know this is going to be used in https://github.com/dotnet/winforms/pull/1932

But annoyingly we need to constantly rebase global.json in that PR because we get merge conflicts every time we add update arcade.

Instead, lets add this sdk to global.json in this PR which can be merged rapidly so we don't have to keep rebasing #1932

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3265)