### PR TITLE
Implementing LegacyIAccessiblePattern supporting for ControlAccessibleObject

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
@@ -427,6 +427,16 @@ namespace System.Windows.Forms
                 return RaiseAutomationEvent(UiaCore.UIA.LiveRegionChangedEventId);
             }
 
+            internal override bool IsPatternSupported(UiaCore.UIA patternId)
+            {
+                if (Owner.SupportsUiaProviders && patternId == UiaCore.UIA.LegacyIAccessiblePatternId)
+                {
+                    return true;
+                }
+
+                return base.IsPatternSupported(patternId);
+            }
+
             internal override bool IsIAccessibleExSupported()
                 => Owner is IAutomationLiveRegion ? true : base.IsIAccessibleExSupported();
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -9,6 +9,7 @@ using System.Windows.Forms.Automation;
 using Accessibility;
 using WinForms.Common.Tests;
 using Xunit;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -873,7 +874,9 @@ namespace System.Windows.Forms.Tests
             using var ownerControl = new AutomationLiveRegionControl();
             var accessibleObject = new Control.ControlAccessibleObject(ownerControl);
             accessibleObject.RaiseLiveRegionChanged();
-        }        [WinFormsFact]
+        }
+
+        [WinFormsFact]
         public void ControlAccessibleObject_RaiseLiveRegionChanged_InvokeNotIAutomationLiveRegion_ThrowsInvalidOperationException()
         {
             using var ownerControl = new Control();
@@ -1337,6 +1340,30 @@ namespace System.Windows.Forms.Tests
             var accessibleObject = new Control.ControlAccessibleObject(ownerControl);
             IAccessible iAccessible = accessibleObject;
             Assert.Throws<ArgumentException>(null, () => iAccessible.set_accValue(varChild, "Value"));
+        }
+
+        [WinFormsFact]
+        public void ControlAccessibleObject_DoesntSupport_LegacyIAccessiblePattern()
+        {
+            using var control = new Control();
+            var accessibleObject = control.AccessibilityObject;
+
+            bool expected = control.SupportsUiaProviders;
+            Assert.False(expected);
+
+            bool actual = accessibleObject.IsPatternSupported(UiaCore.UIA.LegacyIAccessiblePatternId);
+            Assert.Equal(expected, actual);
+        }
+
+        [WinFormsFact]
+        public void ControlAccessibleObject_Supports_LegacyIAccessiblePattern_IfOwnerSupportsUia()
+        {
+            using var control = new Label();
+            var accessibleObject = new Control.ControlAccessibleObject(control);
+
+            Assert.True(control.SupportsUiaProviders);
+            bool actual = accessibleObject.IsPatternSupported(UiaCore.UIA.LegacyIAccessiblePatternId);
+            Assert.True(actual);
         }
 
         private class AutomationLiveRegionControl : Control, IAutomationLiveRegion


### PR DESCRIPTION
 Fixes #3410

## Proposed changes

- Set `IsPatternSupported` for `LegacyIAccessiblePatternId` as true in `ControlAccessibleObject`. It will cause all control accessible objects to implement LegacyIAccessible.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A customer can see correct some accessible properties for accessible objects, which didn't implement LegacyIAccessiblePattern.

## Regression? 

- No

## Risk

- Minimal


## Test methodology <!-- How did you ensure quality? -->

- manual testing
- unit testing
- CTI

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- using Inspect tool
 

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.18363.836]
- .Net Version:   5.0.100-preview.7.20305.3



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3412)