### PR TITLE
Implement TitleImageIndex/Key to ListViewGroup

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,6 @@
+System.Windows.Forms.ListViewGroup.TitleImageIndex.get -> int
+System.Windows.Forms.ListViewGroup.TitleImageIndex.set -> void
+System.Windows.Forms.ListViewGroup.TitleImageKey.get -> string!
+System.Windows.Forms.ListViewGroup.TitleImageKey.set -> void
+~System.Windows.Forms.ListView.GroupImageList.get -> System.Windows.Forms.ImageList
+~System.Windows.Forms.ListView.GroupImageList.set -> void

--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6710,4 +6710,7 @@ Stack trace where the illegal operation occurred was:
   <data name="InputLanguageCultureNotFound" xml:space="preserve">
     <value>Could not find an InputLanguage for culture '{0}'.</value>
   </data>
+  <data name="ListViewGroupImageListDescr" xml:space="preserve">
+    <value>The ImageList control used by the ListView for ListViewGroup images in all views.</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -6376,6 +6376,11 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">ListViewGroup</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupImageListDescr">
+        <source>The ImageList control used by the ListView for ListViewGroup images in all views.</source>
+        <target state="new">The ImageList control used by the ListView for ListViewGroup images in all views.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupNameDescr">
         <source>The name of this group.</source>
         <target state="translated">Název této skupiny</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -6376,6 +6376,11 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">ListViewGroup</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupImageListDescr">
+        <source>The ImageList control used by the ListView for ListViewGroup images in all views.</source>
+        <target state="new">The ImageList control used by the ListView for ListViewGroup images in all views.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupNameDescr">
         <source>The name of this group.</source>
         <target state="translated">Der Name dieser Gruppe.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -6376,6 +6376,11 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">ListViewGroup</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupImageListDescr">
+        <source>The ImageList control used by the ListView for ListViewGroup images in all views.</source>
+        <target state="new">The ImageList control used by the ListView for ListViewGroup images in all views.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupNameDescr">
         <source>The name of this group.</source>
         <target state="translated">Nombre de este grupo.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -6376,6 +6376,11 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">ListViewGroup</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupImageListDescr">
+        <source>The ImageList control used by the ListView for ListViewGroup images in all views.</source>
+        <target state="new">The ImageList control used by the ListView for ListViewGroup images in all views.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupNameDescr">
         <source>The name of this group.</source>
         <target state="translated">Nom de ce groupe.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -6376,6 +6376,11 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">ListViewGroup</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupImageListDescr">
+        <source>The ImageList control used by the ListView for ListViewGroup images in all views.</source>
+        <target state="new">The ImageList control used by the ListView for ListViewGroup images in all views.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupNameDescr">
         <source>The name of this group.</source>
         <target state="translated">Il nome del gruppo.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -6376,6 +6376,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">ListViewGroup</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupImageListDescr">
+        <source>The ImageList control used by the ListView for ListViewGroup images in all views.</source>
+        <target state="new">The ImageList control used by the ListView for ListViewGroup images in all views.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupNameDescr">
         <source>The name of this group.</source>
         <target state="translated">このグループの名前です。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -6376,6 +6376,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">ListViewGroup</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupImageListDescr">
+        <source>The ImageList control used by the ListView for ListViewGroup images in all views.</source>
+        <target state="new">The ImageList control used by the ListView for ListViewGroup images in all views.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupNameDescr">
         <source>The name of this group.</source>
         <target state="translated">이 그룹의 이름입니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -6376,6 +6376,11 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">ListViewGroup</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupImageListDescr">
+        <source>The ImageList control used by the ListView for ListViewGroup images in all views.</source>
+        <target state="new">The ImageList control used by the ListView for ListViewGroup images in all views.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupNameDescr">
         <source>The name of this group.</source>
         <target state="translated">Nazwa tej grupy.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -6376,6 +6376,11 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">ListViewGroup</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupImageListDescr">
+        <source>The ImageList control used by the ListView for ListViewGroup images in all views.</source>
+        <target state="new">The ImageList control used by the ListView for ListViewGroup images in all views.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupNameDescr">
         <source>The name of this group.</source>
         <target state="translated">O nome deste grupo.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -6377,6 +6377,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">ListViewGroup</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupImageListDescr">
+        <source>The ImageList control used by the ListView for ListViewGroup images in all views.</source>
+        <target state="new">The ImageList control used by the ListView for ListViewGroup images in all views.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupNameDescr">
         <source>The name of this group.</source>
         <target state="translated">Имя данной группы.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -6376,6 +6376,11 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">ListViewGroup</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupImageListDescr">
+        <source>The ImageList control used by the ListView for ListViewGroup images in all views.</source>
+        <target state="new">The ImageList control used by the ListView for ListViewGroup images in all views.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupNameDescr">
         <source>The name of this group.</source>
         <target state="translated">Bu grubun adı.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -6376,6 +6376,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">ListViewGroup</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupImageListDescr">
+        <source>The ImageList control used by the ListView for ListViewGroup images in all views.</source>
+        <target state="new">The ImageList control used by the ListView for ListViewGroup images in all views.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupNameDescr">
         <source>The name of this group.</source>
         <target state="translated">此组的名称。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -6376,6 +6376,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">ListViewGroup</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewGroupImageListDescr">
+        <source>The ImageList control used by the ListView for ListViewGroup images in all views.</source>
+        <target state="new">The ImageList control used by the ListView for ListViewGroup images in all views.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewGroupNameDescr">
         <source>The name of this group.</source>
         <target state="translated">此群組的名稱。</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -3670,8 +3670,7 @@ namespace System.Windows.Forms
 
             foreach (ListViewGroup group in Groups)
             {
-                group.TitleImageIndex =
-                    (group.ImageIndexer.ActualIndex == ImageList.Indexer.DefaultIndex || group.ImageIndexer.ActualIndex < _imageListGroup.Images.Count)
+                group.TitleImageIndex = group.ImageIndexer.ActualIndex < _imageListGroup.Images.Count
                     ? group.ImageIndexer.ActualIndex
                     : _imageListGroup.Images.Count - 1;
             }
@@ -4270,8 +4269,7 @@ namespace System.Windows.Forms
 
             foreach (ListViewItem item in Items)
             {
-                int imageIndex =
-                    item.ImageIndexer.ActualIndex == ImageList.Indexer.DefaultIndex || item.ImageIndexer.ActualIndex < _imageListLarge.Images.Count
+                int imageIndex = item.ImageIndexer.ActualIndex < _imageListLarge.Images.Count
                     ? item.ImageIndexer.ActualIndex
                     : _imageListLarge.Images.Count - 1;
                 SetItemImage(item.Index, imageIndex);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -33,6 +32,8 @@ namespace System.Windows.Forms
         private static int s_nextID;
 
         private static int s_nextHeader = 1;
+
+        private ListViewGroupImageIndexer? _imageIndexer;
 
         /// <summary>
         ///  Creates a ListViewGroup.
@@ -175,7 +176,8 @@ namespace System.Windows.Forms
         ///  Controls which <see cref="ListViewGroupCollapsedState"/> the group will appear as.
         /// </summary>
         /// <value>
-        ///  One of the <see cref="ListViewGroupCollapsedState"/> values that specifies how the group is displayed. The default is <see cref="ListViewGroupCollapsedState.Default"/>.
+        ///  One of the <see cref="ListViewGroupCollapsedState"/> values that specifies how the group is displayed.
+        ///  The default is <see cref="ListViewGroupCollapsedState.Default"/>.
         /// </value>
         /// <exception cref="InvalidEnumArgumentException">
         ///  The specified value when setting this property is not a valid <see cref="ListViewGroupCollapsedState"/> value.
@@ -241,6 +243,74 @@ namespace System.Windows.Forms
                 UpdateListView();
             }
         }
+
+        /// <summary>
+        ///  Gets or sets the index of the image that is displayed for the group.
+        /// </summary>
+        /// <value>
+        ///  The zero-based index of the image in the ImageList that is displayed for the group. The default is -1.
+        /// </value>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///  The value specified is less than -1.
+        /// </exception>
+        [DefaultValue(-1)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(Drawing.Design.UITypeEditor))]
+        [Localizable(true)]
+        [RefreshProperties(RefreshProperties.Repaint)]
+        [SRCategory(nameof(SR.CatBehavior))]
+        [TypeConverter(typeof(NoneExcludedImageIndexConverter))]
+        public int TitleImageIndex
+        {
+            get
+            {
+                ImageList? imageList = ImageIndexer.ImageList;
+                return imageList == null || ImageIndexer.Index < imageList.Images.Count
+                    ? ImageIndexer.Index
+                    : imageList.Images.Count - 1;
+            }
+            set
+            {
+                if (value < ImageList.Indexer.DefaultIndex)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), value,
+                        string.Format(SR.InvalidLowBoundArgumentEx, nameof(TitleImageIndex), value, ImageList.Indexer.DefaultIndex));
+                }
+
+                ImageIndexer.Index = value;
+                UpdateListView();
+            }
+        }
+
+        /// <summary>
+        ///  Gets or sets the key of the image that is displayed for the group.
+        /// </summary>
+        /// <value>
+        ///  The key for the image that is displayed for the group.
+        /// </value>
+        [DefaultValue("")]
+        [TypeConverter(typeof(ImageKeyConverter))]
+        [Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(Drawing.Design.UITypeEditor))]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [RefreshProperties(RefreshProperties.Repaint)]
+        [SRCategory(nameof(SR.CatBehavior))]
+        [Localizable(true)]
+        public string TitleImageKey
+        {
+            get => ImageIndexer.Key;
+            set
+            {
+                if (ImageIndexer.Key == value)
+                {
+                    return;
+                }
+
+                ImageIndexer.Key = value;
+                UpdateListView();
+            }
+        }
+
+        internal ListViewGroupImageIndexer ImageIndexer => _imageIndexer ??= new ListViewGroupImageIndexer(this);
 
         internal int ID { get; }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
@@ -277,6 +277,11 @@ namespace System.Windows.Forms
                         string.Format(SR.InvalidLowBoundArgumentEx, nameof(TitleImageIndex), value, ImageList.Indexer.DefaultIndex));
                 }
 
+                if (ImageIndexer.Index == value && value != ImageList.Indexer.DefaultIndex)
+                {
+                    return;
+                }
+
                 ImageIndexer.Index = value;
                 UpdateListView();
             }
@@ -300,7 +305,7 @@ namespace System.Windows.Forms
             get => ImageIndexer.Key;
             set
             {
-                if (ImageIndexer.Key == value)
+                if (ImageIndexer.Key == value && value != ImageList.Indexer.DefaultKey)
                 {
                     return;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupImageIndexer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupImageIndexer.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace System.Windows.Forms
+{
+    /// <summary>
+    ///  We need a special way to defer to the ListView's image list for indexing purposes.
+    ///  ListViewGroupImageIndexer is a class used to support <see cref="ListViewGroup.TitleImageIndex"/> and
+    ///  <see cref="ListViewGroup.TitleImageKey"/>.
+    /// </summary>
+    internal class ListViewGroupImageIndexer : ImageList.Indexer
+    {
+        private readonly ListViewGroup _owner;
+
+        /// <summary>
+        ///  Initializes a new instance of the <see cref="ListViewGroupImageIndexer"/> class.
+        /// </summary>
+        /// <param name="group">The <see cref="ListViewGroup"/> that this object belongs to.</param>
+        public ListViewGroupImageIndexer(ListViewGroup group)
+        {
+            _owner = group;
+        }
+
+        /// <summary>
+        ///  Gets the <see cref="ListView.GroupImageList"/> of the <see cref="ListView"/>
+        ///  associated with the group.
+        /// </summary>
+        public override ImageList? ImageList
+        {
+            get => _owner.ListView?.GroupImageList;
+            set => Debug.Fail("We should never set the image list");
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItemImageIndexer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItemImageIndexer.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System.Diagnostics;
+
+namespace System.Windows.Forms
+{
+    /// <summary>
+    ///  We need a special way to defer to the ListView's image list for indexing purposes.
+    ///  ListViewItemImageIndexer is a class used to support <see cref="ListViewItem.ImageIndex"/> and
+    ///  <see cref="ListViewItem.ImageKey"/>.
+    /// </summary>
+    internal class ListViewItemImageIndexer : ImageList.Indexer
+    {
+        private readonly ListViewItem _owner;
+
+        /// <summary>
+        ///  Initializes a new instance of the <see cref="ListViewItemImageIndexer"/> class.
+        /// </summary>
+        /// <param name="item">The <see cref="ListViewItem"/> that this object belongs to.</param>
+        public ListViewItemImageIndexer(ListViewItem item)
+        {
+            _owner = item;
+        }
+
+        /// <summary>
+        ///  Gets the <see cref="ListViewItem.ImageList"/> associated with the item.
+        /// </summary>
+        public override ImageList ImageList
+        {
+            get => _owner?.ImageList;
+            set => Debug.Fail("We should never set the image list");
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItemImageIndexer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItemImageIndexer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics;
 
 namespace System.Windows.Forms
@@ -29,9 +27,9 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Gets the <see cref="ListViewItem.ImageList"/> associated with the item.
         /// </summary>
-        public override ImageList ImageList
+        public override ImageList? ImageList
         {
-            get => _owner?.ImageList;
+            get => _owner.ImageList;
             set => Debug.Fail("We should never set the image list");
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupTests.cs
@@ -243,6 +243,23 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
+        public void ListViewGroup_TitleImageIndex_SetTitleImageKey_GetReturnsExpected(string key, string expected)
+        {
+            var group = new ListViewGroup
+            {
+                TitleImageIndex = 0
+            };
+
+            Assert.Equal(0, group.TitleImageIndex);
+
+            // verify TitleImageIndex resets to default once TitleImageKey is set
+            group.TitleImageKey = key;
+            Assert.Equal(expected, group.TitleImageKey);
+            Assert.Equal(ImageList.Indexer.DefaultIndex, group.TitleImageIndex);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetStringNormalizedTheoryData))]
         [InlineData("te\0xt", "te\0xt")]
         public void ListViewGroup_TitleImageKey_SetWithoutListView_GetReturnsExpected(string value, string expected)
         {
@@ -353,6 +370,24 @@ namespace System.Windows.Forms.Tests
 
             // verify the remote process succeeded
             Assert.Equal(0, invokerHandle.ExitCode);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetNonNegativeIntTheoryData))]
+        [InlineData(-1)]
+        public void ListViewGroup_TitleImageKey_SetTitleImageIndex_GetReturnsExpected(int value)
+        {
+            var group = new ListViewGroup
+            {
+                TitleImageKey = "key"
+            };
+
+            Assert.Equal("key", group.TitleImageKey);
+
+            // verify TitleImageKey resets to default once TitleImageIndex is set
+            group.TitleImageIndex = value;
+            Assert.Equal(value, group.TitleImageIndex);
+            Assert.Equal(ImageList.Indexer.DefaultKey, group.TitleImageKey);
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -88,6 +88,7 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.GridLines);
             Assert.Empty(control.Groups);
             Assert.Same(control.Groups, control.Groups);
+            Assert.Null(control.GroupImageList);
             Assert.False(control.HasChildren);
             Assert.Equal(ColumnHeaderStyle.Clickable, control.HeaderStyle);
             Assert.Equal(97, control.Height);
@@ -1514,6 +1515,320 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(!value, listView.GridLines);
             Assert.True(listView.IsHandleCreated);
             Assert.Equal(expectedInvalidatedCallCount + 1, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+        }
+
+        public static IEnumerable<object[]> GroupImageList_Set_GetReturnsExpected()
+        {
+            var nonEmptyImageList = new ImageList();
+            nonEmptyImageList.Images.Add(new Bitmap(10, 10));
+
+            foreach (bool autoArrange in new bool[] { true, false })
+            {
+                foreach (bool virtualMode in new bool[] { true, false })
+                {
+                    foreach (View view in new View[] { View.Details, View.LargeIcon, View.List, View.SmallIcon })
+                    {
+                        yield return new object[] { autoArrange, virtualMode, view, null };
+                        yield return new object[] { autoArrange, virtualMode, view, new ImageList() };
+                        yield return new object[] { autoArrange, virtualMode, view, nonEmptyImageList };
+                    }
+                }
+
+                yield return new object[] { autoArrange, false, View.Tile, null };
+                yield return new object[] { autoArrange, false, View.Tile, new ImageList() };
+                yield return new object[] { autoArrange, false, View.Tile, nonEmptyImageList };
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(GroupImageList_Set_GetReturnsExpected))]
+        public void ListView_GroupImageList_Set_GetReturnsExpected(bool autoArrange, bool virtualMode, View view, ImageList value)
+        {
+            using var listView = new ListView
+            {
+                AutoArrange = autoArrange,
+                VirtualMode = virtualMode,
+                View = view,
+                GroupImageList = value
+            };
+
+            Assert.Same(value, listView.GroupImageList);
+            Assert.False(listView.IsHandleCreated);
+
+            // Set same.
+            listView.GroupImageList = value;
+            Assert.Same(value, listView.GroupImageList);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(GroupImageList_Set_GetReturnsExpected))]
+        public void ListView_GroupImageList_SetWithNonNullOldValue_GetReturnsExpected(bool autoArrange, bool virtualMode, View view, ImageList value)
+        {
+            using var imageList = new ImageList();
+            using var listView = new ListView
+            {
+                AutoArrange = autoArrange,
+                VirtualMode = virtualMode,
+                View = view,
+                GroupImageList = imageList
+            };
+
+            listView.GroupImageList = value;
+            Assert.Same(value, listView.GroupImageList);
+            Assert.False(listView.IsHandleCreated);
+
+            // Set same.
+            listView.GroupImageList = value;
+            Assert.Same(value, listView.GroupImageList);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> GroupImageList_SetWithHandle_GetReturnsExpected()
+        {
+            var nonEmptyImageList = new ImageList();
+            nonEmptyImageList.Images.Add(new Bitmap(10, 10));
+
+            yield return new object[] { true, false, View.Details, null };
+            yield return new object[] { true, false, View.Details, new ImageList() };
+            yield return new object[] { true, false, View.Details, nonEmptyImageList };
+            yield return new object[] { true, false, View.LargeIcon, null };
+            yield return new object[] { true, false, View.LargeIcon, new ImageList() };
+            yield return new object[] { true, false, View.LargeIcon, nonEmptyImageList };
+            yield return new object[] { true, false, View.List, null };
+            yield return new object[] { true, false, View.List, new ImageList() };
+            yield return new object[] { true, false, View.List, nonEmptyImageList };
+            yield return new object[] { true, false, View.SmallIcon, null };
+            yield return new object[] { true, false, View.SmallIcon, new ImageList() };
+            yield return new object[] { true, false, View.SmallIcon, nonEmptyImageList };
+            yield return new object[] { true, false, View.Tile, null };
+            yield return new object[] { true, false, View.Tile, new ImageList() };
+            yield return new object[] { true, false, View.Tile, nonEmptyImageList };
+
+            foreach (bool autoArrange in new bool[] { true, false })
+            {
+                yield return new object[] { autoArrange, true, View.Details, null };
+                yield return new object[] { autoArrange, true, View.Details, new ImageList() };
+                yield return new object[] { autoArrange, true, View.Details, nonEmptyImageList };
+                yield return new object[] { autoArrange, true, View.LargeIcon, null };
+                yield return new object[] { autoArrange, true, View.LargeIcon, new ImageList() };
+                yield return new object[] { autoArrange, true, View.LargeIcon, nonEmptyImageList };
+                yield return new object[] { autoArrange, true, View.List, null };
+                yield return new object[] { autoArrange, true, View.List, new ImageList() };
+                yield return new object[] { autoArrange, true, View.List, nonEmptyImageList };
+                yield return new object[] { autoArrange, true, View.SmallIcon, null };
+                yield return new object[] { autoArrange, true, View.SmallIcon, new ImageList() };
+                yield return new object[] { autoArrange, true, View.SmallIcon, nonEmptyImageList };
+            }
+
+            yield return new object[] { false, false, View.Details, null };
+            yield return new object[] { false, false, View.Details, new ImageList() };
+            yield return new object[] { false, false, View.Details, nonEmptyImageList };
+            yield return new object[] { false, false, View.LargeIcon, null };
+            yield return new object[] { false, false, View.LargeIcon, new ImageList() };
+            yield return new object[] { false, false, View.LargeIcon, nonEmptyImageList };
+            yield return new object[] { false, false, View.List, null };
+            yield return new object[] { false, false, View.List, new ImageList() };
+            yield return new object[] { false, false, View.List, nonEmptyImageList };
+            yield return new object[] { false, false, View.SmallIcon, null };
+            yield return new object[] { false, false, View.SmallIcon, new ImageList() };
+            yield return new object[] { false, false, View.SmallIcon, nonEmptyImageList };
+            yield return new object[] { false, false, View.Tile, null };
+            yield return new object[] { false, false, View.Tile, new ImageList() };
+            yield return new object[] { false, false, View.Tile, nonEmptyImageList };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(GroupImageList_SetWithHandle_GetReturnsExpected))]
+        public void ListView_GroupImageList_SetWithHandle_GetReturnsExpected(bool autoArrange, bool virtualMode, View view, ImageList value)
+        {
+            using var listView = new ListView
+            {
+                AutoArrange = autoArrange,
+                VirtualMode = virtualMode,
+                View = view
+            };
+
+            Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            int invalidatedCallCount = 0;
+            listView.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            listView.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            listView.HandleCreated += (sender, e) => createdCallCount++;
+
+            listView.GroupImageList = value;
+            Assert.Same(value, listView.GroupImageList);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+
+            // Set same.
+            listView.GroupImageList = value;
+            Assert.Same(value, listView.GroupImageList);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+        }
+
+        public static IEnumerable<object[]> GroupImageList_SetWithHandleWithNonNullOldValue_GetReturnsExpected()
+        {
+            var nonEmptyImageList = new ImageList();
+            nonEmptyImageList.Images.Add(new Bitmap(10, 10));
+
+            yield return new object[] { true, false, View.Details, null };
+            yield return new object[] { true, false, View.Details, new ImageList() };
+            yield return new object[] { true, false, View.Details, nonEmptyImageList };
+            yield return new object[] { true, false, View.LargeIcon, null };
+            yield return new object[] { true, false, View.LargeIcon, new ImageList() };
+            yield return new object[] { true, false, View.LargeIcon, nonEmptyImageList };
+            yield return new object[] { true, false, View.List, null };
+            yield return new object[] { true, false, View.List, new ImageList() };
+            yield return new object[] { true, false, View.List, nonEmptyImageList };
+            yield return new object[] { true, false, View.SmallIcon, null };
+            yield return new object[] { true, false, View.SmallIcon, new ImageList() };
+            yield return new object[] { true, false, View.SmallIcon, nonEmptyImageList };
+            yield return new object[] { true, false, View.Tile, null };
+            yield return new object[] { true, false, View.Tile, new ImageList() };
+            yield return new object[] { true, false, View.Tile, nonEmptyImageList };
+
+            foreach (bool autoArrange in new bool[] { true, false })
+            {
+                yield return new object[] { autoArrange, true, View.Details, null };
+                yield return new object[] { autoArrange, true, View.Details, new ImageList() };
+                yield return new object[] { autoArrange, true, View.Details, nonEmptyImageList };
+                yield return new object[] { autoArrange, true, View.LargeIcon, null };
+                yield return new object[] { autoArrange, true, View.LargeIcon, new ImageList() };
+                yield return new object[] { autoArrange, true, View.LargeIcon, nonEmptyImageList };
+                yield return new object[] { autoArrange, true, View.List, null };
+                yield return new object[] { autoArrange, true, View.List, new ImageList() };
+                yield return new object[] { autoArrange, true, View.List, nonEmptyImageList };
+                yield return new object[] { autoArrange, true, View.SmallIcon, null };
+                yield return new object[] { autoArrange, true, View.SmallIcon, new ImageList() };
+                yield return new object[] { autoArrange, true, View.SmallIcon, nonEmptyImageList };
+            }
+
+            yield return new object[] { false, false, View.Details, null };
+            yield return new object[] { false, false, View.Details, new ImageList() };
+            yield return new object[] { false, false, View.Details, nonEmptyImageList };
+            yield return new object[] { false, false, View.LargeIcon, null };
+            yield return new object[] { false, false, View.LargeIcon, new ImageList() };
+            yield return new object[] { false, false, View.LargeIcon, nonEmptyImageList };
+            yield return new object[] { false, false, View.List, null };
+            yield return new object[] { false, false, View.List, new ImageList() };
+            yield return new object[] { false, false, View.List, nonEmptyImageList };
+            yield return new object[] { false, false, View.SmallIcon, null };
+            yield return new object[] { false, false, View.SmallIcon, new ImageList() };
+            yield return new object[] { false, false, View.SmallIcon, nonEmptyImageList };
+            yield return new object[] { false, false, View.Tile, null };
+            yield return new object[] { false, false, View.Tile, new ImageList() };
+            yield return new object[] { false, false, View.Tile, nonEmptyImageList };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(GroupImageList_SetWithHandleWithNonNullOldValue_GetReturnsExpected))]
+        public void ListView_GroupImageList_SetWithHandleWithNonNullOldValue_GetReturnsExpected(bool autoArrange, bool virtualMode, View view, ImageList value)
+        {
+            using var listView = new ListView
+            {
+                AutoArrange = autoArrange,
+                VirtualMode = virtualMode,
+                View = view,
+                GroupImageList = new ImageList()
+            };
+
+            Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            int invalidatedCallCount = 0;
+            listView.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            listView.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            listView.HandleCreated += (sender, e) => createdCallCount++;
+
+            listView.GroupImageList = value;
+            Assert.Same(value, listView.GroupImageList);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+
+            // Set same.
+            listView.GroupImageList = value;
+            Assert.Same(value, listView.GroupImageList);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void ListView_GroupImageList_Dispose_DetachesFromListView(bool autoArrange)
+        {
+            using var imageList1 = new ImageList();
+            using var imageList2 = new ImageList();
+            using var listView = new ListView
+            {
+                AutoArrange = autoArrange,
+                GroupImageList = imageList1
+            };
+
+            Assert.Same(imageList1, listView.GroupImageList);
+
+            imageList1.Dispose();
+            Assert.Null(listView.GroupImageList);
+            Assert.False(listView.IsHandleCreated);
+
+            // Make sure we detached the setter.
+            listView.GroupImageList = imageList2;
+            imageList1.Dispose();
+            Assert.Same(imageList2, listView.GroupImageList);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, 1)]
+        [InlineData(false, 0)]
+        public void ListView_GroupImageList_DisposeWithHandle_DetachesFromListView(bool autoArrange, int expectedInvalidatedCallCount)
+        {
+            using var imageList1 = new ImageList();
+            using var imageList2 = new ImageList();
+            using var listView = new ListView
+            {
+                AutoArrange = autoArrange
+            };
+
+            Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            int invalidatedCallCount = 0;
+            listView.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            listView.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            listView.HandleCreated += (sender, e) => createdCallCount++;
+
+            listView.GroupImageList = imageList1;
+            Assert.Same(imageList1, listView.GroupImageList);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+
+            imageList1.Dispose();
+            Assert.Null(listView.GroupImageList);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+
+            // Make sure we detached the setter.
+            listView.GroupImageList = imageList2;
+            imageList1.Dispose();
+            Assert.Same(imageList2, listView.GroupImageList);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
         }


### PR DESCRIPTION
Fixes #3301 


## Proposed changes

- Add `TitleImageIndex` and `TitleImageKey` API to `ListViewGroup`
- Add `GroupImageList` to `ListView`

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Customers will be able to set icons next to `ListViewGroup` header

## Regression? 

- No


<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/30007367/85338352-f7943200-b496-11ea-816c-94eddb85beec.png)

### After

![image](https://user-images.githubusercontent.com/30007367/85338430-23afb300-b497-11ea-98a4-fd123ff0442c.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Unit testing

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3490)