### PR TITLE
Don't measure invalid ComboBox items

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -3696,10 +3696,11 @@ namespace System.Windows.Forms
             MEASUREITEMSTRUCT* mis = (MEASUREITEMSTRUCT*)m.LParam;
 
             // Determine if message was sent by a combo item or the combo edit field
-            if (DrawMode == DrawMode.OwnerDrawVariable && mis->itemID >= 0)
+            int itemID = (int)mis->itemID;
+            if (DrawMode == DrawMode.OwnerDrawVariable && itemID >= 0)
             {
                 using Graphics graphics = CreateGraphicsInternal();
-                var mie = new MeasureItemEventArgs(graphics, (int)mis->itemID, ItemHeight);
+                var mie = new MeasureItemEventArgs(graphics, itemID, ItemHeight);
                 OnMeasureItem(mie);
                 mis->itemHeight = unchecked((uint)mie.ItemHeight);
             }

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiComboBoxTests/DerivedComboBox.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiComboBoxTests/DerivedComboBox.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace System.Windows.Forms.IntegrationTests.MauiTests
+{
+    public class DerivedComboBox : ComboBox
+    {
+        public DerivedComboBox()
+        {
+            DrawMode = DrawMode.OwnerDrawVariable;
+            FormattingEnabled = true;
+        }
+
+        public List<MeasureItemEventArgs> MeasureItemEventArgs { get; } = new List<MeasureItemEventArgs>();
+
+        protected override void OnMeasureItem(MeasureItemEventArgs e)
+        {
+            MeasureItemEventArgs.Add(e);
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiComboBoxTests/MauiComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiComboBoxTests/MauiComboBoxTests.cs
@@ -2,13 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using System.Drawing;
 using System.Threading;
-using System.Windows.Forms;
 using System.Windows.Forms.IntegrationTests.Common;
-using WFCTestLib.Util;
-using WFCTestLib.Log;
 using ReflectTools;
+using WFCTestLib.Log;
 
 namespace System.Windows.Forms.IntegrationTests.MauiTests
 {
@@ -21,8 +19,9 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
         public MauiComboBoxTests(string[] args) : base(args)
         {
             this.BringToForeground();
+
             _comboBox = new ComboBox();
-            _comboBox.SelectedIndexChanged += (x,y) => _numEvents++;
+            _comboBox.SelectedIndexChanged += (x, y) => _numEvents++;
             Controls.Add(_comboBox);
         }
 
@@ -184,6 +183,37 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
             return sr;
         }
 
+        [Scenario(true)]
+        public ScenarioResult Verify_OnMeasureItem_receives_correct_arguments(TParams p)
+        {
+            var _derivedComboBox = new DerivedComboBox();
+            _derivedComboBox.Items.AddRange(new object[] {
+                "One",
+                "Two",
+                "Three"});
+            _derivedComboBox.Location = new Point(0, 50);
+            Controls.Add(_derivedComboBox);
+
+            if (_derivedComboBox.MeasureItemEventArgs.Count != 3)
+                return new ScenarioResult(false, $"Expected 3 events, received: {_derivedComboBox.MeasureItemEventArgs.Count}");
+
+            for (int i = 0; i < 3; i++)
+            {
+                MeasureItemEventArgs e = _derivedComboBox.MeasureItemEventArgs[i];
+
+                if (e.Graphics == null)
+                    return new ScenarioResult(false, $"Expected MeasureItemEventArgs[{i}].Graphics not null");
+                if (e.Index != i)
+                    return new ScenarioResult(false, $"Expected MeasureItemEventArgs[{i}].Index to be {i}, received: {e.Index}");
+                if (e.ItemHeight != 18)
+                    return new ScenarioResult(false, $"Expected MeasureItemEventArgs[{i}].ItemHeight to be 18, received: {e.ItemHeight}");
+                if (e.ItemWidth != 0)
+                    return new ScenarioResult(false, $"Expected MeasureItemEventArgs[{i}].ItemWidth to be {i}, received: {e.ItemWidth}");
+            }
+
+            return new ScenarioResult(true);
+        }
+
         private bool InitializeItems(ComboBox comboBox, TParams p)
         {
             comboBox.Items.Clear();
@@ -257,6 +287,7 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
 
             return true;
         }
+
         bool FindItem(TParams p, ComboBox comboBox, bool isExactMatch)
         {
             var count = comboBox.Items.Count;
@@ -281,6 +312,7 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
 
             return (matchingIndex == expectedMatchingIndex);
         }
+
         bool SelectItemWithKeyboard(ComboBox comboBox, string key, int numKeyPresses)
         {
             Activate();


### PR DESCRIPTION
Fixes #3354

Fix the condition that incorrectly handled the overflow.
Regression introduced in #1837




## Test methodology <!-- How did you ensure quality? -->

- manual tests
- MAUI tests


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3357)