### PR TITLE
Fix local WebBrowser tests

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WebBrowserTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WebBrowserTests.cs
@@ -789,7 +789,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal("about:blank", control.Url.OriginalString);
             Assert.Equal(1, navigatingCallCount);
             Assert.Equal(2, navigatedCallCount);
-            Assert.Equal(3, documentTitleChangedCallCount);
+            Assert.True(documentTitleChangedCallCount > 0);
             Assert.Equal(1, documentCompletedCallCount);
             Assert.Equal(0, canGoBackChangedCallCount);
             Assert.Equal(0, canGoForwardChangedCallCount);
@@ -803,7 +803,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal("about:blank", control.Url.OriginalString);
             Assert.Equal(2, navigatingCallCount);
             Assert.Equal(4, navigatedCallCount);
-            Assert.Equal(6, documentTitleChangedCallCount);
+            Assert.True(documentTitleChangedCallCount > 0);
             Assert.Equal(2, documentCompletedCallCount);
             Assert.Equal(0, canGoBackChangedCallCount);
             Assert.Equal(0, canGoForwardChangedCallCount);


### PR DESCRIPTION
```
[xUnit.net 00:04:07.67]     System.Windows.Forms.Tests.WebBrowserTests.WebBrowser_DocumentText_SetValidHtml_GetReturnsExpected [FAIL]
  X System.Windows.Forms.Tests.WebBrowserTests.WebBrowser_DocumentText_SetValidHtml_GetReturnsExpected [700ms]
  Error Message:
   Assert.Equal() Failure
Expected: 6
Actual:   7
  Stack Trace:
     at System.Windows.Forms.Tests.WebBrowserTests.WebBrowser_DocumentText_SetValidHtml_GetReturnsExpected() in C:\Users\hughbe\Documents\GitHub\winforms\src\System.Windows.Forms\tests\UnitTests\System\Windows\Forms\WebBrowserTests.cs:line 806
--- End of stack trace from previous location ---
```

The number of times the document title changed handler is called depends on the version of windows etc.

Just verify that it was called at least once

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3408)