### PR TITLE
Implement Task Property for ListViewGroup

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.LIF.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.LIF.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        [Flags]
+        public enum LIF : uint
+        {
+            ITEMINDEX = 0x00000001,
+            STATE = 0x00000002,
+            ITEMID = 0x00000004,
+            URL = 0x00000008,
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.LIS.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.LIS.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        [Flags]
+        public enum LIS : uint
+        {
+            ENABLED = 0x00000001,
+            FOCUSED = 0x00000002,
+            VISITED = 0x00000004,
+            HOTTRACK = 0x00000008,
+            DEFAULTCOLORS = 0x00000010,
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.LITEM.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.LITEM.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public unsafe struct LITEM
+        {
+            private const int MAX_LINKID_TEXT = 48;
+            private const int L_MAX_URL_LENGTH = 2048 + 32 + 3;
+
+            public LIF mask;
+            public int iLink;
+            public LIS state;
+            public LIS stateMask;
+            public fixed char szID[MAX_LINKID_TEXT];
+            public fixed char szUrl[L_MAX_URL_LENGTH];
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.NMLVLINK.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.NMLVLINK.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        public struct NMLVLINK
+        {
+            public User32.NMHDR hdr;
+            public LITEM link;
+            public int iItem;
+            public int iSubItem;
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,6 @@
 System.Windows.Forms.ListViewGroup.Subtitle.get -> string!
 System.Windows.Forms.ListViewGroup.Subtitle.set -> void
+System.Windows.Forms.ListView.GroupTaskLinkClick -> System.EventHandler<System.Windows.Forms.ListViewGroupEventArgs>
+System.Windows.Forms.ListViewGroup.TaskLink.get -> string!
+System.Windows.Forms.ListViewGroup.TaskLink.set -> void
+~virtual System.Windows.Forms.ListView.OnGroupTaskLinkClick(System.Windows.Forms.ListViewGroupEventArgs e) -> void

--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6710,4 +6710,7 @@ Stack trace where the illegal operation occurred was:
   <data name="ListViewGroupCollapsedStateChangedDescr" xml:space="preserve">
     <value>Event raised when the CollapsedState property of a ListViewGroup changes.</value>
   </data>
+  <data name="ListViewGroupTaskLinkClickDescr" xml:space="preserve">
+    <value>Event raised when the TaskLink property of a ListViewGroup is clicked.</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -6381,6 +6381,11 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">Název této skupiny</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupTaskLinkClickDescr">
+        <source>Event raised when the TaskLink property of a ListViewGroup is clicked.</source>
+        <target state="new">Event raised when the TaskLink property of a ListViewGroup is clicked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupsDescr">
         <source>The groups in the ListView.</source>
         <target state="translated">Skupiny v zobrazení ListView</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -6381,6 +6381,11 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">Der Name dieser Gruppe.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupTaskLinkClickDescr">
+        <source>Event raised when the TaskLink property of a ListViewGroup is clicked.</source>
+        <target state="new">Event raised when the TaskLink property of a ListViewGroup is clicked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupsDescr">
         <source>The groups in the ListView.</source>
         <target state="translated">Die Gruppen in der ListView.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -6381,6 +6381,11 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">Nombre de este grupo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupTaskLinkClickDescr">
+        <source>Event raised when the TaskLink property of a ListViewGroup is clicked.</source>
+        <target state="new">Event raised when the TaskLink property of a ListViewGroup is clicked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupsDescr">
         <source>The groups in the ListView.</source>
         <target state="translated">Grupos de ListView.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -6381,6 +6381,11 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">Nom de ce groupe.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupTaskLinkClickDescr">
+        <source>Event raised when the TaskLink property of a ListViewGroup is clicked.</source>
+        <target state="new">Event raised when the TaskLink property of a ListViewGroup is clicked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupsDescr">
         <source>The groups in the ListView.</source>
         <target state="translated">Les groupes dans le ListView.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -6381,6 +6381,11 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">Il nome del gruppo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupTaskLinkClickDescr">
+        <source>Event raised when the TaskLink property of a ListViewGroup is clicked.</source>
+        <target state="new">Event raised when the TaskLink property of a ListViewGroup is clicked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupsDescr">
         <source>The groups in the ListView.</source>
         <target state="translated">I gruppi in ListView.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -6381,6 +6381,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">このグループの名前です。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupTaskLinkClickDescr">
+        <source>Event raised when the TaskLink property of a ListViewGroup is clicked.</source>
+        <target state="new">Event raised when the TaskLink property of a ListViewGroup is clicked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupsDescr">
         <source>The groups in the ListView.</source>
         <target state="translated">ListView のグループです。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -6381,6 +6381,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">이 그룹의 이름입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupTaskLinkClickDescr">
+        <source>Event raised when the TaskLink property of a ListViewGroup is clicked.</source>
+        <target state="new">Event raised when the TaskLink property of a ListViewGroup is clicked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupsDescr">
         <source>The groups in the ListView.</source>
         <target state="translated">ListView에 있는 그룹입니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -6381,6 +6381,11 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">Nazwa tej grupy.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupTaskLinkClickDescr">
+        <source>Event raised when the TaskLink property of a ListViewGroup is clicked.</source>
+        <target state="new">Event raised when the TaskLink property of a ListViewGroup is clicked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupsDescr">
         <source>The groups in the ListView.</source>
         <target state="translated">Grupy w elemencie ListView.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -6381,6 +6381,11 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">O nome deste grupo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupTaskLinkClickDescr">
+        <source>Event raised when the TaskLink property of a ListViewGroup is clicked.</source>
+        <target state="new">Event raised when the TaskLink property of a ListViewGroup is clicked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupsDescr">
         <source>The groups in the ListView.</source>
         <target state="translated">Os grupos em ListView.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -6382,6 +6382,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">Имя данной группы.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupTaskLinkClickDescr">
+        <source>Event raised when the TaskLink property of a ListViewGroup is clicked.</source>
+        <target state="new">Event raised when the TaskLink property of a ListViewGroup is clicked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupsDescr">
         <source>The groups in the ListView.</source>
         <target state="translated">Группы в ListView.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -6381,6 +6381,11 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">Bu grubun adı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupTaskLinkClickDescr">
+        <source>Event raised when the TaskLink property of a ListViewGroup is clicked.</source>
+        <target state="new">Event raised when the TaskLink property of a ListViewGroup is clicked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupsDescr">
         <source>The groups in the ListView.</source>
         <target state="translated">ListView içindeki gruplar.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -6381,6 +6381,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">此组的名称。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupTaskLinkClickDescr">
+        <source>Event raised when the TaskLink property of a ListViewGroup is clicked.</source>
+        <target state="new">Event raised when the TaskLink property of a ListViewGroup is clicked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupsDescr">
         <source>The groups in the ListView.</source>
         <target state="translated">ListView 中的组。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -6381,6 +6381,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">此群組的名稱。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupTaskLinkClickDescr">
+        <source>Event raised when the TaskLink property of a ListViewGroup is clicked.</source>
+        <target state="new">Event raised when the TaskLink property of a ListViewGroup is clicked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupsDescr">
         <source>The groups in the ListView.</source>
         <target state="translated">ListView 中的群組。</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
@@ -26,6 +26,7 @@ namespace System.Windows.Forms
         private HorizontalAlignment _footerAlignment = HorizontalAlignment.Left;
         private ListViewGroupCollapsedState _collapsedState = ListViewGroupCollapsedState.Default;
         private string? _subtitle;
+        private string? _taskLink;
 
         private ListView.ListViewItemCollection? _items;
 
@@ -200,6 +201,26 @@ namespace System.Windows.Forms
                 }
 
                 _subtitle = value;
+                UpdateListView();
+            }
+        }
+
+        /// <summary>
+        ///  The name of the task link displayed in the group header.
+        /// </summary>
+        [SRCategory(nameof(SR.CatAppearance))]
+        [AllowNull]
+        public string TaskLink
+        {
+            get => _taskLink ?? string.Empty;
+            set
+            {
+                if (value == _taskLink)
+                {
+                    return;
+                }
+
+                _taskLink = value;
                 UpdateListView();
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupEventArgs.cs
@@ -5,7 +5,7 @@
 namespace System.Windows.Forms
 {
     /// <summary>
-    ///  Provides data for the <see cref='ListView.OnGroupCollapsedStateChanged'/> event.
+    ///  Provides data for the <see cref='ListView.OnGroupCollapsedStateChanged'/> and <see cref='ListView.OnGroupTaskLinkClick'/> event.
     /// </summary>
     public class ListViewGroupEventArgs : EventArgs
     {

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.cs
@@ -38,6 +38,7 @@ namespace WinformsControlsTest
             };
 
             AddCollapsibleGroupToListView();
+            AddGroupTasks();
         }
 
         private void CreateMyListView()
@@ -176,6 +177,30 @@ namespace WinformsControlsTest
         private void listView1_GroupCollapsedStateChanged(object sender, ListViewGroupEventArgs e)
         {
             MessageBox.Show("CollapsedState changed at group with index " + e.GroupIndex);
+        }
+
+        private void AddGroupTasks()
+        {
+            listView1.Groups[0].TaskLink = "Task";
+            listView1.GroupTaskLinkClick += listView1_GroupTaskLinkClick;
+
+            var lvgroup1 = new ListViewGroup
+            {
+                Header = "TaskGroup",
+                TaskLink = "Task2"
+            };
+
+            listView1.Groups.Add(lvgroup1);
+            listView1.Items.Add(new ListViewItem
+            {
+                Text = "Item",
+                Group = lvgroup1
+            });
+        }
+
+        private void listView1_GroupTaskLinkClick(object sender, ListViewGroupEventArgs e)
+        {
+            MessageBox.Show(this, "Task at group index " + e.GroupIndex + " was clicked", "GroupClick Event");
         }
 
         private void listView2_Click(object sender, System.EventArgs e)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/GroupLinkClickEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/GroupLinkClickEventArgsTests.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    // NB: doesn't require thread affinity
+    public class GroupLinkClickEventArgsTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void Ctor_Int(int groupIndex)
+        {
+            var e = new ListViewGroupEventArgs(groupIndex);
+            Assert.Equal(groupIndex, e.GroupIndex);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #2656


## Proposed changes

- Add Task API to `ListViewGroup`
- Add GroupLinkClick event handler/args in `ListView`

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Customers will be able to add tasks to their ListViewGroups
- Customers will receive callback to do as they please once group task clicked

## Regression? 

- No

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://user-images.githubusercontent.com/30007367/82090899-43d79f80-96ab-11ea-86c2-df1ef5c73e1d.png)
### After
![grouptaskex1](https://user-images.githubusercontent.com/30007367/82092331-ebee6800-96ad-11ea-81cc-de7984da8abe.gif)

## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Unit testing

## TODOs:
- [ ] Both narrator and inspect do not pick up on Task property, we'll need to do accessibility improvements here.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3293)