### PR TITLE
Prepare for strict coherency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -95,5 +95,41 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>531ebcd1895aa32a106db5849cd4ace3909cefce</Sha>
     </Dependency>
+    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-preview.7.20320.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>531ebcd1895aa32a106db5849cd4ace3909cefce</Sha>
+    </Dependency>
+    <Dependency Name="System.DirectoryServices" Version="5.0.0-preview.7.20320.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>531ebcd1895aa32a106db5849cd4ace3909cefce</Sha>
+    </Dependency>
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="5.0.0-preview.7.20320.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>531ebcd1895aa32a106db5849cd4ace3909cefce</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.AccessControl" Version="5.0.0-preview.7.20320.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>531ebcd1895aa32a106db5849cd4ace3909cefce</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-preview.7.20320.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>531ebcd1895aa32a106db5849cd4ace3909cefce</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-preview.7.20320.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>531ebcd1895aa32a106db5849cd4ace3909cefce</Sha>
+    </Dependency>
+    <Dependency Name="System.IO.Packaging" Version="5.0.0-preview.7.20320.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>531ebcd1895aa32a106db5849cd4ace3909cefce</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.ILDAsm" Version="5.0.0-preview.7.20320.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>531ebcd1895aa32a106db5849cd4ace3909cefce</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.App.Internal" Version="5.0.0-preview.7.20320.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>531ebcd1895aa32a106db5849cd4ace3909cefce</Sha>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,6 +12,16 @@
   <!-- Core Setup for coherency -->
   <PropertyGroup>
     <MicrosoftNETCoreAppPackageVersion>5.0.0-preview.7.20320.5</MicrosoftNETCoreAppPackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>5.0.0-preview.7.20320.5</SystemDiagnosticsEventLogPackageVersion>
+    <SystemDirectoryServicesPackageVersion>5.0.0-preview.7.20320.5</SystemDirectoryServicesPackageVersion>
+    <SystemReflectionMetadataLoadContextPackageVersion>5.0.0-preview.7.20320.5</SystemReflectionMetadataLoadContextPackageVersion>
+    <SystemSecurityAccessControlPackageVersion>5.0.0-preview.7.20320.5</SystemSecurityAccessControlPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>5.0.0-preview.7.20320.5</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityPrincipalWindowsPackageVersion>5.0.0-preview.7.20320.5</SystemSecurityPrincipalWindowsPackageVersion>
+    <SystemIOPackagingPackageVersion>5.0.0-preview.7.20320.5</SystemIOPackagingPackageVersion>
+    <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>5.0.0-preview.7.20320.5</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
+    <MicrosoftNETCoreILDAsmPackageVersion>5.0.0-preview.7.20320.5</MicrosoftNETCoreILDAsmPackageVersion>
+    <MicrosoftNETCoreAppInternalPackageVersion>5.0.0-preview.7.20320.5</MicrosoftNETCoreAppInternalPackageVersion>
   </PropertyGroup>
   <!-- CoreFX via Core Setup -->
   <PropertyGroup>


### PR DESCRIPTION
Strict coherency means that if your repo declares a dependency with a CPD attribute, the CPD parent must have a direct dependency on that dependency.
This means that for WPF, there are a few dependencies where it declares Microsoft.Private.Winforms to be the parent, but winforms does not have a dependency on those dependencies. Add them.

Reasons for this approach over the current approach:
- This eliminates some ambiguous tie-breaking scenarios that are very problematic and dangerous in servicing
- Those tie breaking scenarios require the use of BAR to break the ties. If the DB data were to be lost then the tie-breaking would do unexpected things.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3489)