### PR TITLE
Add ECO and ECOOP enums in Interop Richedit

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ECO.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ECO.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal partial class Interop
+{
+    internal static partial class Richedit
+    {
+        [Flags]
+        public enum ECO
+        {
+            AUTOWORDSELECTION = 0x00000001,
+            AUTOVSCROLL = 0x00000040,
+            AUTOHSCROLL = 0x00000080,
+            NOHIDESEL = 0x00000100,
+            READONLY = 0x00000800,
+            WANTRETURN = 0x00001000,
+            SAVESEL = 0x00008000,
+            VERTICAL = 0x00400000,
+            SELECTIONBAR = 0x01000000
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ECOOP.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ECOOP.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal partial class Interop
+{
+    internal static partial class Richedit
+    {
+        public enum ECOOP
+        {
+            SET = 0x0001,
+            OR = 0x0002,
+            AND = 0x0003,
+            XOR = 0x0004
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -194,8 +194,8 @@ namespace System.Windows.Forms
                     User32.SendMessageW(
                         this,
                         (User32.WM)RichEditMessages.EM_SETOPTIONS,
-                        value ? (IntPtr)RichTextBoxConstants.ECOOP_OR : (IntPtr)RichTextBoxConstants.ECOOP_XOR,
-                        (IntPtr)RichTextBoxConstants.ECO_AUTOWORDSELECTION);
+                        (IntPtr)(value ? ECOOP.OR : ECOOP.XOR),
+                        (IntPtr)ECO.AUTOWORDSELECTION);
                 }
             }
         }
@@ -1409,8 +1409,8 @@ namespace System.Windows.Forms
                         User32.SendMessageW(
                             this,
                             (User32.WM)RichEditMessages.EM_SETOPTIONS,
-                            value ? (IntPtr)RichTextBoxConstants.ECOOP_OR : (IntPtr)RichTextBoxConstants.ECOOP_XOR,
-                            (IntPtr)RichTextBoxConstants.ECO_SELECTIONBAR);
+                            (IntPtr)(value ? ECOOP.OR : ECOOP.XOR),
+                            (IntPtr)ECO.SELECTIONBAR);
                     }
                 }
             }
@@ -2598,8 +2598,8 @@ namespace System.Windows.Forms
                 User32.PostMessageW(
                     this,
                     (User32.WM)RichEditMessages.EM_SETOPTIONS,
-                    (IntPtr)RichTextBoxConstants.ECOOP_OR,
-                    (IntPtr)RichTextBoxConstants.ECO_SELECTIONBAR);
+                    (IntPtr)ECOOP.OR,
+                    (IntPtr)ECO.SELECTIONBAR);
             }
 
             if (languageOption != LanguageOption)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxConstants.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBoxConstants.cs
@@ -13,30 +13,5 @@ namespace System.Windows.Forms
         internal const int RTB_HORIZ = 0x0001;
         internal const int RTB_VERT = 0x0002;
         internal const int RTB_FORCE = 0x0010;
-
-        /* RichTextBox messages */
-
-        /* TextBox control options */
-        internal const int ECO_AUTOWORDSELECTION = 0x00000001;
-        internal const int ECO_AUTOVSCROLL = 0x00000040;
-        internal const int ECO_AUTOHSCROLL = 0x00000080;
-        internal const int ECO_NOHIDESEL = 0x00000100;
-        internal const int ECO_READONLY = 0x00000800;
-        internal const int ECO_WANTRETURN = 0x00001000;
-        internal const int ECO_SAVESEL = 0x00008000;
-        internal const int ECO_SELECTIONBAR = 0x01000000; // guessing this is selection margin
-        internal const int ECO_VERTICAL = 0x00400000;   /* FE specific */
-
-        /* ECO operations */
-        internal const int ECOOP_SET = 0x0001;
-        internal const int ECOOP_OR = 0x0002;
-        internal const int ECOOP_AND = 0x0003;
-        internal const int ECOOP_XOR = 0x0004;
-
-        /* UNICODE embedding character */
-        // disable csharp compiler warning #0414: field assigned unused value
-#pragma warning disable 0414
-        internal static readonly char WCH_EMBEDDING = (char)0xFFFC;
-#pragma warning restore 0414
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
@@ -589,7 +589,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, createdCallCount);
 
             // Call EM_SETOPTIONS.
-            User32.SendMessageW(control.Handle, (User32.WM)RichEditMessages.EM_SETOPTIONS, (IntPtr)RichTextBoxConstants.ECOOP_OR, (IntPtr)RichTextBoxConstants.ECO_AUTOWORDSELECTION);
+            SendMessageW(control.Handle, (WM)RichEditMessages.EM_SETOPTIONS, (IntPtr)ECOOP.OR, (IntPtr)ECO.AUTOWORDSELECTION);
             Assert.False(control.AutoWordSelection);
             Assert.True(control.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
@@ -6586,7 +6586,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, createdCallCount);
 
             // Call EM_SETOPTIONS.
-            User32.SendMessageW(control.Handle, (User32.WM)RichEditMessages.EM_SETOPTIONS, (IntPtr)RichTextBoxConstants.ECOOP_OR, (IntPtr)RichTextBoxConstants.ECO_SELECTIONBAR);
+            SendMessageW(control.Handle, (WM)RichEditMessages.EM_SETOPTIONS, (IntPtr)ECOOP.OR, (IntPtr)ECO.SELECTIONBAR);
             Assert.False(control.ShowSelectionMargin);
             Assert.True(control.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);


### PR DESCRIPTION
## Proposed changes

- Add ECO and ECOOP enums in Interop Richedit.
- Remove ECO and ECOOP constants from RichTextBoxConstants.cs and replace their usages with the above enum values.
- Remove unused WCH_EMBEDDING constant.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3481)