### PR TITLE
Use generic lists in MonthCalendar

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -4,7 +4,7 @@
 
 #nullable disable
 
-using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
@@ -129,9 +129,9 @@ namespace System.Windows.Forms
         ///  Lists are slow, so this section can be optimized.
         ///  Implementation is such that inserts are fast, removals are slow.
         /// </summary>
-        private readonly ArrayList _arrayOfDates = new ArrayList();
-        private readonly ArrayList _annualArrayOfDates = new ArrayList();
-        private readonly ArrayList _monthlyArrayOfDates = new ArrayList();
+        private readonly List<DateTime> _arrayOfDates = new List<DateTime>();
+        private readonly List<DateTime> _annualArrayOfDates = new List<DateTime>();
+        private readonly List<DateTime> _monthlyArrayOfDates = new List<DateTime>();
 
         private DateRangeEventHandler _onDateChanged;
         private DateRangeEventHandler _onDateSelected;
@@ -178,16 +178,8 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.MonthCalendarAnnuallyBoldedDatesDescr))]
         public DateTime[] AnnuallyBoldedDates
         {
-            get
-            {
-                DateTime[] dateTimes = new DateTime[_annualArrayOfDates.Count];
-                for (int i = 0; i < _annualArrayOfDates.Count; ++i)
-                {
-                    dateTimes[i] = (DateTime)_annualArrayOfDates[i];
-                }
+            get => _annualArrayOfDates.ToArray();
 
-                return dateTimes;
-            }
             set
             {
                 _annualArrayOfDates.Clear();
@@ -198,15 +190,11 @@ namespace System.Windows.Forms
 
                 if (value != null && value.Length > 0)
                 {
-                    // Add each bolded date to our ArrayList.
-                    for (int i = 0; i < value.Length; i++)
+                    // Add each bolded date to our List.
+                    foreach (var dateTime in value)
                     {
-                        _annualArrayOfDates.Add(value[i]);
-                    }
-
-                    for (int i = 0; i < value.Length; ++i)
-                    {
-                        _monthsOfYear[value[i].Month - 1] |= 0x00000001 << (value[i].Day - 1);
+                        _annualArrayOfDates.Add(dateTime);
+                        _monthsOfYear[dateTime.Month - 1] |= 0x00000001 << (dateTime.Day - 1);
                     }
                 }
 
@@ -268,25 +256,17 @@ namespace System.Windows.Forms
         [Localizable(true)]
         public DateTime[] BoldedDates
         {
-            get
-            {
-                DateTime[] dateTimes = new DateTime[_arrayOfDates.Count];
-                for (int i = 0; i < _arrayOfDates.Count; ++i)
-                {
-                    dateTimes[i] = (DateTime)_arrayOfDates[i];
-                }
+            get => _arrayOfDates.ToArray();
 
-                return dateTimes;
-            }
             set
             {
                 _arrayOfDates.Clear();
                 if (value != null && value.Length > 0)
                 {
-                    // Add each bolded date to our ArrayList.
-                    for (int i = 0; i < value.Length; i++)
+                    // Add each bolded date to our List.
+                    foreach (var dateTime in value)
                     {
-                        _arrayOfDates.Add(value[i]);
+                        _arrayOfDates.Add(dateTime);
                     }
                 }
 
@@ -536,16 +516,8 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.MonthCalendarMonthlyBoldedDatesDescr))]
         public DateTime[] MonthlyBoldedDates
         {
-            get
-            {
-                DateTime[] dateTimes = new DateTime[_monthlyArrayOfDates.Count];
-                for (int i = 0; i < _monthlyArrayOfDates.Count; ++i)
-                {
-                    dateTimes[i] = (DateTime)_monthlyArrayOfDates[i];
-                }
+            get => _monthlyArrayOfDates.ToArray();
 
-                return dateTimes;
-            }
             set
             {
                 _monthlyArrayOfDates.Clear();
@@ -553,15 +525,11 @@ namespace System.Windows.Forms
 
                 if (value != null && value.Length > 0)
                 {
-                    // Add each bolded date to our ArrayList.
-                    for (int i = 0; i < value.Length; i++)
+                    // Add each bolded date to our List.
+                    foreach (var  dateTime in value)
                     {
-                        _monthlyArrayOfDates.Add(value[i]);
-                    }
-
-                    for (int i = 0; i < value.Length; ++i)
-                    {
-                        _datesToBoldMonthly |= 0x00000001 << (value[i].Day - 1);
+                        _monthlyArrayOfDates.Add(dateTime);
+                        _datesToBoldMonthly |= 0x00000001 << (dateTime.Day - 1);
                     }
                 }
 
@@ -1125,7 +1093,7 @@ namespace System.Windows.Forms
             int numDates = _arrayOfDates.Count;
             for (int i = 0; i < numDates; ++i)
             {
-                DateTime date = (DateTime)_arrayOfDates[i];
+                DateTime date = _arrayOfDates[i];
                 if (DateTime.Compare(date, range.Start) >= 0 && DateTime.Compare(date, range.End) <= 0)
                 {
                     int month = date.Month;
@@ -1560,7 +1528,7 @@ namespace System.Windows.Forms
             int i = 0;
             for (; i < length; ++i)
             {
-                if (CompareDayAndMonth((DateTime)_annualArrayOfDates[i], date))
+                if (CompareDayAndMonth(_annualArrayOfDates[i], date))
                 {
                     _annualArrayOfDates.RemoveAt(i);
                     break;
@@ -1570,7 +1538,7 @@ namespace System.Windows.Forms
             --length;
             for (int j = i; j < length; ++j)
             {
-                if (CompareDayAndMonth((DateTime)_annualArrayOfDates[j], date))
+                if (CompareDayAndMonth(_annualArrayOfDates[j], date))
                 {
                     return;
                 }
@@ -1590,7 +1558,7 @@ namespace System.Windows.Forms
             int length = _arrayOfDates.Count;
             for (int i = 0; i < length; ++i)
             {
-                if (DateTime.Compare(((DateTime)_arrayOfDates[i]).Date, date.Date) == 0)
+                if (DateTime.Compare(_arrayOfDates[i].Date, date.Date) == 0)
                 {
                     _arrayOfDates.RemoveAt(i);
                     Invalidate();
@@ -1612,7 +1580,7 @@ namespace System.Windows.Forms
             int i = 0;
             for (; i < length; ++i)
             {
-                if (CompareDayAndMonth((DateTime)_monthlyArrayOfDates[i], date))
+                if (CompareDayAndMonth(_monthlyArrayOfDates[i], date))
                 {
                     _monthlyArrayOfDates.RemoveAt(i);
                     break;
@@ -1622,7 +1590,7 @@ namespace System.Windows.Forms
             --length;
             for (int j = i; j < length; ++j)
             {
-                if (CompareDayAndMonth((DateTime)_monthlyArrayOfDates[j], date))
+                if (CompareDayAndMonth(_monthlyArrayOfDates[j], date))
                 {
                     return;
                 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendarTests.cs
@@ -28,14 +28,14 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.AllowDrop);
             Assert.Equal(AnchorStyles.Top | AnchorStyles.Left, control.Anchor);
             Assert.Empty(control.AnnuallyBoldedDates);
-            Assert.NotSame(control.AnnuallyBoldedDates, control.AnnuallyBoldedDates);
+            Assert.Same(control.AnnuallyBoldedDates, control.AnnuallyBoldedDates);
             Assert.False(control.AutoSize);
             Assert.Equal(SystemColors.Window, control.BackColor);
             Assert.Null(control.BackgroundImage);
             Assert.Equal(ImageLayout.Tile, control.BackgroundImageLayout);
             Assert.Null(control.BindingContext);
             Assert.Empty(control.BoldedDates);
-            Assert.NotSame(control.BoldedDates, control.BoldedDates);
+            Assert.Same(control.BoldedDates, control.BoldedDates);
             Assert.True(control.Bottom > 0);
             Assert.Equal(0, control.Bounds.X);
             Assert.Equal(0, control.Bounds.Y);
@@ -101,7 +101,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(new DateTime(1753, 1, 1), control.MinDate);
             Assert.Equal(Size.Empty, control.MinimumSize);
             Assert.Empty(control.MonthlyBoldedDates);
-            Assert.NotSame(control.MonthlyBoldedDates, control.MonthlyBoldedDates);
+            Assert.Same(control.MonthlyBoldedDates, control.MonthlyBoldedDates);
             Assert.Equal(Padding.Empty, control.Padding);
             Assert.Null(control.Parent);
             Assert.True(control.PreferredSize.Width > 0);
@@ -203,14 +203,30 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(expected, calendar.AnnuallyBoldedDates);
             Assert.NotSame(value, calendar.AnnuallyBoldedDates);
-            Assert.NotSame(calendar.AnnuallyBoldedDates, calendar.AnnuallyBoldedDates);
+            if (value?.Length > 0)
+            {
+                Assert.NotSame(calendar.AnnuallyBoldedDates, calendar.AnnuallyBoldedDates);
+            }
+            else
+            {
+                Assert.Same(calendar.AnnuallyBoldedDates, calendar.AnnuallyBoldedDates);
+            }
+
             Assert.False(calendar.IsHandleCreated);
 
             // Set same.
             calendar.AnnuallyBoldedDates = value;
             Assert.Equal(expected, calendar.AnnuallyBoldedDates);
             Assert.NotSame(value, calendar.AnnuallyBoldedDates);
-            Assert.NotSame(calendar.AnnuallyBoldedDates, calendar.AnnuallyBoldedDates);
+            if (value?.Length > 0)
+            {
+                Assert.NotSame(calendar.AnnuallyBoldedDates, calendar.AnnuallyBoldedDates);
+            }
+            else
+            {
+                Assert.Same(calendar.AnnuallyBoldedDates, calendar.AnnuallyBoldedDates);
+            }
+
             Assert.False(calendar.IsHandleCreated);
         }
 
@@ -230,7 +246,15 @@ namespace System.Windows.Forms.Tests
             calendar.AnnuallyBoldedDates = value;
             Assert.Equal(expected, calendar.AnnuallyBoldedDates);
             Assert.NotSame(value, calendar.AnnuallyBoldedDates);
-            Assert.NotSame(calendar.AnnuallyBoldedDates, calendar.AnnuallyBoldedDates);
+            if (value?.Length > 0)
+            {
+                Assert.NotSame(calendar.AnnuallyBoldedDates, calendar.AnnuallyBoldedDates);
+            }
+            else
+            {
+                Assert.Same(calendar.AnnuallyBoldedDates, calendar.AnnuallyBoldedDates);
+            }
+
             Assert.True(calendar.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
@@ -240,7 +264,15 @@ namespace System.Windows.Forms.Tests
             calendar.AnnuallyBoldedDates = value;
             Assert.Equal(expected, calendar.AnnuallyBoldedDates);
             Assert.NotSame(value, calendar.AnnuallyBoldedDates);
-            Assert.NotSame(calendar.AnnuallyBoldedDates, calendar.AnnuallyBoldedDates);
+            if (value?.Length > 0)
+            {
+                Assert.NotSame(calendar.AnnuallyBoldedDates, calendar.AnnuallyBoldedDates);
+            }
+            else
+            {
+                Assert.Same(calendar.AnnuallyBoldedDates, calendar.AnnuallyBoldedDates);
+            }
+
             Assert.True(calendar.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
@@ -499,14 +531,30 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(expected, calendar.BoldedDates);
             Assert.NotSame(value, calendar.BoldedDates);
-            Assert.NotSame(calendar.BoldedDates, calendar.BoldedDates);
+            if (value?.Length > 0)
+            {
+                Assert.NotSame(calendar.BoldedDates, calendar.BoldedDates);
+            }
+            else
+            {
+                Assert.Same(calendar.BoldedDates, calendar.BoldedDates);
+            }
+
             Assert.False(calendar.IsHandleCreated);
 
             // Set same.
             calendar.BoldedDates = value;
             Assert.Equal(expected, calendar.BoldedDates);
             Assert.NotSame(value, calendar.BoldedDates);
-            Assert.NotSame(calendar.BoldedDates, calendar.BoldedDates);
+            if (value?.Length > 0)
+            {
+                Assert.NotSame(calendar.BoldedDates, calendar.BoldedDates);
+            }
+            else
+            {
+                Assert.Same(calendar.BoldedDates, calendar.BoldedDates);
+            }
+
             Assert.False(calendar.IsHandleCreated);
         }
 
@@ -526,7 +574,15 @@ namespace System.Windows.Forms.Tests
             calendar.BoldedDates = value;
             Assert.Equal(expected, calendar.BoldedDates);
             Assert.NotSame(value, calendar.BoldedDates);
-            Assert.NotSame(calendar.BoldedDates, calendar.BoldedDates);
+            if (value?.Length > 0)
+            {
+                Assert.NotSame(calendar.BoldedDates, calendar.BoldedDates);
+            }
+            else
+            {
+                Assert.Same(calendar.BoldedDates, calendar.BoldedDates);
+            }
+
             Assert.True(calendar.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
@@ -536,7 +592,15 @@ namespace System.Windows.Forms.Tests
             calendar.BoldedDates = value;
             Assert.Equal(expected, calendar.BoldedDates);
             Assert.NotSame(value, calendar.BoldedDates);
-            Assert.NotSame(calendar.BoldedDates, calendar.BoldedDates);
+            if (value?.Length > 0)
+            {
+                Assert.NotSame(calendar.BoldedDates, calendar.BoldedDates);
+            }
+            else
+            {
+                Assert.Same(calendar.BoldedDates, calendar.BoldedDates);
+            }
+
             Assert.True(calendar.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
@@ -1492,14 +1556,30 @@ namespace System.Windows.Forms.Tests
             };
             Assert.Equal(expected, calendar.MonthlyBoldedDates);
             Assert.NotSame(value, calendar.MonthlyBoldedDates);
-            Assert.NotSame(calendar.MonthlyBoldedDates, calendar.MonthlyBoldedDates);
+            if (value?.Length > 0)
+            {
+                Assert.NotSame(calendar.MonthlyBoldedDates, calendar.MonthlyBoldedDates);
+            }
+            else
+            {
+                Assert.Same(calendar.MonthlyBoldedDates, calendar.MonthlyBoldedDates);
+            }
+
             Assert.False(calendar.IsHandleCreated);
 
             // Set same.
             calendar.MonthlyBoldedDates = value;
             Assert.Equal(expected, calendar.MonthlyBoldedDates);
             Assert.NotSame(value, calendar.MonthlyBoldedDates);
-            Assert.NotSame(calendar.MonthlyBoldedDates, calendar.MonthlyBoldedDates);
+            if (value?.Length > 0)
+            {
+                Assert.NotSame(calendar.MonthlyBoldedDates, calendar.MonthlyBoldedDates);
+            }
+            else
+            {
+                Assert.Same(calendar.MonthlyBoldedDates, calendar.MonthlyBoldedDates);
+            }
+
             Assert.False(calendar.IsHandleCreated);
         }
 
@@ -1519,7 +1599,15 @@ namespace System.Windows.Forms.Tests
             calendar.MonthlyBoldedDates = value;
             Assert.Equal(expected, calendar.MonthlyBoldedDates);
             Assert.NotSame(value, calendar.MonthlyBoldedDates);
-            Assert.NotSame(calendar.MonthlyBoldedDates, calendar.MonthlyBoldedDates);
+            if (value?.Length > 0)
+            {
+                Assert.NotSame(calendar.MonthlyBoldedDates, calendar.MonthlyBoldedDates);
+            }
+            else
+            {
+                Assert.Same(calendar.MonthlyBoldedDates, calendar.MonthlyBoldedDates);
+            }
+
             Assert.True(calendar.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
@@ -1529,7 +1617,15 @@ namespace System.Windows.Forms.Tests
             calendar.MonthlyBoldedDates = value;
             Assert.Equal(expected, calendar.MonthlyBoldedDates);
             Assert.NotSame(value, calendar.MonthlyBoldedDates);
-            Assert.NotSame(calendar.MonthlyBoldedDates, calendar.MonthlyBoldedDates);
+            if (value?.Length > 0)
+            {
+                Assert.NotSame(calendar.MonthlyBoldedDates, calendar.MonthlyBoldedDates);
+            }
+            else
+            {
+                Assert.Same(calendar.MonthlyBoldedDates, calendar.MonthlyBoldedDates);
+            }
+
             Assert.True(calendar.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);


### PR DESCRIPTION
## Proposed changes

- Use generic lists in MonthCalendar.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3483)