### PR TITLE
do not dispose stream owned by image

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ImageEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ImageEditor.cs
@@ -171,11 +171,10 @@ namespace System.Drawing.Design
             }
 
             // Copy the original stream to a new memory stream to avoid locking the file.
-            using (var memoryStream = new MemoryStream())
-            {
-                stream.CopyTo(memoryStream);
-                return Image.FromStream(memoryStream);
-            }
+            // The created image will take over ownership of the stream.
+            var memoryStream = new MemoryStream();
+            stream.CopyTo(memoryStream);
+            return Image.FromStream(memoryStream);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageListImageEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageListImageEditor.cs
@@ -105,10 +105,9 @@ namespace System.Windows.Forms.Design
             byte[] buffer = new byte[stream.Length];
             stream.Read(buffer, 0, (int)stream.Length);
 
-            using (MemoryStream ms = new MemoryStream(buffer))
-            {
-                return ImageListImage.ImageListImageFromStream(ms, imageIsIcon);
-            }
+            // The created image will take over ownership of the stream.
+            MemoryStream ms = new MemoryStream(buffer);
+            return ImageListImage.ImageListImageFromStream(ms, imageIsIcon);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/BitmapEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/BitmapEditorTests.cs
@@ -84,6 +84,10 @@ namespace System.Drawing.Design.Tests
                 stream.Position = 0;
                 Bitmap result = Assert.IsType<Bitmap>(editor.LoadFromStream(stream));
                 Assert.Equal(new Size(10, 10), result.Size);
+
+                using var resultStream = new MemoryStream();
+                result.Save(resultStream, ImageFormat.Bmp);
+                Assert.Equal(stream.Length, resultStream.Length);
             }
         }
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ImageEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ImageEditorTests.cs
@@ -141,6 +141,10 @@ namespace System.Drawing.Design.Tests
                 stream.Position = 0;
                 Bitmap result = Assert.IsType<Bitmap>(editor.LoadFromStream(stream));
                 Assert.Equal(new Size(10, 10), result.Size);
+
+                using var resultStream = new MemoryStream();
+                result.Save(resultStream, ImageFormat.Bmp);
+                Assert.Equal(stream.Length, resultStream.Length);
             }
         }
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ImageListImageEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ImageListImageEditorTests.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using Xunit;
+
+namespace System.Windows.Forms.Design.Tests
+{
+    public class ImageListImageEditorTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [Fact]
+        public void ImageListImageEditor_LoadImageFromStream_BitmapStream_ReturnsExpected()
+        {
+            var editor = new ImageListImageEditor();
+            var editor_LoadImageFromStream = editor.TestAccessor().CreateDelegate<Func<Stream, bool, ImageListImage>>("LoadImageFromStream");
+
+            using var stream = new MemoryStream();
+            using var image = new Bitmap(10, 10);
+            image.Save(stream, ImageFormat.Bmp);
+            stream.Position = 0;
+
+            var result = Assert.IsType<ImageListImage>(editor_LoadImageFromStream(stream, false));
+            var resultImage = Assert.IsType<Bitmap>(result.Image);
+            Assert.Equal(new Size(10, 10), result.Size);
+            Assert.Equal(new Size(10, 10), resultImage.Size);
+
+            using var resultStream = new MemoryStream();
+            result.Image.Save(resultStream, ImageFormat.Bmp);
+            Assert.Equal(stream.Length, resultStream.Length);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3309

## Proposed changes

Loading an image from a stream passes ownership, do not dispose the stream
* Fix regression in ImageEditor
* Fix regression in ImageListImageEditor
* Add test to ensure BitmapEditor doesn't regress

## Customer Impact

Using ImageEditor or ImageListImageEditor through a property grid or designer was producing partially defunct images whose underlying stream was disposed, depending on the operation performed on the image this could load to errors.

## Regression? 

Yes

## Risk

unlikely to have any risk, this restores behavior from before the regression

### Before

Image loaded from ImageEditor or ImageListImageEditor could throw exceptions on various operations

### After

Image loaded from ImageEditor or ImageListImageEditor should operate normally

## Test methodology

Ensure unit tests perform an operation accessing the underlying stream.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3404)