### PR TITLE
Use generic list in FindInternal and FindControls methods of some classes

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewItemCollection.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 
@@ -343,28 +344,21 @@ namespace System.Windows.Forms
                     throw new ArgumentNullException(nameof(key), SR.FindKeyMayNotBeEmptyOrNull);
                 }
 
-                ArrayList foundItems = FindInternal(key, searchAllSubItems, this, new ArrayList());
+                List<ListViewItem> foundItems = new();
+                FindInternal(key, searchAllSubItems, this, foundItems);
 
-                ListViewItem[] stronglyTypedFoundItems = new ListViewItem[foundItems.Count];
-                foundItems.CopyTo(stronglyTypedFoundItems, 0);
-
-                return stronglyTypedFoundItems;
+                return foundItems.ToArray();
             }
 
             /// <summary>
-            ///  Searches for Controls by their Name property, builds up an arraylist
+            ///  Searches for Controls by their Name property, builds up a list
             ///  of all the controls that match.
             /// </summary>
-            private ArrayList FindInternal(string key, bool searchAllSubItems, ListViewItemCollection listViewItems, ArrayList foundItems)
+            private void FindInternal(string key, bool searchAllSubItems, ListViewItemCollection listViewItems, List<ListViewItem> foundItems)
             {
-                if ((listViewItems is null) || (foundItems is null))
-                {
-                    return null;  //
-                }
-
                 for (int i = 0; i < listViewItems.Count; i++)
                 {
-                    if (WindowsFormsUtils.SafeCompareStrings(listViewItems[i].Name, key, /* ignoreCase = */ true))
+                    if (WindowsFormsUtils.SafeCompareStrings(listViewItems[i].Name, key, ignoreCase: true))
                     {
                         foundItems.Add(listViewItems[i]);
                     }
@@ -375,7 +369,7 @@ namespace System.Windows.Forms
                             // start from 1, as we've already compared subitems[0]
                             for (int j = 1; j < listViewItems[i].SubItems.Count; j++)
                             {
-                                if (WindowsFormsUtils.SafeCompareStrings(listViewItems[i].SubItems[j].Name, key, /* ignoreCase = */ true))
+                                if (WindowsFormsUtils.SafeCompareStrings(listViewItems[i].SubItems[j].Name, key, ignoreCase: true))
                                 {
                                     foundItems.Add(listViewItems[i]);
                                     break;
@@ -384,8 +378,6 @@ namespace System.Windows.Forms
                         }
                     }
                 }
-
-                return foundItems;
             }
 
             public IEnumerator GetEnumerator()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeCollection.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing.Design;
@@ -274,25 +275,15 @@ namespace System.Windows.Forms
                 throw new ArgumentNullException(nameof(key), SR.FindKeyMayNotBeEmptyOrNull);
             }
 
-            ArrayList foundNodes = FindInternal(key, searchAllChildren, this, new ArrayList());
+            List<TreeNode> foundNodes = FindInternal(key, searchAllChildren, this, new List<TreeNode>());
 
-            //
-            TreeNode[] stronglyTypedFoundNodes = new TreeNode[foundNodes.Count];
-            foundNodes.CopyTo(stronglyTypedFoundNodes, 0);
-
-            return stronglyTypedFoundNodes;
+            return foundNodes.ToArray();
         }
 
-        private ArrayList FindInternal(string key, bool searchAllChildren, TreeNodeCollection treeNodeCollectionToLookIn, ArrayList foundTreeNodes)
+        private List<TreeNode> FindInternal(string key, bool searchAllChildren, TreeNodeCollection treeNodeCollectionToLookIn, List<TreeNode> foundTreeNodes)
         {
-            if ((treeNodeCollectionToLookIn is null) || (foundTreeNodes is null))
-            {
-                return null;
-            }
-
             // Perform breadth first search - as it's likely people will want tree nodes belonging
             // to the same parent close to each other.
-
             for (int i = 0; i < treeNodeCollectionToLookIn.Count; i++)
             {
                 if (treeNodeCollectionToLookIn[i] is null)
@@ -300,14 +291,13 @@ namespace System.Windows.Forms
                     continue;
                 }
 
-                if (WindowsFormsUtils.SafeCompareStrings(treeNodeCollectionToLookIn[i].Name, key, /* ignoreCase = */ true))
+                if (WindowsFormsUtils.SafeCompareStrings(treeNodeCollectionToLookIn[i].Name, key, ignoreCase: true))
                 {
                     foundTreeNodes.Add(treeNodeCollectionToLookIn[i]);
                 }
             }
 
-            // Optional recurive search for controls in child collections.
-
+            // Optional recursive search for controls in child collections.
             if (searchAllChildren)
             {
                 for (int i = 0; i < treeNodeCollectionToLookIn.Count; i++)
@@ -318,11 +308,12 @@ namespace System.Windows.Forms
                     }
                     if ((treeNodeCollectionToLookIn[i].Nodes != null) && treeNodeCollectionToLookIn[i].Nodes.Count > 0)
                     {
-                        // if it has a valid child collecion, append those results to our collection
+                        // If it has a valid child collection, append those results to our collection.
                         foundTreeNodes = FindInternal(key, searchAllChildren, treeNodeCollectionToLookIn[i].Nodes, foundTreeNodes);
                     }
                 }
             }
+
             return foundTreeNodes;
         }
 


### PR DESCRIPTION
## Proposed changes

- Use generic list in FindInternal and FindControls methods of some classes.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3480)