### PR TITLE
Define a CompileDesignTime target for Accessibility.ilproj

### DIFF
--- a/src/Accessibility/src/Accessibility.ilproj
+++ b/src/Accessibility/src/Accessibility.ilproj
@@ -14,4 +14,6 @@
                       ReferenceOutputAssembly="false"
                       OutputItemType="ILResourceReference" />
   </ItemGroup>
+
+  <Target Name="CompileDesignTime" />
 </Project>


### PR DESCRIPTION
Fixes failures to resolve `IAccessible` in **System.Windows.Forms.Primitives** inside the IDE.
