### PR TITLE
Adding check for "IsHandleCreated" flag to RaiseAutomation methods

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -2249,7 +2249,7 @@ namespace System.Windows.Forms
             throw new NotSupportedException(SR.AccessibleObjectLiveRegionNotSupported);
         }
 
-        internal bool RaiseAutomationEvent(UiaCore.UIA eventId)
+        internal virtual bool RaiseAutomationEvent(UiaCore.UIA eventId)
         {
             if (UiaCore.UiaClientsAreListening().IsTrue())
             {
@@ -2260,7 +2260,7 @@ namespace System.Windows.Forms
             return false;
         }
 
-        internal bool RaiseAutomationPropertyChangedEvent(UiaCore.UIA propertyId, object oldValue, object newValue)
+        internal virtual bool RaiseAutomationPropertyChangedEvent(UiaCore.UIA propertyId, object oldValue, object newValue)
         {
             if (UiaCore.UiaClientsAreListening().IsTrue())
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
@@ -466,6 +466,26 @@ namespace System.Windows.Forms
                 return base.GetPropertyValue(propertyID);
             }
 
+            internal override bool RaiseAutomationEvent(UiaCore.UIA eventId)
+            {
+                if (!Owner.IsHandleCreated)
+                {
+                    return false;
+                }
+
+                return base.RaiseAutomationEvent(eventId);
+            }
+
+            internal override bool RaiseAutomationPropertyChangedEvent(UiaCore.UIA propertyId, object oldValue, object newValue)
+            {
+                if (!Owner.IsHandleCreated)
+                {
+                    return false;
+                }
+
+                return base.RaiseAutomationPropertyChangedEvent(propertyId, oldValue, newValue);
+            }
+
             internal override UiaCore.IRawElementProviderSimple HostRawElementProvider
             {
                 get

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
@@ -237,10 +237,7 @@ namespace System.Windows.Forms
         protected override void OnGotFocus(EventArgs e)
         {
             base.OnGotFocus(e);
-            if (IsHandleCreated)
-            {
-                AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
-            }
+            AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
         }
 
         protected override void OnMouseWheel(MouseEventArgs e)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -884,6 +884,48 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<InvalidOperationException>(() => accessibleObject.RaiseLiveRegionChanged());
         }
 
+        [WinFormsTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ControlAccessibleObject_RaiseAutomationEvent_IsHandleCreatedFlag(bool isHandleCreated)
+        {
+            using var ownerControl = new Control();
+            var accessibleObject = new Control.ControlAccessibleObject(ownerControl);
+
+            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
+            Assert.True(ownerControl.IsHandleCreated);
+
+            if (isHandleCreated)
+            {
+                Assert.NotEqual(IntPtr.Zero, ownerControl.Handle);
+            }
+
+            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
+            // Assert.Equal(isHandleCreated, accessibleObject.RaiseAutomationEvent(UiaCore.UIA.AutomationPropertyChangedEventId));
+            // Assert.Equal(isHandleCreated, ownerControl.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ControlAccessibleObject_RaiseAutomationPropertyChangedEvent_IsHandleCreatedFlag(bool isHandleCreated)
+        {
+            using var ownerControl = new Control();
+            var accessibleObject = new Control.ControlAccessibleObject(ownerControl);
+
+            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
+            Assert.True(ownerControl.IsHandleCreated);
+
+            if (isHandleCreated)
+            {
+                Assert.NotEqual(IntPtr.Zero, ownerControl.Handle);
+            }
+
+            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
+            // Assert.Equal(isHandleCreated, accessibleObject.RaiseAutomationPropertyChangedEvent(UiaCore.UIA.NamePropertyId, ownerControl.Name, ownerControl.Name));
+            // Assert.Equal(isHandleCreated, ownerControl.IsHandleCreated);
+        }
+
         [WinFormsFact]
         public void ControlAccessibleObject_ToString_Invoke_Success()
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTextBoxEditingControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTextBoxEditingControlTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1143,13 +1143,17 @@ namespace System.Windows.Forms.Tests
             control.GotFocus += handler;
             control.OnGotFocus(eventArgs);
             Assert.Equal(1, callCount);
-            Assert.False(control.IsHandleCreated);
+
+            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
+            Assert.True(control.IsHandleCreated);
 
             // Remove handler.
             control.GotFocus -= handler;
             control.OnGotFocus(eventArgs);
             Assert.Equal(1, callCount);
-            Assert.False(control.IsHandleCreated);
+
+            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
+            Assert.True(control.IsHandleCreated);
         }
 
         [WinFormsTheory]


### PR DESCRIPTION
Fixes #3419


## Proposed changes
Added check for "IsHandleCreated" flag to "RaiseAutomationEvent" and "RaiseAutomationPropertyChangedEvent" methods. Added wrapper of RaiseAutomation methods to ControlAccessibleObject

## Regression? 
- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Unit testing

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.18363.836]
- .Net Version: 5.0.100-preview.7.20308.6


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3426)