### PR TITLE
Correct ImageKey/ImageIndex properties

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
@@ -357,7 +357,7 @@ namespace System.Windows.Forms
                 image = value;
                 if (image != null)
                 {
-                    ImageIndex = -1;
+                    ImageIndex = ImageList.Indexer.DefaultIndex;
                     ImageList = null;
                 }
 
@@ -410,7 +410,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (imageIndex.Index != -1 && imageList != null && imageIndex.Index >= imageList.Images.Count)
+                if (imageIndex.Index != ImageList.Indexer.DefaultIndex && imageList != null && imageIndex.Index >= imageList.Images.Count)
                 {
                     return imageList.Images.Count - 1;
                 }
@@ -422,7 +422,8 @@ namespace System.Windows.Forms
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(ImageIndex), value, -1));
                 }
-                if (value == imageIndex.Index)
+
+                if (value == imageIndex.Index && value != ImageList.Indexer.DefaultIndex)
                 {
                     return;
                 }
@@ -458,7 +459,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value == ImageKey)
+                if (value == imageIndex.Key && !string.Equals(value, ImageList.Indexer.DefaultKey))
                 {
                     return;
                 }
@@ -556,12 +557,12 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-            ///  The area of the button encompassing any changes between the button's
+        ///  The area of the button encompassing any changes between the button's
         ///  resting appearance and its appearance when the mouse is over it.
-                ///  Consider overriding this property if you override any painting methods,
+        ///  Consider overriding this property if you override any painting methods,
         ///  or your button may not paint correctly or may have flicker. Returning
         ///  ClientRectangle is safe for correct painting but may still cause flicker.
-            /// </summary>
+        /// </summary>
         internal virtual Rectangle OverChangeRectangle
         {
             get
@@ -588,12 +589,12 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-            ///  The area of the button encompassing any changes between the button's
+        ///  The area of the button encompassing any changes between the button's
         ///  appearance when the mouse is over it but not pressed and when it is pressed.
-                ///  Consider overriding this property if you override any painting methods,
+        ///  Consider overriding this property if you override any painting methods,
         ///  or your button may not paint correctly or may have flicker. Returning
         ///  ClientRectangle is safe for correct painting but may still cause flicker.
-            /// </summary>
+        /// </summary>
         internal virtual Rectangle DownChangeRectangle
         {
             get

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
@@ -195,7 +195,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (imageIndexer.Index != -1 && ImageList != null && imageIndexer.Index >= ImageList.Images.Count)
+                if (imageIndexer.Index != ImageList.Indexer.DefaultIndex && ImageList != null && imageIndexer.Index >= ImageList.Images.Count)
                 {
                     return ImageList.Images.Count - 1;
                 }
@@ -208,14 +208,16 @@ namespace System.Windows.Forms
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(ImageIndex), value, -1));
                 }
 
-                if (imageIndexer.Index != value)
+                if (imageIndexer.Index == value && value != ImageList.Indexer.DefaultIndex)
                 {
-                    imageIndexer.Index = value;
+                    return;
+                }
 
-                    if (ListView != null && ListView.IsHandleCreated)
-                    {
-                        ListView.SetColumnInfo(LVCF.IMAGE, this);
-                    }
+                imageIndexer.Index = value;
+
+                if (ListView != null && ListView.IsHandleCreated)
+                {
+                    ListView.SetColumnInfo(LVCF.IMAGE, this);
                 }
             }
         }
@@ -243,14 +245,16 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value != imageIndexer.Key)
+                if (value == imageIndexer.Key && !string.Equals(value, ImageList.Indexer.DefaultKey))
                 {
-                    imageIndexer.Key = value;
+                    return;
+                }
 
-                    if (ListView != null && ListView.IsHandleCreated)
-                    {
-                        ListView.SetColumnInfo(LVCF.IMAGE, this);
-                    }
+                imageIndexer.Key = value;
+
+                if (ListView != null && ListView.IsHandleCreated)
+                {
+                    ListView.SetColumnInfo(LVCF.IMAGE, this);
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.Indexer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.Indexer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public sealed partial class ImageList
@@ -15,19 +13,21 @@ namespace System.Windows.Forms
         /// </summary>
         internal class Indexer
         {
-            private string _key = string.Empty;
-            private int _index = -1;
+            internal const string DefaultKey = "";
+            internal const int DefaultIndex = -1;
+            private string _key = DefaultKey;
+            private int _index = DefaultIndex;
             private bool _useIntegerIndex = true;
 
-            public virtual ImageList ImageList { get; set; }
+            public virtual ImageList? ImageList { get; set; }
 
             public virtual string Key
             {
                 get => _key;
                 set
                 {
-                    _index = -1;
-                    _key = (value ?? string.Empty);
+                    _index = DefaultIndex;
+                    _key = value ?? DefaultKey;
                     _useIntegerIndex = false;
                 }
             }
@@ -37,7 +37,7 @@ namespace System.Windows.Forms
                 get => _index;
                 set
                 {
-                    _key = string.Empty;
+                    _key = DefaultKey;
                     _index = value;
                     _useIntegerIndex = true;
                 }
@@ -51,12 +51,13 @@ namespace System.Windows.Forms
                     {
                         return Index;
                     }
-                    else if (ImageList != null)
+
+                    if (ImageList != null)
                     {
                         return ImageList.Images.IndexOfKey(Key);
                     }
 
-                    return -1;
+                    return DefaultIndex;
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
@@ -471,7 +471,8 @@ namespace System.Windows.Forms
                     }
                     return index;
                 }
-                return -1;
+
+                return ImageList.Indexer.DefaultIndex;
             }
             set
             {
@@ -479,17 +480,20 @@ namespace System.Windows.Forms
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(ImageIndex), value, -1));
                 }
-                if (ImageIndex != value)
-                {
-                    if (value != -1)
-                    {
-                        // Image.set calls ImageIndex = -1
-                        Properties.SetObject(PropImage, null);
-                    }
 
-                    ImageIndexer.Index = value;
-                    Invalidate();
+                if (ImageIndex == value && value != ImageList.Indexer.DefaultIndex)
+                {
+                    return;
                 }
+
+                if (value != ImageList.Indexer.DefaultIndex)
+                {
+                    // Image.set calls ImageIndex = -1
+                    Properties.SetObject(PropImage, null);
+                }
+
+                ImageIndexer.Index = value;
+                Invalidate();
             }
         }
 
@@ -517,14 +521,16 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (ImageKey != value)
+                if (ImageKey == value && !string.Equals(value, ImageList.Indexer.DefaultKey))
                 {
-                    // Image.set calls ImageIndex = -1
-                    Properties.SetObject(PropImage, null);
-
-                    ImageIndexer.Key = value;
-                    Invalidate();
+                    return;
                 }
+
+                // Image.set calls ImageIndex = -1
+                Properties.SetObject(PropImage, null);
+
+                ImageIndexer.Key = value;
+                Invalidate();
             }
         }
 
@@ -1693,7 +1699,7 @@ namespace System.Windows.Forms
         public override ImageList ImageList
         {
             get { return owner?.ImageList; }
-            set{ Debug.Assert(false, "Setting the image list in this class is not supported"); }
+            set { Debug.Assert(false, "Setting the image list in this class is not supported"); }
         }
 
         public override string Key

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
@@ -570,7 +570,7 @@ namespace System.Windows.Forms
             get
             {
                 TreeView tv = TreeView;
-                if (ImageIndexer.Index != -1 && tv != null && tv.ImageList != null && ImageIndexer.Index >= tv.ImageList.Images.Count)
+                if (ImageIndexer.Index != ImageList.Indexer.DefaultIndex && tv != null && tv.ImageList != null && ImageIndexer.Index >= tv.ImageList.Images.Count)
                 {
                     return tv.ImageList.Images.Count - 1;
                 }
@@ -584,7 +584,7 @@ namespace System.Windows.Forms
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(ImageIndex), value, -1));
                 }
 
-                if (ImageIndexer.Index == value)
+                if (ImageIndexer.Index == value && value != ImageList.Indexer.DefaultIndex)
                 {
                     return;
                 }
@@ -611,7 +611,7 @@ namespace System.Windows.Forms
             get => ImageIndexer.Key;
             set
             {
-                if (value == ImageIndexer.Key)
+                if (value == ImageIndexer.Key && !string.Equals(value, ImageList.Indexer.DefaultKey))
                 {
                     return;
                 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonBaseTests.cs
@@ -1401,15 +1401,15 @@ namespace System.Windows.Forms.Tests
             // Set same.
             control.Image = null;
             Assert.Equal("ImageKey", control.ImageKey);
-            Assert.Equal(-1, control.ImageIndex);
+            Assert.Equal(ImageList.Indexer.DefaultIndex, control.ImageIndex);
             Assert.Null(control.Image);
             Assert.False(control.IsHandleCreated);
 
             // Set different.
             using var value = new Bitmap(10, 10);
             control.Image = value;
-            Assert.Equal("ImageKey", control.ImageKey);
-            Assert.Equal(-1, control.ImageIndex);
+            Assert.Equal(ImageList.Indexer.DefaultKey, control.ImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultIndex, control.ImageIndex);
             Assert.Same(value, control.Image);
             Assert.False(control.IsHandleCreated);
         }
@@ -1550,7 +1550,7 @@ namespace System.Windows.Forms.Tests
                     foreach (bool visible in new bool[] { true, false })
                     {
                         yield return new object[] { autoSize, enabled, visible, null, 0 };
-                        yield return new object[] { autoSize, enabled, visible, new Bitmap(10, 10), 1 };
+                        yield return new object[] { autoSize, enabled, visible, new Bitmap(10, 10), 2 };
                     }
                 }
             }
@@ -1653,9 +1653,9 @@ namespace System.Windows.Forms.Tests
                 foreach (bool visible in new bool[] { true, false })
                 {
                     yield return new object[] { true, enabled, visible, null, 0, 0 };
-                    yield return new object[] { true, enabled, visible, new Bitmap(10, 10), 1, 1 };
+                    yield return new object[] { true, enabled, visible, new Bitmap(10, 10), 1, 2 };
                     yield return new object[] { false, enabled, visible, null, 0, 0 };
-                    yield return new object[] { false, enabled, visible, new Bitmap(10, 10), 0, 1 };
+                    yield return new object[] { false, enabled, visible, new Bitmap(10, 10), 0, 2 };
                 }
             }
         }
@@ -2045,10 +2045,10 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(-1, "ImageKey")]
-        [InlineData(0, "")]
-        [InlineData(1, "")]
-        public void ButtonBase_ImageIndex_SetWithImageKey_GetReturnsExpected(int value, string expectedImageKey)
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void ButtonBase_ImageIndex_SetWithImageKey_GetReturnsExpected(int value)
         {
             using var control = new SubButtonBase
             {
@@ -2056,13 +2056,13 @@ namespace System.Windows.Forms.Tests
                 ImageIndex = value
             };
             Assert.Equal(value, control.ImageIndex);
-            Assert.Equal(expectedImageKey, control.ImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultKey, control.ImageKey);
             Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.ImageIndex = value;
             Assert.Equal(value, control.ImageIndex);
-            Assert.Equal(expectedImageKey, control.ImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultKey, control.ImageKey);
             Assert.False(control.IsHandleCreated);
         }
 
@@ -2120,10 +2120,10 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(-1, 0)]
-        [InlineData(0, 1)]
-        [InlineData(1, 1)]
-        public void ButtonBase_ImageIndex_SetWithHandle_GetReturnsExpected(int value, int expectedInvalidatedCallCount)
+        [InlineData(-1, 1, 2)]
+        [InlineData(0, 1, 1)]
+        [InlineData(1, 1, 1)]
+        public void ButtonBase_ImageIndex_SetWithHandle_GetReturnsExpected(int value, int expectedInvalidatedCallCount1, int expectedInvalidatedCallCount2)
         {
             using var control = new SubButtonBase();
             Assert.NotEqual(IntPtr.Zero, control.Handle);
@@ -2138,7 +2138,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(value, control.ImageIndex);
             Assert.Empty(control.ImageKey);
             Assert.True(control.IsHandleCreated);
-            Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
+            Assert.Equal(expectedInvalidatedCallCount1, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
 
@@ -2147,7 +2147,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(value, control.ImageIndex);
             Assert.Empty(control.ImageKey);
             Assert.True(control.IsHandleCreated);
-            Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
+            Assert.Equal(expectedInvalidatedCallCount2, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
         }
@@ -2188,40 +2188,32 @@ namespace System.Windows.Forms.Tests
                 Image = image
             };
 
-            // Set same.
-            control.ImageKey = string.Empty;
-            Assert.Empty(control.ImageKey);
-            Assert.Equal(-1, control.ImageIndex);
-            Assert.Same(image, control.Image);
-            Assert.False(control.IsHandleCreated);
-
-            // Set different.
-            control.ImageKey = "ImageKey";
-            Assert.Equal("ImageKey", control.ImageKey);
-            Assert.Equal(-1, control.ImageIndex);
+            control.ImageKey = ImageList.Indexer.DefaultKey;
+            Assert.Equal(ImageList.Indexer.DefaultKey, control.ImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultIndex, control.ImageIndex);
             Assert.Null(control.Image);
             Assert.False(control.IsHandleCreated);
         }
 
         [WinFormsTheory]
-        [InlineData(null, "", -1)]
-        [InlineData("", "", 0)]
-        [InlineData("ImageKey", "ImageKey", -1)]
-        public void ButtonBase_ImageKey_SetWithImageIndex_GetReturnsExpected(string value, string expected, int expectedImageIndex)
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("ImageKey", "ImageKey")]
+        public void ButtonBase_ImageKey_SetWithImageIndex_GetReturnsExpected(string value, string expectedImageKey)
         {
             using var control = new SubButtonBase
             {
                 ImageIndex = 0,
                 ImageKey = value
             };
-            Assert.Equal(expected, control.ImageKey);
-            Assert.Equal(expectedImageIndex, control.ImageIndex);
+            Assert.Equal(expectedImageKey, control.ImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultIndex, control.ImageIndex);
             Assert.False(control.IsHandleCreated);
 
             // Set same.
             control.ImageKey = value;
-            Assert.Equal(expected, control.ImageKey);
-            Assert.Equal(expectedImageIndex, control.ImageIndex);
+            Assert.Equal(expectedImageKey, control.ImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultIndex, control.ImageIndex);
             Assert.False(control.IsHandleCreated);
         }
 
@@ -2280,7 +2272,7 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [InlineData(null, "", 1, 2)]
-        [InlineData("", "", 0, 0)]
+        [InlineData("", "", 1, 2)]
         [InlineData("ImageKey", "ImageKey", 1, 1)]
         public void ButtonBase_ImageKey_SetWithHandle_GetReturnsExpected(string value, string expected, int expectedInvalidatedCallCount1, int expectedInvalidatedCallCount2)
         {
@@ -2463,7 +2455,7 @@ namespace System.Windows.Forms.Tests
         public void ButtonBase_ImageList_Set_DoesNotCreateImageHandle()
         {
             using var control = new SubButtonBase();
-            using var imageList =  new ImageList();
+            using var imageList = new ImageList();
             control.ImageList = imageList;
             Assert.False(imageList.HandleCreated);
             Assert.False(control.IsHandleCreated);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeaderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeaderTests.cs
@@ -301,10 +301,10 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(-1, "ImageKey")]
-        [InlineData(0, "")]
-        [InlineData(1, "")]
-        public void ColumnHeader_ImageIndex_SetWithImageKey_GetReturnsExpected(int value, string expectedImageKey)
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void ColumnHeader_ImageIndex_SetWithImageKey_GetReturnsExpected(int value)
         {
             using var header = new ColumnHeader
             {
@@ -312,12 +312,12 @@ namespace System.Windows.Forms.Tests
                 ImageIndex = value
             };
             Assert.Equal(value, header.ImageIndex);
-            Assert.Equal(expectedImageKey, header.ImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultKey, header.ImageKey);
 
             // Set same.
             header.ImageIndex = value;
             Assert.Equal(value, header.ImageIndex);
-            Assert.Equal(expectedImageKey, header.ImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultKey, header.ImageKey);
         }
 
         [WinFormsTheory]
@@ -522,23 +522,23 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(null, "", -1)]
-        [InlineData("", "", 0)]
-        [InlineData("ImageKey", "ImageKey", -1)]
-        public void ColumnHeader_ImageKey_SetWithImageIndex_GetReturnsExpected(string value, string expected, int expectedImageIndex)
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("ImageKey", "ImageKey")]
+        public void ColumnHeader_ImageKey_SetWithImageIndex_GetReturnsExpected(string value, string expectedImageKey)
         {
             using var header = new ColumnHeader
             {
                 ImageIndex = 0,
                 ImageKey = value
             };
-            Assert.Equal(expected, header.ImageKey);
-            Assert.Equal(expectedImageIndex, header.ImageIndex);
+            Assert.Equal(expectedImageKey, header.ImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultIndex, header.ImageIndex);
 
             // Set same.
             header.ImageKey = value;
-            Assert.Equal(expected, header.ImageKey);
-            Assert.Equal(expectedImageIndex, header.ImageIndex);
+            Assert.Equal(expectedImageKey, header.ImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultIndex, header.ImageIndex);
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LabelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LabelTests.cs
@@ -182,6 +182,40 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.GetTopLevel());
         }
 
+        [WinFormsFact]
+        public void Label_ImageIndex_setting_minus_one_resets_ImageKey()
+        {
+            int index = -1;
+
+            using var control = new SubLabel();
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            Assert.Equal(index, control.ImageIndex);
+            Assert.Equal(string.Empty, control.ImageKey);
+
+            control.ImageKey = "key";
+            control.ImageIndex = index;
+
+            Assert.Equal(index, control.ImageIndex);
+            Assert.Equal(string.Empty, control.ImageKey);
+        }
+
+        [WinFormsFact]
+        public void Label_ImageKey_setting_empty_resets_ImageIndex()
+        {
+            string key = string.Empty;
+
+            using var control = new SubLabel();
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            Assert.Equal(key, control.ImageKey);
+            Assert.Equal(-1, control.ImageIndex);
+
+            control.ImageIndex = 2;
+            control.ImageKey = key;
+
+            Assert.Equal(key, control.ImageKey);
+            Assert.Equal(-1, control.ImageIndex);
+        }
+
         public class SubLabel : Label
         {
             public new bool CanEnableIme => base.CanEnableIme;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeTests.cs
@@ -1005,11 +1005,11 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(-1, "ImageKey", -1)]
-        [InlineData(0, "", 0)]
-        [InlineData(1, "", 0)]
-        [InlineData(2, "", 0)]
-        public void TreeNode_ImageIndex_SetWithImageKey_GetReturnsExpected(int value, string expectedImageKey, int expectedWithImage)
+        [InlineData(-1, -1)]
+        [InlineData(0, 0)]
+        [InlineData(1, 0)]
+        [InlineData(2, 0)]
+        public void TreeNode_ImageIndex_SetWithImageKey_GetReturnsExpected(int value, int expectedWithImage)
         {
             var node = new TreeNode
             {
@@ -1017,32 +1017,32 @@ namespace System.Windows.Forms.Tests
                 ImageIndex = value
             };
             Assert.Equal(value, node.ImageIndex);
-            Assert.Equal(expectedImageKey, node.ImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultKey, node.ImageKey);
 
             // Set same.
             node.ImageIndex = value;
             Assert.Equal(value, node.ImageIndex);
-            Assert.Equal(expectedImageKey, node.ImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultKey, node.ImageKey);
 
             // Set tree view.
             using var control = new TreeView();
             control.Nodes.Add(node);
             Assert.Equal(value, node.ImageIndex);
-            Assert.Equal(expectedImageKey, node.ImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultKey, node.ImageKey);
             Assert.False(control.IsHandleCreated);
 
             // Add image list.
             using var imageList = new ImageList();
             control.ImageList = imageList;
             Assert.Equal(-1, node.ImageIndex);
-            Assert.Equal(expectedImageKey, node.ImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultKey, node.ImageKey);
             Assert.False(control.IsHandleCreated);
 
             // Add to image list.
             using var image = new Bitmap(10, 10);
             imageList.Images.Add(image);
             Assert.Equal(expectedWithImage, node.ImageIndex);
-            Assert.Equal(expectedImageKey, node.ImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultKey, node.ImageKey);
             Assert.False(control.IsHandleCreated);
         }
 
@@ -1341,23 +1341,23 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(null, "", -1)]
-        [InlineData("", "", 0)]
-        [InlineData("ImageKey", "ImageKey", -1)]
-        public void TreeNode_ImageKey_SetWithImageIndex_GetReturnsExpected(string value, string expected, int expectedImageIndex)
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("ImageKey", "ImageKey")]
+        public void TreeNode_ImageKey_SetWithImageIndex_GetReturnsExpected(string value, string expectedImageKey)
         {
             var node = new TreeNode
             {
                 ImageIndex = 0,
                 ImageKey = value
             };
-            Assert.Equal(expected, node.ImageKey);
-            Assert.Equal(expectedImageIndex, node.ImageIndex);
+            Assert.Equal(expectedImageKey, node.ImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultIndex, node.ImageIndex);
 
             // Set same.
             node.ImageKey = value;
-            Assert.Equal(expected, node.ImageKey);
-            Assert.Equal(expectedImageIndex, node.ImageIndex);
+            Assert.Equal(expectedImageKey, node.ImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultIndex, node.ImageIndex);
         }
 
         [WinFormsTheory]


### PR DESCRIPTION



Resolves #3353



## Proposed changes

- Setters for `ImageKey` and `ImageIndex` properties were made idempotent in #3126, however the change didn't account for the fact that the default `ImageKey == ""` and not `null`.
  This caused failures to reset `ImageIndex`, when `ImageKey` was set to `""`; and in reverse - failure to reset `ImageKey` when `ImageIndex` was set to `-1`.
  Tweak the setters to continue execution for default values.

- In addition apply NRT annotations to ` ImageList.Indexer` type, and expose the defaults in a reusable manner.


## Test methodology <!-- How did you ensure quality? -->

- unit tests

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3364)