### PR TITLE
Fixing Issue 3294 to allow specify custom AccessibleName and AccessibleRole for Label control

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
@@ -1673,9 +1673,12 @@ namespace System.Windows.Forms
 
             internal override object GetPropertyValue(UiaCore.UIA propertyID)
             {
-                if (propertyID == UiaCore.UIA.ControlTypePropertyId)
+                switch (propertyID)
                 {
-                    return UiaCore.UIA.TextControlTypeId;
+                    case UiaCore.UIA.NamePropertyId:
+                        return Name;
+                    case UiaCore.UIA.ControlTypePropertyId:
+                        return UiaCore.UIA.TextControlTypeId;
                 }
 
                 return base.GetPropertyValue(propertyID);

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MultipleControls.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MultipleControls.Designer.cs
@@ -89,6 +89,9 @@ namespace WinformsControlsTest
             this.label1.Size = new System.Drawing.Size(35, 13);
             this.label1.TabIndex = 2;
             this.label1.Text = "label1";
+            this.label1.AccessibleName = "Test Label AccessibleName";
+            this.label1.AccessibleDescription = "Test Label AccessibleDescription";
+            this.label1.AccessibleRole = System.Windows.Forms.AccessibleRole.Indicator;
             //
             // maskedTextBox1
             //
@@ -157,7 +160,7 @@ namespace WinformsControlsTest
             this.tabPage2.TabIndex = 1;
             this.tabPage2.Text = "tabPage2";
             this.tabPage2.ToolTipText = "I am tabPage2!\r\nI am multiline tooltip!";
-             this.tabPage2.UseVisualStyleBackColor = true;
+            this.tabPage2.UseVisualStyleBackColor = true;
             //
             // checkBox1
             //
@@ -199,6 +202,9 @@ namespace WinformsControlsTest
             this.groupBox1.TabIndex = 7;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "groupBox1";
+            this.groupBox1.AccessibleName = "Test GroupBox AccessibleName";
+            this.groupBox1.AccessibleDescription = "Test GroupBox AccessibleDescription";
+            this.groupBox1.AccessibleRole = System.Windows.Forms.AccessibleRole.Table;
             //
             // checkedListBox1
             //

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/GroupBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/GroupBoxAccessibleObjectTests.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Windows.Forms.Tests.AccessibleObjects
+{
+    public class GroupBoxAccessibleObjectTests
+    {
+        [WinFormsFact]
+        public void GroupBoxAccessibleObject_GetPropertyValue_Name_ReturnsExpected()
+        {
+            string testAccName = "Test group name";
+            using var groupBox = new GroupBox();
+            groupBox.Text = "Some test groupBox text";
+            groupBox.Name = "Group1";
+            groupBox.AccessibleName = testAccName;
+            AccessibleObject groupBoxAccessibleObject = groupBox.AccessibilityObject;
+
+            // Will fail when https://github.com/dotnet/winforms/pull/3432 is merged.
+            // Assert.False is expected here
+            Assert.True(groupBox.IsHandleCreated);
+
+            var accessibleName = groupBoxAccessibleObject.GetPropertyValue(Interop.UiaCore.UIA.NamePropertyId);
+            Assert.Equal(testAccName, accessibleName);
+        }
+
+        [WinFormsFact]
+        public void GroupBoxAccessibleObject_IsPatternSupported_LegacyIAccessible_ReturnsTrue()
+        {
+            using var groupBox = new GroupBox();
+            groupBox.Name = "Group1";
+            groupBox.Text = "Some test groupBox text";
+            var groupBoxAccessibleObject = new GroupBox.GroupBoxAccessibleObject(groupBox);
+
+            // Will fail when https://github.com/dotnet/winforms/pull/3432 is merged.
+            // Assert.False is expected here
+            Assert.True(groupBox.IsHandleCreated);
+
+            bool supportsLegacyIAccessiblePatternId = groupBoxAccessibleObject.IsPatternSupported(Interop.UiaCore.UIA.LegacyIAccessiblePatternId);
+            Assert.True(supportsLegacyIAccessiblePatternId);
+        }
+
+        [WinFormsFact]
+        public void GroupBoxAccessibleObject_LegacyIAccessible_Role_ReturnsExpected()
+        {
+            using var groupBox = new GroupBox();
+            groupBox.Name = "Group1";
+            groupBox.Text = "Some test groupBox text";
+            groupBox.AccessibleRole = AccessibleRole.Link;
+            var groupBoxAccessibleObject = new GroupBox.GroupBoxAccessibleObject(groupBox);
+
+            // Will fail when https://github.com/dotnet/winforms/pull/3432 is merged.
+            // Assert.False is expected here
+            Assert.True(groupBox.IsHandleCreated);
+
+            Assert.Equal(AccessibleRole.Link, groupBoxAccessibleObject.Role);
+        }
+
+        [WinFormsFact]
+        public void GroupBoxAccessibleObject_LegacyIAccessible_Description_ReturnsExpected()
+        {
+            string testAccDescription = "Test description";
+            using var groupBox = new GroupBox();
+            groupBox.Name = "Group1";
+            groupBox.Text = "Some test groupBox text";
+            groupBox.AccessibleDescription = testAccDescription;
+            var groupBoxAccessibleObject = new GroupBox.GroupBoxAccessibleObject(groupBox);
+
+            // Will fail when https://github.com/dotnet/winforms/pull/3432 is merged.
+            // Assert.False is expected here
+            Assert.True(groupBox.IsHandleCreated);
+
+            Assert.Equal(testAccDescription, groupBoxAccessibleObject.Description);
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/LabelAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/LabelAccessibleObjectTests.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    public class LabelAccessibleObjectTests
+    {
+        [WinFormsFact]
+        public void LabelAccessibleObject_GetPropertyValue_Name_ReturnsExpected()
+        {
+            string testAccName = "Address";
+            using var label = new Label();
+            label.Text = "Some test label text";
+            label.Name = "Label1";
+            label.AccessibleName = testAccName;
+            AccessibleObject labelAccessibleObject = label.AccessibilityObject;
+
+            // Will fail when https://github.com/dotnet/winforms/pull/3432 is merged.
+            // Assert.False is expected here
+            Assert.True(label.IsHandleCreated);
+
+            var accessibleName = labelAccessibleObject.GetPropertyValue(Interop.UiaCore.UIA.NamePropertyId);
+            Assert.Equal(testAccName, accessibleName);
+        }
+
+        [WinFormsFact]
+        public void LabelAccessibleObject_IsPatternSupported_LegacyIAccessible_ReturnsTrue()
+        {
+            using var label = new Label();
+            label.Name = "Label1";
+            label.Text = "Some test label text";
+            var labelAccessibleObject = new Label.LabelAccessibleObject(label);
+
+            // Will fail when https://github.com/dotnet/winforms/pull/3432 is merged.
+            // Assert.False is expected here
+            Assert.True(label.IsHandleCreated);
+
+            bool supportsLegacyIAccessiblePatternId = labelAccessibleObject.IsPatternSupported(Interop.UiaCore.UIA.LegacyIAccessiblePatternId);
+            Assert.True(supportsLegacyIAccessiblePatternId);
+        }
+
+        [WinFormsFact]
+        public void LabelAccessibleObject_LegacyIAccessible_Role_ReturnsExpected()
+        {
+            using var label = new Label();
+            label.Name = "Label1";
+            label.Text = "Some test label text";
+            label.AccessibleRole = AccessibleRole.Link;
+            var labelAccessibleObject = new Label.LabelAccessibleObject(label);
+
+            // Will fail when https://github.com/dotnet/winforms/pull/3432 is merged.
+            // Assert.False is expected here
+            Assert.True(label.IsHandleCreated);
+
+            Assert.Equal(AccessibleRole.Link, labelAccessibleObject.Role);
+        }
+
+        [WinFormsFact]
+        public void LabelAccessibleObject_LegacyIAccessible_Description_ReturnsExpected()
+        {
+            string testAccDescription = "Test description";
+            using var label = new Label();
+            label.Name = "Label1";
+            label.Text = "Some test label text";
+            label.AccessibleDescription = testAccDescription;
+            var labelAccessibleObject = new Label.LabelAccessibleObject(label);
+
+            // Will fail when https://github.com/dotnet/winforms/pull/3432 is merged.
+            // Assert.False is expected here
+            Assert.True(label.IsHandleCreated);
+
+            Assert.Equal(testAccDescription, labelAccessibleObject.Description);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3294


## Proposed changes

- Adding LegacyIAccessiblePattern provider to LabelAccessibleObject.
- Adding LegacyIAccessiblePattern provider to GroupBoxAccessibleObject.
- By adding LegacyIAccessiblePattern properties values from AccessibleName and AccessibleRole is provided to Inspect's LegacyIAccessible.Name and LegacyIAccessible.Role fields and corresponding MSAA fields if UIA support for control is enabled.
- Adding tests to verify the fix.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Developers will be able to specify custom AccessibleName and AccessibleRole for the Label control.

## Regression? 

- Yes (introduced in .NET Framework 4.8)

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Setting custom AccessibleName and AccessibleRole has no effect on the values of AccessibleName and AccessibleRole fields shown in Inspect or Accessibility Insights.

### After

Custom AccessibleName and AccessibleRole are represented as values of AccessibleName and AccessibleRole fields shown in Inspect or Accessibility Insights.


## Test methodology <!-- How did you ensure quality? -->

- Manual tests.
- Unit tests.
- Automation tests.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->

- Inspect;
- Accessibility Insights.
 

## Test environment(s) <!-- Remove any that don't apply -->

<!-- use `dotnet --info` -->
.NET SDK (reflecting any global.json):
 Version:   5.0.100-preview.5.20260.4
 Commit:    0950d416f9

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.18363
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\5.0.100-preview.5.20260.4\

Host (useful for support):
  Version: 5.0.0-preview.5.20260.5
  Commit:  09ee4814cb

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3295)