### PR TITLE
fix MDI forms lost sub control box

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/MDIControlStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MDIControlStrip.cs
@@ -15,15 +15,15 @@ namespace System.Windows.Forms
     ///  This is the toolstrip used for merging the [:)]    [_][#][X] buttons onto an
     ///  mdi parent when an MDI child is maximized.
     /// </summary>
-    internal class MdiControlStrip : MenuStrip
+    internal partial class MdiControlStrip : MenuStrip
     {
-        private readonly ToolStripMenuItem system;
-        private readonly ToolStripMenuItem close;
-        private readonly ToolStripMenuItem minimize;
-        private readonly ToolStripMenuItem restore;
-        private MenuStrip mergedMenu;
+        private readonly ToolStripMenuItem _system;
+        private readonly ToolStripMenuItem _close;
+        private readonly ToolStripMenuItem _minimize;
+        private readonly ToolStripMenuItem _restore;
+        private MenuStrip _mergedMenu;
 
-        private IWin32Window target;
+        private IWin32Window _target;
 
         /// <summary> target is ideally the MDI Child to send the system commands to.
         ///  although there's nothing MDI child specific to it... you could have this
@@ -32,15 +32,15 @@ namespace System.Windows.Forms
         public MdiControlStrip(IWin32Window target)
         {
             IntPtr hMenu = User32.GetSystemMenu(new HandleRef(this, Control.GetSafeHandle(target)), bRevert: BOOL.FALSE);
-            this.target = target;
+            _target = target;
 
             // The menu item itself takes care of enabledness and sending WM_SYSCOMMAND messages to the target.
-            minimize = new ControlBoxMenuItem(hMenu, User32.SC.MINIMIZE, target);
-            close = new ControlBoxMenuItem(hMenu, User32.SC.CLOSE, target);
-            restore = new ControlBoxMenuItem(hMenu, User32.SC.RESTORE, target);
+            _minimize = new ControlBoxMenuItem(hMenu, User32.SC.MINIMIZE, target);
+            _close = new ControlBoxMenuItem(hMenu, User32.SC.CLOSE, target);
+            _restore = new ControlBoxMenuItem(hMenu, User32.SC.RESTORE, target);
 
             // The dropDown of the system menu is the one that talks to native.
-            system = new SystemMenuItem();
+            _system = new SystemMenuItem();
 
             // However in the event that the target handle changes we have to push the new handle into everyone.
             if (target is Control controlTarget)
@@ -50,7 +50,8 @@ namespace System.Windows.Forms
             }
 
             // add in opposite order to how you want it merged
-            Items.AddRange(new ToolStripItem[] { minimize, restore, close, system });
+            Items.AddRange(new ToolStripItem[] { _minimize, _restore, _close, _system });
+
             SuspendLayout();
             foreach (ToolStripItem item in Items)
             {
@@ -66,37 +67,37 @@ namespace System.Windows.Forms
 
             // set up the sytem menu
 
-            system.Image = GetTargetWindowIcon();
-            system.Alignment = ToolStripItemAlignment.Left;
-            system.DropDownOpening += new EventHandler(OnSystemMenuDropDownOpening);
-            system.ImageScaling = ToolStripItemImageScaling.None;
-            system.DoubleClickEnabled = true;
-            system.DoubleClick += new EventHandler(OnSystemMenuDoubleClick);
-            system.Padding = Padding.Empty;
-            system.ShortcutKeys = Keys.Alt | Keys.OemMinus;
+            _system.Image = GetTargetWindowIcon();
+            _system.Alignment = ToolStripItemAlignment.Left;
+            _system.DropDownOpening += new EventHandler(OnSystemMenuDropDownOpening);
+            _system.ImageScaling = ToolStripItemImageScaling.None;
+            _system.DoubleClickEnabled = true;
+            _system.DoubleClick += new EventHandler(OnSystemMenuDoubleClick);
+            _system.Padding = Padding.Empty;
+            _system.ShortcutKeys = Keys.Alt | Keys.OemMinus;
             ResumeLayout(false);
         }
 
         public ToolStripMenuItem Close
         {
-            get { return close; }
+            get { return _close; }
         }
 
         internal MenuStrip MergedMenu
         {
             get
             {
-                return mergedMenu;
+                return _mergedMenu;
             }
             set
             {
-                mergedMenu = value;
+                _mergedMenu = value;
             }
         }
 
         private Image GetTargetWindowIcon()
         {
-            IntPtr hIcon = User32.SendMessageW(new HandleRef(this, GetSafeHandle(target)), User32.WM.GETICON, (IntPtr)User32.ICON.SMALL, IntPtr.Zero);
+            IntPtr hIcon = User32.SendMessageW(new HandleRef(this, GetSafeHandle(_target)), User32.WM.GETICON, (IntPtr)User32.ICON.SMALL, IntPtr.Zero);
             Icon icon = hIcon != IntPtr.Zero ? Icon.FromHandle(hIcon) : Form.DefaultIcon;
             Icon smallIcon = new Icon(icon, SystemInformation.SmallIconSize);
 
@@ -115,7 +116,7 @@ namespace System.Windows.Forms
         private void OnTargetWindowDisposed(object sender, EventArgs e)
         {
             UnhookTarget();
-            target = null;
+            _target = null;
         }
 
         private void OnTargetWindowHandleRecreated(object sender, EventArgs e)
@@ -123,37 +124,37 @@ namespace System.Windows.Forms
             // in the case that the handle for the form is recreated we need to set
             // up the handles to point to the new window handle for the form.
 
-            system.SetNativeTargetWindow(target);
-            minimize.SetNativeTargetWindow(target);
-            close.SetNativeTargetWindow(target);
-            restore.SetNativeTargetWindow(target);
+            _system.SetNativeTargetWindow(_target);
+            _minimize.SetNativeTargetWindow(_target);
+            _close.SetNativeTargetWindow(_target);
+            _restore.SetNativeTargetWindow(_target);
 
-            IntPtr hMenu = User32.GetSystemMenu(new HandleRef(this, Control.GetSafeHandle(target)), bRevert: BOOL.FALSE);
-            system.SetNativeTargetMenu(hMenu);
-            minimize.SetNativeTargetMenu(hMenu);
-            close.SetNativeTargetMenu(hMenu);
-            restore.SetNativeTargetMenu(hMenu);
+            IntPtr hMenu = User32.GetSystemMenu(new HandleRef(this, Control.GetSafeHandle(_target)), bRevert: BOOL.FALSE);
+            _system.SetNativeTargetMenu(hMenu);
+            _minimize.SetNativeTargetMenu(hMenu);
+            _close.SetNativeTargetMenu(hMenu);
+            _restore.SetNativeTargetMenu(hMenu);
 
             // clear off the System DropDown.
-            if (system.HasDropDownItems)
+            if (_system.HasDropDownItems)
             {
                 // next time we need one we'll just fetch it fresh.
-                system.DropDown.Items.Clear();
-                system.DropDown.Dispose();
+                _system.DropDown.Items.Clear();
+                _system.DropDown.Dispose();
             }
 
-            system.Image = GetTargetWindowIcon();
+            _system.Image = GetTargetWindowIcon();
         }
 
         private void OnSystemMenuDropDownOpening(object sender, EventArgs e)
         {
-            if (!system.HasDropDownItems && (target != null))
+            if (!_system.HasDropDownItems && (_target != null))
             {
-                system.DropDown = ToolStripDropDownMenu.FromHMenu(User32.GetSystemMenu(new HandleRef(this, Control.GetSafeHandle(target)), bRevert: BOOL.FALSE), target);
+                _system.DropDown = ToolStripDropDownMenu.FromHMenu(User32.GetSystemMenu(new HandleRef(this, Control.GetSafeHandle(_target)), bRevert: BOOL.FALSE), _target);
             }
             else if (MergedMenu is null)
             {
-                system.DropDown.Dispose();
+                _system.DropDown.Dispose();
             }
         }
 
@@ -167,59 +168,21 @@ namespace System.Windows.Forms
             if (disposing)
             {
                 UnhookTarget();
-                target = null;
+                _target = null;
             }
             base.Dispose(disposing);
         }
 
         private void UnhookTarget()
         {
-            if (target != null)
+            if (_target != null)
             {
-                if (target is Control controlTarget)
+                if (_target is Control controlTarget)
                 {
                     controlTarget.HandleCreated -= new EventHandler(OnTargetWindowHandleRecreated);
                     controlTarget.Disposed -= new EventHandler(OnTargetWindowDisposed);
                 }
-                target = null;
-            }
-        }
-
-        // when the system menu item shortcut is evaluated - pop the dropdown
-        internal class ControlBoxMenuItem : ToolStripMenuItem
-        {
-            internal ControlBoxMenuItem(IntPtr hMenu, User32.SC nativeMenuCommandId, IWin32Window targetWindow) :
-                base(hMenu, (int)nativeMenuCommandId, targetWindow)
-            {
-            }
-
-            internal override bool CanKeyboardSelect => false;
-        }
-
-        // when the system menu item shortcut is evaluated - pop the dropdown
-        internal class SystemMenuItem : ToolStripMenuItem
-        {
-            public SystemMenuItem()
-            {
-                AccessibleName = SR.MDIChildSystemMenuItemAccessibleName;
-            }
-            protected internal override bool ProcessCmdKey(ref Message m, Keys keyData)
-            {
-                if (Visible && ShortcutKeys == keyData)
-                {
-                    ShowDropDown();
-                    DropDown.SelectNextToolStripItem(null, true);
-                    return true;
-                }
-                return base.ProcessCmdKey(ref m, keyData);
-            }
-            protected override void OnOwnerChanged(EventArgs e)
-            {
-                if (HasDropDownItems && DropDown.Visible)
-                {
-                    HideDropDown();
-                }
-                base.OnOwnerChanged(e);
+                _target = null;
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MdiControlStrip.ControlBoxMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MdiControlStrip.ControlBoxMenuItem.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    internal partial class MdiControlStrip
+    {
+        // when the system menu item shortcut is evaluated - pop the dropdown
+        internal class ControlBoxMenuItem : ToolStripMenuItem
+        {
+            internal ControlBoxMenuItem(IntPtr hMenu, User32.SC nativeMenuCommandId, IWin32Window targetWindow)
+                : base(hMenu, (int)nativeMenuCommandId, targetWindow)
+            {
+            }
+
+            internal override bool CanKeyboardSelect => false;
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MdiControlStrip.SystemMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MdiControlStrip.SystemMenuItem.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+namespace System.Windows.Forms
+{
+    internal partial class MdiControlStrip
+    {
+        // when the system menu item shortcut is evaluated - pop the dropdown
+        internal class SystemMenuItem : ToolStripMenuItem
+        {
+            public SystemMenuItem()
+            {
+                AccessibleName = SR.MDIChildSystemMenuItemAccessibleName;
+            }
+
+            protected internal override bool ProcessCmdKey(ref Message m, Keys keyData)
+            {
+                if (Visible && ShortcutKeys == keyData)
+                {
+                    ShowDropDown();
+                    DropDown.SelectNextToolStripItem(null, true);
+                    return true;
+                }
+
+                return base.ProcessCmdKey(ref m, keyData);
+            }
+
+            protected override void OnOwnerChanged(EventArgs e)
+            {
+                if (HasDropDownItems && DropDown.Visible)
+                {
+                    HideDropDown();
+                }
+
+                base.OnOwnerChanged(e);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MenuTimer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MenuTimer.cs
@@ -1,0 +1,188 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System.Diagnostics;
+
+namespace System.Windows.Forms
+{
+    internal class MenuTimer
+    {
+        private readonly Timer autoMenuExpandTimer = new Timer();
+
+        // consider - weak reference?
+        private ToolStripMenuItem currentItem;
+        private ToolStripMenuItem fromItem;
+        private bool inTransition;
+
+        private readonly int quickShow = 1;
+
+        private readonly int slowShow;
+
+        public MenuTimer()
+        {
+            // MenuShowDelay can be set to 0.  In this case, set to something low so it's inperceptable.
+            autoMenuExpandTimer.Tick += new EventHandler(OnTick);
+
+            // since MenuShowDelay is registry tweakable we've gotta make sure we've got some sort
+            // of interval
+            slowShow = Math.Max(quickShow, SystemInformation.MenuShowDelay);
+        }
+        // the current item to autoexpand.
+        private ToolStripMenuItem CurrentItem
+        {
+            get
+            {
+                return currentItem;
+            }
+            set
+            {
+                Debug.WriteLineIf(ToolStrip.s_menuAutoExpandDebug.TraceVerbose && currentItem != value, "[MenuTimer.CurrentItem] changed: " + ((value is null) ? "null" : value.ToString()));
+                currentItem = value;
+            }
+        }
+        public bool InTransition
+        {
+            get { return inTransition; }
+            set { inTransition = value; }
+        }
+
+        public void Start(ToolStripMenuItem item)
+        {
+            if (InTransition)
+            {
+                return;
+            }
+            StartCore(item);
+        }
+
+        private void StartCore(ToolStripMenuItem item)
+        {
+            if (item != CurrentItem)
+            {
+                Cancel(CurrentItem);
+            }
+            CurrentItem = item;
+            if (item != null)
+            {
+                CurrentItem = item;
+                autoMenuExpandTimer.Interval = item.IsOnDropDown ? slowShow : quickShow;
+                autoMenuExpandTimer.Enabled = true;
+            }
+        }
+
+        public void Transition(ToolStripMenuItem fromItem, ToolStripMenuItem toItem)
+        {
+            Debug.WriteLineIf(ToolStrip.s_menuAutoExpandDebug.TraceVerbose, "[MenuTimer.Transition] transitioning items " + fromItem.ToString() + " " + toItem.ToString());
+
+            if (toItem is null && InTransition)
+            {
+                Cancel();
+                // in this case we're likely to have hit an item that's not a menu item
+                // or nothing is selected.
+                EndTransition(/*forceClose*/ true);
+                return;
+            }
+
+            if (this.fromItem != fromItem)
+            {
+                this.fromItem = fromItem;
+                CancelCore();
+                StartCore(toItem);
+            }
+            // set up the current item to be the toItem so it will be auto expanded when complete.
+            CurrentItem = toItem;
+            InTransition = true;
+        }
+
+        public void Cancel()
+        {
+            if (InTransition)
+            {
+                return;
+            }
+            CancelCore();
+        }
+        /// <summary> cancels if and only if this item was the one that
+        ///  requested the timer
+        /// </summary>
+        public void Cancel(ToolStripMenuItem item)
+        {
+            if (InTransition)
+            {
+                return;
+            }
+            if (item == CurrentItem)
+            {
+                CancelCore();
+            }
+        }
+
+        private void CancelCore()
+        {
+            autoMenuExpandTimer.Enabled = false;
+            CurrentItem = null;
+        }
+        private void EndTransition(bool forceClose)
+        {
+            ToolStripMenuItem lastSelected = fromItem;
+            fromItem = null; // immediately clear BEFORE we call user code.
+            if (InTransition)
+            {
+                InTransition = false;
+
+                // we should roolup if the current item has changed and is selected.
+                bool rollup = forceClose || (CurrentItem != null && CurrentItem != lastSelected && CurrentItem.Selected);
+                if (rollup && lastSelected != null && lastSelected.HasDropDownItems)
+                {
+                    lastSelected.HideDropDown();
+                }
+            }
+        }
+        internal void HandleToolStripMouseLeave(ToolStrip toolStrip)
+        {
+            if (InTransition && toolStrip == fromItem.ParentInternal)
+            {
+                // restore the selection back to CurrentItem.
+                // we're about to fall off the edge of the toolstrip, something should be selected
+                // at all times while we're InTransition mode - otherwise it looks really funny
+                // to have an auto expanded item
+                if (CurrentItem != null)
+                {
+                    CurrentItem.Select();
+                }
+            }
+            else
+            {
+                // because we've split up selected/pressed, we need to make sure
+                // that onmouseleave we make sure there's a selected menu item.
+                if (toolStrip.IsDropDown && toolStrip.ActiveDropDowns.Count > 0)
+                {
+                    ToolStripMenuItem menuItem = (!(toolStrip.ActiveDropDowns[0] is ToolStripDropDown dropDown)) ? null : dropDown.OwnerItem as ToolStripMenuItem;
+                    if (menuItem != null && menuItem.Pressed)
+                    {
+                        menuItem.Select();
+                    }
+                }
+            }
+        }
+
+        private void OnTick(object sender, EventArgs e)
+        {
+            autoMenuExpandTimer.Enabled = false;
+
+            if (CurrentItem is null)
+            {
+                return;
+            }
+            EndTransition(/*forceClose*/false);
+            if (CurrentItem != null && !CurrentItem.IsDisposed && CurrentItem.Selected && CurrentItem.Enabled && ToolStripManager.ModalMenuFilter.InMenuMode)
+            {
+                Debug.WriteLineIf(ToolStrip.s_menuAutoExpandDebug.TraceVerbose, "[MenuTimer.OnTick] calling OnMenuAutoExpand");
+                CurrentItem.OnMenuAutoExpand();
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MdiParent.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MdiParent.cs
@@ -18,8 +18,17 @@ namespace WinformsControlsTest
 
             Text = RuntimeInformation.FrameworkDescription;
 
+            ToolStripMenuItem menu = new() { Text = "Open new child" };
+            menu.Click += (s, e) =>
+            {
+                var child = new Form();
+                child.MdiParent = this;
+                child.WindowState = FormWindowState.Maximized;
+                child.Show();
+            };
+
             _menuStrip = new MenuStrip();
-            _menuStrip.Items.Add(new ToolStripMenuItem { Text = "Parent" });
+            _menuStrip.Items.Add(menu);
         }
 
         public MenuStrip MainMenu => _menuStrip;
@@ -30,6 +39,7 @@ namespace WinformsControlsTest
 
             MdiChild frm = new MdiChild();
             frm.MdiParent = this;
+            frm.WindowState = FormWindowState.Maximized;
             frm.Show();
         }
     }


### PR DESCRIPTION
Fixes #3029



## Proposed changes

With the deprecation and removal of `MainMenu` control in #2091 one of MDI scenarios got broken where both parent and child forms don't have `MainMenuStrip` property set nor have `MainMenuStrip` instance added to their respective `Controls` collection.

The fix restores setting an MDI menu via `WM_MDISETMENU` message to the parent form.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

Customers who use MDI scenarios without main menu in both parent or child forms won't be able to minimise maximised child forms

| net472 | netcoreapp3.1 |
| -- | --- |
| ![image](https://user-images.githubusercontent.com/4403806/84857263-fab0ac00-b0ab-11ea-9639-a6db8f04cff4.png) | ![image](https://user-images.githubusercontent.com/4403806/84860154-e96a9e00-b0b1-11ea-857f-e46b6916737e.png) |


## Regression? 

- Yes

## Risk

- Minimal.

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

<details>
<summary>👉 👉 👉  Click for lots of pretty pictures... 🖼️ 🖼️ 🖼️ </summary>

| Parent | Child | Screenshot | Screenshot |
|--- | --- |--- | --- |
| - | - | ![image](https://user-images.githubusercontent.com/4403806/84857307-13b95d00-b0ac-11ea-9c79-fa921f61ce2e.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84860225-0a32f380-b0b2-11ea-9013-e49f78784567.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84865424-87af3180-b0bb-11ea-8781-77daf0d0ea32.png) | ![image](https://user-images.githubusercontent.com/4403806/84857263-fab0ac00-b0ab-11ea-9639-a6db8f04cff4.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84860154-e96a9e00-b0b1-11ea-857f-e46b6916737e.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84865453-93025d00-b0bb-11ea-99a0-792e73f9d1df.png) |
| `Controls.Add(menuStrip)`, `MainMenuStrip` = null | - | ![image](https://user-images.githubusercontent.com/4403806/84857740-0b155680-b0ad-11ea-9ed6-3cb26a48d63e.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84860431-59792400-b0b2-11ea-916d-aca30e4e0f42.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84865604-db217f80-b0bb-11ea-9dea-a3d68e32c30c.png) | ![image](https://user-images.githubusercontent.com/4403806/84857729-0355b200-b0ad-11ea-9356-4f320db58ae8.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84860422-541bd980-b0b2-11ea-975f-c8cdd6e651b7.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84865620-e2488d80-b0bb-11ea-874e-d5d56b5bbb15.png) |
| `Controls.Add(menuStrip)`, `MainMenuStrip` = `menuStrip` | - | ![image](https://user-images.githubusercontent.com/4403806/84857660-e325f300-b0ac-11ea-9edc-fb84de7b7e6d.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84860571-9cd39280-b0b2-11ea-97d2-79c62d4d4853.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84865971-70247880-b0bc-11ea-806c-0235a916f881.png) | ![image](https://user-images.githubusercontent.com/4403806/84857651-dacdb800-b0ac-11ea-80e7-d5b0d1dfc5cc.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84860539-904f3a00-b0b2-11ea-9c4a-63e539aa1855.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84866018-7d416780-b0bc-11ea-906e-62538a546273.png) |
| - | `Controls.Add(menuStrip)`, `MainMenuStrip` = null | ![image](https://user-images.githubusercontent.com/4403806/84858292-3a789300-b0ae-11ea-829d-beaf0c54e8a0.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84860742-f2a83a80-b0b2-11ea-9009-b22867cfd122.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84866248-c98ca780-b0bc-11ea-8aeb-9ce5800f5d1c.png) | ![image](https://user-images.githubusercontent.com/4403806/84858274-30ef2b00-b0ae-11ea-8478-d4bec4ce8bad.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84860730-ecb25980-b0b2-11ea-9053-3ca3e74f7256.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84866268-d14c4c00-b0bc-11ea-91ae-b1e8f15f3acd.png) |
| - | `Controls.Add(menuStrip)`, `MainMenuStrip` = `menuStrip` | ![image](https://user-images.githubusercontent.com/4403806/84858434-81ff1f00-b0ae-11ea-8540-359f7d5a2992.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84860806-153a5380-b0b3-11ea-97cb-41330d267ebc.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84866477-1f614f80-b0bd-11ea-8de3-d7eb7b88d89c.png) | ![image](https://user-images.githubusercontent.com/4403806/84858445-87f50000-b0ae-11ea-981e-6ed729df8564.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84860798-11a6cc80-b0b3-11ea-9eda-4befca74d4a9.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84866493-25efc700-b0bd-11ea-9e30-c7f502b64541.png) |
| `Controls.Add(menuStrip)`, `MainMenuStrip` = null | `Controls.Add(menuStrip)`, `MainMenuStrip` = `null/menuStrip` | ![image](https://user-images.githubusercontent.com/4403806/84859995-95f85000-b0b1-11ea-8b01-5d2a680d3d67.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84859877-5598d200-b0b1-11ea-8613-98574aa498f7.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84867469-8c291980-b0be-11ea-90b4-4961a2a903a0.png) | ![image](https://user-images.githubusercontent.com/4403806/84858593-d6a29a00-b0ae-11ea-8d55-620fa5b1b8f0.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84859882-5a5d8600-b0b1-11ea-93b9-eb25daa95576.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84867409-73206880-b0be-11ea-9c16-d309f920a82c.png) |
| `Controls.Add(menuStrip)`, `MainMenuStrip` = `menuStrip` | `Controls.Add(menuStrip)`, `MainMenuStrip` = null | ![image](https://user-images.githubusercontent.com/4403806/84859645-eae79680-b0b0-11ea-9648-ae822ee96539.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84859565-c2f83300-b0b0-11ea-9375-8ff3d8117918.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84868888-aebc3200-b0c0-11ea-9adf-bd6c96907d8a.png) | ![image](https://user-images.githubusercontent.com/4403806/84858815-3bf68b00-b0af-11ea-93b7-a5e44152670c.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84859545-bc69bb80-b0b0-11ea-83c5-c2b66e0981cf.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84868913-b67bd680-b0c0-11ea-834d-c526a9c038b0.png) |
| `Controls.Add(menuStrip)`, `MainMenuStrip` = `menuStrip` | `Controls.Add(menuStrip)`, `MainMenuStrip` = `menuStrip` | ![image](https://user-images.githubusercontent.com/4403806/84859449-8f1d0d80-b0b0-11ea-9416-4378dd8c2535.png)<br />![image](https://user-images.githubusercontent.com/4403806/84859302-33eb1b00-b0b0-11ea-8829-c5af9a0c3787.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84869095-f3e06400-b0c0-11ea-8e12-00c74a9d465b.png) | ![image](https://user-images.githubusercontent.com/4403806/84858845-4dd82e00-b0af-11ea-8b65-c0763496b85b.png)<br />![image](https://user-images.githubusercontent.com/4403806/84859277-2a61b300-b0b0-11ea-863d-a168c0d964c7.png)<br/>![image](https://user-images.githubusercontent.com/4403806/84869112-f93dae80-b0c0-11ea-8662-60574eb3b398.png) |

</details>


## Test methodology <!-- How did you ensure quality? -->

- Manual comparison of net472 vs netcoreapp3.1 vs net5.0 (current commit)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3461)