### PR TITLE
manually release ITypeInfo references (missed one)

### DIFF
--- a/src/System.Windows.Forms.Primitives/tests/Interop/Oleaut32/IDispatchTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/Interop/Oleaut32/IDispatchTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -43,6 +43,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             HRESULT hr = dispatch.GetTypeInfo(0, Kernel32.GetThreadLocale(), out typeInfo);
             Assert.Equal(HRESULT.S_OK, hr);
             Assert.NotNull(typeInfo);
+            System.Runtime.InteropServices.Marshal.ReleaseComObject(typeInfo);
         }
 
         [WinFormsFact]

--- a/src/System.Windows.Forms.Primitives/tests/Interop/Oleaut32/ITypeInfoTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/Interop/Oleaut32/ITypeInfoTests.cs
@@ -255,6 +255,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
 
             ITypeInfo refTypeInfo;
             hr = typeInfo.GetRefTypeInfo(refType, out refTypeInfo);
+            using var refTypeInfoReleaser = new ComRefReleaser(refTypeInfo);
             Assert.Equal(HRESULT.S_OK, hr);
             Assert.NotNull(refTypeInfo);
         }


### PR DESCRIPTION
Fixes #3305
Relates to #3271

## Proposed changes
Release ITypeInfo RCW manually instead of letting the GC clean up. Original PR #3315 missed one reference, this generally made the test run more stable but it was still flaky.

## Customer Impact
Tests should become more stable regardless how they are run

## Regression? 
Yes (after merging PR #3276)

## Risk
no known risk

### Before
Tests start failing after PR #3276
Test were still failing occasionally after PR #3315

### After
Tests should succeed even more before and after PR #3276

## Test methodology
* Locally running (a lot of) tests with PR #3276
* Running PR #3276 with this fix on the CI machine (this PR is extracted from the nuget package update since it may still need some time)
* going through the test file and looking for ITypeInfo references

## Test environment(s)
local & CI

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3321)