### PR TITLE
WebBrowser doesn't like multiple UI threads

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHost.ConnectionPointCookieTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHost.ConnectionPointCookieTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,6 +8,7 @@ using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
+    [Collection("Sequential")] // workaround for WebBrowser control corrupting memory when run on multiple UI threads (instantiated via GUID)
     public class AxHostConnectionPointCookieTests : IClassFixture<ThreadExceptionFixture>
     {
         private static readonly Guid CLSID_WebBrowser = new Guid("8856f961-340a-11d0-a96b-00c04fd705a2");

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHostTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHostTests.cs
@@ -19,6 +19,7 @@ namespace System.Windows.Forms.Tests
     using Size = System.Drawing.Size;
     using Point = System.Drawing.Point;
 
+    [Collection("Sequential")] // workaround for WebBrowser control corrupting memory when run on multiple UI threads (instantiated via GUID)
     public class AxHostTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlDocumentTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlDocumentTests.cs
@@ -15,7 +15,7 @@ using static Interop.Mshtml;
 
 namespace System.Windows.Forms.Tests
 {
-    [Collection("Sequential")]
+    [Collection("Sequential")] // workaround for WebBrowser control corrupting memory when run on multiple UI threads
     public class HtmlDocumentTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlElementTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlElementTests.cs
@@ -15,7 +15,7 @@ using static Interop.Mshtml;
 
 namespace System.Windows.Forms.Tests
 {
-    [Collection("Sequential")]
+    [Collection("Sequential")] // workaround for WebBrowser control corrupting memory when run on multiple UI threads
     public class HtmlElementTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WebBrowserTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WebBrowserTests.cs
@@ -19,7 +19,7 @@ namespace System.Windows.Forms.Tests
     using Point = System.Drawing.Point;
     using Size = System.Drawing.Size;
 
-    [Collection("Sequential")]
+    [Collection("Sequential")] // workaround for WebBrowser control corrupting memory when run on multiple UI threads
     public class WebBrowserTests
     {
         [WinFormsFact]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Workaround for #3358

(Extended version of PR #3423)

Like mentioned on the other PR this is only a workaround and not a final solution, further investigation to the memory corruption issues are desired. There is also the possibility of another memory corruption source we did not pinpoint yet.

## Proposed changes

Prevent running WebBrowser control tests on multiple UI threads in parallel as that seems to cause memory corruption (unknown whether root cause is in WinForms or native control)

## Customer Impact

no random crashes due to memory corruption in unit tests, should improve CI sucess rates

## Regression? 

no

## Risk

may slow down tests a bit

### Before

random CI crashes or test failures that made no sense due to memory corruption

### After

prevent memory corruption, allowing CI runs to perform normally


## Test methodology

isolated repro scenario into a separate application, it doesn't seem to cause memory corruption when only one UI thread is running the WebBrowser control


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3429)