### PR TITLE
Avoid unnecessarily creating ToolStripDropDownMenu due to keyboard tooltip hook

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
@@ -21,6 +21,7 @@ namespace System.Windows.Forms
     {
         private ToolStripDropDown dropDown = null;
         private ToolStripDropDownDirection toolStripDropDownDirection = ToolStripDropDownDirection.Default;
+        private ToolTip hookedKeyboardTooltip = null;
         private static readonly object EventDropDownShow = new object();
         private static readonly object EventDropDownHide = new object();
         private static readonly object EventDropDownOpened = new object();
@@ -81,6 +82,10 @@ namespace System.Windows.Forms
                 {
                     if (dropDown != null)
                     {
+                        if (hookedKeyboardTooltip != null)
+                        {
+                            KeyboardToolTipStateMachine.Instance.Unhook(dropDown, hookedKeyboardTooltip);
+                        }
                         dropDown.Opened -= new EventHandler(DropDown_Opened);
                         dropDown.Closed -= new ToolStripDropDownClosedEventHandler(DropDown_Closed);
                         dropDown.ItemClicked -= new ToolStripItemClickedEventHandler(DropDown_ItemClicked);
@@ -90,6 +95,10 @@ namespace System.Windows.Forms
                     dropDown = value;
                     if (dropDown != null)
                     {
+                        if (hookedKeyboardTooltip != null)
+                        {
+                            KeyboardToolTipStateMachine.Instance.Hook(dropDown, hookedKeyboardTooltip);
+                        }
                         dropDown.Opened += new EventHandler(DropDown_Opened);
                         dropDown.Closed += new ToolStripDropDownClosedEventHandler(DropDown_Closed);
                         dropDown.ItemClicked += new ToolStripItemClickedEventHandler(DropDown_ItemClicked);
@@ -338,6 +347,11 @@ namespace System.Windows.Forms
         {
             if (dropDown != null)
             {
+                if (hookedKeyboardTooltip != null)
+                {
+                    KeyboardToolTipStateMachine.Instance.Unhook(dropDown, hookedKeyboardTooltip);
+                }
+
                 dropDown.Opened -= new EventHandler(DropDown_Opened);
                 dropDown.Closed -= new ToolStripDropDownClosedEventHandler(DropDown_Closed);
                 dropDown.ItemClicked -= new ToolStripItemClickedEventHandler(DropDown_ItemClicked);
@@ -684,13 +698,21 @@ namespace System.Windows.Forms
         internal override void OnKeyboardToolTipHook(ToolTip toolTip)
         {
             base.OnKeyboardToolTipHook(toolTip);
-            KeyboardToolTipStateMachine.Instance.Hook(DropDown, toolTip);
+            hookedKeyboardTooltip = toolTip;
+            if (dropDown != null)
+            {
+                KeyboardToolTipStateMachine.Instance.Hook(dropDown, toolTip);
+            }
         }
 
         internal override void OnKeyboardToolTipUnhook(ToolTip toolTip)
         {
             base.OnKeyboardToolTipUnhook(toolTip);
-            KeyboardToolTipStateMachine.Instance.Unhook(DropDown, toolTip);
+            hookedKeyboardTooltip = null;
+            if (dropDown != null)
+            {
+                KeyboardToolTipStateMachine.Instance.Unhook(dropDown, toolTip);
+            }
         }
 
         internal override void ToolStrip_RescaleConstants(int oldDpi, int newDpi)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3248

## Proposed changes

- Avoid accessing the `DropDown` property of menu items when there is no drop-down present. The property would always create one which is unintended.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Less memory used

## Regression? 

- Not sure. I couldn't track down when the code for keyboard hooks was first added, the rest of the code tries to avoid unintentionally creating the drop-down objects.

## Risk

- Low

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

- Tested on production application running under SciTech Memory Profiler

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 5 (master, winforms@d851dac649d74c3a1d2b416713dd22de14b93fe1)
- .NET Core 3.1.200 with backported fix

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3337)