### PR TITLE
Add CLIENTCREATESTRUCT in Interop User32 and remove unused COMRECT

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CLIENTCREATESTRUCT.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CLIENTCREATESTRUCT.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public struct CLIENTCREATESTRUCT
+        {
+            public IntPtr hWindowMenu;
+            public uint idFirstChild;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -218,45 +218,6 @@ namespace System.Windows.Forms
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        public class COMRECT
-        {
-            public int left;
-            public int top;
-            public int right;
-            public int bottom;
-
-            public COMRECT()
-            {
-            }
-
-            public COMRECT(Rectangle r)
-            {
-                left = r.X;
-                top = r.Y;
-                right = r.Right;
-                bottom = r.Bottom;
-            }
-
-            public override string ToString()
-            {
-                return "Left = " + left + " Top " + top + " Right = " + right + " Bottom = " + bottom;
-            }
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public class CLIENTCREATESTRUCT
-        {
-            public IntPtr hWindowMenu;
-            public int idFirstChild;
-
-            public CLIENTCREATESTRUCT(IntPtr hmenu, int idFirst)
-            {
-                hWindowMenu = hmenu;
-                idFirstChild = idFirst;
-            }
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
         public class ENLINK
         {
             public User32.NMHDR nmhdr;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MDIClient.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MDIClient.cs
@@ -103,7 +103,10 @@ namespace System.Windows.Forms
                 // to make them not visible but still present.
                 cp.Style |= (int)(User32.WS.VSCROLL | User32.WS.HSCROLL);
                 cp.ExStyle |= (int)User32.WS_EX.CLIENTEDGE;
-                cp.Param = new NativeMethods.CLIENTCREATESTRUCT(IntPtr.Zero, 1);
+                cp.Param = new User32.CLIENTCREATESTRUCT
+                {
+                    idFirstChild = 1
+                };
                 ISite site = ParentInternal?.Site;
                 if (site != null && site.DesignMode)
                 {


### PR DESCRIPTION
## Proposed changes

- Add CLIENTCREATESTRUCT in Interop User32 and remove the corresponding class from NativeMethods.cs.
- Remove unused COMRECT.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3447)