### PR TITLE
Call UiaDisconnectProvider from Control.ReleaseUiaProvider

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.UiaDisconnectProvider.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.UiaDisconnectProvider.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal static partial class UiaCore
+    {
+        [DllImport(Libraries.UiaCore, ExactSpelling = true)]
+        public static extern HRESULT UiaDisconnectProvider(IRawElementProviderSimple provider);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/OsVersion.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/OsVersion.cs
@@ -38,5 +38,11 @@ namespace System.Windows.Forms
         public static bool IsWindows8_1OrGreater
             => s_versionInfo.dwMajorVersion >= 10
                 || (s_versionInfo.dwMajorVersion == 6 && s_versionInfo.dwMinorVersion == 3);
+
+        /// <summary>
+        ///  Is Windows 8 or later.
+        /// </summary>
+        public static bool IsWindows8OrGreater
+            => s_versionInfo.dwMajorVersion >= 8;
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -9920,6 +9920,12 @@ namespace System.Windows.Forms
             // as follows: UiaReturnRawElementProvider(hwnd, 0, 0, NULL). This call tells
             // UI Automation that it can safely remove all map entries that refer to the specified window.
             UiaCore.UiaReturnRawElementProvider(new HandleRef(this, handle), IntPtr.Zero, IntPtr.Zero, null);
+
+            if (OsVersion.IsWindows8OrGreater && Properties.GetObject(s_accessibilityProperty) is object)
+            {
+                var intAccessibleObject = new InternalAccessibleObject(AccessibilityObject);
+                UiaCore.UiaDisconnectProvider(intAccessibleObject);
+            }
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -5817,7 +5817,8 @@ namespace System.Windows.Forms
         /// <returns>Returns the element in the specified direction.</returns>
         internal override UiaCore.IRawElementProviderFragment FragmentNavigate(UiaCore.NavigateDirection direction)
         {
-            if (_parentPropertyGrid.AccessibilityObject is PropertyGridAccessibleObject propertyGridAccessibleObject)
+            if (_parentPropertyGrid.IsHandleCreated &&
+                _parentPropertyGrid.AccessibilityObject is PropertyGridAccessibleObject propertyGridAccessibleObject)
             {
                 UiaCore.IRawElementProviderFragment navigationTarget = propertyGridAccessibleObject.ChildFragmentNavigate(this, direction);
                 if (navigationTarget != null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -8203,7 +8203,8 @@ namespace System.Windows.Forms.PropertyGridInternal
             /// <returns>Returns the element in the specified direction.</returns>
             internal override UiaCore.IRawElementProviderFragment FragmentNavigate(UiaCore.NavigateDirection direction)
             {
-                if (_parentPropertyGrid.AccessibilityObject is PropertyGridAccessibleObject propertyGridAccessibleObject)
+                if (_parentPropertyGrid.IsHandleCreated &&
+                    _parentPropertyGrid.AccessibilityObject is PropertyGridAccessibleObject propertyGridAccessibleObject)
                 {
                     UiaCore.IRawElementProviderFragment navigationTarget = propertyGridAccessibleObject.ChildFragmentNavigate(this, direction);
                     if (navigationTarget != null)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Partially fixes #3182

## Proposed changes

- Call `UiaDisconnectProvider` to explicitly detach UIA providers when a control or form is being disposed. This ensures that clients that leak UIA objects cannot leak them in the target application indefinitely. It follows the pattern from the [Windows SDK sample](https://github.com/microsoft/Windows-classic-samples/tree/master/Samples/UIAutomationCleanShutdown).

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- UIA objects for disposed controls won't cause memory leak
- UIA clients accessing UIA providers for disposed controls will get `UIA_E_ELEMENTNOTAVAILABLE` error

## Regression? 

- No

## Risk

- There should be no risk when the application is accessed by properly implemented UIA clients. These clients should be prepared to handle `UIA_E_ELEMENTNOTAVAILABLE` error and also release the UIA objects in timely manner. For misbehaving UIA clients it could cause a problem in the UIA client instead of a leak in the WinForms application.

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

- Tested with VisualUIAVerifyNative and Accessibility Insight to ensure that the UIA clients react correctly to the change (longer description of effect available in #3182).
- Tested with SciTech Memory Profiler to ensure that controls/forms with UIA providers are released when a form is closed and hence don't keep additional reference that would make these objects have prolonged lifetime.

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 5 (master, winforms@d851dac649d74c3a1d2b416713dd22de14b93fe1)
- .NET Core 3.1.200 with backported fix

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3308)