### PR TITLE
Fixing control Handle force creating when creating ControlAccessibleObject

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.cs
@@ -584,8 +584,14 @@ namespace System.Drawing.Design
 
                 public override AccessibleObject HitTest(int x, int y)
                 {
+                    if (!ColorPalette.IsHandleCreated)
+                    {
+                        return base.HitTest(x, y);
+                    }
+
                     // Convert from screen to client coordinates
                     var pt = new Point(x, y);
+
                     ScreenToClient(new HandleRef(ColorPalette, ColorPalette.Handle), ref pt);
 
                     int cell = ColorPalette.GetCellFromLocationMouse(pt.X, pt.Y);
@@ -620,7 +626,12 @@ namespace System.Drawing.Design
 
                             // Translate rect to screen coordinates
                             var pt = new Point(rect.X, rect.Y);
-                            ClientToScreen(new HandleRef(parent.ColorPalette, parent.ColorPalette.Handle), ref pt);
+                            var palette = parent.ColorPalette;
+
+                            if (palette.IsHandleCreated)
+                            {
+                                ClientToScreen(new HandleRef(palette, palette.Handle), ref pt);
+                            }
 
                             return new Rectangle(pt.X, pt.Y, rect.Width, rect.Height);
                         }

--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -9571,13 +9571,13 @@ System.Windows.Forms.CheckBox.CheckBoxAccessibleObject.CheckBoxAccessibleObject(
 ~System.Windows.Forms.DataGridViewAutoSizeColumnModeEventArgs.DataGridViewAutoSizeColumnModeEventArgs(System.Windows.Forms.DataGridViewColumn dataGridViewColumn, System.Windows.Forms.DataGridViewAutoSizeColumnMode previousMode) -> void
 ~System.Windows.Forms.DataGridViewAutoSizeColumnsModeEventArgs.DataGridViewAutoSizeColumnsModeEventArgs(System.Windows.Forms.DataGridViewAutoSizeColumnMode[] previousModes) -> void
 ~System.Windows.Forms.DataGridViewAutoSizeColumnsModeEventArgs.PreviousModes.get -> System.Windows.Forms.DataGridViewAutoSizeColumnMode[]
-~System.Windows.Forms.DataGridViewButtonCell.DataGridViewButtonCellAccessibleObject.DataGridViewButtonCellAccessibleObject(System.Windows.Forms.DataGridViewCell owner) -> void
+System.Windows.Forms.DataGridViewButtonCell.DataGridViewButtonCellAccessibleObject.DataGridViewButtonCellAccessibleObject(System.Windows.Forms.DataGridViewCell? owner) -> void
 ~System.Windows.Forms.DataGridViewButtonColumn.Text.get -> string
 ~System.Windows.Forms.DataGridViewButtonColumn.Text.set -> void
 ~System.Windows.Forms.DataGridViewCell.AccessibilityObject.get -> System.Windows.Forms.AccessibleObject
-~System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.DataGridViewCellAccessibleObject(System.Windows.Forms.DataGridViewCell owner) -> void
-~System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner.get -> System.Windows.Forms.DataGridViewCell
-~System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner.set -> void
+System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.DataGridViewCellAccessibleObject(System.Windows.Forms.DataGridViewCell? owner) -> void
+System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner.get -> System.Windows.Forms.DataGridViewCell?
+System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner.set -> void
 ~System.Windows.Forms.DataGridViewCell.EditedFormattedValue.get -> object
 ~System.Windows.Forms.DataGridViewCell.ErrorText.get -> string
 ~System.Windows.Forms.DataGridViewCell.ErrorText.set -> void
@@ -9641,7 +9641,7 @@ System.Windows.Forms.CheckBox.CheckBoxAccessibleObject.CheckBoxAccessibleObject(
 ~System.Windows.Forms.DataGridViewCellValidatingEventArgs.FormattedValue.get -> object
 ~System.Windows.Forms.DataGridViewCellValueEventArgs.Value.get -> object
 ~System.Windows.Forms.DataGridViewCellValueEventArgs.Value.set -> void
-~System.Windows.Forms.DataGridViewCheckBoxCell.DataGridViewCheckBoxCellAccessibleObject.DataGridViewCheckBoxCellAccessibleObject(System.Windows.Forms.DataGridViewCell owner) -> void
+System.Windows.Forms.DataGridViewCheckBoxCell.DataGridViewCheckBoxCellAccessibleObject.DataGridViewCheckBoxCellAccessibleObject(System.Windows.Forms.DataGridViewCell? owner) -> void
 ~System.Windows.Forms.DataGridViewCheckBoxCell.FalseValue.get -> object
 ~System.Windows.Forms.DataGridViewCheckBoxCell.FalseValue.set -> void
 ~System.Windows.Forms.DataGridViewCheckBoxCell.IndeterminateValue.get -> object
@@ -9684,10 +9684,10 @@ System.Windows.Forms.CheckBox.CheckBoxAccessibleObject.CheckBoxAccessibleObject(
 ~System.Windows.Forms.DataGridViewColumnDividerDoubleClickEventArgs.DataGridViewColumnDividerDoubleClickEventArgs(int columnIndex, System.Windows.Forms.HandledMouseEventArgs e) -> void
 ~System.Windows.Forms.DataGridViewColumnEventArgs.Column.get -> System.Windows.Forms.DataGridViewColumn
 ~System.Windows.Forms.DataGridViewColumnEventArgs.DataGridViewColumnEventArgs(System.Windows.Forms.DataGridViewColumn dataGridViewColumn) -> void
-~System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.DataGridViewColumnHeaderCellAccessibleObject(System.Windows.Forms.DataGridViewColumnHeaderCell owner) -> void
+System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.DataGridViewColumnHeaderCellAccessibleObject(System.Windows.Forms.DataGridViewColumnHeaderCell? owner) -> void
 ~System.Windows.Forms.DataGridViewColumnStateChangedEventArgs.Column.get -> System.Windows.Forms.DataGridViewColumn
 ~System.Windows.Forms.DataGridViewColumnStateChangedEventArgs.DataGridViewColumnStateChangedEventArgs(System.Windows.Forms.DataGridViewColumn dataGridViewColumn, System.Windows.Forms.DataGridViewElementStates stateChanged) -> void
-~System.Windows.Forms.DataGridViewComboBoxCell.DataGridViewComboBoxCellAccessibleObject.DataGridViewComboBoxCellAccessibleObject(System.Windows.Forms.DataGridViewCell owner) -> void
+System.Windows.Forms.DataGridViewComboBoxCell.DataGridViewComboBoxCellAccessibleObject.DataGridViewComboBoxCellAccessibleObject(System.Windows.Forms.DataGridViewCell? owner) -> void
 ~System.Windows.Forms.DataGridViewComboBoxCell.ObjectCollection.Add(object item) -> int
 ~System.Windows.Forms.DataGridViewComboBoxCell.ObjectCollection.AddRange(System.Windows.Forms.DataGridViewComboBoxCell.ObjectCollection value) -> void
 ~System.Windows.Forms.DataGridViewComboBoxCell.ObjectCollection.AddRange(params object[] items) -> void
@@ -9711,7 +9711,7 @@ System.Windows.Forms.CheckBox.CheckBoxAccessibleObject.CheckBoxAccessibleObject(
 ~System.Windows.Forms.DataGridViewEditingControlShowingEventArgs.CellStyle.set -> void
 ~System.Windows.Forms.DataGridViewEditingControlShowingEventArgs.Control.get -> System.Windows.Forms.Control
 ~System.Windows.Forms.DataGridViewEditingControlShowingEventArgs.DataGridViewEditingControlShowingEventArgs(System.Windows.Forms.Control control, System.Windows.Forms.DataGridViewCellStyle cellStyle) -> void
-~System.Windows.Forms.DataGridViewImageCell.DataGridViewImageCellAccessibleObject.DataGridViewImageCellAccessibleObject(System.Windows.Forms.DataGridViewCell owner) -> void
+System.Windows.Forms.DataGridViewImageCell.DataGridViewImageCellAccessibleObject.DataGridViewImageCellAccessibleObject(System.Windows.Forms.DataGridViewCell? owner) -> void
 ~System.Windows.Forms.DataGridViewImageCell.Description.get -> string
 ~System.Windows.Forms.DataGridViewImageCell.Description.set -> void
 ~System.Windows.Forms.DataGridViewImageColumn.Description.get -> string
@@ -9720,7 +9720,7 @@ System.Windows.Forms.CheckBox.CheckBoxAccessibleObject.CheckBoxAccessibleObject(
 ~System.Windows.Forms.DataGridViewImageColumn.Icon.set -> void
 ~System.Windows.Forms.DataGridViewImageColumn.Image.get -> System.Drawing.Image
 ~System.Windows.Forms.DataGridViewImageColumn.Image.set -> void
-~System.Windows.Forms.DataGridViewLinkCell.DataGridViewLinkCellAccessibleObject.DataGridViewLinkCellAccessibleObject(System.Windows.Forms.DataGridViewCell owner) -> void
+System.Windows.Forms.DataGridViewLinkCell.DataGridViewLinkCellAccessibleObject.DataGridViewLinkCellAccessibleObject(System.Windows.Forms.DataGridViewCell? owner) -> void
 ~System.Windows.Forms.DataGridViewLinkColumn.Text.get -> string
 ~System.Windows.Forms.DataGridViewLinkColumn.Text.set -> void
 ~System.Windows.Forms.DataGridViewRow.AccessibilityObject.get -> System.Windows.Forms.AccessibleObject
@@ -9755,7 +9755,7 @@ System.Windows.Forms.CheckBox.CheckBoxAccessibleObject.CheckBoxAccessibleObject(
 ~System.Windows.Forms.DataGridViewRowErrorTextNeededEventArgs.ErrorText.set -> void
 ~System.Windows.Forms.DataGridViewRowEventArgs.DataGridViewRowEventArgs(System.Windows.Forms.DataGridViewRow dataGridViewRow) -> void
 ~System.Windows.Forms.DataGridViewRowEventArgs.Row.get -> System.Windows.Forms.DataGridViewRow
-~System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.DataGridViewRowHeaderCellAccessibleObject(System.Windows.Forms.DataGridViewRowHeaderCell owner) -> void
+System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.DataGridViewRowHeaderCellAccessibleObject(System.Windows.Forms.DataGridViewRowHeaderCell? owner) -> void
 ~System.Windows.Forms.DataGridViewRowPostPaintEventArgs.DataGridViewRowPostPaintEventArgs(System.Windows.Forms.DataGridView dataGridView, System.Drawing.Graphics graphics, System.Drawing.Rectangle clipBounds, System.Drawing.Rectangle rowBounds, int rowIndex, System.Windows.Forms.DataGridViewElementStates rowState, string errorText, System.Windows.Forms.DataGridViewCellStyle inheritedRowStyle, bool isFirstDisplayedRow, bool isLastVisibleRow) -> void
 ~System.Windows.Forms.DataGridViewRowPostPaintEventArgs.ErrorText.get -> string
 ~System.Windows.Forms.DataGridViewRowPostPaintEventArgs.Graphics.get -> System.Drawing.Graphics
@@ -9782,7 +9782,7 @@ System.Windows.Forms.CheckBox.CheckBoxAccessibleObject.CheckBoxAccessibleObject(
 ~System.Windows.Forms.DataGridViewSortCompareEventArgs.CellValue2.get -> object
 ~System.Windows.Forms.DataGridViewSortCompareEventArgs.Column.get -> System.Windows.Forms.DataGridViewColumn
 ~System.Windows.Forms.DataGridViewSortCompareEventArgs.DataGridViewSortCompareEventArgs(System.Windows.Forms.DataGridViewColumn dataGridViewColumn, object cellValue1, object cellValue2, int rowIndex1, int rowIndex2) -> void
-~System.Windows.Forms.DataGridViewTextBoxCell.DataGridViewTextBoxCellAccessibleObject.DataGridViewTextBoxCellAccessibleObject(System.Windows.Forms.DataGridViewCell owner) -> void
+System.Windows.Forms.DataGridViewTextBoxCell.DataGridViewTextBoxCellAccessibleObject.DataGridViewTextBoxCellAccessibleObject(System.Windows.Forms.DataGridViewCell? owner) -> void
 ~System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.DataGridViewTopLeftHeaderCellAccessibleObject(System.Windows.Forms.DataGridViewTopLeftHeaderCell owner) -> void
 ~System.Windows.Forms.DataObject.DataObject(object data) -> void
 ~System.Windows.Forms.DataObject.DataObject(string format, object data) -> void
@@ -11218,7 +11218,7 @@ override System.Windows.Forms.CheckBox.CheckBoxAccessibleObject.DefaultAction.ge
 ~override System.Windows.Forms.DataGridViewAdvancedBorderStyle.ToString() -> string
 ~override System.Windows.Forms.DataGridViewButtonCell.Clone() -> object
 ~override System.Windows.Forms.DataGridViewButtonCell.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridViewButtonCell.DataGridViewButtonCellAccessibleObject.DefaultAction.get -> string
+override System.Windows.Forms.DataGridViewButtonCell.DataGridViewButtonCellAccessibleObject.DefaultAction.get -> string!
 ~override System.Windows.Forms.DataGridViewButtonCell.EditType.get -> System.Type
 ~override System.Windows.Forms.DataGridViewButtonCell.FormattedValueType.get -> System.Type
 ~override System.Windows.Forms.DataGridViewButtonCell.GetContentBounds(System.Drawing.Graphics graphics, System.Windows.Forms.DataGridViewCellStyle cellStyle, int rowIndex) -> System.Drawing.Rectangle
@@ -11243,15 +11243,15 @@ override System.Windows.Forms.CheckBox.CheckBoxAccessibleObject.DefaultAction.ge
 ~override System.Windows.Forms.DataGridViewButtonColumn.DefaultCellStyle.get -> System.Windows.Forms.DataGridViewCellStyle
 ~override System.Windows.Forms.DataGridViewButtonColumn.DefaultCellStyle.set -> void
 ~override System.Windows.Forms.DataGridViewButtonColumn.ToString() -> string
-~override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.DefaultAction.get -> string
-~override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.GetChild(int index) -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.GetFocused() -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.GetSelected() -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Name.get -> string
-~override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Navigate(System.Windows.Forms.AccessibleNavigation navigationDirection) -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Parent.get -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Value.get -> string
-~override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Value.set -> void
+override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.DefaultAction.get -> string!
+override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.GetChild(int index) -> System.Windows.Forms.AccessibleObject?
+override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.GetFocused() -> System.Windows.Forms.AccessibleObject?
+override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.GetSelected() -> System.Windows.Forms.AccessibleObject?
+override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Name.get -> string?
+override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Navigate(System.Windows.Forms.AccessibleNavigation navigationDirection) -> System.Windows.Forms.AccessibleObject?
+override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Parent.get -> System.Windows.Forms.AccessibleObject?
+override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Value.get -> string?
+override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Value.set -> void
 ~override System.Windows.Forms.DataGridViewCell.ToString() -> string
 ~override System.Windows.Forms.DataGridViewCellCollection.List.get -> System.Collections.ArrayList
 ~override System.Windows.Forms.DataGridViewCellStyle.Equals(object o) -> bool
@@ -11262,7 +11262,7 @@ override System.Windows.Forms.CheckBox.CheckBoxAccessibleObject.DefaultAction.ge
 ~override System.Windows.Forms.DataGridViewCheckBoxCell.ContentClickUnsharesRow(System.Windows.Forms.DataGridViewCellEventArgs e) -> bool
 ~override System.Windows.Forms.DataGridViewCheckBoxCell.ContentDoubleClickUnsharesRow(System.Windows.Forms.DataGridViewCellEventArgs e) -> bool
 ~override System.Windows.Forms.DataGridViewCheckBoxCell.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridViewCheckBoxCell.DataGridViewCheckBoxCellAccessibleObject.DefaultAction.get -> string
+override System.Windows.Forms.DataGridViewCheckBoxCell.DataGridViewCheckBoxCellAccessibleObject.DefaultAction.get -> string!
 ~override System.Windows.Forms.DataGridViewCheckBoxCell.EditType.get -> System.Type
 ~override System.Windows.Forms.DataGridViewCheckBoxCell.FormattedValueType.get -> System.Type
 ~override System.Windows.Forms.DataGridViewCheckBoxCell.GetContentBounds(System.Drawing.Graphics graphics, System.Windows.Forms.DataGridViewCellStyle cellStyle, int rowIndex) -> System.Drawing.Rectangle
@@ -11301,11 +11301,11 @@ override System.Windows.Forms.CheckBox.CheckBoxAccessibleObject.DefaultAction.ge
 ~override System.Windows.Forms.DataGridViewColumnDesignTimeVisibleAttribute.Equals(object obj) -> bool
 ~override System.Windows.Forms.DataGridViewColumnHeaderCell.Clone() -> object
 ~override System.Windows.Forms.DataGridViewColumnHeaderCell.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.DefaultAction.get -> string
-~override System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.Name.get -> string
-~override System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.Navigate(System.Windows.Forms.AccessibleNavigation navigationDirection) -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.Parent.get -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.Value.get -> string
+override System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.DefaultAction.get -> string!
+override System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.Name.get -> string!
+override System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.Navigate(System.Windows.Forms.AccessibleNavigation navigationDirection) -> System.Windows.Forms.AccessibleObject?
+override System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.Parent.get -> System.Windows.Forms.AccessibleObject?
+override System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.Value.get -> string!
 ~override System.Windows.Forms.DataGridViewColumnHeaderCell.GetClipboardContent(int rowIndex, bool firstCell, bool lastCell, bool inFirstRow, bool inLastRow, string format) -> object
 ~override System.Windows.Forms.DataGridViewColumnHeaderCell.GetContentBounds(System.Drawing.Graphics graphics, System.Windows.Forms.DataGridViewCellStyle cellStyle, int rowIndex) -> System.Drawing.Rectangle
 ~override System.Windows.Forms.DataGridViewColumnHeaderCell.GetInheritedContextMenuStrip(int rowIndex) -> System.Windows.Forms.ContextMenuStrip
@@ -11352,10 +11352,10 @@ override System.Windows.Forms.CheckBox.CheckBoxAccessibleObject.DefaultAction.ge
 ~override System.Windows.Forms.DataGridViewHeaderCell.ValueType.set -> void
 ~override System.Windows.Forms.DataGridViewImageCell.Clone() -> object
 ~override System.Windows.Forms.DataGridViewImageCell.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridViewImageCell.DataGridViewImageCellAccessibleObject.DefaultAction.get -> string
-~override System.Windows.Forms.DataGridViewImageCell.DataGridViewImageCellAccessibleObject.Description.get -> string
-~override System.Windows.Forms.DataGridViewImageCell.DataGridViewImageCellAccessibleObject.Value.get -> string
-~override System.Windows.Forms.DataGridViewImageCell.DataGridViewImageCellAccessibleObject.Value.set -> void
+override System.Windows.Forms.DataGridViewImageCell.DataGridViewImageCellAccessibleObject.DefaultAction.get -> string!
+override System.Windows.Forms.DataGridViewImageCell.DataGridViewImageCellAccessibleObject.Description.get -> string?
+override System.Windows.Forms.DataGridViewImageCell.DataGridViewImageCellAccessibleObject.Value.get -> string?
+override System.Windows.Forms.DataGridViewImageCell.DataGridViewImageCellAccessibleObject.Value.set -> void
 ~override System.Windows.Forms.DataGridViewImageCell.DefaultNewRowValue.get -> object
 ~override System.Windows.Forms.DataGridViewImageCell.EditType.get -> System.Type
 ~override System.Windows.Forms.DataGridViewImageCell.FormattedValueType.get -> System.Type
@@ -11376,7 +11376,7 @@ override System.Windows.Forms.CheckBox.CheckBoxAccessibleObject.DefaultAction.ge
 ~override System.Windows.Forms.DataGridViewImageColumn.ToString() -> string
 ~override System.Windows.Forms.DataGridViewLinkCell.Clone() -> object
 ~override System.Windows.Forms.DataGridViewLinkCell.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridViewLinkCell.DataGridViewLinkCellAccessibleObject.DefaultAction.get -> string
+override System.Windows.Forms.DataGridViewLinkCell.DataGridViewLinkCellAccessibleObject.DefaultAction.get -> string!
 ~override System.Windows.Forms.DataGridViewLinkCell.EditType.get -> System.Type
 ~override System.Windows.Forms.DataGridViewLinkCell.FormattedValueType.get -> System.Type
 ~override System.Windows.Forms.DataGridViewLinkCell.GetContentBounds(System.Drawing.Graphics graphics, System.Windows.Forms.DataGridViewCellStyle cellStyle, int rowIndex) -> System.Drawing.Rectangle
@@ -11414,11 +11414,11 @@ override System.Windows.Forms.CheckBox.CheckBoxAccessibleObject.DefaultAction.ge
 ~override System.Windows.Forms.DataGridViewRow.ToString() -> string
 ~override System.Windows.Forms.DataGridViewRowHeaderCell.Clone() -> object
 ~override System.Windows.Forms.DataGridViewRowHeaderCell.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.DefaultAction.get -> string
-~override System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.Name.get -> string
-~override System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.Navigate(System.Windows.Forms.AccessibleNavigation navigationDirection) -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.Parent.get -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.Value.get -> string
+override System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.DefaultAction.get -> string!
+override System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.Name.get -> string?
+override System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.Navigate(System.Windows.Forms.AccessibleNavigation navigationDirection) -> System.Windows.Forms.AccessibleObject?
+override System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.Parent.get -> System.Windows.Forms.AccessibleObject?
+override System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.Value.get -> string!
 ~override System.Windows.Forms.DataGridViewRowHeaderCell.GetClipboardContent(int rowIndex, bool firstCell, bool lastCell, bool inFirstRow, bool inLastRow, string format) -> object
 ~override System.Windows.Forms.DataGridViewRowHeaderCell.GetContentBounds(System.Drawing.Graphics graphics, System.Windows.Forms.DataGridViewCellStyle cellStyle, int rowIndex) -> System.Drawing.Rectangle
 ~override System.Windows.Forms.DataGridViewRowHeaderCell.GetErrorIconBounds(System.Drawing.Graphics graphics, System.Windows.Forms.DataGridViewCellStyle cellStyle, int rowIndex) -> System.Drawing.Rectangle

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
@@ -1479,7 +1479,13 @@ namespace System.Windows.Forms
 
             public override AccessibleObject GetFocused()
             {
+                if (!CheckedListBox.IsHandleCreated)
+                {
+                    return null;
+                }
+
                 int index = CheckedListBox.FocusedIndex;
+
                 if (index >= 0)
                 {
                     return GetChild(index);
@@ -1490,7 +1496,13 @@ namespace System.Windows.Forms
 
             public override AccessibleObject GetSelected()
             {
+                if (!CheckedListBox.IsHandleCreated)
+                {
+                    return null;
+                }
+
                 int index = CheckedListBox.SelectedIndex;
+
                 if (index >= 0)
                 {
                     return GetChild(index);
@@ -1501,12 +1513,19 @@ namespace System.Windows.Forms
 
             public override AccessibleObject HitTest(int x, int y)
             {
+                if (!CheckedListBox.IsHandleCreated)
+                {
+                    return null;
+                }
+
                 // Within a child element?
                 //
                 int count = GetChildCount();
+
                 for (int index = 0; index < count; ++index)
                 {
                     AccessibleObject child = GetChild(index);
+
                     if (child.Bounds.Contains(x, y))
                     {
                         return child;
@@ -1557,6 +1576,11 @@ namespace System.Windows.Forms
             {
                 get
                 {
+                    if (!ParentCheckedListBox.IsHandleCreated)
+                    {
+                        return Rectangle.Empty;
+                    }
+
                     Rectangle rect = ParentCheckedListBox.GetItemRectangle(_index);
 
                     if (rect.IsEmpty)
@@ -1584,6 +1608,11 @@ namespace System.Windows.Forms
             {
                 get
                 {
+                    if (!ParentCheckedListBox.IsHandleCreated)
+                    {
+                        return string.Empty;
+                    }
+
                     if (ParentCheckedListBox.GetItemChecked(_index))
                     {
                         return SR.AccessibleActionUncheck;
@@ -1635,6 +1664,11 @@ namespace System.Windows.Forms
             {
                 get
                 {
+                    if (!ParentCheckedListBox.IsHandleCreated)
+                    {
+                        return AccessibleStates.None;
+                    }
+
                     AccessibleStates state = AccessibleStates.Selectable | AccessibleStates.Focusable;
 
                     // Checked state
@@ -1678,6 +1712,11 @@ namespace System.Windows.Forms
 
             public override void DoDefaultAction()
             {
+                if (!ParentCheckedListBox.IsHandleCreated)
+                {
+                    return;
+                }
+
                 ParentCheckedListBox.SetItemChecked(_index, !ParentCheckedListBox.GetItemChecked(_index));
             }
 
@@ -1712,7 +1751,10 @@ namespace System.Windows.Forms
             {
                 try
                 {
-                    ParentCheckedListBox.AccessibilityObject.GetSystemIAccessibleInternal().accSelect((int)flags, _index + 1);
+                    if (ParentCheckedListBox.IsHandleCreated)
+                    {
+                        ParentCheckedListBox.AccessibilityObject.GetSystemIAccessibleInternal()?.accSelect((int)flags, _index + 1);
+                    }
                 }
                 catch (ArgumentException)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -4508,10 +4508,14 @@ namespace System.Windows.Forms
 
             public ChildAccessibleObject(ComboBox owner, IntPtr handle)
             {
-                Debug.Assert(owner != null && owner.Handle != IntPtr.Zero, "ComboBox's handle hasn't been created");
+                Debug.Assert(owner?.IsHandleCreated is true, "ComboBox's handle hasn't been created");
 
                 _owner = owner;
-                UseStdAccessibleObjects(handle);
+
+                if (owner?.IsHandleCreated is true)
+                {
+                    UseStdAccessibleObjects(handle);
+                }
             }
 
             public override string Name
@@ -4734,7 +4738,7 @@ namespace System.Windows.Forms
 
                     var runtimeId = new int[4];
                     runtimeId[0] = RuntimeIDFirstItem;
-                    runtimeId[1] = (int)(long)_owningComboBox.Handle;
+                    runtimeId[1] = (int)(long)_owningComboBox.InternalHandle;
                     runtimeId[2] = _owningComboBox.GetListNativeWindowRuntimeIdPart();
 
                     var comboBoxAccessibleObject = _owningComboBox.AccessibilityObject as ComboBoxAccessibleObject;
@@ -4767,12 +4771,22 @@ namespace System.Windows.Forms
 
             internal unsafe override void SelectItem()
             {
+                if (!_owningComboBox.IsHandleCreated)
+                {
+                    return;
+                }
+
                 _owningComboBox.SelectedIndex = GetCurrentIndex();
                 InvalidateRect(new HandleRef(this, _owningComboBox.GetListHandle()), null, BOOL.FALSE);
             }
 
             internal override void AddToSelection()
             {
+                if (!_owningComboBox.IsHandleCreated)
+                {
+                    return;
+                }
+
                 SelectItem();
             }
 
@@ -4859,7 +4873,7 @@ namespace System.Windows.Forms
 
             private void ComboBoxDefaultAction(bool expand)
             {
-                if (_owningComboBox.DroppedDown != expand)
+                if (_owningComboBox.IsHandleCreated && _owningComboBox.DroppedDown != expand)
                 {
                     _owningComboBox.DroppedDown = expand;
                 }
@@ -4908,7 +4922,7 @@ namespace System.Windows.Forms
 
                         var runtimeId = new int[3];
                         runtimeId[0] = RuntimeIDFirstItem;
-                        runtimeId[1] = (int)(long)_owningComboBox.Handle;
+                        runtimeId[1] = (int)(long)_owningComboBox.InternalHandle;
                         runtimeId[2] = _owningComboBox.GetHashCode();
 
                         return runtimeId;
@@ -4932,7 +4946,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    return _owningComboBox.DroppedDown == true ? UiaCore.ExpandCollapseState.Expanded : UiaCore.ExpandCollapseState.Collapsed;
+                    return _owningComboBox.IsHandleCreated && _owningComboBox.DroppedDown ? UiaCore.ExpandCollapseState.Expanded : UiaCore.ExpandCollapseState.Collapsed;
                 }
             }
 
@@ -4973,7 +4987,7 @@ namespace System.Windows.Forms
                 {
                     if (_dropDownButtonUiaProvider is null)
                     {
-                        _dropDownButtonUiaProvider = new ComboBoxChildDropDownButtonUiaProvider(_owningComboBox, _owningComboBox.Handle);
+                        _dropDownButtonUiaProvider = new ComboBoxChildDropDownButtonUiaProvider(_owningComboBox, _owningComboBox.InternalHandle);
                     }
 
                     return _dropDownButtonUiaProvider;
@@ -5095,7 +5109,7 @@ namespace System.Windows.Forms
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
                         return _owningComboBox.Focused;
                     case UiaCore.UIA.NativeWindowHandlePropertyId:
-                        return _owningComboBox.Handle;
+                        return _owningComboBox.InternalHandle;
                     case UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId:
                         return IsPatternSupported(UiaCore.UIA.ExpandCollapsePatternId);
                     case UiaCore.UIA.IsValuePatternAvailablePropertyId:
@@ -5113,6 +5127,11 @@ namespace System.Windows.Forms
 
             internal void SetComboBoxItemFocus()
             {
+                if (!_owningComboBox.IsHandleCreated)
+                {
+                    return;
+                }
+
                 var selectedItem = _owningComboBox.SelectedItem;
                 if (selectedItem is null)
                 {
@@ -5127,6 +5146,11 @@ namespace System.Windows.Forms
 
             internal void SetComboBoxItemSelection()
             {
+                if (!_owningComboBox.IsHandleCreated)
+                {
+                    return;
+                }
+
                 var selectedItem = _owningComboBox.SelectedItem;
                 if (selectedItem is null)
                 {
@@ -5141,6 +5165,11 @@ namespace System.Windows.Forms
 
             internal override void SetFocus()
             {
+                if (!_owningComboBox.IsHandleCreated)
+                {
+                    return;
+                }
+
                 base.SetFocus();
 
                 RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
@@ -5439,15 +5468,26 @@ namespace System.Windows.Forms
 
             public override AccessibleObject GetFocused()
             {
+                if (!_owningComboBox.IsHandleCreated)
+                {
+                    return null;
+                }
+
                 int selectedIndex = _owningComboBox.SelectedIndex;
                 return GetChildFragment(selectedIndex);
             }
 
             internal override UiaCore.IRawElementProviderSimple[] GetSelection()
             {
+                if (!_owningComboBox.IsHandleCreated)
+                {
+                    return Array.Empty<UiaCore.IRawElementProviderSimple>();
+                }
+
                 int selectedIndex = _owningComboBox.SelectedIndex;
 
                 AccessibleObject itemAccessibleObject = GetChildFragment(selectedIndex);
+
                 if (itemAccessibleObject != null)
                 {
                     return new UiaCore.IRawElementProviderSimple[] {
@@ -5508,7 +5548,7 @@ namespace System.Windows.Forms
                 {
                     var runtimeId = new int[3];
                     runtimeId[0] = RuntimeIDFirstItem;
-                    runtimeId[1] = (int)(long)_owningComboBox.Handle;
+                    runtimeId[1] = (int)(long)_owningComboBox.InternalHandle;
                     runtimeId[2] = _owningComboBox.GetListNativeWindowRuntimeIdPart();
 
                     return runtimeId;
@@ -5680,7 +5720,7 @@ namespace System.Windows.Forms
                 {
                     var runtimeId = new int[5];
                     runtimeId[0] = RuntimeIDFirstItem;
-                    runtimeId[1] = (int)(long)_owner.Handle;
+                    runtimeId[1] = (int)(long)_owner.InternalHandle;
                     runtimeId[2] = _owner.GetHashCode();
                     runtimeId[3] = GetHashCode();
                     runtimeId[4] = GetChildId();
@@ -5919,7 +5959,7 @@ namespace System.Windows.Forms
                 {
                     var runtimeId = new int[5];
                     runtimeId[0] = RuntimeIDFirstItem;
-                    runtimeId[1] = (int)(long)_owner.Handle;
+                    runtimeId[1] = (int)(long)_owner.InternalHandle;
                     runtimeId[2] = _owner.GetHashCode();
 
                     // Made up constant from MSAA proxy. When MSAA proxy is used as an accessibility provider,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
@@ -20,24 +20,36 @@ namespace System.Windows.Forms
         {
             private static IntPtr s_oleAccAvailable = NativeMethods.InvalidIntPtr;
 
-            private IntPtr _handle = IntPtr.Zero; // Associated window handle (if any)
-            private int[]? _runtimeId;     // Used by UIAutomation
+            private IntPtr _handle = IntPtr.Zero;   // Associated window handle (if any)
+            private int[]? _runtimeId;              // Used by UIAutomation
+            private bool _getOwnerControlHandle;
 
             public ControlAccessibleObject(Control ownerControl)
             {
                 Owner = ownerControl ?? throw new ArgumentNullException(nameof(ownerControl));
-                IntPtr handle = ownerControl.Handle;
-                Handle = handle;
+                InitHandle(ownerControl);
             }
 
             internal ControlAccessibleObject(Control ownerControl, int accObjId)
             {
-                Debug.Assert(ownerControl != null, "Cannot construct a ControlAccessibleObject with a null ownerControl");
-
                 AccessibleObjectId = accObjId; // ...must set this *before* setting the Handle property
                 Owner = ownerControl ?? throw new ArgumentNullException(nameof(ownerControl));
-                IntPtr handle = ownerControl.Handle;
-                Handle = handle;
+                InitHandle(ownerControl);
+            }
+
+            private void InitHandle(Control ownerControl)
+            {
+                if (ownerControl.IsHandleCreated)
+                {
+                    Handle = ownerControl.Handle;
+                }
+                else
+                {
+                    // If the owner control doesn't have a valid handle, wait until there is either
+                    // a request to create it, or the owner control creates a handle, which will
+                    // be set via Handle property.
+                    _getOwnerControlHandle = true;
+                }
             }
 
             /// <summary>
@@ -162,7 +174,7 @@ namespace System.Windows.Forms
                 {
                     if (_runtimeId is null)
                     {
-                        _runtimeId = new int[] { 0x2a, (int)(long)Handle };
+                        _runtimeId = new int[] { 0x2a, (int)(long)HandleInternal };
                     }
 
                     return _runtimeId;
@@ -173,7 +185,16 @@ namespace System.Windows.Forms
 
             public IntPtr Handle
             {
-                get => _handle;
+                get
+                {
+                    if (_getOwnerControlHandle)
+                    {
+                        _getOwnerControlHandle = false;
+                        _handle = Owner.Handle;
+                    }
+
+                    return _handle;
+                }
                 set
                 {
                     if (_handle == value)
@@ -182,8 +203,9 @@ namespace System.Windows.Forms
                     }
 
                     _handle = value;
+                    _getOwnerControlHandle = false;
 
-                    if (s_oleAccAvailable == IntPtr.Zero)
+                    if (s_oleAccAvailable == IntPtr.Zero || _handle == IntPtr.Zero)
                     {
                         return;
                     }
@@ -201,7 +223,7 @@ namespace System.Windows.Forms
                     // We need to store internally the system provided
                     // IAccessible, because some windows forms controls use it
                     // as the default IAccessible implementation.
-                    if (_handle != IntPtr.Zero && s_oleAccAvailable != IntPtr.Zero)
+                    if (s_oleAccAvailable != IntPtr.Zero)
                     {
                         UseStdAccessibleObjects(_handle);
                     }
@@ -212,6 +234,8 @@ namespace System.Windows.Forms
                     }
                 }
             }
+
+            internal IntPtr HandleInternal => _handle;
 
             public override string? Help
             {
@@ -388,26 +412,41 @@ namespace System.Windows.Forms
 
             public void NotifyClients(AccessibleEvents accEvent)
             {
+                if (HandleInternal == IntPtr.Zero)
+                {
+                    return;
+                }
+
                 Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo,
                     $"Control.NotifyClients: this = {ToString()}, accEvent = {accEvent}, childID = self");
 
-                User32.NotifyWinEvent((uint)accEvent, new HandleRef(this, Handle), User32.OBJID.CLIENT, 0);
+                User32.NotifyWinEvent((uint)accEvent, new HandleRef(this, HandleInternal), User32.OBJID.CLIENT, 0);
             }
 
             public void NotifyClients(AccessibleEvents accEvent, int childID)
             {
+                if (HandleInternal == IntPtr.Zero)
+                {
+                    return;
+                }
+
                 Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo,
                     $"Control.NotifyClients: this = {ToString()}, accEvent = {accEvent}, childID = {childID}");
 
-                User32.NotifyWinEvent((uint)accEvent, new HandleRef(this, Handle), User32.OBJID.CLIENT, childID + 1);
+                User32.NotifyWinEvent((uint)accEvent, new HandleRef(this, HandleInternal), User32.OBJID.CLIENT, childID + 1);
             }
 
             public void NotifyClients(AccessibleEvents accEvent, int objectID, int childID)
             {
+                if (HandleInternal == IntPtr.Zero)
+                {
+                    return;
+                }
+
                 Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo,
                     $"Control.NotifyClients: this = {ToString()}, accEvent = {accEvent}, childID = {childID}");
 
-                User32.NotifyWinEvent((uint)accEvent, new HandleRef(this, Handle), objectID, childID + 1);
+                User32.NotifyWinEvent((uint)accEvent, new HandleRef(this, HandleInternal), objectID, childID + 1);
             }
 
             /// <summary>
@@ -489,13 +528,18 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    UiaCore.UiaHostProviderFromHwnd(new HandleRef(this, Handle), out UiaCore.IRawElementProviderSimple provider);
+                    if (HandleInternal == IntPtr.Zero)
+                    {
+                        return null;
+                    }
+
+                    UiaCore.UiaHostProviderFromHwnd(new HandleRef(this, HandleInternal), out UiaCore.IRawElementProviderSimple provider);
                     return provider;
                 }
             }
 
             public override string ToString()
-                => $"ControlAccessibleObject: Owner = {Owner?.ToString() ?? "null"}";
+                => $"{nameof(ControlAccessibleObject)}: Owner = {Owner?.ToString() ?? "null"}";
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
@@ -164,6 +164,11 @@ namespace System.Windows.Forms
 
             public override AccessibleObject HitTest(int x, int y)
             {
+                if (!owner.IsHandleCreated)
+                {
+                    return null;
+                }
+
                 Point pt = owner.PointToClient(new Point(x, y));
                 HitTestInfo hti = owner.HitTest(pt.X, pt.Y);
 
@@ -407,7 +412,7 @@ namespace System.Windows.Forms
 
             internal override void SetFocus()
             {
-                if (owner.CanFocus)
+                if (owner.IsHandleCreated && owner.CanFocus)
                 {
                     owner.Focus();
                 }
@@ -418,14 +423,9 @@ namespace System.Windows.Forms
             #region IRawElementProviderFragmentRoot Implementation
 
             internal override UiaCore.IRawElementProviderFragment ElementProviderFromPoint(double x, double y)
-            {
-                return HitTest((int)x, (int)y);
-            }
+                => owner.IsHandleCreated ? HitTest((int)x, (int)y) : null;
 
-            internal override UiaCore.IRawElementProviderFragment GetFocus()
-            {
-                return GetFocused();
-            }
+            internal override UiaCore.IRawElementProviderFragment GetFocus() => GetFocused();
 
             #endregion
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.DataGridViewEditingPanelAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.DataGridViewEditingPanelAccessibleObject.cs
@@ -69,7 +69,7 @@ namespace System.Windows.Forms
 
             internal override void SetFocus()
             {
-                if (_panel.CanFocus)
+                if (_panel.IsHandleCreated && _panel.CanFocus)
                 {
                     _panel.Focus();
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.TopRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.TopRowAccessibleObject.cs
@@ -35,15 +35,13 @@ namespace System.Windows.Forms
                     {
                         throw new InvalidOperationException(SR.DataGridViewTopRowAccessibleObject_OwnerNotSet);
                     }
-                    if (owner.ColumnHeadersVisible)
+
+                    if (owner.IsHandleCreated && owner.ColumnHeadersVisible)
                     {
                         Rectangle rect = Rectangle.Union(owner._layout.ColumnHeaders, owner._layout.TopLeftHeader);
                         return owner.RectangleToScreen(rect);
                     }
-                    else
-                    {
-                        return Rectangle.Empty;
-                    }
+                    return Rectangle.Empty;
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.DataGridViewButtonCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.DataGridViewButtonCellAccessibleObject.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 using static Interop;
 
@@ -12,7 +10,7 @@ namespace System.Windows.Forms
     {
         protected class DataGridViewButtonCellAccessibleObject : DataGridViewCellAccessibleObject
         {
-            public DataGridViewButtonCellAccessibleObject(DataGridViewCell owner) : base(owner)
+            public DataGridViewButtonCellAccessibleObject(DataGridViewCell? owner) : base(owner)
             {
             }
 
@@ -26,12 +24,25 @@ namespace System.Windows.Forms
 
             public override void DoDefaultAction()
             {
-                DataGridViewButtonCell dataGridViewCell = (DataGridViewButtonCell)Owner;
-                DataGridView dataGridView = dataGridViewCell.DataGridView;
+                if (Owner is null)
+                {
+                    throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
+                }
 
-                if (dataGridView != null && dataGridViewCell.RowIndex == -1)
+                if (!(Owner is DataGridViewButtonCell dataGridViewCell))
+                {
+                    return;
+                }
+
+                if (dataGridViewCell.RowIndex == -1)
                 {
                     throw new InvalidOperationException(SR.DataGridView_InvalidOperationOnSharedCell);
+                }
+
+                DataGridView? dataGridView = dataGridViewCell.DataGridView;
+                if (dataGridView?.IsHandleCreated != true)
+                {
+                    return;
                 }
 
                 if (dataGridViewCell.OwningColumn != null && dataGridViewCell.OwningRow != null)
@@ -41,22 +52,14 @@ namespace System.Windows.Forms
                 }
             }
 
-            public override int GetChildCount()
-            {
-                return 0;
-            }
+            public override int GetChildCount() => 0;
 
             internal override bool IsIAccessibleExSupported() => true;
 
-            internal override object GetPropertyValue(UiaCore.UIA propertyID)
-            {
-                if (propertyID == UiaCore.UIA.ControlTypePropertyId)
-                {
-                    return UiaCore.UIA.ButtonControlTypeId;
-                }
-
-                return base.GetPropertyValue(propertyID);
-            }
+            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
+                => propertyID == UiaCore.UIA.ControlTypePropertyId
+                    ? UiaCore.UIA.ButtonControlTypeId
+                    : base.GetPropertyValue(propertyID);
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
@@ -15,26 +13,20 @@ namespace System.Windows.Forms
     {
         protected class DataGridViewCellAccessibleObject : AccessibleObject
         {
-            private int[] _runtimeId; // Used by UIAutomation
-            private AccessibleObject _child;
-            private DataGridViewCell _owner;
+            private int[] _runtimeId = null!; // Used by UIAutomation
+            private AccessibleObject? _child;
+            private DataGridViewCell? _owner;
 
             public DataGridViewCellAccessibleObject()
             {
             }
 
-            public DataGridViewCellAccessibleObject(DataGridViewCell owner)
+            public DataGridViewCellAccessibleObject(DataGridViewCell? owner)
             {
                 _owner = owner;
             }
 
-            public override Rectangle Bounds
-            {
-                get
-                {
-                    return GetAccessibleObjectBounds(GetAccessibleObjectParent());
-                }
-            }
+            public override Rectangle Bounds => GetAccessibleObjectBounds(GetAccessibleObjectParent());
 
             public override string DefaultAction
             {
@@ -44,18 +36,12 @@ namespace System.Windows.Forms
                     {
                         throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                     }
-                    if (!Owner.ReadOnly)
-                    {
-                        return SR.DataGridView_AccCellDefaultAction;
-                    }
-                    else
-                    {
-                        return string.Empty;
-                    }
+
+                    return !Owner.ReadOnly ? SR.DataGridView_AccCellDefaultAction : string.Empty;
                 }
             }
 
-            public override string Name
+            public override string? Name
             {
                 get
                 {
@@ -63,62 +49,54 @@ namespace System.Windows.Forms
                     {
                         throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                     }
-                    if (_owner.OwningColumn != null)
-                    {
-                        string name = string.Format(SR.DataGridView_AccDataGridViewCellName, _owner.OwningColumn.HeaderText, _owner.OwningRow.Index);
 
-                        if (_owner.OwningColumn.SortMode != DataGridViewColumnSortMode.NotSortable)
-                        {
-                            DataGridViewCell dataGridViewCell = Owner;
-                            DataGridView dataGridView = dataGridViewCell.DataGridView;
-
-                            if (dataGridViewCell.OwningColumn != null &&
-                                dataGridViewCell.OwningColumn == dataGridView.SortedColumn)
-                            {
-                                name += ", " + (dataGridView.SortOrder == SortOrder.Ascending
-                                    ? SR.SortedAscendingAccessibleStatus
-                                    : SR.SortedDescendingAccessibleStatus);
-                            }
-                            else
-                            {
-                                name += ", " + SR.NotSortedAccessibleStatus;
-                            }
-                        }
-
-                        return name;
-                    }
-                    else
+                    if (_owner.OwningColumn is null)
                     {
                         return string.Empty;
                     }
+
+                    string name = string.Format(SR.DataGridView_AccDataGridViewCellName, _owner.OwningColumn.HeaderText, _owner.OwningRow.Index);
+
+                    if (_owner.OwningColumn.SortMode != DataGridViewColumnSortMode.NotSortable)
+                    {
+                        DataGridViewCell dataGridViewCell = _owner;
+                        DataGridView? dataGridView = dataGridViewCell.DataGridView;
+
+                        if (dataGridView != null &&
+                            dataGridViewCell.OwningColumn != null &&
+                            dataGridViewCell.OwningColumn == dataGridView.SortedColumn)
+                        {
+                            name += ", " + (dataGridView.SortOrder == SortOrder.Ascending
+                                ? SR.SortedAscendingAccessibleStatus
+                                : SR.SortedDescendingAccessibleStatus);
+                        }
+                        else
+                        {
+                            name += $", {SR.NotSortedAccessibleStatus}";
+                        }
+                    }
+
+                    return name;
                 }
             }
 
-            public DataGridViewCell Owner
+            public DataGridViewCell? Owner
             {
-                get
-                {
-                    return _owner;
-                }
+                get => _owner;
                 set
                 {
                     if (_owner != null)
                     {
                         throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerAlreadySet);
                     }
+
                     _owner = value;
                 }
             }
 
-            public override AccessibleObject Parent
-            {
-                get
-                {
-                    return ParentPrivate;
-                }
-            }
+            public override AccessibleObject? Parent => ParentPrivate;
 
-            private AccessibleObject ParentPrivate
+            private AccessibleObject? ParentPrivate
             {
                 get
                 {
@@ -131,13 +109,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            public override AccessibleRole Role
-            {
-                get
-                {
-                    return AccessibleRole.Cell;
-                }
-            }
+            public override AccessibleRole Role => AccessibleRole.Cell;
 
             public override AccessibleStates State
             {
@@ -164,37 +136,39 @@ namespace System.Windows.Forms
                         state |= AccessibleStates.ReadOnly;
                     }
 
-                    if (Owner.DataGridView != null)
+                    if (_owner.DataGridView?.IsHandleCreated != true)
                     {
-                        Rectangle cellBounds;
-                        if (_owner.OwningColumn != null && _owner.OwningRow != null)
-                        {
-                            cellBounds = _owner.DataGridView.GetCellDisplayRectangle(_owner.OwningColumn.Index, _owner.OwningRow.Index, false /*cutOverflow*/);
-                        }
-                        else if (_owner.OwningRow != null)
-                        {
-                            cellBounds = _owner.DataGridView.GetCellDisplayRectangle(-1, _owner.OwningRow.Index, false /*cutOverflow*/);
-                        }
-                        else if (_owner.OwningColumn != null)
-                        {
-                            cellBounds = _owner.DataGridView.GetCellDisplayRectangle(_owner.OwningColumn.Index, -1, false /*cutOverflow*/);
-                        }
-                        else
-                        {
-                            cellBounds = _owner.DataGridView.GetCellDisplayRectangle(-1, -1, false /*cutOverflow*/);
-                        }
+                        return state;
+                    }
 
-                        if (!cellBounds.IntersectsWith(_owner.DataGridView.ClientRectangle))
-                        {
-                            state |= AccessibleStates.Offscreen;
-                        }
+                    Rectangle cellBounds;
+                    if (_owner.OwningColumn != null && _owner.OwningRow != null)
+                    {
+                        cellBounds = _owner.DataGridView.GetCellDisplayRectangle(_owner.OwningColumn.Index, _owner.OwningRow.Index, cutOverflow: false);
+                    }
+                    else if (_owner.OwningRow != null)
+                    {
+                        cellBounds = _owner.DataGridView.GetCellDisplayRectangle(-1, _owner.OwningRow.Index, cutOverflow: false);
+                    }
+                    else if (_owner.OwningColumn != null)
+                    {
+                        cellBounds = _owner.DataGridView.GetCellDisplayRectangle(_owner.OwningColumn.Index, -1, cutOverflow: false);
+                    }
+                    else
+                    {
+                        cellBounds = _owner.DataGridView.GetCellDisplayRectangle(-1, -1, cutOverflow: false);
+                    }
+
+                    if (!cellBounds.IntersectsWith(_owner.DataGridView.ClientRectangle))
+                    {
+                        state |= AccessibleStates.Offscreen;
                     }
 
                     return state;
                 }
             }
 
-            public override string Value
+            public override string? Value
             {
                 get
                 {
@@ -203,8 +177,8 @@ namespace System.Windows.Forms
                         throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                     }
 
-                    object formattedValue = _owner.FormattedValue;
-                    string formattedValueAsString = formattedValue as string;
+                    object? formattedValue = _owner.FormattedValue;
+                    string? formattedValueAsString = formattedValue as string;
                     if (formattedValue is null || (formattedValueAsString != null && string.IsNullOrEmpty(formattedValueAsString)))
                     {
                         return SR.DataGridView_AccNullValue;
@@ -230,20 +204,14 @@ namespace System.Windows.Forms
                         return string.Empty;
                     }
                 }
-
                 set
                 {
-                    if (_owner is DataGridViewHeaderCell)
+                    if (_owner is null)
                     {
-                        return;
+                        throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                     }
 
-                    if (_owner.ReadOnly)
-                    {
-                        return;
-                    }
-
-                    if (_owner.OwningRow is null)
+                    if (_owner is DataGridViewHeaderCell || _owner.ReadOnly || _owner.DataGridView is null || _owner.OwningRow is null)
                     {
                         return;
                     }
@@ -258,17 +226,17 @@ namespace System.Windows.Forms
                     DataGridViewCellStyle dataGridViewCellStyle = _owner.InheritedStyle;
 
                     // Format string "True" to boolean True.
-                    object formattedValue = _owner.GetFormattedValue(value,
-                                                                         _owner.OwningRow.Index,
-                                                                         ref dataGridViewCellStyle,
-                                                                         null /*formattedValueTypeConverter*/ ,
-                                                                         null /*valueTypeConverter*/,
-                                                                         DataGridViewDataErrorContexts.Formatting);
+                    object? formattedValue = _owner.GetFormattedValue(value,
+                                                                      _owner.OwningRow.Index,
+                                                                      ref dataGridViewCellStyle,
+                                                                      valueTypeConverter: null,
+                                                                      formattedValueTypeConverter: null,
+                                                                      DataGridViewDataErrorContexts.Formatting);
                     // Parse the formatted value and push it into the back end.
                     _owner.Value = _owner.ParseFormattedValue(formattedValue,
-                                                                 dataGridViewCellStyle,
-                                                                 null /*formattedValueTypeConverter*/,
-                                                                 null /*valueTypeConverter*/);
+                                                               dataGridViewCellStyle,
+                                                               formattedValueTypeConverter: null,
+                                                               valueTypeConverter: null);
                 }
             }
 
@@ -279,15 +247,14 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                 }
 
-                DataGridViewCell dataGridViewCell = (DataGridViewCell)Owner;
-                DataGridView dataGridView = dataGridViewCell.DataGridView;
-
-                if (dataGridViewCell is DataGridViewHeaderCell)
+                DataGridViewCell dataGridViewCell = _owner;
+                DataGridView? dataGridView = dataGridViewCell.DataGridView;
+                if (dataGridViewCell is DataGridViewHeaderCell || dataGridView?.IsHandleCreated != true)
                 {
                     return;
                 }
 
-                if (dataGridView != null && dataGridViewCell.RowIndex == -1)
+                if (dataGridViewCell.RowIndex == -1)
                 {
                     throw new InvalidOperationException(SR.DataGridView_InvalidOperationOnSharedCell);
                 }
@@ -322,21 +289,25 @@ namespace System.Windows.Forms
                 }
             }
 
-            internal Rectangle GetAccessibleObjectBounds(AccessibleObject parentAccObject)
+            internal Rectangle GetAccessibleObjectBounds(AccessibleObject? parentAccObject)
             {
                 if (_owner is null)
                 {
                     throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                 }
 
-                if (_owner.OwningColumn is null)
+                if (parentAccObject is null
+                    || _owner.DataGridView is null
+                    || !_owner.DataGridView.IsHandleCreated
+                    || _owner.OwningColumn is null)
                 {
                     return Rectangle.Empty;
                 }
 
                 Rectangle rowRect = parentAccObject.Bounds;
                 Rectangle cellRect = rowRect;
-                Rectangle columnRect = _owner.DataGridView.RectangleToScreen(_owner.DataGridView.GetColumnDisplayRectangle(_owner.ColumnIndex, false /*cutOverflow*/));
+                Rectangle columnRect = _owner.DataGridView.RectangleToScreen(
+                    _owner.DataGridView.GetColumnDisplayRectangle(_owner.ColumnIndex, cutOverflow: false));
 
                 var cellRight = columnRect.Left + columnRect.Width;
                 var cellLeft = columnRect.Left;
@@ -378,7 +349,7 @@ namespace System.Windows.Forms
                 return cellRect;
             }
 
-            private AccessibleObject GetAccessibleObjectParent()
+            private AccessibleObject? GetAccessibleObjectParent()
             {
                 // If this is one of our types, use the shortcut provided by ParentPrivate property.
                 // Otherwise, use the Parent property.
@@ -397,7 +368,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            public override AccessibleObject GetChild(int index)
+            public override AccessibleObject? GetChild(int index)
             {
                 if (_owner is null)
                 {
@@ -438,24 +409,18 @@ namespace System.Windows.Forms
                 }
             }
 
-            public override AccessibleObject GetFocused()
-            {
-                return null;
-            }
+            public override AccessibleObject? GetFocused() => null;
 
-            public override AccessibleObject GetSelected()
-            {
-                return null;
-            }
+            public override AccessibleObject? GetSelected() => null;
 
-            public override AccessibleObject Navigate(AccessibleNavigation navigationDirection)
+            public override AccessibleObject? Navigate(AccessibleNavigation navigationDirection)
             {
                 if (_owner is null)
                 {
                     throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                 }
 
-                if (_owner.OwningColumn is null || _owner.OwningRow is null)
+                if (_owner.DataGridView?.IsHandleCreated != true || _owner.OwningColumn is null || _owner.OwningRow is null)
                 {
                     return null;
                 }
@@ -463,45 +428,34 @@ namespace System.Windows.Forms
                 switch (navigationDirection)
                 {
                     case AccessibleNavigation.Right:
-                        if (_owner.DataGridView.RightToLeft == RightToLeft.No)
-                        {
-                            return NavigateForward(true /*wrapAround*/);
-                        }
-                        else
-                        {
-                            return NavigateBackward(true /*wrapAround*/);
-                        }
+                        return _owner.DataGridView.RightToLeft == RightToLeft.No
+                            ? NavigateForward(wrapAround: true)
+                            : NavigateBackward(wrapAround: true);
+
                     case AccessibleNavigation.Next:
-                        return NavigateForward(false /*wrapAround*/);
+                        return NavigateForward(wrapAround: false);
+
                     case AccessibleNavigation.Left:
-                        if (_owner.DataGridView.RightToLeft == RightToLeft.No)
-                        {
-                            return NavigateBackward(true /*wrapAround*/);
-                        }
-                        else
-                        {
-                            return NavigateForward(true /*wrapAround*/);
-                        }
+                        return _owner.DataGridView.RightToLeft == RightToLeft.No
+                            ? NavigateBackward(wrapAround: true)
+                            : NavigateForward(wrapAround: true);
+
                     case AccessibleNavigation.Previous:
-                        return NavigateBackward(false /*wrapAround*/);
+                        return NavigateBackward(wrapAround: false);
+
                     case AccessibleNavigation.Up:
                         if (_owner.OwningRow.Index == _owner.DataGridView.Rows.GetFirstRow(DataGridViewElementStates.Visible))
                         {
-                            if (_owner.DataGridView.ColumnHeadersVisible)
-                            {
-                                // Return the column header accessible object.
-                                return _owner.OwningColumn.HeaderCell.AccessibilityObject;
-                            }
-                            else
-                            {
-                                return null;
-                            }
+                            return _owner.DataGridView.ColumnHeadersVisible
+                                ? _owner.OwningColumn.HeaderCell.AccessibilityObject // Return the column header accessible object
+                                : null;
                         }
                         else
                         {
                             int previousVisibleRow = _owner.DataGridView.Rows.GetPreviousRow(_owner.OwningRow.Index, DataGridViewElementStates.Visible);
                             return _owner.DataGridView.Rows[previousVisibleRow].Cells[_owner.OwningColumn.Index].AccessibilityObject;
                         }
+
                     case AccessibleNavigation.Down:
                         if (_owner.OwningRow.Index == _owner.DataGridView.Rows.GetLastRow(DataGridViewElementStates.Visible))
                         {
@@ -512,86 +466,75 @@ namespace System.Windows.Forms
                             int nextVisibleRow = _owner.DataGridView.Rows.GetNextRow(_owner.OwningRow.Index, DataGridViewElementStates.Visible);
                             return _owner.DataGridView.Rows[nextVisibleRow].Cells[_owner.OwningColumn.Index].AccessibilityObject;
                         }
+
                     default:
                         return null;
                 }
             }
 
-            private AccessibleObject NavigateBackward(bool wrapAround)
+            private AccessibleObject? NavigateBackward(bool wrapAround)
             {
+                Debug.Assert(_owner != null);
+                Debug.Assert(_owner.DataGridView != null);
+                Debug.Assert(_owner.OwningColumn != null);
+                Debug.Assert(_owner.OwningRow != null);
+
                 if (_owner.OwningColumn == _owner.DataGridView.Columns.GetFirstColumn(DataGridViewElementStates.Visible))
                 {
                     if (wrapAround)
                     {
                         // Return the last accessible object in the previous row
-                        AccessibleObject previousRow = Owner.OwningRow.AccessibilityObject.Navigate(AccessibleNavigation.Previous);
-                        if (previousRow != null && previousRow.GetChildCount() > 0)
-                        {
-                            return previousRow.GetChild(previousRow.GetChildCount() - 1);
-                        }
-                        else
+                        AccessibleObject? previousRow = _owner.OwningRow.AccessibilityObject.Navigate(AccessibleNavigation.Previous);
+                        if (previousRow is null)
                         {
                             return null;
                         }
+
+                        int childCount = previousRow.GetChildCount();
+                        return childCount > 0 ? previousRow.GetChild(childCount - 1) : null;
                     }
                     else
                     {
                         // return the row header cell if the row headers are visible.
-                        if (_owner.DataGridView.RowHeadersVisible)
-                        {
-                            return _owner.OwningRow.AccessibilityObject.GetChild(0);
-                        }
-                        else
-                        {
-                            return null;
-                        }
+                        return _owner.DataGridView.RowHeadersVisible ? _owner.OwningRow.AccessibilityObject.GetChild(0) : null;
                     }
                 }
                 else
                 {
                     int previousVisibleColumnIndex = _owner.DataGridView.Columns.GetPreviousColumn(_owner.OwningColumn,
-                                                                                                       DataGridViewElementStates.Visible,
-                                                                                                       DataGridViewElementStates.None).Index;
+                                                                                                   DataGridViewElementStates.Visible,
+                                                                                                   DataGridViewElementStates.None).Index;
                     return _owner.OwningRow.Cells[previousVisibleColumnIndex].AccessibilityObject;
                 }
             }
 
-            private AccessibleObject NavigateForward(bool wrapAround)
+            private AccessibleObject? NavigateForward(bool wrapAround)
             {
+                Debug.Assert(_owner != null);
+                Debug.Assert(_owner.DataGridView != null);
+                Debug.Assert(_owner.OwningColumn != null);
+                Debug.Assert(_owner.OwningRow != null);
+
                 if (_owner.OwningColumn == _owner.DataGridView.Columns.GetLastColumn(DataGridViewElementStates.Visible,
-                                                                                             DataGridViewElementStates.None))
+                                                                                        DataGridViewElementStates.None))
                 {
                     if (wrapAround)
                     {
                         // Return the first cell in the next visible row.
-                        //
-                        AccessibleObject nextRow = Owner.OwningRow.AccessibilityObject.Navigate(AccessibleNavigation.Next);
+                        AccessibleObject? nextRow = _owner.OwningRow.AccessibilityObject.Navigate(AccessibleNavigation.Next);
                         if (nextRow != null && nextRow.GetChildCount() > 0)
                         {
-                            if (Owner.DataGridView.RowHeadersVisible)
-                            {
-                                return nextRow.GetChild(1);
-                            }
-                            else
-                            {
-                                return nextRow.GetChild(0);
-                            }
-                        }
-                        else
-                        {
-                            return null;
+                            return _owner.DataGridView.RowHeadersVisible ? nextRow.GetChild(1) : nextRow.GetChild(0);
                         }
                     }
-                    else
-                    {
-                        return null;
-                    }
+
+                    return null;
                 }
                 else
                 {
                     int nextVisibleColumnIndex = _owner.DataGridView.Columns.GetNextColumn(_owner.OwningColumn,
-                                                                                               DataGridViewElementStates.Visible,
-                                                                                               DataGridViewElementStates.None).Index;
+                                                                                           DataGridViewElementStates.Visible,
+                                                                                           DataGridViewElementStates.None).Index;
                     return _owner.OwningRow.Cells[nextVisibleColumnIndex].AccessibilityObject;
                 }
             }
@@ -602,17 +545,20 @@ namespace System.Windows.Forms
                 {
                     throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                 }
+
+                if (_owner.DataGridView?.IsHandleCreated != true)
+                {
+                    return;
+                }
+
                 if ((flags & AccessibleSelection.TakeFocus) == AccessibleSelection.TakeFocus)
                 {
-                    _owner.DataGridView?.Focus();
+                    _owner.DataGridView.Focus();
                 }
                 if ((flags & AccessibleSelection.TakeSelection) == AccessibleSelection.TakeSelection)
                 {
                     _owner.Selected = true;
-                    if (_owner.DataGridView != null)
-                    {
-                        _owner.DataGridView.CurrentCell = _owner; // Do not change old selection
-                    }
+                    _owner.DataGridView.CurrentCell = _owner; // Do not change old selection
                 }
                 if ((flags & AccessibleSelection.AddSelection) == AccessibleSelection.AddSelection)
                 {
@@ -630,13 +576,18 @@ namespace System.Windows.Forms
             ///  Sets the detachable child accessible object which may be added or removed to/from hierachy nodes.
             /// </summary>
             /// <param name="child">The child accessible object.</param>
-            internal override void SetDetachableChild(AccessibleObject child)
+            internal override void SetDetachableChild(AccessibleObject? child)
             {
                 _child = child;
             }
 
             internal override void SetFocus()
             {
+                if (_owner?.DataGridView?.IsHandleCreated != true)
+                {
+                    return;
+                }
+
                 base.SetFocus();
 
                 RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
@@ -675,30 +626,19 @@ namespace System.Windows.Forms
 
             #region IRawElementProviderFragment Implementation
 
-            internal override Rectangle BoundingRectangle
-            {
-                get
-                {
-                    return Bounds;
-                }
-            }
+            internal override Rectangle BoundingRectangle => Bounds;
 
-            internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot
-            {
-                get
-                {
-                    return _owner.DataGridView.AccessibilityObject;
-                }
-            }
+            internal override UiaCore.IRawElementProviderFragmentRoot? FragmentRoot
+                => _owner?.DataGridView?.AccessibilityObject;
 
-            internal override UiaCore.IRawElementProviderFragment FragmentNavigate(UiaCore.NavigateDirection direction)
+            internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
             {
                 if (_owner is null)
                 {
                     throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                 }
 
-                if (_owner.OwningColumn is null || _owner.OwningRow is null)
+                if (_owner.DataGridView?.IsHandleCreated != true || _owner.OwningColumn is null || _owner.OwningRow is null)
                 {
                     return null;
                 }
@@ -707,10 +647,13 @@ namespace System.Windows.Forms
                 {
                     case UiaCore.NavigateDirection.Parent:
                         return _owner.OwningRow.AccessibilityObject;
+
                     case UiaCore.NavigateDirection.NextSibling:
-                        return NavigateForward(false);
+                        return NavigateForward(wrapAround: false);
+
                     case UiaCore.NavigateDirection.PreviousSibling:
-                        return NavigateBackward(false);
+                        return NavigateBackward(wrapAround: false);
+
                     case UiaCore.NavigateDirection.FirstChild:
                     case UiaCore.NavigateDirection.LastChild:
                         if (_owner.DataGridView.CurrentCell == _owner &&
@@ -720,6 +663,7 @@ namespace System.Windows.Forms
                             return _child;
                         }
                         break;
+
                     default:
                         return null;
                 }
@@ -731,38 +675,23 @@ namespace System.Windows.Forms
 
             #region IRawElementProviderSimple Implementation
 
-            internal override object GetPropertyValue(UiaCore.UIA propertyID)
-            {
-                switch (propertyID)
+            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
+                => propertyID switch
                 {
-                    case UiaCore.UIA.NamePropertyId:
-                        return Name;
-                    case UiaCore.UIA.HasKeyboardFocusPropertyId:
-                        return (State & AccessibleStates.Focused) == AccessibleStates.Focused; // Announce the cell when focusing.
-                    case UiaCore.UIA.IsEnabledPropertyId:
-                        return _owner.DataGridView.Enabled;
-                    case UiaCore.UIA.AutomationIdPropertyId:
-                        return AutomationId;
-                    case UiaCore.UIA.HelpTextPropertyId:
-                        return Help ?? string.Empty;
-                    case UiaCore.UIA.IsKeyboardFocusablePropertyId:
-                        return (State & AccessibleStates.Focusable) == AccessibleStates.Focusable;
-                    case UiaCore.UIA.IsPasswordPropertyId:
-                        return false;
-                    case UiaCore.UIA.IsOffscreenPropertyId:
-                        return (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen;
-                    case UiaCore.UIA.AccessKeyPropertyId:
-                        return string.Empty;
-                    case UiaCore.UIA.GridItemContainingGridPropertyId:
-                        return Owner.DataGridView.AccessibilityObject;
-                    case UiaCore.UIA.IsTableItemPatternAvailablePropertyId:
-                        return IsPatternSupported(UiaCore.UIA.TableItemPatternId);
-                    case UiaCore.UIA.IsGridItemPatternAvailablePropertyId:
-                        return IsPatternSupported(UiaCore.UIA.GridItemPatternId);
-                }
-
-                return base.GetPropertyValue(propertyID);
-            }
+                    UiaCore.UIA.NamePropertyId => Name,
+                    UiaCore.UIA.HasKeyboardFocusPropertyId => (State & AccessibleStates.Focused) == AccessibleStates.Focused,// Announce the cell when focusing.
+                    UiaCore.UIA.IsEnabledPropertyId => _owner?.DataGridView?.Enabled ?? false,
+                    UiaCore.UIA.AutomationIdPropertyId => AutomationId,
+                    UiaCore.UIA.HelpTextPropertyId => Help ?? string.Empty,
+                    UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
+                    UiaCore.UIA.IsPasswordPropertyId => false,
+                    UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
+                    UiaCore.UIA.AccessKeyPropertyId => string.Empty,
+                    UiaCore.UIA.GridItemContainingGridPropertyId => _owner?.DataGridView?.AccessibilityObject,
+                    UiaCore.UIA.IsTableItemPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.TableItemPatternId),
+                    UiaCore.UIA.IsGridItemPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.GridItemPatternId),
+                    _ => base.GetPropertyValue(propertyID),
+                };
 
             internal override bool IsPatternSupported(UiaCore.UIA patternId)
             {
@@ -773,10 +702,9 @@ namespace System.Windows.Forms
                     return true;
                 }
 
-                if ((patternId == UiaCore.UIA.TableItemPatternId ||
-                    patternId == UiaCore.UIA.GridItemPatternId) &&
+                if ((patternId == UiaCore.UIA.TableItemPatternId || patternId == UiaCore.UIA.GridItemPatternId)
                     // We don't want to implement patterns for header cells
-                    _owner.ColumnIndex != -1 && _owner.RowIndex != -1)
+                    && _owner?.ColumnIndex != -1 && _owner?.RowIndex != -1)
                 {
                     return true;
                 }
@@ -786,9 +714,9 @@ namespace System.Windows.Forms
 
             #endregion
 
-            internal override UiaCore.IRawElementProviderSimple[] GetRowHeaderItems()
+            internal override UiaCore.IRawElementProviderSimple[]? GetRowHeaderItems()
             {
-                if (_owner.DataGridView.RowHeadersVisible && _owner.OwningRow.HasHeaderCell)
+                if (_owner?.DataGridView?.IsHandleCreated is true && _owner.DataGridView.RowHeadersVisible && _owner.OwningRow.HasHeaderCell)
                 {
                     return new UiaCore.IRawElementProviderSimple[1] { _owner.OwningRow.HeaderCell.AccessibilityObject };
                 }
@@ -796,9 +724,9 @@ namespace System.Windows.Forms
                 return null;
             }
 
-            internal override UiaCore.IRawElementProviderSimple[] GetColumnHeaderItems()
+            internal override UiaCore.IRawElementProviderSimple[]? GetColumnHeaderItems()
             {
-                if (_owner.DataGridView.ColumnHeadersVisible && _owner.OwningColumn.HasHeaderCell)
+                if (_owner?.DataGridView?.IsHandleCreated is true && _owner.DataGridView.ColumnHeadersVisible && _owner.OwningColumn.HasHeaderCell)
                 {
                     return new UiaCore.IRawElementProviderSimple[1] { _owner.OwningColumn.HeaderCell.AccessibilityObject };
                 }
@@ -806,31 +734,13 @@ namespace System.Windows.Forms
                 return null;
             }
 
-            internal override int Row
-            {
-                get
-                {
-                    return _owner.OwningRow != null ? _owner.OwningRow.Index : -1;
-                }
-            }
+            internal override int Row => _owner?.OwningRow != null ? _owner.OwningRow.Index : -1;
 
-            internal override int Column
-            {
-                get
-                {
-                    return _owner.OwningColumn != null ? _owner.OwningColumn.Index : -1;
-                }
-            }
+            internal override int Column => _owner?.OwningColumn != null ? _owner.OwningColumn.Index : -1;
 
-            internal override UiaCore.IRawElementProviderSimple ContainingGrid
-            {
-                get
-                {
-                    return _owner.DataGridView.AccessibilityObject;
-                }
-            }
+            internal override UiaCore.IRawElementProviderSimple? ContainingGrid => _owner?.DataGridView?.AccessibilityObject;
 
-            internal override bool IsReadOnly => _owner.ReadOnly;
+            internal override bool IsReadOnly => _owner?.ReadOnly ?? false;
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.DataGridViewComboBoxCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.DataGridViewComboBoxCellAccessibleObject.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 using static Interop;
 
@@ -12,41 +10,33 @@ namespace System.Windows.Forms
     {
         protected class DataGridViewComboBoxCellAccessibleObject : DataGridViewCellAccessibleObject
         {
-            public DataGridViewComboBoxCellAccessibleObject(DataGridViewCell owner) : base(owner)
+            public DataGridViewComboBoxCellAccessibleObject(DataGridViewCell? owner) : base(owner)
             {
             }
 
             internal override bool IsIAccessibleExSupported() => true;
 
-            internal override object GetPropertyValue(UiaCore.UIA propertyID)
-            {
-                switch (propertyID)
+            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
+                => propertyID switch
                 {
-                    case UiaCore.UIA.ControlTypePropertyId:
-                        return UiaCore.UIA.ComboBoxControlTypeId;
-                    case UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId:
-                        return IsPatternSupported(UiaCore.UIA.ExpandCollapsePatternId);
-                }
-
-                return base.GetPropertyValue(propertyID);
-            }
+                    UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ComboBoxControlTypeId,
+                    UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ExpandCollapsePatternId),
+                    _ => base.GetPropertyValue(propertyID)
+                };
 
             internal override bool IsPatternSupported(UiaCore.UIA patternId)
-            {
-                if (patternId == UiaCore.UIA.ExpandCollapsePatternId)
-                {
-                    return true;
-                }
-
-                return base.IsPatternSupported(patternId);
-            }
+                => patternId == UiaCore.UIA.ExpandCollapsePatternId ? true : base.IsPatternSupported(patternId);
 
             internal override UiaCore.ExpandCollapseState ExpandCollapseState
             {
                 get
                 {
-                    DataGridViewComboBoxEditingControl comboBox = Owner.Properties.GetObject(s_propComboBoxCellEditingComboBox) as DataGridViewComboBoxEditingControl;
-                    if (comboBox != null)
+                    if (Owner is null)
+                    {
+                        throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
+                    }
+
+                    if (Owner.Properties.GetObject(s_propComboBoxCellEditingComboBox) is DataGridViewComboBoxEditingControl comboBox && comboBox.IsHandleCreated)
                     {
                         return comboBox.DroppedDown ? UiaCore.ExpandCollapseState.Expanded : UiaCore.ExpandCollapseState.Collapsed;
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewImageCell.DataGridViewImageCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewImageCell.DataGridViewImageCellAccessibleObject.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 using static Interop;
 
@@ -12,7 +10,7 @@ namespace System.Windows.Forms
     {
         protected class DataGridViewImageCellAccessibleObject : DataGridViewCellAccessibleObject
         {
-            public DataGridViewImageCellAccessibleObject(DataGridViewCell owner) : base(owner)
+            public DataGridViewImageCellAccessibleObject(DataGridViewCell? owner) : base(owner)
             {
             }
 
@@ -24,25 +22,11 @@ namespace System.Windows.Forms
                 }
             }
 
-            public override string Description
-            {
-                get
-                {
-                    if (Owner is DataGridViewImageCell imageCell)
-                    {
-                        return imageCell.Description;
-                    }
-                    else
-                    {
-                        return null;
-                    }
-                }
-            }
+            public override string? Description => Owner is DataGridViewImageCell imageCell ? imageCell.Description : null;
 
-            public override string Value
+            public override string? Value
             {
                 get => base.Value;
-
                 set
                 {
                     // do nothing.
@@ -51,47 +35,41 @@ namespace System.Windows.Forms
 
             public override void DoDefaultAction()
             {
-                DataGridViewImageCell dataGridViewCell = (DataGridViewImageCell)Owner;
-                DataGridView dataGridView = dataGridViewCell.DataGridView;
+                if (Owner is null)
+                {
+                    throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
+                }
 
-                if (dataGridView != null && dataGridViewCell.RowIndex != -1 &&
-                    dataGridViewCell.OwningColumn != null && dataGridViewCell.OwningRow != null)
+                if (!(Owner is DataGridViewImageCell dataGridViewCell))
+                {
+                    return;
+                }
+
+                DataGridView? dataGridView = dataGridViewCell.DataGridView;
+                if (dataGridView != null &&
+                    dataGridView.IsHandleCreated &&
+                    dataGridViewCell.RowIndex != -1 &&
+                    dataGridViewCell.OwningColumn != null &&
+                    dataGridViewCell.OwningRow != null)
                 {
                     dataGridView.OnCellContentClickInternal(new DataGridViewCellEventArgs(dataGridViewCell.ColumnIndex, dataGridViewCell.RowIndex));
                 }
             }
 
-            public override int GetChildCount()
-            {
-                return 0;
-            }
+            public override int GetChildCount() => 0;
 
             internal override bool IsIAccessibleExSupported() => true;
 
-            internal override object GetPropertyValue(UiaCore.UIA propertyID)
-            {
-                if (propertyID == UiaCore.UIA.ControlTypePropertyId)
+            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
+                => propertyID switch
                 {
-                    return UiaCore.UIA.ImageControlTypeId;
-                }
-
-                if (propertyID == UiaCore.UIA.IsInvokePatternAvailablePropertyId)
-                {
-                    return true;
-                }
-
-                return base.GetPropertyValue(propertyID);
-            }
+                    UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ImageControlTypeId,
+                    UiaCore.UIA.IsInvokePatternAvailablePropertyId => true,
+                    _ => base.GetPropertyValue(propertyID)
+                };
 
             internal override bool IsPatternSupported(UiaCore.UIA patternId)
-            {
-                if (patternId == UiaCore.UIA.InvokePatternId)
-                {
-                    return true;
-                }
-
-                return base.IsPatternSupported(patternId);
-            }
+                => patternId == UiaCore.UIA.InvokePatternId ? true : base.IsPatternSupported(patternId);
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.DataGridViewLinkCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.DataGridViewLinkCellAccessibleObject.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 using static Interop;
 
@@ -12,7 +10,7 @@ namespace System.Windows.Forms
     {
         protected class DataGridViewLinkCellAccessibleObject : DataGridViewCellAccessibleObject
         {
-            public DataGridViewLinkCellAccessibleObject(DataGridViewCell owner) : base(owner)
+            public DataGridViewLinkCellAccessibleObject(DataGridViewCell? owner) : base(owner)
             {
             }
 
@@ -26,12 +24,25 @@ namespace System.Windows.Forms
 
             public override void DoDefaultAction()
             {
-                DataGridViewLinkCell dataGridViewCell = (DataGridViewLinkCell)Owner;
-                DataGridView dataGridView = dataGridViewCell.DataGridView;
+                if (Owner is null)
+                {
+                    throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
+                }
 
-                if (dataGridView != null && dataGridViewCell.RowIndex == -1)
+                if (!(Owner is DataGridViewLinkCell dataGridViewCell))
+                {
+                    return;
+                }
+
+                if (dataGridViewCell.RowIndex == -1)
                 {
                     throw new InvalidOperationException(SR.DataGridView_InvalidOperationOnSharedCell);
+                }
+
+                DataGridView? dataGridView = dataGridViewCell.DataGridView;
+                if (dataGridView?.IsHandleCreated != true)
+                {
+                    return;
                 }
 
                 if (dataGridViewCell.OwningColumn != null && dataGridViewCell.OwningRow != null)
@@ -40,22 +51,16 @@ namespace System.Windows.Forms
                 }
             }
 
-            public override int GetChildCount()
-            {
-                return 0;
-            }
+            public override int GetChildCount() => 0;
 
             internal override bool IsIAccessibleExSupported() => true;
 
-            internal override object GetPropertyValue(UiaCore.UIA propertyID)
-            {
-                if (propertyID == UiaCore.UIA.ControlTypePropertyId)
+            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
+                => propertyID switch
                 {
-                    return UiaCore.UIA.HyperlinkControlTypeId;
-                }
-
-                return base.GetPropertyValue(propertyID);
-            }
+                    UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.HyperlinkControlTypeId,
+                    _ => base.GetPropertyValue(propertyID)
+                };
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
@@ -1793,7 +1793,7 @@ namespace System.Windows.Forms
                         throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                     }
 
-                    if (owner.DataGridView is null)
+                    if (owner.DataGridView is null || !owner.DataGridView.IsHandleCreated)
                     {
                         return Rectangle.Empty;
                     }
@@ -1941,7 +1941,7 @@ namespace System.Windows.Forms
                         accState |= AccessibleStates.Selected;
                     }
 
-                    if (owner.DataGridView != null)
+                    if (owner.DataGridView != null && owner.DataGridView.IsHandleCreated)
                     {
                         Rectangle rowBounds = owner.DataGridView.GetRowDisplayRectangle(owner.Index, true /*cutOverflow*/);
                         if (!rowBounds.IntersectsWith(owner.DataGridView.ClientRectangle))
@@ -2157,14 +2157,17 @@ namespace System.Windows.Forms
                 }
 
                 DataGridView dataGridView = owner.DataGridView;
-                if (dataGridView is null)
+
+                if (dataGridView is null || !dataGridView.IsHandleCreated)
                 {
                     return;
                 }
+
                 if ((flags & AccessibleSelection.TakeFocus) == AccessibleSelection.TakeFocus)
                 {
                     dataGridView.Focus();
                 }
+
                 if ((flags & AccessibleSelection.TakeSelection) == AccessibleSelection.TakeSelection)
                 {
                     if (owner.Cells.Count > 0)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 using System.Diagnostics;
 using System.Drawing;
@@ -14,7 +12,7 @@ namespace System.Windows.Forms
     {
         protected class DataGridViewRowHeaderCellAccessibleObject : DataGridViewCellAccessibleObject
         {
-            public DataGridViewRowHeaderCellAccessibleObject(DataGridViewRowHeaderCell owner) : base(owner)
+            public DataGridViewRowHeaderCellAccessibleObject(DataGridViewRowHeaderCell? owner) : base(owner)
             {
             }
 
@@ -22,7 +20,12 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (Owner.OwningRow is null)
+                    if (Owner is null)
+                    {
+                        throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
+                    }
+
+                    if (Owner.DataGridView is null || Owner.OwningRow is null || ParentPrivate is null)
                     {
                         return Rectangle.Empty;
                     }
@@ -44,68 +47,50 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.FullRowSelect ||
-                        Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.RowHeaderSelect)
+                    if (Owner is null)
+                    {
+                        throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
+                    }
+
+                    if (Owner.DataGridView != null &&
+                        (Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.FullRowSelect ||
+                         Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.RowHeaderSelect))
                     {
                         return SR.DataGridView_RowHeaderCellAccDefaultAction;
                     }
-                    else
-                    {
-                        return string.Empty;
-                    }
+
+                    return string.Empty;
                 }
             }
 
-            public override string Name
+            public override string? Name => ParentPrivate?.Name ?? string.Empty;
+
+            public override AccessibleObject? Parent => ParentPrivate;
+
+            private AccessibleObject? ParentPrivate
             {
                 get
                 {
-                    if (ParentPrivate != null)
+                    if (Owner is null)
                     {
-                        return ParentPrivate.Name;
+                        throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                     }
-                    else
-                    {
-                        return string.Empty;
-                    }
+
+                    return Owner.OwningRow?.AccessibilityObject;
                 }
             }
 
-            public override AccessibleObject Parent
-            {
-                get
-                {
-                    return ParentPrivate;
-                }
-            }
-
-            private AccessibleObject ParentPrivate
-            {
-                get
-                {
-                    if (Owner.OwningRow is null)
-                    {
-                        return null;
-                    }
-                    else
-                    {
-                        return Owner.OwningRow.AccessibilityObject;
-                    }
-                }
-            }
-
-            public override AccessibleRole Role
-            {
-                get
-                {
-                    return AccessibleRole.RowHeader;
-                }
-            }
+            public override AccessibleRole Role => AccessibleRole.RowHeader;
 
             public override AccessibleStates State
             {
                 get
                 {
+                    if (Owner is null)
+                    {
+                        throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
+                    }
+
                     AccessibleStates resultState = AccessibleStates.Selectable;
 
                     // get the Offscreen state from the base method.
@@ -115,8 +100,9 @@ namespace System.Windows.Forms
                         resultState |= AccessibleStates.Offscreen;
                     }
 
-                    if (Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.FullRowSelect ||
-                        Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.RowHeaderSelect)
+                    if (Owner.DataGridView != null &&
+                        (Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.FullRowSelect ||
+                         Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.RowHeaderSelect))
                     {
                         if (Owner.OwningRow != null && Owner.OwningRow.Selected)
                         {
@@ -128,87 +114,74 @@ namespace System.Windows.Forms
                 }
             }
 
-            public override string Value
-            {
-                get
-                {
-                    return string.Empty;
-                }
-            }
+            public override string Value => string.Empty;
 
             public override void DoDefaultAction()
             {
-                if ((Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.FullRowSelect ||
-                    Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.RowHeaderSelect) &&
-                    Owner.OwningRow != null)
+                if (Owner is null)
+                {
+                    throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
+                }
+
+                if (Owner.DataGridView?.IsHandleCreated == true &&
+                    Owner.OwningRow != null &&
+                    (Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.FullRowSelect ||
+                     Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.RowHeaderSelect))
                 {
                     Owner.OwningRow.Selected = true;
                 }
             }
 
-            public override AccessibleObject Navigate(AccessibleNavigation navigationDirection)
+            public override AccessibleObject? Navigate(AccessibleNavigation navigationDirection)
             {
-                Debug.Assert(Owner.DataGridView.RowHeadersVisible, "if the rows are not visible how did you get the row headers acc obj?");
+                if (Owner is null)
+                {
+                    throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
+                }
+
+                if (Owner.OwningRow is null || Owner.DataGridView is null)
+                {
+                    return null;
+                }
+
                 switch (navigationDirection)
                 {
                     case AccessibleNavigation.Next:
-                        if (Owner.OwningRow != null && Owner.DataGridView.Columns.GetColumnCount(DataGridViewElementStates.Visible) > 0)
-                        {
-                            // go to the next sibling
-                            return ParentPrivate.GetChild(1);
-                        }
-                        else
-                        {
-                            return null;
-                        }
+                        return (Owner.DataGridView.Columns.GetColumnCount(DataGridViewElementStates.Visible) > 0)
+                            ? ParentPrivate?.GetChild(1) // go to the next sibling
+                            : null;
+
                     case AccessibleNavigation.Down:
-                        if (Owner.OwningRow is null)
-                        {
-                            return null;
-                        }
-                        else
                         {
                             if (Owner.OwningRow.Index == Owner.DataGridView.Rows.GetLastRow(DataGridViewElementStates.Visible))
                             {
                                 return null;
                             }
-                            else
-                            {
-                                int nextVisibleRow = Owner.DataGridView.Rows.GetNextRow(Owner.OwningRow.Index, DataGridViewElementStates.Visible);
-                                int actualDisplayIndex = Owner.DataGridView.Rows.GetRowCount(DataGridViewElementStates.Visible, 0, nextVisibleRow);
 
-                                if (Owner.DataGridView.ColumnHeadersVisible)
-                                {
-                                    // + 1 because the first child in the data grid view acc obj is the top row header acc obj
-                                    return Owner.DataGridView.AccessibilityObject.GetChild(1 + actualDisplayIndex).GetChild(0);
-                                }
-                                else
-                                {
-                                    return Owner.DataGridView.AccessibilityObject.GetChild(actualDisplayIndex).GetChild(0);
-                                }
+                            int nextVisibleRow = Owner.DataGridView.Rows.GetNextRow(Owner.OwningRow.Index, DataGridViewElementStates.Visible);
+                            int actualDisplayIndex = Owner.DataGridView.Rows.GetRowCount(DataGridViewElementStates.Visible, 0, nextVisibleRow);
+
+                            if (Owner.DataGridView.ColumnHeadersVisible)
+                            {
+                                // Add 1 because the first child in the data grid view acc obj is the top row header acc obj
+                                actualDisplayIndex++;
                             }
+
+                            return Owner.DataGridView.AccessibilityObject.GetChild(actualDisplayIndex)?.GetChild(0);
                         }
-                    case AccessibleNavigation.Previous:
-                        return null;
+
                     case AccessibleNavigation.Up:
-                        if (Owner.OwningRow is null)
-                        {
-                            return null;
-                        }
-                        else
                         {
                             if (Owner.OwningRow.Index == Owner.DataGridView.Rows.GetFirstRow(DataGridViewElementStates.Visible))
                             {
-                                if (Owner.DataGridView.ColumnHeadersVisible)
-                                {
-                                    // Return the top left header cell accessible object.
-                                    Debug.Assert(Owner.DataGridView.TopLeftHeaderCell.AccessibilityObject == Owner.DataGridView.AccessibilityObject.GetChild(0).GetChild(0));
-                                    return Owner.DataGridView.AccessibilityObject.GetChild(0).GetChild(0);
-                                }
-                                else
+                                if (!Owner.DataGridView.ColumnHeadersVisible)
                                 {
                                     return null;
                                 }
+
+                                // Return the top left header cell accessible object.
+                                Debug.Assert(Owner.DataGridView.TopLeftHeaderCell.AccessibilityObject == Owner.DataGridView.AccessibilityObject.GetChild(0)!.GetChild(0));
+                                return Owner.DataGridView.AccessibilityObject.GetChild(0)?.GetChild(0);
                             }
                             else
                             {
@@ -216,15 +189,15 @@ namespace System.Windows.Forms
                                 int actualDisplayIndex = Owner.DataGridView.Rows.GetRowCount(DataGridViewElementStates.Visible, 0, previousVisibleRow);
                                 if (Owner.DataGridView.ColumnHeadersVisible)
                                 {
-                                    // + 1 because the first child in the data grid view acc obj is the top row header acc obj
-                                    return Owner.DataGridView.AccessibilityObject.GetChild(actualDisplayIndex + 1).GetChild(0);
+                                    // Add 1 because the first child in the data grid view acc obj is the top row header acc obj
+                                    actualDisplayIndex++;
                                 }
-                                else
-                                {
-                                    return Owner.DataGridView.AccessibilityObject.GetChild(actualDisplayIndex).GetChild(0);
-                                }
+
+                                return Owner.DataGridView.AccessibilityObject.GetChild(actualDisplayIndex)?.GetChild(0);
                             }
                         }
+
+                    case AccessibleNavigation.Previous:
                     default:
                         return null;
                 }
@@ -237,17 +210,22 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                 }
 
-                DataGridViewRowHeaderCell dataGridViewCell = (DataGridViewRowHeaderCell)Owner;
-                DataGridView dataGridView = dataGridViewCell.DataGridView;
-
-                if (dataGridView is null)
+                if (!(Owner is DataGridViewRowHeaderCell dataGridViewCell))
                 {
                     return;
                 }
+
+                DataGridView? dataGridView = dataGridViewCell.DataGridView;
+                if (dataGridView?.IsHandleCreated != true)
+                {
+                    return;
+                }
+
                 if ((flags & AccessibleSelection.TakeFocus) == AccessibleSelection.TakeFocus)
                 {
                     dataGridView.Focus();
                 }
+
                 if (dataGridViewCell.OwningRow != null &&
                     (dataGridView.SelectionMode == DataGridViewSelectionMode.FullRowSelect ||
                      dataGridView.SelectionMode == DataGridViewSelectionMode.RowHeaderSelect))
@@ -265,62 +243,47 @@ namespace System.Windows.Forms
 
             #region IRawElementProviderFragment Implementation
 
-            internal override UiaCore.IRawElementProviderFragment FragmentNavigate(UiaCore.NavigateDirection direction)
+            internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
             {
+                if (Owner is null)
+                {
+                    throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
+                }
+
                 if (Owner.OwningRow is null)
                 {
                     return null;
                 }
 
-                switch (direction)
+                return direction switch
                 {
-                    case UiaCore.NavigateDirection.Parent:
-                        return Owner.OwningRow.AccessibilityObject;
-                    case UiaCore.NavigateDirection.NextSibling:
-                        if (Owner.DataGridView.Columns.GetColumnCount(DataGridViewElementStates.Visible) > 0)
-                        {
-                            // go to the next sibling
-                            return Owner.OwningRow.AccessibilityObject.GetChild(1);
-                        }
-                        else
-                        {
-                            return null;
-                        }
-                    case UiaCore.NavigateDirection.PreviousSibling:
-                    default:
-                        return null;
-                }
+                    UiaCore.NavigateDirection.Parent => Owner.OwningRow.AccessibilityObject,
+                    UiaCore.NavigateDirection.NextSibling =>
+                            (Owner.DataGridView != null && Owner.DataGridView.Columns.GetColumnCount(DataGridViewElementStates.Visible) > 0)
+                                ? Owner.OwningRow.AccessibilityObject.GetChild(1) // go to the next sibling
+                                : null,
+                    _ => null,
+                };
             }
 
             #endregion
 
             #region IRawElementProviderSimple Implementation
 
-            internal override object GetPropertyValue(UiaCore.UIA propertyId)
-            {
-                switch (propertyId)
+            internal override object? GetPropertyValue(UiaCore.UIA propertyId)
+                => propertyId switch
                 {
-                    case UiaCore.UIA.NamePropertyId:
-                        return Name;
-                    case UiaCore.UIA.ControlTypePropertyId:
-                        return UiaCore.UIA.HeaderControlTypeId;
-                    case UiaCore.UIA.IsEnabledPropertyId:
-                        return Owner.DataGridView.Enabled;
-                    case UiaCore.UIA.HelpTextPropertyId:
-                        return Help ?? string.Empty;
-                    case UiaCore.UIA.IsKeyboardFocusablePropertyId:
-                        return (State & AccessibleStates.Focusable) == AccessibleStates.Focusable;
-                    case UiaCore.UIA.HasKeyboardFocusPropertyId:
-                    case UiaCore.UIA.IsPasswordPropertyId:
-                        return false;
-                    case UiaCore.UIA.IsOffscreenPropertyId:
-                        return (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen;
-                    case UiaCore.UIA.AccessKeyPropertyId:
-                        return string.Empty;
-                }
-
-                return base.GetPropertyValue(propertyId);
-            }
+                    UiaCore.UIA.NamePropertyId => Name,
+                    UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.HeaderControlTypeId,
+                    UiaCore.UIA.IsEnabledPropertyId => Owner?.DataGridView?.Enabled ?? false,
+                    UiaCore.UIA.HelpTextPropertyId => Help ?? string.Empty,
+                    UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
+                    UiaCore.UIA.HasKeyboardFocusPropertyId => false,
+                    UiaCore.UIA.IsPasswordPropertyId => false,
+                    UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
+                    UiaCore.UIA.AccessKeyPropertyId => string.Empty,
+                    _ => base.GetPropertyValue(propertyId),
+                };
 
             #endregion
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxCell.DataGridViewTextBoxCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxCell.DataGridViewTextBoxCellAccessibleObject.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 using static Interop;
 
@@ -12,21 +10,18 @@ namespace System.Windows.Forms
     {
         protected class DataGridViewTextBoxCellAccessibleObject : DataGridViewCellAccessibleObject
         {
-            public DataGridViewTextBoxCellAccessibleObject(DataGridViewCell owner) : base(owner)
+            public DataGridViewTextBoxCellAccessibleObject(DataGridViewCell? owner) : base(owner)
             {
             }
 
             internal override bool IsIAccessibleExSupported() => true;
 
-            internal override object GetPropertyValue(UiaCore.UIA propertyID)
-            {
-                if (propertyID == UiaCore.UIA.ControlTypePropertyId)
+            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
+                => propertyID switch
                 {
-                    return UiaCore.UIA.EditControlTypeId;
-                }
-
-                return base.GetPropertyValue(propertyID);
-            }
+                    UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.EditControlTypeId,
+                    _ => base.GetPropertyValue(propertyID)
+                };
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTopLeftHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTopLeftHeaderCell.cs
@@ -449,6 +449,11 @@ namespace System.Windows.Forms
             {
                 get
                 {
+                    if (!Owner.DataGridView.IsHandleCreated)
+                    {
+                        return Rectangle.Empty;
+                    }
+
                     Rectangle cellRect = Owner.DataGridView.GetCellDisplayRectangle(-1, -1, false /*cutOverflow*/);
                     return Owner.DataGridView.RectangleToScreen(cellRect);
                 }
@@ -542,7 +547,10 @@ namespace System.Windows.Forms
 
             public override void DoDefaultAction()
             {
-                Owner.DataGridView.SelectAll();
+                if (Owner?.DataGridView?.IsHandleCreated is true)
+                {
+                    Owner.DataGridView.SelectAll();
+                }
             }
 
             public override AccessibleObject Navigate(AccessibleNavigation navigationDirection)
@@ -593,6 +601,11 @@ namespace System.Windows.Forms
                 if (Owner is null)
                 {
                     throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
+                }
+
+                if (Owner.DataGridView?.IsHandleCreated != true)
+                {
+                    return;
                 }
 
                 // AccessibleSelection.TakeFocus should focus the grid and then focus the first data grid view data cell

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
@@ -1806,7 +1806,10 @@ namespace System.Windows.Forms
 
             internal override void Toggle()
             {
-                ((DateTimePicker)Owner).Checked = !((DateTimePicker)Owner).Checked;
+                if (Owner.IsHandleCreated)
+                {
+                    ((DateTimePicker)Owner).Checked = !((DateTimePicker)Owner).Checked;
+                }
             }
 
             #endregion

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.cs
@@ -770,7 +770,7 @@ namespace System.Windows.Forms
 
                     var runtimeId = new int[3];
                     runtimeId[0] = RuntimeIDFirstItem;
-                    runtimeId[1] = (int)(long)_owner.Handle;
+                    runtimeId[1] = (int)(long)_owner.InternalHandle;
                     runtimeId[2] = _owner.GetHashCode();
 
                     return runtimeId;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ControlItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ControlItemAccessibleObject.cs
@@ -28,7 +28,8 @@ namespace System.Windows.Forms
 
             internal override Rectangle BoundingRectangle => Bounds;
 
-            public override Rectangle Bounds => _control.RectangleToScreen(_controlItem.GetIconBounds(_provider.Region.Size));
+            public override Rectangle Bounds => _control.IsHandleCreated ?
+                                                _control.RectangleToScreen(_controlItem.GetIconBounds(_provider.Region.Size)) : Rectangle.Empty;
 
             private int ControlItemsCount => _window.ControlItems.Count;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.AccessibleObject.cs
@@ -25,9 +25,9 @@ namespace System.Windows.Forms
                 _owner = owner;
             }
 
-            public override Rectangle Bounds => _owner.RectangleToScreen(_owner.ClientRectangle);
+            public override Rectangle Bounds => _owner.IsHandleCreated ? _owner.RectangleToScreen(_owner.ClientRectangle) : Rectangle.Empty;
 
-            internal override Rectangle BoundingRectangle => _owner.Bounds;
+            internal override Rectangle BoundingRectangle => _owner.IsHandleCreated ? _owner.Bounds : Rectangle.Empty;
 
             internal override object GetPropertyValue(UiaCore.UIA propertyID)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
@@ -67,8 +67,8 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-            ///  Gets or sets the color used to display active links.
-            /// </summary>
+        ///  Gets or sets the color used to display active links.
+        /// </summary>
         [SRCategory(nameof(SR.CatAppearance))]
         [SRDescription(nameof(SR.LinkLabelActiveLinkColorDescr))]
         public Color ActiveLinkColor
@@ -258,8 +258,8 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-            ///  Gets ir sets a value that represents how the link will be underlined.
-            /// </summary>
+        ///  Gets ir sets a value that represents how the link will be underlined.
+        /// </summary>
         [DefaultValue(LinkBehavior.SystemDefault)]
         [SRCategory(nameof(SR.CatBehavior))]
         [SRDescription(nameof(SR.LinkLabelLinkBehaviorDescr))]
@@ -286,8 +286,8 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-            ///  Gets or sets the color used to display links in normal cases.
-            /// </summary>
+        ///  Gets or sets the color used to display links in normal cases.
+        /// </summary>
         [SRCategory(nameof(SR.CatAppearance))]
         [SRDescription(nameof(SR.LinkLabelLinkColorDescr))]
         public Color LinkColor
@@ -335,8 +335,8 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-            ///  Gets or sets a value indicating whether the link should be displayed as if it was visited.
-            /// </summary>
+        ///  Gets or sets a value indicating whether the link should be displayed as if it was visited.
+        /// </summary>
         [DefaultValue(false)]
         [SRCategory(nameof(SR.CatAppearance))]
         [SRDescription(nameof(SR.LinkLabelLinkVisitedDescr))]
@@ -882,10 +882,10 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-            ///  Gets or sets a value that is returned to the
+        ///  Gets or sets a value that is returned to the
         ///  parent form when the link label.
         ///  is clicked.
-            /// </summary>
+        /// </summary>
         DialogResult IButtonControl.DialogResult
         {
             get
@@ -2608,16 +2608,24 @@ namespace System.Windows.Forms
 
             public override AccessibleObject HitTest(int x, int y)
             {
+                if (!Owner.IsHandleCreated)
+                {
+                    return null;
+                }
+
                 Point p = Owner.PointToClient(new Point(x, y));
                 Link hit = ((LinkLabel)Owner).PointInLink(p.X, p.Y);
+
                 if (hit != null)
                 {
                     return new LinkAccessibleObject(hit);
                 }
+
                 if (Bounds.Contains(x, y))
                 {
                     return this;
                 }
+
                 return null;
             }
 
@@ -2642,6 +2650,11 @@ namespace System.Windows.Forms
             {
                 get
                 {
+                    if (!_link.Owner.IsHandleCreated)
+                    {
+                        return Rectangle.Empty;
+                    }
+
                     Region region = _link.VisualRegion;
                     Graphics g = Graphics.FromHwnd(_link.Owner.Handle);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ItemAccessibleObject.cs
@@ -77,6 +77,11 @@ namespace System.Windows.Forms
             {
                 get
                 {
+                    if (!_owningListBox.IsHandleCreated)
+                    {
+                        return Rectangle.Empty;
+                    }
+
                     Rectangle bounds = _owningListBox.GetItemRectangle(CurrentIndex);
 
                     if (bounds.IsEmpty)
@@ -162,12 +167,18 @@ namespace System.Windows.Forms
 
             internal override void AddToSelection()
             {
-                SelectItem();
+                if (_owningListBox.IsHandleCreated)
+                {
+                    SelectItem();
+                }
             }
 
             public override void DoDefaultAction()
             {
-                SetFocus();
+                if (_owningListBox.IsHandleCreated)
+                {
+                    SetFocus();
+                }
             }
 
             internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
@@ -246,6 +257,11 @@ namespace System.Windows.Forms
 
             internal override void ScrollIntoView()
             {
+                if (!_owningListBox.IsHandleCreated)
+                {
+                    return;
+                }
+
                 int currentIndex = CurrentIndex;
 
                 if (_owningListBox.SelectedIndex == -1) //no item selected
@@ -289,6 +305,11 @@ namespace System.Windows.Forms
 
             internal unsafe override void SelectItem()
             {
+                if (!_owningListBox.IsHandleCreated)
+                {
+                    return;
+                }
+
                 _owningListBox.SelectedIndex = CurrentIndex;
 
                 User32.InvalidateRect(new HandleRef(this, _owningListBox.Handle), null, BOOL.FALSE);
@@ -298,6 +319,11 @@ namespace System.Windows.Forms
 
             internal override void SetFocus()
             {
+                if (!_owningListBox.IsHandleCreated)
+                {
+                    return;
+                }
+
                 RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
                 SelectItem();
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObject.cs
@@ -83,9 +83,10 @@ namespace System.Windows.Forms
                         return state |= AccessibleStates.Selected | AccessibleStates.Focused;
                     }
 
-                    if (_systemIAccessible != null)
+                    object? systemIAccessibleState = _systemIAccessible?.get_accState(GetChildId());
+                    if (systemIAccessibleState != null)
                     {
-                        return state |= (AccessibleStates)(_systemIAccessible.get_accState(GetChildId()));
+                        return state |= (AccessibleStates)systemIAccessibleState;
                     }
 
                     return state;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarButtonAccessibleObject.cs
@@ -43,7 +43,13 @@ namespace System.Windows.Forms
             internal override bool IsPatternSupported(UiaCore.UIA patternId) =>
                 (patternId == UiaCore.UIA.InvokePatternId) || base.IsPatternSupported(patternId);
 
-            internal override void Invoke() => RaiseMouseClick();
+            internal override void Invoke()
+            {
+                if (_calendarAccessibleObject.Owner.IsHandleCreated)
+                {
+                    RaiseMouseClick();
+                }
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarCellAccessibleObject.cs
@@ -39,7 +39,7 @@ namespace System.Windows.Forms
                 new int[5]
                 {
                     RuntimeIDFirstItem,
-                    _calendarAccessibleObject.Owner.Handle.ToInt32(),
+                    (int)(long)_calendarAccessibleObject.Owner.InternalHandle,
                     Parent.Parent.GetChildId(),
                     Parent.GetChildId(),
                     GetChildId()
@@ -88,14 +88,17 @@ namespace System.Windows.Forms
 
             internal override void Invoke()
             {
-                RaiseMouseClick();
+                if (_calendarAccessibleObject.Owner.IsHandleCreated)
+                {
+                    RaiseMouseClick();
+                }
             }
 
             internal override UiaCore.IRawElementProviderSimple[] GetRowHeaderItems() => null;
 
             internal override UiaCore.IRawElementProviderSimple[] GetColumnHeaderItems()
             {
-                if (!_calendarAccessibleObject.HasHeaderRow)
+                if (!_calendarAccessibleObject.Owner.IsHandleCreated || !_calendarAccessibleObject.HasHeaderRow)
                 {
                     return null;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarChildAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarChildAccessibleObject.cs
@@ -53,14 +53,14 @@ namespace System.Windows.Forms
                 new int[]
                 {
                     RuntimeIDFirstItem,
-                    _calendarAccessibleObject.Owner.Handle.ToInt32(),
+                    (int)(long)_calendarAccessibleObject.Owner.InternalHandle,
                     GetChildId()
                 };
 
             public void RaiseMouseClick()
             {
                 // Make sure that the control is enabled.
-                if (User32.IsWindowEnabled(_calendarAccessibleObject.Owner.Handle).IsFalse())
+                if (!_calendarAccessibleObject.Owner.IsHandleCreated || User32.IsWindowEnabled(_calendarAccessibleObject.Owner.Handle).IsFalse())
                 {
                     return;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarHeaderAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarHeaderAccessibleObject.cs
@@ -48,7 +48,13 @@ namespace System.Windows.Forms
             internal override bool IsPatternSupported(UiaCore.UIA patternId) =>
                 (patternId == UiaCore.UIA.InvokePatternId) || base.IsPatternSupported(patternId);
 
-            internal override void Invoke() => RaiseMouseClick();
+            internal override void Invoke()
+            {
+                if (_calendarAccessibleObject.Owner.IsHandleCreated)
+                {
+                    RaiseMouseClick();
+                }
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarRowAccessibleObject.cs
@@ -26,7 +26,7 @@ namespace System.Windows.Forms
                 new int[4]
                 {
                     RuntimeIDFirstItem,
-                    _calendarAccessibleObject.Owner.Handle.ToInt32(),
+                    (int)(long)_calendarAccessibleObject.Owner.InternalHandle,
                     Parent.GetChildId(),
                     GetChildId()
                 };

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarTodayLinkAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarTodayLinkAccessibleObject.cs
@@ -46,7 +46,13 @@ namespace System.Windows.Forms
                     _ => base.FragmentNavigate(direction)
                 };
 
-            internal override void Invoke() => RaiseMouseClick();
+            internal override void Invoke()
+            {
+                if (_calendarAccessibleObject.Owner.IsHandleCreated)
+                {
+                    RaiseMouseClick();
+                }
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDown.cs
@@ -971,7 +971,7 @@ namespace System.Windows.Forms
 
                     var runtimeId = new int[3];
                     runtimeId[0] = RuntimeIDFirstItem;
-                    runtimeId[1] = (int)(long)_owner.Handle;
+                    runtimeId[1] = (int)(long)_owner.InternalHandle;
                     runtimeId[2] = _owner.GetHashCode();
 
                     return runtimeId;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -5464,6 +5464,11 @@ namespace System.Windows.Forms
         /// </returns>
         internal override UiaCore.IRawElementProviderFragment ElementProviderFromPoint(double x, double y)
         {
+            if (!_owningPropertyGrid.IsHandleCreated)
+            {
+                return null;
+            }
+
             Point clientPoint = _owningPropertyGrid.PointToClient(new Point((int)x, (int)y));
 
             Control element = _owningPropertyGrid.GetElementFromPoint(clientPoint);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.cs
@@ -251,12 +251,18 @@ namespace System.Windows.Forms.PropertyGridInternal
             _owningDropDownButton = owningDropDownButton;
             _owningPropertyGrid = owningDropDownButton.Parent as PropertyGridView;
 
-            UseStdAccessibleObjects(owningDropDownButton.Handle);
+            if (owningDropDownButton.IsHandleCreated)
+            {
+                UseStdAccessibleObjects(owningDropDownButton.Handle);
+            }
         }
 
         public override void DoDefaultAction()
         {
-            _owningDropDownButton.PerformButtonClick();
+            if (_owningDropDownButton.IsHandleCreated)
+            {
+                _owningDropDownButton.PerformButtonClick();
+            }
         }
 
         /// <summary>
@@ -318,6 +324,11 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         internal override void SetFocus()
         {
+            if (!_owningDropDownButton.IsHandleCreated)
+            {
+                return;
+            }
+
             RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
 
             base.SetFocus();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
@@ -2944,15 +2944,9 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             public override Rectangle Bounds
             {
-                get
-                {
-                    if (PropertyGridView != null && PropertyGridView.IsHandleCreated)
-                    {
-                        return PropertyGridView.AccessibilityGetGridEntryBounds(owner);
-                    }
-
-                    return Rectangle.Empty;
-                }
+                get => PropertyGridView != null && PropertyGridView.IsHandleCreated
+                    ? PropertyGridView.AccessibilityGetGridEntryBounds(owner)
+                    : Rectangle.Empty;
             }
 
             public override string DefaultAction
@@ -3068,7 +3062,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                         runtimeId = new int[3];
                         runtimeId[0] = 0x2a;
-                        runtimeId[1] = (int)(long)owner.GridEntryHost.Handle;
+                        runtimeId[1] = (int)(long)owner.GridEntryHost.InternalHandle;
                         runtimeId[2] = GetHashCode();
                     }
 
@@ -3192,7 +3186,10 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             public override void DoDefaultAction()
             {
-                owner.OnOutlineClick(EventArgs.Empty);
+                if (PropertyGridView.IsHandleCreated)
+                {
+                    owner.OnOutlineClick(EventArgs.Empty);
+                }
             }
 
             public override string Name
@@ -3237,6 +3234,11 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 get
                 {
+                    if (!PropertyGridView.IsHandleCreated)
+                    {
+                        return AccessibleStates.None;
+                    }
+
                     AccessibleStates state = AccessibleStates.Selectable | AccessibleStates.Focusable;
 
                     // Determine focus
@@ -3356,6 +3358,11 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             public override void Select(AccessibleSelection flags)
             {
+                if (!PropertyGridView.IsHandleCreated)
+                {
+                    return;
+                }
+
                 // make sure we're on the right thread.
                 //
                 if (PropertyGridView.InvokeRequired)
@@ -3381,6 +3388,11 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             internal override void SetFocus()
             {
+                if (!PropertyGridView.IsHandleCreated)
+                {
+                    return;
+                }
+
                 base.SetFocus();
 
                 RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
@@ -1268,6 +1268,11 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             private void ExpandOrCollapse()
             {
+                if (!GetPropertyGridView().IsHandleCreated)
+                {
+                    return;
+                }
+
                 var propertyGridView = GetPropertyGridView();
                 if (propertyGridView is null)
                 {
@@ -1275,6 +1280,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
 
                 int row = propertyGridView.GetRowFromGridEntry(_owningPropertyDescriptorGridEntry);
+
                 if (row != -1)
                 {
                     propertyGridView.PopupDialog(row);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -6309,9 +6309,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             ///  otherwise return null.
             /// </returns>
             internal override UiaCore.IRawElementProviderFragment ElementProviderFromPoint(double x, double y)
-            {
-                return HitTest((int)x, (int)y);
-            }
+                => Owner.IsHandleCreated ? HitTest((int)x, (int)y) : null;
 
             /// <summary>
             ///  Request to return the element in the specified direction.
@@ -6754,6 +6752,11 @@ namespace System.Windows.Forms.PropertyGridInternal
             /// </summary>
             public override AccessibleObject HitTest(int x, int y)
             {
+                if (!Owner.IsHandleCreated)
+                {
+                    return null;
+                }
+
                 // Convert to client coordinates
                 var pt = new Point(x, y);
                 User32.ScreenToClient(new HandleRef(Owner, Owner.Handle), ref pt);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusStrip.cs
@@ -713,14 +713,9 @@ namespace System.Windows.Forms
             }
 
             internal override UiaCore.IRawElementProviderFragment ElementProviderFromPoint(double x, double y)
-            {
-                return HitTest((int)x, (int)y);
-            }
+                => Owner.IsHandleCreated ? HitTest((int)x, (int)y) : null;
 
-            internal override UiaCore.IRawElementProviderFragment GetFocus()
-            {
-                return GetFocused();
-            }
+            internal override UiaCore.IRawElementProviderFragment GetFocus() => Owner.IsHandleCreated ? GetFocused() : null;
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -4915,20 +4915,23 @@ namespace System.Windows.Forms
             }
 
             internal override UiaCore.IRawElementProviderFragment ElementProviderFromPoint(double x, double y)
-            {
-                return HitTest((int)x, (int)y);
-            }
+                => owner.IsHandleCreated ? HitTest((int)x, (int)y) : null;
 
             /// <summary>
             ///  Return the child object at the given screen coordinates.
             /// </summary>
             public override AccessibleObject HitTest(int x, int y)
             {
+                if (!owner.IsHandleCreated)
+                {
+                    return null;
+                }
+
                 Point clientHit = owner.PointToClient(new Point(x, y));
                 ToolStripItem item = owner.GetItemAt(clientHit);
-                return ((item != null) && (item.AccessibilityObject != null)) ?
-                    item.AccessibilityObject :
-                    base.HitTest(x, y);
+                return ((item != null) && (item.AccessibilityObject != null))
+                    ? item.AccessibilityObject
+                    : base.HitTest(x, y);
             }
 
             /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripComboBox.cs
@@ -690,7 +690,7 @@ namespace System.Windows.Forms
                 public ToolStripComboBoxControlAccessibleObject(ToolStripComboBoxControl toolStripComboBoxControl)
                     : base(toolStripComboBoxControl)
                 {
-                    _childAccessibleObject = new ChildAccessibleObject(toolStripComboBoxControl, toolStripComboBoxControl.Handle);
+                    _childAccessibleObject = new ChildAccessibleObject(toolStripComboBoxControl, toolStripComboBoxControl.InternalHandle);
                 }
 
                 internal override UiaCore.IRawElementProviderFragment FragmentNavigate(UiaCore.NavigateDirection direction)

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/CheckBox.CheckBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/CheckBox.CheckBoxAccessibleObjectTests.cs
@@ -30,13 +30,12 @@ namespace System.Windows.Forms.Tests
             var checkBoxAccessibleObject = new CheckBox.CheckBoxAccessibleObject(checkBox);
 
             Assert.NotNull(checkBoxAccessibleObject.Owner);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(checkBox.IsHandleCreated);
+            Assert.False(checkBox.IsHandleCreated);
         }
 
         [WinFormsFact]
         public void CheckBoxAccessibleObject_CustomDoDefaultAction_ReturnsExpected()
-        {;
+        {
             using var checkBox = new CheckBox
             {
                 Name = "CheckBox1",
@@ -47,8 +46,7 @@ namespace System.Windows.Forms.Tests
             var checkBoxAccessibleObject = new CheckBox.CheckBoxAccessibleObject(checkBox);
 
             Assert.Equal("TestActionDescription", checkBoxAccessibleObject.DefaultAction);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(checkBox.IsHandleCreated);
+            Assert.False(checkBox.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -59,8 +57,7 @@ namespace System.Windows.Forms.Tests
             var checkBoxAccessibleObject = new CheckBox.CheckBoxAccessibleObject(checkBox);
 
             Assert.Equal(AccessibleRole.CheckButton, checkBoxAccessibleObject.Role);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(checkBox.IsHandleCreated);
+            Assert.False(checkBox.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -75,34 +72,45 @@ namespace System.Windows.Forms.Tests
             var checkBoxAccessibleObject = new CheckBox.CheckBoxAccessibleObject(checkBox);
 
             Assert.Equal(AccessibleRole.PushButton, checkBoxAccessibleObject.Role);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(checkBox.IsHandleCreated);
+            Assert.False(checkBox.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void CheckBoxAccessibleObject_State_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData(true, AccessibleStates.Focusable)]
+        [InlineData(false, AccessibleStates.None)]
+        public void CheckBoxAccessibleObject_State_ReturnsExpected(bool createControl, AccessibleStates accessibleStates)
         {
             using var checkBox = new CheckBox();
-            Assert.False(checkBox.IsHandleCreated);
+
+            if (createControl)
+            {
+                checkBox.CreateControl();
+            }
+
             var checkBoxAccessibleObject = new CheckBox.CheckBoxAccessibleObject(checkBox);
 
-            Assert.Equal(AccessibleStates.Focusable, checkBoxAccessibleObject.State);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(checkBox.IsHandleCreated);
+            Assert.Equal(accessibleStates, checkBoxAccessibleObject.State);
+            Assert.Equal(createControl, checkBox.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void CheckBoxAccessibleObject_ToggleState_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData(true, (int)ToggleState.On)]
+        [InlineData(false, (int)ToggleState.Off)]
+        public void CheckBoxAccessibleObject_ToggleState_ReturnsExpected(bool createControl, int toggleState)
         {
             using var checkBox = new CheckBox();
-            Assert.False(checkBox.IsHandleCreated);
+
+            if (createControl)
+            {
+                checkBox.CreateControl();
+            }
+
             var checkBoxAccessibleObject = new CheckBox.CheckBoxAccessibleObject(checkBox);
             Assert.Equal(ToggleState.Off, checkBoxAccessibleObject.ToggleState);
             checkBoxAccessibleObject.DoDefaultAction();
 
-            Assert.Equal(ToggleState.On, checkBoxAccessibleObject.ToggleState);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(checkBox.IsHandleCreated);
+            Assert.Equal((ToggleState)toggleState, checkBoxAccessibleObject.ToggleState);
+            Assert.Equal(createControl, checkBox.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -117,8 +125,7 @@ namespace System.Windows.Forms.Tests
             var checkBoxAccessibleObject = new CheckBox.CheckBoxAccessibleObject(checkBox);
 
             Assert.Equal("TestDescription", checkBoxAccessibleObject.Description);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(checkBox.IsHandleCreated);
+            Assert.False(checkBox.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -133,8 +140,7 @@ namespace System.Windows.Forms.Tests
             var checkBoxAccessibleObject = new CheckBox.CheckBoxAccessibleObject(checkBox);
 
             Assert.Equal("TestName", checkBoxAccessibleObject.Name);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(checkBox.IsHandleCreated);
+            Assert.False(checkBox.IsHandleCreated);
         }
 
         [WinFormsTheory]
@@ -155,8 +161,7 @@ namespace System.Windows.Forms.Tests
             object value = checkBoxAccessibleObject.GetPropertyValue((UIA)propertyID);
 
             Assert.Equal(expected, value);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(checkBox.IsHandleCreated);
+            Assert.False(checkBox.IsHandleCreated);
         }
 
         [WinFormsTheory]
@@ -169,8 +174,7 @@ namespace System.Windows.Forms.Tests
             var checkBoxAccessibleObject = new CheckBox.CheckBoxAccessibleObject(checkBox);
 
             Assert.True(checkBoxAccessibleObject.IsPatternSupported((UIA)patternId));
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(checkBox.IsHandleCreated);
+            Assert.False(checkBox.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -188,8 +192,7 @@ namespace System.Windows.Forms.Tests
             checkBoxAccessibleObject.Toggle();
 
             Assert.False(checkBox.Checked);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(checkBox.IsHandleCreated);
+            Assert.False(checkBox.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewAccessibleObjectTests.cs
@@ -97,9 +97,10 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
         }
 
         [WinFormsFact]
-        public void DataGridViewAccessibleObject_Bounds_ReturnsCorrectValue()
+        public void DataGridViewAccessibleObject_Bounds_ReturnsCorrectValue_IfHandleIsCreated()
         {
             using DataGridView dataGridView = new DataGridView();
+            dataGridView.CreateControl();
             dataGridView.Size = new Size(500, 300);
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
 
@@ -115,6 +116,27 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             actualBounds.Location = new Point(0, 0);
             Rectangle expectedBounds = dataGridView.Bounds;
             Assert.Equal(expectedBounds, actualBounds);
+            Assert.True(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_Bounds_ReturnsCorrectValue_IfHandleIsNotCreated()
+        {
+            using DataGridView dataGridView = new DataGridView();
+            dataGridView.Size = new Size(500, 300);
+            AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
+
+            int actualWidth = accessibleObject.Bounds.Width;
+            Assert.Equal(0, actualWidth);
+
+            int actualHeight = accessibleObject.Bounds.Height;
+            Assert.Equal(0, actualHeight);
+
+            Rectangle actualBounds = accessibleObject.Bounds;
+            actualBounds.Location = new Point(0, 0);
+            Rectangle expectedBounds = dataGridView.Bounds;
+            Assert.Equal(Rectangle.Empty, actualBounds);
+            Assert.False(dataGridView.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -133,7 +155,6 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             using DataGridView dataGridView = new DataGridView();
             dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
             dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
-            dataGridView.CreateControl();
             User32.SetFocus(new HandleRef(dataGridView, dataGridView.Handle));
 
             DataGridViewCell cell = dataGridView.Rows[0].Cells[0];
@@ -182,12 +203,21 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             Assert.Equal(expectedStatus, actualStatus);
         }
 
-        [WinFormsFact]
-        public void DataGridViewAccessibleObject_State_IsFocusable()
+        [WinFormsTheory]
+        [InlineData(true, AccessibleStates.Focusable)]
+        [InlineData(false, AccessibleStates.None)]
+        public void DataGridViewAccessibleObject_State_IsFocusable(bool createControl, AccessibleStates expectedAccessibleStates)
         {
             using DataGridView dataGridView = new DataGridView();
+            if (createControl)
+            {
+                dataGridView.CreateControl();
+            }
+
+            Assert.Equal(createControl, dataGridView.IsHandleCreated);
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
-            Assert.Equal(AccessibleStates.Focusable, accessibleObject.State & AccessibleStates.Focusable);
+            Assert.Equal(createControl, dataGridView.IsHandleCreated);
+            Assert.Equal(expectedAccessibleStates, accessibleObject.State & AccessibleStates.Focusable);
         }
 
         [WinFormsFact]
@@ -226,10 +256,18 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             Assert.True((bool)accessibilityObject.GetPropertyValue((UiaCore.UIA)propertyId));
         }
 
-        [WinFormsFact]
-        public void DataGridViewAccessibleObject_Cell_IsOffscreen_ReturnsCorrectValue()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewAccessibleObject_Cell_IsOffscreen_ReturnsCorrectValue(bool createControl)
         {
             using DataGridView dataGridView = new DataGridView();
+
+            if (createControl)
+            {
+                dataGridView.CreateControl();
+            }
+
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
             dataGridView.Size = new Size(200, 100);
             dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
@@ -242,7 +280,9 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             dataGridView.Rows.Add(); // 3
             dataGridView.Rows.Add(); // 4
             isOffscreen = dataGridView.Rows[4].Cells[0].AccessibilityObject.GetPropertyValue(UiaCore.UIA.IsOffscreenPropertyId);
-            Assert.True((bool)isOffscreen); // Out of the visible area
+
+            Assert.Equal(createControl, (bool)isOffscreen); // Out of the visible area
+            Assert.Equal(createControl, dataGridView.IsHandleCreated);
         }
 
         [WinFormsTheory]
@@ -333,11 +373,22 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
         }
 
         [WinFormsFact]
-        public void DataGridViewAccessibleObject_Parent_IsNotNull()
+        public void DataGridViewAccessibleObject_Parent_IsNotNull_IfHandleIsCreated()
+        {
+            using DataGridView dataGridView = new DataGridView();
+            dataGridView.CreateControl();
+            AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
+            Assert.NotNull(accessibleObject.Parent);
+            Assert.True(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_Parent_IsNotNull_IfHandleIsNotCreated()
         {
             using DataGridView dataGridView = new DataGridView();
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
-            Assert.NotNull(accessibleObject.Parent);
+            Assert.Null(accessibleObject.Parent);
+            Assert.False(dataGridView.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewCellAccessibleObjectTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
-using System.Threading;
 using Xunit;
 
 namespace System.Windows.Forms.Tests.AccessibleObjects
@@ -13,7 +11,37 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
         [WinFormsTheory]
         [InlineData(RightToLeft.No)]
         [InlineData(RightToLeft.Yes)]
-        public void DataGridViewCellsAccessibleObject_Ctor_Default(RightToLeft rightToLeft)
+        public void DataGridViewCellsAccessibleObject_Ctor_Default_IfHandleIsCreated(RightToLeft rightToLeft)
+        {
+            using var dataGridView = new DataGridView
+            {
+                RightToLeft = rightToLeft,
+                ColumnCount = 4,
+                Width = 85
+            };
+
+            dataGridView.CreateControl();
+            dataGridView.Columns[0].Width = 40;
+            dataGridView.Columns[1].Width = 40;
+            dataGridView.Columns[2].Width = 40;
+            dataGridView.Columns[3].Width = 40;
+
+            AccessibleObject rr = dataGridView.AccessibilityObject; //it is necessary to be in time to initialize elements
+
+            var accCellWidthSum = 0;
+            for (int i = 0; i < 4; i++)
+            {
+                accCellWidthSum += dataGridView.Rows[0].Cells[i].AccessibilityObject.BoundingRectangle.Width;
+            }
+            var accRowWidth = dataGridView.Rows[0].AccessibilityObject.BoundingRectangle.Width;
+
+            Assert.Equal(accCellWidthSum, accRowWidth - dataGridView.RowHeadersWidth);
+        }
+
+        [WinFormsTheory]
+        [InlineData(RightToLeft.No)]
+        [InlineData(RightToLeft.Yes)]
+        public void DataGridViewCellsAccessibleObject_Ctor_Default_IfHandleIsNotCreated(RightToLeft rightToLeft)
         {
             using var dataGridView = new DataGridView
             {
@@ -36,7 +64,8 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             }
             var accRowWidth = dataGridView.Rows[0].AccessibilityObject.BoundingRectangle.Width;
 
-            Assert.True(accCellWidthSum == accRowWidth - dataGridView.RowHeadersWidth);
+            Assert.Equal(0, accCellWidthSum);
+            Assert.Equal(0, accRowWidth);
         }
 
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewRowsAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewRowsAccessibleObjectTests.cs
@@ -9,7 +9,36 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
     public class DataGridViewRowsAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]
-        public void DataGridViewRowsAccessibleObject_Ctor_Default()
+        public void DataGridViewRowsAccessibleObject_Ctor_Default_IfHandleIsCreated()
+        {
+            using DataGridView dataGridView = new DataGridView
+            {
+                RowCount = 5,
+                Height = 87
+            };
+
+            dataGridView.CreateControl();
+            dataGridView.Rows[0].Height = 20;
+            dataGridView.Rows[1].Height = 20;
+            dataGridView.Rows[2].Height = 20;
+            dataGridView.Rows[3].Height = 20;
+            dataGridView.Rows[4].Height = 20;
+
+            AccessibleObject accObject = dataGridView.AccessibilityObject; //it is necessary to be in time to initialize elements
+
+            int accRowHeightSum = 0;
+            for (int i = 0; i < 5; i++)
+            {
+                accRowHeightSum += dataGridView.Rows[i].AccessibilityObject.BoundingRectangle.Height;
+            }
+            int accDataGridViewHeight = dataGridView.AccessibilityObject.BoundingRectangle.Height;
+            int borders = 2 * dataGridView.BorderWidth; //top border and bottom border
+
+            Assert.Equal(accRowHeightSum, accDataGridViewHeight - borders - dataGridView.ColumnHeadersHeight);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowsAccessibleObject_Ctor_Default_IfHandleIsNotCreated()
         {
             using DataGridView dataGridView = new DataGridView
             {
@@ -31,9 +60,9 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
                 accRowHeightSum += dataGridView.Rows[i].AccessibilityObject.BoundingRectangle.Height;
             }
             int accDataGridViewHeight = dataGridView.AccessibilityObject.BoundingRectangle.Height;
-            int borders = 2 * dataGridView.BorderWidth; //top border and bottom border
 
-            Assert.True(accRowHeightSum == accDataGridViewHeight - borders - dataGridView.ColumnHeadersHeight);
+            Assert.Equal(0, accDataGridViewHeight);
+            Assert.Equal(0, accRowHeightSum);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/GroupBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/GroupBoxAccessibleObjectTests.cs
@@ -18,9 +18,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             groupBox.AccessibleName = testAccName;
             AccessibleObject groupBoxAccessibleObject = groupBox.AccessibilityObject;
 
-            // Will fail when https://github.com/dotnet/winforms/pull/3432 is merged.
-            // Assert.False is expected here
-            Assert.True(groupBox.IsHandleCreated);
+            Assert.False(groupBox.IsHandleCreated);
 
             var accessibleName = groupBoxAccessibleObject.GetPropertyValue(Interop.UiaCore.UIA.NamePropertyId);
             Assert.Equal(testAccName, accessibleName);
@@ -34,9 +32,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             groupBox.Text = "Some test groupBox text";
             var groupBoxAccessibleObject = new GroupBox.GroupBoxAccessibleObject(groupBox);
 
-            // Will fail when https://github.com/dotnet/winforms/pull/3432 is merged.
-            // Assert.False is expected here
-            Assert.True(groupBox.IsHandleCreated);
+            Assert.False(groupBox.IsHandleCreated);
 
             bool supportsLegacyIAccessiblePatternId = groupBoxAccessibleObject.IsPatternSupported(Interop.UiaCore.UIA.LegacyIAccessiblePatternId);
             Assert.True(supportsLegacyIAccessiblePatternId);
@@ -51,10 +47,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             groupBox.AccessibleRole = AccessibleRole.Link;
             var groupBoxAccessibleObject = new GroupBox.GroupBoxAccessibleObject(groupBox);
 
-            // Will fail when https://github.com/dotnet/winforms/pull/3432 is merged.
-            // Assert.False is expected here
-            Assert.True(groupBox.IsHandleCreated);
-
+            Assert.False(groupBox.IsHandleCreated);
             Assert.Equal(AccessibleRole.Link, groupBoxAccessibleObject.Role);
         }
 
@@ -68,10 +61,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             groupBox.AccessibleDescription = testAccDescription;
             var groupBoxAccessibleObject = new GroupBox.GroupBoxAccessibleObject(groupBox);
 
-            // Will fail when https://github.com/dotnet/winforms/pull/3432 is merged.
-            // Assert.False is expected here
-            Assert.True(groupBox.IsHandleCreated);
-
+            Assert.False(groupBox.IsHandleCreated);
             Assert.Equal(testAccDescription, groupBoxAccessibleObject.Description);
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/LabelAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/LabelAccessibleObjectTests.cs
@@ -18,9 +18,7 @@ namespace System.Windows.Forms.Tests
             label.AccessibleName = testAccName;
             AccessibleObject labelAccessibleObject = label.AccessibilityObject;
 
-            // Will fail when https://github.com/dotnet/winforms/pull/3432 is merged.
-            // Assert.False is expected here
-            Assert.True(label.IsHandleCreated);
+            Assert.False(label.IsHandleCreated);
 
             var accessibleName = labelAccessibleObject.GetPropertyValue(Interop.UiaCore.UIA.NamePropertyId);
             Assert.Equal(testAccName, accessibleName);
@@ -34,9 +32,7 @@ namespace System.Windows.Forms.Tests
             label.Text = "Some test label text";
             var labelAccessibleObject = new Label.LabelAccessibleObject(label);
 
-            // Will fail when https://github.com/dotnet/winforms/pull/3432 is merged.
-            // Assert.False is expected here
-            Assert.True(label.IsHandleCreated);
+            Assert.False(label.IsHandleCreated);
 
             bool supportsLegacyIAccessiblePatternId = labelAccessibleObject.IsPatternSupported(Interop.UiaCore.UIA.LegacyIAccessiblePatternId);
             Assert.True(supportsLegacyIAccessiblePatternId);
@@ -51,10 +47,7 @@ namespace System.Windows.Forms.Tests
             label.AccessibleRole = AccessibleRole.Link;
             var labelAccessibleObject = new Label.LabelAccessibleObject(label);
 
-            // Will fail when https://github.com/dotnet/winforms/pull/3432 is merged.
-            // Assert.False is expected here
-            Assert.True(label.IsHandleCreated);
-
+            Assert.False(label.IsHandleCreated);
             Assert.Equal(AccessibleRole.Link, labelAccessibleObject.Role);
         }
 
@@ -68,10 +61,7 @@ namespace System.Windows.Forms.Tests
             label.AccessibleDescription = testAccDescription;
             var labelAccessibleObject = new Label.LabelAccessibleObject(label);
 
-            // Will fail when https://github.com/dotnet/winforms/pull/3432 is merged.
-            // Assert.False is expected here
-            Assert.True(label.IsHandleCreated);
-
+            Assert.False(label.IsHandleCreated);
             Assert.Equal(testAccDescription, labelAccessibleObject.Description);
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PictureBox.PictureBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PictureBox.PictureBoxAccessibleObjectTests.cs
@@ -23,8 +23,7 @@ namespace System.Windows.Forms.Tests
             var pictureBoxAccessibleObject = new PictureBox.PictureBoxAccessibleObject(pictureBox);
 
             Assert.NotNull(pictureBoxAccessibleObject.Owner);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(pictureBox.IsHandleCreated);
+            Assert.False(pictureBox.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -39,8 +38,7 @@ namespace System.Windows.Forms.Tests
             var pictureBoxAccessibleObject = new PictureBox.PictureBoxAccessibleObject(pictureBox);
 
             Assert.Equal("TestDescription", pictureBoxAccessibleObject.Description);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(pictureBox.IsHandleCreated);
+            Assert.False(pictureBox.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -55,8 +53,7 @@ namespace System.Windows.Forms.Tests
             var pictureBoxAccessibleObject = new PictureBox.PictureBoxAccessibleObject(pictureBox);
 
             Assert.Equal("TestName", pictureBoxAccessibleObject.Name);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(pictureBox.IsHandleCreated);
+            Assert.False(pictureBox.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -71,20 +68,24 @@ namespace System.Windows.Forms.Tests
             var pictureBoxAccessibleObject = new PictureBox.PictureBoxAccessibleObject(pictureBox);
 
             Assert.Equal(AccessibleRole.PushButton, pictureBoxAccessibleObject.Role);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(pictureBox.IsHandleCreated);
+            Assert.False(pictureBox.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void PictureBoxAccessibleObject_DefaultRole_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData(true, AccessibleRole.Client)]
+        [InlineData(false, AccessibleRole.None)]
+        public void PictureBoxAccessibleObject_DefaultRole_ReturnsExpected(bool createControl, AccessibleRole accessibleRole)
         {
             using var pictureBox = new PictureBox();
-            Assert.False(pictureBox.IsHandleCreated);
-            var pictureBoxAccessibleObject = new PictureBox.PictureBoxAccessibleObject(pictureBox);
-            Assert.Equal(AccessibleRole.Client, pictureBoxAccessibleObject.Role);
 
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(pictureBox.IsHandleCreated);
+            if (createControl)
+            {
+                pictureBox.CreateControl();
+            }
+
+            var pictureBoxAccessibleObject = new PictureBox.PictureBoxAccessibleObject(pictureBox);
+            Assert.Equal(accessibleRole, pictureBoxAccessibleObject.Role);
+            Assert.Equal(createControl, pictureBox.IsHandleCreated);
         }
 
         [WinFormsTheory]
@@ -105,8 +106,7 @@ namespace System.Windows.Forms.Tests
             object value = pictureBoxAccessibleObject.GetPropertyValue((UIA)propertyID);
 
             Assert.Equal(expected, value);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(pictureBox.IsHandleCreated);
+            Assert.False(pictureBox.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -117,8 +117,7 @@ namespace System.Windows.Forms.Tests
             var pictureBoxAccessibleObject = new PictureBox.PictureBoxAccessibleObject(pictureBox);
 
             Assert.True(pictureBoxAccessibleObject.IsPatternSupported(UIA.LegacyIAccessiblePatternId));
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(pictureBox.IsHandleCreated);
+            Assert.False(pictureBox.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ProgressBarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ProgressBarAccessibleObjectTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
 using Accessibility;
 using Xunit;
 
@@ -10,17 +11,20 @@ namespace System.Windows.Forms.Tests
     public class ProgressBarAccessibleObject : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]
-        public void ProgressBarAccessibilityObject_Properties_ReturnsExpected()
+        public void ProgressBarAccessibilityObject_Properties_ReturnsExpected_IfHandleIsCreated()
         {
             using var ownerControl = new ProgressBar
             {
                 Value = 5,
             };
+
+            ownerControl.CreateControl();
+
             Control.ControlAccessibleObject accessibilityObject = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(ownerControl.AccessibilityObject);
+
             Assert.Equal(ownerControl.ClientSize, accessibilityObject.Bounds.Size);
             Assert.Null(accessibilityObject.DefaultAction);
             Assert.Null(accessibilityObject.Description);
-            Assert.Equal(ownerControl.Handle, accessibilityObject.Handle);
             Assert.Null(accessibilityObject.Help);
             Assert.Null(accessibilityObject.KeyboardShortcut);
             Assert.Null(accessibilityObject.Name);
@@ -29,25 +33,65 @@ namespace System.Windows.Forms.Tests
             Assert.NotNull(accessibilityObject.Parent);
             Assert.Equal(AccessibleStates.ReadOnly | AccessibleStates.Focusable, accessibilityObject.State);
             Assert.Equal("5%", accessibilityObject.Value);
+            Assert.True(ownerControl.IsHandleCreated);
+            Assert.Equal(ownerControl.Handle, accessibilityObject.Handle);
+        }
+
+        [WinFormsFact]
+        public void ProgressBarAccessibilityObject_Properties_ReturnsExpected_IfHandleIsNotCreated()
+        {
+            using var ownerControl = new ProgressBar
+            {
+                Value = 5,
+            };
+
+            Control.ControlAccessibleObject accessibilityObject = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(ownerControl.AccessibilityObject);
+
+            Assert.Equal(Rectangle.Empty.Size, accessibilityObject.Bounds.Size);
+            Assert.Null(accessibilityObject.DefaultAction);
+            Assert.Null(accessibilityObject.Description);
+            Assert.Null(accessibilityObject.Help);
+            Assert.Null(accessibilityObject.KeyboardShortcut);
+            Assert.Null(accessibilityObject.Name);
+            Assert.Equal(AccessibleRole.None, accessibilityObject.Role);
+            Assert.Same(ownerControl, accessibilityObject.Owner);
+            Assert.Null(accessibilityObject.Parent);
+            Assert.Equal(AccessibleStates.None, accessibilityObject.State);
+            Assert.Equal(string.Empty, accessibilityObject.Value);
+            Assert.False(ownerControl.IsHandleCreated);
+            Assert.Equal(ownerControl.Handle, accessibilityObject.Handle);
         }
 
         [WinFormsTheory]
-        [InlineData("100%")]
-        [InlineData("0%")]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("INVALID")]
-        public void ProgressBarAccessibilityObject_Value_Set_GetReturnsExpected(string value)
+        [InlineData("100%", true, "0%")]
+        [InlineData("0%", true, "0%")]
+        [InlineData(null, true, "0%")]
+        [InlineData("", true, "0%")]
+        [InlineData("INVALID", true, "0%")]
+        [InlineData("100%", false, "")]
+        [InlineData("0%", false, "")]
+        [InlineData(null, false, "")]
+        [InlineData("", false, "")]
+        [InlineData("INVALID", false, "")]
+        public void ProgressBarAccessibilityObject_Value_Set_GetReturnsExpected(string value, bool createControl, string expectedValue)
         {
             using var ownerControl = new ProgressBar();
+            if (createControl)
+            {
+                ownerControl.CreateControl();
+            }
+
+            Assert.Equal(createControl, ownerControl.IsHandleCreated);
+
             Control.ControlAccessibleObject accessibilityObject = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(ownerControl.AccessibilityObject);
+            Assert.Equal(createControl, ownerControl.IsHandleCreated);
             accessibilityObject.Value = value;
-            Assert.Equal("0%", accessibilityObject.Value);
+            Assert.Equal(expectedValue, accessibilityObject.Value);
             Assert.Equal(0, ownerControl.Value);
 
             // Set same.
             accessibilityObject.Value = value;
-            Assert.Equal("0%", accessibilityObject.Value);
+            Assert.Equal(expectedValue, accessibilityObject.Value);
             Assert.Equal(0, ownerControl.Value);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridAccessibleObjectTests.cs
@@ -39,6 +39,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
         public void PropertyGridAccessibleObject_SupportsPattern(int pattern)
         {
             using PropertyGrid propertyGrid = new PropertyGrid();
+            propertyGrid.CreateControl();
             using ComboBox comboBox = new ComboBox();
             propertyGrid.SelectedObject = comboBox;
             PropertyGridAccessibleObject propertyGridAccessibleObject = new PropertyGridAccessibleObject(propertyGrid);

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridViewAccessibleObjectTests.cs
@@ -257,11 +257,20 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
         }
 
         [WinFormsFact]
-        public void PropertyGridViewAccessibleObject_Parent_IsNotNull()
+        public void PropertyGridViewAccessibleObject_Parent_IsNotNull_IfHandleIsCreated()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            propertyGrid.CreateControl();
+            ControlAccessibleObject accessibleObject = (ControlAccessibleObject)propertyGrid.GridViewAccessibleObject;
+            Assert.NotNull(accessibleObject.Parent);
+        }
+
+        [WinFormsFact]
+        public void PropertyGridViewAccessibleObject_Parent_IsNull_IfHandleIsNotCreated()
         {
             using PropertyGrid propertyGrid = new PropertyGrid();
             ControlAccessibleObject accessibleObject = (ControlAccessibleObject)propertyGrid.GridViewAccessibleObject;
-            Assert.NotNull(accessibleObject.Parent);
+            Assert.Null(accessibleObject.Parent);
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/RadioButton.RadioButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/RadioButton.RadioButtonAccessibleObjectTests.cs
@@ -23,8 +23,7 @@ namespace System.Windows.Forms.Tests
             var radioButtonAccessibleObject = new RadioButton.RadioButtonAccessibleObject(radioButton);
 
             Assert.NotNull(radioButtonAccessibleObject.Owner);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(radioButton.IsHandleCreated);
+            Assert.False(radioButton.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -39,8 +38,7 @@ namespace System.Windows.Forms.Tests
             var radioButtonAccessibleObject = new RadioButton.RadioButtonAccessibleObject(radioButton);
 
             Assert.Equal("TestActionDescription", radioButtonAccessibleObject.DefaultAction);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(radioButton.IsHandleCreated);
+            Assert.False(radioButton.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -55,8 +53,7 @@ namespace System.Windows.Forms.Tests
             var radioButtonAccessibleObject = new RadioButton.RadioButtonAccessibleObject(radioButton);
 
             Assert.Equal("TestDescription", radioButtonAccessibleObject.Description);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(radioButton.IsHandleCreated);
+            Assert.False(radioButton.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -71,8 +68,7 @@ namespace System.Windows.Forms.Tests
             var radioButtonAccessibleObject = new RadioButton.RadioButtonAccessibleObject(radioButton);
 
             Assert.Equal("TestName", radioButtonAccessibleObject.Name);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(radioButton.IsHandleCreated);
+            Assert.False(radioButton.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -87,8 +83,7 @@ namespace System.Windows.Forms.Tests
             var radioButtonAccessibleObject = new RadioButton.RadioButtonAccessibleObject(radioButton);
 
             Assert.Equal(AccessibleRole.PushButton, radioButtonAccessibleObject.Role);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(radioButton.IsHandleCreated);
+            Assert.False(radioButton.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -99,38 +94,49 @@ namespace System.Windows.Forms.Tests
             var radioButtonAccessibleObject = new RadioButton.RadioButtonAccessibleObject(radioButton);
 
             Assert.Equal(AccessibleRole.RadioButton, radioButtonAccessibleObject.Role);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(radioButton.IsHandleCreated);
+            Assert.False(radioButton.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void RadioButtonAccessibleObject_State_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData(true, AccessibleStates.Focusable, AccessibleStates.Focusable | AccessibleStates.Checked)]
+        [InlineData(false, AccessibleStates.None, AccessibleStates.None)]
+        public void RadioButtonAccessibleObject_State_ReturnsExpected(bool createControl, AccessibleStates accessibleStatesFirstStage, AccessibleStates accessibleStatesSecondStage)
         {
             using var radioButton = new RadioButton();
-            Assert.False(radioButton.IsHandleCreated);
+
+            if (createControl)
+            {
+                radioButton.CreateControl();
+            }
+
             var radioButtonAccessibleObject = new RadioButton.RadioButtonAccessibleObject(radioButton);
-            Assert.Equal(AccessibleStates.Focusable, radioButtonAccessibleObject.State);
+            Assert.Equal(accessibleStatesFirstStage, radioButtonAccessibleObject.State);
 
             radioButtonAccessibleObject.DoDefaultAction();
 
-            Assert.Equal(AccessibleStates.Focusable | AccessibleStates.Checked, radioButtonAccessibleObject.State);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(radioButton.IsHandleCreated);
+            Assert.Equal(accessibleStatesSecondStage, radioButtonAccessibleObject.State);
+            Assert.Equal(createControl, radioButton.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void RadioButtonAccessibleObject_IsItemSelected_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void RadioButtonAccessibleObject_IsItemSelected_ReturnsExpected(bool createControl)
         {
             using var radioButton = new RadioButton();
-            Assert.False(radioButton.IsHandleCreated);
+
+            if (createControl)
+            {
+                radioButton.CreateControl();
+            }
+
             var radioButtonAccessibleObject = new RadioButton.RadioButtonAccessibleObject(radioButton);
             Assert.False(radioButtonAccessibleObject.IsItemSelected);
 
             radioButtonAccessibleObject.DoDefaultAction();
 
-            Assert.True(radioButtonAccessibleObject.IsItemSelected);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(radioButton.IsHandleCreated);
+            Assert.Equal(createControl, radioButtonAccessibleObject.IsItemSelected);
+            Assert.Equal(createControl, radioButton.IsHandleCreated);
         }
 
         [WinFormsTheory]
@@ -151,8 +157,7 @@ namespace System.Windows.Forms.Tests
             object value = radioButtonAccessibleObject.GetPropertyValue((UIA)propertyID);
 
             Assert.Equal(expected, value);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(radioButton.IsHandleCreated);
+            Assert.False(radioButton.IsHandleCreated);
         }
 
         [WinFormsTheory]
@@ -169,8 +174,7 @@ namespace System.Windows.Forms.Tests
             var radioButtonAccessibleObject = new RadioButton.RadioButtonAccessibleObject(radioButton);
 
             Assert.True(radioButtonAccessibleObject.IsPatternSupported((UIA)patternId));
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(radioButton.IsHandleCreated);
+            Assert.False(radioButton.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/Splitter.SplitterAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/Splitter.SplitterAccessibleObjectTests.cs
@@ -23,8 +23,7 @@ namespace System.Windows.Forms.Tests
             var splitterAccessibleObject = new Splitter.SplitterAccessibleObject(splitter);
 
             Assert.NotNull(splitterAccessibleObject.Owner);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(splitter.IsHandleCreated);
+            Assert.False(splitter.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -39,8 +38,7 @@ namespace System.Windows.Forms.Tests
             var splitterAccessibleObject = new Splitter.SplitterAccessibleObject(splitter);
 
             Assert.Equal("TestDescription", splitterAccessibleObject.Description);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(splitter.IsHandleCreated);
+            Assert.False(splitter.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -55,8 +53,7 @@ namespace System.Windows.Forms.Tests
             var splitterAccessibleObject = new Splitter.SplitterAccessibleObject(splitter);
 
             Assert.Equal("TestName", splitterAccessibleObject.Name);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(splitter.IsHandleCreated);
+            Assert.False(splitter.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -71,20 +68,25 @@ namespace System.Windows.Forms.Tests
             var splitterAccessibleObject = new Splitter.SplitterAccessibleObject(splitter);
 
             Assert.Equal(AccessibleRole.PushButton, splitterAccessibleObject.Role);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(splitter.IsHandleCreated);
+            Assert.False(splitter.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void SplitterAccessibleObject_DefaultRole_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData(true, AccessibleRole.Client)]
+        [InlineData(false, AccessibleRole.None)]
+        public void SplitterAccessibleObject_DefaultRole_ReturnsNone_IfControlIsNotCreated(bool createControl, AccessibleRole accessibleRole)
         {
             using var splitter = new Splitter();
-            Assert.False(splitter.IsHandleCreated);
+
+            if (createControl)
+            {
+                splitter.CreateControl();
+            }
+
             var splitterAccessibleObject = new Splitter.SplitterAccessibleObject(splitter);
 
-            Assert.Equal(AccessibleRole.Client, splitterAccessibleObject.Role);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(splitter.IsHandleCreated);
+            Assert.Equal(accessibleRole, splitterAccessibleObject.Role);
+            Assert.Equal(createControl, splitter.IsHandleCreated);
         }
 
         [WinFormsTheory]
@@ -105,8 +107,7 @@ namespace System.Windows.Forms.Tests
             object value = splitterAccessibleObject.GetPropertyValue((UIA)propertyID);
 
             Assert.Equal(expected, value);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(splitter.IsHandleCreated);
+            Assert.False(splitter.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -120,8 +121,7 @@ namespace System.Windows.Forms.Tests
             var splitterAccessibleObject = new Splitter.SplitterAccessibleObject(splitter);
 
             Assert.True(splitterAccessibleObject.IsPatternSupported(UIA.LegacyIAccessiblePatternId));
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(splitter.IsHandleCreated);
+            Assert.False(splitter.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ToolStripItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ToolStripItemAccessibleObjectTests.cs
@@ -51,13 +51,16 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(ToolStripItemAccessibleObject_TestData))]
         public void ToolStripItemAccessibleObject_LegacyIAccessible_Custom_Role_ReturnsExpected(Type type)
         {
-            using ToolStripItem item = ReflectionHelper.InvokePublicConstructor<ToolStripItem>(type);
-            item.AccessibleRole = AccessibleRole.Link;
-            AccessibleObject toolStripItemAccessibleObject = item.AccessibilityObject;
+            using (new NoAssertContext())
+            {
+                using ToolStripItem item = ReflectionHelper.InvokePublicConstructor<ToolStripItem>(type);
+                item.AccessibleRole = AccessibleRole.Link;
+                AccessibleObject toolStripItemAccessibleObject = item.AccessibilityObject;
 
-            var accessibleObjectRole = toolStripItemAccessibleObject.Role;
+                var accessibleObjectRole = toolStripItemAccessibleObject.Role;
 
-            Assert.Equal(AccessibleRole.Link, accessibleObjectRole);
+                Assert.Equal(AccessibleRole.Link, accessibleObjectRole);
+            }
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/TrackBarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/TrackBarAccessibleObjectTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
 using System.Runtime.InteropServices;
 using Accessibility;
 using Xunit;
@@ -11,16 +12,19 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
     public class TrackBarAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]
-        public void TrackBarAccessibilityObject_Properties_ReturnsExpected()
+        public void TrackBarAccessibilityObject_Properties_ReturnsExpected_IfHandleIsCreated()
         {
             using var ownerControl = new TrackBar
             {
                 Value = 5,
             };
+
+            ownerControl.CreateControl();
             Control.ControlAccessibleObject accessibilityObject = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(ownerControl.AccessibilityObject);
             Assert.Equal(ownerControl.Size, accessibilityObject.Bounds.Size);
             Assert.Null(accessibilityObject.DefaultAction);
             Assert.Null(accessibilityObject.Description);
+            Assert.True(ownerControl.IsHandleCreated);
             Assert.Equal(ownerControl.Handle, accessibilityObject.Handle);
             Assert.Null(accessibilityObject.Help);
             Assert.Null(accessibilityObject.KeyboardShortcut);
@@ -32,16 +36,52 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             Assert.Equal("50", accessibilityObject.Value);
         }
 
+        [WinFormsFact]
+        public void TrackBarAccessibilityObject_Properties_ReturnsExpected_IfHandleIsNotCreated()
+        {
+            using var ownerControl = new TrackBar
+            {
+                Value = 5,
+            };
+
+            Control.ControlAccessibleObject accessibilityObject = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(ownerControl.AccessibilityObject);
+            Assert.Equal(Rectangle.Empty.Size, accessibilityObject.Bounds.Size);
+            Assert.Null(accessibilityObject.DefaultAction);
+            Assert.Null(accessibilityObject.Description);
+            Assert.Null(accessibilityObject.Help);
+            Assert.Null(accessibilityObject.KeyboardShortcut);
+            Assert.Null(accessibilityObject.Name);
+            Assert.Equal(AccessibleRole.None, accessibilityObject.Role);
+            Assert.Same(ownerControl, accessibilityObject.Owner);
+            Assert.Null(accessibilityObject.Parent);
+            Assert.Equal(AccessibleStates.None, accessibilityObject.State);
+            Assert.Equal(string.Empty, accessibilityObject.Value);
+            Assert.False(ownerControl.IsHandleCreated);
+            Assert.Equal(ownerControl.Handle, accessibilityObject.Handle);
+        }
+
         [WinFormsTheory]
-        [InlineData("100", 10, "100")]
-        [InlineData("50", 5, "50")]
-        [InlineData("54", 5, "50")]
-        [InlineData("56", 5, "50")]
-        [InlineData("0", 0, "0")]
-        public void TrackBarAccessibilityObject_Value_Set_GetReturnsExpected(string value, int expected, string expectedValueString)
+        [InlineData("100", 10, "100", true)]
+        [InlineData("50", 5, "50", true)]
+        [InlineData("54", 5, "50", true)]
+        [InlineData("56", 5, "50", true)]
+        [InlineData("0", 0, "0", true)]
+        [InlineData("100", 0, "", false)]
+        [InlineData("50", 0, "", false)]
+        [InlineData("54", 0, "", false)]
+        [InlineData("56", 0, "", false)]
+        [InlineData("0", 0, "", false)]
+        public void TrackBarAccessibilityObject_Value_Set_GetReturnsExpected(string value, int expected, string expectedValueString, bool createControl)
         {
             using var ownerControl = new TrackBar();
+            if (createControl)
+            {
+                ownerControl.CreateControl();
+            }
+
+            Assert.Equal(createControl, ownerControl.IsHandleCreated);
             Control.ControlAccessibleObject accessibilityObject = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(ownerControl.AccessibilityObject);
+            Assert.Equal(createControl, ownerControl.IsHandleCreated);
             accessibilityObject.Value = value;
             Assert.Equal(expectedValueString, accessibilityObject.Value);
             Assert.Equal(expected, ownerControl.Value);
@@ -56,28 +96,55 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
         [InlineData(null)]
         [InlineData("")]
         [InlineData("NotAnInt")]
-        public void TrackBarAccessibilityObject_Value_SetInvalid_ThrowsCOMException(string value)
+        public void TrackBarAccessibilityObject_Value_SetInvalid_ThrowsCOMException_IfHandleIsCreated(string value)
         {
             using var ownerControl = new TrackBar
             {
                 Value = 5
             };
+
+            ownerControl.CreateControl();
             Control.ControlAccessibleObject accessibilityObject = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(ownerControl.AccessibilityObject);
             Assert.Throws<COMException>(() => accessibilityObject.Value = value);
             Assert.Equal("50", accessibilityObject.Value);
             Assert.Equal(5, ownerControl.Value);
         }
 
-        [WinFormsFact]
-        public void TrackBarAccessibilityObject_GetChildCount_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("NotAnInt")]
+        public void TrackBarAccessibilityObject_Value_SetInvalid_ThrowsCOMException_IfHandleIsNotCreated(string value)
         {
             using var ownerControl = new TrackBar
             {
                 Value = 5
             };
+
+            Control.ControlAccessibleObject accessibilityObject = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(ownerControl.AccessibilityObject);
+            accessibilityObject.Value = value;
+            Assert.Equal(string.Empty, accessibilityObject.Value);
+            Assert.Equal(5, ownerControl.Value);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, 3)]
+        [InlineData(false, 0)]
+        public void TrackBarAccessibilityObject_GetChildCount_ReturnsExpected(bool createControl, int expectedChildACount)
+        {
+            using var ownerControl = new TrackBar
+            {
+                Value = 5
+            };
+
+            if (createControl)
+            {
+                ownerControl.CreateControl();
+            }
+
             Control.ControlAccessibleObject accessibilityObject = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(ownerControl.AccessibilityObject);
             IAccessible iAccessible = accessibilityObject;
-            Assert.Equal(3, iAccessible.accChildCount);
+            Assert.Equal(expectedChildACount, iAccessible.accChildCount);
             Assert.Equal(-1, accessibilityObject.GetChildCount());
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/HScrollBar.HScrollBarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/HScrollBar.HScrollBarAccessibleObjectTests.cs
@@ -20,16 +20,22 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<ArgumentNullException>(() => new HScrollBar.HScrollBarAccessibleObject(null));
         }
 
-        [WinFormsFact]
-        public void HScrollBarAccessibleObject_Ctor_Default()
+        [WinFormsTheory]
+        [InlineData(true, AccessibleRole.ScrollBar)]
+        [InlineData(false, AccessibleRole.None)]
+        public void HScrollBarAccessibleObject_Ctor_Default(bool createControl, AccessibleRole accessibleRole)
         {
             using var horScrollBar = new HScrollBar();
-            AccessibleObject accessibleObject = horScrollBar.AccessibilityObject;
 
+            if (createControl)
+            {
+                horScrollBar.CreateControl();
+            }
+
+            AccessibleObject accessibleObject = horScrollBar.AccessibilityObject;
             Assert.NotNull(accessibleObject);
-            Assert.Equal(AccessibleRole.ScrollBar, accessibleObject.Role);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(horScrollBar.IsHandleCreated);
+            Assert.Equal(accessibleRole, accessibleObject.Role);
+            Assert.Equal(createControl, horScrollBar.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -39,8 +45,7 @@ namespace System.Windows.Forms.Tests
             HScrollBar.HScrollBarAccessibleObject accessibleObject =
                 Assert.IsType<HScrollBar.HScrollBarAccessibleObject>(horScrollBar.AccessibilityObject);
             Assert.Equal("Horizontal", accessibleObject.Name);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(horScrollBar.IsHandleCreated);
+            Assert.False(horScrollBar.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/ScrollBar.ScrollBarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/ScrollBar.ScrollBarAccessibleObjectTests.cs
@@ -2,11 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 using static Interop.UiaCore;
 
@@ -21,26 +16,33 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<ArgumentNullException>(() => new ScrollBar.ScrollBarAccessibleObject(null));
         }
 
-        [WinFormsFact]
-        public void ScrollBarAccessibleObject_Ctor_Default()
+        [WinFormsTheory]
+        [InlineData(true, AccessibleRole.ScrollBar)]
+        [InlineData(false, AccessibleRole.None)]
+        public void ScrollBarAccessibleObject_Ctor_Default(bool createControl, AccessibleRole accessibleRole)
         {
             using var scrollBar = new SubScrollBar();
+
+            if (createControl)
+            {
+                scrollBar.CreateControl();
+            }
+
             AccessibleObject accessibleObject = scrollBar.AccessibilityObject;
 
             Assert.NotNull(accessibleObject);
-            Assert.Equal(AccessibleRole.ScrollBar, accessibleObject.Role);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(scrollBar.IsHandleCreated);
+            Assert.Equal(accessibleRole, accessibleObject.Role);
+            Assert.Equal(createControl, scrollBar.IsHandleCreated);
         }
 
         [WinFormsFact]
         public void ScrollBarAccessibleObject_IsPatternSupported_Invoke_ReturnsExpected()
         {
             using var scrollBar = new SubScrollBar();
+            scrollBar.CreateControl();
             AccessibleObject accessibleObject = scrollBar.AccessibilityObject;
 
             Assert.True(accessibleObject.IsPatternSupported(UIA.ValuePatternId));
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
             Assert.True(scrollBar.IsHandleCreated);
         }
 
@@ -63,8 +65,7 @@ namespace System.Windows.Forms.Tests
             object value = scrollBarAccessibleObject.GetPropertyValue((UIA)propertyID);
 
             Assert.Equal(expected, value);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(scrollBar.IsHandleCreated);
+            Assert.False(scrollBar.IsHandleCreated);
         }
 
         private class SubScrollBar : ScrollBar

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Button.ButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Button.ButtonAccessibleObjectTests.cs
@@ -23,24 +23,28 @@ namespace System.Windows.Forms.Tests
             var buttonAccessibleObject = new Button.ButtonAccessibleObject(button);
 
             Assert.Same(button, buttonAccessibleObject.Owner);
-            // TODO: ControlAccessibleObject should not force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(button.IsHandleCreated);
+            Assert.False(button.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void ButtonAccessibleObject_AccessibleRole_Default_ReturnsPushButton()
+        [WinFormsTheory]
+        [InlineData(true, AccessibleRole.PushButton)]
+        [InlineData(false, AccessibleRole.None)]
+        public void ButtonAccessibleObject_AccessibleRole_Default_ReturnsExpected(bool createControl, AccessibleRole accessibleRole)
         {
             using var button = new Button
             {
                 AccessibleRole = AccessibleRole.Default
             };
 
-            Assert.False(button.IsHandleCreated);
+            if (createControl)
+            {
+                button.CreateControl();
+            }
+
             var buttonAccessibleObject = new Button.ButtonAccessibleObject(button);
 
-            Assert.Equal(AccessibleRole.PushButton, buttonAccessibleObject.Role);
-            // TODO: ControlAccessibleObject should not force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(button.IsHandleCreated);
+            Assert.Equal(accessibleRole, buttonAccessibleObject.Role);
+            Assert.Equal(createControl, button.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -55,8 +59,7 @@ namespace System.Windows.Forms.Tests
             var buttonAccessibleObject = new Button.ButtonAccessibleObject(button);
 
             Assert.Equal(AccessibleRole.Link, buttonAccessibleObject.Role);
-            // TODO: ControlAccessibleObject should not force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(button.IsHandleCreated);
+            Assert.False(button.IsHandleCreated);
         }
 
         [WinFormsTheory]
@@ -77,8 +80,7 @@ namespace System.Windows.Forms.Tests
             object value = buttonAccessibleObject.GetPropertyValue((UIA)propertyID);
 
             Assert.Equal(expected, value);
-            // TODO: ControlAccessibleObject should not force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(button.IsHandleCreated);
+            Assert.False(button.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -90,8 +92,7 @@ namespace System.Windows.Forms.Tests
             var buttonAccessibleObject = new Button.ButtonAccessibleObject(button);
 
             Assert.True(buttonAccessibleObject.IsPatternSupported(UIA.LegacyIAccessiblePatternId));
-            // TODO: ControlAccessibleObject should not force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(button.IsHandleCreated);
+            Assert.False(button.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonBase.ButtonBaseAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonBase.ButtonBaseAccessibleObjectTests.cs
@@ -24,21 +24,21 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [InlineData(FlatStyle.Flat, true, true, AccessibleStates.Focusable | AccessibleStates.Pressed)]
-        [InlineData(FlatStyle.Flat, false, true, AccessibleStates.Focusable | AccessibleStates.Pressed)]
+        [InlineData(FlatStyle.Flat, false, true, AccessibleStates.None)]
         [InlineData(FlatStyle.Flat, true, false, AccessibleStates.Focusable)]
-        [InlineData(FlatStyle.Flat, false, false, AccessibleStates.Focusable)]
+        [InlineData(FlatStyle.Flat, false, false, AccessibleStates.None)]
         [InlineData(FlatStyle.Popup, true, true, AccessibleStates.Focusable | AccessibleStates.Pressed)]
-        [InlineData(FlatStyle.Popup, false, true, AccessibleStates.Focusable | AccessibleStates.Pressed)]
+        [InlineData(FlatStyle.Popup, false, true, AccessibleStates.None)]
         [InlineData(FlatStyle.Popup, true, false, AccessibleStates.Focusable)]
-        [InlineData(FlatStyle.Popup, false, false, AccessibleStates.Focusable)]
+        [InlineData(FlatStyle.Popup, false, false, AccessibleStates.None)]
         [InlineData(FlatStyle.Standard, true, true, AccessibleStates.Focusable | AccessibleStates.Pressed)]
-        [InlineData(FlatStyle.Standard, false, true, AccessibleStates.Focusable | AccessibleStates.Pressed)]
+        [InlineData(FlatStyle.Standard, false, true, AccessibleStates.None)]
         [InlineData(FlatStyle.Standard, true, false, AccessibleStates.Focusable)]
-        [InlineData(FlatStyle.Standard, false, false, AccessibleStates.Focusable)]
+        [InlineData(FlatStyle.Standard, false, false, AccessibleStates.None)]
         [InlineData(FlatStyle.System, true, true, AccessibleStates.Focusable)]
-        [InlineData(FlatStyle.System, false, true, AccessibleStates.Focusable)]
+        [InlineData(FlatStyle.System, false, true, AccessibleStates.None)]
         [InlineData(FlatStyle.System, true, false, AccessibleStates.Focusable)]
-        [InlineData(FlatStyle.System, false, false, AccessibleStates.Focusable)]
+        [InlineData(FlatStyle.System, false, false, AccessibleStates.None)]
         public void ButtonBaseAccessibleObject_State_is_correct(FlatStyle flatStyle, bool createControl, bool mouseIsDown, AccessibleStates expectedAccessibleState)
         {
             using var button = new SubButtonBase()
@@ -61,14 +61,13 @@ namespace System.Windows.Forms.Tests
             var buttonBaseAccessibleObject = new ButtonBase.ButtonBaseAccessibleObject(button);
 
             Assert.Equal(expectedAccessibleState, buttonBaseAccessibleObject.State);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(button.IsHandleCreated);
+            Assert.Equal(createControl, button.IsHandleCreated);
         }
 
         [WinFormsTheory]
         [InlineData(true, true, AccessibleRole.Client)]
         [InlineData(true, false, AccessibleRole.HelpBalloon)]
-        [InlineData(false, true, AccessibleRole.Client)]
+        [InlineData(false, true, AccessibleRole.None)]
         [InlineData(false, false, AccessibleRole.HelpBalloon)]
         public void ButtonBase_CreateAccessibilityInstance_InvokeWithRole_ReturnsExpected(bool createControl, bool defaultRole, AccessibleRole expectedAccessibleRole)
         {
@@ -93,13 +92,26 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expectedAccessibleRole, instance.Role);
             Assert.NotSame(control.CreateAccessibilityInstance(), instance);
             Assert.NotSame(control.AccessibilityObject, instance);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
+            Assert.Equal(createControl, control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(FlatStyle))]
+        public void ButtonBase_CreateAccessibilityInstance_InvokeWithDefaultRole_ReturnsExpected_ForAllFlatStyles_IfControlIsCreated(FlatStyle flatStyle)
+        {
+            using var control = new SubButtonBase()
+            {
+                FlatStyle = flatStyle
+            };
+            control.CreateControl();
+            ButtonBase.ButtonBaseAccessibleObject instance = Assert.IsType<ButtonBase.ButtonBaseAccessibleObject>(control.CreateAccessibilityInstance());
+            Assert.Equal(AccessibleRole.Client, instance.Role);
             Assert.True(control.IsHandleCreated);
         }
 
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(FlatStyle))]
-        public void ButtonBase_CreateAccessibilityInstance_InvokeWithDefaultRole_ReturnsExpected_ForAllFlatStyles(FlatStyle flatStyle)
+        public void ButtonBase_CreateAccessibilityInstance_InvokeWithDefaultRole_ReturnsNone_ForAllFlatStyles_IfControlIsNotCreated(FlatStyle flatStyle)
         {
             using var control = new SubButtonBase()
             {
@@ -109,9 +121,8 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.IsHandleCreated);
 
             ButtonBase.ButtonBaseAccessibleObject instance = Assert.IsType<ButtonBase.ButtonBaseAccessibleObject>(control.CreateAccessibilityInstance());
-            Assert.Equal(AccessibleRole.Client, instance.Role);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(control.IsHandleCreated);
+            Assert.Equal(AccessibleRole.None, instance.Role);
+            Assert.False(control.IsHandleCreated);
         }
 
         [WinFormsTheory]
@@ -139,15 +150,14 @@ namespace System.Windows.Forms.Tests
             var buttonBaseAccessibleObject = new ButtonBase.ButtonBaseAccessibleObject(control);
             buttonBaseAccessibleObject.DoDefaultAction();
 
-            Assert.Equal(1, callCount);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(control.IsHandleCreated);
+            Assert.Equal(createControl ? 1 : 0, callCount);
+            Assert.Equal(createControl, control.IsHandleCreated);
         }
 
         [WinFormsTheory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void ButtonBase_CreateAccessibilityInstance_InvokeIButtonControlDoDefaultAction_CallsOnClick(bool createControl)
+        [InlineData(true, 1)]
+        [InlineData(false, 0)]
+        public void ButtonBase_CreateAccessibilityInstance_InvokeIButtonControlDoDefaultAction_CallsOnClick(bool createControl, int expectedCallCount)
         {
             using var control = new SubButtonBase();
 
@@ -155,8 +165,6 @@ namespace System.Windows.Forms.Tests
             {
                 control.CreateControl();
             }
-
-            Assert.Equal(createControl, control.IsHandleCreated);
 
             int callCount = 0;
             control.Click += (sender, e) =>
@@ -171,10 +179,9 @@ namespace System.Windows.Forms.Tests
 
             buttonBaseAccessibleObject.DoDefaultAction();
 
-            Assert.Equal(1, callCount);
+            Assert.Equal(expectedCallCount, callCount);
             Assert.Equal(0, performClickCallCount);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(control.IsHandleCreated);
+            Assert.Equal(createControl, control.IsHandleCreated);
         }
 
         private class SubButtonBase : ButtonBase

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonTests.cs
@@ -993,12 +993,35 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(FlatStyle))]
-        public void Button_CreateAccessibilityInstance_Invoke_ReturnsExpected(FlatStyle flatStyle)
+        public void Button_CreateAccessibilityInstance_Invoke_ReturnsExpected_IfHandleIsNotCreated(FlatStyle flatStyle)
         {
             using var control = new SubButton
             {
                 FlatStyle = flatStyle
             };
+
+            Assert.False(control.IsHandleCreated);
+            Button.ButtonBaseAccessibleObject instance = Assert.IsAssignableFrom<Button.ButtonBaseAccessibleObject>(control.CreateAccessibilityInstance());
+            Assert.NotNull(instance);
+            Assert.Same(control, instance.Owner);
+            Assert.Equal(AccessibleStates.None, instance.State);
+            Assert.Equal(AccessibleRole.None, instance.Role);
+            Assert.NotSame(control.CreateAccessibilityInstance(), instance);
+            Assert.NotSame(control.AccessibilityObject, instance);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(FlatStyle))]
+        public void Button_CreateAccessibilityInstance_Invoke_ReturnsExpected_IfHandleIsCreated(FlatStyle flatStyle)
+        {
+            using var control = new SubButton
+            {
+                FlatStyle = flatStyle
+            };
+
+            control.CreateControl();
+            Assert.True(control.IsHandleCreated);
             Button.ButtonBaseAccessibleObject instance = Assert.IsAssignableFrom<Button.ButtonBaseAccessibleObject>(control.CreateAccessibilityInstance());
             Assert.NotNull(instance);
             Assert.Same(control, instance.Owner);
@@ -1006,38 +1029,55 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(AccessibleRole.PushButton, instance.Role);
             Assert.NotSame(control.CreateAccessibilityInstance(), instance);
             Assert.NotSame(control.AccessibilityObject, instance);
+            Assert.True(control.IsHandleCreated);
         }
 
         [WinFormsTheory]
-        [InlineData(FlatStyle.Flat, AccessibleStates.Pressed | AccessibleStates.Focusable)]
-        [InlineData(FlatStyle.Popup, AccessibleStates.Pressed | AccessibleStates.Focusable)]
-        [InlineData(FlatStyle.Standard, AccessibleStates.Pressed | AccessibleStates.Focusable)]
-        [InlineData(FlatStyle.System, AccessibleStates.Focusable)]
-        public void Button_CreateAccessibilityInstance_InvokeMouseDown_ReturnsExpected(FlatStyle flatStyle, AccessibleStates expectedState)
+        [InlineData(true, FlatStyle.Flat, AccessibleStates.Pressed | AccessibleStates.Focusable, AccessibleRole.PushButton)]
+        [InlineData(true, FlatStyle.Popup, AccessibleStates.Pressed | AccessibleStates.Focusable, AccessibleRole.PushButton)]
+        [InlineData(true, FlatStyle.Standard, AccessibleStates.Pressed | AccessibleStates.Focusable, AccessibleRole.PushButton)]
+        [InlineData(true, FlatStyle.System, AccessibleStates.Focusable, AccessibleRole.PushButton)]
+        [InlineData(false, FlatStyle.Flat, AccessibleStates.None, AccessibleRole.None)]
+        [InlineData(false, FlatStyle.Popup, AccessibleStates.None, AccessibleRole.None)]
+        [InlineData(false, FlatStyle.Standard, AccessibleStates.None, AccessibleRole.None)]
+        [InlineData(false, FlatStyle.System, AccessibleStates.None, AccessibleRole.None)]
+        public void Button_CreateAccessibilityInstance_InvokeMouseDown_ReturnsExpected(bool createControl, FlatStyle flatStyle, AccessibleStates expectedState, AccessibleRole expectedRole)
         {
             using var control = new SubButton
             {
                 FlatStyle = flatStyle
             };
+
+            if (createControl)
+            {
+                control.CreateControl();
+            }
+
+            Assert.Equal(createControl, control.IsHandleCreated);
+
             control.OnMouseDown(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, 0));
             Button.ButtonBaseAccessibleObject instance = Assert.IsAssignableFrom<Button.ButtonBaseAccessibleObject>(control.CreateAccessibilityInstance());
             Assert.NotNull(instance);
             Assert.Same(control, instance.Owner);
             Assert.Equal(expectedState, instance.State);
-            Assert.Equal(AccessibleRole.PushButton, instance.Role);
+            Assert.Equal(expectedRole, instance.Role);
             Assert.NotSame(control.CreateAccessibilityInstance(), instance);
             Assert.NotSame(control.AccessibilityObject, instance);
+            Assert.Equal(createControl, control.IsHandleCreated);
         }
 
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(FlatStyle))]
-        public void Button_CreateAccessibilityInstance_InvokeWithCustomRole_ReturnsExpected(FlatStyle flatStyle)
+        public void Button_CreateAccessibilityInstance_InvokeWithCustomRole_ReturnsExpected_IfHandleIsCreated(FlatStyle flatStyle)
         {
             using var control = new SubButton
             {
                 FlatStyle = flatStyle,
                 AccessibleRole = AccessibleRole.HelpBalloon
             };
+
+            control.CreateControl();
+            Assert.True(control.IsHandleCreated);
             Button.ButtonBaseAccessibleObject instance = Assert.IsAssignableFrom<Button.ButtonBaseAccessibleObject>(control.CreateAccessibilityInstance());
             Assert.NotNull(instance);
             Assert.Same(control, instance.Owner);
@@ -1045,16 +1085,40 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(AccessibleRole.HelpBalloon, instance.Role);
             Assert.NotSame(control.CreateAccessibilityInstance(), instance);
             Assert.NotSame(control.AccessibilityObject, instance);
+            Assert.True(control.IsHandleCreated);
         }
 
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(FlatStyle))]
-        public void Button_CreateAccessibilityInstance_InvokeDoDefaultAction_CallsOnClick(FlatStyle flatStyle)
+        public void Button_CreateAccessibilityInstance_InvokeWithCustomRole_ReturnsExpected_IfHandleIsNotCreated(FlatStyle flatStyle)
+        {
+            using var control = new SubButton
+            {
+                FlatStyle = flatStyle,
+                AccessibleRole = AccessibleRole.HelpBalloon
+            };
+
+            Assert.False(control.IsHandleCreated);
+            Button.ButtonBaseAccessibleObject instance = Assert.IsAssignableFrom<Button.ButtonBaseAccessibleObject>(control.CreateAccessibilityInstance());
+            Assert.NotNull(instance);
+            Assert.Same(control, instance.Owner);
+            Assert.Equal(AccessibleStates.None, instance.State);
+            Assert.Equal(AccessibleRole.HelpBalloon, instance.Role);
+            Assert.NotSame(control.CreateAccessibilityInstance(), instance);
+            Assert.NotSame(control.AccessibilityObject, instance);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(FlatStyle))]
+        public void Button_CreateAccessibilityInstance_InvokeDoDefaultAction_CallsOnClick_IfHandleIsCreated(FlatStyle flatStyle)
         {
             using var control = new SubButton
             {
                 FlatStyle = flatStyle
             };
+
+            control.CreateControl();
             int callCount = 0;
             control.Click += (sender, e) =>
             {
@@ -1065,6 +1129,29 @@ namespace System.Windows.Forms.Tests
             Button.ButtonBaseAccessibleObject instance = Assert.IsAssignableFrom<Button.ButtonBaseAccessibleObject>(control.CreateAccessibilityInstance());
             instance.DoDefaultAction();
             Assert.Equal(1, callCount);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(FlatStyle))]
+        public void Button_CreateAccessibilityInstance_InvokeDoDefaultAction_CallsOnClick_IfHandleIsNotCreated(FlatStyle flatStyle)
+        {
+            using var control = new SubButton
+            {
+                FlatStyle = flatStyle
+            };
+
+            int callCount = 0;
+            control.Click += (sender, e) =>
+            {
+                Assert.Same(control, sender);
+                Assert.Same(EventArgs.Empty, e);
+                callCount++;
+            };
+            Button.ButtonBaseAccessibleObject instance = Assert.IsAssignableFrom<Button.ButtonBaseAccessibleObject>(control.CreateAccessibilityInstance());
+            instance.DoDefaultAction();
+            Assert.Equal(0, callCount);
+            Assert.False(control.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -1830,17 +1917,13 @@ namespace System.Windows.Forms.Tests
             control.Click += handler;
             control.OnClick(eventArgs);
             Assert.Equal(1, callCount);
-
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(control.IsHandleCreated);
+            Assert.False(control.IsHandleCreated);
 
             // Remove handler.
             control.Click -= handler;
             control.OnClick(eventArgs);
             Assert.Equal(1, callCount);
-
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(control.IsHandleCreated);
+            Assert.False(control.IsHandleCreated);
         }
 
         [WinFormsTheory]
@@ -1871,8 +1954,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, callCount);
             Assert.Equal(DialogResult.Yes, form.DialogResult);
 
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(control.IsHandleCreated);
+            Assert.False(control.IsHandleCreated);
             Assert.False(parent.IsHandleCreated);
             Assert.False(form.IsHandleCreated);
 
@@ -1882,8 +1964,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, callCount);
             Assert.Equal(DialogResult.Yes, form.DialogResult);
 
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(control.IsHandleCreated);
+            Assert.False(control.IsHandleCreated);
             Assert.False(parent.IsHandleCreated);
             Assert.False(form.IsHandleCreated);
         }
@@ -3019,17 +3100,13 @@ namespace System.Windows.Forms.Tests
             control.Click += handler;
             control.PerformClick();
             Assert.Equal(1, callCount);
-
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(control.IsHandleCreated);
+            Assert.False(control.IsHandleCreated);
 
             // Remove handler.
             control.Click -= handler;
             control.PerformClick();
             Assert.Equal(1, callCount);
-
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(control.IsHandleCreated);
+            Assert.False(control.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -3195,8 +3272,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expectedClickCallCount != 0, control.ProcessMnemonic(charCode));
             Assert.Equal(expectedClickCallCount, clickCallCount);
 
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.Equal(expectedClickCallCount != 0, control.IsHandleCreated);
+            Assert.False(control.IsHandleCreated);
         }
 
         [WinFormsTheory]
@@ -3237,11 +3313,11 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void Button_RaiseAutomationEvent_Invoke_Success()
+        public void Button_RaiseAutomationEvent_Invoke_Success_IfControlIsCreated()
         {
             using var button = new TestButton();
             Assert.False(button.IsHandleCreated);
-
+            button.CreateControl();
             var accessibleObject = (SubButtonAccessibleObject)button.AccessibilityObject;
             Assert.Equal(0, accessibleObject.RaiseAutomationEventCallsCount);
             Assert.Equal(0, accessibleObject.RaiseAutomationPropertyChangedEventCallsCount);
@@ -3250,8 +3326,22 @@ namespace System.Windows.Forms.Tests
 
             Assert.Equal(1, accessibleObject.RaiseAutomationEventCallsCount);
             Assert.Equal(1, accessibleObject.RaiseAutomationPropertyChangedEventCallsCount);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
             Assert.True(button.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void Button_RaiseAutomationEvent_IsNotInvoked_IfControlIsNotCreated()
+        {
+            using var button = new TestButton();
+            var accessibleObject = (SubButtonAccessibleObject)button.AccessibilityObject;
+            Assert.Equal(0, accessibleObject.RaiseAutomationEventCallsCount);
+            Assert.Equal(0, accessibleObject.RaiseAutomationPropertyChangedEventCallsCount);
+
+            button.PerformClick();
+
+            Assert.Equal(0, accessibleObject.RaiseAutomationEventCallsCount);
+            Assert.Equal(0, accessibleObject.RaiseAutomationPropertyChangedEventCallsCount);
+            Assert.False(button.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -3512,9 +3602,7 @@ namespace System.Windows.Forms.Tests
                 control.WndProc(ref m);
                 Assert.Equal(expectedResult, m.Result);
                 Assert.Equal(expectedCallCount, callCount);
-
-                // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-                Assert.Equal(expectedCallCount > 0, control.IsHandleCreated);
+                Assert.False(control.IsHandleCreated);
             }
         }
 
@@ -3677,13 +3765,21 @@ namespace System.Windows.Forms.Tests
 
             internal override bool RaiseAutomationEvent(UIA eventId)
             {
-                RaiseAutomationEventCallsCount++;
+                if (Owner.IsHandleCreated)
+                {
+                    RaiseAutomationEventCallsCount++;
+                }
+
                 return base.RaiseAutomationEvent(eventId);
             }
 
             internal override bool RaiseAutomationPropertyChangedEvent(UIA propertyId, object oldValue, object newValue)
             {
-                RaiseAutomationPropertyChangedEventCallsCount++;
+                if (Owner.IsHandleCreated)
+                {
+                    RaiseAutomationPropertyChangedEventCallsCount++;
+                }
+
                 return base.RaiseAutomationPropertyChangedEvent(propertyId, oldValue, newValue);
             }
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CheckBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CheckBoxTests.cs
@@ -430,8 +430,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.Equal(1, accessibleObject.RaiseAutomationEventCallsCount);
             Assert.Equal(1, accessibleObject.RaiseAutomationPropertyChangedEventCallsCount);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(checkBox.IsHandleCreated);
+            Assert.False(checkBox.IsHandleCreated);
         }
 
         // the zero here may be an issue with cultural variance

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxAccessibleObjectTests.cs
@@ -9,24 +9,34 @@ namespace System.Windows.Forms.Tests
 {
     public class ComboBox_ComboBoxAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
     {
-        [WinFormsFact]
-        public void ComboBoxAccessibleObject_Ctor_Default()
+        [WinFormsTheory]
+        [InlineData(true, AccessibleRole.ComboBox)]
+        [InlineData(false, AccessibleRole.None)]
+        public void ComboBoxAccessibleObject_Ctor_Default(bool createControl, AccessibleRole expectedAccessibleRole)
         {
             using var control = new ComboBox();
+            if (createControl)
+            {
+                control.CreateControl();
+            }
+
+            Assert.Equal(createControl, control.IsHandleCreated);
             var accessibleObject = new ComboBox.ComboBoxAccessibleObject(control);
+            Assert.Equal(createControl, control.IsHandleCreated);
             Assert.NotNull(accessibleObject.Owner);
-            Assert.Equal(AccessibleRole.ComboBox, accessibleObject.Role);
+            Assert.Equal(expectedAccessibleRole, accessibleObject.Role);
         }
 
         [WinFormsTheory]
         [InlineData(ComboBoxStyle.DropDown)]
         [InlineData(ComboBoxStyle.DropDownList)]
-        public void ComboBoxAccessibleObject_ExpandCollapse_Set_CollapsedState(ComboBoxStyle comboBoxStyle)
+        public void ComboBoxAccessibleObject_ExpandCollapse_Set_CollapsedState_IfControlIsCreated(ComboBoxStyle comboBoxStyle)
         {
             using var control = new ComboBox
             {
                 DropDownStyle = comboBoxStyle
             };
+            control.CreateControl();
             var accessibleObject = control.AccessibilityObject;
 
             accessibleObject.Expand();
@@ -36,21 +46,56 @@ namespace System.Windows.Forms.Tests
             accessibleObject.Collapse();
             Assert.Equal(AccessibleStates.Collapsed, accessibleObject.State & AccessibleStates.Collapsed);
             Assert.NotEqual(AccessibleStates.Expanded, accessibleObject.State & AccessibleStates.Expanded);
+
+            Assert.True(control.IsHandleCreated);
         }
 
         [WinFormsTheory]
         [InlineData(ComboBoxStyle.DropDown)]
         [InlineData(ComboBoxStyle.DropDownList)]
-        public void ComboBoxAccessibleObject_FragmentNavigate_FirstChild_NotNull(ComboBoxStyle comboBoxStyle)
+        public void ComboBoxAccessibleObject_ExpandCollapse_Set_CollapsedState_IfControlIsNotCreated(ComboBoxStyle comboBoxStyle)
         {
             using var control = new ComboBox
             {
                 DropDownStyle = comboBoxStyle
             };
             var accessibleObject = control.AccessibilityObject;
+            Assert.False(control.IsHandleCreated);
+
+            accessibleObject.Expand();
+            Assert.Equal(AccessibleStates.None, accessibleObject.State);
+            Assert.NotEqual(AccessibleStates.Collapsed, accessibleObject.State & AccessibleStates.Collapsed);
+            Assert.NotEqual(AccessibleStates.Expanded, accessibleObject.State & AccessibleStates.Expanded);
+
+            accessibleObject.Collapse();
+            Assert.Equal(AccessibleStates.None, accessibleObject.State);
+            Assert.NotEqual(AccessibleStates.Collapsed, accessibleObject.State & AccessibleStates.Collapsed);
+            Assert.NotEqual(AccessibleStates.Expanded, accessibleObject.State & AccessibleStates.Expanded);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(ComboBoxStyle.DropDown, true)]
+        [InlineData(ComboBoxStyle.DropDownList, true)]
+        [InlineData(ComboBoxStyle.DropDown, false)]
+        [InlineData(ComboBoxStyle.DropDownList, false)]
+        public void ComboBoxAccessibleObject_FragmentNavigate_FirstChild_NotNull(ComboBoxStyle comboBoxStyle, bool createControl)
+        {
+            using var control = new ComboBox
+            {
+                DropDownStyle = comboBoxStyle
+            };
+
+            if (createControl)
+            {
+                control.CreateControl();
+            }
+
+            var accessibleObject = control.AccessibilityObject;
 
             UiaCore.IRawElementProviderFragment firstChild = accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild);
             Assert.NotNull(firstChild);
+            Assert.Equal(createControl, control.IsHandleCreated);
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObjectTests.cs
@@ -12,30 +12,33 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void ComboBoxItemAccessibleObject_Get_Not_ThrowsException()
         {
-            using var control = new ComboBox();
-
-            var item1 = new HashNotImplementedObject();
-            var item2 = new HashNotImplementedObject();
-            var item3 = new HashNotImplementedObject();
-
-            control.Items.AddRange(new[] { item1, item2, item3 });
-
-            var comboBoxAccessibleObject = (ComboBox.ComboBoxAccessibleObject)control.AccessibilityObject;
-
-            var exceptionThrown = false;
-
-            try
+            using (new NoAssertContext())
             {
-                var item1AccessibleObject= comboBoxAccessibleObject.ItemAccessibleObjects[item1];
-                var item2AccessibleObject = comboBoxAccessibleObject.ItemAccessibleObjects[item2];
-                var item3AccessibleObject = comboBoxAccessibleObject.ItemAccessibleObjects[item3];
-            }
-            catch
-            {
-                exceptionThrown = true;
-            }
+                using var control = new ComboBox();
 
-            Assert.False(exceptionThrown, "Getting accessible object for ComboBox item has thrown an exception.");
+                var item1 = new HashNotImplementedObject();
+                var item2 = new HashNotImplementedObject();
+                var item3 = new HashNotImplementedObject();
+
+                control.Items.AddRange(new[] { item1, item2, item3 });
+
+                var comboBoxAccessibleObject = (ComboBox.ComboBoxAccessibleObject)control.AccessibilityObject;
+
+                var exceptionThrown = false;
+
+                try
+                {
+                    var item1AccessibleObject = comboBoxAccessibleObject.ItemAccessibleObjects[item1];
+                    var item2AccessibleObject = comboBoxAccessibleObject.ItemAccessibleObjects[item2];
+                    var item3AccessibleObject = comboBoxAccessibleObject.ItemAccessibleObjects[item3];
+                }
+                catch
+                {
+                    exceptionThrown = true;
+                }
+
+                Assert.False(exceptionThrown, "Getting accessible object for ComboBox item has thrown an exception.");
+            }
         }
 
         public class HashNotImplementedObject
@@ -49,21 +52,23 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void ComboBoxItemAccessibleObject_DataBoundAccessibleName()
         {
-            // Regression test for https://github.com/dotnet/winforms/issues/3549
-
-            using var control = new ComboBox()
+            using (new NoAssertContext())
             {
-                DataSource = TestDataSources.GetPersons(),
-                DisplayMember = TestDataSources.PersonDisplayMember
-            };
+                // Regression test for https://github.com/dotnet/winforms/issues/3549
+                using var control = new ComboBox()
+                {
+                    DataSource = TestDataSources.GetPersons(),
+                    DisplayMember = TestDataSources.PersonDisplayMember
+                };
 
-            ComboBox.ComboBoxAccessibleObject accessibleObject = Assert.IsType<ComboBox.ComboBoxAccessibleObject>(control.AccessibilityObject);
+                ComboBox.ComboBoxAccessibleObject accessibleObject = Assert.IsType<ComboBox.ComboBoxAccessibleObject>(control.AccessibilityObject);
 
-            foreach (Person person in TestDataSources.GetPersons())
-            {
-                var item = accessibleObject.ItemAccessibleObjects[person];
-                AccessibleObject itemAccessibleObject = Assert.IsType<ComboBox.ComboBoxItemAccessibleObject>(item);
-                Assert.Equal(person.Name, itemAccessibleObject.Name);
+                foreach (Person person in TestDataSources.GetPersons())
+                {
+                    var item = accessibleObject.ItemAccessibleObjects[person];
+                    AccessibleObject itemAccessibleObject = Assert.IsType<ComboBox.ComboBoxItemAccessibleObject>(item);
+                    Assert.Equal(person.Name, itemAccessibleObject.Name);
+                }
             }
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -1081,8 +1081,9 @@ namespace System.Windows.Forms.Tests
         public void ComboBox_SelectionStart_GetWithoutHandle_ReturnsExpected()
         {
             using var control = new ComboBox();
+            Assert.False(control.IsHandleCreated);
             Assert.Equal(0, control.SelectionStart);
-            Assert.True(control.IsHandleCreated);
+            Assert.True(control.IsHandleCreated); // SelectionStart forces Handle creating
 
             // Get again.
             Assert.Equal(0, control.SelectionStart);
@@ -1377,18 +1378,6 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => control.FindStringExact("s", startIndex, ignoreCase: false));
         }
 
-        private SubComboBox CreateControlForCtrlBackspace(string text = "", int cursorRelativeToEnd = 0)
-        {
-            var tb = new SubComboBox
-            {
-                Text = text
-            };
-            tb.Focus();
-            tb.SelectionStart = tb.Text.Length + cursorRelativeToEnd;
-            tb.SelectionLength = 0;
-            return tb;
-        }
-
         private void SendCtrlBackspace(SubComboBox tb)
         {
             var message = new Message();
@@ -1398,7 +1387,8 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void CtrlBackspaceTextRemainsEmpty()
         {
-            using SubComboBox control = CreateControlForCtrlBackspace();
+            using SubComboBox control = new SubComboBox();
+            control.ConfigureForCtrlBackspace();
             SendCtrlBackspace(control);
             Assert.Equal("", control.Text);
         }
@@ -1407,7 +1397,8 @@ namespace System.Windows.Forms.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetCtrlBackspaceData))]
         public void CtrlBackspaceTextChanged(string value, string expected, int cursorRelativeToEnd)
         {
-            using SubComboBox control = CreateControlForCtrlBackspace(value, cursorRelativeToEnd);
+            using SubComboBox control = new SubComboBox(value);
+            control.ConfigureForCtrlBackspace(cursorRelativeToEnd);
             SendCtrlBackspace(control);
             Assert.Equal(expected, control.Text);
         }
@@ -1416,7 +1407,8 @@ namespace System.Windows.Forms.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetCtrlBackspaceRepeatedData))]
         public void CtrlBackspaceRepeatedTextChanged(string value, string expected, int repeats)
         {
-            using SubComboBox control = CreateControlForCtrlBackspace(value);
+            using SubComboBox control = new SubComboBox(value);
+            control.ConfigureForCtrlBackspace();
             for (int i = 0; i < repeats; i++)
             {
                 SendCtrlBackspace(control);
@@ -1427,7 +1419,8 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void CtrlBackspaceDeletesSelection()
         {
-            using SubComboBox control = CreateControlForCtrlBackspace("123-5-7-9");
+            using SubComboBox control = new SubComboBox("123-5-7-9");
+            control.ConfigureForCtrlBackspace();
             control.SelectionStart = 2;
             control.SelectionLength = 5;
             SendCtrlBackspace(control);
@@ -1816,6 +1809,14 @@ namespace System.Windows.Forms.Tests
 
         private class SubComboBox : ComboBox
         {
+            public SubComboBox()
+            { }
+
+            public SubComboBox(string text)
+            {
+                Text = text;
+            }
+
             public new bool AllowSelection => base.AllowSelection;
 
             public new bool CanEnableIme => base.CanEnableIme;
@@ -1879,6 +1880,13 @@ namespace System.Windows.Forms.Tests
             public new AccessibleObject CreateAccessibilityInstance() => base.CreateAccessibilityInstance();
 
             public new void CreateHandle() => base.CreateHandle();
+
+            public void ConfigureForCtrlBackspace(int cursorRelativeToEnd = 0)
+            {
+                Focus();
+                SelectionStart = this.Text.Length + cursorRelativeToEnd;
+                SelectionLength = 0;
+            }
 
             public new void Dispose(bool disposing) => base.Dispose(disposing);
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.cs
@@ -393,16 +393,25 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, createdCallCount);
         }
 
-        [WinFormsFact]
-        public void Control_CreateAccessibilityInstance_Invoke_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData(true, AccessibleRole.Client)]
+        [InlineData(false, AccessibleRole.None)]
+        public void Control_CreateAccessibilityInstance_Invoke_ReturnsExpected(bool createHandle, AccessibleRole expectedAccessibleRole)
         {
             using var control = new SubControl();
+            if (createHandle)
+            {
+                control.CreateHandle();
+            }
+
+            Assert.Equal(createHandle, control.IsHandleCreated);
             Control.ControlAccessibleObject instance = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(control.CreateAccessibilityInstance());
             Assert.NotNull(instance);
             Assert.Same(control, instance.Owner);
-            Assert.Equal(AccessibleRole.Client, instance.Role);
+            Assert.Equal(expectedAccessibleRole, instance.Role);
             Assert.NotSame(control.CreateAccessibilityInstance(), instance);
             Assert.NotSame(control.AccessibilityObject, instance);
+            Assert.Equal(createHandle, control.IsHandleCreated);
         }
 
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Properties.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Properties.cs
@@ -19,13 +19,21 @@ namespace System.Windows.Forms.Tests
 {
     public partial class ControlTests
     {
-        [WinFormsFact]
-        public void Control_AccessibilityObject_Get_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Control_AccessibilityObject_Get_ReturnsExpected(bool createControl)
         {
             using var control = new Control();
+            if (createControl)
+            {
+                control.CreateControl();
+            }
+
+            Assert.Equal(createControl, control.IsHandleCreated);
             Control.ControlAccessibleObject accessibleObject = Assert.IsType<Control.ControlAccessibleObject>(control.AccessibilityObject);
             Assert.Same(accessibleObject, control.AccessibilityObject);
-            Assert.True(control.IsHandleCreated);
+            Assert.Equal(createControl, control.IsHandleCreated);
             Assert.Same(control, accessibleObject.Owner);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowAccessibleObjectTests.cs
@@ -103,7 +103,7 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> Parent_TestData()
         {
-            yield return new object[] { new DataGridViewRowAccessibleObject(new DataGridViewRow()), null  };
+            yield return new object[] { new DataGridViewRowAccessibleObject(new DataGridViewRow()), null };
         }
 
         [Theory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HelpProviderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HelpProviderTests.cs
@@ -173,22 +173,34 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(null, 0, null)]
-        [InlineData("", 0, null)]
-        [InlineData("helpKeyword", 0, "HelpNamespace")]
-        [InlineData("1", 1, "HelpNamespace")]
-        public void HelpProvider_SetHelpKeyword_GetHelpKeyword_ReturnsExpected(string keyword, int expectedHelpTopic, string expectedFileName)
+        [InlineData(null, 0, null, true)]
+        [InlineData("", 0, null, true)]
+        [InlineData("helpKeyword", 0, "HelpNamespace", true)]
+        [InlineData("1", 1, "HelpNamespace", true)]
+        [InlineData(null, -1, null, false)]
+        [InlineData("", -1, null, false)]
+        [InlineData("helpKeyword", 0, "HelpNamespace", false)]
+        [InlineData("1", 1, "HelpNamespace", false)]
+        public void HelpProvider_SetHelpKeyword_GetHelpKeyword_ReturnsExpected(string keyword, int expectedHelpTopic, string expectedFileName, bool createControl)
         {
             using var provider = new HelpProvider
             {
                 HelpNamespace = "HelpNamespace"
             };
+
             using var control = new Control();
+            if (createControl)
+            {
+                control.CreateControl();
+            }
+
+            Assert.Equal(createControl, control.IsHandleCreated);
 
             provider.SetHelpKeyword(control, keyword);
             Assert.Same(keyword, provider.GetHelpKeyword(control));
             Assert.Equal(!string.IsNullOrEmpty(keyword), provider.GetShowHelp(control));
             Assert.Equal(expectedHelpTopic, control.AccessibilityObject.GetHelpTopic(out string fileName));
+            Assert.Equal(createControl, control.IsHandleCreated);
             Assert.Equal(expectedFileName, fileName);
 
             // Set same.
@@ -228,23 +240,34 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(null, 0, null)]
-        [InlineData("", 0, null)]
-        [InlineData("helpKeyword", 0, "HelpNamespace")]
-        [InlineData("1", 1, "HelpNamespace")]
-        public void HelpProvider_SetHelpKeyword_WithShowHelpFalse_ReturnsExpected(string keyword, int expectedHelpTopic, string expectedFileName)
+        [InlineData(null, 0, null, true)]
+        [InlineData("", 0, null, true)]
+        [InlineData("helpKeyword", 0, "HelpNamespace", true)]
+        [InlineData("1", 1, "HelpNamespace", true)]
+        [InlineData(null, -1, null, false)]
+        [InlineData("", -1, null, false)]
+        [InlineData("helpKeyword", 0, "HelpNamespace", false)]
+        [InlineData("1", 1, "HelpNamespace", false)]
+        public void HelpProvider_SetHelpKeyword_WithShowHelpFalse_ReturnsExpected(string keyword, int expectedHelpTopic, string expectedFileName, bool createControl)
         {
             using var provider = new HelpProvider
             {
                 HelpNamespace = "HelpNamespace"
             };
             using var control = new Control();
+            if (createControl)
+            {
+                control.CreateControl();
+            }
+
+            Assert.Equal(createControl, control.IsHandleCreated);
             provider.SetShowHelp(control, false);
 
             provider.SetHelpKeyword(control, keyword);
             Assert.Same(keyword, provider.GetHelpKeyword(control));
             Assert.Equal(!string.IsNullOrEmpty(keyword), provider.GetShowHelp(control));
             Assert.Equal(expectedHelpTopic, control.AccessibilityObject.GetHelpTopic(out string fileName));
+            Assert.Equal(createControl, control.IsHandleCreated);
             Assert.Equal(expectedFileName, fileName);
 
             // Set same.
@@ -419,25 +442,34 @@ namespace System.Windows.Forms.Tests
             Assert.True(provider.ShouldSerializeShowHelp(control));
         }
 
-        [WinFormsFact]
-        public void HelpProvider_SetShowHelp_SetFalseThenTrue_UnbindsAndBindsControl()
+        [WinFormsTheory]
+        [InlineData(true, 0)]
+        [InlineData(false, -1)]
+        public void HelpProvider_SetShowHelp_SetFalseThenTrue_UnbindsAndBindsControl(bool createControl, int expectedHelpTopic)
         {
             using var provider = new HelpProvider
             {
                 HelpNamespace = "HelpNamespace"
             };
             using var control = new Control();
+            if (createControl)
+            {
+                control.CreateControl();
+            }
+
+            Assert.Equal(createControl, control.IsHandleCreated);
             provider.SetShowHelp(control, true);
             provider.SetHelpKeyword(control, "1");
             provider.SetHelpString(control, "HelpString");
 
             Assert.Equal(1, control.AccessibilityObject.GetHelpTopic(out string fileName));
+            Assert.Equal(createControl, control.IsHandleCreated);
             Assert.Equal("HelpNamespace", fileName);
             Assert.Equal("HelpString", control.AccessibilityObject.Help);
 
             // Set false.
             provider.SetShowHelp(control, false);
-            Assert.Equal(0, control.AccessibilityObject.GetHelpTopic(out fileName));
+            Assert.Equal(expectedHelpTopic, control.AccessibilityObject.GetHelpTopic(out fileName));
             Assert.Null(fileName);
             Assert.Null(control.AccessibilityObject.Help);
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxTests.cs
@@ -4752,16 +4752,25 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, createdCallCount);
         }
 
-        [WinFormsFact]
-        public void ListBox_CreateAccessibilityInstance_Invoke_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData(true, AccessibleRole.List)]
+        [InlineData(false, AccessibleRole.None)]
+        public void ListBox_CreateAccessibilityInstance_Invoke_ReturnsExpected(bool createControl, AccessibleRole accessibleRole)
         {
             using var control = new SubListBox();
+
+            if (createControl)
+            {
+                control.CreateControl();
+            }
+
             Control.ControlAccessibleObject instance = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(control.CreateAccessibilityInstance());
             Assert.NotNull(instance);
             Assert.Same(control, instance.Owner);
-            Assert.Equal(AccessibleRole.List, instance.Role);
+            Assert.Equal(accessibleRole, instance.Role);
             Assert.NotSame(control.CreateAccessibilityInstance(), instance);
             Assert.NotSame(control.AccessibilityObject, instance);
+            Assert.Equal(createControl, control.IsHandleCreated);
         }
 
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
@@ -37,7 +37,7 @@ namespace System.Windows.Forms.Tests
             list.Items.Add(listItem);
 
             AccessibleObject accessibleObject = listItem.AccessibilityObject;
-            Assert.True(list.IsHandleCreated);
+            Assert.False(list.IsHandleCreated);
             Assert.NotNull(accessibleObject);
             Assert.Equal(AccessibleRole.ListItem, accessibleObject.Role);
         }
@@ -49,7 +49,6 @@ namespace System.Windows.Forms.Tests
             ListViewItem listItem = new ListViewItem("ListItem");
             list.Items.Add(listItem);
             AccessibleObject listItemAccessibleObject = listItem.AccessibilityObject;
-            Assert.True(list.IsHandleCreated);
 
             object accessibleName = listItemAccessibleObject.GetPropertyValue(UiaCore.UIA.NamePropertyId);
             Assert.Equal("ListItem", accessibleName);
@@ -64,12 +63,14 @@ namespace System.Windows.Forms.Tests
             Assert.True((bool)listItemAccessibleObject.GetPropertyValue(UiaCore.UIA.IsSelectionItemPatternAvailablePropertyId));
             Assert.True((bool)listItemAccessibleObject.GetPropertyValue(UiaCore.UIA.IsScrollItemPatternAvailablePropertyId));
             Assert.True((bool)listItemAccessibleObject.GetPropertyValue(UiaCore.UIA.IsInvokePatternAvailablePropertyId));
+            Assert.False(list.IsHandleCreated);
         }
 
         [WinFormsFact]
-        public void ListViewItemAccessibleObject_ListWithTwoItems_FragmentNavigateWorkCorrectly()
+        public void ListViewItemAccessibleObject_ListWithTwoItems_FragmentNavigateWorkCorrectly_IfHandleIsCreated()
         {
             using ListView listView = new ListView();
+            listView.CreateControl();
             ListViewItem listItem1 = new ListViewItem(new string[] {
                 "Test A",
                 "Alpha"}, -1);
@@ -85,7 +86,6 @@ namespace System.Windows.Forms.Tests
             AccessibleObject accessibleObject1 = listItem1.AccessibilityObject;
             AccessibleObject accessibleObject2 = listItem2.AccessibilityObject;
             AccessibleObject accessibleObject3 = listItem3.AccessibilityObject;
-            Assert.True(listView.IsHandleCreated);
 
             // First list view item
             Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
@@ -118,6 +118,50 @@ namespace System.Windows.Forms.Tests
             Assert.IsType<ListViewSubItemAccessibleObject>(firstChild);
             Assert.IsType<ListViewSubItemAccessibleObject>(lastChild);
             Assert.NotEqual(firstChild, lastChild);
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemAccessibleObject_ListWithTwoItems_FragmentNavigateWorkCorrectly_IfHandleIsNotCreated()
+        {
+            using ListView listView = new ListView();
+            ListViewItem listItem1 = new ListViewItem(new string[] {
+                "Test A",
+                "Alpha"}, -1);
+            ListViewItem listItem2 = new ListViewItem(new string[] {
+                "Test B",
+                "Beta"}, -1);
+            ListViewItem listItem3 = new ListViewItem(new string[] {
+                "Test C",
+                "Gamma"}, -1);
+            listView.Items.Add(listItem1);
+            listView.Items.Add(listItem2);
+            listView.Items.Add(listItem3);
+            AccessibleObject accessibleObject1 = listItem1.AccessibilityObject;
+            AccessibleObject accessibleObject2 = listItem2.AccessibilityObject;
+            AccessibleObject accessibleObject3 = listItem3.AccessibilityObject;
+
+            // List view items
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            // Childs
+            AccessibleObject firstChild = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChild = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChild);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChild);
+            Assert.NotEqual(firstChild, lastChild);
+
+            // Parent
+            Assert.Equal(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
+            Assert.Equal(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
+            Assert.Equal(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
+
+            Assert.False(listView.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
@@ -33,9 +33,9 @@ namespace System.Windows.Forms.Tests
             list.View = View.Details;
 
             AccessibleObject accessibleObject = listViewItem1.AccessibilityObject.GetChild(0);
-            Assert.True(list.IsHandleCreated);
             Assert.NotNull(accessibleObject);
             Assert.IsType<ListViewSubItemAccessibleObject>(accessibleObject);
+            Assert.False(list.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -60,7 +60,6 @@ namespace System.Windows.Forms.Tests
             list.View = View.Details;
 
             AccessibleObject accessibleObject = listViewItem1.AccessibilityObject.GetChild(0);
-            Assert.True(list.IsHandleCreated);
 
             object accessibleName = accessibleObject.GetPropertyValue(UiaCore.UIA.NamePropertyId);
             Assert.Equal("Test 1", accessibleName);
@@ -77,6 +76,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.True((bool)accessibleObject.GetPropertyValue(UiaCore.UIA.IsGridItemPatternAvailablePropertyId));
             Assert.True((bool)accessibleObject.GetPropertyValue(UiaCore.UIA.IsTableItemPatternAvailablePropertyId));
+            Assert.False(list.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -103,7 +103,6 @@ namespace System.Windows.Forms.Tests
             AccessibleObject subItemAccObj1 = listViewItem1.AccessibilityObject.GetChild(0);
             AccessibleObject subItemAccObj2 = listViewItem1.AccessibilityObject.GetChild(1);
             AccessibleObject subItemAccObj3 = listViewItem1.AccessibilityObject.GetChild(2);
-            Assert.True(list.IsHandleCreated);
 
             Assert.Null(subItemAccObj1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             UiaCore.IRawElementProviderFragment subItem1NextSibling = subItemAccObj1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling);
@@ -126,6 +125,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(subItemAccObj1.FragmentNavigate(UiaCore.NavigateDirection.Parent), listViewItem1.AccessibilityObject);
             Assert.Equal(subItemAccObj2.FragmentNavigate(UiaCore.NavigateDirection.Parent), listViewItem1.AccessibilityObject);
             Assert.Equal(subItemAccObj3.FragmentNavigate(UiaCore.NavigateDirection.Parent), listViewItem1.AccessibilityObject);
+
+            Assert.False(list.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -151,7 +152,6 @@ namespace System.Windows.Forms.Tests
 
             ListViewItem.ListViewSubItem subItem = listViewItem1.SubItems[0];
             AccessibleObject accessibleObject = listViewItem1.AccessibilityObject.GetChild(0);
-            Assert.True(list.IsHandleCreated);
 
             int actualWidth = accessibleObject.Bounds.Width;
             int expectedWidth = listViewItem1.SubItems[1].Bounds.X - subItem.Bounds.X;
@@ -166,6 +166,7 @@ namespace System.Windows.Forms.Tests
             Rectangle expectedBounds = new Rectangle(subItem.Bounds.X, subItem.Bounds.Y, expectedWidth, expectedHeight);
             expectedBounds.Location = new Point(0, 0);
             Assert.Equal(expectedBounds, actualBounds);
+            Assert.False(list.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -192,7 +193,7 @@ namespace System.Windows.Forms.Tests
             AccessibleObject subItemAccObj1 = listViewItem1.AccessibilityObject.GetChild(0);
             AccessibleObject subItemAccObj2 = listViewItem1.AccessibilityObject.GetChild(1);
             AccessibleObject subItemAccObj3 = listViewItem1.AccessibilityObject.GetChild(2);
-            Assert.True(list.IsHandleCreated);
+            Assert.False(list.IsHandleCreated);
 
             Assert.Equal(0, subItemAccObj1.Column);
             Assert.Equal(1, subItemAccObj2.Column);
@@ -223,7 +224,7 @@ namespace System.Windows.Forms.Tests
             AccessibleObject subItemAccObj1 = listViewItem1.AccessibilityObject.GetChild(0);
             AccessibleObject subItemAccObj2 = listViewItem1.AccessibilityObject.GetChild(1);
             AccessibleObject subItemAccObj3 = listViewItem1.AccessibilityObject.GetChild(2);
-            Assert.True(list.IsHandleCreated);
+            Assert.False(list.IsHandleCreated);
 
             Assert.Equal(0, subItemAccObj1.Row);
             Assert.Equal(0, subItemAccObj2.Row);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ProgressBarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ProgressBarTests.cs
@@ -1758,14 +1758,23 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<ArgumentOutOfRangeException>("value", () => control.Value = value);
         }
 
-        [WinFormsFact]
-        public void ProgressBar_CreateAccessibilityInstance_Invoke_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData(true, AccessibleRole.ProgressBar)]
+        [InlineData(false, AccessibleRole.None)]
+        public void ProgressBar_CreateAccessibilityInstance_Invoke_ReturnsExpected(bool createControl, AccessibleRole expectedAccessibleRole)
         {
             using var control = new SubProgressBar();
+            if (createControl)
+            {
+                control.CreateControl();
+            }
+
+            Assert.Equal(createControl, control.IsHandleCreated);
             Control.ControlAccessibleObject instance = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(control.CreateAccessibilityInstance());
+            Assert.Equal(createControl, control.IsHandleCreated);
             Assert.NotNull(instance);
             Assert.Same(control, instance.Owner);
-            Assert.Equal(AccessibleRole.ProgressBar, instance.Role);
+            Assert.Equal(expectedAccessibleRole, instance.Role);
             Assert.NotSame(control.CreateAccessibilityInstance(), instance);
             Assert.NotSame(control.AccessibilityObject, instance);
         }
@@ -2616,6 +2625,8 @@ namespace System.Windows.Forms.Tests
                 get => base.ImeModeBase;
                 set => base.ImeModeBase = value;
             }
+
+            public new bool IsHandleCreated => base.IsHandleCreated;
 
             public new bool ResizeRedraw
             {

--- a/src/System.Windows.Forms/tests/UnitTests/VScrollBar.VScrollBarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/VScrollBar.VScrollBarAccessibleObjectTests.cs
@@ -2,11 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace System.Windows.Forms.Tests
@@ -20,16 +15,23 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<ArgumentNullException>(() => new VScrollBar.VScrollBarAccessibleObject(null));
         }
 
-        [WinFormsFact]
-        public void VScrollBarAccessibleObject_Ctor_Default()
+        [WinFormsTheory]
+        [InlineData(true, AccessibleRole.ScrollBar)]
+        [InlineData(false, AccessibleRole.None)]
+        public void VScrollBarAccessibleObject_Ctor_Default(bool createControl, AccessibleRole accessibleRole)
         {
             using var vertScrollBar = new VScrollBar();
+
+            if (createControl)
+            {
+                vertScrollBar.CreateControl();
+            }
+
             AccessibleObject accessibleObject = vertScrollBar.AccessibilityObject;
 
             Assert.NotNull(accessibleObject);
-            Assert.Equal(AccessibleRole.ScrollBar, accessibleObject.Role);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(vertScrollBar.IsHandleCreated);
+            Assert.Equal(accessibleRole, accessibleObject.Role);
+            Assert.Equal(createControl, vertScrollBar.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -39,8 +41,7 @@ namespace System.Windows.Forms.Tests
             VScrollBar.VScrollBarAccessibleObject accessibleObject
                 = Assert.IsType<VScrollBar.VScrollBarAccessibleObject>(vertScrollBar.AccessibilityObject);
             Assert.Equal("Vertical", accessibleObject.Name);
-            // TODO: ControlAccessibleObject shouldn't force handle creation, tracked in https://github.com/dotnet/winforms/issues/3062
-            Assert.True(vertScrollBar.IsHandleCreated);
+            Assert.False(vertScrollBar.IsHandleCreated);
         }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3062
Based on [this comment](https://github.com/dotnet/winforms/issues/3062#issuecomment-642313370)


## Proposed changes

- Check IsHandleCreated property before setting Handle value in ControlAccessibleObject constructor
- Fix affected unit tests 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Has no distinct user impact but may resolve latent bugs. (like this #2797)

## Regression? 

- No

## Risk

- Breaks 150+ unit tests (will be fixed here)
- May break customer workarounds

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

- unit tests
- CTI

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.18363.900]
- .NET SDK (5.0.100-preview.7.20305.3)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3432)