### PR TITLE
Dispose controls in unit tests

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ErrorProviderAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ErrorProviderAccessibleObjectTests.cs
@@ -7,7 +7,7 @@ using static Interop;
 
 namespace System.Windows.Forms.Tests.AccessibleObjects
 {
-    public class ErrorProviderAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
+    public class ErrorProviderAccessibleObjectTests : IDisposable, IClassFixture<ThreadExceptionFixture>
     {
         private readonly Form _form;
         private readonly Control _control1;
@@ -46,6 +46,14 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             _errorWindow = _errorProvider.EnsureErrorWindow(_form);
             _controlItem1 = _errorWindow.ControlItems.Count > 0 ? _errorWindow.ControlItems[0] : null;
             _controlItem2 = _errorWindow.ControlItems.Count > 0 ? _errorWindow.ControlItems[1] : null;
+        }
+
+        public void Dispose()
+        {
+            _errorProvider?.Dispose();
+            _control2?.Dispose();
+            _control1?.Dispose();
+            _form?.Dispose();
         }
 
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/PropertyGridInternal/PropertyGridView.GridViewListBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/PropertyGridInternal/PropertyGridView.GridViewListBoxAccessibleObjectTests.cs
@@ -15,9 +15,9 @@ namespace System.Windows.Forms.Tests.PropertyGridInternal.Tests
         public void GridViewListBoxAccessibleObject_DoesNotThrowException_OnFocus()
         {
             Mock<IServiceProvider> mockServiceProvider = new Mock<IServiceProvider>(MockBehavior.Strict);
-            PropertyGrid propertyGrid = new PropertyGrid();
+            using PropertyGrid propertyGrid = new PropertyGrid();
 
-            PropertyGridView propertyGridView = new PropertyGridView(mockServiceProvider.Object, propertyGrid);
+            using PropertyGridView propertyGridView = new PropertyGridView(mockServiceProvider.Object, propertyGrid);
             var dropDownListBoxAccessibleObject = propertyGridView.DropDownListBoxAccessibleObject;
 
             Type type = dropDownListBoxAccessibleObject.GetType();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -1398,7 +1398,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void CtrlBackspaceTextRemainsEmpty()
         {
-            SubComboBox control = CreateControlForCtrlBackspace();
+            using SubComboBox control = CreateControlForCtrlBackspace();
             SendCtrlBackspace(control);
             Assert.Equal("", control.Text);
         }
@@ -1407,7 +1407,7 @@ namespace System.Windows.Forms.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetCtrlBackspaceData))]
         public void CtrlBackspaceTextChanged(string value, string expected, int cursorRelativeToEnd)
         {
-            SubComboBox control = CreateControlForCtrlBackspace(value, cursorRelativeToEnd);
+            using SubComboBox control = CreateControlForCtrlBackspace(value, cursorRelativeToEnd);
             SendCtrlBackspace(control);
             Assert.Equal(expected, control.Text);
         }
@@ -1416,7 +1416,7 @@ namespace System.Windows.Forms.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetCtrlBackspaceRepeatedData))]
         public void CtrlBackspaceRepeatedTextChanged(string value, string expected, int repeats)
         {
-            SubComboBox control = CreateControlForCtrlBackspace(value);
+            using SubComboBox control = CreateControlForCtrlBackspace(value);
             for (int i = 0; i < repeats; i++)
             {
                 SendCtrlBackspace(control);
@@ -1427,7 +1427,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void CtrlBackspaceDeletesSelection()
         {
-            SubComboBox control = CreateControlForCtrlBackspace("123-5-7-9");
+            using SubComboBox control = CreateControlForCtrlBackspace("123-5-7-9");
             control.SelectionStart = 2;
             control.SelectionLength = 5;
             SendCtrlBackspace(control);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -461,7 +461,7 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(BackColor_Set_TestData))]
         public void ListView_BackColor_Set_GetReturnsExpected(Color value, Color expected)
         {
-            var control = new ListView
+            using var control = new ListView
             {
                 BackColor = value
             };
@@ -484,7 +484,7 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(BackColor_SetWithHandle_TestData))]
         public void ListView_BackColor_SetWithHandle_GetReturnsExpected(Color value, Color expected, int expectedInvalidatedCallCount)
         {
-            var control = new ListView();
+            using var control = new ListView();
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             int invalidatedCallCount = 0;
             control.Invalidated += (sender, e) => invalidatedCallCount++;
@@ -522,7 +522,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void ListView_BackColor_SetWithHandler_CallsBackColorChanged()
         {
-            var control = new ListView();
+            using var control = new ListView();
             int callCount = 0;
             EventHandler handler = (sender, e) =>
             {
@@ -558,7 +558,7 @@ namespace System.Windows.Forms.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(ImageLayout))]
         public void ListView_BackgroundImageLayout_Set_GetReturnsExpected(ImageLayout value)
         {
-            var control = new SubListView
+            using var control = new SubListView
             {
                 BackgroundImageLayout = value
             };
@@ -576,7 +576,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void ListView_BackgroundImageLayout_SetWithHandler_CallsBackgroundImageLayoutChanged()
         {
-            var control = new ListView();
+            using var control = new ListView();
             int callCount = 0;
             EventHandler handler = (sender, e) =>
             {
@@ -612,7 +612,7 @@ namespace System.Windows.Forms.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryDataInvalid), typeof(ImageLayout))]
         public void ListView_BackgroundImageLayout_SetInvalid_ThrowsInvalidEnumArgumentException(ImageLayout value)
         {
-            var control = new ListView();
+            using var control = new ListView();
             Assert.Throws<InvalidEnumArgumentException>("value", () => control.BackgroundImageLayout = value);
         }
 
@@ -1096,7 +1096,7 @@ namespace System.Windows.Forms.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void ListView_DoubleBuffered_Get_ReturnsExpected(bool value)
         {
-            var control = new SubListView();
+            using var control = new SubListView();
             control.SetStyle(ControlStyles.OptimizedDoubleBuffer, value);
             Assert.Equal(value, control.DoubleBuffered);
         }
@@ -1105,7 +1105,7 @@ namespace System.Windows.Forms.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void ListView_DoubleBuffered_Set_GetReturnsExpected(bool value)
         {
-            var control = new SubListView
+            using var control = new SubListView
             {
                 DoubleBuffered = value
             };
@@ -1131,7 +1131,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(false, 0)]
         public void ListView_DoubleBuffered_SetWithHandle_GetReturnsExpected(bool value, int expectedInvalidatedCallCount)
         {
-            var control = new SubListView();
+            using var control = new SubListView();
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             int invalidatedCallCount = 0;
             control.Invalidated += (sender, e) => invalidatedCallCount++;
@@ -1177,7 +1177,7 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(FocusedItem_Set_TestData))]
         public void ListView_FocusedItem_Set_GetReturnsExpected(ListViewItem value, bool? expectedFocused)
         {
-            var control = new SubListView
+            using var control = new SubListView
             {
                 FocusedItem = value
             };
@@ -1196,7 +1196,7 @@ namespace System.Windows.Forms.Tests
         public void ListView_FocusedItem_SetChild_GetReturnsExpected()
         {
             var value = new ListViewItem();
-            var control = new SubListView();
+            using var control = new SubListView();
             control.Items.Add(value);
 
             control.FocusedItem = value;
@@ -1221,7 +1221,7 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(FocusedItem_Set_TestData))]
         public void ListView_FocusedItem_SetWithHandle_GetReturnsExpected(ListViewItem value, bool? expectedFocused)
         {
-            var control = new SubListView();
+            using var control = new SubListView();
             Assert.NotEqual(IntPtr.Zero, control.Handle);
 
             control.FocusedItem = value;
@@ -1238,7 +1238,7 @@ namespace System.Windows.Forms.Tests
         public void ListView_FocusedItem_SetChildWithHandle_GetReturnsExpected()
         {
             var value = new ListViewItem();
-            var control = new SubListView();
+            using var control = new SubListView();
             control.Items.Add(value);
             Assert.NotEqual(IntPtr.Zero, control.Handle);
 
@@ -1270,7 +1270,7 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(ForeColor_Set_TestData))]
         public void ListView_ForeColor_Set_GetReturnsExpected(Color value, Color expected)
         {
-            var control = new ListView
+            using var control = new ListView
             {
                 ForeColor = value
             };
@@ -1296,7 +1296,7 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(ForeColor_SetWithHandle_TestData))]
         public void ListView_ForeColor_SetWithHandle_GetReturnsExpected(Color value, Color expected, int expectedInvalidatedCallCount)
         {
-            var control = new ListView();
+            using var control = new ListView();
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             int invalidatedCallCount = 0;
             control.Invalidated += (sender, e) => invalidatedCallCount++;
@@ -1334,7 +1334,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void ListView_ForeColor_SetWithHandler_CallsForeColorChanged()
         {
-            var control = new ListView();
+            using var control = new ListView();
             int callCount = 0;
             EventHandler handler = (sender, e) =>
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PictureBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PictureBoxTests.cs
@@ -239,7 +239,7 @@ namespace System.Windows.Forms.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void PictureBox_Enabled_Set_GetReturnsExpected(bool value)
         {
-            var control = new Control
+            using var control = new Control
             {
                 Enabled = value
             };
@@ -258,7 +258,7 @@ namespace System.Windows.Forms.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void PictureBox_Enabled_SetWithHandle_GetReturnsExpected(bool value)
         {
-            var control = new Control();
+            using var control = new Control();
             Assert.NotEqual(IntPtr.Zero, control.Handle);
 
             control.Enabled = value;
@@ -276,7 +276,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void PictureBox_Enabled_SetWithHandler_CallsEnabledChanged()
         {
-            var control = new Control
+            using var control = new Control
             {
                 Enabled = true
             };
@@ -819,7 +819,7 @@ namespace System.Windows.Forms.Tests
             mockSite
                 .Setup(s => s.DesignMode)
                 .Returns(true);
-            var pictureBox = new PictureBox
+            using var pictureBox = new PictureBox
             {
                 InitialImage = initialImage,
                 ErrorImage = errorImage,

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolTipTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolTipTests.cs
@@ -45,7 +45,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void Ctor_IContainer_TestData()
         {
-            var container = new Container();
+            using var container = new Container();
             using var toolTip = new SubToolTip(container);
             Assert.True(toolTip.Active);
             Assert.Equal(500, toolTip.AutomaticDelay);
@@ -568,7 +568,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void ToolTip_RemoveAll_InvokeWithTools_GetToolTipReturnsEmpty()
         {
-            var control = new Control();
+            using var control = new Control();
             using var toolTip = new ToolTip();
             toolTip.SetToolTip(control, "caption");
             toolTip.RemoveAll();
@@ -591,7 +591,7 @@ namespace System.Windows.Forms.Tests
         public void ToolTip_SetToolTip_Invoke_GetToolTipReturnsExpected(string caption, string expected)
         {
             using var toolTip = new ToolTip();
-            var control = new Control();
+            using var control = new Control();
             toolTip.SetToolTip(control, caption);
             Assert.Equal(expected, toolTip.GetToolTip(control));
 
@@ -612,7 +612,7 @@ namespace System.Windows.Forms.Tests
             {
                 Site = mockSite.Object
             };
-            var control = new Control();
+            using var control = new Control();
             toolTip.SetToolTip(control, caption);
             Assert.Equal(expected, toolTip.GetToolTip(control));
 
@@ -638,7 +638,8 @@ namespace System.Windows.Forms.Tests
         public void ToolTip_Show_InvokeStringIWin32WindowControlWindow_Nop(string text)
         {
             using var toolTip = new ToolTip();
-            toolTip.Show(text, new Control());
+            using var control = new Control();
+            toolTip.Show(text, control);
         }
 
         [WinFormsTheory]
@@ -665,7 +666,8 @@ namespace System.Windows.Forms.Tests
         public void ToolTip_Show_InvokeStringIWin32WindowIntControlWindow_Nop(string text, int duration)
         {
             using var toolTip = new ToolTip();
-            toolTip.Show(text, new Control(), duration);
+            using var control = new Control();
+            toolTip.Show(text, control, duration);
         }
 
         [WinFormsTheory]


### PR DESCRIPTION
Contributes to #3361

## Proposed changes

Dispose controls instead of letting GC collect them
- Add missing using statements
- Make `ErrorProviderAccessibleObjectTests` disposable

Not doing so may hang CI if their UI thread terminates before GC collects them

## Customer Impact

- lower risk of hanging CI test runs

## Risk

- minimal, unlikely to break any test

### Before

- tests were leaving controls for GC to collect

### After

- controls are disposed before UI thread terminates

## Test methodology

- making sure tests still succeed
- logging finalizer calls like described in #3361


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3403)