### PR TITLE
Add links in "new issue" flow to other related repos

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,20 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Issue with .NET runtime or core .NET libraries
+    url:  https://github.com/dotnet/runtime/issues/new/choose
+    about: Please open issues with the .NET runtime or core in their repo
+  - name: Issue with .NET Core SDK
+    url:  https://github.com/dotnet/sdk/issues/new/choose
+    about: Please open issues with the .NET Core SDK in their repo
+  - name: Issue with Entity Framework
+    url:  https://github.com/dotnet/efcore/issues/new/choose
+    about: Please open issues with Entity Framework in their repo
+  - name: Issue with Roslyn compiler
+    url:  https://github.com/dotnet/roslyn/issues/new/choose
+    about: Please open issues with the Roslyn compiler in their repo
+  - name: Issue with ASP.NET
+    url:  https://github.com/dotnet/aspnetcore/issues/new/choose
+    about: Please open issues with ASP.NET Core in their repo
+  - name: Issue with WPF
+    url:  https://github.com/dotnet/wpf/issues/new/choose
+    about: Please open issues with WPF in their repo


### PR DESCRIPTION
This .yml adds quick links to other repos below the existing issue template buttons in your new issue flow.

For an example of what this looks like, see https://github.com/danmosemsft/runtime/issues/new/choose (the white buttons below your existing green buttons)

We are adding this in dotnet/runtime (https://github.com/dotnet/runtime/pull/36431). Reasoning: it's sometimes confusing which is the correct repo to open an issue in. The goal here is to make it easier to open an issue in the correct repo first time so we need to move fewer issues and they more quickly get attention from the right people.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3286)