### PR TITLE
Fix HDC in BeginPaintScope

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.BeginPaintScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.BeginPaintScope.cs
@@ -26,7 +26,6 @@ internal static partial class Interop
                 _paintStruct = default;
                 HDC = BeginPaint(hwnd, ref _paintStruct);
                 HWND = hwnd;
-                HDC = GetDC(hwnd);
             }
 
             public static implicit operator IntPtr(BeginPaintScope paintScope) => paintScope.HDC;


### PR DESCRIPTION
Getting the DC again was a copy/paste mistake

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3507)