### PR TITLE
Add ENM enum in Interop RichEdit

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ENM.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ENM.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal partial class Interop
+{
+    internal static partial class Richedit
+    {
+        [Flags]
+        public enum ENM
+        {
+            NONE = 0x00000000,
+            CHANGE = 0x00000001,
+            UPDATE = 0x00000002,
+            SCROLL = 0x00000004,
+            SCROLLEVENTS = 0x00000008,
+            DRAGDROPDONE = 0x00000010,
+            PARAGRAPHEXPANDED = 0x00000020,
+            PAGECHANGE = 0x00000040,
+            CLIPFORMAT = 0x00000080,
+            KEYEVENTS = 0x00010000,
+            MOUSEEVENTS = 0x00020000,
+            REQUESTRESIZE = 0x00040000,
+            SELCHANGE = 0x00080000,
+            DROPFILES = 0x00100000,
+            PROTECTED = 0x00200000,
+            CORRECTTEXT = 0x00400000,
+            IMECHANGE = 0x00800000,
+            LANGCHANGE = 0x01000000,
+            OBJECTPOSITIONS = 0x02000000,
+            LINK = 0x04000000,
+            LOWFIRTF = 0x08000000,
+            STARTCOMPOSITION = 0x10000000,
+            ENDCOMPOSITION = 0x20000000,
+            GROUPTYPINGCHANGE = 0x40000000,
+            HIDELINKTOOLTIP = unchecked((int)0x80000000)
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -2536,12 +2536,12 @@ namespace System.Windows.Forms
                 this,
                 (User32.WM)RichEditMessages.EM_SETEVENTMASK,
                 IntPtr.Zero,
-                (IntPtr)(RichTextBoxConstants.ENM_PROTECTED | RichTextBoxConstants.ENM_SELCHANGE |
-                        RichTextBoxConstants.ENM_DROPFILES | RichTextBoxConstants.ENM_REQUESTRESIZE |
-                        RichTextBoxConstants.ENM_IMECHANGE | RichTextBoxConstants.ENM_CHANGE |
-                        RichTextBoxConstants.ENM_UPDATE | RichTextBoxConstants.ENM_SCROLL |
-                        RichTextBoxConstants.ENM_KEYEVENTS | RichTextBoxConstants.ENM_MOUSEEVENTS |
-                        RichTextBoxConstants.ENM_SCROLLEVENTS | RichTextBoxConstants.ENM_LINK));
+                (IntPtr)(ENM.PROTECTED | ENM.SELCHANGE |
+                         ENM.DROPFILES | ENM.REQUESTRESIZE |
+                         ENM.IMECHANGE | ENM.CHANGE |
+                         ENM.UPDATE | ENM.SCROLL |
+                         ENM.KEYEVENTS | ENM.MOUSEEVENTS |
+                         ENM.SCROLLEVENTS | ENM.LINK));
 
             int rm = rightMargin;
             rightMargin = 0;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxConstants.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxConstants.cs
@@ -16,28 +16,6 @@ namespace System.Windows.Forms
 
         /* RichTextBox messages */
 
-        // Event notification masks */
-        internal const int ENM_NONE = 0x00000000;
-        internal const int ENM_CHANGE = 0x00000001;
-        internal const int ENM_UPDATE = 0x00000002;
-        internal const int ENM_SCROLL = 0x00000004;
-        internal const int ENM_KEYEVENTS = 0x00010000;
-        internal const int ENM_MOUSEEVENTS = 0x00020000;
-        internal const int ENM_REQUESTRESIZE = 0x00040000;
-        internal const int ENM_SELCHANGE = 0x00080000;
-        internal const int ENM_DROPFILES = 0x00100000;
-        internal const int ENM_PROTECTED = 0x00200000;
-        internal const int ENM_CORRECTTEXT = 0x00400000;   /* PenWin specific */
-        internal const int ENM_SCROLLEVENTS = 0x00000008;
-        internal const int ENM_DRAGDROPDONE = 0x00000010;
-        internal const int ENM_PARAGRAPHEXPANDED = 0x00000020;
-
-        /* Asia specific notification mask */
-        internal const int ENM_IMECHANGE = 0x00800000;   /* unused by RE2.0 */
-        internal const int ENM_LANGCHANGE = 0x01000000;
-        internal const int ENM_OBJECTPOSITIONS = 0x02000000;
-        internal const int ENM_LINK = 0x04000000;
-
         /* New edit control styles */
         internal const int ES_SAVESEL = 0x00008000;
         internal const int ES_SUNKEN = 0x00004000;


### PR DESCRIPTION
## Proposed changes

- Add ENM enum in Interop RichEdit.
- Remove ENM constants from RichTextBoxConstants.cs.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3449)