### PR TITLE
fix: ContextMenuStrip leads to crash on W10 1607

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/DpiHelper.DpiAwarenessContext.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/DpiHelper.DpiAwarenessContext.cs
@@ -64,10 +64,9 @@ namespace System.Windows.Forms
                             originalAwareness = SetThreadDpiAwarenessContext(awareness);
 
                             // As reported in https://github.com/dotnet/winforms/issues/2969
-                            // under unknown conditions originalAwareness may remain UNSPECIFIED_DPI_AWARENESS_CONTEXT
+                            // under unknown conditions originalAwareness may remain 0 (which means the call failed)
                             // causing us to set dpiAwarenessScopeIsSet=true, which would lead to a crash when we attempt to dispose the scope.
-                            // To avoid it, only set the scope if we're not in UNSPECIFIED_DPI_AWARENESS_CONTEXT.
-                            dpiAwarenessScopeIsSet = originalAwareness != UNSPECIFIED_DPI_AWARENESS_CONTEXT;
+                            dpiAwarenessScopeIsSet = originalAwareness != IntPtr.Zero;
                         }
                     }
                 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/DpiHelper.DpiAwarenessContext.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/DpiHelper.DpiAwarenessContext.cs
@@ -62,7 +62,12 @@ namespace System.Windows.Forms
                             !AreDpiAwarenessContextsEqual(originalAwareness, DPI_AWARENESS_CONTEXT.UNAWARE))
                         {
                             originalAwareness = SetThreadDpiAwarenessContext(awareness);
-                            dpiAwarenessScopeIsSet = true;
+
+                            // As reported in https://github.com/dotnet/winforms/issues/2969
+                            // under unknown conditions originalAwareness may remain UNSPECIFIED_DPI_AWARENESS_CONTEXT
+                            // causing us to set dpiAwarenessScopeIsSet=true, which would lead to a crash when we attempt to dispose the scope.
+                            // To avoid it, only set the scope if we're not in UNSPECIFIED_DPI_AWARENESS_CONTEXT.
+                            dpiAwarenessScopeIsSet = originalAwareness != UNSPECIFIED_DPI_AWARENESS_CONTEXT;
                         }
                     }
                 }


### PR DESCRIPTION

Resolves #2969.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->




## Proposed changes

W10 1607 is not fully compatible with PerMonv2, and this leads to crashes interacting with `ContextMenuStrip`.

`CommonUnsafeNativeMethods.SetThreadDpiAwarenessContext` may return `DPI_AWARENESS_CONTEXT_UNSPECIFIED` result that is never checked, however we set `dpiAwarenessScopeIsSet` flag assuming the scope was set.

When disposing the scope we pass the obtained context to `TrySetThreadDpiAwarenessContext` that tries to restore the scope back to the original. However in event the original was `DPI_AWARENESS_CONTEXT_UNSPECIFIED` it leads to ANE, that was observed in #2969.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Customers on W10 1607 will now be able to use `ContextMenuStrip` in `HighDpiMode.PerMonitorV2`
- 

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3279)