### PR TITLE
Add x86 runtime for testing

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,9 +2,8 @@
   "tools": {
     "dotnet": "5.0.100-preview.6.20266.3",
     "runtimes": {
-      "dotnet": [
-        "$(MicrosoftNETCoreAppPackageVersion)"
-      ]
+      "dotnet/x64": [ "$(MicrosoftNETCoreAppPackageVersion)" ],
+      "dotnet/x86": [ "$(MicrosoftNETCoreAppPackageVersion)" ]
     }
   },
   "sdk": {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -1620,7 +1620,9 @@ namespace System.Windows.Forms.Tests
         {
             using var control = new ListView();
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal((IntPtr)0xFFFFFFFF, User32.SendMessageW(control.Handle, (User32.WM)LVM.GETTEXTBKCOLOR));
+
+            IntPtr expected = IntPtr.Size == 8 ? (IntPtr)0xFFFFFFFF : (IntPtr)(-1);
+            Assert.Equal(expected, User32.SendMessageW(control.Handle, (User32.WM)LVM.GETTEXTBKCOLOR));
         }
 
         [WinFormsFact]


### PR DESCRIPTION
Contributes to dotnet/arcade#5583

## Proposed changes

- Install x86 runtime for testing.

## Customer Impact

- Ensures proper testing in a 32 bit process.

## Regression? 

- No

## Risk

- None, other than increased download at first build and potential test failures from the increased coverage.

### After

![image](https://user-images.githubusercontent.com/19413848/83842642-44ff5980-a6b8-11ea-8e9e-d78dfc64f68f.png)

## Test methodology 

- This adds no functionality so no added tests.

## Test environment(s) 

- Using default runtimes and SDK already used for testing.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3396)