### PR TITLE
Cleanup CopyMemory/WideCharToMultiByte

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ByteViewer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ByteViewer.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Windows.Forms;
+using static Interop;
 
 namespace System.ComponentModel.Design
 {
@@ -421,12 +422,20 @@ namespace System.ComponentModel.Design
         /// <summary>
         ///  Initializes the ansi string variable that will be assigned to the edit box.
         /// </summary>
-        private void InitAnsi()
+        private unsafe void InitAnsi()
         {
-            int size = _dataBuf.Length;
-            char[] text = new char[size + 1];
-            size = Interop.Kernel32.MultiByteToWideChar(0, 0, _dataBuf, size, text, size);
-            text[size] = (char)0;
+            char[] text;
+            int size;
+            fixed (byte* pDataBuff = _dataBuf)
+            {
+                size = Kernel32.MultiByteToWideChar(Kernel32.CP.ACP, 0, pDataBuff, _dataBuf.Length, null, 0);
+                text = new char[size + 1];
+                fixed (char* pText = text)
+                {
+                    size = Kernel32.MultiByteToWideChar(Kernel32.CP.ACP, 0, pDataBuff, size, pText, size);
+                }
+            }
+            text[size] = '\0';
 
             for (int i = 0; i < size; i++)
             {

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ByteViewerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ByteViewerTests.cs
@@ -1,0 +1,1124 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.IO;
+using System.Windows.Forms;
+using WinForms.Common.Tests;
+using Xunit;
+
+namespace System.ComponentModel.Design.Tests
+{
+    using Point = System.Drawing.Point;
+    using Size = System.Drawing.Size;
+
+    public class ByteViewerTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsFact]
+        public void ByteViewer_Ctor_Default()
+        {
+            using var control = new SubByteViewer();
+            Assert.Null(control.AccessibleDefaultActionDescription);
+            Assert.Null(control.AccessibleDescription);
+            Assert.Null(control.AccessibleName);
+            Assert.Equal(AccessibleRole.Default, control.AccessibleRole);
+            Assert.False(control.AllowDrop);
+            Assert.Equal(AnchorStyles.Top | AnchorStyles.Left, control.Anchor);
+            Assert.False(control.AutoScroll);
+            Assert.Equal(Size.Empty, control.AutoScrollMargin);
+            Assert.Equal(Size.Empty, control.AutoScrollMinSize);
+            Assert.Equal(Point.Empty, control.AutoScrollPosition);
+            Assert.False(control.AutoSize);
+            Assert.Equal(AutoSizeMode.GrowOnly, control.AutoSizeMode);
+            Assert.Equal(Control.DefaultBackColor, control.BackColor);
+            Assert.Null(control.BackgroundImage);
+            Assert.Equal(ImageLayout.Tile, control.BackgroundImageLayout);
+            Assert.Null(control.BindingContext);
+            Assert.Equal(BorderStyle.None, control.BorderStyle);
+            Assert.True(control.Bottom > 0);
+            Assert.Equal(new Rectangle(0, 0, control.Width, control.Height), control.Bounds);
+            Assert.True(control.CanEnableIme);
+            Assert.False(control.CanFocus);
+            Assert.True(control.CanRaiseEvents);
+            Assert.False(control.CanSelect);
+            Assert.False(control.Capture);
+            Assert.True(control.CausesValidation);
+            Assert.Equal(TableLayoutPanelCellBorderStyle.Inset, control.CellBorderStyle);
+            Assert.Equal(new Rectangle(0, 0, control.Width, control.Height), control.ClientRectangle);
+            Assert.Equal(new Size(control.Width, control.Height), control.ClientSize);
+            Assert.Equal(1, control.ColumnCount);
+            ColumnStyle columnStyle = Assert.IsType<ColumnStyle>(Assert.Single(control.ColumnStyles));
+            Assert.Equal(SizeType.Percent, columnStyle.SizeType);
+            Assert.Equal(100F, columnStyle.Width);
+            Assert.Same(control.LayoutSettings.ColumnStyles, control.ColumnStyles);
+            Assert.Null(control.Container);
+            Assert.False(control.ContainsFocus);
+            Assert.Null(control.ContextMenuStrip);
+            Assert.NotEmpty(control.Controls);
+            Assert.Same(control.Controls, control.Controls);
+            Assert.False(control.Created);
+            Assert.Equal(Cursors.Default, control.Cursor);
+            Assert.Equal(Cursors.Default, control.DefaultCursor);
+            Assert.Equal(ImeMode.Inherit, control.DefaultImeMode);
+            Assert.Equal(new Padding(3), control.DefaultMargin);
+            Assert.Equal(Size.Empty, control.DefaultMaximumSize);
+            Assert.Equal(Size.Empty, control.DefaultMinimumSize);
+            Assert.Equal(Padding.Empty, control.DefaultPadding);
+            Assert.Equal(new Size(200, 100), control.DefaultSize);
+            Assert.False(control.DesignMode);
+            Assert.Equal(new Rectangle(0, 0, control.Width, control.Height), control.DisplayRectangle);
+            Assert.Equal(DockStyle.None, control.Dock);
+            Assert.NotNull(control.DockPadding);
+            Assert.Same(control.DockPadding, control.DockPadding);
+            Assert.Equal(0, control.DockPadding.Top);
+            Assert.Equal(0, control.DockPadding.Bottom);
+            Assert.Equal(0, control.DockPadding.Left);
+            Assert.Equal(0, control.DockPadding.Right);
+            Assert.True(control.DoubleBuffered);
+            Assert.True(control.Enabled);
+            Assert.NotNull(control.Events);
+            Assert.Same(control.Events, control.Events);
+            Assert.False(control.Focused);
+            Assert.Equal(Control.DefaultFont, control.Font);
+            Assert.Equal(control.Font.Height, control.FontHeight);
+            Assert.Equal(Control.DefaultForeColor, control.ForeColor);
+            Assert.Equal(TableLayoutPanelGrowStyle.AddRows, control.GrowStyle);
+            Assert.True(control.HasChildren);
+            Assert.True(control.Height > 0);
+            Assert.NotNull(control.HorizontalScroll);
+            Assert.Same(control.HorizontalScroll, control.HorizontalScroll);
+            Assert.False(control.HScroll);
+            Assert.Equal(ImeMode.NoControl, control.ImeMode);
+            Assert.Equal(ImeMode.NoControl, control.ImeModeBase);
+            Assert.False(control.IsAccessible);
+            Assert.False(control.IsMirrored);
+            Assert.NotNull(control.LayoutEngine);
+            Assert.Same(control.LayoutEngine, control.LayoutEngine);
+            Assert.NotNull(control.LayoutSettings);
+            Assert.Same(control.LayoutSettings, control.LayoutSettings);
+            Assert.Equal(0, control.Left);
+            Assert.Equal(Point.Empty, control.Location);
+            Assert.Equal(new Padding(3), control.Margin);
+            Assert.Equal(Size.Empty, control.MaximumSize);
+            Assert.Equal(Size.Empty, control.MinimumSize);
+            Assert.Equal(Padding.Empty, control.Padding);
+            Assert.Null(control.Parent);
+            Assert.Equal(new Size(4, 4), control.PreferredSize);
+            Assert.Equal("Microsoft\u00AE .NET", control.ProductName);
+            Assert.False(control.RecreatingHandle);
+            Assert.Null(control.Region);
+            Assert.True(control.ResizeRedraw);
+            Assert.True(control.Right > 0);
+            Assert.Equal(RightToLeft.No, control.RightToLeft);
+            Assert.Equal(1, control.RowCount);
+            RowStyle rowStyle = Assert.IsType<RowStyle>(Assert.Single(control.RowStyles));
+            Assert.Equal(SizeType.Percent, rowStyle.SizeType);
+            Assert.Equal(100F, rowStyle.Height);
+            Assert.Same(control.LayoutSettings.RowStyles, control.RowStyles);
+            Assert.True(control.ShowFocusCues);
+            Assert.True(control.ShowKeyboardCues);
+            Assert.Equal(new Size(control.Width, control.Height), control.Size);
+            Assert.Equal(0, control.TabIndex);
+            Assert.False(control.TabStop);
+            Assert.Empty(control.Text);
+            Assert.Equal(0, control.Top);
+            Assert.Null(control.TopLevelControl);
+            Assert.False(control.UseWaitCursor);
+            Assert.True(control.Visible);
+            Assert.NotNull(control.VerticalScroll);
+            Assert.Same(control.VerticalScroll, control.VerticalScroll);
+            Assert.False(control.VScroll);
+            Assert.True(control.Width > 0);
+
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ByteViewer_CreateParams_GetDefault_ReturnsExpected()
+        {
+            using var control = new SubByteViewer();
+            CreateParams createParams = control.CreateParams;
+            Assert.Null(createParams.Caption);
+            Assert.Null(createParams.ClassName);
+            Assert.Equal(0x8, createParams.ClassStyle);
+            Assert.Equal(0x10000, createParams.ExStyle);
+            Assert.Equal(control.Height, createParams.Height);
+            Assert.Equal(IntPtr.Zero, createParams.Parent);
+            Assert.Null(createParams.Param);
+            Assert.Equal(0x56000000, createParams.Style);
+            Assert.Equal(control.Width, createParams.Width);
+            Assert.Equal(0, createParams.X);
+            Assert.Equal(0, createParams.Y);
+            Assert.Same(createParams, control.CreateParams);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ByteViewer_GetAutoSizeMode_Invoke_ReturnsExpected()
+        {
+            using var control = new SubByteViewer();
+            Assert.Equal(AutoSizeMode.GrowOnly, control.GetAutoSizeMode());
+        }
+
+        [WinFormsFact]
+        public void ByteViewer_GetBytes_Invoke_ReturnsExpected()
+        {
+            using var control = new ByteViewer();
+            Assert.Null(control.GetBytes());
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ByteViewer_GetDisplayMode_Invoke_ReturnsExpected()
+        {
+            using var control = new ByteViewer();
+            Assert.Equal(DisplayMode.Hexdump, control.GetDisplayMode());
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(0, true)]
+        [InlineData(SubByteViewer.ScrollStateAutoScrolling, false)]
+        [InlineData(SubByteViewer.ScrollStateFullDrag, false)]
+        [InlineData(SubByteViewer.ScrollStateHScrollVisible, false)]
+        [InlineData(SubByteViewer.ScrollStateUserHasScrolled, false)]
+        [InlineData(SubByteViewer.ScrollStateVScrollVisible, false)]
+        [InlineData(int.MaxValue, false)]
+        [InlineData((-1), false)]
+        public void ByteViewer_GetScrollState_Invoke_ReturnsExpected(int bit, bool expected)
+        {
+            using var control = new SubByteViewer();
+            Assert.Equal(expected, control.GetScrollState(bit));
+        }
+
+        [WinFormsTheory]
+        [InlineData(ControlStyles.ContainerControl, true)]
+        [InlineData(ControlStyles.UserPaint, true)]
+        [InlineData(ControlStyles.Opaque, false)]
+        [InlineData(ControlStyles.ResizeRedraw, true)]
+        [InlineData(ControlStyles.FixedWidth, false)]
+        [InlineData(ControlStyles.FixedHeight, false)]
+        [InlineData(ControlStyles.StandardClick, true)]
+        [InlineData(ControlStyles.Selectable, false)]
+        [InlineData(ControlStyles.UserMouse, false)]
+        [InlineData(ControlStyles.SupportsTransparentBackColor, true)]
+        [InlineData(ControlStyles.StandardDoubleClick, true)]
+        [InlineData(ControlStyles.AllPaintingInWmPaint, true)]
+        [InlineData(ControlStyles.CacheText, false)]
+        [InlineData(ControlStyles.EnableNotifyMessage, false)]
+        [InlineData(ControlStyles.DoubleBuffer, false)]
+        [InlineData(ControlStyles.OptimizedDoubleBuffer, true)]
+        [InlineData(ControlStyles.UseTextForAccessibility, true)]
+        [InlineData((ControlStyles)0, true)]
+        [InlineData((ControlStyles)int.MaxValue, false)]
+        [InlineData((ControlStyles)(-1), false)]
+        public void ByteViewer_GetStyle_Invoke_ReturnsExpected(ControlStyles flag, bool expected)
+        {
+            using var control = new SubByteViewer();
+            Assert.Equal(expected, control.GetStyle(flag));
+
+            // Call again to test caching.
+            Assert.Equal(expected, control.GetStyle(flag));
+        }
+
+        [WinFormsFact]
+        public void ByteViewer_GetTopLevel_Invoke_ReturnsExpected()
+        {
+            using var control = new SubByteViewer();
+            Assert.False(control.GetTopLevel());
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
+        public void ByteViewer_OnHandleCreated_InvokeWithHandle_CallsHandleCreated(EventArgs eventArgs)
+        {
+            using var control = new SubByteViewer();
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            int callCount = 0;
+            EventHandler handler = (sender, e) =>
+            {
+                Assert.Same(control, sender);
+                Assert.Same(eventArgs, e);
+                callCount++;
+            };
+
+            // Call with handler.
+            control.HandleCreated += handler;
+            control.OnHandleCreated(eventArgs);
+            Assert.Equal(1, callCount);
+            Assert.True(control.IsHandleCreated);
+
+            // Remove handler.
+            control.HandleCreated -= handler;
+            control.OnHandleCreated(eventArgs);
+            Assert.Equal(1, callCount);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
+        public void ByteViewer_OnHandleDestroyed_Invoke_CallsHandleDestroyed(EventArgs eventArgs)
+        {
+            using var control = new SubByteViewer();
+            int callCount = 0;
+            EventHandler handler = (sender, e) =>
+            {
+                Assert.Same(control, sender);
+                Assert.Same(eventArgs, e);
+                callCount++;
+            };
+
+            // Call with handler.
+            control.HandleDestroyed += handler;
+            control.OnHandleDestroyed(eventArgs);
+            Assert.Equal(1, callCount);
+            Assert.False(control.IsHandleCreated);
+
+            // Remove handler.
+            control.HandleDestroyed -= handler;
+            control.OnHandleDestroyed(eventArgs);
+            Assert.Equal(1, callCount);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
+        public void ByteViewer_OnHandleDestroyed_InvokeWithHandle_CallsHandleDestroyed(EventArgs eventArgs)
+        {
+            using var control = new SubByteViewer();
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            int callCount = 0;
+            EventHandler handler = (sender, e) =>
+            {
+                Assert.Same(control, sender);
+                Assert.Same(eventArgs, e);
+                callCount++;
+            };
+
+            // Call with handler.
+            control.HandleDestroyed += handler;
+            control.OnHandleDestroyed(eventArgs);
+            Assert.Equal(1, callCount);
+            Assert.True(control.IsHandleCreated);
+
+            // Remove handler.
+            control.HandleDestroyed -= handler;
+            control.OnHandleDestroyed(eventArgs);
+            Assert.Equal(1, callCount);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> OnLayout_TestData()
+        {
+            yield return new object[] { new LayoutEventArgs(null, null) };
+            yield return new object[] { new LayoutEventArgs(new Control(), null) };
+            yield return new object[] { new LayoutEventArgs(new Control(), string.Empty) };
+            yield return new object[] { new LayoutEventArgs(new Control(), "ChildIndex") };
+            yield return new object[] { new LayoutEventArgs(new Control(), "Visible") };
+            yield return new object[] { new LayoutEventArgs(new Control(), "Items") };
+            yield return new object[] { new LayoutEventArgs(new Control(), "Rows") };
+            yield return new object[] { new LayoutEventArgs(new Control(), "Columns") };
+            yield return new object[] { new LayoutEventArgs(new Control(), "RowStyles") };
+            yield return new object[] { new LayoutEventArgs(new Control(), "ColumnStyles") };
+            yield return new object[] { new LayoutEventArgs(new Control(), "TableIndex") };
+            yield return new object[] { new LayoutEventArgs(new Control(), "GrowStyle") };
+            yield return new object[] { new LayoutEventArgs(new Control(), "CellBorderStyle") };
+            yield return new object[] { new LayoutEventArgs(new Control(), "LayoutSettings") };
+            yield return new object[] { new LayoutEventArgs(new Control(), "NoSuchProperty") };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(OnLayout_TestData))]
+        public void ByteViewer_OnLayout_Invoke_CallsLayout(LayoutEventArgs eventArgs)
+        {
+            using var control = new SubByteViewer();
+            int callCount = 0;
+            LayoutEventHandler handler = (sender, e) =>
+            {
+                Assert.Same(control, sender);
+                Assert.Same(eventArgs, e);
+                callCount++;
+            };
+
+            // Call with handler.
+            control.Layout += handler;
+            control.OnLayout(eventArgs);
+            Assert.Equal(1, callCount);
+            Assert.False(control.IsHandleCreated);
+
+            // Remove handler.
+            control.Layout -= handler;
+            control.OnLayout(eventArgs);
+            Assert.Equal(1, callCount);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(OnLayout_TestData))]
+        public void ByteViewer_OnLayout_InvokeWithHandle_CallsLayout(LayoutEventArgs eventArgs)
+        {
+            using var control = new SubByteViewer();
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            int invalidatedCallCount = 0;
+            control.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            control.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            control.HandleCreated += (sender, e) => createdCallCount++;
+            int callCount = 0;
+            LayoutEventHandler handler = (sender, e) =>
+            {
+                Assert.Same(control, sender);
+                Assert.Same(eventArgs, e);
+                callCount++;
+            };
+
+            // Call with handler.
+            control.Layout += handler;
+            control.OnLayout(eventArgs);
+            Assert.Equal(1, callCount);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(1, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+
+            // Remove handler.
+            control.Layout -= handler;
+            control.OnLayout(eventArgs);
+            Assert.Equal(1, callCount);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(2, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+        }
+
+        [WinFormsFact]
+        public void ByteViewer_OnLayout_InvokeNullE_ThrowsNullReferenceException()
+        {
+            using var control = new SubByteViewer();
+            Assert.Throws<NullReferenceException>(() => control.OnLayout(null));
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetKeyEventArgsTheoryData))]
+        public void ByteViewer_OnKeyDown_Invoke_CallsKeyDown(KeyEventArgs eventArgs)
+        {
+            using var control = new SubByteViewer();
+            int callCount = 0;
+            KeyEventHandler handler = (sender, e) =>
+            {
+                Assert.Same(control, sender);
+                Assert.Same(eventArgs, e);
+                callCount++;
+            };
+
+            // Call with handler.
+            control.KeyDown += handler;
+            control.OnKeyDown(eventArgs);
+            Assert.Equal(0, callCount);
+
+            // Remove handler.
+            control.KeyDown -= handler;
+            control.OnKeyDown(eventArgs);
+            Assert.Equal(0, callCount);
+        }
+
+        [WinFormsFact]
+        public void ByteViewer_OnPaint_Invoke_CallsPaint()
+        {
+            using var image = new Bitmap(10, 10);
+            using Graphics graphics = Graphics.FromImage(image);
+            var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
+
+            using var control = new SubByteViewer();
+            int callCount = 0;
+            PaintEventHandler handler = (sender, e) =>
+            {
+                Assert.Same(control, sender);
+                Assert.Same(eventArgs, e);
+                callCount++;
+            };
+
+            // Call with handler.
+            control.Paint += handler;
+            control.OnPaint(eventArgs);
+            Assert.Equal(1, callCount);
+            Assert.False(control.IsHandleCreated);
+
+            // Remove handler.
+            control.Paint -= handler;
+            control.OnPaint(eventArgs);
+            Assert.Equal(1, callCount);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> OnPaint_WithBytes_TestData()
+        {
+            foreach (DisplayMode displayMode in Enum.GetValues(typeof(DisplayMode)))
+            {
+                yield return new object[] { Array.Empty<byte>(), displayMode };
+                yield return new object[] { new byte[] { 1, 2, 3 }, displayMode };
+                yield return new object[] { new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }, displayMode };
+                yield return new object[] { new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, displayMode };
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(OnPaint_WithBytes_TestData))]
+        public void ByteViewer_OnPaint_InvokeWithBytes_CallsPaint(byte[] bytes, DisplayMode displayMode)
+        {
+            using var image = new Bitmap(10, 10);
+            using Graphics graphics = Graphics.FromImage(image);
+            var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
+
+            using var control = new SubByteViewer();
+            control.SetBytes(bytes);
+            control.SetDisplayMode(displayMode);
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            int invalidatedCallCount = 0;
+            control.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            control.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            control.HandleCreated += (sender, e) => createdCallCount++;
+
+            int callCount = 0;
+            PaintEventHandler handler = (sender, e) =>
+            {
+                Assert.Same(control, sender);
+                Assert.Same(eventArgs, e);
+                callCount++;
+            };
+
+            // Call with handler.
+            control.Paint += handler;
+            control.OnPaint(eventArgs);
+            Assert.Equal(1, callCount);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+
+            // Remove handler.
+            control.Paint -= handler;
+            control.OnPaint(eventArgs);
+            Assert.Equal(1, callCount);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+        }
+
+        [WinFormsFact]
+        public void ByteViewer_OnPaint_InvokeWithHandle_CallsPaint()
+        {
+            using var image = new Bitmap(10, 10);
+            using Graphics graphics = Graphics.FromImage(image);
+            var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
+
+            using var control = new SubByteViewer();
+            int callCount = 0;
+            PaintEventHandler handler = (sender, e) =>
+            {
+                Assert.Same(control, sender);
+                Assert.Same(eventArgs, e);
+                callCount++;
+            };
+
+            // Call with handler.
+            control.Paint += handler;
+            control.OnPaint(eventArgs);
+            Assert.Equal(1, callCount);
+            Assert.False(control.IsHandleCreated);
+
+            // Remove handler.
+            control.Paint -= handler;
+            control.OnPaint(eventArgs);
+            Assert.Equal(1, callCount);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(OnPaint_WithBytes_TestData))]
+        public void ByteViewer_OnPaint_InvokeWithBytesWithHandle_CallsPaint(byte[] bytes, DisplayMode displayMode)
+        {
+            using var image = new Bitmap(10, 10);
+            using Graphics graphics = Graphics.FromImage(image);
+            var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
+
+            using var control = new SubByteViewer();
+            control.SetBytes(bytes);
+            control.SetDisplayMode(displayMode);
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            int invalidatedCallCount = 0;
+            control.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            control.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            control.HandleCreated += (sender, e) => createdCallCount++;
+
+            int callCount = 0;
+            PaintEventHandler handler = (sender, e) =>
+            {
+                Assert.Same(control, sender);
+                Assert.Same(eventArgs, e);
+                callCount++;
+            };
+
+            // Call with handler.
+            control.Paint += handler;
+            control.OnPaint(eventArgs);
+            Assert.Equal(1, callCount);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+
+            // Remove handler.
+            control.Paint -= handler;
+            control.OnPaint(eventArgs);
+            Assert.Equal(1, callCount);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+        }
+
+        [WinFormsFact]
+        public void ByteViewer_OnPaint_NullE_ThrowsNullReferenceException()
+        {
+            using var control = new SubByteViewer();
+            Assert.Throws<NullReferenceException>(() => control.OnPaint(null));
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetStringWithNullTheoryData))]
+        public void ByteViewer_SaveToFile_InvokeNoBytes_Nop(string path)
+        {
+            using var control = new ByteViewer();
+            control.SaveToFile(path);
+        }
+
+        [WinFormsFact]
+        public void ByteViewer_SaveToFile_InvokeWithBytes_Success()
+        {
+            using var control = new ByteViewer();
+            control.SetBytes(new byte[] { 1, 2, 3 });
+            string path = "ByteViewerContent";
+            try
+            {
+                control.SaveToFile(path);
+                Assert.Equal(new byte[] { 1, 2, 3 }, File.ReadAllBytes(path));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [WinFormsFact]
+        public void ByteViewer_SaveToFile_InvokeNullPath_ThrowsArgumentNullException()
+        {
+            using var control = new ByteViewer();
+            control.SetBytes(Array.Empty<byte>());
+            Assert.Throws<ArgumentNullException>("path", () => control.SaveToFile(null));
+        }
+
+        [WinFormsTheory]
+        [InlineData("")]
+        [InlineData("\0")]
+        public void ByteViewer_SaveToFile_InvokeInvalidPath_ThrowsArgumentException(string path)
+        {
+            using var control = new ByteViewer();
+            control.SetBytes(Array.Empty<byte>());
+            Assert.Throws<ArgumentException>("path", () => control.SaveToFile(path));
+        }
+
+        public static IEnumerable<object[]> ScrollChanged_TestData()
+        {
+            yield return new object[] { null, null };
+            yield return new object[] { null, new EventArgs() };
+            yield return new object[] { new object(), null };
+            yield return new object[] { new object(), new EventArgs() };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ScrollChanged_TestData))]
+        public void ByteViewer_ScrollChanged_Invoke_Success(object source, EventArgs e)
+        {
+            using var control = new SubByteViewer();
+            control.ScrollChanged(source, e);
+            Assert.False(control.IsHandleCreated);
+
+            // Call again.
+            control.ScrollChanged(source, e);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ScrollChanged_TestData))]
+        public void ByteViewer_ScrollChanged_InvokeWithHandle_Success(object source, EventArgs e)
+        {
+            using var control = new SubByteViewer();
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            int invalidatedCallCount = 0;
+            control.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            control.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            control.HandleCreated += (sender, e) => createdCallCount++;
+
+            control.ScrollChanged(source, e);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(1, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+
+            // Call again.
+            control.ScrollChanged(source, e);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(2, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+        }
+
+        public static IEnumerable<object[]> SetBytes_TestData()
+        {
+            yield return new object[] { Array.Empty<byte>() };
+            yield return new object[] { new byte[] { 1, 2, 3 } };
+            yield return new object[] { new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 } };
+            yield return new object[] { new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 } };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(SetBytes_TestData))]
+        public void ByteViewer_SetBytes_Invoke_GetReturnExpected(byte[] bytes)
+        {
+            using var control = new ByteViewer();
+            control.SetBytes(bytes);
+            Assert.Same(bytes, control.GetBytes());
+            Assert.False(control.IsHandleCreated);
+
+            // Set same.
+            control.SetBytes(bytes);
+            Assert.Same(bytes, control.GetBytes());
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(SetBytes_TestData))]
+        public void ByteViewer_SetBytes_InvokeWithBytes_GetReturnExpected(byte[] bytes)
+        {
+            using var control = new ByteViewer();
+            control.SetBytes(new byte[] { 1 });
+
+            control.SetBytes(bytes);
+            Assert.Same(bytes, control.GetBytes());
+            Assert.False(control.IsHandleCreated);
+
+            // Set same.
+            control.SetBytes(bytes);
+            Assert.Same(bytes, control.GetBytes());
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ByteViewer_SetBytes_NullBytes_ThrowsArgumentNullException()
+        {
+            using var control = new ByteViewer();
+            Assert.Throws<ArgumentNullException>("bytes", () => control.SetBytes(null));
+        }
+
+        [WinFormsTheory]
+        [InlineData(DisplayMode.Auto)]
+        [InlineData(DisplayMode.Hexdump)]
+        public void ByteViewer_SetDisplayMode_InvokeNoBytes_GetReturnsExpected(DisplayMode value)
+        {
+            using var control = new ByteViewer();
+            control.SetDisplayMode(value);
+            Assert.Equal(value, control.GetDisplayMode());
+            Assert.False(control.IsHandleCreated);
+
+            // Set same.
+            control.SetDisplayMode(value);
+            Assert.Equal(value, control.GetDisplayMode());
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(DisplayMode))]
+        public void ByteViewer_SetDisplayMode_InvokeWithBytes_GetReturnsExpected(DisplayMode value)
+        {
+            using var control = new ByteViewer();
+            control.SetBytes(new byte[] { 1, 2, 3 });
+
+            control.SetDisplayMode(value);
+            Assert.Equal(value, control.GetDisplayMode());
+            Assert.False(control.IsHandleCreated);
+
+            // Set same.
+            control.SetDisplayMode(value);
+            Assert.Equal(value, control.GetDisplayMode());
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(DisplayMode.Ansi, 2, 3)]
+        [InlineData(DisplayMode.Auto, 0, 0)]
+        [InlineData(DisplayMode.Hexdump, 0, 0)]
+        [InlineData(DisplayMode.Unicode, 2, 3)]
+        public void ByteViewer_SetDisplayMode_InvokeWithBytesWithHandle_GetReturnsExpected(DisplayMode value, int expectedInvalidatedCallCount1, int expectedInvalidatedCallCount2)
+        {
+            using var control = new ByteViewer();
+            control.SetBytes(new byte[] { 1, 2, 3 });
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            int invalidatedCallCount = 0;
+            control.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            control.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            control.HandleCreated += (sender, e) => createdCallCount++;
+
+            control.SetDisplayMode(value);
+            Assert.Equal(value, control.GetDisplayMode());
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(expectedInvalidatedCallCount1, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+
+            // Set same.
+            control.SetDisplayMode(value);
+            Assert.Equal(value, control.GetDisplayMode());
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(expectedInvalidatedCallCount2, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+        }
+
+        public static IEnumerable<object[]> SetDisplayMode_AnsiWithBytes_TestData()
+        {
+            yield return new object[] { new byte[] { 1, 2, 3 }, "\u0001\u0002\u0003" };
+            yield return new object[] { new byte[] { (byte)'a', (byte)'b', (byte)'c' }, "abc" };
+            yield return new object[] { new byte[] { (byte)'a', (byte)'b', (byte)'c', (byte)'\0', (byte)'d', (byte)'e', (byte)'f' }, $"abc\u000Bdef" };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(SetDisplayMode_AnsiWithBytes_TestData))]
+        public void ByteViewer_SetDisplayMode_AnsiWithBytes_EditReturnsExpected(byte[] bytes, string expected)
+        {
+            using var control = new ByteViewer();
+            control.SetBytes(bytes);
+            control.SetDisplayMode(DisplayMode.Ansi);
+
+            TextBox textBox = control.Controls.OfType<TextBox>().Single();
+            ScrollBar scrollBar = control.Controls.OfType<ScrollBar>().Single();
+            Assert.Equal(expected, textBox.Text);
+            Assert.True(textBox.Visible);
+            Assert.False(scrollBar.Visible);
+            Assert.False(control.IsHandleCreated);
+
+            // Set different.
+            control.SetBytes(new byte[] { (byte)'1', (byte)'2', (byte)'3' });
+            Assert.Equal("123", textBox.Text);
+            Assert.True(textBox.Visible);
+            Assert.False(scrollBar.Visible);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> SetDisplayMode_UnicodeWithBytes_TestData()
+        {
+            yield return new object[] { new byte[] { 1, 0, 2, 0, 3, 0 }, "\u0001\u0002\u0003" };
+            yield return new object[] { new byte[] { (byte)'a', 0, (byte)'b', 0, (byte)'c', 0 }, "abc" };
+            yield return new object[] { new byte[] { (byte)'a', 0, (byte)'b', 0, (byte)'c', 0, (byte)'\0', 0, (byte)'d', 0, (byte)'e', 0, (byte)'f', 0 }, $"abc\u000Bdef" };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(SetDisplayMode_UnicodeWithBytes_TestData))]
+        public void ByteViewer_SetDisplayMode_UnicodeWithBytes_EditReturnsExpected(byte[] bytes, string expected)
+        {
+            using var control = new ByteViewer();
+            control.SetBytes(bytes);
+            control.SetDisplayMode(DisplayMode.Unicode);
+
+            TextBox textBox = control.Controls.OfType<TextBox>().Single();
+            ScrollBar scrollBar = control.Controls.OfType<ScrollBar>().Single();
+            Assert.Equal(expected, textBox.Text);
+            Assert.True(textBox.Visible);
+            Assert.False(scrollBar.Visible);
+            Assert.False(control.IsHandleCreated);
+
+            // Set different.
+            control.SetBytes(new byte[] { (byte)'1', 0, (byte)'2', 0, (byte)'3', 0 });
+            Assert.Equal("123", textBox.Text);
+            Assert.True(textBox.Visible);
+            Assert.False(scrollBar.Visible);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(DisplayMode.Ansi)]
+        [InlineData(DisplayMode.Unicode)]
+        public void ByteViewer_SetDisplayMode_InvokeNoBytes_ThrowsNullReferenceException(DisplayMode value)
+        {
+            using var control = new ByteViewer();
+            Assert.Throws<NullReferenceException>(() => control.SetDisplayMode(value));
+            Assert.Equal(value, control.GetDisplayMode());
+            Assert.False(control.IsHandleCreated);
+
+            // Set same.
+            Assert.Throws<NullReferenceException>(() => control.SetDisplayMode(value));
+            Assert.Equal(value, control.GetDisplayMode());
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryDataInvalid), typeof(DisplayMode))]
+        public void ByteViewer_SetDisplayMode_InvokeInvalidMode_ThrowsInvalidEnumArgumentException(DisplayMode value)
+        {
+            using var control = new ByteViewer();
+            Assert.Throws<InvalidEnumArgumentException>("mode", () => control.SetDisplayMode(value));
+        }
+
+        [WinFormsFact]
+        public void ByteViewer_SetFile_InvokeNoBytes_Success()
+        {
+            using var control = new ByteViewer();
+            using TempFile file = TempFile.Create(new byte[] { 1, 2, 3 });
+            control.SetFile(file.Path);
+            Assert.Equal(new byte[] { 1, 2, 3, 0 }, control.GetBytes());
+        }
+
+        [WinFormsFact]
+        public void ByteViewer_SetFile_InvokeWithBytes_Success()
+        {
+            using var control = new ByteViewer();
+            control.SetBytes(new byte[] { 4, 5, 6 });
+
+            using TempFile file = TempFile.Create(new byte[] { 1, 2, 3 });
+            control.SetFile(file.Path);
+            Assert.Equal(new byte[] { 1, 2, 3, 0 }, control.GetBytes());
+        }
+
+        [WinFormsFact]
+        public void ByteViewer_SetFile_InvokeNullPath_ThrowsArgumentNullException()
+        {
+            using var control = new ByteViewer();
+            control.SetBytes(Array.Empty<byte>());
+            Assert.Throws<ArgumentNullException>("path", () => control.SetFile(null));
+        }
+
+        [WinFormsTheory]
+        [InlineData("")]
+        [InlineData("\0")]
+        public void ByteViewer_SetFile_InvokeInvalidPath_ThrowsArgumentException(string path)
+        {
+            using var control = new ByteViewer();
+            control.SetBytes(Array.Empty<byte>());
+            Assert.Throws<ArgumentException>("path", () => control.SetFile(path));
+        }
+
+        [WinFormsTheory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void ByteViewer_SetStartLine_InvokeNoBytes_Success(int line)
+        {
+            using var control = new ByteViewer();
+            control.SetStartLine(line);
+            Assert.False(control.IsHandleCreated);
+
+            // Call again.
+            control.SetStartLine(line);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> SetStartLine_WithBytes_TestData()
+        {
+            yield return new object[] { Array.Empty<byte>(), -1 };
+            yield return new object[] { Array.Empty<byte>(), 0 };
+            yield return new object[] { Array.Empty<byte>(), 1 };
+            yield return new object[] { Array.Empty<byte>(), int.MaxValue };
+            yield return new object[] { new byte[] { 1, 2, 3 }, -1 };
+            yield return new object[] { new byte[] { 1, 2, 3 }, 0 };
+            yield return new object[] { new byte[] { 1, 2, 3 }, 1 };
+            yield return new object[] { new byte[] { 1, 2, 3 }, int.MaxValue };
+            yield return new object[] { new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 }, -1 };
+            yield return new object[] { new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 }, 0 };
+            yield return new object[] { new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 }, 1 };
+            yield return new object[] { new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 }, int.MaxValue };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(SetStartLine_WithBytes_TestData))]
+        public void ByteViewer_SetStartLine_InvokeWithBytes_Success(byte[] bytes, int line)
+        {
+            using var control = new ByteViewer();
+            control.SetBytes(bytes);
+
+            control.SetStartLine(line);
+            Assert.False(control.IsHandleCreated);
+
+            // Call again.
+            control.SetStartLine(line);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(int.MaxValue)]
+        public void ByteViewer_SetStartLine_InvokeNoBytesWithHandle_Success(int line)
+        {
+            using var control = new ByteViewer();
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            int invalidatedCallCount = 0;
+            control.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            control.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            control.HandleCreated += (sender, e) => createdCallCount++;
+
+            control.SetStartLine(line);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+
+            // Call again.
+            control.SetStartLine(line);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(SetStartLine_WithBytes_TestData))]
+        public void ByteViewer_SetStartLine_InvokeWithBytesWithHandle_Success(byte[] bytes, int line)
+        {
+            using var control = new ByteViewer();
+            control.SetBytes(bytes);
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            int invalidatedCallCount = 0;
+            control.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            control.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            control.HandleCreated += (sender, e) => createdCallCount++;
+
+            control.SetStartLine(line);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+
+            // Call again.
+            control.SetStartLine(line);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+        }
+
+        private class SubByteViewer : ByteViewer
+        {
+            public new const int ScrollStateAutoScrolling = ByteViewer.ScrollStateAutoScrolling;
+
+            public new const int ScrollStateHScrollVisible = ByteViewer.ScrollStateHScrollVisible;
+
+            public new const int ScrollStateVScrollVisible = ByteViewer.ScrollStateVScrollVisible;
+
+            public new const int ScrollStateUserHasScrolled = ByteViewer.ScrollStateUserHasScrolled;
+
+            public new const int ScrollStateFullDrag = ByteViewer.ScrollStateFullDrag;
+
+            public new bool CanEnableIme => base.CanEnableIme;
+
+            public new bool CanRaiseEvents => base.CanRaiseEvents;
+
+            public new CreateParams CreateParams => base.CreateParams;
+
+            public new Cursor DefaultCursor => base.DefaultCursor;
+
+            public new ImeMode DefaultImeMode => base.DefaultImeMode;
+
+            public new Padding DefaultMargin => base.DefaultMargin;
+
+            public new Size DefaultMaximumSize => base.DefaultMaximumSize;
+
+            public new Size DefaultMinimumSize => base.DefaultMinimumSize;
+
+            public new Padding DefaultPadding => base.DefaultPadding;
+
+            public new Size DefaultSize => base.DefaultSize;
+
+            public new bool DesignMode => base.DesignMode;
+
+            public new bool DoubleBuffered
+            {
+                get => base.DoubleBuffered;
+                set => base.DoubleBuffered = value;
+            }
+
+            public new EventHandlerList Events => base.Events;
+
+            public new int FontHeight
+            {
+                get => base.FontHeight;
+                set => base.FontHeight = value;
+            }
+
+            public new ImeMode ImeModeBase
+            {
+                get => base.ImeModeBase;
+                set => base.ImeModeBase = value;
+            }
+
+            public new bool HScroll
+            {
+                get => base.HScroll;
+                set => base.HScroll = value;
+            }
+
+            public new bool ResizeRedraw
+            {
+                get => base.ResizeRedraw;
+                set => base.ResizeRedraw = value;
+            }
+
+            public new bool ShowFocusCues => base.ShowFocusCues;
+
+            public new bool ShowKeyboardCues => base.ShowKeyboardCues;
+
+            public new bool VScroll
+            {
+                get => base.VScroll;
+                set => base.VScroll = value;
+            }
+
+            public new AutoSizeMode GetAutoSizeMode() => base.GetAutoSizeMode();
+
+            public new bool GetScrollState(int bit) => base.GetScrollState(bit);
+
+            public new bool GetStyle(ControlStyles flag) => base.GetStyle(flag);
+
+            public new bool GetTopLevel() => base.GetTopLevel();
+
+            public new void OnHandleCreated(EventArgs e) => base.OnHandleCreated(e);
+
+            public new void OnHandleDestroyed(EventArgs e) => base.OnHandleDestroyed(e);
+
+            public new void OnLayout(LayoutEventArgs levent) => base.OnLayout(levent);
+
+            public new void OnKeyDown(KeyEventArgs e) => base.OnKeyDown(e);
+
+            public new void OnPaint(PaintEventArgs e) => base.OnPaint(e);
+
+            public new void ScrollChanged(object source, EventArgs e) => base.ScrollChanged(source, e);
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.CP.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.CP.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        public enum CP : uint
+        {
+            ACP = 0,
+            OEMCP = 1,
+            MACCP = 2,
+            THREAD_ACP = 3,
+            SYMBOL = 42,
+            UTF7 = 65000,
+            UTF8 = 65001,
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.MultiByteToWideChar.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.MultiByteToWideChar.cs
@@ -14,7 +14,13 @@ internal partial class Interop
         //            of WCHARs in the string, while the size of the Out buffer equals the number of bytes. To avoid a buffer overrun, be sure to specify
         //            a buffer size appropriate for the data type the buffer receives. For more information, see Security Considerations: International Features.
         //            Always call these functions passing a null destination buffer to get its size and the create the buffer with the exact size.
-        [DllImport(Libraries.Kernel32, ExactSpelling = true, CharSet = CharSet.Unicode, SetLastError = true)]
-        public static extern int MultiByteToWideChar(int CodePage, int dwFlags, byte[] lpMultiByteStr, int cchMultiByte, char[] lpWideCharStr, int cchWideChar);
+        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
+        public unsafe static extern int MultiByteToWideChar(
+            CP CodePage,
+            uint dwFlags,
+            byte* lpMultiByteStr,
+            int cchMultiByte,
+            char* lpWideCharStr,
+            int cchWideChar);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.WideCharToMultiByte.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.WideCharToMultiByte.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
+        public unsafe static extern int WideCharToMultiByte(
+            CP CodePage,
+            uint dwFlags,
+            char* lpWideCharStr,
+            int cchWideChar,
+            byte* lpMultiByteStr,
+            int cbMultiByte,
+            IntPtr lpDefaultChar,
+            BOOL* lpUsedDefaultChar);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.DROPFILES.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.DROPFILES.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+
+internal partial class Interop
+{
+    internal static partial class Shell32
+    {
+        public struct DROPFILES
+        {
+            public uint pFiles;
+            public Point pt;
+            public BOOL fNC;
+            public BOOL fWide;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -24,9 +24,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.Comdlg32, SetLastError = true, CharSet = CharSet.Auto)]
         public static extern bool GetOpenFileName([In, Out] NativeMethods.OPENFILENAME_I ofn);
 
-        [DllImport(ExternDll.Kernel32, ExactSpelling = true, CharSet = CharSet.Unicode)]
-        public static extern int WideCharToMultiByte(int codePage, int flags, [MarshalAs(UnmanagedType.LPWStr)]string wideStr, int chars, [In, Out]byte[] pOutBytes, int bufferBytes, IntPtr defaultChar, IntPtr pDefaultUsed);
-
         [DllImport(ExternDll.Kernel32, SetLastError = true, ExactSpelling = true, EntryPoint = "RtlMoveMemory", CharSet = CharSet.Auto)]
         public static extern void CopyMemory(HandleRef destData, HandleRef srcData, int size);
 

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -24,18 +24,6 @@ namespace System.Windows.Forms
         [DllImport(ExternDll.Comdlg32, SetLastError = true, CharSet = CharSet.Auto)]
         public static extern bool GetOpenFileName([In, Out] NativeMethods.OPENFILENAME_I ofn);
 
-        [DllImport(ExternDll.Kernel32, SetLastError = true, ExactSpelling = true, EntryPoint = "RtlMoveMemory", CharSet = CharSet.Auto)]
-        public static extern void CopyMemory(HandleRef destData, HandleRef srcData, int size);
-
-        [DllImport(ExternDll.Kernel32, ExactSpelling = true, EntryPoint = "RtlMoveMemory")]
-        public static extern void CopyMemory(IntPtr pdst, byte[] psrc, int cb);
-
-        [DllImport(ExternDll.Kernel32, ExactSpelling = true, EntryPoint = "RtlMoveMemory", CharSet = CharSet.Unicode)]
-        public static extern void CopyMemoryW(IntPtr pdst, string psrc, int cb);
-
-        [DllImport(ExternDll.Kernel32, ExactSpelling = true, EntryPoint = "RtlMoveMemory", CharSet = CharSet.Unicode)]
-        public static extern void CopyMemoryW(IntPtr pdst, char[] psrc, int cb);
-
         [DllImport(ExternDll.Kernel32, CharSet = CharSet.Auto, SetLastError = true)]
         public static extern int GetModuleFileName(HandleRef hModule, StringBuilder buffer, int length);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
@@ -873,9 +873,9 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Saves a list of files out to the handle in HDROP format.
         /// </summary>
-        private HRESULT SaveFileListToHandle(IntPtr handle, string[] files)
+        private unsafe HRESULT SaveFileListToHandle(IntPtr handle, string[] files)
         {
-            if (files == null || files.Length < 1)
+            if (files == null || files.Length == 0)
             {
                 return HRESULT.S_OK;
             }
@@ -885,18 +885,21 @@ namespace System.Windows.Forms
                 return HRESULT.E_INVALIDARG;
             }
 
-            IntPtr currentPtr = IntPtr.Zero;
-            uint baseStructSize = 4 + 8 + 4 + 4;
-            uint sizeInBytes = baseStructSize;
+            // CF_HDROP consists of a DROPFILES struct followed by an list of strings
+            // including the terminating null character. An additional null character
+            // is appended to the final string to terminate the array.
+            // E.g. if the files c:\temp1.txt and c:\temp2.txt are being transferred,
+            // the character array is: "c:\temp1.txt\0c:\temp2.txt\0\0"
 
-            // First determine the size of the array
+            // Determine the size of the data structure.
+            uint sizeInBytes = (uint)sizeof(Shell32.DROPFILES);
             for (int i = 0; i < files.Length; i++)
             {
                 sizeInBytes += ((uint)files[i].Length + 1) * 2;
             }
             sizeInBytes += 2;
 
-            // Alloc the Win32 memory
+            // Allocate the Win32 memory
             IntPtr newHandle = Kernel32.GlobalReAlloc(
                 handle,
                 sizeInBytes,
@@ -912,24 +915,31 @@ namespace System.Windows.Forms
                 return HRESULT.E_OUTOFMEMORY;
             }
 
-            currentPtr = basePtr;
+            // Write out the DROPFILES struct.
+            Shell32.DROPFILES* pDropFiles = (Shell32.DROPFILES*)basePtr;
+            pDropFiles->pFiles = (uint)sizeof(Shell32.DROPFILES);
+            pDropFiles->pt = Point.Empty;
+            pDropFiles->fNC = BOOL.FALSE;
+            pDropFiles->fWide = BOOL.TRUE;
 
-            // Write out the struct...
-            int[] structData = new int[] { (int)baseStructSize, 0, 0, 0, unchecked((int)0xFFFFFFFF) };
-            Marshal.Copy(structData, 0, currentPtr, structData.Length);
-            currentPtr = (IntPtr)((long)currentPtr + baseStructSize);
+            char* dataPtr = (char*)(basePtr + (int)pDropFiles->pFiles);
 
             // Write out the strings.
             for (int i = 0; i < files.Length; i++)
             {
-                UnsafeNativeMethods.CopyMemoryW(currentPtr, files[i], files[i].Length * 2);
-                currentPtr = (IntPtr)((long)currentPtr + (files[i].Length * 2));
-                Marshal.Copy(new byte[] { 0, 0 }, 0, currentPtr, 2);
-                currentPtr = (IntPtr)((long)currentPtr + 2);
+                int bytesToCopy = files[i].Length * 2;
+                fixed (char* pFile = files[i])
+                {
+                    Buffer.MemoryCopy(pFile, dataPtr, bytesToCopy, bytesToCopy);
+                }
+
+                dataPtr = (char*)((IntPtr)dataPtr + bytesToCopy);
+                *dataPtr = '\0';
+                dataPtr++;
             }
 
-            Marshal.Copy(new char[] { '\0' }, 0, currentPtr, 1);
-            currentPtr = (IntPtr)((long)currentPtr + 2);
+            *dataPtr = '\0';
+            dataPtr++;
 
             Kernel32.GlobalUnlock(newHandle);
             return HRESULT.S_OK;
@@ -939,12 +949,13 @@ namespace System.Windows.Forms
         ///  Save string to handle. If unicode is set to true
         ///  then the string is saved as Unicode, else it is saves as DBCS.
         /// </summary>
-        private HRESULT SaveStringToHandle(IntPtr handle, string str, bool unicode)
+        private unsafe HRESULT SaveStringToHandle(IntPtr handle, string str, bool unicode)
         {
             if (handle == IntPtr.Zero)
             {
                 return HRESULT.E_INVALIDARG;
             }
+
             IntPtr newHandle = IntPtr.Zero;
             if (unicode)
             {
@@ -958,78 +969,73 @@ namespace System.Windows.Forms
                     return HRESULT.E_OUTOFMEMORY;
                 }
 
-                IntPtr ptr = Kernel32.GlobalLock(newHandle);
-                if (ptr == IntPtr.Zero)
+                char* ptr = (char*)Kernel32.GlobalLock(newHandle);
+                if (ptr == null)
                 {
                     return HRESULT.E_OUTOFMEMORY;
                 }
 
-                char[] chars = str.ToCharArray(0, str.Length);
-                UnsafeNativeMethods.CopyMemoryW(ptr, chars, chars.Length * 2);
+                var data = new Span<char>(ptr, str.Length + 1);
+                str.AsSpan().CopyTo(data);
+                data[str.Length] = '\0'; // Null terminator.
             }
             else
             {
-                int pinvokeSize = UnsafeNativeMethods.WideCharToMultiByte(0 /*CP_ACP*/, 0, str, str.Length, null, 0, IntPtr.Zero, IntPtr.Zero);
-
-                byte[] strBytes = new byte[pinvokeSize];
-                UnsafeNativeMethods.WideCharToMultiByte(0 /*CP_ACP*/, 0, str, str.Length, strBytes, strBytes.Length, IntPtr.Zero, IntPtr.Zero);
-
-                newHandle = Kernel32.GlobalReAlloc(
-                    handle,
-                    (uint)pinvokeSize + 1,
-
-                    Kernel32.GMEM.MOVEABLE | Kernel32.GMEM.DDESHARE | Kernel32.GMEM.ZEROINIT);
-                if (newHandle == IntPtr.Zero)
+                fixed (char* pStr = str)
                 {
-                    return HRESULT.E_OUTOFMEMORY;
-                }
+                    int pinvokeSize = Kernel32.WideCharToMultiByte(Kernel32.CP.ACP, 0, pStr, str.Length, null, 0, IntPtr.Zero, null);
+                    newHandle = Kernel32.GlobalReAlloc(
+                        handle,
+                        (uint)pinvokeSize + 1,
+                        Kernel32.GMEM.MOVEABLE | Kernel32.GMEM.DDESHARE | Kernel32.GMEM.ZEROINIT);
+                    if (newHandle == IntPtr.Zero)
+                    {
+                        return HRESULT.E_OUTOFMEMORY;
+                    }
 
-                IntPtr ptr = Kernel32.GlobalLock(newHandle);
-                if (ptr == IntPtr.Zero)
-                {
-                    return HRESULT.E_OUTOFMEMORY;
-                }
+                    byte* ptr = (byte*)Kernel32.GlobalLock(newHandle);
+                    if (ptr == null)
+                    {
+                        return HRESULT.E_OUTOFMEMORY;
+                    }
 
-                UnsafeNativeMethods.CopyMemory(ptr, strBytes, pinvokeSize);
-                Marshal.Copy(new byte[] { 0 }, 0, (IntPtr)((long)ptr + pinvokeSize), 1);
+                    Kernel32.WideCharToMultiByte(Kernel32.CP.ACP, 0, pStr, str.Length, ptr, pinvokeSize, IntPtr.Zero, null);
+                    ptr[pinvokeSize] = 0; // Null terminator
+                }
             }
 
-            if (newHandle != IntPtr.Zero)
-            {
-                Kernel32.GlobalUnlock(newHandle);
-            }
+            Kernel32.GlobalUnlock(newHandle);
             return HRESULT.S_OK;
         }
 
-        private HRESULT SaveHtmlToHandle(IntPtr handle, string str)
+        private unsafe HRESULT SaveHtmlToHandle(IntPtr handle, string str)
         {
             if (handle == IntPtr.Zero)
             {
                 return HRESULT.E_INVALIDARG;
             }
-            IntPtr newHandle = IntPtr.Zero;
 
-            UTF8Encoding encoding = new UTF8Encoding();
-            byte[] bytes = encoding.GetBytes(str);
-            newHandle = Kernel32.GlobalReAlloc(
+            int byteLength = Encoding.UTF8.GetByteCount(str);
+            IntPtr newHandle = Kernel32.GlobalReAlloc(
                 handle,
-                (uint)bytes.Length + 1,
+                (uint)byteLength + 1,
                 Kernel32.GMEM.MOVEABLE | Kernel32.GMEM.DDESHARE | Kernel32.GMEM.ZEROINIT);
             if (newHandle == IntPtr.Zero)
             {
                 return HRESULT.E_OUTOFMEMORY;
             }
 
-            IntPtr ptr = Kernel32.GlobalLock(newHandle);
-            if (ptr == IntPtr.Zero)
+            byte* ptr = (byte*)Kernel32.GlobalLock(newHandle);
+            if (ptr == null)
             {
                 return HRESULT.E_OUTOFMEMORY;
             }
 
             try
             {
-                UnsafeNativeMethods.CopyMemory(ptr, bytes, bytes.Length);
-                Marshal.Copy(new byte[] { 0 }, 0, (IntPtr)((long)ptr + bytes.Length), 1);
+                var span = new Span<byte>(ptr, byteLength + 1);
+                Encoding.UTF8.GetBytes(str, span);
+                span[byteLength] = 0; // Null terminator
             }
             finally
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageList.ImageCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageList.ImageCollectionTests.cs
@@ -140,6 +140,124 @@ namespace System.Windows.Forms.Tests
             Assert.True(list.HandleCreated);
         }
 
+        [WinFormsFact]
+        public void ImageCollection_Item_Get32bppColorDepth_Success()
+        {
+            using var list = new ImageList
+            {
+                ColorDepth = ColorDepth.Depth32Bit
+            };
+            ImageList.ImageCollection collection = list.Images;
+
+            using var image1bppIndexedEmpty = new Bitmap(16, 16, PixelFormat.Format1bppIndexed);
+            collection.Add(image1bppIndexedEmpty);
+
+            using var image1bppIndexedCustom = new Bitmap(16, 16, PixelFormat.Format1bppIndexed);
+            collection.Add(image1bppIndexedCustom);
+
+            using var image24bppRgbEmpty = new Bitmap(16, 16, PixelFormat.Format24bppRgb);
+            collection.Add(image24bppRgbEmpty);
+
+            using var image24bppRgbCustom = new Bitmap(16, 16, PixelFormat.Format24bppRgb);
+            image24bppRgbCustom.SetPixel(0, 0, Color.Red);
+            image24bppRgbCustom.SetPixel(1, 0, Color.FromArgb(200, 50, 75, 100));
+            collection.Add(image24bppRgbCustom);
+
+            using var image32bppRgbEmpty = new Bitmap(16, 16, PixelFormat.Format32bppRgb);
+            collection.Add(image32bppRgbEmpty);
+
+            using var image32bppRgbCustom = new Bitmap(16, 16, PixelFormat.Format32bppRgb);
+            image32bppRgbCustom.SetPixel(0, 0, Color.Red);
+            image32bppRgbCustom.SetPixel(1, 0, Color.FromArgb(200, 50, 75, 100));
+            collection.Add(image32bppRgbCustom);
+
+            using var image32bppArgbEmpty = new Bitmap(16, 16, PixelFormat.Format32bppArgb);
+            collection.Add(image32bppArgbEmpty);
+
+            using var image32bppArgbCustom = new Bitmap(16, 16, PixelFormat.Format32bppArgb);
+            image32bppArgbCustom.SetPixel(0, 0, Color.Red);
+            image32bppArgbCustom.SetPixel(1, 0, Color.FromArgb(200, 50, 75, 100));
+            collection.Add(image32bppArgbCustom);
+
+            using var image32bppPargbEmpty = new Bitmap(16, 16, PixelFormat.Format32bppPArgb);
+            collection.Add(image32bppPargbEmpty);
+
+            using var image32bppPargbCustom = new Bitmap(16, 16, PixelFormat.Format32bppPArgb);
+            image32bppPargbCustom.SetPixel(0, 0, Color.Red);
+            image32bppPargbCustom.SetPixel(1, 0, Color.FromArgb(200, 50, 75, 100));
+            collection.Add(image32bppPargbCustom);
+
+            using Bitmap resultImage1bppEmpty = Assert.IsType<Bitmap>(collection[0]);
+            Assert.NotSame(image1bppIndexedEmpty, resultImage1bppEmpty);
+            Assert.Equal(new Size(16, 16), resultImage1bppEmpty.Size);
+            Assert.Equal(PixelFormat.Format32bppArgb, resultImage1bppEmpty.PixelFormat);
+            Assert.Equal(Color.FromArgb(0xFF, 0x00, 0x00, 0x00), resultImage1bppEmpty.GetPixel(0, 0));
+            Assert.Equal(Color.FromArgb(0xFF, 0x00, 0x00, 0x00), resultImage1bppEmpty.GetPixel(1, 0));
+
+            using Bitmap resultImage1bppRgbCustom = Assert.IsType<Bitmap>(collection[1]);
+            Assert.NotSame(image1bppIndexedCustom, resultImage1bppRgbCustom);
+            Assert.Equal(new Size(16, 16), resultImage1bppRgbCustom.Size);
+            Assert.Equal(PixelFormat.Format32bppArgb, resultImage1bppRgbCustom.PixelFormat);
+            Assert.Equal(Color.FromArgb(0xFF, 0x00, 0x00, 0x00), resultImage1bppRgbCustom.GetPixel(0, 0));
+            Assert.Equal(Color.FromArgb(0xFF, 0x00, 0x00, 0x00), resultImage1bppRgbCustom.GetPixel(1, 0));
+
+            using Bitmap resultImage24bppEmpty = Assert.IsType<Bitmap>(collection[4]);
+            Assert.NotSame(image24bppRgbEmpty, resultImage24bppEmpty);
+            Assert.Equal(new Size(16, 16), resultImage24bppEmpty.Size);
+            Assert.Equal(PixelFormat.Format32bppArgb, resultImage24bppEmpty.PixelFormat);
+            Assert.Equal(Color.FromArgb(0xFF, 0x00, 0x00, 0x00), resultImage24bppEmpty.GetPixel(0, 0));
+            Assert.Equal(Color.FromArgb(0xFF, 0x00, 0x00, 0x00), resultImage24bppEmpty.GetPixel(1, 0));
+
+            using Bitmap resultImage24bppRgbCustom = Assert.IsType<Bitmap>(collection[5]);
+            Assert.NotSame(image24bppRgbCustom, resultImage24bppRgbCustom);
+            Assert.Equal(new Size(16, 16), resultImage24bppRgbCustom.Size);
+            Assert.Equal(PixelFormat.Format32bppArgb, resultImage24bppRgbCustom.PixelFormat);
+            Assert.Equal(Color.FromArgb(0xFF, 0xFF, 0x00, 0x00), resultImage24bppRgbCustom.GetPixel(0, 0));
+            Assert.Equal(Color.FromArgb(0xFF, 50, 75, 100), resultImage24bppRgbCustom.GetPixel(1, 0));
+
+            using Bitmap resultImage32bppEmpty = Assert.IsType<Bitmap>(collection[4]);
+            Assert.NotSame(image32bppRgbEmpty, resultImage32bppEmpty);
+            Assert.Equal(new Size(16, 16), resultImage32bppEmpty.Size);
+            Assert.Equal(PixelFormat.Format32bppArgb, resultImage32bppEmpty.PixelFormat);
+            Assert.Equal(Color.FromArgb(0xFF, 0x00, 0x00, 0x00), resultImage32bppEmpty.GetPixel(0, 0));
+            Assert.Equal(Color.FromArgb(0xFF, 0x00, 0x00, 0x00), resultImage32bppEmpty.GetPixel(1, 0));
+
+            using Bitmap resultImage32bppRgbCustom = Assert.IsType<Bitmap>(collection[5]);
+            Assert.NotSame(image32bppRgbCustom, resultImage32bppRgbCustom);
+            Assert.Equal(new Size(16, 16), resultImage32bppRgbCustom.Size);
+            Assert.Equal(PixelFormat.Format32bppArgb, resultImage32bppRgbCustom.PixelFormat);
+            Assert.Equal(Color.FromArgb(0xFF, 0xFF, 0x00, 0x00), resultImage32bppRgbCustom.GetPixel(0, 0));
+            Assert.Equal(Color.FromArgb(0xFF, 50, 75, 100), resultImage32bppRgbCustom.GetPixel(1, 0));
+
+            using Bitmap resultImage32bppArgbEmpty = Assert.IsType<Bitmap>(collection[6]);
+            Assert.NotSame(image32bppArgbEmpty, resultImage32bppArgbEmpty);
+            Assert.Equal(new Size(16, 16), resultImage32bppArgbEmpty.Size);
+            Assert.Equal(PixelFormat.Format32bppArgb, resultImage32bppArgbEmpty.PixelFormat);
+            Assert.Equal(Color.FromArgb(0x00, 0x00, 0x00, 0x00), resultImage32bppArgbEmpty.GetPixel(0, 0));
+            Assert.Equal(Color.FromArgb(0x00, 0x00, 0x00, 0x00), resultImage32bppArgbEmpty.GetPixel(1, 0));
+
+            using Bitmap resultImage32bppArgbCustom = Assert.IsType<Bitmap>(collection[7]);
+            Assert.NotSame(image32bppArgbCustom, resultImage32bppArgbCustom);
+            Assert.Equal(new Size(16, 16), resultImage32bppArgbCustom.Size);
+            Assert.Equal(PixelFormat.Format32bppArgb, resultImage32bppArgbCustom.PixelFormat);
+            Assert.Equal(Color.FromArgb(0xFF, 0xFF, 0x00, 0x00), resultImage32bppArgbCustom.GetPixel(0, 0));
+            Assert.Equal(Color.FromArgb(0xC8, 0x55, 0x68, 0x7B), resultImage32bppArgbCustom.GetPixel(1, 0));
+
+            using Bitmap resultImage32bppPargbEmpty = Assert.IsType<Bitmap>(collection[8]);
+            Assert.NotSame(image32bppPargbEmpty, resultImage32bppPargbEmpty);
+            Assert.Equal(new Size(16, 16), resultImage32bppPargbEmpty.Size);
+            Assert.Equal(PixelFormat.Format32bppArgb, resultImage32bppPargbEmpty.PixelFormat);
+            Assert.Equal(Color.FromArgb(0x00, 0x00, 0x00, 0x00), resultImage32bppPargbEmpty.GetPixel(0, 0));
+            Assert.Equal(Color.FromArgb(0x00, 0x00, 0x00, 0x00), resultImage32bppPargbEmpty.GetPixel(1, 0));
+
+            using Bitmap resultImage32bppPargbCustom = Assert.IsType<Bitmap>(collection[9]);
+            Assert.NotSame(image32bppPargbCustom, resultImage32bppPargbCustom);
+            Assert.Equal(new Size(16, 16), resultImage32bppPargbCustom.Size);
+            Assert.Equal(PixelFormat.Format32bppArgb, resultImage32bppPargbCustom.PixelFormat);
+            Assert.Equal(Color.FromArgb(0xFF, 0xFF, 0x00, 0x00), resultImage32bppPargbCustom.GetPixel(0, 0));
+            Assert.Equal(Color.FromArgb(0xC8, 0x55, 0x68, 0x7B), resultImage32bppPargbCustom.GetPixel(1, 0));
+        }
+
         [WinFormsTheory]
         [InlineData(-1)]
         [InlineData(0)]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TableLayoutPanelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TableLayoutPanelTests.cs
@@ -18,7 +18,7 @@ namespace System.Windows.Forms.Tests
     public class TableLayoutPanelTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]
-        public void Panel_Ctor_Default()
+        public void TableLayoutPanel_Ctor_Default()
         {
             using var control = new SubTableLayoutPanel();
             Assert.Null(control.AccessibleDefaultActionDescription);
@@ -129,6 +129,26 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.VScroll);
             Assert.Equal(200, control.Width);
 
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TableLayoutPanel_CreateParams_GetDefault_ReturnsExpected()
+        {
+            using var control = new SubTableLayoutPanel();
+            CreateParams createParams = control.CreateParams;
+            Assert.Null(createParams.Caption);
+            Assert.Null(createParams.ClassName);
+            Assert.Equal(0x8, createParams.ClassStyle);
+            Assert.Equal(0x10000, createParams.ExStyle);
+            Assert.Equal(100, createParams.Height);
+            Assert.Equal(IntPtr.Zero, createParams.Parent);
+            Assert.Null(createParams.Param);
+            Assert.Equal(0x56000000, createParams.Style);
+            Assert.Equal(200, createParams.Width);
+            Assert.Equal(0, createParams.X);
+            Assert.Equal(0, createParams.Y);
+            Assert.Same(createParams, control.CreateParams);
             Assert.False(control.IsHandleCreated);
         }
 
@@ -1218,6 +1238,86 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, callCount);
         }
 
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
+        public void TableLayoutPanel_OnHandleCreated_InvokeWithHandle_CallsHandleCreated(EventArgs eventArgs)
+        {
+            using var control = new SubTableLayoutPanel();
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            int callCount = 0;
+            EventHandler handler = (sender, e) =>
+            {
+                Assert.Same(control, sender);
+                Assert.Same(eventArgs, e);
+                callCount++;
+            };
+
+            // Call with handler.
+            control.HandleCreated += handler;
+            control.OnHandleCreated(eventArgs);
+            Assert.Equal(1, callCount);
+            Assert.True(control.IsHandleCreated);
+
+            // Remove handler.
+            control.HandleCreated -= handler;
+            control.OnHandleCreated(eventArgs);
+            Assert.Equal(1, callCount);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
+        public void TableLayoutPanel_OnHandleDestroyed_Invoke_CallsHandleDestroyed(EventArgs eventArgs)
+        {
+            using var control = new SubTableLayoutPanel();
+            int callCount = 0;
+            EventHandler handler = (sender, e) =>
+            {
+                Assert.Same(control, sender);
+                Assert.Same(eventArgs, e);
+                callCount++;
+            };
+
+            // Call with handler.
+            control.HandleDestroyed += handler;
+            control.OnHandleDestroyed(eventArgs);
+            Assert.Equal(1, callCount);
+            Assert.False(control.IsHandleCreated);
+
+            // Remove handler.
+            control.HandleDestroyed -= handler;
+            control.OnHandleDestroyed(eventArgs);
+            Assert.Equal(1, callCount);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEventArgsTheoryData))]
+        public void TableLayoutPanel_OnHandleDestroyed_InvokeWithHandle_CallsHandleDestroyed(EventArgs eventArgs)
+        {
+            using var control = new SubTableLayoutPanel();
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            int callCount = 0;
+            EventHandler handler = (sender, e) =>
+            {
+                Assert.Same(control, sender);
+                Assert.Same(eventArgs, e);
+                callCount++;
+            };
+
+            // Call with handler.
+            control.HandleDestroyed += handler;
+            control.OnHandleDestroyed(eventArgs);
+            Assert.Equal(1, callCount);
+            Assert.True(control.IsHandleCreated);
+
+            // Remove handler.
+            control.HandleDestroyed -= handler;
+            control.OnHandleDestroyed(eventArgs);
+            Assert.Equal(1, callCount);
+            Assert.True(control.IsHandleCreated);
+        }
+
         public static IEnumerable<object[]> OnLayout_TestData()
         {
             yield return new object[] { new LayoutEventArgs(null, null) };
@@ -2141,6 +2241,10 @@ namespace System.Windows.Forms.Tests
             public new bool GetTopLevel() => base.GetTopLevel();
 
             public new void OnCellPaint(TableLayoutCellPaintEventArgs e) => base.OnCellPaint(e);
+
+            public new void OnHandleCreated(EventArgs e) => base.OnHandleCreated(e);
+
+            public new void OnHandleDestroyed(EventArgs e) => base.OnHandleDestroyed(e);
 
             public new void OnLayout(LayoutEventArgs levent) => base.OnLayout(levent);
 


### PR DESCRIPTION
## Proposed Changes
- Cleanup CopyMemory/WideCharToMultiByte


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3324)