### PR TITLE
Add EN enum in Interop RichEdit

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.EN.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.EN.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal partial class Interop
+{
+    internal static partial class Richedit
+    {
+        public enum EN
+        {
+            MSGFILTER = 0x0700,
+            REQUESTRESIZE = 0x0701,
+            SELCHANGE = 0x0702,
+            DROPFILES = 0x0703,
+            PROTECTED = 0x0704,
+            CORRECTTEXT = 0x0705,
+            STOPNOUNDO = 0x0706,
+            IMECHANGE = 0x0707,
+            SAVECLIPBOARD = 0x0708,
+            OLEOPFAILED = 0x0709,
+            OBJECTPOSITIONS = 0x070a,
+            LINK = 0x070b,
+            DRAGDROPDONE = 0x070c,
+            PARAGRAPHEXPANDED = 0x070d,
+            PAGECHANGE = 0x070e,
+            LOWFIRTF = 0x070f,
+            ALIGNLTR = 0x0710,
+            ALIGNRTL = 0x0711,
+            CLIPFORMAT = 0x0712,
+            STARTCOMPOSITION = 0x0713,
+            ENDCOMPOSITION = 0x0714
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -3352,12 +3352,12 @@ namespace System.Windows.Forms
             if (m.HWnd == Handle)
             {
                 User32.NMHDR* nmhdr = (User32.NMHDR*)m.LParam;
-                switch (nmhdr->code)
+                switch ((EN)nmhdr->code)
                 {
-                    case RichTextBoxConstants.EN_LINK:
+                    case EN.LINK:
                         EnLinkMsgHandler(ref m);
                         break;
-                    case RichTextBoxConstants.EN_DROPFILES:
+                    case EN.DROPFILES:
                         ENDROPFILES* endropfiles = (ENDROPFILES*)m.LParam;
 
                         // Only look at the first file.
@@ -3385,11 +3385,11 @@ namespace System.Windows.Forms
                         m.Result = (IntPtr)1;   // tell them we did the drop
                         break;
 
-                    case RichTextBoxConstants.EN_REQUESTRESIZE:
+                    case EN.REQUESTRESIZE:
                         if (!CallOnContentsResized)
                         {
-                            Richedit.REQRESIZE* reqResize = (Richedit.REQRESIZE*)m.LParam;
-                            if (BorderStyle == System.Windows.Forms.BorderStyle.Fixed3D)
+                            REQRESIZE* reqResize = (REQRESIZE*)m.LParam;
+                            if (BorderStyle == BorderStyle.Fixed3D)
                             {
                                 reqResize->rc.bottom++;
                             }
@@ -3397,12 +3397,12 @@ namespace System.Windows.Forms
                         }
                         break;
 
-                    case RichTextBoxConstants.EN_SELCHANGE:
-                        Richedit.SELCHANGE* selChange = (Richedit.SELCHANGE*)m.LParam;
+                    case EN.SELCHANGE:
+                        SELCHANGE* selChange = (SELCHANGE*)m.LParam;
                         WmSelectionChange(*selChange);
                         break;
 
-                    case RichTextBoxConstants.EN_PROTECTED:
+                    case EN.PROTECTED:
                         {
                             NativeMethods.ENPROTECTED enprotected;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxConstants.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxConstants.cs
@@ -16,22 +16,6 @@ namespace System.Windows.Forms
 
         /* RichTextBox messages */
 
-        // New notifications
-        internal const int EN_MSGFILTER = 0x0700;
-        internal const int EN_REQUESTRESIZE = 0x0701;
-        internal const int EN_SELCHANGE = 0x0702;
-        internal const int EN_DROPFILES = 0x0703;
-        internal const int EN_PROTECTED = 0x0704;
-        internal const int EN_CORRECTTEXT = 0x0705;       /* PenWin specific */
-        internal const int EN_STOPNOUNDO = 0x0706;
-        internal const int EN_IMECHANGE = 0x0707;       /* Asia specific */
-        internal const int EN_SAVECLIPBOARD = 0x0708;
-        internal const int EN_OLEOPFAILED = 0x0709;
-        internal const int EN_OBJECTPOSITIONS = 0x070a;
-        internal const int EN_LINK = 0x070b;
-        internal const int EN_DRAGDROPDONE = 0x070c;
-        internal const int EN_PARAGRAPHEXPANDED = 0x070d;
-
         // Event notification masks */
         internal const int ENM_NONE = 0x00000000;
         internal const int ENM_CHANGE = 0x00000001;


### PR DESCRIPTION
## Proposed changes

- Add EN enum in Interop RichEdit.
- Remove EN constants and replace their usages with the above enum values.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3351)