### PR TITLE
ImageList must be disposed

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
@@ -464,7 +464,7 @@ namespace System.Windows.Forms.Tests
             };
             var image = new Bitmap(10, 10);
             sourceList.Images.Add(image);
-            ImageListStreamer stream = RoundtripSerialize(sourceList.ImageStream);
+            using ImageListStreamer stream = RoundtripSerialize(sourceList.ImageStream);
             Assert.True(sourceList.HandleCreated);
 
             using var list = new ImageList();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
@@ -462,7 +462,7 @@ namespace System.Windows.Forms.Tests
                 ColorDepth = colorDepth,
                 ImageSize = new Size(32, 32)
             };
-            var image = new Bitmap(10, 10);
+            using var image = new Bitmap(10, 10);
             sourceList.Images.Add(image);
             using ImageListStreamer stream = RoundtripSerialize(sourceList.ImageStream);
             Assert.True(sourceList.HandleCreated);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -2171,12 +2171,13 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(LargeImageList_Set_GetReturnsExpected))]
         public void ListView_LargeImageList_SetWithNonNullOldValue_GetReturnsExpected(bool autoArrange, bool virtualMode, View view, ImageList value)
         {
+            using var imageList = new ImageList();
             using var listView = new ListView
             {
                 AutoArrange = autoArrange,
                 VirtualMode = virtualMode,
                 View = view,
-                LargeImageList = new ImageList()
+                LargeImageList = imageList
             };
 
             listView.LargeImageList = value;
@@ -2335,12 +2336,13 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(LargeImageList_SetWithHandleWithNonNullOldValue_GetReturnsExpected))]
         public void ListView_LargeImageList_SetWithHandleWithNonNullOldValue_GetReturnsExpected(bool autoArrange, bool virtualMode, View view, ImageList value, int expectedInvalidatedCallCount)
         {
+            using var imageList = new ImageList();
             using var listView = new ListView
             {
                 AutoArrange = autoArrange,
                 VirtualMode = virtualMode,
                 View = view,
-                LargeImageList = new ImageList()
+                LargeImageList = imageList
             };
             Assert.NotEqual(IntPtr.Zero, listView.Handle);
             int invalidatedCallCount = 0;
@@ -2778,12 +2780,13 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(SmallImageList_Set_GetReturnsExpected))]
         public void ListView_SmallImageList_SetWithNonNullOldValue_GetReturnsExpected(bool autoArrange, bool virtualMode, View view, ImageList value)
         {
+            using var imageList = new ImageList();
             using var listView = new ListView
             {
                 AutoArrange = autoArrange,
                 VirtualMode = virtualMode,
                 View = view,
-                SmallImageList = new ImageList()
+                SmallImageList = imageList
             };
 
             listView.SmallImageList = value;
@@ -2942,12 +2945,13 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(SmallImageList_SetWithHandleWithNonNullOldValue_GetReturnsExpected))]
         public void ListView_SmallImageList_SetWithHandleWithNonNullOldValue_GetReturnsExpected(bool autoArrange, bool virtualMode, View view, ImageList value, int expectedInvalidatedCallCount, int expectedStyleChangedCallCount)
         {
+            using var imageList = new ImageList();
             using var listView = new ListView
             {
                 AutoArrange = autoArrange,
                 VirtualMode = virtualMode,
                 View = view,
-                SmallImageList = new ImageList()
+                SmallImageList = imageList
             };
             Assert.NotEqual(IntPtr.Zero, listView.Handle);
             int invalidatedCallCount = 0;
@@ -3098,6 +3102,7 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(StateImageList_Set_GetReturnsExpected))]
         public void ListView_StateImageList_SetWithNonNullOldValue_GetReturnsExpected(bool useCompatibleStateImageBehavior, bool checkBoxes, bool autoArrange, bool virtualMode, View view, ImageList value)
         {
+            using var imageList = new ImageList();
             using var listView = new ListView
             {
                 UseCompatibleStateImageBehavior = useCompatibleStateImageBehavior,
@@ -3105,7 +3110,7 @@ namespace System.Windows.Forms.Tests
                 AutoArrange = autoArrange,
                 VirtualMode = virtualMode,
                 View = view,
-                StateImageList = new ImageList()
+                StateImageList = imageList
             };
 
             listView.StateImageList = value;
@@ -3462,6 +3467,7 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(StateImageList_SetWithHandleWithNonNullOldValue_GetReturnsExpected))]
         public void ListView_StateImageList_SetWithHandleWithNonNullOldValue_GetReturnsExpected(bool useCompatibleStateImageBehavior, bool checkBoxes, bool autoArrange, bool virtualMode, View view, ImageList value, int expectedInvalidatedCallCount, int expectedCreatedCallCount)
         {
+            using var imageList = new ImageList();
             using var listView = new ListView
             {
                 UseCompatibleStateImageBehavior = useCompatibleStateImageBehavior,
@@ -3469,7 +3475,7 @@ namespace System.Windows.Forms.Tests
                 AutoArrange = autoArrange,
                 VirtualMode = virtualMode,
                 View = view,
-                StateImageList = new ImageList()
+                StateImageList = imageList
             };
             Assert.NotEqual(IntPtr.Zero, listView.Handle);
             int invalidatedCallCount = 0;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
@@ -1263,7 +1263,7 @@ namespace System.Windows.Forms.Tests
             control.TabPages.Add(page1);
             control.TabPages.Add(page2);
 
-            var imageList = new ImageList();
+            using var imageList = new ImageList();
             using var image1 = new Bitmap(10, 10);
             using var image2 = new Bitmap(10, 10);
             using var image3 = new Bitmap(10, 10);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -2460,9 +2460,10 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(ImageList_TestData))]
         public void ImageList_SetWithNonNullOldValue_GetReturnsExpected(ImageList value)
         {
+            using var imageList = new ImageList();
             using var treeView = new TreeView
             {
-                ImageList = new ImageList()
+                ImageList = imageList
             };
 
             treeView.ImageList = value;
@@ -2526,9 +2527,10 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(ImageList_TestData))]
         public void ImageList_SetWithNonNullOldValueWithHandle_GetReturnsExpected(ImageList value)
         {
+            using var imageList = new ImageList();
             using var treeView = new TreeView
             {
-                ImageList = new ImageList()
+                ImageList = imageList
             };
             Assert.NotEqual(IntPtr.Zero, treeView.Handle);
 


### PR DESCRIPTION
## Proposed changes

During investigation of #3358 I noticed that some ImageLists were finalized.

ImageLists are designer components that need to be disposed.

## Customer Impact

none

## Regression? 

no

## Risk

none

### Before

ImageList handles were collected by GC and released in the finalizer

### After

ImageList handles should be disposed by the test that created them

## Test methodology

setting a breakpoint in the `NativeImageList` finalizer and ensure its not hit


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3486)