### PR TITLE
Reduce sharing of disposable objects across MemberData sets

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeaderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeaderTests.cs
@@ -1633,6 +1633,7 @@ namespace System.Windows.Forms.Tests
             using (new NoAssertContext())
             {
                 using var imageList = new ImageList();
+                using var imageList2 = new ImageList();
                 using var listView = new ListView
                 {
                     SmallImageList = imageList
@@ -1640,7 +1641,7 @@ namespace System.Windows.Forms.Tests
                 using var header = new ColumnHeader();
                 listView.Columns.Add(header);
                 var indexer = new ColumnHeader.ColumnHeaderImageListIndexer(header);
-                indexer.ImageList = new ImageList();
+                indexer.ImageList = imageList2;
                 Assert.Same(imageList, indexer.ImageList);
             }
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
@@ -818,7 +818,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void ImageList_Dispose_InvokeEmptyWithoutHandle_Nop()
         {
-            var list = new ImageList();
+            using var list = new ImageList();
             list.Dispose();
             Assert.Empty(list.Images);
             Assert.False(list.HandleCreated);
@@ -833,7 +833,7 @@ namespace System.Windows.Forms.Tests
         {
             using var icon = new Icon("bitmaps/10x16_one_entry_32bit.ico");
             using var bitmap = new Bitmap(10, 10);
-            var list = new ImageList();
+            using var list = new ImageList();
             list.Images.Add(icon);
             list.Images.Add(bitmap);
 
@@ -857,7 +857,7 @@ namespace System.Windows.Forms.Tests
         {
             using var bitmap1 = new Bitmap(10, 10);
             using var bitmap2 = new Bitmap(10, 10);
-            var list = new ImageList();
+            using var list = new ImageList();
             list.Images.Add(bitmap1);
             list.Images.Add(bitmap2);
 
@@ -874,7 +874,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void ImageList_Dispose_InvokeEmptyWithHandle_Nop()
         {
-            var list = new ImageList();
+            using var list = new ImageList();
             Assert.NotEqual(IntPtr.Zero, list.Handle);
 
             list.Dispose();
@@ -891,7 +891,7 @@ namespace System.Windows.Forms.Tests
         {
             using var icon = new Icon("bitmaps/10x16_one_entry_32bit.ico");
             using var bitmap = new Bitmap(10, 10);
-            var list = new ImageList();
+            using var list = new ImageList();
             list.Images.Add(icon);
             list.Images.Add(bitmap);
             Assert.NotEqual(IntPtr.Zero, list.Handle);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -801,14 +801,14 @@ namespace System.Windows.Forms.Tests
             {
                 foreach (ListViewAlignment alignment in Enum.GetValues(typeof(ListViewAlignment)))
                 {
-                    foreach (ImageList imageList in new ImageList[] { new ImageList(), null })
+                    foreach (Func<ImageList> imageListFactory in new Func<ImageList>[] { () => new ImageList(), () => null })
                     {
                         foreach (bool value in new bool[] { true, false })
                         {
-                            yield return new object[] { useCompatibleStateImageBehavior, View.Details, alignment, imageList, value };
-                            yield return new object[] { useCompatibleStateImageBehavior, View.LargeIcon, alignment, imageList, value };
-                            yield return new object[] { useCompatibleStateImageBehavior, View.List, alignment, imageList, value };
-                            yield return new object[] { useCompatibleStateImageBehavior, View.SmallIcon, alignment, imageList, value };
+                            yield return new object[] { useCompatibleStateImageBehavior, View.Details, alignment, imageListFactory(), value };
+                            yield return new object[] { useCompatibleStateImageBehavior, View.LargeIcon, alignment, imageListFactory(), value };
+                            yield return new object[] { useCompatibleStateImageBehavior, View.List, alignment, imageListFactory(), value };
+                            yield return new object[] { useCompatibleStateImageBehavior, View.SmallIcon, alignment, imageListFactory(), value };
                         }
                     }
                 }
@@ -907,16 +907,16 @@ namespace System.Windows.Forms.Tests
         {
             foreach (ListViewAlignment alignment in Enum.GetValues(typeof(ListViewAlignment)))
             {
-                foreach (ImageList imageList in new ImageList[] { new ImageList(), null })
+                foreach (Func<ImageList> imageListFactory in new Func<ImageList>[] { () => new ImageList(), () => null })
                 {
-                    yield return new object[] { true, View.Details, alignment, imageList, true, 1, 0, 2, 0 };
-                    yield return new object[] { true, View.LargeIcon, alignment, imageList, true, 1, 0, 2, 0 };
-                    yield return new object[] { true, View.List, alignment, imageList, true, 1, 0, 2, 0 };
-                    yield return new object[] { true, View.SmallIcon, alignment, imageList, true, 1, 0, 2, 0 };
-                    yield return new object[] { true, View.Details, alignment, imageList, false, 0, 0, 1, 0 };
-                    yield return new object[] { true, View.LargeIcon, alignment, imageList, false, 0, 0, 1, 0 };
-                    yield return new object[] { true, View.List, alignment, imageList, false, 0, 0, 1, 0 };
-                    yield return new object[] { true, View.SmallIcon, alignment, imageList, false, 0, 0, 1, 0 };
+                    yield return new object[] { true, View.Details, alignment, imageListFactory(), true, 1, 0, 2, 0 };
+                    yield return new object[] { true, View.LargeIcon, alignment, imageListFactory(), true, 1, 0, 2, 0 };
+                    yield return new object[] { true, View.List, alignment, imageListFactory(), true, 1, 0, 2, 0 };
+                    yield return new object[] { true, View.SmallIcon, alignment, imageListFactory(), true, 1, 0, 2, 0 };
+                    yield return new object[] { true, View.Details, alignment, imageListFactory(), false, 0, 0, 1, 0 };
+                    yield return new object[] { true, View.LargeIcon, alignment, imageListFactory(), false, 0, 0, 1, 0 };
+                    yield return new object[] { true, View.List, alignment, imageListFactory(), false, 0, 0, 1, 0 };
+                    yield return new object[] { true, View.SmallIcon, alignment, imageListFactory(), false, 0, 0, 1, 0 };
                 }
 
                 if (alignment != ListViewAlignment.Left)
@@ -941,16 +941,16 @@ namespace System.Windows.Forms.Tests
                 }
             }
 
-            foreach (ImageList imageList in new ImageList[] { new ImageList(), null })
+            foreach (Func<ImageList> imageListFactory in new Func<ImageList>[] { () => new ImageList(), () => null })
             {
-                yield return new object[] { false, View.Details, ListViewAlignment.Left, imageList, true, 1, 0, 2, 1 };
-                yield return new object[] { false, View.LargeIcon, ListViewAlignment.Left, imageList, true, 2, 1, 4, 2 };
-                yield return new object[] { false, View.List, ListViewAlignment.Left, imageList, true, 1, 1, 2, 2 };
-                yield return new object[] { false, View.SmallIcon, ListViewAlignment.Left, imageList, true, 2, 1, 4, 2 };
-                yield return new object[] { false, View.Details, ListViewAlignment.Left, imageList, false, 0, 0, 1, 0 };
-                yield return new object[] { false, View.LargeIcon, ListViewAlignment.Left, imageList, false, 0, 0, 2, 1 };
-                yield return new object[] { false, View.List, ListViewAlignment.Left, imageList, false, 0, 0, 1, 1 };
-                yield return new object[] { false, View.SmallIcon, ListViewAlignment.Left, imageList, false, 0, 0, 2, 1 };
+                yield return new object[] { false, View.Details, ListViewAlignment.Left, imageListFactory(), true, 1, 0, 2, 1 };
+                yield return new object[] { false, View.LargeIcon, ListViewAlignment.Left, imageListFactory(), true, 2, 1, 4, 2 };
+                yield return new object[] { false, View.List, ListViewAlignment.Left, imageListFactory(), true, 1, 1, 2, 2 };
+                yield return new object[] { false, View.SmallIcon, ListViewAlignment.Left, imageListFactory(), true, 2, 1, 4, 2 };
+                yield return new object[] { false, View.Details, ListViewAlignment.Left, imageListFactory(), false, 0, 0, 1, 0 };
+                yield return new object[] { false, View.LargeIcon, ListViewAlignment.Left, imageListFactory(), false, 0, 0, 2, 1 };
+                yield return new object[] { false, View.List, ListViewAlignment.Left, imageListFactory(), false, 0, 0, 1, 1 };
+                yield return new object[] { false, View.SmallIcon, ListViewAlignment.Left, imageListFactory(), false, 0, 0, 2, 1 };
             }
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -4488,9 +4488,10 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(ImageList_TestData))]
         public void StateImageList_SetWithNonNullOldValue_GetReturnsExpected(ImageList value)
         {
+            using var imageList = new ImageList();
             using var treeView = new TreeView
             {
-                StateImageList = new ImageList()
+                StateImageList = imageList
             };
 
             treeView.StateImageList = value;
@@ -4520,9 +4521,10 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(ImageList_TestData))]
         public void StateImageList_SetWithNonNullOldValueWithHandle_GetReturnsExpected(ImageList value)
         {
+            using var imageList = new ImageList();
             using var treeView = new TreeView
             {
-                StateImageList = new ImageList()
+                StateImageList = imageList
             };
             Assert.NotEqual(IntPtr.Zero, treeView.Handle);
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/VisualStyles/VisualStyleRendererTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/VisualStyles/VisualStyleRendererTests.cs
@@ -294,8 +294,9 @@ namespace System.Windows.Forms.VisualStyles.Tests
         {
             var renderer = new VisualStyleRenderer(VisualStyleElement.Button.PushButton.Normal);
             using var image = new Bitmap(10, 10);
+            using var imageList = new ImageList();
             Assert.Throws<ArgumentNullException>("g", () => renderer.DrawImage(null, new Rectangle(1, 2, 3, 4), image));
-            Assert.Throws<ArgumentNullException>("g", () => renderer.DrawImage(null, new Rectangle(1, 2, 3, 4), new ImageList(), 0));
+            Assert.Throws<ArgumentNullException>("g", () => renderer.DrawImage(null, new Rectangle(1, 2, 3, 4), imageList, 0));
         }
 
         [Fact]


### PR DESCRIPTION
Contributes to #3487

## Proposed changes

Use factory methods instead of sharing disposable objects across MemberData sets

Sharing disposable objects relies on undocumented behavior of xunit (it does not guarantee that disposal happens after all tests are run, it could just as well dispose each set individually after running it). It also introduces hidden dependencies between tests that may lead to undesired interaction between tests.

## Customer Impact

none

## Regression? 

no

## Risk

none

### Before

sometimes disposable objects were shared between MemberData sets

### After

disposable objects should not be shared between MemberData sets

## Test methodology

code review


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3488)