### PR TITLE
Throw Exception setting invalid value for 'ListViewGroupCollapsedState'

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
@@ -174,6 +174,9 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Controls which <see cref="ListViewGroupCollapsedState"/> the group will appear as.
         /// </summary>
+        /// <value>
+        ///  One of the <see cref="ListViewGroupCollapsedState"/> values that specifies how the group is displayed. The default is <see cref="ListViewGroupCollapsedState.Default"/>.
+        /// </value>
         /// <exception cref="InvalidEnumArgumentException">
         ///  The specified value when setting this property is not a valid <see cref="ListViewGroupCollapsedState"/> value.
         /// </exception>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
@@ -143,6 +143,12 @@ namespace System.Windows.Forms
         /// <summary>
         ///  The alignment of the group footer.
         /// </summary>
+        /// <value>
+        ///  One of the <see cref="HorizontalAlignment"/> values that specifies the alignment of the footer text. The default is <see cref="HorizontalAlignment.Left"/>.
+        /// </value>
+        /// <exception cref="InvalidEnumArgumentException">
+        ///  The specified value when setting this property is not a valid <see cref="HorizontalAlignment"/> value.
+        /// </exception>
         [DefaultValue(HorizontalAlignment.Left)]
         [SRCategory(nameof(SR.CatAppearance))]
         public HorizontalAlignment FooterAlignment
@@ -168,6 +174,9 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Controls which <see cref="ListViewGroupCollapsedState"/> the group will appear as.
         /// </summary>
+        /// <exception cref="InvalidEnumArgumentException">
+        ///  The specified value when setting this property is not a valid <see cref="ListViewGroupCollapsedState"/> value.
+        /// </exception>
         [DefaultValue(ListViewGroupCollapsedState.Default)]
         [SRCategory(nameof(SR.CatAppearance))]
         public ListViewGroupCollapsedState CollapsedState
@@ -175,6 +184,11 @@ namespace System.Windows.Forms
             get => _collapsedState;
             set
             {
+                if (!ClientUtils.IsEnumValid(value, (int)value, (int)ListViewGroupCollapsedState.Default, (int)ListViewGroupCollapsedState.Collapsed))
+                {
+                    throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ListViewGroupCollapsedState));
+                }
+
                 if (_collapsedState == value)
                 {
                     return;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupTests.cs
@@ -853,6 +853,14 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryDataInvalid), typeof(ListViewGroupCollapsedState))]
+        public void ListViewGroup_CollapsedState_SetInvalid_ThrowsInvalidEnumArgumentException(ListViewGroupCollapsedState value)
+        {
+            var group = new ListViewGroup();
+            Assert.Throws<InvalidEnumArgumentException>("value", () => group.CollapsedState = value);
+        }
+
+        [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringWithNullTheoryData))]
         public void ListViewGroup_Name_Set_GetReturnsExpected(string value)
         {


### PR DESCRIPTION
Fixes #3424 


## Proposed changes

- throw `InvalidEnumArgumentException` when the `CollapsedState` of a `ListViewGroup `
is set to a value outside the range of the `ListViewGroupCollapsedState` enum

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Prevents user from having invalid enum for `ListViewGroup.CollapsedState`

## Regression? 

- No

## Risk

- Low

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Unit testing


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3435)