### PR TITLE
Fixing DataGridViewComboBoxCell: ComboBox causes application crash on handle recreating related to accessibility hierarchy tree restructuring

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -1904,16 +1904,6 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Indicates whether the ComboBox editing control was just detached. (focused out to another cell)
-        /// </summary>
-        internal bool ComboBoxControlWasDetached { get; set; }
-
-        /// <summary>
-        ///  Indicates whether the TextBox editing control was just detached. (focused out to another cell)
-        /// </summary>
-        internal bool TextBoxControlWasDetached { get; set; }
-
-        /// <summary>
         ///  Gets
         ///  or sets a value indicating if the dataGridView's column headers are visible.
         /// </summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -1292,16 +1292,6 @@ namespace System.Windows.Forms
 
                 if (AccessibleRestructuringNeeded)
                 {
-                    if (dgv.EditingControl is DataGridViewTextBoxEditingControl)
-                    {
-                        dgv.TextBoxControlWasDetached = true;
-                    }
-
-                    if (dgv.EditingControl is DataGridViewComboBoxEditingControl)
-                    {
-                        dgv.ComboBoxControlWasDetached = true;
-                    }
-
                     dgv.EditingControlAccessibleObject.SetParent(null);
                     AccessibilityObject.SetDetachableChild(null);
 
@@ -2728,18 +2718,6 @@ namespace System.Windows.Forms
             }
             Debug.Assert(dgv.EditingControl.ParentInternal == dgv.EditingPanel);
             Debug.Assert(dgv.EditingPanel.ParentInternal == dgv);
-
-            if (AccessibleRestructuringNeeded &&
-                ((dgv.ComboBoxControlWasDetached && dgv.EditingControl is DataGridViewComboBoxEditingControl) ||
-                (dgv.TextBoxControlWasDetached && dgv.EditingControl is DataGridViewTextBoxEditingControl)))
-            {
-                // Recreate control handle is necessary for cases when the same control was detached and then
-                // reattached to clear accessible hierarchy cache and not announce previous editing cell.
-                dgv.EditingControl.RecreateHandleCore();
-
-                dgv.ComboBoxControlWasDetached = false;
-                dgv.TextBoxControlWasDetached = false;
-            }
         }
 
         protected virtual bool KeyDownUnsharesRow(KeyEventArgs e, int rowIndex)


### PR DESCRIPTION

Fixes #3251
(cherry picked from commit 7a5e6e589d97cb585db29233e1f6c5709c52dc22)

## Proposed changes

- Porting .NET Framework fix for DataGridViewComboBox cell issue related to the control handle recreating when restructuring accessibility hierarchy tree.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Costumers will not experience application error when working with the DataGridView containing ComboBox cell. 

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3289)