### PR TITLE
Enable nullable reference types for System.Windows.Forms.Primitives

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.MCGRIDINFO.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.MCGRIDINFO.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TTOOLINFOW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TTOOLINFOW.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TTOOLINFOW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TTOOLINFOW.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop
@@ -28,6 +29,7 @@ internal static partial class Interop
         {
             public TTOOLINFOW Info;
             public string? Text { get; set; }
+            [MaybeNull]
             private readonly T _handle;
 
             public unsafe ToolInfoWrapper(T handle, TTF flags = default, string? text = null)

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TTOOLINFOW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TTOOLINFOW.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
 
@@ -29,10 +27,10 @@ internal static partial class Interop
             where T : IHandle
         {
             public TTOOLINFOW Info;
-            public string Text { get; set; }
+            public string? Text { get; set; }
             private readonly T _handle;
 
-            public unsafe ToolInfoWrapper(T handle, TTF flags = default, string text = null)
+            public unsafe ToolInfoWrapper(T handle, TTF flags = default, string? text = null)
             {
                 Info = new TTOOLINFOW
                 {
@@ -44,7 +42,7 @@ internal static partial class Interop
                 _handle = handle;
             }
 
-            public unsafe ToolInfoWrapper(T handle, IntPtr id, TTF flags = default, string text = null, RECT rect = default)
+            public unsafe ToolInfoWrapper(T handle, IntPtr id, TTF flags = default, string? text = null, RECT rect = default)
             {
                 Info = new TTOOLINFOW
                 {

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.BITMAPINFO.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.BITMAPINFO.cs
@@ -16,7 +16,7 @@ internal static partial class Interop
             public BITMAPINFOHEADER bmiHeader;
 
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = MaxColorSize * 4)]
-            public byte[] bmiColors; // RGBQUAD structs: repeating Blue-Green-Red-Reserved
+            public byte[]? bmiColors; // RGBQUAD structs: repeating Blue-Green-Red-Reserved
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.CreateDC.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.CreateDC.cs
@@ -14,6 +14,6 @@ internal static partial class Interop
         ///  Calling with ("DISPLAY", null, null, IntPtr.Zero) will retrieve a DC for the entire desktop.
         /// </remarks>
         [DllImport(Libraries.Gdi32, SetLastError = true, CharSet = CharSet.Unicode)]
-        public static extern IntPtr CreateDC(string lpszDriver, string lpszDeviceName, string lpszOutput, IntPtr devMode);
+        public static extern IntPtr CreateDC(string lpszDriver, string? lpszDeviceName, string? lpszOutput, IntPtr devMode);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Mso/Interop.IMsoComponent.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Mso/Interop.IMsoComponent.cs
@@ -145,7 +145,7 @@ internal static partial class Interop
             /// </param>
             [PreserveSig]
             void OnActivationChange(
-                IMsoComponent pic,
+                IMsoComponent? pic,
                 BOOL fSameComponent,
                 MSOCRINFO* pcrinfo,
                 BOOL fHostIsActivating,

--- a/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.GPStream.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.GPStream.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Buffers;
 using System.IO;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.GPStream.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.GPStream.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Buffers;
 using System.IO;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.OLEVERB.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.OLEVERB.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.InteropServices;
 
 internal static partial class Interop

--- a/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.OLEVERB.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.OLEVERB.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 
 internal static partial class Interop
@@ -15,7 +13,7 @@ internal static partial class Interop
         {
             public OLEIVERB lVerb;
             [MarshalAs(UnmanagedType.LPWStr)]
-            public string lpszVerbName;
+            public string? lpszVerbName;
             public User32.MF fuFlags;
             public OLEVERBATTRIB grfAttribs;
         }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.QACONTAINER.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.QACONTAINER.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.QACONTAINER.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.QACONTAINER.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
@@ -16,20 +14,20 @@ internal static partial class Interop
         public sealed class QACONTAINER
         {
             public uint cbSize;
-            public IOleClientSite pClientSite;
-            public IAdviseSink pAdviseSink;
-            public IPropertyNotifySink pPropertyNotifySink;
+            public IOleClientSite? pClientSite;
+            public IAdviseSink? pAdviseSink;
+            public IPropertyNotifySink? pPropertyNotifySink;
             [MarshalAs(UnmanagedType.Interface)]
-            public object pUnkEventSink;
+            public object? pUnkEventSink;
             public QACONTAINERFLAGS dwAmbientFlags;
             public uint colorFore;
             public uint colorBack;
-            public IFont pFont;
+            public IFont? pFont;
             public IntPtr pUndoMgr;
             public uint dwAppearance;
             public int lcid;
             public IntPtr hpal;
-            public IServiceProvider pBindHost;
+            public IServiceProvider? pBindHost;
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.STATSTG.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.STATSTG.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.STATSTG.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.STATSTG.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
@@ -62,7 +60,7 @@ internal static partial class Interop
             public uint grfStateBits;
             public uint reserved;
 
-            public string GetName() => Marshal.PtrToStringUni(pwcsName);
+            public string? GetName() => Marshal.PtrToStringUni(pwcsName);
 
             /// <summary>
             ///  Caller is responsible for freeing the name memory.
@@ -78,7 +76,7 @@ internal static partial class Interop
             /// <summary>
             ///  Callee is repsonsible for allocating the name memory.
             /// </summary>
-            public void AllocName(string name)
+            public void AllocName(string? name)
             {
                 pwcsName = Marshal.StringToCoTaskMemUni(name);
             }

--- a/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.FONTDESC.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.FONTDESC.cs
@@ -13,7 +13,7 @@ internal partial class Interop
         public struct FONTDESC
         {
             public uint cbSizeOfStruct;
-            public string lpstrName;
+            public string? lpstrName;
             public long cySize;
             public short sWeight;
             public short sCharset;

--- a/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.IEnumVariant.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.IEnumVariant.cs
@@ -29,7 +29,7 @@ internal partial class Interop
 
             [PreserveSig]
             HRESULT Clone(
-                [Out, MarshalAs(UnmanagedType.LPArray)] IEnumVariant[] ppEnum);
+                [Out, MarshalAs(UnmanagedType.LPArray)] IEnumVariant[]? ppEnum);
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.VARIANT.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.VARIANT.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.VARIANT.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.VARIANT.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Windows.Forms.Primitives.Resources;

--- a/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.VARIANT.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.VARIANT.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
 using System.Windows.Forms.Primitives.Resources;
@@ -47,7 +45,7 @@ internal static partial class Interop
 
             public void Dispose() => Clear();
 
-            public object ToObject()
+            public object? ToObject()
             {
                 IntPtr val = data1;
                 long longVal;

--- a/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.VARIANTVector.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.VARIANTVector.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
         {
             public VARIANT[] Variants;
 
-            public VARIANTVector(object[] values)
+            public VARIANTVector(object[]? values)
             {
                 if (values == null)
                 {

--- a/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.DragQueryFileW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.DragQueryFileW.cs
@@ -11,9 +11,9 @@ internal static partial class Interop
     internal static partial class Shell32
     {
         [DllImport(Libraries.Shell32, ExactSpelling = true, EntryPoint = "DragQueryFileW", CharSet = CharSet.Unicode)]
-        private static extern uint DragQueryFileWInternal(IntPtr hDrop, uint iFile, StringBuilder lpszFile, uint cch);
+        private static extern uint DragQueryFileWInternal(IntPtr hDrop, uint iFile, StringBuilder? lpszFile, uint cch);
 
-        public static uint DragQueryFileW(IntPtr hDrop, uint iFile, StringBuilder lpszFile)
+        public static uint DragQueryFileW(IntPtr hDrop, uint iFile, StringBuilder? lpszFile)
         {
             if (lpszFile == null || lpszFile.Capacity == 0 || iFile == 0xFFFFFFFF)
             {

--- a/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.SHBrowseForFolder.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.SHBrowseForFolder.cs
@@ -34,15 +34,15 @@ internal static partial class Interop
         {
             public IntPtr hwndOwner;
 
-            public CoTaskMemSafeHandle pidlRoot;
+            public CoTaskMemSafeHandle? pidlRoot;
 
             public char* pszDisplayName;
 
-            public string lpszTitle;
+            public string? lpszTitle;
 
             public uint ulFlags;
 
-            public BrowseCallbackProc lpfn;
+            public BrowseCallbackProc? lpfn;
 
             public IntPtr lParam;
 

--- a/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.SHGetPathFromIDListLongPath.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.SHGetPathFromIDListLongPath.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.SHGetPathFromIDListLongPath.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.SHGetPathFromIDListLongPath.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
 
@@ -14,7 +12,7 @@ internal static partial class Interop
         [DllImport(Libraries.Shell32, ExactSpelling = true)]
         private static extern BOOL SHGetPathFromIDListEx(IntPtr pidl, IntPtr pszPath, int cchPath, int flags);
 
-        public static bool SHGetPathFromIDListLongPath(IntPtr pidl, out string path)
+        public static bool SHGetPathFromIDListLongPath(IntPtr pidl, out string? path)
         {
             IntPtr pszPath = Marshal.AllocHGlobal((Kernel32.MAX_PATH + 1) * sizeof(char));
             int length = Kernel32.MAX_PATH;

--- a/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.IAccessibleEx.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.IAccessibleEx.cs
@@ -25,7 +25,7 @@ internal static partial class Interop
             ///  IAccessible. Only idChild values that do not have a corresponding
             ///  IAccessible can be used here.
             /// </summary>
-            IAccessibleEx GetObjectForChild(int idChild);
+            IAccessibleEx? GetObjectForChild(int idChild);
 
             /// <summary>
             ///  Returns an IAccessible and idChild pair for this IAccessibleEx.
@@ -37,11 +37,11 @@ internal static partial class Interop
             /// </summary>
             [PreserveSig]
             HRESULT GetIAccessiblePair(
-                [MarshalAs(UnmanagedType.Interface)] out object ppAcc,
+                [MarshalAs(UnmanagedType.Interface)] out object? ppAcc,
                 int* pidChild);
 
             [return: MarshalAs(UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_I4)]
-            int[] GetRuntimeId();
+            int[]? GetRuntimeId();
 
             /// <summary>
             ///  Some wrapper-based implementations (notably UIABridge) can't reasonably wrap all
@@ -58,7 +58,7 @@ internal static partial class Interop
             [PreserveSig]
             HRESULT ConvertReturnedElement(
                 IRawElementProviderSimple pIn,
-                out IAccessibleEx ppRetValOut);
+                out IAccessibleEx? ppRetValOut);
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.IAccessibleInternal.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.IAccessibleInternal.cs
@@ -17,7 +17,7 @@ internal static partial class Interop
             [return: MarshalAs(UnmanagedType.IDispatch)]
             [DispId(unchecked((int)0xFFFFEC78))]
             [TypeLibFunc(0x0040)]
-            object get_accParent();
+            object? get_accParent();
 
             [DispId(unchecked((int)0xFFFFEC77))]
             [TypeLibFunc(0x0040)]
@@ -26,39 +26,39 @@ internal static partial class Interop
             [return: MarshalAs(UnmanagedType.IDispatch)]
             [TypeLibFunc(0x0040)]
             [DispId(unchecked((int)0xFFFFEC76))]
-            object get_accChild(
+            object? get_accChild(
                 [MarshalAs(UnmanagedType.Struct)] object varChild);
 
             [DispId(unchecked((int)0xFFFFEC75))]
             [TypeLibFunc(0x0040)]
-            string get_accName(
+            string? get_accName(
                 [Optional][MarshalAs(UnmanagedType.Struct)] object varChild);
 
             [TypeLibFunc(0x0040)]
             [DispId(unchecked((int)0xFFFFEC74))]
-            string get_accValue(
+            string? get_accValue(
                 [Optional][MarshalAs(UnmanagedType.Struct)] object varChild);
 
             [DispId(unchecked((int)0xFFFFEC73))]
             [TypeLibFunc(0x0040)]
-            string get_accDescription(
+            string? get_accDescription(
                 [Optional][MarshalAs(UnmanagedType.Struct)] object varChild);
 
             [return: MarshalAs(UnmanagedType.Struct)]
             [DispId(unchecked((int)0xFFFFEC72))]
             [TypeLibFunc(0x0040)]
-            object get_accRole(
+            object? get_accRole(
                 [Optional][MarshalAs(UnmanagedType.Struct)] object varChild);
 
             [return: MarshalAs(UnmanagedType.Struct)]
             [TypeLibFunc(0x0040)]
             [DispId(unchecked((int)0xFFFFEC71))]
-            object get_accState(
+            object? get_accState(
                 [Optional][MarshalAs(UnmanagedType.Struct)] object varChild);
 
             [TypeLibFunc(0x0040)]
             [DispId(unchecked((int)0xFFFFEC70))]
-            string get_accHelp(
+            string? get_accHelp(
                 [Optional][MarshalAs(UnmanagedType.Struct)] object varChild);
 
             [DispId(unchecked((int)0xFFFFEC6F))]
@@ -69,23 +69,23 @@ internal static partial class Interop
 
             [DispId(unchecked((int)0xFFFFEC6E))]
             [TypeLibFunc(0x0040)]
-            string get_accKeyboardShortcut(
+            string? get_accKeyboardShortcut(
                 [Optional][MarshalAs(UnmanagedType.Struct)] object varChild);
 
             [return: MarshalAs(UnmanagedType.Struct)]
             [DispId(unchecked((int)0xFFFFEC6D))]
             [TypeLibFunc(0x0040)]
-            object get_accFocus();
+            object? get_accFocus();
 
             [return: MarshalAs(UnmanagedType.Struct)]
             [DispId(unchecked((int)0xFFFFEC6C))]
             [TypeLibFunc(0x0040)]
-            object get_accSelection();
+            object? get_accSelection();
 
             [return: MarshalAs(UnmanagedType.BStr)]
             [TypeLibFunc(0x0040)]
             [DispId(unchecked((int)0xFFFFEC6B))]
-            string get_accDefaultAction(
+            string? get_accDefaultAction(
                 [Optional][MarshalAs(UnmanagedType.Struct)] object varChild);
 
             [DispId(unchecked((int)0xFFFFEC6A))]
@@ -106,14 +106,14 @@ internal static partial class Interop
             [return: MarshalAs(UnmanagedType.Struct)]
             [TypeLibFunc(0x0040)]
             [DispId(unchecked((int)0xFFFFEC68))]
-            object accNavigate(
+            object? accNavigate(
                 int navDir,
                 [Optional][MarshalAs(UnmanagedType.Struct)] object varStart);
 
             [return: MarshalAs(UnmanagedType.Struct)]
             [TypeLibFunc(0x0040)]
             [DispId(unchecked((int)0xFFFFEC67))]
-            object accHitTest(
+            object? accHitTest(
                 int xLeft,
                 int yTop);
 

--- a/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.IGridItemProvider.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.IGridItemProvider.cs
@@ -22,7 +22,7 @@ internal static partial class Interop
 
             int ColumnSpan { get; }
 
-            IRawElementProviderSimple ContainingGrid { get; }
+            IRawElementProviderSimple? ContainingGrid { get; }
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.IGridProvider.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.IGridProvider.cs
@@ -15,7 +15,7 @@ internal static partial class Interop
         public interface IGridProvider
         {
             [return: MarshalAs(UnmanagedType.IUnknown)]
-            object /*IRawElementProviderSimple*/ GetItem(int row, int column);
+            object? /*IRawElementProviderSimple*/ GetItem(int row, int column);
 
             int RowCount { get; }
 

--- a/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.ILegacyIAccessibleProvider.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.ILegacyIAccessibleProvider.cs
@@ -21,27 +21,27 @@ internal static partial class Interop
 
             void SetValue([MarshalAs(UnmanagedType.LPWStr)] string szValue);
 
-            IAccessible GetIAccessible();
+            IAccessible? GetIAccessible();
 
             int ChildId { get; }
 
-            string Name { get; }
+            string? Name { get; }
 
-            string Value { get; }
+            string? Value { get; }
 
-            string Description { get; }
+            string? Description { get; }
 
             uint Role { get; }
 
             uint State { get; }
 
-            string Help { get; }
+            string? Help { get; }
 
-            string KeyboardShortcut { get; }
+            string? KeyboardShortcut { get; }
 
-            object[] /* IRawElementProviderSimple[] */ GetSelection();
+            object[]? /* IRawElementProviderSimple[] */ GetSelection();
 
-            string DefaultAction { get; }
+            string? DefaultAction { get; }
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.IRawElementProviderFragment.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.IRawElementProviderFragment.cs
@@ -29,7 +29,7 @@ internal static partial class Interop
             /// <param name="direction">Indicates the direction in which to navigate</param>
             /// <returns>Returns the element in the specified direction</returns>
             [return: MarshalAs(UnmanagedType.IUnknown)]
-            object /*IRawElementProviderFragment*/ Navigate(NavigateDirection direction);
+            object? /*IRawElementProviderFragment*/ Navigate(NavigateDirection direction);
 
             /// <summary>
             ///  Gets the runtime ID of an elemenent. This should be unique
@@ -41,7 +41,7 @@ internal static partial class Interop
             ///  with AutomationInteropProvider.AppendRuntimeId, followed by values
             ///  which are then unique within that proxy's HWNDs.
             /// </remarks>
-            int[] GetRuntimeId();
+            int[]? GetRuntimeId();
 
             /// <summary>
             ///  Return a bounding rectangle of this element
@@ -56,7 +56,7 @@ internal static partial class Interop
             ///  If this UI does not host other UI, it may return null.
             /// </summary>
             [return: MarshalAs(UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_UNKNOWN)]
-            object[] /*IRawElementProviderSimple[]*/ GetEmbeddedFragmentRoots();
+            object[]? /*IRawElementProviderSimple[]*/ GetEmbeddedFragmentRoots();
 
             /// <summary>
             ///  Request that focus is set to this item.
@@ -69,7 +69,7 @@ internal static partial class Interop
             /// <summary>
             ///  Return the element that is the root node of this fragment of UI.
             /// </summary>
-            IRawElementProviderFragmentRoot FragmentRoot { get; }
+            IRawElementProviderFragmentRoot? FragmentRoot { get; }
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.IRawElementProviderFragmentRoot.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.IRawElementProviderFragmentRoot.cs
@@ -31,7 +31,7 @@ internal static partial class Interop
             ///  otherwise return null.
             /// </returns>
             [return: MarshalAs(UnmanagedType.IUnknown)]
-            object /*IRawElementProviderFragment*/ ElementProviderFromPoint(double x, double y);
+            object? /*IRawElementProviderFragment*/ ElementProviderFromPoint(double x, double y);
 
             /// <summary>
             ///  Return the element in this fragment which has the keyboard focus,
@@ -39,7 +39,7 @@ internal static partial class Interop
             /// <returns>Return the element in this fragment which has the keyboard focus,
             ///  if any; otherwise return null.</returns>
             [return: MarshalAs(UnmanagedType.IUnknown)]
-            object /*IRawElementProviderFragment*/ GetFocus();
+            object? /*IRawElementProviderFragment*/ GetFocus();
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.IRawElementProviderHwndOverride.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.IRawElementProviderHwndOverride.cs
@@ -24,7 +24,7 @@ internal static partial class Interop
             /// </summary>
             /// <param name="hwnd">The window handle of the component.</param>
             /// <returns>Return the provider for the specified component, or null if the component is not being overridden.</returns>
-            IRawElementProviderSimple GetOverrideProviderForHwnd(IntPtr hwnd);
+            IRawElementProviderSimple? GetOverrideProviderForHwnd(IntPtr hwnd);
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.IRawElementProviderSimple.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.IRawElementProviderSimple.cs
@@ -34,14 +34,14 @@ internal static partial class Interop
             /// <param name="patternId">Identifier indicating the interface to return</param>
             /// <returns>Returns the interface as an object, if supported; otherwise returns null/</returns>
             [return: MarshalAs(UnmanagedType.IUnknown)]
-            object GetPatternProvider(UIA patternId);
+            object? GetPatternProvider(UIA patternId);
 
             /// <summary>
             ///  Request value of specified property from an element.
             /// </summary>
             /// <param name="propertyId">Identifier indicating the property to return</param>
             /// <returns>Returns a ValInfo indicating whether the element supports this property, or has no value for it.</returns>
-            object GetPropertyValue(UIA propertyId);
+            object? GetPropertyValue(UIA propertyId);
 
             // Only native impl roots need to return something for this,
             // proxies always return null (cause we already know their HWNDs)
@@ -54,7 +54,7 @@ internal static partial class Interop
             ///  Typically only used by elements that correspond directly to a Win32 Window Handle,
             ///  in which case the implementation returns AutomationInteropProvider.BaseElementFromHandle( hwnd ).
             /// </summary>
-            IRawElementProviderSimple HostRawElementProvider { get; }
+            IRawElementProviderSimple? HostRawElementProvider { get; }
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.ISelectionItemProvider.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.ISelectionItemProvider.cs
@@ -45,7 +45,7 @@ internal static partial class Interop
             ///  The logical element that supports the SelectionPattern for this Item.
             /// </summary>
             /// <returns>Returns a IRawElementProviderSimple.</returns>
-            IRawElementProviderSimple SelectionContainer { get; }
+            IRawElementProviderSimple? SelectionContainer { get; }
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.ISelectionProvider.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.ISelectionProvider.cs
@@ -26,8 +26,7 @@ internal static partial class Interop
             /// </summary>
             /// <returns>An AutomationElement array containing the currently selected elements</returns>
             [return: MarshalAs(UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_UNKNOWN)]
-            /* IRawElementProviderSimple */
-            object[] GetSelection();
+            object[]? /* IRawElementProviderSimple */ GetSelection();
 
             /// <summary>
             ///  Indicates whether the control allows more than one element to be selected

--- a/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.ITableItemProvider.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.ITableItemProvider.cs
@@ -15,10 +15,10 @@ internal static partial class Interop
         public interface ITableItemProvider
         {
             [return: MarshalAs(UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_UNKNOWN)]
-            object[] /*IRawElementProviderSimple[]*/ GetRowHeaderItems();
+            object[]? /*IRawElementProviderSimple[]*/ GetRowHeaderItems();
 
             [return: MarshalAs(UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_UNKNOWN)]
-            object[] /*IRawElementProviderSimple[]*/ GetColumnHeaderItems();
+            object[]? /*IRawElementProviderSimple[]*/ GetColumnHeaderItems();
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.ITableProvider.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.ITableProvider.cs
@@ -15,10 +15,10 @@ internal static partial class Interop
         public interface ITableProvider
         {
             [return: MarshalAs(UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_UNKNOWN)]
-            object[] /*IRawElementProviderSimple[]*/ GetRowHeaders();
+            object[]? /*IRawElementProviderSimple[]*/ GetRowHeaders();
 
             [return: MarshalAs(UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_UNKNOWN)]
-            object[] /*IRawElementProviderSimple[]*/ GetColumnHeaders();
+            object[]? /*IRawElementProviderSimple[]*/ GetColumnHeaders();
 
             RowOrColumnMajor RowOrColumnMajor { get; }
         }

--- a/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.IValueProvider.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.IValueProvider.cs
@@ -18,10 +18,10 @@ internal static partial class Interop
             ///  Request to set the value that this UI element is representing
             /// </summary>
             /// <param name="value">Value to set the UI to</param>
-            void SetValue([MarshalAs(UnmanagedType.LPWStr)] string value);
+            void SetValue([MarshalAs(UnmanagedType.LPWStr)] string? value);
 
             /// <summary>Value of a value control, as a a string.</summary>
-            string Value { get; }
+            string? Value { get; }
 
             /// <summary>Indicates that the value can only be read, not modified.
             ///returns True if the control is read-only</summary>

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DEVMODEW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DEVMODEW.cs
@@ -17,7 +17,7 @@ internal static partial class Interop
             private const int CCHFORMNAME = 32;
 
             [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCHDEVICENAME)]
-            public string dmDeviceName;
+            public string? dmDeviceName;
             public ushort dmSpecVersion;
             public ushort dmDriverVersion;
             public ushort dmSize;
@@ -33,7 +33,7 @@ internal static partial class Interop
             public short dmTTOption;
             public short dmCollate;
             [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCHFORMNAME)]
-            public string dmFormName;
+            public string? dmFormName;
             public ushort dmLogPixels;
             public uint dmBitsPerPel;
             public uint dmPelsWidth;

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnumChildWindows.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnumChildWindows.cs
@@ -50,12 +50,7 @@ internal static partial class Interop
 
         private static BOOL HandleEnumChildWindowsNativeCallback(IntPtr hWnd, IntPtr lParam)
         {
-            if (GCHandle.FromIntPtr(lParam).Target is EnumChildWindowsCallback callback)
-            {
-                return callback(hWnd);
-            }
-
-            return BOOL.FALSE;
+            return ((EnumChildWindowsCallback)GCHandle.FromIntPtr(lParam).Target!)(hWnd);
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnumChildWindows.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnumChildWindows.cs
@@ -50,7 +50,12 @@ internal static partial class Interop
 
         private static BOOL HandleEnumChildWindowsNativeCallback(IntPtr hWnd, IntPtr lParam)
         {
-            return ((EnumChildWindowsCallback)GCHandle.FromIntPtr(lParam).Target)(hWnd);
+            if (GCHandle.FromIntPtr(lParam).Target is EnumChildWindowsCallback callback)
+            {
+                return callback(hWnd);
+            }
+
+            return BOOL.FALSE;
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnumThreadWindows.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnumThreadWindows.cs
@@ -36,12 +36,7 @@ internal static partial class Interop
 
         private static BOOL HandleEnumThreadWindowsNativeCallback(IntPtr hWnd, IntPtr lParam)
         {
-            if (GCHandle.FromIntPtr(lParam).Target is EnumThreadWindowsCallback callback)
-            {
-                return callback(hWnd);
-            }
-
-            return BOOL.FALSE;
+            return ((EnumThreadWindowsCallback)GCHandle.FromIntPtr(lParam).Target!)(hWnd);
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnumThreadWindows.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnumThreadWindows.cs
@@ -36,7 +36,12 @@ internal static partial class Interop
 
         private static BOOL HandleEnumThreadWindowsNativeCallback(IntPtr hWnd, IntPtr lParam)
         {
-            return ((EnumThreadWindowsCallback)GCHandle.FromIntPtr(lParam).Target)(hWnd);
+            if (GCHandle.FromIntPtr(lParam).Target is EnumThreadWindowsCallback callback)
+            {
+                return callback(hWnd);
+            }
+
+            return BOOL.FALSE;
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnumWindows.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnumWindows.cs
@@ -36,7 +36,12 @@ internal static partial class Interop
 
         private static BOOL HandleEnumWindowsNativeCallback(IntPtr hWnd, IntPtr lParam)
         {
-            return ((EnumWindowsCallback)GCHandle.FromIntPtr(lParam).Target)(hWnd);
+            if (GCHandle.FromIntPtr(lParam).Target is EnumWindowsCallback callback)
+            {
+                return callback(hWnd);
+            }
+
+            return BOOL.FALSE;
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnumWindows.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnumWindows.cs
@@ -36,12 +36,7 @@ internal static partial class Interop
 
         private static BOOL HandleEnumWindowsNativeCallback(IntPtr hWnd, IntPtr lParam)
         {
-            if (GCHandle.FromIntPtr(lParam).Target is EnumWindowsCallback callback)
-            {
-                return callback(hWnd);
-            }
-
-            return BOOL.FALSE;
+            return ((EnumWindowsCallback)GCHandle.FromIntPtr(lParam).Target!)(hWnd);
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetClipboardFormatNameW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetClipboardFormatNameW.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
@@ -15,7 +13,7 @@ internal static partial class Interop
         [DllImport(Libraries.User32, ExactSpelling = true)]
         private static unsafe extern int GetClipboardFormatNameW(uint format, char* lpszFormatName, int cchMaxCount);
 
-        public static unsafe string GetClipboardFormatNameW(uint format)
+        public static unsafe string? GetClipboardFormatNameW(uint format)
         {
             // The max length of the name of clipboard formats is equal to the max length
             // of a Win32 Atom of 255 chars. An additional null terminator character is added,

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetClipboardFormatNameW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetClipboardFormatNameW.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetCursor.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetCursor.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
         [DllImport(Libraries.User32, ExactSpelling = true)]
         private static extern IntPtr SetCursor(IntPtr hCursor);
 
-        public static IntPtr SetCursor(IHandle hCursor)
+        public static IntPtr SetCursor(IHandle? hCursor)
         {
             IntPtr result = SetCursor(hCursor?.Handle ?? IntPtr.Zero);
             GC.KeepAlive(hCursor);

--- a/src/System.Windows.Forms.Primitives/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Primitives/src/PublicAPI.Shipped.txt
@@ -1,3 +1,4 @@
+#nullable enable
 System.Windows.Forms.Automation.AutomationLiveSetting
 System.Windows.Forms.Automation.AutomationLiveSetting.Assertive = 2 -> System.Windows.Forms.Automation.AutomationLiveSetting
 System.Windows.Forms.Automation.AutomationLiveSetting.Off = 0 -> System.Windows.Forms.Automation.AutomationLiveSetting
@@ -16,14 +17,14 @@ System.Windows.Forms.Automation.AutomationNotificationProcessing.ImportantMostRe
 System.Windows.Forms.Automation.AutomationNotificationProcessing.MostRecent = 3 -> System.Windows.Forms.Automation.AutomationNotificationProcessing
 System.Windows.Forms.FileDialogCustomPlace
 System.Windows.Forms.FileDialogCustomPlace.FileDialogCustomPlace(System.Guid knownFolderGuid) -> void
-System.Windows.Forms.FileDialogCustomPlace.FileDialogCustomPlace(string path) -> void
+System.Windows.Forms.FileDialogCustomPlace.FileDialogCustomPlace(string? path) -> void
 System.Windows.Forms.FileDialogCustomPlace.KnownFolderGuid.get -> System.Guid
 System.Windows.Forms.FileDialogCustomPlace.KnownFolderGuid.set -> void
-System.Windows.Forms.FileDialogCustomPlace.Path.get -> string
+System.Windows.Forms.FileDialogCustomPlace.Path.get -> string!
 System.Windows.Forms.FileDialogCustomPlace.Path.set -> void
 System.Windows.Forms.FileDialogCustomPlacesCollection
 System.Windows.Forms.FileDialogCustomPlacesCollection.Add(System.Guid knownFolderGuid) -> void
-System.Windows.Forms.FileDialogCustomPlacesCollection.Add(string path) -> void
+System.Windows.Forms.FileDialogCustomPlacesCollection.Add(string? path) -> void
 System.Windows.Forms.FileDialogCustomPlacesCollection.FileDialogCustomPlacesCollection() -> void
 System.Windows.Forms.HighDpiMode
 System.Windows.Forms.HighDpiMode.DpiUnaware = 0 -> System.Windows.Forms.HighDpiMode
@@ -32,7 +33,7 @@ System.Windows.Forms.HighDpiMode.PerMonitor = 2 -> System.Windows.Forms.HighDpiM
 System.Windows.Forms.HighDpiMode.PerMonitorV2 = 3 -> System.Windows.Forms.HighDpiMode
 System.Windows.Forms.HighDpiMode.SystemAware = 1 -> System.Windows.Forms.HighDpiMode
 System.Windows.Forms.Message
-System.Windows.Forms.Message.GetLParam(System.Type cls) -> object
+System.Windows.Forms.Message.GetLParam(System.Type! cls) -> object?
 System.Windows.Forms.Message.HWnd.get -> System.IntPtr
 System.Windows.Forms.Message.HWnd.set -> void
 System.Windows.Forms.Message.LParam.get -> System.IntPtr
@@ -138,21 +139,21 @@ System.Windows.Forms.VisualStyles.ThemeSizeType
 System.Windows.Forms.VisualStyles.ThemeSizeType.Draw = 2 -> System.Windows.Forms.VisualStyles.ThemeSizeType
 System.Windows.Forms.VisualStyles.ThemeSizeType.Minimum = 0 -> System.Windows.Forms.VisualStyles.ThemeSizeType
 System.Windows.Forms.VisualStyles.ThemeSizeType.True = 1 -> System.Windows.Forms.VisualStyles.ThemeSizeType
-override System.Windows.Forms.FileDialogCustomPlace.ToString() -> string
-override System.Windows.Forms.Message.Equals(object o) -> bool
+override System.Windows.Forms.FileDialogCustomPlace.ToString() -> string!
+override System.Windows.Forms.Message.Equals(object? o) -> bool
 override System.Windows.Forms.Message.GetHashCode() -> int
-override System.Windows.Forms.Message.ToString() -> string
-override System.Windows.Forms.Padding.Equals(object other) -> bool
+override System.Windows.Forms.Message.ToString() -> string!
+override System.Windows.Forms.Padding.Equals(object? other) -> bool
 override System.Windows.Forms.Padding.GetHashCode() -> int
-override System.Windows.Forms.Padding.ToString() -> string
-override System.Windows.Forms.PaddingConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Type sourceType) -> bool
-override System.Windows.Forms.PaddingConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Type destinationType) -> bool
-override System.Windows.Forms.PaddingConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value) -> object
-override System.Windows.Forms.PaddingConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, System.Type destinationType) -> object
-override System.Windows.Forms.PaddingConverter.CreateInstance(System.ComponentModel.ITypeDescriptorContext context, System.Collections.IDictionary propertyValues) -> object
-override System.Windows.Forms.PaddingConverter.GetCreateInstanceSupported(System.ComponentModel.ITypeDescriptorContext context) -> bool
-override System.Windows.Forms.PaddingConverter.GetProperties(System.ComponentModel.ITypeDescriptorContext context, object value, System.Attribute[] attributes) -> System.ComponentModel.PropertyDescriptorCollection
-override System.Windows.Forms.PaddingConverter.GetPropertiesSupported(System.ComponentModel.ITypeDescriptorContext context) -> bool
+override System.Windows.Forms.Padding.ToString() -> string!
+override System.Windows.Forms.PaddingConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
+override System.Windows.Forms.PaddingConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type! destinationType) -> bool
+override System.Windows.Forms.PaddingConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value) -> object?
+override System.Windows.Forms.PaddingConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
+override System.Windows.Forms.PaddingConverter.CreateInstance(System.ComponentModel.ITypeDescriptorContext? context, System.Collections.IDictionary! propertyValues) -> object!
+override System.Windows.Forms.PaddingConverter.GetCreateInstanceSupported(System.ComponentModel.ITypeDescriptorContext? context) -> bool
+override System.Windows.Forms.PaddingConverter.GetProperties(System.ComponentModel.ITypeDescriptorContext? context, object! value, System.Attribute![]! attributes) -> System.ComponentModel.PropertyDescriptorCollection!
+override System.Windows.Forms.PaddingConverter.GetPropertiesSupported(System.ComponentModel.ITypeDescriptorContext? context) -> bool
 static System.Windows.Forms.Message.Create(System.IntPtr hWnd, int msg, System.IntPtr wparam, System.IntPtr lparam) -> System.Windows.Forms.Message
 static System.Windows.Forms.Message.operator !=(System.Windows.Forms.Message a, System.Windows.Forms.Message b) -> bool
 static System.Windows.Forms.Message.operator ==(System.Windows.Forms.Message a, System.Windows.Forms.Message b) -> bool

--- a/src/System.Windows.Forms.Primitives/src/System.Windows.Forms.Primitives.csproj
+++ b/src/System.Windows.Forms.Primitives/src/System.Windows.Forms.Primitives.csproj
@@ -4,6 +4,7 @@
     <AssemblyName>System.Windows.Forms.Primitives</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLSCompliant>true</CLSCompliant>
+    <Nullable>enable</Nullable>
     <!--the obsolete usage in public surface can't be removed-->
     <NoWarn>$(NoWarn);618</NoWarn>
     <Deterministic>true</Deterministic>

--- a/src/System.Windows.Forms.Primitives/src/System/ComponentModel/CompModSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/ComponentModel/CompModSwitches.cs
@@ -2,47 +2,45 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics;
 
 namespace System.ComponentModel
 {
     internal static class CompModSwitches
     {
-        private static TraceSwitch activeX;
-        private static TraceSwitch flowLayout;
-        private static TraceSwitch dataCursor;
-        private static TraceSwitch dataGridCursor;
-        private static TraceSwitch dataGridEditing;
-        private static TraceSwitch dataGridKeys;
-        private static TraceSwitch dataGridLayout;
-        private static TraceSwitch dataGridPainting;
-        private static TraceSwitch dataGridParents;
-        private static TraceSwitch dataGridScrolling;
-        private static TraceSwitch dataGridSelection;
-        private static TraceSwitch dataObject;
-        private static TraceSwitch dataView;
-        private static TraceSwitch debugGridView;
-        private static TraceSwitch dgCaptionPaint;
-        private static TraceSwitch dgEditColumnEditing;
-        private static TraceSwitch dgRelationShpRowLayout;
-        private static TraceSwitch dgRelationShpRowPaint;
-        private static TraceSwitch dgRowPaint;
-        private static TraceSwitch dragDrop;
-        private static TraceSwitch imeMode;
-        private static TraceSwitch msaa;
-        private static TraceSwitch msoComponentManager;
-        private static TraceSwitch layoutPerformance;
-        private static TraceSwitch layoutSuspendResume;
-        private static TraceSwitch richLayout;
-        private static TraceSwitch setBounds;
+        private static TraceSwitch? activeX;
+        private static TraceSwitch? flowLayout;
+        private static TraceSwitch? dataCursor;
+        private static TraceSwitch? dataGridCursor;
+        private static TraceSwitch? dataGridEditing;
+        private static TraceSwitch? dataGridKeys;
+        private static TraceSwitch? dataGridLayout;
+        private static TraceSwitch? dataGridPainting;
+        private static TraceSwitch? dataGridParents;
+        private static TraceSwitch? dataGridScrolling;
+        private static TraceSwitch? dataGridSelection;
+        private static TraceSwitch? dataObject;
+        private static TraceSwitch? dataView;
+        private static TraceSwitch? debugGridView;
+        private static TraceSwitch? dgCaptionPaint;
+        private static TraceSwitch? dgEditColumnEditing;
+        private static TraceSwitch? dgRelationShpRowLayout;
+        private static TraceSwitch? dgRelationShpRowPaint;
+        private static TraceSwitch? dgRowPaint;
+        private static TraceSwitch? dragDrop;
+        private static TraceSwitch? imeMode;
+        private static TraceSwitch? msaa;
+        private static TraceSwitch? msoComponentManager;
+        private static TraceSwitch? layoutPerformance;
+        private static TraceSwitch? layoutSuspendResume;
+        private static TraceSwitch? richLayout;
+        private static TraceSwitch? setBounds;
 
-        private static BooleanSwitch lifetimeTracing;
+        private static BooleanSwitch? lifetimeTracing;
 
-        private static TraceSwitch s_handleLeak;
-        private static BooleanSwitch s_traceCollect;
-        private static BooleanSwitch s_commonDesignerServices;
+        private static TraceSwitch? s_handleLeak;
+        private static BooleanSwitch? s_traceCollect;
+        private static BooleanSwitch? s_commonDesignerServices;
 
         public static TraceSwitch ActiveX
         {

--- a/src/System.Windows.Forms.Primitives/src/System/ComponentModel/CompModSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/ComponentModel/CompModSwitches.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 
 namespace System.ComponentModel

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlace.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlace.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using static Interop;
 using static Interop.Shell32;
 
@@ -19,7 +20,7 @@ namespace System.Windows.Forms
         private string _path = string.Empty;
         private Guid _knownFolderGuid = Guid.Empty;
 
-        public FileDialogCustomPlace(string path)
+        public FileDialogCustomPlace(string? path)
         {
             Path = path;
         }
@@ -29,6 +30,7 @@ namespace System.Windows.Forms
             KnownFolderGuid = knownFolderGuid;
         }
 
+        [AllowNull]
         public string Path
         {
             get => _path ?? string.Empty;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlace.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlace.cs
@@ -1,8 +1,6 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 using static Interop;
 using static Interop.Shell32;
@@ -61,7 +59,7 @@ namespace System.Windows.Forms
         ///  to an actual filesystem directory.
         ///  The caller is responsible for handling these situations.
         /// </remarks>
-        internal IShellItem GetNativePath()
+        internal IShellItem? GetNativePath()
         {
             string filePathString;
             if (!string.IsNullOrEmpty(_path))

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlace.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlace.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using static Interop;
 using static Interop.Shell32;
 

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlacesCollection.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlacesCollection.cs
@@ -19,7 +19,7 @@ namespace System.Windows.Forms
 
                 try
                 {
-                    IShellItem shellItem? = customPlace.GetNativePath();
+                    IShellItem? shellItem = customPlace.GetNativePath();
                     if (null != shellItem)
                     {
                         dialog.AddPlace(shellItem, 0);

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlacesCollection.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlacesCollection.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -19,7 +19,7 @@ namespace System.Windows.Forms
 
                 try
                 {
-                    IShellItem shellItem = customPlace.GetNativePath();
+                    IShellItem shellItem? = customPlace.GetNativePath();
                     if (null != shellItem)
                     {
                         dialog.AddPlace(shellItem, 0);

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlacesCollection.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlacesCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -20,7 +20,7 @@ namespace System.Windows.Forms
                 try
                 {
                     IShellItem? shellItem = customPlace.GetNativePath();
-                    if (shellItem is object)
+                    if (shellItem != null)
                     {
                         dialog.AddPlace(shellItem, 0);
                     }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlacesCollection.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlacesCollection.cs
@@ -20,7 +20,7 @@ namespace System.Windows.Forms
                 try
                 {
                     IShellItem? shellItem = customPlace.GetNativePath();
-                    if (null != shellItem)
+                    if (shellItem is object)
                     {
                         dialog.AddPlace(shellItem, 0);
                     }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlacesCollection.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlacesCollection.cs
@@ -33,7 +33,7 @@ namespace System.Windows.Forms
             }
         }
 
-        public void Add(string path) => Add(new FileDialogCustomPlace(path));
+        public void Add(string? path) => Add(new FileDialogCustomPlace(path));
 
         public void Add(Guid knownFolderGuid) => Add(new FileDialogCustomPlace(knownFolderGuid));
     }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ClientUtils.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ClientUtils.cs
@@ -1,11 +1,10 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Numerics;
 
@@ -148,7 +147,7 @@ namespace System.Windows.Forms
 
 #if DEBUG
         [ThreadStatic]
-        private static Hashtable enumValueInfo;
+        private static Hashtable? enumValueInfo;
         public const int MAXCACHE = 300;  // we think we're going to get O(100) of these, put in a tripwire if it gets larger.
 
         private class SequentialEnumInfo
@@ -159,7 +158,9 @@ namespace System.Windows.Forms
                 int actualMaximum = int.MinValue;
                 int countEnumVals = 0;
 
+#pragma warning disable CS8605 // Unboxing a possibly null value.
                 foreach (int iVal in Enum.GetValues(t))
+#pragma warning restore CS8605 // Unboxing a possibly null value.
                 {
                     actualMinimum = Math.Min(actualMinimum, iVal);
                     actualMaximum = Math.Max(actualMaximum, iVal);
@@ -186,7 +187,7 @@ namespace System.Windows.Forms
                 enumValueInfo = new Hashtable();
             }
 
-            SequentialEnumInfo sequentialEnumInfo = null;
+            SequentialEnumInfo? sequentialEnumInfo = null;
 
             if (enumValueInfo.ContainsKey(t))
             {
@@ -220,7 +221,9 @@ namespace System.Windows.Forms
         {
             Type t = value.GetType();
             uint newmask = 0;
+#pragma warning disable CS8605 // Unboxing a possibly null value.
             foreach (int iVal in Enum.GetValues(t))
+#pragma warning restore CS8605 // Unboxing a possibly null value.
             {
                 newmask |= (uint)iVal;
             }
@@ -234,7 +237,9 @@ namespace System.Windows.Forms
                int checkedValue = Convert.ToInt32(value, CultureInfo.InvariantCulture);
                int maxBitsFound = 0;
                bool foundValue = false;
+#pragma warning disable CS8605 // Unboxing a possibly null value.
                foreach (int iVal in Enum.GetValues(t)){
+#pragma warning restore CS8605 // Unboxing a possibly null value.
                    actualMinimum = Math.Min(actualMinimum, iVal);
                    actualMaximum = Math.Max(actualMaximum, iVal);
                    maxBitsFound = Math.Max(maxBitsFound, BitOperations.PopCount((uint)iVal));

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ClientUtils.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ClientUtils.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Diagnostics;
 using System.Globalization;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/DpiHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/DpiHelper.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
+using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using static Interop;
@@ -289,7 +288,8 @@ namespace System.Windows.Forms
         /// </summary>
         /// <param name="logicalImage">The image to scale from logical units to device units</param>
         /// <param name="targetImageSize">The size to scale image to</param>
-        public static Bitmap CreateResizedBitmap(Bitmap logicalImage, Size targetImageSize)
+        [return: NotNullIfNotNull("logicalImage")]
+        public static Bitmap? CreateResizedBitmap(Bitmap? logicalImage, Size targetImageSize)
         {
             if (logicalImage == null)
             {

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/DpiHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/DpiHelper.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using static Interop;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/FileDialog_Vista_Interop.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/FileDialog_Vista_Interop.cs
@@ -345,9 +345,9 @@ namespace System.Windows.Forms
         public struct COMDLG_FILTERSPEC
         {
             [MarshalAs(UnmanagedType.LPWStr)]
-            public string pszName;
+            public string? pszName;
             [MarshalAs(UnmanagedType.LPWStr)]
-            public string pszSpec;
+            public string? pszSpec;
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/FileDialog_Vista_Interop.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/FileDialog_Vista_Interop.cs
@@ -1,6 +1,8 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+#nullable disable
 
 using System.ComponentModel;
 using System.IO;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/FileDialog_Vista_Interop.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/FileDialog_Vista_Interop.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.IO;
 using System.Runtime.InteropServices;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/MessageDecoder.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/MessageDecoder.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 using static Interop.User32;
 
@@ -19,9 +17,9 @@ namespace System.Windows.Forms
         ///  Returns the symbolic name of the msg value, or null if it isn't one of the
         ///  existing constants.
         /// </summary>
-        private static string MsgToString(int msg)
+        private static string? MsgToString(int msg)
         {
-            string text;
+            string? text;
             switch (msg)
             {
                 case (int)WM.NULL:
@@ -841,7 +839,7 @@ namespace System.Windows.Forms
             return text;
         }
 
-        private static string Parenthesize(string input)
+        private static string Parenthesize(string? input)
         {
             if (input == null)
             {

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/MessageDecoder.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/MessageDecoder.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using static Interop;
 using static Interop.User32;
 

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -1,8 +1,6 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 using System.Drawing;
 using System.Runtime.InteropServices;
@@ -100,11 +98,11 @@ namespace System.Windows.Forms
         {
             internal int cbStruct = Marshal.SizeOf<HH_AKLINK>();
             internal bool fReserved = false;
-            internal string pszKeywords = null;
-            internal string pszUrl = null;
-            internal string pszMsgText = null;
-            internal string pszMsgTitle = null;
-            internal string pszWindow = null;
+            internal string? pszKeywords = null;
+            internal string? pszUrl = null;
+            internal string? pszMsgText = null;
+            internal string? pszMsgTitle = null;
+            internal string? pszWindow = null;
             internal bool fIndexOnFail = false;
         }
 
@@ -119,7 +117,7 @@ namespace System.Windows.Forms
             internal int clrForeground = -1;
             internal int clrBackground = -1;
             internal RECT rcMargins = new RECT(-1, -1, -1, -1);     // amount of space between edges of window and text, -1 for each member to ignore
-            internal string pszFont = null;
+            internal string? pszFont = null;
         }
 
         public const int HH_FTS_DEFAULT_PROXIMITY = -1;
@@ -130,13 +128,13 @@ namespace System.Windows.Forms
             internal int cbStruct = Marshal.SizeOf<HH_FTS_QUERY>();
             internal bool fUniCodeStrings = false;
             [MarshalAs(UnmanagedType.LPStr)]
-            internal string pszSearchQuery = null;
+            internal string? pszSearchQuery = null;
             internal int iProximity = NativeMethods.HH_FTS_DEFAULT_PROXIMITY;
             internal bool fStemmedSearch = false;
             internal bool fTitleOnly = false;
             internal bool fExecute = true;
             [MarshalAs(UnmanagedType.LPStr)]
-            internal string pszWindow = null;
+            internal string? pszWindow = null;
         }
 
         public delegate IntPtr WndProc(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
@@ -171,9 +169,9 @@ namespace System.Windows.Forms
 
             public IntPtr hInstance;
             [MarshalAs(UnmanagedType.LPStr)]
-            public string lpPrintTemplateName;
+            public string? lpPrintTemplateName;
 
-            public WndProc lpCallback = null;
+            public WndProc? lpCallback = null;
 
             public int nPropertyPages;
 
@@ -197,7 +195,7 @@ namespace System.Windows.Forms
             public int lStructSize = Marshal.SizeOf<OPENFILENAME_I>(); //ndirect.DllLib.sizeOf(this);
             public IntPtr hwndOwner;
             public IntPtr hInstance;
-            public string lpstrFilter;   // use embedded nulls to separate filters
+            public string? lpstrFilter;   // use embedded nulls to separate filters
             public IntPtr lpstrCustomFilter = IntPtr.Zero;
             public int nMaxCustFilter = 0;
             public int nFilterIndex;
@@ -205,15 +203,15 @@ namespace System.Windows.Forms
             public int nMaxFile = Kernel32.MAX_PATH;
             public IntPtr lpstrFileTitle = IntPtr.Zero;
             public int nMaxFileTitle = Kernel32.MAX_PATH;
-            public string lpstrInitialDir;
-            public string lpstrTitle;
+            public string? lpstrInitialDir;
+            public string? lpstrTitle;
             public int Flags;
             public short nFileOffset = 0;
             public short nFileExtension = 0;
-            public string lpstrDefExt;
+            public string? lpstrDefExt;
             public IntPtr lCustData = IntPtr.Zero;
-            public WndProc lpfnHook;
-            public string lpTemplateName = null;
+            public WndProc? lpfnHook;
+            public string? lpTemplateName = null;
             public IntPtr pvReserved = IntPtr.Zero;
             public int dwReserved = 0;
             public int FlagsEx;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Drawing;
 using System.Runtime.InteropServices;
 using static Interop;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -56,6 +56,6 @@ namespace System.Windows.Forms
         public static extern void GetTempFileName(string tempDirName, string prefixName, int unique, StringBuilder sb);
 
         [DllImport(Libraries.Oleacc, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern int CreateStdAccessibleObject(HandleRef hWnd, int objID, ref Guid refiid, [In, Out, MarshalAs(UnmanagedType.Interface)] ref object pAcc);
+        public static extern int CreateStdAccessibleObject(HandleRef hWnd, int objID, ref Guid refiid, [In, Out, MarshalAs(UnmanagedType.Interface)] ref object? pAcc);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/WeakRefCollection.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/WeakRefCollection.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 using System.Collections;
 using System.Diagnostics;
@@ -45,7 +43,7 @@ namespace System.Windows.Forms
         /// </summary>
         public int RefCheckThreshold { get; set; } = int.MaxValue; // this means this is disabled by default.
 
-        public object this[int index]
+        public object? this[int index]
         {
             get
             {
@@ -65,7 +63,7 @@ namespace System.Windows.Forms
             int currentCount = Count;
             for (int i = 0; i < currentCount; i++)
             {
-                object item = this[currentIndex];
+                object? item = this[currentIndex];
 
                 if (item == null)
                 {
@@ -79,9 +77,9 @@ namespace System.Windows.Forms
             }
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
-            WeakRefCollection other = obj as WeakRefCollection;
+            WeakRefCollection? other = obj as WeakRefCollection;
             if (other == this)
             {
                 return true;
@@ -94,9 +92,10 @@ namespace System.Windows.Forms
 
             for (int i = 0; i < Count; i++)
             {
-                if (InnerList[i] != other.InnerList[i])
+                WeakRefObject? item = (WeakRefObject?)InnerList[i];
+                if (item != other.InnerList[i])
                 {
-                    if (InnerList[i] == null || !InnerList[i].Equals(other.InnerList[i]))
+                    if (item is null || !item.Equals(other.InnerList[i]))
                     {
                         return false;
                     }
@@ -109,7 +108,7 @@ namespace System.Windows.Forms
         public override int GetHashCode()
         {
             var hash = new HashCode();
-            foreach (object o in InnerList)
+            foreach (WeakRefObject? o in InnerList)
             {
                 hash.Add(o);
             }
@@ -117,7 +116,7 @@ namespace System.Windows.Forms
             return hash.ToHashCode();
         }
 
-        private WeakRefObject CreateWeakRefObject(object value)
+        private WeakRefObject? CreateWeakRefObject(object? value)
         {
             if (value == null)
             {
@@ -166,7 +165,8 @@ namespace System.Windows.Forms
             int hash = value.GetHashCode();
             for (int idx = 0; idx < InnerList.Count; idx++)
             {
-                if (InnerList[idx] != null && InnerList[idx].GetHashCode() == hash)
+                WeakRefObject? item = (WeakRefObject?)InnerList[idx];
+                if (item != null && item.GetHashCode() == hash)
                 {
                     RemoveAt(idx);
                     return;
@@ -178,17 +178,17 @@ namespace System.Windows.Forms
 
         public bool IsFixedSize => InnerList.IsFixedSize;
 
-        public bool Contains(object value) => InnerList.Contains(CreateWeakRefObject(value));
+        public bool Contains(object? value) => InnerList.Contains(CreateWeakRefObject(value));
 
         public void RemoveAt(int index) => InnerList.RemoveAt(index);
 
-        public void Remove(object value) => InnerList.Remove(CreateWeakRefObject(value));
+        public void Remove(object? value) => InnerList.Remove(CreateWeakRefObject(value));
 
-        public int IndexOf(object value) => InnerList.IndexOf(CreateWeakRefObject(value));
+        public int IndexOf(object? value) => InnerList.IndexOf(CreateWeakRefObject(value));
 
-        public void Insert(int index, object value) => InnerList.Insert(index, CreateWeakRefObject(value));
+        public void Insert(int index, object? value) => InnerList.Insert(index, CreateWeakRefObject(value));
 
-        public int Add(object value)
+        public int Add(object? value)
         {
             if (Count > RefCheckThreshold)
             {
@@ -230,13 +230,13 @@ namespace System.Windows.Forms
 
             internal bool IsAlive => weakHolder.IsAlive;
 
-            internal object Target => weakHolder.Target;
+            internal object? Target => weakHolder.Target;
 
             public override int GetHashCode() => _hash;
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
-                WeakRefObject other = obj as WeakRefObject;
+                WeakRefObject? other = obj as WeakRefObject;
 
                 if (other == this)
                 {

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Message.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Message.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using static Interop;
@@ -32,7 +30,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Gets the <see cref='LParam'/> value, and converts the value to an object.
         /// </summary>
-        public object GetLParam(Type cls) => Marshal.PtrToStructure(LParam, cls);
+        public object? GetLParam(Type cls) => Marshal.PtrToStructure(LParam, cls);
 
         internal static Message Create(IntPtr hWnd, User32.WM msg, IntPtr wparam, IntPtr lparam)
             => Create(hWnd, (int)msg, wparam, lparam);
@@ -57,7 +55,7 @@ namespace System.Windows.Forms
             return m;
         }
 
-        public override bool Equals(object o)
+        public override bool Equals(object? o)
         {
             if (!(o is Message m))
             {

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Message.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Message.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using static Interop;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Padding.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Padding.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Padding.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Padding.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
@@ -132,7 +130,7 @@ namespace System.Windows.Forms
 
         public static Padding Subtract(Padding p1, Padding p2) => p1 - p2;
 
-        public override bool Equals(object other)
+        public override bool Equals(object? other)
         {
             if (!(other is Padding otherPadding))
             {

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/PaddingConverter.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/PaddingConverter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/PaddingConverter.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/PaddingConverter.cs
@@ -16,7 +16,7 @@ namespace System.Windows.Forms
         ///  Determines if this converter can convert an object in the given source type to
         ///  the native type of the converter.
         /// </summary>
-        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
         {
             if (sourceType == typeof(string))
             {
@@ -26,7 +26,7 @@ namespace System.Windows.Forms
             return base.CanConvertFrom(context, sourceType);
         }
 
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        public override bool CanConvertTo(ITypeDescriptorContext? context, Type destinationType)
         {
             if (destinationType == typeof(InstanceDescriptor))
             {
@@ -39,7 +39,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Converts the given object to the converter's native type.
         /// </summary>
-        public override object? ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object? value)
         {
             if (value is string stringValue)
             {
@@ -75,7 +75,7 @@ namespace System.Windows.Forms
             return base.ConvertFrom(context, culture, value);
         }
 
-        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
         {
             if (value is Padding padding)
             {
@@ -120,7 +120,7 @@ namespace System.Windows.Forms
             return base.ConvertTo(context, culture, value, destinationType);
         }
 
-        public override object CreateInstance(ITypeDescriptorContext context, IDictionary propertyValues)
+        public override object CreateInstance(ITypeDescriptorContext? context, IDictionary propertyValues)
         {
             if (propertyValues is null)
             {
@@ -164,14 +164,14 @@ namespace System.Windows.Forms
             }
         }
 
-        public override bool GetCreateInstanceSupported(ITypeDescriptorContext context) => true;
+        public override bool GetCreateInstanceSupported(ITypeDescriptorContext? context) => true;
 
-        public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object value, Attribute[] attributes)
+        public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext? context, object value, Attribute[] attributes)
         {
             PropertyDescriptorCollection props = TypeDescriptor.GetProperties(typeof(Padding), attributes);
             return props.Sort(new string[] { nameof(Padding.All), nameof(Padding.Left), nameof(Padding.Top), nameof(Padding.Right), nameof(Padding.Bottom) });
         }
 
-        public override bool GetPropertiesSupported(ITypeDescriptorContext context) => true;
+        public override bool GetPropertiesSupported(ITypeDescriptorContext? context) => true;
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/PaddingConverter.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/PaddingConverter.cs
@@ -1,8 +1,6 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 using System.Collections;
 using System.ComponentModel;
@@ -41,7 +39,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Converts the given object to the converter's native type.
         /// </summary>
-        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        public override object? ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
             if (value is string stringValue)
             {
@@ -124,7 +122,7 @@ namespace System.Windows.Forms
 
         public override object CreateInstance(ITypeDescriptorContext context, IDictionary propertyValues)
         {
-            if (propertyValues == null)
+            if (propertyValues is null)
             {
                 throw new ArgumentNullException(nameof(propertyValues));
             }
@@ -142,16 +140,18 @@ namespace System.Windows.Forms
 
                 if (original is Padding originalPadding)
                 {
-                    int all = (int)propertyValues[nameof(Padding.All)];
+                    int all = (int)propertyValues[nameof(Padding.All)]!;
                     if (originalPadding.All != all)
+                    {
                         return new Padding(all);
+                    }
                 }
 
                 return new Padding(
-                    (int)propertyValues[nameof(Padding.Left)],
-                    (int)propertyValues[nameof(Padding.Top)],
-                    (int)propertyValues[nameof(Padding.Right)],
-                    (int)propertyValues[nameof(Padding.Bottom)]
+                    (int)propertyValues[nameof(Padding.Left)]!,
+                    (int)propertyValues[nameof(Padding.Top)]!,
+                    (int)propertyValues[nameof(Padding.Right)]!,
+                    (int)propertyValues[nameof(Padding.Bottom)]!
                 );
             }
             catch (InvalidCastException invalidCast)

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Mocks/MockAxHost.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Mocks/MockAxHost.cs
@@ -39,7 +39,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Mocks
             return (IPicture)OleCreatePictureIndirect(ref desc, ref ipicture_Guid, fOwn: BOOL.TRUE);
         }
 
-        public static Image GetPictureFromIPicture(object picture)
+        public static Image? GetPictureFromIPicture(object picture)
         {
             int hPal = default;
             IPicture pict = (IPicture)picture;
@@ -58,7 +58,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Mocks
             return GetPictureFromParams(pict.Handle, type, hPal, pict.Width, pict.Height);
         }
 
-        public static Image GetPictureFromIPictureDisp(object picture)
+        public static Image? GetPictureFromIPictureDisp(object picture)
         {
             if (picture == null)
             {
@@ -79,7 +79,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Mocks
                 }
             }
 
-            Image image = GetPictureFromParams(pict.Handle, type, hPal, pict.Width, pict.Height);
+            Image? image = GetPictureFromParams(pict.Handle, type, hPal, pict.Width, pict.Height);
             GC.KeepAlive(pict);
             return image;
         }
@@ -99,7 +99,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Mocks
             throw new ArgumentException("AXUnknownImage", nameof(image));
         }
 
-        private static Image GetPictureFromParams(
+        private static Image? GetPictureFromParams(
             int handle,
             PICTYPE type,
             int paletteHandle,

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Ole32/IPictureTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Ole32/IPictureTests.cs
@@ -60,7 +60,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Ole32
             using Bitmap bitmap = icon.ToBitmap();
             IPicture picture = MockAxHost.GetIPictureFromPicture(bitmap);
             Assert.NotNull(picture);
-            using Image image = MockAxHost.GetPictureFromIPicture(picture);
+            using Image image = MockAxHost.GetPictureFromIPicture(picture)!;
             Assert.NotNull(image);
             Assert.Equal(bitmap.Size, image.Size);
         }
@@ -71,7 +71,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Ole32
             using Bitmap bitmap = new Bitmap(100, 200);
             IPictureDisp picture = MockAxHost.GetIPictureDispFromPicture(bitmap);
             Assert.NotNull(picture);
-            using Image image = MockAxHost.GetPictureFromIPictureDisp(picture);
+            using Image image = MockAxHost.GetPictureFromIPictureDisp(picture)!;
             Assert.NotNull(image);
             Assert.Equal(bitmap.Size, image.Size);
         }

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Oleaut32/ITypeInfoTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Oleaut32/ITypeInfoTests.cs
@@ -412,9 +412,9 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
         // to an error so manual release is required to avoid running into this condition.
         private struct ComRefReleaser : IDisposable
         {
-            private object _reference;
+            private object? _reference;
 
-            public ComRefReleaser(object reference)
+            public ComRefReleaser(object? reference)
             {
                 _reference = reference;
             }

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/User32/GetWindowTextTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/User32/GetWindowTextTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -46,13 +46,13 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.User32
 
         private class ChangeWindowTextClass : WindowClass
         {
-            public Func<string> BeforeGetTextLengthCallback
+            public Func<string>? BeforeGetTextLengthCallback
             {
                 get;
                 set;
             }
 
-            public Func<string> BeforeGetTextCallback
+            public Func<string>? BeforeGetTextCallback
             {
                 get;
                 set;
@@ -63,7 +63,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.User32
                 switch (msg)
                 {
                     case WM.GETTEXTLENGTH:
-                        string text = BeforeGetTextLengthCallback?.Invoke();
+                        string? text = BeforeGetTextLengthCallback?.Invoke();
                         if (text != null)
                         {
                             SetWindowTextW(hWnd, text);

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System.Windows.Forms.Primitives.Tests.csproj
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System.Windows.Forms.Primitives.Tests.csproj
@@ -4,6 +4,7 @@
     <AssemblyName>System.Windows.Forms.Primitives.Tests</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);618</NoWarn>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/FileDialogCustomPlaceTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/FileDialogCustomPlaceTests.cs
@@ -9,9 +9,9 @@ namespace System.Windows.Forms.Tests
 {
     public class FileDialogCustomPlaceTests
     {
-        public static TheoryData<string> GetStringWithNullTheoryData()
+        public static TheoryData<string?> GetStringWithNullTheoryData()
         {
-            var data = new TheoryData<string>
+            var data = new TheoryData<string?>
             {
                 null,
                 string.Empty,
@@ -22,7 +22,7 @@ namespace System.Windows.Forms.Tests
 
         [Theory]
         [MemberData(nameof(GetStringWithNullTheoryData))]
-        public void FileDialogCustomPlace_Ctor_String(string path)
+        public void FileDialogCustomPlace_Ctor_String(string? path)
         {
             var place = new FileDialogCustomPlace(path);
             Assert.Equal(Guid.Empty, place.KnownFolderGuid);
@@ -67,7 +67,7 @@ namespace System.Windows.Forms.Tests
 
         [Theory]
         [MemberData(nameof(GetStringWithNullTheoryData))]
-        public void FileDialogCustomPlace_Path_Set_GetReturnsExpected(string value)
+        public void FileDialogCustomPlace_Path_Set_GetReturnsExpected(string? value)
         {
             var place = new FileDialogCustomPlace(Guid.NewGuid())
             {

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/FileDialogCustomPlacesCollectionTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/FileDialogCustomPlacesCollectionTests.cs
@@ -9,9 +9,9 @@ namespace System.Windows.Forms.Tests
 {
     public class FileDialogCustomPlacesCollectionTests
     {
-        public static TheoryData<string> GetStringWithNullTheoryData()
+        public static TheoryData<string?> GetStringWithNullTheoryData()
         {
-            var data = new TheoryData<string>
+            var data = new TheoryData<string?>
             {
                 null,
                 string.Empty,
@@ -22,7 +22,7 @@ namespace System.Windows.Forms.Tests
 
         [Theory]
         [MemberData(nameof(GetStringWithNullTheoryData))]
-        public void FileDialogCustomPlacesCollection_Add_String_Success(string path)
+        public void FileDialogCustomPlacesCollection_Add_String_Success(string? path)
         {
             var collection = new FileDialogCustomPlacesCollection
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -667,7 +667,7 @@ namespace System.Windows.Forms
 
         internal virtual bool IsReadOnly => false;
 
-        internal virtual void SetValue(string newValue)
+        internal virtual void SetValue(string? newValue)
         {
             Value = newValue;
         }
@@ -832,12 +832,14 @@ namespace System.Windows.Forms
 
         IAccessible? UiaCore.ILegacyIAccessibleProvider.GetIAccessible() => AsIAccessible(this);
 
-        object?[] UiaCore.ILegacyIAccessibleProvider.GetSelection()
+        object[]? UiaCore.ILegacyIAccessibleProvider.GetSelection()
         {
-            return new UiaCore.IRawElementProviderSimple?[]
+            if (GetSelected() is UiaCore.IRawElementProviderSimple selected)
             {
-                GetSelected() as UiaCore.IRawElementProviderSimple
-            };
+                return new UiaCore.IRawElementProviderSimple[] { selected };
+            }
+
+            return null;
         }
 
         void UiaCore.ILegacyIAccessibleProvider.Select(int flagsSelect) => Select((AccessibleSelection)flagsSelect);
@@ -856,7 +858,7 @@ namespace System.Windows.Forms
 
         string? UiaCore.IValueProvider.Value => Value;
 
-        void UiaCore.IValueProvider.SetValue(string newValue) => SetValue(newValue);
+        void UiaCore.IValueProvider.SetValue(string? newValue) => SetValue(newValue);
 
         void UiaCore.IToggleProvider.Toggle() => Toggle();
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/InternalAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/InternalAccessibleObject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -103,7 +103,7 @@ namespace System.Windows.Forms
         ///  If the given object is an AccessibleObject return it as a InternalAccessibleObject
         ///  This ensures we wrap all AccessibleObjects before handing them out to OLEACC
         /// </summary>
-        private object AsNativeAccessible(object accObject)
+        private object? AsNativeAccessible(object? accObject)
         {
             if (accObject is AccessibleObject accessibleObject)
             {
@@ -122,7 +122,7 @@ namespace System.Windows.Forms
             {
                 for (int i = 0; i < accObjectArray.Length; i++)
                 {
-                    accObjectArray[i] = AsNativeAccessible(accObjectArray[i]);
+                    accObjectArray[i] = AsNativeAccessible(accObjectArray[i])!;
                 }
             }
 
@@ -132,57 +132,57 @@ namespace System.Windows.Forms
         void IAccessibleInternal.accDoDefaultAction(object childID)
             => publicIAccessible.accDoDefaultAction(childID);
 
-        object IAccessibleInternal.accHitTest(int xLeft, int yTop)
+        object? IAccessibleInternal.accHitTest(int xLeft, int yTop)
             => AsNativeAccessible(publicIAccessible.accHitTest(xLeft, yTop));
 
         void IAccessibleInternal.accLocation(out int l, out int t, out int w, out int h, object childID)
             => publicIAccessible.accLocation(out l, out t, out w, out h, childID);
 
-        object IAccessibleInternal.accNavigate(int navDir, object childID)
+        object? IAccessibleInternal.accNavigate(int navDir, object childID)
             => AsNativeAccessible(publicIAccessible.accNavigate(navDir, childID));
 
         void IAccessibleInternal.accSelect(int flagsSelect, object childID)
             => publicIAccessible.accSelect(flagsSelect, childID);
 
-        object IAccessibleInternal.get_accChild(object childID)
+        object? IAccessibleInternal.get_accChild(object childID)
             => AsNativeAccessible(publicIAccessible.get_accChild(childID));
 
         int IAccessibleInternal.get_accChildCount() => publicIAccessible.accChildCount;
 
-        string IAccessibleInternal.get_accDefaultAction(object childID)
+        string? IAccessibleInternal.get_accDefaultAction(object childID)
             => publicIAccessible.get_accDefaultAction(childID);
 
-        string IAccessibleInternal.get_accDescription(object childID)
+        string? IAccessibleInternal.get_accDescription(object childID)
             => publicIAccessible.get_accDescription(childID);
 
-        object IAccessibleInternal.get_accFocus()
+        object? IAccessibleInternal.get_accFocus()
             => AsNativeAccessible(publicIAccessible.accFocus);
 
-        string IAccessibleInternal.get_accHelp(object childID)
+        string? IAccessibleInternal.get_accHelp(object childID)
             => publicIAccessible.get_accHelp(childID);
 
         int IAccessibleInternal.get_accHelpTopic(out string pszHelpFile, object childID)
             => publicIAccessible.get_accHelpTopic(out pszHelpFile, childID);
 
-        string IAccessibleInternal.get_accKeyboardShortcut(object childID)
+        string? IAccessibleInternal.get_accKeyboardShortcut(object childID)
             => publicIAccessible.get_accKeyboardShortcut(childID);
 
-        string IAccessibleInternal.get_accName(object childID)
+        string? IAccessibleInternal.get_accName(object childID)
             => publicIAccessible.get_accName(childID);
 
-        object IAccessibleInternal.get_accParent()
+        object? IAccessibleInternal.get_accParent()
             => AsNativeAccessible(publicIAccessible.accParent);
 
-        object IAccessibleInternal.get_accRole(object childID)
+        object? IAccessibleInternal.get_accRole(object childID)
             => publicIAccessible.get_accRole(childID);
 
-        object IAccessibleInternal.get_accSelection()
+        object? IAccessibleInternal.get_accSelection()
             => AsNativeAccessible(publicIAccessible.accSelection);
 
-        object IAccessibleInternal.get_accState(object childID)
+        object? IAccessibleInternal.get_accState(object childID)
             => publicIAccessible.get_accState(childID);
 
-        string IAccessibleInternal.get_accValue(object childID)
+        string? IAccessibleInternal.get_accValue(object childID)
             => publicIAccessible.get_accValue(childID);
 
         void IAccessibleInternal.set_accName(object childID, string newName)
@@ -191,7 +191,7 @@ namespace System.Windows.Forms
         void IAccessibleInternal.set_accValue(object childID, string newValue)
             => publicIAccessible.set_accValue(childID, newValue);
 
-        HRESULT Oleaut32.IEnumVariant.Clone(Oleaut32.IEnumVariant[] ppEnum)
+        HRESULT Oleaut32.IEnumVariant.Clone(Oleaut32.IEnumVariant[]? ppEnum)
             => publicIEnumVariant.Clone(ppEnum);
 
         unsafe HRESULT Oleaut32.IEnumVariant.Next(uint celt, IntPtr rgVar, uint* pCeltFetched)
@@ -254,7 +254,7 @@ namespace System.Windows.Forms
             return hr;
         }
 
-        IAccessibleEx IAccessibleEx.GetObjectForChild(int idChild)
+        IAccessibleEx? IAccessibleEx.GetObjectForChild(int idChild)
         {
             return publicIAccessibleEx.GetObjectForChild(idChild);
         }
@@ -273,15 +273,15 @@ namespace System.Windows.Forms
             return HRESULT.S_OK;
         }
 
-        int[] IAccessibleEx.GetRuntimeId() => publicIAccessibleEx.GetRuntimeId();
+        int[]? IAccessibleEx.GetRuntimeId() => publicIAccessibleEx.GetRuntimeId();
 
-        HRESULT IAccessibleEx.ConvertReturnedElement(IRawElementProviderSimple pIn, out IAccessibleEx ppRetValOut)
+        HRESULT IAccessibleEx.ConvertReturnedElement(IRawElementProviderSimple pIn, out IAccessibleEx? ppRetValOut)
             => publicIAccessibleEx.ConvertReturnedElement(pIn, out ppRetValOut);
 
         ProviderOptions IRawElementProviderSimple.ProviderOptions
             => publicIRawElementProviderSimple.ProviderOptions;
 
-        IRawElementProviderSimple IRawElementProviderSimple.HostRawElementProvider
+        IRawElementProviderSimple? IRawElementProviderSimple.HostRawElementProvider
             => publicIRawElementProviderSimple.HostRawElementProvider;
 
         object? IRawElementProviderSimple.GetPatternProvider(UIA patternId)
@@ -353,13 +353,13 @@ namespace System.Windows.Forms
             }
         }
 
-        object IRawElementProviderSimple.GetPropertyValue(UIA propertyID)
+        object? IRawElementProviderSimple.GetPropertyValue(UIA propertyID)
             => publicIRawElementProviderSimple.GetPropertyValue(propertyID);
 
-        object IRawElementProviderFragment.Navigate(NavigateDirection direction)
+        object? IRawElementProviderFragment.Navigate(NavigateDirection direction)
             => AsNativeAccessible(publicIRawElementProviderFragment.Navigate(direction));
 
-        int[] IRawElementProviderFragment.GetRuntimeId()
+        int[]? IRawElementProviderFragment.GetRuntimeId()
             => publicIRawElementProviderFragment.GetRuntimeId();
 
         object[]? IRawElementProviderFragment.GetEmbeddedFragmentRoots()
@@ -371,37 +371,37 @@ namespace System.Windows.Forms
         UiaRect IRawElementProviderFragment.BoundingRectangle
             => publicIRawElementProviderFragment.BoundingRectangle;
 
-        IRawElementProviderFragmentRoot IRawElementProviderFragment.FragmentRoot
+        IRawElementProviderFragmentRoot? IRawElementProviderFragment.FragmentRoot
             => publicIRawElementProviderFragment.FragmentRoot;
 
-        object IRawElementProviderFragmentRoot.ElementProviderFromPoint(double x, double y)
+        object? IRawElementProviderFragmentRoot.ElementProviderFromPoint(double x, double y)
             => AsNativeAccessible(publicIRawElementProviderFragmentRoot.ElementProviderFromPoint(x, y));
 
-        object IRawElementProviderFragmentRoot.GetFocus()
+        object? IRawElementProviderFragmentRoot.GetFocus()
             => AsNativeAccessible(publicIRawElementProviderFragmentRoot.GetFocus());
 
-        string ILegacyIAccessibleProvider.DefaultAction => publicILegacyIAccessibleProvider.DefaultAction;
+        string? ILegacyIAccessibleProvider.DefaultAction => publicILegacyIAccessibleProvider.DefaultAction;
 
-        string ILegacyIAccessibleProvider.Description => publicILegacyIAccessibleProvider.Description;
+        string? ILegacyIAccessibleProvider.Description => publicILegacyIAccessibleProvider.Description;
 
-        string ILegacyIAccessibleProvider.Help => publicILegacyIAccessibleProvider.Help;
+        string? ILegacyIAccessibleProvider.Help => publicILegacyIAccessibleProvider.Help;
 
-        string ILegacyIAccessibleProvider.KeyboardShortcut => publicILegacyIAccessibleProvider.KeyboardShortcut;
+        string? ILegacyIAccessibleProvider.KeyboardShortcut => publicILegacyIAccessibleProvider.KeyboardShortcut;
 
-        string ILegacyIAccessibleProvider.Name => publicILegacyIAccessibleProvider.Name;
+        string? ILegacyIAccessibleProvider.Name => publicILegacyIAccessibleProvider.Name;
 
         uint ILegacyIAccessibleProvider.Role => publicILegacyIAccessibleProvider.Role;
 
         uint ILegacyIAccessibleProvider.State => publicILegacyIAccessibleProvider.State;
 
-        string ILegacyIAccessibleProvider.Value => publicILegacyIAccessibleProvider.Value;
+        string? ILegacyIAccessibleProvider.Value => publicILegacyIAccessibleProvider.Value;
 
         int ILegacyIAccessibleProvider.ChildId => publicILegacyIAccessibleProvider.ChildId;
 
         void ILegacyIAccessibleProvider.DoDefaultAction()
             => publicILegacyIAccessibleProvider.DoDefaultAction();
 
-        IAccessible ILegacyIAccessibleProvider.GetIAccessible()
+        IAccessible? ILegacyIAccessibleProvider.GetIAccessible()
             => publicILegacyIAccessibleProvider.GetIAccessible();
 
         object[]? ILegacyIAccessibleProvider.GetSelection()
@@ -417,9 +417,9 @@ namespace System.Windows.Forms
 
         BOOL IValueProvider.IsReadOnly => publicIValueProvider.IsReadOnly;
 
-        string IValueProvider.Value => publicIValueProvider.Value;
+        string? IValueProvider.Value => publicIValueProvider.Value;
 
-        void IValueProvider.SetValue(string newValue)
+        void IValueProvider.SetValue(string? newValue)
             => publicIValueProvider.SetValue(newValue);
 
         BOOL IRangeValueProvider.IsReadOnly => publicIValueProvider.IsReadOnly;
@@ -462,7 +462,7 @@ namespace System.Windows.Forms
         object[]? ITableItemProvider.GetColumnHeaderItems()
             => AsArrayOfNativeAccessibles(publicITableItemProvider.GetColumnHeaderItems());
 
-        object IGridProvider.GetItem(int row, int column)
+        object? IGridProvider.GetItem(int row, int column)
             => AsNativeAccessible(publicIGridProvider.GetItem(row, column));
 
         int IGridProvider.RowCount => publicIGridProvider.RowCount;
@@ -477,14 +477,14 @@ namespace System.Windows.Forms
 
         int IGridItemProvider.ColumnSpan => publicIGridItemProvider.ColumnSpan;
 
-        IRawElementProviderSimple IGridItemProvider.ContainingGrid
+        IRawElementProviderSimple? IGridItemProvider.ContainingGrid
             => publicIGridItemProvider.ContainingGrid;
 
         /// <summary>
         ///  Get the currently selected elements
         /// </summary>
         /// <returns>An AutomationElement array containing the currently selected elements</returns>
-        object[] ISelectionProvider.GetSelection() => publicISelectionProvider.GetSelection();
+        object[]? ISelectionProvider.GetSelection() => publicISelectionProvider.GetSelection();
 
         /// <summary>
         ///  Indicates whether the control allows more than one element to be selected
@@ -528,7 +528,7 @@ namespace System.Windows.Forms
         ///  The logical element that supports the SelectionPattern for this Item.
         /// </summary>
         /// <returns>Returns a IRawElementProviderSimple.</returns>
-        IRawElementProviderSimple ISelectionItemProvider.SelectionContainer
+        IRawElementProviderSimple? ISelectionItemProvider.SelectionContainer
             => publicISelectionItemProvider.SelectionContainer;
 
         /// <summary>
@@ -537,7 +537,7 @@ namespace System.Windows.Forms
         /// </summary>
         /// <param name="hwnd">The window handle of the component.</param>
         /// <returns>Return the provider for the specified component, or null if the component is not being overridden.</returns>
-        IRawElementProviderSimple IRawElementProviderHwndOverride.GetOverrideProviderForHwnd(IntPtr hwnd)
+        IRawElementProviderSimple? IRawElementProviderHwndOverride.GetOverrideProviderForHwnd(IntPtr hwnd)
             => publicIRawElementProviderHwndOverride.GetOverrideProviderForHwnd(hwnd);
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/InternalAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/InternalAccessibleObject.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -103,6 +104,7 @@ namespace System.Windows.Forms
         ///  If the given object is an AccessibleObject return it as a InternalAccessibleObject
         ///  This ensures we wrap all AccessibleObjects before handing them out to OLEACC
         /// </summary>
+        [return: NotNullIfNotNull("accObject")]
         private object? AsNativeAccessible(object? accObject)
         {
             if (accObject is AccessibleObject accessibleObject)
@@ -122,7 +124,7 @@ namespace System.Windows.Forms
             {
                 for (int i = 0; i < accObjectArray.Length; i++)
                 {
-                    accObjectArray[i] = AsNativeAccessible(accObjectArray[i])!;
+                    accObjectArray[i] = AsNativeAccessible(accObjectArray[i]);
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialog.cs
@@ -812,10 +812,10 @@ namespace System.Windows.Forms
             {
                 caption = Path.GetFileName(
                     UnsafeNativeMethods.GetModuleFileNameLongPath(NativeMethods.NullHandleRef)
-                    .ToString());
+                                       .ToString());
             }
 
-            User32.SetWindowTextW(Handle, caption);
+            User32.SetWindowTextW(Handle, caption ?? string.Empty);
         }
 
         private HRESULT HandleTaskDialogCallback(

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialog.cs
@@ -815,7 +815,7 @@ namespace System.Windows.Forms
                                        .ToString());
             }
 
-            User32.SetWindowTextW(Handle, caption ?? string.Empty);
+            User32.SetWindowTextW(Handle, caption);
         }
 
         private HRESULT HandleTaskDialogCallback(

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogPage.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using static Interop;
 
@@ -590,7 +591,7 @@ namespace System.Windows.Forms
             BoundDialog.Navigate(page);
         }
 
-        internal static bool IsNativeStringNullOrEmpty(string? str)
+        internal static bool IsNativeStringNullOrEmpty([NotNullWhen(false)] string? str)
         {
             // From a native point of view, the string is empty if its first
             // character is a NUL char.

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Application.ComponentManagerTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Application.ComponentManagerTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.InteropServices;
 using Moq;
 using Xunit;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Application.ComponentManagerTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Application.ComponentManagerTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 using Moq;
 using Xunit;
@@ -16,8 +14,8 @@ namespace System.Windows.Forms.Tests.Interop_Mso
     {
         private IMsoComponentManager CreateComponentManager()
             => (IMsoComponentManager)Activator.CreateInstance(
-                typeof(Application).Assembly.GetType("System.Windows.Forms.Application+ComponentManager"),
-                nonPublic: true);
+                typeof(Application).Assembly.GetType("System.Windows.Forms.Application+ComponentManager")!,
+                nonPublic: true)!;
 
         [Fact]
         public void FDebugMessage_ReturnsTrue()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Based on work started by @sharwell in #2676, renders it obsolete.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3451)