### PR TITLE
Add FontProperty.TextFont

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/UxTheme/Interop.TMT.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UxTheme/Interop.TMT.cs
@@ -13,6 +13,8 @@ internal static partial class Interop
         [Flags]
         public enum TMT
         {
+            FONT = 210,
+
             FLATMENUS = 1001,
             MINCOLORDEPTH = 1301,
 

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+System.Windows.Forms.VisualStyles.FontProperty.TextFont = 210 -> System.Windows.Forms.VisualStyles.FontProperty

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/FontProperty.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/FontProperty.cs
@@ -8,6 +8,9 @@ namespace System.Windows.Forms.VisualStyles
 {
     public enum FontProperty
     {
+        /// <summary>
+        /// The font that will be used to draw text within the context of this part.
+        /// </summary>
         TextFont = TMT.FONT,
         GlyphFont = TMT.GLYPHFONT
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/FontProperty.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/FontProperty.cs
@@ -8,6 +8,7 @@ namespace System.Windows.Forms.VisualStyles
 {
     public enum FontProperty
     {
+        TextFont = TMT.FONT,
         GlyphFont = TMT.GLYPHFONT
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
@@ -667,9 +667,7 @@ namespace System.Windows.Forms.VisualStyles
                 throw new ArgumentNullException(nameof(dc));
             }
 
-            //valid values are 0xd2 to 0xd2, and 0xa29 to 0xa29
-            if (!ClientUtils.IsEnumValid(prop, (int)prop, (int)FontProperty.TextFont, (int)FontProperty.TextFont) &&
-                !ClientUtils.IsEnumValid(prop, (int)prop, (int)FontProperty.GlyphFont, (int)FontProperty.GlyphFont))
+            if (!ClientUtils.IsEnumValid_NotSequential(prop, (int)prop, (int)FontProperty.TextFont, (int)FontProperty.GlyphFont))
             {
                 throw new InvalidEnumArgumentException(nameof(prop), (int)prop, typeof(FontProperty));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
@@ -667,7 +667,7 @@ namespace System.Windows.Forms.VisualStyles
                 throw new ArgumentNullException(nameof(dc));
             }
 
-            //valid values are 0xd2 to 0x2, and 0xa29 to 0xa29
+            //valid values are 0xd2 to 0xd2, and 0xa29 to 0xa29
             if (!ClientUtils.IsEnumValid(prop, (int)prop, (int)FontProperty.TextFont, (int)FontProperty.TextFont) &&
                 !ClientUtils.IsEnumValid(prop, (int)prop, (int)FontProperty.GlyphFont, (int)FontProperty.GlyphFont))
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
@@ -667,8 +667,9 @@ namespace System.Windows.Forms.VisualStyles
                 throw new ArgumentNullException(nameof(dc));
             }
 
-            //valid values are 0xa29 to 0xa29
-            if (!ClientUtils.IsEnumValid(prop, (int)prop, (int)FontProperty.GlyphFont, (int)FontProperty.GlyphFont))
+            //valid values are 0xd2 to 0x2, and 0xa29 to 0xa29
+            if (!ClientUtils.IsEnumValid(prop, (int)prop, (int)FontProperty.TextFont, (int)FontProperty.TextFont) &&
+                !ClientUtils.IsEnumValid(prop, (int)prop, (int)FontProperty.GlyphFont, (int)FontProperty.GlyphFont))
             {
                 throw new InvalidEnumArgumentException(nameof(prop), (int)prop, typeof(FontProperty));
             }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/VisualStyles/VisualStyleRendererTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/VisualStyles/VisualStyleRendererTests.cs
@@ -565,5 +565,16 @@ namespace System.Windows.Forms.VisualStyles.Tests
             var renderer = new VisualStyleRenderer("BUTTON", 0, 0);
             Assert.False(renderer.IsBackgroundPartiallyTransparent());
         }
+
+        [Fact]
+        public void VisualStyleRenderer_GetFont_for_TextFont()
+        {
+            var renderer = new VisualStyleRenderer("TEXTSTYLE", 1, 0);
+            using var image = new Bitmap(10, 10);
+            using Graphics graphics = Graphics.FromImage(image);
+            using Font font = renderer.GetFont(graphics, FontProperty.TextFont);
+
+            Assert.NotNull(font);
+        }
     }
 }


### PR DESCRIPTION
Fixes #3340

## Proposed changes

- Add `FontProperty.TextFont`, which maps to `TMT_FONT` on the native side.

## Customer Impact

- I can now get the font used by "instruction text" in Windows using class name `TEXTSTYLE`, part 1, state 0, and `FontProperty.TextFont`.

## Regression? 

- No, this was never before possible.

## Risk

- This is a new feature, it should not break anything.

## Test methodology

- No unit tests yet. Guidance here would be appreciated.

## Test environment(s)

```
.NET SDK (reflecting any global.json):
 Version:   5.0.100-preview.5.20264.10
 Commit:    b0f362349a

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.19631
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\5.0.100-preview.5.20264.10\

Host (useful for support):
  Version: 5.0.0-preview.6.20264.1
  Commit:  bdd7235c43

.NET SDKs installed:
  3.0.100 [C:\Program Files\dotnet\sdk]
  3.1.200 [C:\Program Files\dotnet\sdk]
  3.1.300-preview-015135 [C:\Program Files\dotnet\sdk]
  5.0.100-preview.5.20264.10 [C:\Program Files\dotnet\sdk]

.NET runtimes installed:
  Microsoft.AspNetCore.All 2.1.16 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.All]
  Microsoft.AspNetCore.App 2.1.16 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.AspNetCore.App 3.0.0 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.AspNetCore.App 3.1.2 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.AspNetCore.App 5.0.0-preview.5.20255.6 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 2.1.16 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 3.0.0 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 3.1.2 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 3.1.3 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 5.0.0-preview.6.20264.1 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.WindowsDesktop.App 3.0.0 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
  Microsoft.WindowsDesktop.App 3.1.2 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
  Microsoft.WindowsDesktop.App 3.1.3 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
  Microsoft.WindowsDesktop.App 5.0.0-preview.6.20263.1 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]

To install additional .NET runtimes or SDKs:
  https://aka.ms/dotnet-download
```

Try using the above element using different themes, both the normal theme and with High Contrast enabled. (The fonts returned aren't guaranteed to be different, but this is how you would manually test this.) This feature builds on top of existing High-DPI support in Windows Forms.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3341)