### PR TITLE
Fix trailing null in NativeGetItemText

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -2358,19 +2358,24 @@ namespace System.Windows.Forms
         /// </summary>
         private unsafe string NativeGetItemText(int index)
         {
-            int maxLen = PARAM.ToInt(SendMessageW(this, (WM)CB.GETLBTEXTLEN, (IntPtr)index));
-            if (maxLen == LB_ERR)
+            int maxLength = PARAM.ToInt(SendMessageW(this, (WM)CB.GETLBTEXTLEN, (IntPtr)index));
+            if (maxLength == LB_ERR)
             {
                 return string.Empty;
             }
 
-            char[] text = ArrayPool<char>.Shared.Rent(maxLen + 1);
+            char[] text = ArrayPool<char>.Shared.Rent(maxLength + 1);
             string result;
             fixed (char* pText = text)
             {
-                int actualLen = PARAM.ToInt(SendMessageW(this, (WM)CB.GETLBTEXT, (IntPtr)index, (IntPtr)pText));
-                Debug.Assert(actualLen != LB_ERR, "Should have validated the index above");
-                result = new string(pText, 0, actualLen);
+                int actualLength = PARAM.ToInt(SendMessageW(this, (WM)CB.GETLBTEXT, (IntPtr)index, (IntPtr)pText));
+                Debug.Assert(actualLength != LB_ERR, "Should have validated the index above");
+                if (actualLength == LB_ERR)
+                {
+                    return string.Empty;
+                }
+
+                result = new string(pText, 0, Math.Min(maxLength, actualLength));
             }
 
             ArrayPool<char>.Shared.Return(text);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System.Buffers;
 using System.Collections;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -2355,13 +2356,25 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Get the text stored by the native control for the specified list item.
         /// </summary>
-        private string NativeGetItemText(int index)
+        private unsafe string NativeGetItemText(int index)
         {
-            int len = unchecked((int)(long)SendMessageW(this, (WM)CB.GETLBTEXTLEN, (IntPtr)index));
-            return string.Create(len + 1, this, (span, comboBox) =>
+            int maxLen = PARAM.ToInt(SendMessageW(this, (WM)CB.GETLBTEXTLEN, (IntPtr)index));
+            if (maxLen == LB_ERR)
             {
-                SendMessageW(comboBox, (WM)CB.GETLBTEXT, (IntPtr)index, ref span[0]);
-            });
+                return string.Empty;
+            }
+
+            char[] text = ArrayPool<char>.Shared.Rent(maxLen + 1);
+            string result;
+            fixed (char* pText = text)
+            {
+                int actualLen = PARAM.ToInt(SendMessageW(this, (WM)CB.GETLBTEXT, (IntPtr)index, (IntPtr)pText));
+                Debug.Assert(actualLen != LB_ERR, "Should have validated the index above");
+                result = new string(pText, 0, actualLen);
+            }
+
+            ArrayPool<char>.Shared.Return(text);
+            return result;
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -1621,19 +1621,24 @@ namespace System.Windows.Forms
         /// </summary>
         internal unsafe string NativeGetItemText(int index)
         {
-            int maxLen = PARAM.ToInt(SendMessageW(this, (WM)LB.GETTEXTLEN, (IntPtr)index));
-            if (maxLen == LB_ERR)
+            int maxLength = PARAM.ToInt(SendMessageW(this, (WM)LB.GETTEXTLEN, (IntPtr)index));
+            if (maxLength == LB_ERR)
             {
                 return string.Empty;
             }
 
-            char[] text = ArrayPool<char>.Shared.Rent(maxLen + 1);
+            char[] text = ArrayPool<char>.Shared.Rent(maxLength + 1);
             string result;
             fixed (char* pText = text)
             {
-                int actualLen = PARAM.ToInt(SendMessageW(this, (WM)LB.GETTEXT, (IntPtr)index, (IntPtr)pText));
-                Debug.Assert(actualLen != LB_ERR, "Should have validated the index above");
-                result = new string(pText, 0, actualLen);
+                int actualLength = PARAM.ToInt(SendMessageW(this, (WM)LB.GETTEXT, (IntPtr)index, (IntPtr)pText));
+                Debug.Assert(actualLength != LB_ERR, "Should have validated the index above");
+                if (actualLength == LB_ERR)
+                {
+                    return string.Empty;
+                }
+
+                result = new string(pText, 0, Math.Min(maxLength, actualLength));
             }
 
             ArrayPool<char>.Shared.Return(text);


### PR DESCRIPTION
See https://github.com/dotnet/winforms/pull/3174#discussion_r422615154

It now returns "ABC\0", which is unintended.

So I wrote some more tests in #3107 that exercise this code path and the tests passed on .NET Framework and .NET Core. It seems like we also already had tests testing this code path as well.

I was a little confused why the tests passed until I realised that the only place where this method was called was in code like

```cs
if (string.Compare(owner.GetItemText(value), owner.NativeGetItemText(index), true, CultureInfo.CurrentCulture) != 0)
```

So I tested in my sandbox and found that 
```cs
Console.WriteLine(string.Compare("abc", "abc\0", true, CultureInfo.CurrentCulture));
```

prints out
```cs
0
```

Essentially meaning that whilst this changed behaviour, it didn't break anything as string.Compare already handles trailing `\0`

This just fixes things for correctness


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3282)