### PR TITLE
Fixing DPI changed events by changing the order in setting child Form owner

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -5208,20 +5208,20 @@ namespace System.Windows.Forms
                                                           "showDialog"), "owner");
                     }
 
-                    // In a multi DPI environment, DPI changed events triggered only when there is a DPI change
-                    // happened for the Handle directly or via its parent. So, it is necessary to not set the
-                    // owner before creating the handle. Otherwise, the window may never receive DPI changed
-                    // event even if its parent has different DPI.Users at runtime, has to move the window
-                    // between the screens to get the DPI changed events triggered.
+                    // In a multi DPI environment and applications in PMV2 mode, DPI changed events triggered
+                    // only when there is a DPI change happened for the Handle directly or via its parent.
+                    // So, it is necessary to not set the owner before creating the handle. Otherwise,
+                    // the window may never receive DPI changed event even if its parent has different DPI.
+                    // Users at runtime, has to move the window between the screens to get the DPI changed events triggered.
 
                     Properties.SetObject(PropDialogOwner, owner);
-                    if (owner is Form && owner != oldOwner)
+                    if (owner is Form form && owner != oldOwner)
                     {
-                        Owner = (Form)owner;
+                        Owner = form;
                     }
                     else
                     {
-                        // Set the new owner.
+                        // Set the new parent.
                         User32.SetWindowLong(this, User32.GWL.HWNDPARENT, new HandleRef(owner, hWndOwner));
                     }
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -5175,15 +5175,8 @@ namespace System.Windows.Forms
             }
             IntPtr hWndActive = User32.GetActiveWindow();
             IntPtr hWndOwner = owner == null ? hWndActive : Control.GetSafeHandle(owner);
-            IntPtr hWndOldOwner = IntPtr.Zero;
-            Properties.SetObject(PropDialogOwner, owner);
 
             Form oldOwner = OwnerInternal;
-
-            if (owner is Form ownerForm && owner != oldOwner)
-            {
-                Owner = ownerForm;
-            }
 
             try
             {
@@ -5215,9 +5208,22 @@ namespace System.Windows.Forms
                                                           "showDialog"), "owner");
                     }
 
-                    // Set the new owner.
-                    hWndOldOwner = User32.GetWindowLong(new HandleRef(this, Handle), User32.GWL.HWNDPARENT);
-                    User32.SetWindowLong(this, User32.GWL.HWNDPARENT, new HandleRef(owner, hWndOwner));
+                    // In a multi DPI environment, DPI changed events triggered only when there is a DPI change
+                    // happened for the Handle directly or via its parent. So, it is necessary to not set the
+                    // owner before creating the handle. Otherwise, the window may never receive DPI changed
+                    // event even if its parent has different DPI.Users at runtime, has to move the window
+                    // between the screens to get the DPI changed events triggered.
+
+                    Properties.SetObject(PropDialogOwner, owner);
+                    if (owner is Form && owner != oldOwner)
+                    {
+                        Owner = (Form)owner;
+                    }
+                    else
+                    {
+                        // Set the new owner.
+                        User32.SetWindowLong(this, User32.GWL.HWNDPARENT, new HandleRef(owner, hWndOwner));
+                    }
                 }
 
                 try


### PR DESCRIPTION
In a multi DPI environment, DPI changed events triggered only when there is a DPI change happened for the Handle directly or via its parent. So, it is necessary to **not** set the
owner before creating the Form handle. Otherwise, the window may never receive DPI changed
event even if its parent Form has different DPI. Users at runtime, has to move the Form window
between the screens to get the DPI changed events triggered.

Please see associated issue for more details and screen shots the behavior at runtime.

Fixes #3390 

## Proposed changes

Changing the order when setting the owner of a child form.

## Regression? 

-No


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3394)