### PR TITLE
Cleanup remaining ExternDll.Shell32 interop

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.IShellItem.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.IShellItem.cs
@@ -14,24 +14,29 @@ internal static partial class Interop
         [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
         public interface IShellItem
         {
-            void BindToHandler(
+            [PreserveSig]
+            HRESULT BindToHandler(
                 IntPtr pbc,
                 ref Guid bhid,
                 ref Guid riid,
                 out IntPtr ppv);
 
-            void GetParent(
+            [PreserveSig]
+            HRESULT GetParent(
                 out IShellItem ppsi);
 
-            void GetDisplayName(
+            [PreserveSig]
+            HRESULT GetDisplayName(
                 SIGDN sigdnName,
                 [MarshalAs(UnmanagedType.LPWStr)] out string ppszName);
 
-            void GetAttributes(
+            [PreserveSig]
+            HRESULT GetAttributes(
                 uint sfgaoMask,
                 out uint psfgaoAttribs);
 
-            void Compare(
+            [PreserveSig]
+            HRESULT Compare(
                 IShellItem psi,
                 uint hint,
                 out int piOrder);

--- a/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.IShellItem.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.IShellItem.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Shell32
+    {
+        [ComImport]
+        [Guid("43826D1E-E718-42EE-BC55-A1E261C37BFE")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        public interface IShellItem
+        {
+            void BindToHandler(
+                IntPtr pbc,
+                ref Guid bhid,
+                ref Guid riid,
+                out IntPtr ppv);
+
+            void GetParent(
+                out IShellItem ppsi);
+
+            void GetDisplayName(
+                SIGDN sigdnName,
+                [MarshalAs(UnmanagedType.LPWStr)] out string ppszName);
+
+            void GetAttributes(
+                uint sfgaoMask,
+                out uint psfgaoAttribs);
+
+            void Compare(
+                IShellItem psi,
+                uint hint,
+                out int piOrder);
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.SHCreateItemFromParsingName.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.SHCreateItemFromParsingName.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Shell32
+    {
+        [DllImport(Libraries.Shell32, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        public static extern HRESULT SHCreateItemFromParsingName(string pszPath, IntPtr pbc, ref Guid riid, [MarshalAs(UnmanagedType.Interface)] out object ppv);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.SHCreateShellItem.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.SHCreateShellItem.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Shell32
+    {
+        [DllImport(Libraries.Shell32, ExactSpelling = true)]
+        public static extern HRESULT SHCreateShellItem(IntPtr pidlParent, IntPtr psfParent, IntPtr pidl, out IShellItem ppsi);
+
+        public static IShellItem GetShellItemForPath(string path)
+        {
+            uint zero = 0;
+            if (SHILCreateFromPath(path, out IntPtr pidl, ref zero).Succeeded())
+            {
+                // No parent specified
+                if (SHCreateShellItem(IntPtr.Zero, IntPtr.Zero, pidl, out IShellItem ret).Succeeded())
+                {
+                    return ret;
+                }
+            }
+
+            throw new FileNotFoundException();
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.SHILCreateFromPath.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.SHILCreateFromPath.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Shell32
+    {
+        [DllImport(Libraries.Shell32, ExactSpelling = true)]
+        public static extern HRESULT SHILCreateFromPath(string pszPath, out IntPtr ppidl, ref uint rgflnOut);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/ExternDll.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/ExternDll.cs
@@ -10,7 +10,6 @@ namespace System
         public const string Gdi32 = "gdi32.dll";
         public const string Hhctrl = "hhctrl.ocx";
         public const string Kernel32 = "kernel32.dll";
-        public const string Shell32 = "shell32.dll";
         public const string User32 = "user32.dll";
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlace.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlace.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using static Interop;
+using static Interop.Shell32;
 
 namespace System.Windows.Forms
 {
@@ -58,7 +59,7 @@ namespace System.Windows.Forms
         ///  to an actual filesystem directory.
         ///  The caller is responsible for handling these situations.
         /// </remarks>
-        internal FileDialogNative.IShellItem GetNativePath()
+        internal IShellItem GetNativePath()
         {
             string filePathString;
             if (!string.IsNullOrEmpty(_path))
@@ -67,14 +68,14 @@ namespace System.Windows.Forms
             }
             else
             {
-                int result = Shell32.SHGetKnownFolderPath(ref _knownFolderGuid, 0, IntPtr.Zero, out filePathString);
+                int result = SHGetKnownFolderPath(ref _knownFolderGuid, 0, IntPtr.Zero, out filePathString);
                 if (result == 0)
                 {
                     return null;
                 }
             }
 
-            return FileDialogNative.GetShellItemForPath(filePathString);
+            return GetShellItemForPath(filePathString);
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlacesCollection.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlacesCollection.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.ObjectModel;
 using System.IO;
+using static Interop.Shell32;
 
 namespace System.Windows.Forms
 {
@@ -18,7 +19,7 @@ namespace System.Windows.Forms
 
                 try
                 {
-                    FileDialogNative.IShellItem shellItem = customPlace.GetNativePath();
+                    IShellItem shellItem = customPlace.GetNativePath();
                     if (null != shellItem)
                     {
                         dialog.AddPlace(shellItem, 0);

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -76,14 +76,5 @@ namespace System.Windows.Forms
 
         [DllImport(Libraries.Oleacc, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern int CreateStdAccessibleObject(HandleRef hWnd, int objID, ref Guid refiid, [In, Out, MarshalAs(UnmanagedType.Interface)] ref object pAcc);
-
-        internal class Shell32
-        {
-            [DllImport(ExternDll.Shell32, PreserveSig = true)]
-            public static extern int SHCreateShellItem(IntPtr pidlParent, IntPtr psfParent, IntPtr pidl, out FileDialogNative.IShellItem ppsi);
-
-            [DllImport(ExternDll.Shell32, PreserveSig = true)]
-            public static extern int SHILCreateFromPath([MarshalAs(UnmanagedType.LPWStr)]string pszPath, out IntPtr ppIdl, ref uint rgflnOut);
-        }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
 using static Interop;
+using static Interop.Shell32;
 
 namespace System.Windows.Forms
 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog_Vista.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog_Vista.cs
@@ -84,7 +84,7 @@ namespace System.Windows.Forms
             {
                 try
                 {
-                    FileDialogNative.IShellItem initialDirectory = FileDialogNative.GetShellItemForPath(InitialDirectory);
+                    IShellItem initialDirectory = GetShellItemForPath(InitialDirectory);
 
                     dialog.SetDefaultFolder(initialDirectory);
                     dialog.SetFolder(initialDirectory);
@@ -213,7 +213,7 @@ namespace System.Windows.Forms
                 return _dialog.HandleVistaFileOk(pfd) ? (int)HRESULT.S_OK : (int)HRESULT.S_FALSE;
             }
 
-            public int OnFolderChanging(FileDialogNative.IFileDialog pfd, FileDialogNative.IShellItem psiFolder)
+            public int OnFolderChanging(FileDialogNative.IFileDialog pfd, IShellItem psiFolder)
             {
                 return (int)HRESULT.S_OK;
             }
@@ -226,7 +226,7 @@ namespace System.Windows.Forms
             {
             }
 
-            public void OnShareViolation(FileDialogNative.IFileDialog pfd, FileDialogNative.IShellItem psi, out FDESVR pResponse)
+            public void OnShareViolation(FileDialogNative.IFileDialog pfd, IShellItem psi, out FDESVR pResponse)
             {
                 pResponse = FDESVR.DEFAULT;
             }
@@ -235,7 +235,7 @@ namespace System.Windows.Forms
             {
             }
 
-            public void OnOverwrite(FileDialogNative.IFileDialog pfd, FileDialogNative.IShellItem psi, out FDEOR pResponse)
+            public void OnOverwrite(FileDialogNative.IFileDialog pfd, IShellItem psi, out FDEOR pResponse)
             {
                 pResponse = FDEOR.DEFAULT;
             }
@@ -278,7 +278,7 @@ namespace System.Windows.Forms
             return extensions.ToArray();
         }
 
-        private protected static string GetFilePathFromShellItem(FileDialogNative.IShellItem item)
+        private protected static string GetFilePathFromShellItem(IShellItem item)
         {
             item.GetDisplayName(SIGDN.DESKTOPABSOLUTEPARSING, out string filename);
             return filename;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog_Vista.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog_Vista.cs
@@ -280,7 +280,12 @@ namespace System.Windows.Forms
 
         private protected static string GetFilePathFromShellItem(IShellItem item)
         {
-            item.GetDisplayName(SIGDN.DESKTOPABSOLUTEPARSING, out string filename);
+            HRESULT hr = item.GetDisplayName(SIGDN.DESKTOPABSOLUTEPARSING, out string filename);
+            if (!hr.Succeeded())
+            {
+                throw Marshal.GetExceptionForHR((int)hr);
+            }
+
             return filename;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
@@ -261,7 +261,11 @@ namespace System.Windows.Forms
         private void GetResult(FileDialogNative.IFileDialog dialog)
         {
             dialog.GetResult(out IShellItem item);
-            item.GetDisplayName(SIGDN.FILESYSPATH, out _selectedPath);
+            HRESULT hr = item.GetDisplayName(SIGDN.FILESYSPATH, out _selectedPath);
+            if (!hr.Succeeded())
+            {
+                throw Marshal.GetExceptionForHR((int)hr);
+            }
         }
 
         private unsafe bool RunDialogOld(IntPtr hWndOwner)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
@@ -240,15 +240,27 @@ namespace System.Windows.Forms
                 else
                 {
                     string folder = Path.GetFileName(_selectedPath);
-                    dialog.SetFolder(FileDialogNative.CreateItemFromParsingName(parent));
+                    dialog.SetFolder(CreateItemFromParsingName(parent));
                     dialog.SetFileName(folder);
                 }
             }
         }
 
+        private static IShellItem CreateItemFromParsingName(string path)
+        {
+            Guid guid = typeof(IShellItem).GUID;
+            HRESULT hr = SHCreateItemFromParsingName(path, IntPtr.Zero, ref guid, out object item);
+            if (hr != HRESULT.S_OK)
+            {
+                throw new Win32Exception((int)hr);
+            }
+
+            return (IShellItem)item;
+        }
+
         private void GetResult(FileDialogNative.IFileDialog dialog)
         {
-            dialog.GetResult(out FileDialogNative.IShellItem item);
+            dialog.GetResult(out IShellItem item);
             item.GetDisplayName(SIGDN.FILESYSPATH, out _selectedPath);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
@@ -7,6 +7,7 @@
 using System.ComponentModel;
 using System.IO;
 using static Interop;
+using static Interop.Shell32;
 
 namespace System.Windows.Forms
 {
@@ -124,14 +125,14 @@ namespace System.Windows.Forms
                 string[] files = new string[count];
                 for (uint i = 0; i < count; ++i)
                 {
-                    results.GetItemAt(i, out FileDialogNative.IShellItem item);
+                    results.GetItemAt(i, out IShellItem item);
                     files[unchecked((int)i)] = GetFilePathFromShellItem(item);
                 }
                 return files;
             }
             else
             {
-                openDialog.GetResult(out FileDialogNative.IShellItem item);
+                openDialog.GetResult(out IShellItem item);
                 return new string[] { GetFilePathFromShellItem(item) };
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SaveFileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SaveFileDialog.cs
@@ -7,6 +7,7 @@
 using System.ComponentModel;
 using System.IO;
 using static Interop;
+using static Interop.Shell32;
 
 namespace System.Windows.Forms
 {
@@ -146,7 +147,7 @@ namespace System.Windows.Forms
         private protected override string[] ProcessVistaFiles(FileDialogNative.IFileDialog dialog)
         {
             FileDialogNative.IFileSaveDialog saveDialog = (FileDialogNative.IFileSaveDialog)dialog;
-            dialog.GetResult(out FileDialogNative.IShellItem item);
+            dialog.GetResult(out IShellItem item);
             return new string[] { GetFilePathFromShellItem(item) };
         }
 


### PR DESCRIPTION
## Proposed Changes
- Cleanup remaining ExternDll.Shell32 interop

There's still a bunch left in `FileBrowserNative` for vista stuff, but that can wait for another day. Priority is to clean things out of `UnsafeNativeMethods`!

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3311)