### PR TITLE
Correct SelectedImageKey/SelectedImageIndex/StateImageKey/StateImageIndex properties

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
@@ -402,7 +402,7 @@ namespace System.Windows.Forms
         [TypeConverter(typeof(ImageIndexConverter))]
         [Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
         [Localizable(true)]
-        [DefaultValue(-1)]
+        [DefaultValue(ImageList.Indexer.DefaultIndex)]
         [RefreshProperties(RefreshProperties.Repaint)]
         [SRDescription(nameof(SR.ButtonImageIndexDescr))]
         [SRCategory(nameof(SR.CatAppearance))]
@@ -418,9 +418,9 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value < -1)
+                if (value < ImageList.Indexer.DefaultIndex)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(ImageIndex), value, -1));
+                    throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(ImageIndex), value, ImageList.Indexer.DefaultIndex));
                 }
 
                 if (value == imageIndex.Index && value != ImageList.Indexer.DefaultIndex)
@@ -428,7 +428,7 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                if (value != -1)
+                if (value != ImageList.Indexer.DefaultIndex)
                 {
                     // Image.set calls ImageIndex = -1
                     image = null;
@@ -447,7 +447,7 @@ namespace System.Windows.Forms
         [TypeConverter(typeof(ImageKeyConverter))]
         [Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
         [Localizable(true)]
-        [DefaultValue("")]
+        [DefaultValue(ImageList.Indexer.DefaultKey)]
         [RefreshProperties(RefreshProperties.Repaint)]
         [SRDescription(nameof(SR.ButtonImageIndexDescr))]
         [SRCategory(nameof(SR.CatAppearance))]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
@@ -186,7 +186,7 @@ namespace System.Windows.Forms
             }
         }
 
-        [DefaultValue(-1)]
+        [DefaultValue(ImageList.Indexer.DefaultIndex)]
         [TypeConverter(typeof(ImageIndexConverter))]
         [Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
         [RefreshProperties(RefreshProperties.Repaint)]
@@ -203,9 +203,9 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value < -1)
+                if (value < ImageList.Indexer.DefaultIndex)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(ImageIndex), value, -1));
+                    throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(ImageIndex), value, ImageList.Indexer.DefaultIndex));
                 }
 
                 if (imageIndexer.Index == value && value != ImageList.Indexer.DefaultIndex)
@@ -232,7 +232,7 @@ namespace System.Windows.Forms
             }
         }
 
-        [DefaultValue("")]
+        [DefaultValue(ImageList.Indexer.DefaultKey)]
         [TypeConverter(typeof(ImageKeyConverter))]
         [Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
         [RefreshProperties(RefreshProperties.Repaint)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
@@ -452,7 +452,7 @@ namespace System.Windows.Forms
         /// </summary>
         [TypeConverter(typeof(ImageIndexConverter))]
         [Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
-        [DefaultValue(-1)]
+        [DefaultValue(ImageList.Indexer.DefaultIndex)]
         [Localizable(true)]
         [RefreshProperties(RefreshProperties.Repaint)]
         [SRDescription(nameof(SR.ButtonImageIndexDescr))]
@@ -476,9 +476,9 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value < -1)
+                if (value < ImageList.Indexer.DefaultIndex)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(ImageIndex), value, -1));
+                    throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(ImageIndex), value, ImageList.Indexer.DefaultIndex));
                 }
 
                 if (ImageIndex == value && value != ImageList.Indexer.DefaultIndex)
@@ -504,7 +504,7 @@ namespace System.Windows.Forms
         /// </summary>
         [TypeConverter(typeof(ImageKeyConverter))]
         [Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
-        [DefaultValue("")]
+        [DefaultValue(ImageList.Indexer.DefaultKey)]
         [Localizable(true)]
         [RefreshProperties(RefreshProperties.Repaint)]
         [SRDescription(nameof(SR.ButtonImageIndexDescr))]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
@@ -91,7 +91,7 @@ namespace System.Windows.Forms
             Deserialize(info, context);
         }
 
-        public ListViewItem(string text) : this(text, -1)
+        public ListViewItem(string text) : this(text, ImageList.Indexer.DefaultIndex)
         {
         }
 
@@ -101,7 +101,7 @@ namespace System.Windows.Forms
             Text = text;
         }
 
-        public ListViewItem(string[] items) : this(items, -1)
+        public ListViewItem(string[] items) : this(items, ImageList.Indexer.DefaultIndex)
         {
         }
 
@@ -431,7 +431,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Returns the ListViewItem's currently set image index
         /// </summary>
-        [DefaultValue(-1)]
+        [DefaultValue(ImageList.Indexer.DefaultIndex)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
         [Localizable(true)]
@@ -443,7 +443,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (ImageIndexer.Index != -1 && ImageList != null && ImageIndexer.Index >= ImageList.Images.Count)
+                if (ImageIndexer.Index != ImageList.Indexer.DefaultIndex && ImageList != null && ImageIndexer.Index >= ImageList.Images.Count)
                 {
                     return ImageList.Images.Count - 1;
                 }
@@ -452,9 +452,9 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value < -1)
+                if (value < ImageList.Indexer.DefaultIndex)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(ImageIndex), value, -1));
+                    throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(ImageIndex), value, ImageList.Indexer.DefaultIndex));
                 }
 
                 ImageIndexer.Index = value;
@@ -471,7 +471,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Returns the ListViewItem's currently set image index
         /// </summary>
-        [DefaultValue("")]
+        [DefaultValue(ImageList.Indexer.DefaultKey)]
         [TypeConverter(typeof(ImageKeyConverter))]
         [Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
@@ -639,7 +639,7 @@ namespace System.Windows.Forms
             set
             {
                 // flag whether we've set a value.
-                state[s_stateImageMaskSet] = (value == -1 ? 0 : 1);
+                state[s_stateImageMaskSet] = (value == ImageList.Indexer.DefaultIndex ? 0 : 1);
 
                 // push in the actual value
                 state[s_avedStateImageIndexSection] = value + 1;
@@ -685,7 +685,7 @@ namespace System.Windows.Forms
 
         [Localizable(true)]
         [TypeConverter(typeof(NoneExcludedImageIndexConverter))]
-        [DefaultValue(-1)]
+        [DefaultValue(ImageList.Indexer.DefaultIndex)]
         [SRDescription(nameof(SR.ListViewItemStateImageIndexDescr))]
         [SRCategory(nameof(SR.CatBehavior))]
         [RefreshProperties(RefreshProperties.Repaint)]
@@ -705,14 +705,14 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value < -1 || value > 14)
+                if (value < ImageList.Indexer.DefaultIndex || value > 14)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidArgument, nameof(StateImageIndex), value));
                 }
 
                 if (listView != null && listView.IsHandleCreated)
                 {
-                    this.state[s_stateImageMaskSet] = (value == -1 ? 0 : 1);
+                    this.state[s_stateImageMaskSet] = (value == ImageList.Indexer.DefaultIndex ? 0 : 1);
                     LVIS state = (LVIS)((value + 1) << 12);  // index is 1-based
                     listView.SetItemState(Index, state, LVIS.STATEIMAGEMASK);
                 }
@@ -1038,7 +1038,7 @@ namespace System.Windows.Forms
                 stateMask |= LVIS.SELECTED;
             }
 
-            if (SavedStateImageIndex > -1)
+            if (SavedStateImageIndex > ImageList.Indexer.DefaultIndex)
             {
                 itemState |= (LVIS)((SavedStateImageIndex + 1) << 12);
                 stateMask |= LVIS.STATEIMAGEMASK;
@@ -1135,7 +1135,7 @@ namespace System.Windows.Forms
             bool foundSubItems = false;
 
             string imageKey = null;
-            int imageIndex = -1;
+            int imageIndex = ImageList.Indexer.DefaultIndex;
 
             foreach (SerializationEntry entry in info)
             {
@@ -1191,7 +1191,7 @@ namespace System.Windows.Forms
             {
                 ImageKey = imageKey;
             }
-            else if (imageIndex != -1)
+            else if (imageIndex != ImageList.Indexer.DefaultIndex)
             {
                 ImageIndex = imageIndex;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -1050,7 +1050,7 @@ namespace System.Windows.Forms
                     }
                     if (value != null)
                     {
-                        ImageIndex = -1;
+                        ImageIndex = ImageList.Indexer.DefaultIndex;
                     }
 
                     Properties.SetObject(s_imageProperty, value);
@@ -1101,7 +1101,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if ((Owner != null) && ImageIndexer.Index != -1 && Owner.ImageList != null && ImageIndexer.Index >= Owner.ImageList.Images.Count)
+                if ((Owner != null) && ImageIndexer.Index != ImageList.Indexer.DefaultIndex && Owner.ImageList != null && ImageIndexer.Index >= Owner.ImageList.Images.Count)
                 {
                     return Owner.ImageList.Images.Count - 1;
                 }
@@ -1110,9 +1110,9 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value < -1)
+                if (value < ImageList.Indexer.DefaultIndex)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), string.Format(SR.InvalidLowBoundArgumentEx, nameof(ImageIndex), value, -1));
+                    throw new ArgumentOutOfRangeException(nameof(value), string.Format(SR.InvalidLowBoundArgumentEx, nameof(ImageIndex), value, ImageList.Indexer.DefaultIndex));
                 }
 
                 ImageIndexer.Index = value;
@@ -3254,7 +3254,7 @@ namespace System.Windows.Forms
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         private bool ShouldSerializeImageIndex()
-            => Image != null && ImageIndexer.ActualIndex >= 0 && ImageIndexer.Index != -1;
+            => Image != null && ImageIndexer.ActualIndex >= 0 && ImageIndexer.Index != ImageList.Indexer.DefaultIndex;
 
         /// <summary>
         ///  Determines if the <see cref='RightToLeft'/> property needs to be persisted.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
@@ -988,7 +988,7 @@ namespace System.Windows.Forms
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(SelectedImageIndex), value, ImageList.Indexer.DefaultIndex));
                 }
 
-                if (SelectedImageIndexer.Index == value)
+                if (SelectedImageIndexer.Index == value && value != ImageList.Indexer.DefaultIndex)
                 {
                     return;
                 }
@@ -1015,7 +1015,7 @@ namespace System.Windows.Forms
             get => SelectedImageIndexer.Key;
             set
             {
-                if (SelectedImageIndexer.Key == value)
+                if (SelectedImageIndexer.Key == value && !string.Equals(value, ImageList.Indexer.DefaultKey))
                 {
                     return;
                 }
@@ -1073,13 +1073,15 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (StateImageIndexer.Key != value)
+                if (StateImageIndexer.Key == value && !string.Equals(value, ImageList.Indexer.DefaultKey))
                 {
-                    StateImageIndexer.Key = value;
-                    if (treeView != null && !treeView.CheckBoxes)
-                    {
-                        UpdateNode(TVIF.STATE);
-                    }
+                    return;
+                }
+
+                StateImageIndexer.Key = value;
+                if (treeView != null && !treeView.CheckBoxes)
+                {
+                    UpdateNode(TVIF.STATE);
                 }
             }
         }
@@ -1111,7 +1113,7 @@ namespace System.Windows.Forms
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidArgument, nameof(StateImageIndex), value));
                 }
 
-                if (StateImageIndexer.Index == value)
+                if (StateImageIndexer.Index == value && value != ImageList.Indexer.DefaultIndex)
                 {
                     return;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
@@ -563,7 +563,7 @@ namespace System.Windows.Forms
         [TypeConverter(typeof(TreeViewImageIndexConverter))]
         [Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
         [RefreshProperties(RefreshProperties.Repaint)]
-        [DefaultValue(-1)]
+        [DefaultValue(ImageList.Indexer.DefaultIndex)]
         [RelatedImageList("TreeView.ImageList")]
         public int ImageIndex
         {
@@ -579,9 +579,9 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value < -1)
+                if (value < ImageList.Indexer.DefaultIndex)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(ImageIndex), value, -1));
+                    throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(ImageIndex), value, ImageList.Indexer.DefaultIndex));
                 }
 
                 if (ImageIndexer.Index == value && value != ImageList.Indexer.DefaultIndex)
@@ -602,7 +602,7 @@ namespace System.Windows.Forms
         [SRCategory(nameof(SR.CatBehavior))]
         [SRDescription(nameof(SR.TreeNodeImageKeyDescr))]
         [TypeConverter(typeof(TreeViewImageKeyConverter))]
-        [DefaultValue("")]
+        [DefaultValue(ImageList.Indexer.DefaultKey)]
         [Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
         [RefreshProperties(RefreshProperties.Repaint)]
         [RelatedImageList("TreeView.ImageList")]
@@ -965,7 +965,7 @@ namespace System.Windows.Forms
         [SRCategory(nameof(SR.CatBehavior))]
         [SRDescription(nameof(SR.TreeNodeSelectedImageIndexDescr))]
         [TypeConverter(typeof(TreeViewImageIndexConverter))]
-        [DefaultValue(-1)]
+        [DefaultValue(ImageList.Indexer.DefaultIndex)]
         [RefreshProperties(RefreshProperties.Repaint)]
         [Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
         [RelatedImageList("TreeView.ImageList")]
@@ -974,7 +974,7 @@ namespace System.Windows.Forms
             get
             {
                 TreeView tv = TreeView;
-                if (SelectedImageIndexer.Index != -1 && tv != null && tv.ImageList != null && SelectedImageIndexer.Index >= tv.ImageList.Images.Count)
+                if (SelectedImageIndexer.Index != ImageList.Indexer.DefaultIndex && tv != null && tv.ImageList != null && SelectedImageIndexer.Index >= tv.ImageList.Images.Count)
                 {
                     return tv.ImageList.Images.Count - 1;
                 }
@@ -983,9 +983,9 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value < -1)
+                if (value < ImageList.Indexer.DefaultIndex)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(SelectedImageIndex), value, -1));
+                    throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(SelectedImageIndex), value, ImageList.Indexer.DefaultIndex));
                 }
 
                 if (SelectedImageIndexer.Index == value)
@@ -1006,7 +1006,7 @@ namespace System.Windows.Forms
         [SRCategory(nameof(SR.CatBehavior))]
         [SRDescription(nameof(SR.TreeNodeSelectedImageKeyDescr))]
         [TypeConverter(typeof(TreeViewImageKeyConverter))]
-        [DefaultValue("")]
+        [DefaultValue(ImageList.Indexer.DefaultKey)]
         [RefreshProperties(RefreshProperties.Repaint)]
         [Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
         [RelatedImageList("TreeView.ImageList")]
@@ -1061,7 +1061,7 @@ namespace System.Windows.Forms
         [SRCategory(nameof(SR.CatBehavior))]
         [SRDescription(nameof(SR.TreeNodeStateImageKeyDescr))]
         [TypeConverter(typeof(ImageKeyConverter))]
-        [DefaultValue("")]
+        [DefaultValue(ImageList.Indexer.DefaultKey)]
         [Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
         [RefreshProperties(RefreshProperties.Repaint)]
         [RelatedImageList("TreeView.StateImageList")]
@@ -1086,7 +1086,7 @@ namespace System.Windows.Forms
 
         [Localizable(true)]
         [TypeConverter(typeof(NoneExcludedImageIndexConverter))]
-        [DefaultValue(-1)]
+        [DefaultValue(ImageList.Indexer.DefaultIndex)]
         [SRCategory(nameof(SR.CatBehavior))]
         [SRDescription(nameof(SR.TreeNodeStateImageIndexDescr))]
         [Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
@@ -1097,7 +1097,7 @@ namespace System.Windows.Forms
             get
             {
                 TreeView tv = TreeView;
-                if (StateImageIndexer.Index != -1 && tv != null && tv.StateImageList != null && StateImageIndexer.Index >= tv.StateImageList.Images.Count)
+                if (StateImageIndexer.Index != ImageList.Indexer.DefaultIndex && tv != null && tv.StateImageList != null && StateImageIndexer.Index >= tv.StateImageList.Images.Count)
                 {
                     return tv.StateImageList.Images.Count - 1;
                 }
@@ -1106,7 +1106,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value < -1 || value > ALLOWEDIMAGES)
+                if (value < ImageList.Indexer.DefaultIndex || value > ALLOWEDIMAGES)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidArgument, nameof(StateImageIndex), value));
                 }
@@ -1575,13 +1575,13 @@ namespace System.Windows.Forms
         protected virtual void Deserialize(SerializationInfo serializationInfo, StreamingContext context)
         {
             int childCount = 0;
-            int imageIndex = -1;
+            int imageIndex = ImageList.Indexer.DefaultIndex;
             string imageKey = null;
 
-            int selectedImageIndex = -1;
+            int selectedImageIndex = ImageList.Indexer.DefaultIndex;
             string selectedImageKey = null;
 
-            int stateImageIndex = -1;
+            int stateImageIndex = ImageList.Indexer.DefaultIndex;
             string stateImageKey = null;
 
             foreach (SerializationEntry entry in serializationInfo)
@@ -1636,7 +1636,7 @@ namespace System.Windows.Forms
             {
                 ImageKey = imageKey;
             }
-            else if (imageIndex != -1)
+            else if (imageIndex != ImageList.Indexer.DefaultIndex)
             {
                 ImageIndex = imageIndex;
             }
@@ -1646,7 +1646,7 @@ namespace System.Windows.Forms
             {
                 SelectedImageKey = selectedImageKey;
             }
-            else if (selectedImageIndex != -1)
+            else if (selectedImageIndex != ImageList.Indexer.DefaultIndex)
             {
                 SelectedImageIndex = selectedImageIndex;
             }
@@ -1656,7 +1656,7 @@ namespace System.Windows.Forms
             {
                 StateImageKey = stateImageKey;
             }
-            else if (stateImageIndex != -1)
+            else if (stateImageIndex != ImageList.Indexer.DefaultIndex)
             {
                 StateImageIndex = stateImageIndex;
             }
@@ -1916,8 +1916,8 @@ namespace System.Windows.Forms
                 }
 
                 tvis.item.pszText = Marshal.StringToHGlobalAuto(text);
-                tvis.item.iImage = (ImageIndexer.ActualIndex == -1) ? tv.ImageIndexer.ActualIndex : ImageIndexer.ActualIndex;
-                tvis.item.iSelectedImage = (SelectedImageIndexer.ActualIndex == -1) ? tv.SelectedImageIndexer.ActualIndex : SelectedImageIndexer.ActualIndex;
+                tvis.item.iImage = (ImageIndexer.ActualIndex == ImageList.Indexer.DefaultIndex) ? tv.ImageIndexer.ActualIndex : ImageIndexer.ActualIndex;
+                tvis.item.iSelectedImage = (SelectedImageIndexer.ActualIndex == ImageList.Indexer.DefaultIndex) ? tv.SelectedImageIndexer.ActualIndex : SelectedImageIndexer.ActualIndex;
                 tvis.item.mask = TVIF.TEXT;
 
                 tvis.item.stateMask = 0;
@@ -2209,18 +2209,18 @@ namespace System.Windows.Forms
 
             if ((mask & TVIF.IMAGE) != 0)
             {
-                item.iImage = (ImageIndexer.ActualIndex == -1) ? tv.ImageIndexer.ActualIndex : ImageIndexer.ActualIndex;
+                item.iImage = (ImageIndexer.ActualIndex == ImageList.Indexer.DefaultIndex) ? tv.ImageIndexer.ActualIndex : ImageIndexer.ActualIndex;
             }
 
             if ((mask & TVIF.SELECTEDIMAGE) != 0)
             {
-                item.iSelectedImage = (SelectedImageIndexer.ActualIndex == -1) ? tv.SelectedImageIndexer.ActualIndex : SelectedImageIndexer.ActualIndex;
+                item.iSelectedImage = (SelectedImageIndexer.ActualIndex == ImageList.Indexer.DefaultIndex) ? tv.SelectedImageIndexer.ActualIndex : SelectedImageIndexer.ActualIndex;
             }
 
             if ((mask & TVIF.STATE) != 0)
             {
                 item.stateMask = TVIS.STATEIMAGEMASK;
-                if (StateImageIndexer.ActualIndex != -1)
+                if (StateImageIndexer.ActualIndex != ImageList.Indexer.DefaultIndex)
                 {
                     item.state = (TVIS)((StateImageIndexer.ActualIndex + 1) << SHIFTVAL);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -548,7 +548,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  The default image index for nodes in the tree view.
         /// </summary>
-        [DefaultValue(-1)]
+        [DefaultValue(ImageList.Indexer.DefaultIndex)]
         [SRCategory(nameof(SR.CatBehavior))]
         [Localizable(true)]
         [RefreshProperties(RefreshProperties.Repaint)]
@@ -562,7 +562,7 @@ namespace System.Windows.Forms
             {
                 if (imageList == null)
                 {
-                    return -1;
+                    return ImageList.Indexer.DefaultIndex;
                 }
                 if (ImageIndexer.Index >= imageList.Images.Count)
                 {
@@ -577,7 +577,7 @@ namespace System.Windows.Forms
                 // mean image index 0. This is because a treeview must always have an image index -
                 // even if no imagelist exists we want the image index to be 0.
                 //
-                if (value == -1)
+                if (value == ImageList.Indexer.DefaultIndex)
                 {
                     value = 0;
                 }
@@ -605,7 +605,7 @@ namespace System.Windows.Forms
         [Localizable(true)]
         [TypeConverter(typeof(ImageKeyConverter))]
         [Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
-        [DefaultValue("")]
+        [DefaultValue(ImageList.Indexer.DefaultKey)]
         [RefreshProperties(RefreshProperties.Repaint)]
         [SRDescription(nameof(SR.TreeViewImageKeyDescr))]
         [RelatedImageList("ImageList")]
@@ -623,7 +623,7 @@ namespace System.Windows.Forms
                     ImageIndexer.Key = value;
                     if (string.IsNullOrEmpty(value) || value.Equals(SR.toStringNone))
                     {
-                        ImageIndex = (ImageList != null) ? 0 : -1;
+                        ImageIndex = (ImageList != null) ? 0 : ImageList.Indexer.DefaultIndex;
                     }
                     if (IsHandleCreated)
                     {
@@ -1065,7 +1065,7 @@ namespace System.Windows.Forms
         ///  The image index that a node will display when selected.
         ///  The index applies to the ImageList referred to by the imageList property,
         /// </summary>
-        [DefaultValue(-1)]
+        [DefaultValue(ImageList.Indexer.DefaultIndex)]
         [SRCategory(nameof(SR.CatBehavior))]
         [TypeConverter(typeof(NoneExcludedImageIndexConverter))]
         [Localizable(true)]
@@ -1078,7 +1078,7 @@ namespace System.Windows.Forms
             {
                 if (imageList == null)
                 {
-                    return -1;
+                    return ImageList.Indexer.DefaultIndex;
                 }
                 if (SelectedImageIndexer.Index >= imageList.Images.Count)
                 {
@@ -1092,7 +1092,7 @@ namespace System.Windows.Forms
                 // mean image index 0. This is because a treeview must always have an image index -
                 // even if no imagelist exists we want the image index to be 0.
                 //
-                if (value == -1)
+                if (value == ImageList.Indexer.DefaultIndex)
                 {
                     value = 0;
                 }
@@ -1119,7 +1119,7 @@ namespace System.Windows.Forms
         [Localizable(true)]
         [TypeConverter(typeof(ImageKeyConverter))]
         [Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
-        [DefaultValue("")]
+        [DefaultValue(ImageList.Indexer.DefaultKey)]
         [RefreshProperties(RefreshProperties.Repaint)]
         [SRDescription(nameof(SR.TreeViewSelectedImageKeyDescr))]
         [RelatedImageList("ImageList")]
@@ -1138,7 +1138,7 @@ namespace System.Windows.Forms
 
                     if (string.IsNullOrEmpty(value) || value.Equals(SR.toStringNone))
                     {
-                        SelectedImageIndex = (ImageList != null) ? 0 : -1;
+                        SelectedImageIndex = (ImageList != null) ? 0 : ImageList.Indexer.DefaultIndex;
                     }
                     if (IsHandleCreated)
                     {
@@ -2394,7 +2394,7 @@ namespace System.Windows.Forms
             {
                 return (SelectedImageIndex != 0);
             }
-            return (SelectedImageIndex != -1);
+            return (SelectedImageIndex != ImageList.Indexer.DefaultIndex);
         }
 
         private bool ShouldSerializeImageIndex()
@@ -2403,7 +2403,7 @@ namespace System.Windows.Forms
             {
                 return (ImageIndex != 0);
             }
-            return (ImageIndex != -1);
+            return (ImageIndex != ImageList.Indexer.DefaultIndex);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeTests.cs
@@ -2993,11 +2993,11 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(-1, "SelectedImageKey", -1)]
-        [InlineData(0, "", 0)]
-        [InlineData(1, "", 0)]
-        [InlineData(2, "", 0)]
-        public void TreeNode_SelectedImageIndex_SetWithSelectedImageKey_GetReturnsExpected(int value, string expectedSelectedImageKey, int expectedWithImage)
+        [InlineData(-1, -1)]
+        [InlineData(0, 0)]
+        [InlineData(1, 0)]
+        [InlineData(2, 0)]
+        public void TreeNode_SelectedImageIndex_SetWithSelectedImageKey_GetReturnsExpected(int value, int expectedWithImage)
         {
             var node = new TreeNode
             {
@@ -3005,32 +3005,32 @@ namespace System.Windows.Forms.Tests
                 SelectedImageIndex = value
             };
             Assert.Equal(value, node.SelectedImageIndex);
-            Assert.Equal(expectedSelectedImageKey, node.SelectedImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultKey, node.SelectedImageKey);
 
             // Set same.
             node.SelectedImageIndex = value;
             Assert.Equal(value, node.SelectedImageIndex);
-            Assert.Equal(expectedSelectedImageKey, node.SelectedImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultKey, node.SelectedImageKey);
 
             // Set tree view.
             using var control = new TreeView();
             control.Nodes.Add(node);
             Assert.Equal(value, node.SelectedImageIndex);
-            Assert.Equal(expectedSelectedImageKey, node.SelectedImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultKey, node.SelectedImageKey);
             Assert.False(control.IsHandleCreated);
 
             // Add image list.
             using var imageList = new ImageList();
             control.ImageList = imageList;
             Assert.Equal(-1, node.SelectedImageIndex);
-            Assert.Equal(expectedSelectedImageKey, node.SelectedImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultKey, node.SelectedImageKey);
             Assert.False(control.IsHandleCreated);
 
             // Add to image list.
             using var image = new Bitmap(10, 10);
             imageList.Images.Add(image);
             Assert.Equal(expectedWithImage, node.SelectedImageIndex);
-            Assert.Equal(expectedSelectedImageKey, node.SelectedImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultKey, node.SelectedImageKey);
             Assert.False(control.IsHandleCreated);
         }
 
@@ -3331,23 +3331,23 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(null, "", -1)]
-        [InlineData("", "", 0)]
-        [InlineData("SelectedImageKey", "SelectedImageKey", -1)]
-        public void TreeNode_SelectedImageKey_SetWithSelectedImageIndex_GetReturnsExpected(string value, string expected, int expectedSelectedImageIndex)
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("SelectedImageKey", "SelectedImageKey")]
+        public void TreeNode_SelectedImageKey_SetWithSelectedImageIndex_GetReturnsExpected(string value, string expectedSelectedImageKey)
         {
             var node = new TreeNode
             {
                 SelectedImageIndex = 0,
                 SelectedImageKey = value
             };
-            Assert.Equal(expected, node.SelectedImageKey);
-            Assert.Equal(expectedSelectedImageIndex, node.SelectedImageIndex);
+            Assert.Equal(expectedSelectedImageKey, node.SelectedImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultIndex, node.SelectedImageIndex);
 
             // Set same.
             node.SelectedImageKey = value;
-            Assert.Equal(expected, node.SelectedImageKey);
-            Assert.Equal(expectedSelectedImageIndex, node.SelectedImageIndex);
+            Assert.Equal(expectedSelectedImageKey, node.SelectedImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultIndex, node.SelectedImageIndex);
         }
 
         [WinFormsTheory]
@@ -3622,12 +3622,12 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(-1, "StateImageKey", -1)]
-        [InlineData(0, "", 0)]
-        [InlineData(1, "", 0)]
-        [InlineData(2, "", 0)]
-        [InlineData(14, "", 0)]
-        public void TreeNode_StateImageIndex_SetWithStateImageKey_GetReturnsExpected(int value, string expectedStateImageKey, int expectedWithImage)
+        [InlineData(-1, -1)]
+        [InlineData(0, 0)]
+        [InlineData(1, 0)]
+        [InlineData(2, 0)]
+        [InlineData(14, 0)]
+        public void TreeNode_StateImageIndex_SetWithStateImageKey_GetReturnsExpected(int value, int expectedWithImage)
         {
             var node = new TreeNode
             {
@@ -3635,32 +3635,32 @@ namespace System.Windows.Forms.Tests
                 StateImageIndex = value
             };
             Assert.Equal(value, node.StateImageIndex);
-            Assert.Equal(expectedStateImageKey, node.StateImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultKey, node.StateImageKey);
 
             // Set same.
             node.StateImageIndex = value;
             Assert.Equal(value, node.StateImageIndex);
-            Assert.Equal(expectedStateImageKey, node.StateImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultKey, node.StateImageKey);
 
             // Set tree view.
             using var control = new TreeView();
             control.Nodes.Add(node);
             Assert.Equal(value, node.StateImageIndex);
-            Assert.Equal(expectedStateImageKey, node.StateImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultKey, node.StateImageKey);
             Assert.False(control.IsHandleCreated);
 
             // Add image list.
             using var imageList = new ImageList();
             control.StateImageList = imageList;
             Assert.Equal(-1, node.StateImageIndex);
-            Assert.Equal(expectedStateImageKey, node.StateImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultKey, node.StateImageKey);
             Assert.False(control.IsHandleCreated);
 
             // Add to image list.
             using var image = new Bitmap(10, 10);
             imageList.Images.Add(image);
             Assert.Equal(expectedWithImage, node.StateImageIndex);
-            Assert.Equal(expectedStateImageKey, node.StateImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultKey, node.StateImageKey);
             Assert.False(control.IsHandleCreated);
         }
 
@@ -4039,35 +4039,35 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(null, "", -1)]
-        [InlineData("", "", 0)]
-        [InlineData("StateImageKey", "StateImageKey", -1)]
-        public void TreeNode_StateImageKey_SetWithStateImageIndex_GetReturnsExpected(string value, string expected, int expectedStateImageIndex)
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("StateImageKey", "StateImageKey")]
+        public void TreeNode_StateImageKey_SetWithStateImageIndex_GetReturnsExpected(string value, string expectedStateImageKey)
         {
             var node = new TreeNode
             {
                 StateImageIndex = 0,
                 StateImageKey = value
             };
-            Assert.Equal(expected, node.StateImageKey);
-            Assert.Equal(expectedStateImageIndex, node.StateImageIndex);
+            Assert.Equal(expectedStateImageKey, node.StateImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultIndex, node.StateImageIndex);
 
             // Set same.
             node.StateImageKey = value;
-            Assert.Equal(expected, node.StateImageKey);
-            Assert.Equal(expectedStateImageIndex, node.StateImageIndex);
+            Assert.Equal(expectedStateImageKey, node.StateImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultIndex, node.StateImageIndex);
 
             // Set tree view.
             using var control = new TreeView();
             control.Nodes.Add(node);
-            Assert.Equal(expected, node.StateImageKey);
-            Assert.Equal(expectedStateImageIndex, node.StateImageIndex);
+            Assert.Equal(expectedStateImageKey, node.StateImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultIndex, node.StateImageIndex);
 
             // Add image list.
             using var imageList = new ImageList();
             control.StateImageList = imageList;
-            Assert.Equal(expected, node.StateImageKey);
-            Assert.Equal(-1, node.StateImageIndex);
+            Assert.Equal(expectedStateImageKey, node.StateImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultIndex, node.StateImageIndex);
         }
 
         public static IEnumerable<object[]> StateImageKey_SetWithTreeView_TestData()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Resolves #3425
Relates to #3364


## Proposed changes

- Setters for `ImageKey` and `ImageIndex` properties were made idempotent in #3126, however the change didn't account for the fact that the default `ImageKey == ""` and not `null`.
  This caused failures to reset `SelectedImageIndex` or `StateImageIndex`, when `SelectedImageKey` or `StateImageKey` were set respectively to `""`; and in reverse - failure to reset keys when indices were set to `-1`.
  Tweak the setters to continue execution for default values.
- More clean up to use const instead of magic number.


## Test methodology <!-- How did you ensure quality? -->

- unit tests

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3440)