### PR TITLE
Avoid initializing native tools twice

### DIFF
--- a/eng/configure-toolset.ps1
+++ b/eng/configure-toolset.ps1
@@ -1,4 +1,2 @@
-$DoNotAbortNativeToolsInstallationOnFailure = $true
-$DoNotDisplayNativeToolsInstallationWarnings = $true
-
-. $PsScriptRoot\common\init-tools-native.ps1 -InstallDirectory $PSScriptRoot\..\.tools\native -GlobalJsonFile $PSScriptRoot\..\global.json
+$script:DoNotAbortNativeToolsInstallationOnFailure = $true
+$script:DoNotDisplayNativeToolsInstallationWarnings = $true

--- a/eng/packageContent.targets
+++ b/eng/packageContent.targets
@@ -14,20 +14,20 @@
   <PropertyGroup>
     <!-- Also in global.json -->
     <DotNetApiDocsNetCoreApp30>0.0.0.1</DotNetApiDocsNetCoreApp30>
-    <IntellisenseXmlDir>$(RepositoryToolsDir)native\bin\dotnet-api-docs_netcoreapp3.0\$(DotNetApiDocsNetCoreApp30)\_intellisense\netcore-3.0\</IntellisenseXmlDir>
+    <IntellisenseXmlDir>$(RepositoryToolsDir)\bin\dotnet-api-docs_netcoreapp3.0\$(DotNetApiDocsNetCoreApp30)\_intellisense\netcore-3.0\</IntellisenseXmlDir>
   </PropertyGroup>
 
   <PropertyGroup>
     <IntellisenseXmlFileSource>$(IntellisenseXmlDir)$(AssemblyName).xml</IntellisenseXmlFileSource>
     <!-- TODO: remove when we get dotnet-api-docs_netcoreapp5.0 -->
     <IntellisenseXmlFileSource Condition="!Exists('$(IntellisenseXmlFileSource)')">$([System.IO.Path]::ChangeExtension('$(TargetPath)', '.xml'))</IntellisenseXmlFileSource>
-    
+
     <IntellisenseXml Condition="'$(ProduceReferenceAssembly)' == 'true' And '$(PackageAsRefAndLib)' != 'true'" >$([System.IO.Path]::ChangeExtension('$(TargetRefPath)', '.xml'))</IntellisenseXml>
     <IntellisenseXml Condition="'$(PackageAsRefAndLib)' == 'true'" >$([System.IO.Path]::ChangeExtension('$(TargetPath)', '.xml'))</IntellisenseXml>
 
     <IntellisenseXmlDir Condition="'$(IntellisenseXml)' != ''">$([System.IO.Path]::GetDirectoryName('$(IntellisenseXml)'))</IntellisenseXmlDir>
   </PropertyGroup>
-  
+
   <Target Name="GetPackageContent"
           DependsOnTargets="SatelliteDllsProjectOutputGroup"
           Returns="@(PackageFile)">
@@ -35,8 +35,8 @@
       <PackageFile Include="$(TargetPath)" PackagePath="$(PackagePath)" />
       <PackageFile Condition="'$(IncludePdbInPackage)' == 'true'" Include="$(TargetDir)$(TargetName).pdb" PackagePath="$(PackagePath)" />
       <PackageFile Condition="'$(ProduceReferenceAssembly)' == 'true'" Include="$(TargetRefPath)" PackagePath="$(RefPackagePath)" />
-      <PackageFile Condition="'$(ProduceReferenceAssembly)' == 'true' Or '$(PackageAsRefAndLib)' == 'true'" 
-                   Include="$(IntellisenseXml)" 
+      <PackageFile Condition="'$(ProduceReferenceAssembly)' == 'true' Or '$(PackageAsRefAndLib)' == 'true'"
+                   Include="$(IntellisenseXml)"
                    PackagePath="$(RefPackagePath)" />
       <PackageFile Condition="'$(PackageAsRefAndLib)' == 'true'" Include="$(TargetPath)" PackagePath="$(RefPackagePath)" />
       <PackageFile Condition="'$(IncludeResourcesInPackage)' == 'true'"
@@ -44,20 +44,20 @@
                    PackagePath="$(PackagePath)/%(SatelliteDllsProjectOutputGroupOutput.Culture)" />
     </ItemGroup>
   </Target>
-  
+
   <!-- xml files can be added here for intellisense -->
   <Target Name="CopyIntellisenseXmlsToTargetRefPath"
           AfterTargets="Build"
           Inputs="$(IntellisenseXmlFileSource)"
           Outputs="$(IntellisenseXml)"
           Condition="'$(ProduceReferenceAssembly)' == 'true' Or '$(PackageAsRefAndLib)' == 'true'">
-    
+
     <Message Condition="!Exists('$(IntellisenseXmlFileSource)')"
              Text="$(IntellisenseXmlFileSource) is missing" />
 
     <MakeDir Condition="!Exists('$(IntellisenseXmlDir)')"
              Directories="$([System.IO.Path]::GetDirectoryName('$(IntellisenseXml)'))" />
-    
+
     <Copy SourceFiles="$(IntellisenseXmlFileSource)"
           Condition="Exists('$(IntellisenseXmlFileSource)')"
           DestinationFiles="$(IntellisenseXml)"


### PR DESCRIPTION
## Proposed Changes
Example log from running `build.ps1`
```
PS C:\Users\hughbe\Documents\GitHub\winforms> .\build-local.ps1
Building the solution...
Processing C:\Users\hughbe\Documents\GitHub\winforms\eng\..\global.json
File 'C:\Users\hughbe\.netcoreeng\native\temp\cmake-3.14.2-win64-x64.zip' already exists, skipping download
File 'C:\Users\hughbe\.netcoreeng\native\temp\WinShimmer.zip' already exists, skipping download
VERBOSE: Extracting 'C:\Users\hughbe\.netcoreeng\native\temp\WinShimmer.zip' to
'C:\Users\hughbe\Documents\GitHub\winforms\eng\..\.tools\native\bin\WinShimmer'
File 'C:\Users\hughbe\.netcoreeng\native\temp\dotnet-api-docs_netcoreapp3.0-0.0.0.1-win64-x64.zip' already exists, skipping download
dotnet-api-docs_netcoreapp3.0 was not found in .
Native tools bootstrap failed
The property 'path' cannot be found on this object. Verify that the property exists.
exit /b 1
Processing C:\Users\hughbe\Documents\GitHub\winforms\global.json
cmake.exe already exists; replacing...
dotnet-api-docs_netcoreapp3.0 was not found in .
Native tools bootstrap failed
GET https://dot.net/v1/dotnet-install.ps1
dotnet-install: Downloading link: https://dotnetcli.azureedge.net/dotnet/Sdk/5.0.100-preview.5.20251.2/dotnet-sdk-5.0.100-preview.5.20251.2-win-x64.zip
dotnet-install: Extracting zip from https://dotnetcli.azureedge.net/dotnet/Sdk/5.0.100-preview.5.20251.2/dotnet-sdk-5.0.100-preview.5.20251.2-win-x64.zip
dotnet-install: Adding to current process PATH: "C:\Users\hughbe\Documents\GitHub\winforms\.dotnet\". Note: This change will not be visible if PowerShell was run as a child process.
dotnet-install: Installation finished
C:\Users\hughbe\Documents\GitHub\winforms\.dotnet\sdk\5.0.100-preview.5.20251.2\MSBuild.dll /nologo -distributedlogger:Microsoft.DotNet.Tools.MSBuild.MSBuildLogger,C:\Users\hughbe\Documents\GitHub\winforms\.dotnet\sdk\5.0.100-preview.5.20251.2\dotnet.dll*Microsoft.DotNet.Tools.MSBuild.MSBuildForwardingLogger,C:\Users\hughbe\Documents\GitHub\winforms\.dotnet\sdk\5.0.100-preview.5.20251.2\dotnet.dll -maxcpucount /m -verbosity:m /v:minimal /bl:C:\Users\hughbe\Documents\GitHub\winforms\artifacts\log\Debug\ToolsetRestore.binlog /clp:Summary /clp:ErrorsOnly;NoSummary /nr:True /p:ContinuousIntegrationBuild=False /p:TreatWarningsAsErrors=true /p:__ToolsetLocationOutputFile=C:\Users\hughbe\Documents\GitHub\winforms\artifacts\toolset\5.0.0-beta.20261.9.txt /t:__WriteToolsetLocation /warnaserror C:\Users\hughbe\Documents\GitHub\winforms\artifacts\toolset\restore.proj
C:\Users\hughbe\Documents\GitHub\winforms\.dotnet\sdk\5.0.100-preview.5.20251.2\MSBuild.dll /nologo -distributedlogger:Microsoft.DotNet.Tools.MSBuild.MSBuildLogger,C:\Users\hughbe\Documents\GitHub\winforms\.dotnet\sdk\5.0.100-preview.5.20251.2\dotnet.dll*Microsoft.DotNet.Tools.MSBuild.MSBuildForwardingLogger,C:\Users\hughbe\Documents\GitHub\winforms\.dotnet\sdk\5.0.100-preview.5.20251.2\dotnet.dll -maxcpucount /m -verbosity:m /v:minimal /bl:C:\Users\hughbe\Documents\GitHub\winforms\artifacts\log\Debug\Build.binlog /clp:Summary /nr:True /p:ContinuousIntegrationBuild=False /p:TreatWarningsAsErrors=true /p:Configuration=Debug /p:RepoRoot=C:\Users\hughbe\Documents\GitHub\winforms /p:Restore=True /p:DeployDeps=False /p:Build=True /p:Rebuild=False /p:Deploy=False /p:Test=False /p:Pack=False /p:IntegrationTest=False /p:PerformanceTest=False /p:Sign=False /p:Publish=False /warnaserror C:\Users\hughbe\.nuget\packages\microsoft.dotnet.arcade.sdk\5.0.0-beta.20261.9\tools\Build.proj
  Determining projects to restore...
  Restored C:\Users\hughbe\.nuget\packages\microsoft.dotnet.arcade.sdk\5.0.0-beta.20261.9\tools\Tools.proj (in 566 ms).
Processing C:\Users\hughbe\Documents\GitHub\winforms\eng\..\global.json
cmake.exe already exists; replacing...
dotnet-api-docs_netcoreapp3.0 was not found in .
Native tools bootstrap failed
The property 'path' cannot be found on this object. Verify that the property exists.
exit /b 1
dotnet-install: Downloading link: https://dotnetcli.azureedge.net/dotnet/Runtime/5.0.0-preview.6.20271.10/dotnet-runtime-5.0.0-preview.6.20271.10-win-x64.zip
dotnet-install: Extracting zip from https://dotnetcli.azureedge.net/dotnet/Runtime/5.0.0-preview.6.20271.10/dotnet-runtime-5.0.0-preview.6.20271.10-win-x64.zip
dotnet-install: Installation finished
  Determining projects to restore...
  Determining projects to restore...
...
```

Note that we have two entries for `Processing C:\Users\hughbe\Documents\GitHub\winforms\eng\..\global.json`

This is because we actually shouldn't be calling `init-tools-native` from `configure-toolset.ps1`. `init-tools-native` is called in `build.ps1`: https://github.com/dotnet/arcade/blob/8078d8f3f77b7e8b7f6e289cf82cfdfa9c7a9355/eng/common/build.ps1#L146

Therefore we end up calling this twice

Also make the variables `script:` prefixed to match dotnet/runtime https://github.com/dotnet/runtime/blob/master/eng/configure-toolset.ps1

Would be nice to get this script documented in arcade: https://github.com/dotnet/arcade/issues/1456

@RussKie could you copy in an arcade folk to make sure this is the right thing if you think