### PR TITLE
Add ES enum in Interop Richedit

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ES.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ES.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal partial class Interop
+{
+    internal static partial class Richedit
+    {
+        [Flags]
+        public enum ES
+        {
+            NOOLEDRAGDROP = 0x00000008,
+            DISABLENOSCROLL = 0x00002000,
+            SUNKEN = 0x00004000,
+            SAVESEL = 0x00008000,
+            SELFIME = 0x00040000,
+            NOIME = 0x00080000,
+            VERTICAL = 0x00400000,
+            SELECTIONBAR = 0x01000000
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -342,7 +342,7 @@ namespace System.Windows.Forms
                         cp.Style |= (int)User32.WS.HSCROLL;
                         if (((int)ScrollBars & RichTextBoxConstants.RTB_FORCE) != 0)
                         {
-                            cp.Style |= RichTextBoxConstants.ES_DISABLENOSCROLL;
+                            cp.Style |= (int)ES.DISABLENOSCROLL;
                         }
                     }
 
@@ -351,7 +351,7 @@ namespace System.Windows.Forms
                         cp.Style |= (int)User32.WS.VSCROLL;
                         if (((int)ScrollBars & RichTextBoxConstants.RTB_FORCE) != 0)
                         {
-                            cp.Style |= RichTextBoxConstants.ES_DISABLENOSCROLL;
+                            cp.Style |= (int)ES.DISABLENOSCROLL;
                         }
                     }
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxConstants.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxConstants.cs
@@ -16,23 +16,6 @@ namespace System.Windows.Forms
 
         /* RichTextBox messages */
 
-        /* New edit control styles */
-        internal const int ES_SAVESEL = 0x00008000;
-        internal const int ES_SUNKEN = 0x00004000;
-        internal const int ES_DISABLENOSCROLL = 0x00002000;
-        /* same as WS_MAXIMIZE, but that doesn't make sense so we re-use the value */
-        internal const int ES_SELECTIONBAR = 0x01000000;
-        /* same as ES_UPPERCASE, but re-used to completely disable OLE drag'n'drop */
-        internal const int ES_NOOLEDRAGDROP = 0x00000008;
-
-        /* New edit control extended style */
-        internal const int ES_EX_NOCALLOLEINIT = 0x01000000;
-
-        /* These flags are used in FE Windows */
-        internal const int ES_VERTICAL = 0x00400000; // NOT IN RE3.0/2.0
-        internal const int ES_NOIME = 0x00080000;
-        internal const int ES_SELFIME = 0x00040000;
-
         /* TextBox control options */
         internal const int ECO_AUTOWORDSELECTION = 0x00000001;
         internal const int ECO_AUTOVSCROLL = 0x00000040;


### PR DESCRIPTION
## Proposed changes

- Add ES enum in Interop Richedit.
- Remove ES and ES_X constants from RichTextBoxConstants.cs and replace their usages with the above enum values.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3474)