### PR TITLE
WebBrowser doesn't like multiple UI threads

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHost.AxPropertyDescriptorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHost.AxPropertyDescriptorTests.cs
@@ -12,6 +12,7 @@ using static Interop.Ole32;
 
 namespace System.Windows.Forms.Tests
 {
+    [Collection("Sequential")] // workaround for WebBrowser control corrupting memory when run on multiple UI threads (instantiated via GUID)
     public class AxHostPropertyDescriptorTests : IClassFixture<ThreadExceptionFixture>
     {
         private const string EmptyClsidString = "00000000-0000-0000-0000-000000000000";

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.ControlCollection.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.ControlCollection.cs
@@ -16,6 +16,7 @@ using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
+    [Collection("Sequential")] // workaround for WebBrowser control corrupting memory when run on multiple UI threads (instantiated via GUID)
     public class ControlControlCollectionTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/WebBrowserBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/WebBrowserBaseTests.cs
@@ -12,6 +12,7 @@ namespace System.Windows.Forms.Tests
 {
     using Size = System.Drawing.Size;
 
+    [Collection("Sequential")] // workaround for WebBrowser control corrupting memory when run on multiple UI threads (instantiated via GUID)
     public class WebBrowserBaseTests
     {
         public static IEnumerable<object[]> Bounds_Set_TestData()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Workaround for #3358

(Extended version of PR #3423 and #3429)

Like mentioned on the other PR this is only a workaround and not a final solution, further investigation to the memory corruption issues are desired. There is also the possibility of another memory corruption source we did not pinpoint yet.

## Proposed changes

Prevent running WebBrowser control tests on multiple UI threads in parallel as that seems to cause memory corruption (unknown whether root cause is in WinForms or native control)

## Customer Impact

no random crashes due to memory corruption in unit tests, should improve CI sucess rates

## Regression? 

no

## Risk

may slow down tests a bit

### Before

random CI crashes or test failures that made no sense due to memory corruption

### After

prevent memory corruption, allowing CI runs to perform normally


## Test methodology

isolated repro scenario into a separate application, it doesn't seem to cause memory corruption when only one UI thread is running the WebBrowser control


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3473)