### PR TITLE
WebBrowser doesn't like multiple UI threads

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlDocumentTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlDocumentTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -15,6 +15,7 @@ using static Interop.Mshtml;
 
 namespace System.Windows.Forms.Tests
 {
+    [Collection("Sequential")]
     public class HtmlDocumentTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlElementTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlElementTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -15,6 +15,7 @@ using static Interop.Mshtml;
 
 namespace System.Windows.Forms.Tests
 {
+    [Collection("Sequential")]
     public class HtmlElementTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WebBrowserTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WebBrowserTests.cs
@@ -19,6 +19,7 @@ namespace System.Windows.Forms.Tests
     using Point = System.Drawing.Point;
     using Size = System.Drawing.Size;
 
+    [Collection("Sequential")]
     public class WebBrowserTests
     {
         [WinFormsFact]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Workaround for #3358

## Proposed changes

Prevent running WebBrowser control tests on multiple UI threads in parallel as that seems to cause memory corruption (unknown whether root cause is in WinForms or native control)

## Customer Impact

no random crashes due to memory corruption in unit tests, should improve CI sucess rates

## Regression? 

no

## Risk

may slow down tests a bit

### Before

random CI crashes or test failures that made no sense due to memory corruption

### After

prevent memory corruption, allowing CI runs to perform normally


## Test methodology

isolated repro scenario into a separate application, it doesn't seem to cause memory corruption when only one UI thread is running the WebBrowser control
