### PR TITLE
manually release ITypeInfo references

### DIFF
--- a/src/System.Windows.Forms.Primitives/tests/Interop/Oleaut32/ITypeInfoTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/Interop/Oleaut32/ITypeInfoTests.cs
@@ -412,6 +412,11 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             public new static IPictureDisp GetIPictureDispFromPicture(Image image) => (IPictureDisp)AxHost.GetIPictureDispFromPicture(image);
         }
 
+        // ITypeInfo often requires manual RCW reference management. The native object may be free threaded
+        // but when created on an STA thread it will be associated with that thread. If the native code keeps
+        // reusing the same instance you can run into a condition where the GC cleans up the RCW from one STA
+        // thread while you want to start using the same underlying object on a new STA thread. This will lead
+        // to an error so manual release is required to avoid running into this condition.
         private struct ComRefReleaser : IDisposable
         {
             private object _reference;

--- a/src/System.Windows.Forms.Primitives/tests/Interop/Oleaut32/ITypeInfoTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/Interop/Oleaut32/ITypeInfoTests.cs
@@ -1,8 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Drawing;
+using System.Runtime.InteropServices;
 using Xunit;
 using static Interop;
 using static Interop.Ole32;
@@ -21,6 +22,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             IDispatch dispatch = (IDispatch)picture;
             ITypeInfo typeInfo;
             HRESULT hr = dispatch.GetTypeInfo(0, Kernel32.GetThreadLocale(), out typeInfo);
+            using var typeInfoReleaser = new ComRefReleaser(typeInfo);
             Assert.Equal(HRESULT.S_OK, hr);
 
             IntPtr pv = (IntPtr)int.MaxValue;
@@ -37,6 +39,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             IDispatch dispatch = (IDispatch)picture;
             ITypeInfo typeInfo;
             HRESULT hr = dispatch.GetTypeInfo(0, Kernel32.GetThreadLocale(), out typeInfo);
+            using var typeInfoReleaser = new ComRefReleaser(typeInfo);
             Assert.Equal(HRESULT.S_OK, hr);
 
             Guid riid = typeof(IPictureDisp).GUID;
@@ -54,6 +57,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             IDispatch dispatch = (IDispatch)picture;
             ITypeInfo typeInfo;
             HRESULT hr = dispatch.GetTypeInfo(0, Kernel32.GetThreadLocale(), out typeInfo);
+            using var typeInfoReleaser = new ComRefReleaser(typeInfo);
             Assert.Equal(HRESULT.S_OK, hr);
 
             IntPtr typeLib = (IntPtr)int.MaxValue;
@@ -79,6 +83,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             IDispatch dispatch = (IDispatch)picture;
             ITypeInfo typeInfo;
             HRESULT hr = dispatch.GetTypeInfo(0, Kernel32.GetThreadLocale(), out typeInfo);
+            using var typeInfoReleaser = new ComRefReleaser(typeInfo);
             Assert.Equal(HRESULT.S_OK, hr);
 
             var dllName = new BSTR("DllName");
@@ -99,6 +104,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             IDispatch dispatch = (IDispatch)picture;
             ITypeInfo typeInfo;
             HRESULT hr = dispatch.GetTypeInfo(0, Kernel32.GetThreadLocale(), out typeInfo);
+            using var typeInfoReleaser = new ComRefReleaser(typeInfo);
             Assert.Equal(HRESULT.S_OK, hr);
 
             using var name = new BSTR("Name");
@@ -121,6 +127,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             IDispatch dispatch = (IDispatch)picture;
             ITypeInfo typeInfo;
             HRESULT hr = dispatch.GetTypeInfo(0, Kernel32.GetThreadLocale(), out typeInfo);
+            using var typeInfoReleaser = new ComRefReleaser(typeInfo);
             Assert.Equal(HRESULT.S_OK, hr);
 
             FUNCDESC* pFuncDesc = null;
@@ -157,6 +164,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             IDispatch dispatch = (IDispatch)picture;
             ITypeInfo typeInfo;
             HRESULT hr = dispatch.GetTypeInfo(0, Kernel32.GetThreadLocale(), out typeInfo);
+            using var typeInfoReleaser = new ComRefReleaser(typeInfo);
             Assert.Equal(HRESULT.S_OK, hr);
 
             var rgszNames = new string[] { "Width", "Other" };
@@ -178,6 +186,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             IDispatch dispatch = (IDispatch)picture;
             ITypeInfo typeInfo;
             HRESULT hr = dispatch.GetTypeInfo(0, Kernel32.GetThreadLocale(), out typeInfo);
+            using var typeInfoReleaser = new ComRefReleaser(typeInfo);
             Assert.Equal(HRESULT.S_OK, hr);
 
             IMPLTYPEFLAG implTypeFlags = (IMPLTYPEFLAG)(-1);
@@ -194,6 +203,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             IDispatch dispatch = (IDispatch)picture;
             ITypeInfo typeInfo;
             HRESULT hr = dispatch.GetTypeInfo(0, Kernel32.GetThreadLocale(), out typeInfo);
+            using var typeInfoReleaser = new ComRefReleaser(typeInfo);
             Assert.Equal(HRESULT.S_OK, hr);
 
             var mops = new BSTR("Mops");
@@ -210,6 +220,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             IDispatch dispatch = (IDispatch)picture;
             ITypeInfo typeInfo;
             HRESULT hr = dispatch.GetTypeInfo(0, Kernel32.GetThreadLocale(), out typeInfo);
+            using var typeInfoReleaser = new ComRefReleaser(typeInfo);
             Assert.Equal(HRESULT.S_OK, hr);
 
             BSTR* rgszNames = stackalloc BSTR[2];
@@ -234,6 +245,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             IDispatch dispatch = (IDispatch)picture;
             ITypeInfo typeInfo;
             HRESULT hr = dispatch.GetTypeInfo(0, Kernel32.GetThreadLocale(), out typeInfo);
+            using var typeInfoReleaser = new ComRefReleaser(typeInfo);
             Assert.Equal(HRESULT.S_OK, hr);
 
             uint refType = uint.MaxValue;
@@ -255,6 +267,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             IDispatch dispatch = (IDispatch)picture;
             ITypeInfo typeInfo;
             HRESULT hr = dispatch.GetTypeInfo(0, Kernel32.GetThreadLocale(), out typeInfo);
+            using var typeInfoReleaser = new ComRefReleaser(typeInfo);
             Assert.Equal(HRESULT.S_OK, hr);
 
             uint refType = uint.MaxValue;
@@ -271,6 +284,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             IDispatch dispatch = (IDispatch)picture;
             ITypeInfo typeInfo;
             HRESULT hr = dispatch.GetTypeInfo(0, Kernel32.GetThreadLocale(), out typeInfo);
+            using var typeInfoReleaser = new ComRefReleaser(typeInfo);
             Assert.Equal(HRESULT.S_OK, hr);
 
             TYPEATTR* pTypeAttr = null;
@@ -312,6 +326,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             IDispatch dispatch = (IDispatch)picture;
             ITypeInfo typeInfo;
             HRESULT hr = dispatch.GetTypeInfo(0, Kernel32.GetThreadLocale(), out typeInfo);
+            using var typeInfoReleaser = new ComRefReleaser(typeInfo);
             Assert.Equal(HRESULT.S_OK, hr);
 
             IntPtr typeComp = IntPtr.Zero;
@@ -335,6 +350,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             IDispatch dispatch = (IDispatch)picture;
             ITypeInfo typeInfo;
             HRESULT hr = dispatch.GetTypeInfo(0, Kernel32.GetThreadLocale(), out typeInfo);
+            using var typeInfoReleaser = new ComRefReleaser(typeInfo);
             Assert.Equal(HRESULT.S_OK, hr);
 
             VARDESC* pVarDesc = null;
@@ -366,6 +382,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             IDispatch dispatch = (IDispatch)picture;
             ITypeInfo typeInfo;
             HRESULT hr = dispatch.GetTypeInfo(0, Kernel32.GetThreadLocale(), out typeInfo);
+            using var typeInfoReleaser = new ComRefReleaser(typeInfo);
             Assert.Equal(HRESULT.S_OK, hr);
 
             var dispParams = new DISPPARAMS();
@@ -393,6 +410,25 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             }
 
             public new static IPictureDisp GetIPictureDispFromPicture(Image image) => (IPictureDisp)AxHost.GetIPictureDispFromPicture(image);
+        }
+
+        private struct ComRefReleaser : IDisposable
+        {
+            private object _reference;
+
+            public ComRefReleaser(object reference)
+            {
+                _reference = reference;
+            }
+
+            public void Dispose()
+            {
+                if (_reference != null)
+                {
+                    Marshal.ReleaseComObject(_reference);
+                    _reference = null;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #3305
Fixes #3271

## Proposed changes
Release ITypeInfo RCW manually instead of letting the GC clean up

I'm doing this seperately from PR #3276 so it can be reviewed and merged before figuring out all the problems of the package updates.

## Customer Impact
Tests should become more stable regardless how they are run

## Regression? 
Yes (after merging PR #3276)

## Risk
no known risk

### Before
Tests start failing after PR #3276

### After
Tests should succeed before and after PR #3276

## Test methodology
Locally running tests both with and without PR #3276

## Test environment(s)
local


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3315)