### PR TITLE
Check for illegal cross-thread calls in the TaskDialog

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TaskDialogTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TaskDialogTests.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.RemoteExecutor;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    public class TaskDialogTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsFact]
+        public void TaskDialog_ShowDialog_SetProperty_SameThread_Success()
+        {
+            // Run this from another thread as we call Application.EnableVisualStyles.
+            using RemoteInvokeHandle invokeHandle = RemoteExecutor.Invoke(() =>
+            {
+                Application.EnableVisualStyles();
+                Control.CheckForIllegalCrossThreadCalls = true;
+
+                TaskDialogPage page = new TaskDialogPage();
+                page.Created += (_, __) =>
+                {
+                    // Set the property in the same thread.
+                    page.Text = "X";
+                    page.BoundDialog.Close();
+                };
+
+                TaskDialog.ShowDialog(page);
+            });
+
+            // verify the remote process succeeded
+            Assert.Equal(0, invokeHandle.ExitCode);
+        }
+
+        [WinFormsFact]
+        public void TaskDialog_ShowDialog_SetProperty_DifferentThread_ThrowsInvalidOperationException()
+        {
+            // Run this from another thread as we call Application.EnableVisualStyles.
+            using RemoteInvokeHandle invokeHandle = RemoteExecutor.Invoke(() =>
+            {
+                Application.EnableVisualStyles();
+                Control.CheckForIllegalCrossThreadCalls = true;
+
+                TaskDialogPage page = new TaskDialogPage();
+                page.Created += (_, __) =>
+                {
+                    // Set the property in a different thread.
+                    var separateTask = Task.Run(() => page.Text = "X");
+                    Assert.Throws<InvalidOperationException>(separateTask.GetAwaiter().GetResult);
+
+                    page.BoundDialog.Close();
+                };
+
+                TaskDialog.ShowDialog(page);
+            });
+
+            // verify the remote process succeeded
+            Assert.Equal(0, invokeHandle.ExitCode);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Contributes to dotnet/winforms#3222


## Proposed changes

- The `TaskDialog.Handle` getter will now throw an `InvalidOperationException` when `Control.CheckForIllegalCrossThreadCalls` is `true`, the task dialog is currently being shown, and the current thread is not the one which created the handle.
This is a "best-effort" mechanism to make developers aware of incorrect thread usage, as the task dialog implementation is not thread-safe. (However, because the code is not thread-safe, you cannot rely on the exception being thrown.)
- Because the `TaskDialog.Handle` property is also used internally by code that updates the dialog while it is shown, such code may also throw the `InvalidOperationException` in such cases, for example:
  - `TaskDialogPage.Text.set`
  - `TaskDialogButton.PerformClick()`
  - `TaskDialogRadioButton.Checked.set` etc.

**TODO:** Add Tests

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Customers will be able to detect incorrect threading usage when using the task dialog. The `InvalidOperationException` may only be thrown when `Control.CheckForIllegalCrossThreadCalls` is `true`, which is the default value when a debugger is attached.

## Regression? 

- No

## Risk

-

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

- Manual testing by showing a task dialog and then starting a new thread in the `TaskDialogPage.Created` event that tries to update the dialog while a debugger is attached.


## Test environment(s) <!-- Remove any that don't apply -->

<!-- use `dotnet --info` -->
.NET SDK (reflecting any global.json):
 Version:   5.0.100-rc.1.20367.2
 Commit:    0dd3ff77c7

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.18363
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\5.0.100-rc.1.20367.2\

Host (useful for support):
  Version: 5.0.0-preview.8.20361.2
  Commit:  f37dd6fc85

.NET SDKs installed:
  3.1.400-preview-015203 [C:\Program Files\dotnet\sdk]
  5.0.100-rc.1.20367.2 [C:\Program Files\dotnet\sdk]

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3417)