### PR TITLE
Solve image list woes

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.Duplicate.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.Duplicate.cs
@@ -14,13 +14,6 @@ internal partial class Interop
         {
             [DllImport(Libraries.Comctl32, ExactSpelling = true, EntryPoint = "ImageList_Duplicate")]
             public static extern IntPtr Duplicate(IntPtr himl);
-
-            public static IntPtr Duplicate(IHandle himl)
-            {
-                IntPtr result = Duplicate(himl.Handle);
-                GC.KeepAlive(himl);
-                return result;
-            }
         }
     }
 }

--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -3344,6 +3344,9 @@ Stack trace where the illegal operation occurred was:
   <data name="ImageListCreateFailed" xml:space="preserve">
     <value>Creation of the ImageList handle did not succeed.</value>
   </data>
+  <data name="ImageListDuplicateFailed" xml:space="preserve">
+    <value>Duplication of the ImageList handle did not succeed.</value>
+  </data>
   <data name="ImageListEntryType" xml:space="preserve">
     <value>Image added to an ImageList must either derive from Image or be an Icon.</value>
   </data>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -5556,6 +5556,11 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">Vytvoření popisovače ImageList se nezdařilo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageListDuplicateFailed">
+        <source>Duplication of the ImageList handle did not succeed.</source>
+        <target state="new">Duplication of the ImageList handle did not succeed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageListEntryType">
         <source>Image added to an ImageList must either derive from Image or be an Icon.</source>
         <target state="translated">Obrázek přidaný do seznamu ImageList musí být buď odvozen od objektu Image, nebo musí být objektem Icon.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -5556,6 +5556,11 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">Fehler beim Erstellen des ImageList-Handles.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageListDuplicateFailed">
+        <source>Duplication of the ImageList handle did not succeed.</source>
+        <target state="new">Duplication of the ImageList handle did not succeed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageListEntryType">
         <source>Image added to an ImageList must either derive from Image or be an Icon.</source>
         <target state="translated">Das zu einer ImageList hinzugefügte Bild muss von "Image" abgeleitet oder ein Symbol sein.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -5556,6 +5556,11 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">Error al crear el identificador de ImageList.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageListDuplicateFailed">
+        <source>Duplication of the ImageList handle did not succeed.</source>
+        <target state="new">Duplication of the ImageList handle did not succeed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageListEntryType">
         <source>Image added to an ImageList must either derive from Image or be an Icon.</source>
         <target state="translated">Las imágenes que se agreguen a ImageList deben derivar de una imagen o ser un icono.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -5556,6 +5556,11 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">Échec de la création du handle ImageList.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageListDuplicateFailed">
+        <source>Duplication of the ImageList handle did not succeed.</source>
+        <target state="new">Duplication of the ImageList handle did not succeed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageListEntryType">
         <source>Image added to an ImageList must either derive from Image or be an Icon.</source>
         <target state="translated">Une image ajoutée à ImageList doit dériver de Image ou être un Icon.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -5556,6 +5556,11 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">Creazione dell'handle di ImageList non riuscita.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageListDuplicateFailed">
+        <source>Duplication of the ImageList handle did not succeed.</source>
+        <target state="new">Duplication of the ImageList handle did not succeed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageListEntryType">
         <source>Image added to an ImageList must either derive from Image or be an Icon.</source>
         <target state="translated">Un'immagine aggiunta a ImageList deve essere un'icona o derivare da Image.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -5556,6 +5556,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">ImageList ハンドルを作成できませんでした。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageListDuplicateFailed">
+        <source>Duplication of the ImageList handle did not succeed.</source>
+        <target state="new">Duplication of the ImageList handle did not succeed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageListEntryType">
         <source>Image added to an ImageList must either derive from Image or be an Icon.</source>
         <target state="translated">ImageList に追加されるイメージは Image から派生しているか、またはアイコンでなければなりません。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -5556,6 +5556,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">ImageList 핸들을 만들지 못했습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageListDuplicateFailed">
+        <source>Duplication of the ImageList handle did not succeed.</source>
+        <target state="new">Duplication of the ImageList handle did not succeed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageListEntryType">
         <source>Image added to an ImageList must either derive from Image or be an Icon.</source>
         <target state="translated">ImageList에 추가하는 이미지는 이미지에서 파생되거나 아이콘이어야 합니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -5556,6 +5556,11 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">Nie można utworzyć uchwytu elementu ImageList.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageListDuplicateFailed">
+        <source>Duplication of the ImageList handle did not succeed.</source>
+        <target state="new">Duplication of the ImageList handle did not succeed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageListEntryType">
         <source>Image added to an ImageList must either derive from Image or be an Icon.</source>
         <target state="translated">Obraz dodany do listy ImageList musi dziedziczyć po elemencie Image lub musi być elementem Icon.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -5556,6 +5556,11 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">A criação do identificador de ImageList não teve êxito.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageListDuplicateFailed">
+        <source>Duplication of the ImageList handle did not succeed.</source>
+        <target state="new">Duplication of the ImageList handle did not succeed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageListEntryType">
         <source>Image added to an ImageList must either derive from Image or be an Icon.</source>
         <target state="translated">A imagem adicionada a ImageList deve derivar de Image ou ser um Ícone.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -5557,6 +5557,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">Не удалось создать дескриптор ImageList.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageListDuplicateFailed">
+        <source>Duplication of the ImageList handle did not succeed.</source>
+        <target state="new">Duplication of the ImageList handle did not succeed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageListEntryType">
         <source>Image added to an ImageList must either derive from Image or be an Icon.</source>
         <target state="translated">Изображение, добавляемое к ImageList, должно иметь тип, производный от Image, либо тип Icon.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -5556,6 +5556,11 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">ImageList işleyicisi oluşturulamadı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageListDuplicateFailed">
+        <source>Duplication of the ImageList handle did not succeed.</source>
+        <target state="new">Duplication of the ImageList handle did not succeed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageListEntryType">
         <source>Image added to an ImageList must either derive from Image or be an Icon.</source>
         <target state="translated">ImageList'e eklenen resim Image'den türetilmeli veya Icon olmalıdır.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -5556,6 +5556,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">创建 ImageList 句柄失败。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageListDuplicateFailed">
+        <source>Duplication of the ImageList handle did not succeed.</source>
+        <target state="new">Duplication of the ImageList handle did not succeed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageListEntryType">
         <source>Image added to an ImageList must either derive from Image or be an Icon.</source>
         <target state="translated">添加到 ImageList 的图像必须从 Image 派生或者为 Icon。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -5556,6 +5556,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">建立 ImageList 控制代碼失敗。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageListDuplicateFailed">
+        <source>Duplication of the ImageList handle did not succeed.</source>
+        <target state="new">Duplication of the ImageList handle did not succeed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageListEntryType">
         <source>Image added to an ImageList must either derive from Image or be an Icon.</source>
         <target state="translated">只有衍生自 Image 或本身為 Icon 的影像才可以加入至 ImageList 中。</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.NativeImageList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.NativeImageList.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Drawing;
 using static Interop;
+using static Interop.ComCtl32;
 
 namespace System.Windows.Forms
 {
@@ -11,30 +13,61 @@ namespace System.Windows.Forms
     {
         internal class NativeImageList : IDisposable, IHandle
         {
-#if DEBUG
-            private readonly string _callStack;
-#endif
+            private const int GrowBy = 4;
+            private const int InitialCapacity = 4;
 
-            internal NativeImageList(IntPtr himl)
+            private static readonly object s_syncLock = new object();
+
+            public NativeImageList(Ole32.IStream pstm)
+            {
+                IntPtr himl;
+                lock (s_syncLock)
+                {
+                    himl = ComCtl32.ImageList.Read(pstm);
+                    Init(himl);
+                }
+            }
+
+            public NativeImageList(Size imageSize, ILC flags)
+            {
+                IntPtr himl;
+                lock (s_syncLock)
+                {
+                    himl = ComCtl32.ImageList.Create(imageSize.Width, imageSize.Height, flags, InitialCapacity, GrowBy);
+                    Init(himl);
+                }
+            }
+
+            private NativeImageList(IntPtr himl)
             {
                 Handle = himl;
+            }
+
+            private void Init(IntPtr himl)
+            {
+                if (himl != IntPtr.Zero)
+                {
+                    Handle = himl;
+                    return;
+                }
+
 #if DEBUG
-                _callStack = Environment.StackTrace;
+                Debug.Fail($"{nameof(NativeImageList)} could not be created. Originating stack:\n{_callStack}");
 #endif
+                throw new InvalidOperationException(SR.ImageListCreateFailed);
             }
 
             public IntPtr Handle { get; private set; }
 
             public void Dispose()
             {
-                Dispose(true);
-                GC.SuppressFinalize(this);
-            }
-
-            public void Dispose(bool disposing)
-            {
-                if (Handle != IntPtr.Zero)
+                lock (s_syncLock)
                 {
+                    if (Handle == IntPtr.Zero)
+                    {
+                        return;
+                    }
+
                     ComCtl32.ImageList.Destroy(Handle);
                     Handle = IntPtr.Zero;
                 }
@@ -44,13 +77,35 @@ namespace System.Windows.Forms
 #endif
             }
 
+#if DEBUG
+            private readonly string _callStack = new StackTrace().ToString();
+
             ~NativeImageList()
             {
-#if DEBUG
                 Debug.Fail($"{nameof(NativeImageList)} was not disposed properly. Originating stack:\n{_callStack}");
+
+                // We can't do anything with the fields when we're on the finalizer as they're all classes. If any of
+                // them become structs they'll be a part of this instance and possible to clean up. Ideally we fix
+                // the leaks and never come in on the finalizer.
+                return;
+            }
 #endif
 
-                Dispose(false);
+            internal NativeImageList Duplicate()
+            {
+                lock (s_syncLock)
+                {
+                    IntPtr himl = ComCtl32.ImageList.Duplicate(Handle);
+                    if (himl != IntPtr.Zero)
+                    {
+                        return new NativeImageList(himl);
+                    }
+                }
+
+#if DEBUG
+                Debug.Fail($"{nameof(NativeImageList)} could not be duplicated. Originating stack:\n{_callStack}");
+#endif
+                throw new InvalidOperationException(SR.ImageListDuplicateFailed);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.NativeImageList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.NativeImageList.cs
@@ -1,9 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
+using System.Diagnostics;
 using static Interop;
 
 namespace System.Windows.Forms
@@ -12,20 +11,19 @@ namespace System.Windows.Forms
     {
         internal class NativeImageList : IDisposable, IHandle
         {
-            private IntPtr _himl;
 #if DEBUG
             private readonly string _callStack;
 #endif
 
             internal NativeImageList(IntPtr himl)
             {
-                _himl = himl;
+                Handle = himl;
 #if DEBUG
                 _callStack = Environment.StackTrace;
 #endif
             }
 
-            public IntPtr Handle => _himl;
+            public IntPtr Handle { get; private set; }
 
             public void Dispose()
             {
@@ -35,14 +33,25 @@ namespace System.Windows.Forms
 
             public void Dispose(bool disposing)
             {
-                if (_himl != IntPtr.Zero)
+                if (Handle != IntPtr.Zero)
                 {
-                    ComCtl32.ImageList.Destroy(_himl);
-                    _himl = IntPtr.Zero;
+                    ComCtl32.ImageList.Destroy(Handle);
+                    Handle = IntPtr.Zero;
                 }
+
+#if DEBUG
+                GC.SuppressFinalize(this);
+#endif
             }
 
-            ~NativeImageList() => Dispose(false);
+            ~NativeImageList()
+            {
+#if DEBUG
+                Debug.Fail($"{nameof(NativeImageList)} was not disposed properly. Originating stack:\n{_callStack}");
+#endif
+
+                Dispose(false);
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
@@ -531,6 +531,8 @@ namespace System.Windows.Forms
                     }
                 }
 
+                ImageStream?.Dispose();
+
                 DestroyHandle();
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
@@ -33,9 +33,6 @@ namespace System.Windows.Forms
         private static readonly Color s_fakeTransparencyColor = Color.FromArgb(0x0d, 0x0b, 0x0c);
         private static readonly Size s_defaultImageSize = new Size(16, 16);
 
-        private const int InitialCapacity = 4;
-        private const int GrowBy = 4;
-
         private const int MaxDimension = 256;
         private static int s_maxImageWidth = MaxDimension;
         private static int s_maxImageHeight = MaxDimension;
@@ -235,7 +232,7 @@ namespace System.Windows.Forms
                     bool recreatingHandle = HandleCreated; // We only need to fire RecreateHandle if there was a previous handle
                     DestroyHandle();
                     _originals = null;
-                    _nativeImageList = new NativeImageList(ComCtl32.ImageList.Duplicate(himl));
+                    _nativeImageList = himl.Duplicate();
                     if (ComCtl32.ImageList.GetIconSize(new HandleRef(this, _nativeImageList.Handle), out int x, out int y).IsTrue())
                     {
                         _imageSize = new Size(x, y);
@@ -460,16 +457,18 @@ namespace System.Windows.Forms
             try
             {
                 ComCtl32.InitCommonControls();
-                _nativeImageList = new NativeImageList(ComCtl32.ImageList.Create(_imageSize.Width, _imageSize.Height, flags, InitialCapacity, GrowBy));
+
+                if (_nativeImageList != null)
+                {
+                    _nativeImageList.Dispose();
+                    _nativeImageList = null;
+                }
+
+                _nativeImageList = new NativeImageList(_imageSize, flags);
             }
             finally
             {
                 ThemingScope.Deactivate(userCookie);
-            }
-
-            if (Handle == IntPtr.Zero)
-            {
-                throw new InvalidOperationException(SR.ImageListCreateFailed);
             }
 
             ComCtl32.ImageList.SetBkColor(this, ComCtl32.CLR.NONE);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageListStreamer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageListStreamer.cs
@@ -54,12 +54,11 @@ namespace System.Windows.Forms
 
                             try
                             {
-                                MemoryStream ms = new MemoryStream(Decompress(dat));
-
+                                using MemoryStream ms = new MemoryStream(Decompress(dat));
                                 lock (internalSyncObject)
                                 {
                                     ComCtl32.InitCommonControls();
-                                    nativeImageList = new ImageList.NativeImageList(ComCtl32.ImageList.Read(new Ole32.GPStream(ms)));
+                                    nativeImageList = new ImageList.NativeImageList(new Ole32.GPStream(ms));
                                 }
                             }
                             finally

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -1018,9 +1018,10 @@ namespace System.Windows.Forms
             get
             {
                 Image image = (Image)Properties.GetObject(s_imageProperty);
-                if (image == null && (Owner != null) && (Owner.ImageList != null) && ImageIndexer.ActualIndex >= 0)
+                if (image == null && Owner?.ImageList != null && ImageIndexer.ActualIndex >= 0)
                 {
-                    if (ImageIndexer.ActualIndex < Owner.ImageList.Images.Count)
+                    bool disposing = _state[s_stateDisposing];
+                    if (!disposing && ImageIndexer.ActualIndex < Owner.ImageList.Images.Count)
                     {
                         // CACHE (by design). If we fetched out of the image list every time it would dramatically hit perf.
                         image = Owner.ImageList.Images[ImageIndexer.ActualIndex];

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -1037,28 +1037,32 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (Image != value)
+                if (Image == value)
                 {
-                    StopAnimate();
-                    if (value is Bitmap bmp && ImageTransparentColor != Color.Empty)
-                    {
-                        if (bmp.RawFormat.Guid != ImageFormat.Icon.Guid && !ImageAnimator.CanAnimate(bmp))
-                        {
-                            bmp.MakeTransparent(ImageTransparentColor);
-                        }
-
-                        value = bmp;
-                    }
-                    if (value != null)
-                    {
-                        ImageIndex = ImageList.Indexer.DefaultIndex;
-                    }
-
-                    Properties.SetObject(s_imageProperty, value);
-                    _state[s_stateInvalidMirroredImage] = true;
-                    Animate();
-                    InvalidateItemLayout(PropertyNames.Image);
+                    return;
                 }
+
+                StopAnimate();
+
+                if (value is Bitmap bmp && ImageTransparentColor != Color.Empty)
+                {
+                    if (bmp.RawFormat.Guid != ImageFormat.Icon.Guid && !ImageAnimator.CanAnimate(bmp))
+                    {
+                        bmp.MakeTransparent(ImageTransparentColor);
+                    }
+
+                    value = bmp;
+                }
+                if (value != null)
+                {
+                    ImageIndex = ImageList.Indexer.DefaultIndex;
+                }
+
+                Properties.SetObject(s_imageProperty, value);
+                _state[s_stateInvalidMirroredImage] = true;
+
+                Animate();
+                InvalidateItemLayout(PropertyNames.Image);
             }
         }
 
@@ -2057,25 +2061,27 @@ namespace System.Windows.Forms
 
         private void Animate(bool animate)
         {
-            if (animate != _state[s_stateCurrentlyAnimatingImage])
+            if (animate == _state[s_stateCurrentlyAnimatingImage])
             {
-                if (animate)
-                {
-                    if (Image != null)
-                    {
-                        ImageAnimator.Animate(Image, new EventHandler(OnAnimationFrameChanged));
-                        _state[s_stateCurrentlyAnimatingImage] = animate;
-                    }
-                }
-                else
-                {
-                    if (Image != null)
-                    {
-                        ImageAnimator.StopAnimate(Image, new EventHandler(OnAnimationFrameChanged));
-                        _state[s_stateCurrentlyAnimatingImage] = animate;
-                    }
-                }
+                return;
             }
+
+            Image image = Image;
+            if (image == null)
+            {
+                return;
+            }
+
+            if (animate)
+            {
+                ImageAnimator.Animate(image, new EventHandler(OnAnimationFrameChanged));
+            }
+            else
+            {
+                ImageAnimator.StopAnimate(image, new EventHandler(OnAnimationFrameChanged));
+            }
+
+            _state[s_stateCurrentlyAnimatingImage] = animate;
         }
 
         internal bool BeginDragForItemReorder()

--- a/src/System.Windows.Forms/tests/UnitTests/SerializableTypesTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/SerializableTypesTests.cs
@@ -92,8 +92,7 @@ namespace System.Windows.Forms.Tests.Serialization
 
             void ValidateResult(string blob)
             {
-                ImageListStreamer result = BinarySerialization.EnsureDeserialize<ImageListStreamer>(blob);
-
+                using ImageListStreamer result = BinarySerialization.EnsureDeserialize<ImageListStreamer>(blob);
                 using (NativeImageList nativeImageList = result.GetNativeImageList())
                 {
                     Assert.True(ComCtl32.ImageList.GetIconSize(new HandleRef(this, nativeImageList.Handle), out int x, out int y).IsTrue());

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -1521,9 +1521,6 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> GroupImageList_Set_GetReturnsExpected()
         {
-            var nonEmptyImageList = new ImageList();
-            nonEmptyImageList.Images.Add(new Bitmap(10, 10));
-
             foreach (bool autoArrange in new bool[] { true, false })
             {
                 foreach (bool virtualMode in new bool[] { true, false })
@@ -1532,13 +1529,13 @@ namespace System.Windows.Forms.Tests
                     {
                         yield return new object[] { autoArrange, virtualMode, view, null };
                         yield return new object[] { autoArrange, virtualMode, view, new ImageList() };
-                        yield return new object[] { autoArrange, virtualMode, view, nonEmptyImageList };
+                        yield return new object[] { autoArrange, virtualMode, view, CreateNonEmpty() };
                     }
                 }
 
                 yield return new object[] { autoArrange, false, View.Tile, null };
                 yield return new object[] { autoArrange, false, View.Tile, new ImageList() };
-                yield return new object[] { autoArrange, false, View.Tile, nonEmptyImageList };
+                yield return new object[] { autoArrange, false, View.Tile, CreateNonEmpty() };
             }
         }
 
@@ -1588,56 +1585,53 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> GroupImageList_SetWithHandle_GetReturnsExpected()
         {
-            var nonEmptyImageList = new ImageList();
-            nonEmptyImageList.Images.Add(new Bitmap(10, 10));
-
             yield return new object[] { true, false, View.Details, null };
             yield return new object[] { true, false, View.Details, new ImageList() };
-            yield return new object[] { true, false, View.Details, nonEmptyImageList };
+            yield return new object[] { true, false, View.Details, CreateNonEmpty() };
             yield return new object[] { true, false, View.LargeIcon, null };
             yield return new object[] { true, false, View.LargeIcon, new ImageList() };
-            yield return new object[] { true, false, View.LargeIcon, nonEmptyImageList };
+            yield return new object[] { true, false, View.LargeIcon, CreateNonEmpty() };
             yield return new object[] { true, false, View.List, null };
             yield return new object[] { true, false, View.List, new ImageList() };
-            yield return new object[] { true, false, View.List, nonEmptyImageList };
+            yield return new object[] { true, false, View.List, CreateNonEmpty() };
             yield return new object[] { true, false, View.SmallIcon, null };
             yield return new object[] { true, false, View.SmallIcon, new ImageList() };
-            yield return new object[] { true, false, View.SmallIcon, nonEmptyImageList };
+            yield return new object[] { true, false, View.SmallIcon, CreateNonEmpty() };
             yield return new object[] { true, false, View.Tile, null };
             yield return new object[] { true, false, View.Tile, new ImageList() };
-            yield return new object[] { true, false, View.Tile, nonEmptyImageList };
+            yield return new object[] { true, false, View.Tile, CreateNonEmpty() };
 
             foreach (bool autoArrange in new bool[] { true, false })
             {
                 yield return new object[] { autoArrange, true, View.Details, null };
                 yield return new object[] { autoArrange, true, View.Details, new ImageList() };
-                yield return new object[] { autoArrange, true, View.Details, nonEmptyImageList };
+                yield return new object[] { autoArrange, true, View.Details, CreateNonEmpty() };
                 yield return new object[] { autoArrange, true, View.LargeIcon, null };
                 yield return new object[] { autoArrange, true, View.LargeIcon, new ImageList() };
-                yield return new object[] { autoArrange, true, View.LargeIcon, nonEmptyImageList };
+                yield return new object[] { autoArrange, true, View.LargeIcon, CreateNonEmpty() };
                 yield return new object[] { autoArrange, true, View.List, null };
                 yield return new object[] { autoArrange, true, View.List, new ImageList() };
-                yield return new object[] { autoArrange, true, View.List, nonEmptyImageList };
+                yield return new object[] { autoArrange, true, View.List, CreateNonEmpty() };
                 yield return new object[] { autoArrange, true, View.SmallIcon, null };
                 yield return new object[] { autoArrange, true, View.SmallIcon, new ImageList() };
-                yield return new object[] { autoArrange, true, View.SmallIcon, nonEmptyImageList };
+                yield return new object[] { autoArrange, true, View.SmallIcon, CreateNonEmpty() };
             }
 
             yield return new object[] { false, false, View.Details, null };
             yield return new object[] { false, false, View.Details, new ImageList() };
-            yield return new object[] { false, false, View.Details, nonEmptyImageList };
+            yield return new object[] { false, false, View.Details, CreateNonEmpty() };
             yield return new object[] { false, false, View.LargeIcon, null };
             yield return new object[] { false, false, View.LargeIcon, new ImageList() };
-            yield return new object[] { false, false, View.LargeIcon, nonEmptyImageList };
+            yield return new object[] { false, false, View.LargeIcon, CreateNonEmpty() };
             yield return new object[] { false, false, View.List, null };
             yield return new object[] { false, false, View.List, new ImageList() };
-            yield return new object[] { false, false, View.List, nonEmptyImageList };
+            yield return new object[] { false, false, View.List, CreateNonEmpty() };
             yield return new object[] { false, false, View.SmallIcon, null };
             yield return new object[] { false, false, View.SmallIcon, new ImageList() };
-            yield return new object[] { false, false, View.SmallIcon, nonEmptyImageList };
+            yield return new object[] { false, false, View.SmallIcon, CreateNonEmpty() };
             yield return new object[] { false, false, View.Tile, null };
             yield return new object[] { false, false, View.Tile, new ImageList() };
-            yield return new object[] { false, false, View.Tile, nonEmptyImageList };
+            yield return new object[] { false, false, View.Tile, CreateNonEmpty() };
         }
 
         [WinFormsTheory]
@@ -1677,56 +1671,53 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> GroupImageList_SetWithHandleWithNonNullOldValue_GetReturnsExpected()
         {
-            var nonEmptyImageList = new ImageList();
-            nonEmptyImageList.Images.Add(new Bitmap(10, 10));
-
             yield return new object[] { true, false, View.Details, null };
             yield return new object[] { true, false, View.Details, new ImageList() };
-            yield return new object[] { true, false, View.Details, nonEmptyImageList };
+            yield return new object[] { true, false, View.Details, CreateNonEmpty() };
             yield return new object[] { true, false, View.LargeIcon, null };
             yield return new object[] { true, false, View.LargeIcon, new ImageList() };
-            yield return new object[] { true, false, View.LargeIcon, nonEmptyImageList };
+            yield return new object[] { true, false, View.LargeIcon, CreateNonEmpty() };
             yield return new object[] { true, false, View.List, null };
             yield return new object[] { true, false, View.List, new ImageList() };
-            yield return new object[] { true, false, View.List, nonEmptyImageList };
+            yield return new object[] { true, false, View.List, CreateNonEmpty() };
             yield return new object[] { true, false, View.SmallIcon, null };
             yield return new object[] { true, false, View.SmallIcon, new ImageList() };
-            yield return new object[] { true, false, View.SmallIcon, nonEmptyImageList };
+            yield return new object[] { true, false, View.SmallIcon, CreateNonEmpty() };
             yield return new object[] { true, false, View.Tile, null };
             yield return new object[] { true, false, View.Tile, new ImageList() };
-            yield return new object[] { true, false, View.Tile, nonEmptyImageList };
+            yield return new object[] { true, false, View.Tile, CreateNonEmpty() };
 
             foreach (bool autoArrange in new bool[] { true, false })
             {
                 yield return new object[] { autoArrange, true, View.Details, null };
                 yield return new object[] { autoArrange, true, View.Details, new ImageList() };
-                yield return new object[] { autoArrange, true, View.Details, nonEmptyImageList };
+                yield return new object[] { autoArrange, true, View.Details, CreateNonEmpty() };
                 yield return new object[] { autoArrange, true, View.LargeIcon, null };
                 yield return new object[] { autoArrange, true, View.LargeIcon, new ImageList() };
-                yield return new object[] { autoArrange, true, View.LargeIcon, nonEmptyImageList };
+                yield return new object[] { autoArrange, true, View.LargeIcon, CreateNonEmpty() };
                 yield return new object[] { autoArrange, true, View.List, null };
                 yield return new object[] { autoArrange, true, View.List, new ImageList() };
-                yield return new object[] { autoArrange, true, View.List, nonEmptyImageList };
+                yield return new object[] { autoArrange, true, View.List, CreateNonEmpty() };
                 yield return new object[] { autoArrange, true, View.SmallIcon, null };
                 yield return new object[] { autoArrange, true, View.SmallIcon, new ImageList() };
-                yield return new object[] { autoArrange, true, View.SmallIcon, nonEmptyImageList };
+                yield return new object[] { autoArrange, true, View.SmallIcon, CreateNonEmpty() };
             }
 
             yield return new object[] { false, false, View.Details, null };
             yield return new object[] { false, false, View.Details, new ImageList() };
-            yield return new object[] { false, false, View.Details, nonEmptyImageList };
+            yield return new object[] { false, false, View.Details, CreateNonEmpty() };
             yield return new object[] { false, false, View.LargeIcon, null };
             yield return new object[] { false, false, View.LargeIcon, new ImageList() };
-            yield return new object[] { false, false, View.LargeIcon, nonEmptyImageList };
+            yield return new object[] { false, false, View.LargeIcon, CreateNonEmpty() };
             yield return new object[] { false, false, View.List, null };
             yield return new object[] { false, false, View.List, new ImageList() };
-            yield return new object[] { false, false, View.List, nonEmptyImageList };
+            yield return new object[] { false, false, View.List, CreateNonEmpty() };
             yield return new object[] { false, false, View.SmallIcon, null };
             yield return new object[] { false, false, View.SmallIcon, new ImageList() };
-            yield return new object[] { false, false, View.SmallIcon, nonEmptyImageList };
+            yield return new object[] { false, false, View.SmallIcon, CreateNonEmpty() };
             yield return new object[] { false, false, View.Tile, null };
             yield return new object[] { false, false, View.Tile, new ImageList() };
-            yield return new object[] { false, false, View.Tile, nonEmptyImageList };
+            yield return new object[] { false, false, View.Tile, CreateNonEmpty() };
         }
 
         [WinFormsTheory]
@@ -1738,7 +1729,6 @@ namespace System.Windows.Forms.Tests
                 AutoArrange = autoArrange,
                 VirtualMode = virtualMode,
                 View = view,
-                GroupImageList = new ImageList()
             };
 
             Assert.NotEqual(IntPtr.Zero, listView.Handle);
@@ -2473,9 +2463,6 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> LargeImageList_Set_GetReturnsExpected()
         {
-            var nonEmptyImageList = new ImageList();
-            nonEmptyImageList.Images.Add(new Bitmap(10, 10));
-
             foreach (bool autoArrange in new bool[] { true, false })
             {
                 foreach (bool virtualMode in new bool[] { true, false })
@@ -2484,13 +2471,13 @@ namespace System.Windows.Forms.Tests
                     {
                         yield return new object[] { autoArrange, virtualMode, view, null };
                         yield return new object[] { autoArrange, virtualMode, view, new ImageList() };
-                        yield return new object[] { autoArrange, virtualMode, view, nonEmptyImageList };
+                        yield return new object[] { autoArrange, virtualMode, view, CreateNonEmpty() };
                     }
                 }
 
                 yield return new object[] { autoArrange, false, View.Tile, null };
                 yield return new object[] { autoArrange, false, View.Tile, new ImageList() };
-                yield return new object[] { autoArrange, false, View.Tile, nonEmptyImageList };
+                yield return new object[] { autoArrange, false, View.Tile, CreateNonEmpty() };
             }
         }
 
@@ -2539,56 +2526,53 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> LargeImageList_SetWithHandle_GetReturnsExpected()
         {
-            var nonEmptyImageList = new ImageList();
-            nonEmptyImageList.Images.Add(new Bitmap(10, 10));
-
             yield return new object[] { true, false, View.Details, null, 0 };
             yield return new object[] { true, false, View.Details, new ImageList(), 0 };
-            yield return new object[] { true, false, View.Details, nonEmptyImageList, 0 };
+            yield return new object[] { true, false, View.Details, CreateNonEmpty(), 0 };
             yield return new object[] { true, false, View.LargeIcon, null, 0 };
             yield return new object[] { true, false, View.LargeIcon, new ImageList(), 1 };
-            yield return new object[] { true, false, View.LargeIcon, nonEmptyImageList, 1 };
+            yield return new object[] { true, false, View.LargeIcon, CreateNonEmpty(), 1 };
             yield return new object[] { true, false, View.List, null, 0 };
             yield return new object[] { true, false, View.List, new ImageList(), 0 };
-            yield return new object[] { true, false, View.List, nonEmptyImageList, 0 };
+            yield return new object[] { true, false, View.List, CreateNonEmpty(), 0 };
             yield return new object[] { true, false, View.SmallIcon, null, 0 };
             yield return new object[] { true, false, View.SmallIcon, new ImageList(), 1 };
-            yield return new object[] { true, false, View.SmallIcon, nonEmptyImageList, 1 };
+            yield return new object[] { true, false, View.SmallIcon, CreateNonEmpty(), 1 };
             yield return new object[] { true, false, View.Tile, null, 0 };
             yield return new object[] { true, false, View.Tile, new ImageList(), 0 };
-            yield return new object[] { true, false, View.Tile, nonEmptyImageList, 0 };
+            yield return new object[] { true, false, View.Tile, CreateNonEmpty(), 0 };
 
             foreach (bool autoArrange in new bool[] { true, false })
             {
                 yield return new object[] { autoArrange, true, View.Details, null, 0 };
                 yield return new object[] { autoArrange, true, View.Details, new ImageList(), 0 };
-                yield return new object[] { autoArrange, true, View.Details, nonEmptyImageList, 0 };
+                yield return new object[] { autoArrange, true, View.Details, CreateNonEmpty(), 0 };
                 yield return new object[] { autoArrange, true, View.LargeIcon, null, 0 };
                 yield return new object[] { autoArrange, true, View.LargeIcon, new ImageList(), 0 };
-                yield return new object[] { autoArrange, true, View.LargeIcon, nonEmptyImageList, 0 };
+                yield return new object[] { autoArrange, true, View.LargeIcon, CreateNonEmpty(), 0 };
                 yield return new object[] { autoArrange, true, View.List, null, 0 };
                 yield return new object[] { autoArrange, true, View.List, new ImageList(), 0 };
-                yield return new object[] { autoArrange, true, View.List, nonEmptyImageList, 0 };
+                yield return new object[] { autoArrange, true, View.List, CreateNonEmpty(), 0 };
                 yield return new object[] { autoArrange, true, View.SmallIcon, null, 0 };
                 yield return new object[] { autoArrange, true, View.SmallIcon, new ImageList(), 0 };
-                yield return new object[] { autoArrange, true, View.SmallIcon, nonEmptyImageList, 0 };
+                yield return new object[] { autoArrange, true, View.SmallIcon, CreateNonEmpty(), 0 };
             }
 
             yield return new object[] { false, false, View.Details, null, 0 };
             yield return new object[] { false, false, View.Details, new ImageList(), 0 };
-            yield return new object[] { false, false, View.Details, nonEmptyImageList, 0 };
+            yield return new object[] { false, false, View.Details, CreateNonEmpty(), 0 };
             yield return new object[] { false, false, View.LargeIcon, null, 0 };
             yield return new object[] { false, false, View.LargeIcon, new ImageList(), 0 };
-            yield return new object[] { false, false, View.LargeIcon, nonEmptyImageList, 0 };
+            yield return new object[] { false, false, View.LargeIcon, CreateNonEmpty(), 0 };
             yield return new object[] { false, false, View.List, null, 0 };
             yield return new object[] { false, false, View.List, new ImageList(), 0 };
-            yield return new object[] { false, false, View.List, nonEmptyImageList, 0 };
+            yield return new object[] { false, false, View.List, CreateNonEmpty(), 0 };
             yield return new object[] { false, false, View.SmallIcon, null, 0 };
             yield return new object[] { false, false, View.SmallIcon, new ImageList(), 0 };
-            yield return new object[] { false, false, View.SmallIcon, nonEmptyImageList, 0 };
+            yield return new object[] { false, false, View.SmallIcon, CreateNonEmpty(), 0 };
             yield return new object[] { false, false, View.Tile, null, 0 };
             yield return new object[] { false, false, View.Tile, new ImageList(), 0 };
-            yield return new object[] { false, false, View.Tile, nonEmptyImageList, 0 };
+            yield return new object[] { false, false, View.Tile, CreateNonEmpty(), 0 };
         }
 
         [WinFormsTheory]
@@ -2627,56 +2611,53 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> LargeImageList_SetWithHandleWithNonNullOldValue_GetReturnsExpected()
         {
-            var nonEmptyImageList = new ImageList();
-            nonEmptyImageList.Images.Add(new Bitmap(10, 10));
-
             yield return new object[] { true, false, View.Details, null, 0 };
             yield return new object[] { true, false, View.Details, new ImageList(), 0 };
-            yield return new object[] { true, false, View.Details, nonEmptyImageList, 0 };
+            yield return new object[] { true, false, View.Details, CreateNonEmpty(), 0 };
             yield return new object[] { true, false, View.LargeIcon, null, 1 };
             yield return new object[] { true, false, View.LargeIcon, new ImageList(), 1 };
-            yield return new object[] { true, false, View.LargeIcon, nonEmptyImageList, 1 };
+            yield return new object[] { true, false, View.LargeIcon, CreateNonEmpty(), 1 };
             yield return new object[] { true, false, View.List, null, 0 };
             yield return new object[] { true, false, View.List, new ImageList(), 0 };
-            yield return new object[] { true, false, View.List, nonEmptyImageList, 0 };
+            yield return new object[] { true, false, View.List, CreateNonEmpty(), 0 };
             yield return new object[] { true, false, View.SmallIcon, null, 1 };
             yield return new object[] { true, false, View.SmallIcon, new ImageList(), 1 };
-            yield return new object[] { true, false, View.SmallIcon, nonEmptyImageList, 1 };
+            yield return new object[] { true, false, View.SmallIcon, CreateNonEmpty(), 1 };
             yield return new object[] { true, false, View.Tile, null, 0 };
             yield return new object[] { true, false, View.Tile, new ImageList(), 0 };
-            yield return new object[] { true, false, View.Tile, nonEmptyImageList, 0 };
+            yield return new object[] { true, false, View.Tile, CreateNonEmpty(), 0 };
 
             foreach (bool autoArrange in new bool[] { true, false })
             {
                 yield return new object[] { autoArrange, true, View.Details, null, 0 };
                 yield return new object[] { autoArrange, true, View.Details, new ImageList(), 0 };
-                yield return new object[] { autoArrange, true, View.Details, nonEmptyImageList, 0 };
+                yield return new object[] { autoArrange, true, View.Details, CreateNonEmpty(), 0 };
                 yield return new object[] { autoArrange, true, View.LargeIcon, null, 0 };
                 yield return new object[] { autoArrange, true, View.LargeIcon, new ImageList(), 0 };
-                yield return new object[] { autoArrange, true, View.LargeIcon, nonEmptyImageList, 0 };
+                yield return new object[] { autoArrange, true, View.LargeIcon, CreateNonEmpty(), 0 };
                 yield return new object[] { autoArrange, true, View.List, null, 0 };
                 yield return new object[] { autoArrange, true, View.List, new ImageList(), 0 };
-                yield return new object[] { autoArrange, true, View.List, nonEmptyImageList, 0 };
+                yield return new object[] { autoArrange, true, View.List, CreateNonEmpty(), 0 };
                 yield return new object[] { autoArrange, true, View.SmallIcon, null, 0 };
                 yield return new object[] { autoArrange, true, View.SmallIcon, new ImageList(), 0 };
-                yield return new object[] { autoArrange, true, View.SmallIcon, nonEmptyImageList, 0 };
+                yield return new object[] { autoArrange, true, View.SmallIcon, CreateNonEmpty(), 0 };
             }
 
             yield return new object[] { false, false, View.Details, null, 0 };
             yield return new object[] { false, false, View.Details, new ImageList(), 0 };
-            yield return new object[] { false, false, View.Details, nonEmptyImageList, 0 };
+            yield return new object[] { false, false, View.Details, CreateNonEmpty(), 0 };
             yield return new object[] { false, false, View.LargeIcon, null, 0 };
             yield return new object[] { false, false, View.LargeIcon, new ImageList(), 0 };
-            yield return new object[] { false, false, View.LargeIcon, nonEmptyImageList, 0 };
+            yield return new object[] { false, false, View.LargeIcon, CreateNonEmpty(), 0 };
             yield return new object[] { false, false, View.List, null, 0 };
             yield return new object[] { false, false, View.List, new ImageList(), 0 };
-            yield return new object[] { false, false, View.List, nonEmptyImageList, 0 };
+            yield return new object[] { false, false, View.List, CreateNonEmpty(), 0 };
             yield return new object[] { false, false, View.SmallIcon, null, 0 };
             yield return new object[] { false, false, View.SmallIcon, new ImageList(), 0 };
-            yield return new object[] { false, false, View.SmallIcon, nonEmptyImageList, 0 };
+            yield return new object[] { false, false, View.SmallIcon, CreateNonEmpty(), 0 };
             yield return new object[] { false, false, View.Tile, null, 0 };
             yield return new object[] { false, false, View.Tile, new ImageList(), 0 };
-            yield return new object[] { false, false, View.Tile, nonEmptyImageList, 0 };
+            yield return new object[] { false, false, View.Tile, CreateNonEmpty(), 0 };
         }
 
         [WinFormsTheory]
@@ -3082,9 +3063,6 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> SmallImageList_Set_GetReturnsExpected()
         {
-            var nonEmptyImageList = new ImageList();
-            nonEmptyImageList.Images.Add(new Bitmap(10, 10));
-
             foreach (bool autoArrange in new bool[] { true, false })
             {
                 foreach (bool virtualMode in new bool[] { true, false })
@@ -3093,13 +3071,13 @@ namespace System.Windows.Forms.Tests
                     {
                         yield return new object[] { autoArrange, virtualMode, view, null };
                         yield return new object[] { autoArrange, virtualMode, view, new ImageList() };
-                        yield return new object[] { autoArrange, virtualMode, view, nonEmptyImageList };
+                        yield return new object[] { autoArrange, virtualMode, view, CreateNonEmpty() };
                     }
                 }
 
                 yield return new object[] { autoArrange, false, View.Tile, null };
                 yield return new object[] { autoArrange, false, View.Tile, new ImageList() };
-                yield return new object[] { autoArrange, false, View.Tile, nonEmptyImageList };
+                yield return new object[] { autoArrange, false, View.Tile, CreateNonEmpty() };
             }
         }
 
@@ -3148,56 +3126,53 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> SmallImageList_SetWithHandle_GetReturnsExpected()
         {
-            var nonEmptyImageList = new ImageList();
-            nonEmptyImageList.Images.Add(new Bitmap(10, 10));
-
             yield return new object[] { true, false, View.Details, null, 0, 0 };
             yield return new object[] { true, false, View.Details, new ImageList(), 1, 0 };
-            yield return new object[] { true, false, View.Details, nonEmptyImageList, 1, 0 };
+            yield return new object[] { true, false, View.Details, CreateNonEmpty(), 1, 0 };
             yield return new object[] { true, false, View.LargeIcon, null, 0, 0 };
             yield return new object[] { true, false, View.LargeIcon, new ImageList(), 1, 0 };
-            yield return new object[] { true, false, View.LargeIcon, nonEmptyImageList, 1, 0 };
+            yield return new object[] { true, false, View.LargeIcon, CreateNonEmpty(), 1, 0 };
             yield return new object[] { true, false, View.List, null, 0, 0 };
             yield return new object[] { true, false, View.List, new ImageList(), 0, 0 };
-            yield return new object[] { true, false, View.List, nonEmptyImageList, 0, 0 };
+            yield return new object[] { true, false, View.List, CreateNonEmpty(), 0, 0 };
             yield return new object[] { true, false, View.SmallIcon, null, 0, 0 };
             yield return new object[] { true, false, View.SmallIcon, new ImageList(), 4, 2 };
-            yield return new object[] { true, false, View.SmallIcon, nonEmptyImageList, 4, 2 };
+            yield return new object[] { true, false, View.SmallIcon, CreateNonEmpty(), 4, 2 };
             yield return new object[] { true, false, View.Tile, null, 0, 0 };
             yield return new object[] { true, false, View.Tile, new ImageList(), 0, 0 };
-            yield return new object[] { true, false, View.Tile, nonEmptyImageList, 0, 0 };
+            yield return new object[] { true, false, View.Tile, CreateNonEmpty(), 0, 0 };
 
             foreach (bool autoArrange in new bool[] { true, false })
             {
                 yield return new object[] { autoArrange, true, View.Details, null, 0, 0 };
                 yield return new object[] { autoArrange, true, View.Details, new ImageList(), 1, 0 };
-                yield return new object[] { autoArrange, true, View.Details, nonEmptyImageList, 1, 0 };
+                yield return new object[] { autoArrange, true, View.Details, CreateNonEmpty(), 1, 0 };
                 yield return new object[] { autoArrange, true, View.LargeIcon, null, 0, 0 };
                 yield return new object[] { autoArrange, true, View.LargeIcon, new ImageList(), 0, 0 };
-                yield return new object[] { autoArrange, true, View.LargeIcon, nonEmptyImageList, 0, 0 };
+                yield return new object[] { autoArrange, true, View.LargeIcon, CreateNonEmpty(), 0, 0 };
                 yield return new object[] { autoArrange, true, View.List, null, 0, 0 };
                 yield return new object[] { autoArrange, true, View.List, new ImageList(), 0, 0 };
-                yield return new object[] { autoArrange, true, View.List, nonEmptyImageList, 0, 0 };
+                yield return new object[] { autoArrange, true, View.List, CreateNonEmpty(), 0, 0 };
                 yield return new object[] { autoArrange, true, View.SmallIcon, null, 0, 0 };
                 yield return new object[] { autoArrange, true, View.SmallIcon, new ImageList(), 2, 2 };
-                yield return new object[] { autoArrange, true, View.SmallIcon, nonEmptyImageList, 2, 2 };
+                yield return new object[] { autoArrange, true, View.SmallIcon, CreateNonEmpty(), 2, 2 };
             }
 
             yield return new object[] { false, false, View.Details, null, 0, 0 };
             yield return new object[] { false, false, View.Details, new ImageList(), 1, 0 };
-            yield return new object[] { false, false, View.Details, nonEmptyImageList, 1, 0 };
+            yield return new object[] { false, false, View.Details, CreateNonEmpty(), 1, 0 };
             yield return new object[] { false, false, View.LargeIcon, null, 0, 0 };
             yield return new object[] { false, false, View.LargeIcon, new ImageList(), 0, 0 };
-            yield return new object[] { false, false, View.LargeIcon, nonEmptyImageList, 0, 0 };
+            yield return new object[] { false, false, View.LargeIcon, CreateNonEmpty(), 0, 0 };
             yield return new object[] { false, false, View.List, null, 0, 0 };
             yield return new object[] { false, false, View.List, new ImageList(), 0, 0 };
-            yield return new object[] { false, false, View.List, nonEmptyImageList, 0, 0 };
+            yield return new object[] { false, false, View.List, CreateNonEmpty(), 0, 0 };
             yield return new object[] { false, false, View.SmallIcon, null, 0, 0 };
             yield return new object[] { false, false, View.SmallIcon, new ImageList(), 2, 2 };
-            yield return new object[] { false, false, View.SmallIcon, nonEmptyImageList, 2, 2 };
+            yield return new object[] { false, false, View.SmallIcon, CreateNonEmpty(), 2, 2 };
             yield return new object[] { false, false, View.Tile, null, 0, 0 };
             yield return new object[] { false, false, View.Tile, new ImageList(), 0, 0 };
-            yield return new object[] { false, false, View.Tile, nonEmptyImageList, 0, 0 };
+            yield return new object[] { false, false, View.Tile, CreateNonEmpty(), 0, 0 };
         }
 
         [WinFormsTheory]
@@ -3236,56 +3211,53 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> SmallImageList_SetWithHandleWithNonNullOldValue_GetReturnsExpected()
         {
-            var nonEmptyImageList = new ImageList();
-            nonEmptyImageList.Images.Add(new Bitmap(10, 10));
-
             yield return new object[] { true, false, View.Details, null, 1, 0 };
             yield return new object[] { true, false, View.Details, new ImageList(), 1, 0 };
-            yield return new object[] { true, false, View.Details, nonEmptyImageList, 1, 0 };
+            yield return new object[] { true, false, View.Details, CreateNonEmpty(), 1, 0 };
             yield return new object[] { true, false, View.LargeIcon, null, 1, 0 };
             yield return new object[] { true, false, View.LargeIcon, new ImageList(), 1, 0 };
-            yield return new object[] { true, false, View.LargeIcon, nonEmptyImageList, 1, 0 };
+            yield return new object[] { true, false, View.LargeIcon, CreateNonEmpty(), 1, 0 };
             yield return new object[] { true, false, View.List, null, 0, 0 };
             yield return new object[] { true, false, View.List, new ImageList(), 0, 0 };
-            yield return new object[] { true, false, View.List, nonEmptyImageList, 0, 0 };
+            yield return new object[] { true, false, View.List, CreateNonEmpty(), 0, 0 };
             yield return new object[] { true, false, View.SmallIcon, null, 4, 2 };
             yield return new object[] { true, false, View.SmallIcon, new ImageList(), 4, 2 };
-            yield return new object[] { true, false, View.SmallIcon, nonEmptyImageList, 4, 2 };
+            yield return new object[] { true, false, View.SmallIcon, CreateNonEmpty(), 4, 2 };
             yield return new object[] { true, false, View.Tile, null, 0, 0 };
             yield return new object[] { true, false, View.Tile, new ImageList(), 0, 0 };
-            yield return new object[] { true, false, View.Tile, nonEmptyImageList, 0, 0 };
+            yield return new object[] { true, false, View.Tile, CreateNonEmpty(), 0, 0 };
 
             foreach (bool autoArrange in new bool[] { true, false })
             {
                 yield return new object[] { autoArrange, true, View.Details, null, 1, 0 };
                 yield return new object[] { autoArrange, true, View.Details, new ImageList(), 1, 0 };
-                yield return new object[] { autoArrange, true, View.Details, nonEmptyImageList, 1, 0 };
+                yield return new object[] { autoArrange, true, View.Details, CreateNonEmpty(), 1, 0 };
                 yield return new object[] { autoArrange, true, View.LargeIcon, null, 0, 0 };
                 yield return new object[] { autoArrange, true, View.LargeIcon, new ImageList(), 0, 0 };
-                yield return new object[] { autoArrange, true, View.LargeIcon, nonEmptyImageList, 0, 0 };
+                yield return new object[] { autoArrange, true, View.LargeIcon, CreateNonEmpty(), 0, 0 };
                 yield return new object[] { autoArrange, true, View.List, null, 0, 0 };
                 yield return new object[] { autoArrange, true, View.List, new ImageList(), 0, 0 };
-                yield return new object[] { autoArrange, true, View.List, nonEmptyImageList, 0, 0 };
+                yield return new object[] { autoArrange, true, View.List, CreateNonEmpty(), 0, 0 };
                 yield return new object[] { autoArrange, true, View.SmallIcon, null, 2, 2 };
                 yield return new object[] { autoArrange, true, View.SmallIcon, new ImageList(), 2, 2 };
-                yield return new object[] { autoArrange, true, View.SmallIcon, nonEmptyImageList, 2, 2 };
+                yield return new object[] { autoArrange, true, View.SmallIcon, CreateNonEmpty(), 2, 2 };
             }
 
             yield return new object[] { false, false, View.Details, null, 1, 0 };
             yield return new object[] { false, false, View.Details, new ImageList(), 1, 0 };
-            yield return new object[] { false, false, View.Details, nonEmptyImageList, 1, 0 };
+            yield return new object[] { false, false, View.Details, CreateNonEmpty(), 1, 0 };
             yield return new object[] { false, false, View.LargeIcon, null, 0, 0 };
             yield return new object[] { false, false, View.LargeIcon, new ImageList(), 0, 0 };
-            yield return new object[] { false, false, View.LargeIcon, nonEmptyImageList, 0, 0 };
+            yield return new object[] { false, false, View.LargeIcon, CreateNonEmpty(), 0, 0 };
             yield return new object[] { false, false, View.List, null, 0, 0 };
             yield return new object[] { false, false, View.List, new ImageList(), 0, 0 };
-            yield return new object[] { false, false, View.List, nonEmptyImageList, 0, 0 };
+            yield return new object[] { false, false, View.List, CreateNonEmpty(), 0, 0 };
             yield return new object[] { false, false, View.SmallIcon, null, 2, 2 };
             yield return new object[] { false, false, View.SmallIcon, new ImageList(), 2, 2 };
-            yield return new object[] { false, false, View.SmallIcon, nonEmptyImageList, 2, 2 };
+            yield return new object[] { false, false, View.SmallIcon, CreateNonEmpty(), 2, 2 };
             yield return new object[] { false, false, View.Tile, null, 0, 0 };
             yield return new object[] { false, false, View.Tile, new ImageList(), 0, 0 };
-            yield return new object[] { false, false, View.Tile, nonEmptyImageList, 0, 0 };
+            yield return new object[] { false, false, View.Tile, CreateNonEmpty(), 0, 0 };
         }
 
         [WinFormsTheory]
@@ -3392,9 +3364,6 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> StateImageList_Set_GetReturnsExpected()
         {
-            var nonEmptyImageList = new ImageList();
-            nonEmptyImageList.Images.Add(new Bitmap(10, 10));
-
             foreach (bool useCompatibleStateImageBehavior in new bool[] { true, false })
             {
                 foreach (bool checkBoxes in new bool[] { true, false })
@@ -3407,7 +3376,7 @@ namespace System.Windows.Forms.Tests
                             {
                                 yield return new object[] { useCompatibleStateImageBehavior, checkBoxes, autoArrange, virtualMode, view, null };
                                 yield return new object[] { useCompatibleStateImageBehavior, checkBoxes, autoArrange, virtualMode, view, new ImageList() };
-                                yield return new object[] { useCompatibleStateImageBehavior, checkBoxes, autoArrange, virtualMode, view, nonEmptyImageList };
+                                yield return new object[] { useCompatibleStateImageBehavior, checkBoxes, autoArrange, virtualMode, view, CreateNonEmpty() };
                             }
                         }
                     }
@@ -3415,11 +3384,11 @@ namespace System.Windows.Forms.Tests
 
                 yield return new object[] { useCompatibleStateImageBehavior, false, true, false, View.Tile, null };
                 yield return new object[] { useCompatibleStateImageBehavior, false, true, false, View.Tile, new ImageList() };
-                yield return new object[] { useCompatibleStateImageBehavior, false, true, false, View.Tile, nonEmptyImageList };
+                yield return new object[] { useCompatibleStateImageBehavior, false, true, false, View.Tile, CreateNonEmpty() };
 
                 yield return new object[] { useCompatibleStateImageBehavior, false, false, false, View.Tile, null };
                 yield return new object[] { useCompatibleStateImageBehavior, false, false, false, View.Tile, new ImageList() };
-                yield return new object[] { useCompatibleStateImageBehavior, false, false, false, View.Tile, nonEmptyImageList };
+                yield return new object[] { useCompatibleStateImageBehavior, false, false, false, View.Tile, CreateNonEmpty() };
             }
         }
 
@@ -3472,154 +3441,151 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> StateImageList_SetWithHandle_GetReturnsExpected()
         {
-            var nonEmptyImageList = new ImageList();
-            nonEmptyImageList.Images.Add(new Bitmap(10, 10));
-
             // UseCompatibleStateImageBehavior true
             foreach (bool checkBoxes in new bool[] { true, false })
             {
                 yield return new object[] { true, checkBoxes, true, false, View.Details, null, 0, 0 };
                 yield return new object[] { true, checkBoxes, true, false, View.Details, new ImageList(), 0, 0 };
-                yield return new object[] { true, checkBoxes, true, false, View.Details, nonEmptyImageList, 0, 0 };
+                yield return new object[] { true, checkBoxes, true, false, View.Details, CreateNonEmpty(), 0, 0 };
                 yield return new object[] { true, checkBoxes, true, false, View.LargeIcon, null, 0, 0 };
                 yield return new object[] { true, checkBoxes, true, false, View.LargeIcon, new ImageList(), 0, 0 };
-                yield return new object[] { true, checkBoxes, true, false, View.LargeIcon, nonEmptyImageList, 0, 0 };
+                yield return new object[] { true, checkBoxes, true, false, View.LargeIcon, CreateNonEmpty(), 0, 0 };
                 yield return new object[] { true, checkBoxes, true, false, View.List, null, 0, 0 };
                 yield return new object[] { true, checkBoxes, true, false, View.List, new ImageList(), 0, 0 };
-                yield return new object[] { true, checkBoxes, true, false, View.List, nonEmptyImageList, 0, 0 };
+                yield return new object[] { true, checkBoxes, true, false, View.List, CreateNonEmpty(), 0, 0 };
                 yield return new object[] { true, checkBoxes, true, false, View.SmallIcon, null, 0, 0 };
                 yield return new object[] { true, checkBoxes, true, false, View.SmallIcon, new ImageList(), 0, 0 };
-                yield return new object[] { true, checkBoxes, true, false, View.SmallIcon, nonEmptyImageList, 0, 0 };
+                yield return new object[] { true, checkBoxes, true, false, View.SmallIcon, CreateNonEmpty(), 0, 0 };
 
                 foreach (bool autoArrange in new bool[] { true, false })
                 {
                     yield return new object[] { true, checkBoxes, autoArrange, true, View.Details, null, 0, 0 };
                     yield return new object[] { true, checkBoxes, autoArrange, true, View.Details, new ImageList(), 0, 0 };
-                    yield return new object[] { true, checkBoxes, autoArrange, true, View.Details, nonEmptyImageList, 0, 0 };
+                    yield return new object[] { true, checkBoxes, autoArrange, true, View.Details, CreateNonEmpty(), 0, 0 };
                     yield return new object[] { true, checkBoxes, autoArrange, true, View.LargeIcon, null, 0, 0 };
                     yield return new object[] { true, checkBoxes, autoArrange, true, View.LargeIcon, new ImageList(), 0, 0 };
-                    yield return new object[] { true, checkBoxes, autoArrange, true, View.LargeIcon, nonEmptyImageList, 0, 0 };
+                    yield return new object[] { true, checkBoxes, autoArrange, true, View.LargeIcon, CreateNonEmpty(), 0, 0 };
                     yield return new object[] { true, checkBoxes, autoArrange, true, View.List, null, 0, 0 };
                     yield return new object[] { true, checkBoxes, autoArrange, true, View.List, new ImageList(), 0, 0 };
-                    yield return new object[] { true, checkBoxes, autoArrange, true, View.List, nonEmptyImageList, 0, 0 };
+                    yield return new object[] { true, checkBoxes, autoArrange, true, View.List, CreateNonEmpty(), 0, 0 };
                     yield return new object[] { true, checkBoxes, autoArrange, true, View.SmallIcon, null, 0, 0 };
                     yield return new object[] { true, checkBoxes, autoArrange, true, View.SmallIcon, new ImageList(), 0, 0 };
-                    yield return new object[] { true, checkBoxes, autoArrange, true, View.SmallIcon, nonEmptyImageList, 0, 0 };
+                    yield return new object[] { true, checkBoxes, autoArrange, true, View.SmallIcon, CreateNonEmpty(), 0, 0 };
                 }
 
                 yield return new object[] { true, checkBoxes, false, false, View.Details, null, 0, 0 };
                 yield return new object[] { true, checkBoxes, false, false, View.Details, new ImageList(), 0, 0 };
-                yield return new object[] { true, checkBoxes, false, false, View.Details, nonEmptyImageList, 0, 0 };
+                yield return new object[] { true, checkBoxes, false, false, View.Details, CreateNonEmpty(), 0, 0 };
                 yield return new object[] { true, checkBoxes, false, false, View.LargeIcon, null, 0, 0 };
                 yield return new object[] { true, checkBoxes, false, false, View.LargeIcon, new ImageList(), 0, 0 };
-                yield return new object[] { true, checkBoxes, false, false, View.LargeIcon, nonEmptyImageList, 0, 0 };
+                yield return new object[] { true, checkBoxes, false, false, View.LargeIcon, CreateNonEmpty(), 0, 0 };
                 yield return new object[] { true, checkBoxes, false, false, View.List, null, 0, 0 };
                 yield return new object[] { true, checkBoxes, false, false, View.List, new ImageList(), 0, 0 };
-                yield return new object[] { true, checkBoxes, false, false, View.List, nonEmptyImageList, 0, 0 };
+                yield return new object[] { true, checkBoxes, false, false, View.List, CreateNonEmpty(), 0, 0 };
                 yield return new object[] { true, checkBoxes, false, false, View.SmallIcon, null, 0, 0 };
                 yield return new object[] { true, checkBoxes, false, false, View.SmallIcon, new ImageList(), 0, 0 };
-                yield return new object[] { true, checkBoxes, false, false, View.SmallIcon, nonEmptyImageList, 0, 0 };
+                yield return new object[] { true, checkBoxes, false, false, View.SmallIcon, CreateNonEmpty(), 0, 0 };
             }
 
             yield return new object[] { true, false, true, false, View.Tile, null, 0, 0 };
             yield return new object[] { true, false, true, false, View.Tile, new ImageList(), 0, 0 };
-            yield return new object[] { true, false, true, false, View.Tile, nonEmptyImageList, 0, 0 };
+            yield return new object[] { true, false, true, false, View.Tile, CreateNonEmpty(), 0, 0 };
 
             yield return new object[] { true, false, false, false, View.Tile, null, 0, 0 };
             yield return new object[] { true, false, false, false, View.Tile, new ImageList(), 0, 0 };
-            yield return new object[] { true, false, false, false, View.Tile, nonEmptyImageList, 0, 0 };
+            yield return new object[] { true, false, false, false, View.Tile, CreateNonEmpty(), 0, 0 };
 
             // UseCompatibleStateImageBehavior false, CheckBoxes true
             yield return new object[] { false, true, true, false, View.Details, null, 0, 0 };
             yield return new object[] { false, true, true, false, View.Details, new ImageList(), 1, 1 };
-            yield return new object[] { false, true, true, false, View.Details, nonEmptyImageList, 1, 1 };
+            yield return new object[] { false, true, true, false, View.Details, CreateNonEmpty(), 1, 1 };
             yield return new object[] { false, true, true, false, View.LargeIcon, null, 0, 0 };
             yield return new object[] { false, true, true, false, View.LargeIcon, new ImageList(), 3, 1 };
-            yield return new object[] { false, true, true, false, View.LargeIcon, nonEmptyImageList, 3, 1 };
+            yield return new object[] { false, true, true, false, View.LargeIcon, CreateNonEmpty(), 3, 1 };
             yield return new object[] { false, true, true, false, View.List, null, 0, 0 };
             yield return new object[] { false, true, true, false, View.List, new ImageList(), 1, 1 };
-            yield return new object[] { false, true, true, false, View.List, nonEmptyImageList, 1, 1 };
+            yield return new object[] { false, true, true, false, View.List, CreateNonEmpty(), 1, 1 };
             yield return new object[] { false, true, true, false, View.SmallIcon, null, 0, 0 };
             yield return new object[] { false, true, true, false, View.SmallIcon, new ImageList(), 3, 1 };
-            yield return new object[] { false, true, true, false, View.SmallIcon, nonEmptyImageList, 3, 1 };
+            yield return new object[] { false, true, true, false, View.SmallIcon, CreateNonEmpty(), 3, 1 };
 
             foreach (bool autoArrange in new bool[] { true, false })
             {
                 yield return new object[] { false, true, autoArrange, true, View.Details, null, 0, 0 };
                 yield return new object[] { false, true, autoArrange, true, View.Details, new ImageList(), 1, 1 };
-                yield return new object[] { false, true, autoArrange, true, View.Details, nonEmptyImageList, 1, 1 };
+                yield return new object[] { false, true, autoArrange, true, View.Details, CreateNonEmpty(), 1, 1 };
                 yield return new object[] { false, true, autoArrange, true, View.LargeIcon, null, 0, 0 };
                 yield return new object[] { false, true, autoArrange, true, View.LargeIcon, new ImageList(), 1, 1 };
-                yield return new object[] { false, true, autoArrange, true, View.LargeIcon, nonEmptyImageList, 1, 1 };
+                yield return new object[] { false, true, autoArrange, true, View.LargeIcon, CreateNonEmpty(), 1, 1 };
                 yield return new object[] { false, true, autoArrange, true, View.List, null, 0, 0 };
                 yield return new object[] { false, true, autoArrange, true, View.List, new ImageList(), 1, 1 };
-                yield return new object[] { false, true, autoArrange, true, View.List, nonEmptyImageList, 1, 1 };
+                yield return new object[] { false, true, autoArrange, true, View.List, CreateNonEmpty(), 1, 1 };
                 yield return new object[] { false, true, autoArrange, true, View.SmallIcon, null, 0, 0 };
                 yield return new object[] { false, true, autoArrange, true, View.SmallIcon, new ImageList(), 1, 1 };
-                yield return new object[] { false, true, autoArrange, true, View.SmallIcon, nonEmptyImageList, 1, 1 };
+                yield return new object[] { false, true, autoArrange, true, View.SmallIcon, CreateNonEmpty(), 1, 1 };
             }
 
             yield return new object[] { false, true, false, false, View.Details, null, 0, 0 };
             yield return new object[] { false, true, false, false, View.Details, new ImageList(), 1, 1 };
-            yield return new object[] { false, true, false, false, View.Details, nonEmptyImageList, 1, 1 };
+            yield return new object[] { false, true, false, false, View.Details, CreateNonEmpty(), 1, 1 };
             yield return new object[] { false, true, false, false, View.LargeIcon, null, 0, 0 };
             yield return new object[] { false, true, false, false, View.LargeIcon, new ImageList(), 1, 1 };
-            yield return new object[] { false, true, false, false, View.LargeIcon, nonEmptyImageList, 1, 1 };
+            yield return new object[] { false, true, false, false, View.LargeIcon, CreateNonEmpty(), 1, 1 };
             yield return new object[] { false, true, false, false, View.List, null, 0, 0 };
             yield return new object[] { false, true, false, false, View.List, new ImageList(), 1, 1 };
-            yield return new object[] { false, true, false, false, View.List, nonEmptyImageList, 1, 1 };
+            yield return new object[] { false, true, false, false, View.List, CreateNonEmpty(), 1, 1 };
             yield return new object[] { false, true, false, false, View.SmallIcon, null, 0, 0 };
             yield return new object[] { false, true, false, false, View.SmallIcon, new ImageList(), 1, 1 };
-            yield return new object[] { false, true, false, false, View.SmallIcon, nonEmptyImageList, 1, 1 };
+            yield return new object[] { false, true, false, false, View.SmallIcon, CreateNonEmpty(), 1, 1 };
 
             // UseCompatibleStateImageBehavior false, CheckBoxes false
             yield return new object[] { false, false, true, false, View.Details, null, 0, 0 };
             yield return new object[] { false, false, true, false, View.Details, new ImageList(), 0, 0 };
-            yield return new object[] { false, false, true, false, View.Details, nonEmptyImageList, 0, 0 };
+            yield return new object[] { false, false, true, false, View.Details, CreateNonEmpty(), 0, 0 };
             yield return new object[] { false, false, true, false, View.LargeIcon, null, 0, 0 };
             yield return new object[] { false, false, true, false, View.LargeIcon, new ImageList(), 1, 0 };
-            yield return new object[] { false, false, true, false, View.LargeIcon, nonEmptyImageList, 1, 0 };
+            yield return new object[] { false, false, true, false, View.LargeIcon, CreateNonEmpty(), 1, 0 };
             yield return new object[] { false, false, true, false, View.List, null, 0, 0 };
             yield return new object[] { false, false, true, false, View.List, new ImageList(), 0, 0 };
-            yield return new object[] { false, false, true, false, View.List, nonEmptyImageList, 0, 0 };
+            yield return new object[] { false, false, true, false, View.List, CreateNonEmpty(), 0, 0 };
             yield return new object[] { false, false, true, false, View.SmallIcon, null, 0, 0 };
             yield return new object[] { false, false, true, false, View.SmallIcon, new ImageList(), 1, 0 };
-            yield return new object[] { false, false, true, false, View.SmallIcon, nonEmptyImageList, 1, 0 };
+            yield return new object[] { false, false, true, false, View.SmallIcon, CreateNonEmpty(), 1, 0 };
             yield return new object[] { false, false, true, false, View.Tile, null, 0, 0 };
             yield return new object[] { false, false, true, false, View.Tile, new ImageList(), 0, 0 };
-            yield return new object[] { false, false, true, false, View.Tile, nonEmptyImageList, 0, 0 };
+            yield return new object[] { false, false, true, false, View.Tile, CreateNonEmpty(), 0, 0 };
 
             foreach (bool autoArrange in new bool[] { true, false })
             {
                 yield return new object[] { false, false, autoArrange, true, View.Details, null, 0, 0 };
                 yield return new object[] { false, false, autoArrange, true, View.Details, new ImageList(), 0, 0 };
-                yield return new object[] { false, false, autoArrange, true, View.Details, nonEmptyImageList, 0, 0 };
+                yield return new object[] { false, false, autoArrange, true, View.Details, CreateNonEmpty(), 0, 0 };
                 yield return new object[] { false, false, autoArrange, true, View.LargeIcon, null, 0, 0 };
                 yield return new object[] { false, false, autoArrange, true, View.LargeIcon, new ImageList(), 0, 0 };
-                yield return new object[] { false, false, autoArrange, true, View.LargeIcon, nonEmptyImageList, 0, 0 };
+                yield return new object[] { false, false, autoArrange, true, View.LargeIcon, CreateNonEmpty(), 0, 0 };
                 yield return new object[] { false, false, autoArrange, true, View.List, null, 0, 0 };
                 yield return new object[] { false, false, autoArrange, true, View.List, new ImageList(), 0, 0 };
-                yield return new object[] { false, false, autoArrange, true, View.List, nonEmptyImageList, 0, 0 };
+                yield return new object[] { false, false, autoArrange, true, View.List, CreateNonEmpty(), 0, 0 };
                 yield return new object[] { false, false, autoArrange, true, View.SmallIcon, null, 0, 0 };
                 yield return new object[] { false, false, autoArrange, true, View.SmallIcon, new ImageList(), 0, 0 };
-                yield return new object[] { false, false, autoArrange, true, View.SmallIcon, nonEmptyImageList, 0, 0 };
+                yield return new object[] { false, false, autoArrange, true, View.SmallIcon, CreateNonEmpty(), 0, 0 };
             }
 
             yield return new object[] { false, false, false, false, View.Details, null, 0, 0 };
             yield return new object[] { false, false, false, false, View.Details, new ImageList(), 0, 0 };
-            yield return new object[] { false, false, false, false, View.Details, nonEmptyImageList, 0, 0 };
+            yield return new object[] { false, false, false, false, View.Details, CreateNonEmpty(), 0, 0 };
             yield return new object[] { false, false, false, false, View.LargeIcon, null, 0, 0 };
             yield return new object[] { false, false, false, false, View.LargeIcon, new ImageList(), 0, 0 };
-            yield return new object[] { false, false, false, false, View.LargeIcon, nonEmptyImageList, 0, 0 };
+            yield return new object[] { false, false, false, false, View.LargeIcon, CreateNonEmpty(), 0, 0 };
             yield return new object[] { false, false, false, false, View.List, null, 0, 0 };
             yield return new object[] { false, false, false, false, View.List, new ImageList(), 0, 0 };
-            yield return new object[] { false, false, false, false, View.List, nonEmptyImageList, 0, 0 };
+            yield return new object[] { false, false, false, false, View.List, CreateNonEmpty(), 0, 0 };
             yield return new object[] { false, false, false, false, View.SmallIcon, null, 0, 0 };
             yield return new object[] { false, false, false, false, View.SmallIcon, new ImageList(), 0, 0 };
-            yield return new object[] { false, false, false, false, View.SmallIcon, nonEmptyImageList, 0, 0 };
+            yield return new object[] { false, false, false, false, View.SmallIcon, CreateNonEmpty(), 0, 0 };
             yield return new object[] { false, false, false, false, View.Tile, null, 0, 0 };
             yield return new object[] { false, false, false, false, View.Tile, new ImageList(), 0, 0 };
-            yield return new object[] { false, false, false, false, View.Tile, nonEmptyImageList, 0, 0 };
+            yield return new object[] { false, false, false, false, View.Tile, CreateNonEmpty(), 0, 0 };
         }
 
         [WinFormsTheory]
@@ -3660,154 +3626,151 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> StateImageList_SetWithHandleWithNonNullOldValue_GetReturnsExpected()
         {
-            var nonEmptyImageList = new ImageList();
-            nonEmptyImageList.Images.Add(new Bitmap(10, 10));
-
             // UseCompatibleStateImageBehavior true
             foreach (bool checkBoxes in new bool[] { true, false })
             {
                 yield return new object[] { true, checkBoxes, true, false, View.Details, null, 0, 0 };
                 yield return new object[] { true, checkBoxes, true, false, View.Details, new ImageList(), 0, 0 };
-                yield return new object[] { true, checkBoxes, true, false, View.Details, nonEmptyImageList, 0, 0 };
+                yield return new object[] { true, checkBoxes, true, false, View.Details, CreateNonEmpty(), 0, 0 };
                 yield return new object[] { true, checkBoxes, true, false, View.LargeIcon, null, 0, 0 };
                 yield return new object[] { true, checkBoxes, true, false, View.LargeIcon, new ImageList(), 0, 0 };
-                yield return new object[] { true, checkBoxes, true, false, View.LargeIcon, nonEmptyImageList, 0, 0 };
+                yield return new object[] { true, checkBoxes, true, false, View.LargeIcon, CreateNonEmpty(), 0, 0 };
                 yield return new object[] { true, checkBoxes, true, false, View.List, null, 0, 0 };
                 yield return new object[] { true, checkBoxes, true, false, View.List, new ImageList(), 0, 0 };
-                yield return new object[] { true, checkBoxes, true, false, View.List, nonEmptyImageList, 0, 0 };
+                yield return new object[] { true, checkBoxes, true, false, View.List, CreateNonEmpty(), 0, 0 };
                 yield return new object[] { true, checkBoxes, true, false, View.SmallIcon, null, 0, 0 };
                 yield return new object[] { true, checkBoxes, true, false, View.SmallIcon, new ImageList(), 0, 0 };
-                yield return new object[] { true, checkBoxes, true, false, View.SmallIcon, nonEmptyImageList, 0, 0 };
+                yield return new object[] { true, checkBoxes, true, false, View.SmallIcon, CreateNonEmpty(), 0, 0 };
 
                 foreach (bool autoArrange in new bool[] { true, false })
                 {
                     yield return new object[] { true, checkBoxes, autoArrange, true, View.Details, null, 0, 0 };
                     yield return new object[] { true, checkBoxes, autoArrange, true, View.Details, new ImageList(), 0, 0 };
-                    yield return new object[] { true, checkBoxes, autoArrange, true, View.Details, nonEmptyImageList, 0, 0 };
+                    yield return new object[] { true, checkBoxes, autoArrange, true, View.Details, CreateNonEmpty(), 0, 0 };
                     yield return new object[] { true, checkBoxes, autoArrange, true, View.LargeIcon, null, 0, 0 };
                     yield return new object[] { true, checkBoxes, autoArrange, true, View.LargeIcon, new ImageList(), 0, 0 };
-                    yield return new object[] { true, checkBoxes, autoArrange, true, View.LargeIcon, nonEmptyImageList, 0, 0 };
+                    yield return new object[] { true, checkBoxes, autoArrange, true, View.LargeIcon, CreateNonEmpty(), 0, 0 };
                     yield return new object[] { true, checkBoxes, autoArrange, true, View.List, null, 0, 0 };
                     yield return new object[] { true, checkBoxes, autoArrange, true, View.List, new ImageList(), 0, 0 };
-                    yield return new object[] { true, checkBoxes, autoArrange, true, View.List, nonEmptyImageList, 0, 0 };
+                    yield return new object[] { true, checkBoxes, autoArrange, true, View.List, CreateNonEmpty(), 0, 0 };
                     yield return new object[] { true, checkBoxes, autoArrange, true, View.SmallIcon, null, 0, 0 };
                     yield return new object[] { true, checkBoxes, autoArrange, true, View.SmallIcon, new ImageList(), 0, 0 };
-                    yield return new object[] { true, checkBoxes, autoArrange, true, View.SmallIcon, nonEmptyImageList, 0, 0 };
+                    yield return new object[] { true, checkBoxes, autoArrange, true, View.SmallIcon, CreateNonEmpty(), 0, 0 };
                 }
 
                 yield return new object[] { true, checkBoxes, false, false, View.Details, null, 0, 0 };
                 yield return new object[] { true, checkBoxes, false, false, View.Details, new ImageList(), 0, 0 };
-                yield return new object[] { true, checkBoxes, false, false, View.Details, nonEmptyImageList, 0, 0 };
+                yield return new object[] { true, checkBoxes, false, false, View.Details, CreateNonEmpty(), 0, 0 };
                 yield return new object[] { true, checkBoxes, false, false, View.LargeIcon, null, 0, 0 };
                 yield return new object[] { true, checkBoxes, false, false, View.LargeIcon, new ImageList(), 0, 0 };
-                yield return new object[] { true, checkBoxes, false, false, View.LargeIcon, nonEmptyImageList, 0, 0 };
+                yield return new object[] { true, checkBoxes, false, false, View.LargeIcon, CreateNonEmpty(), 0, 0 };
                 yield return new object[] { true, checkBoxes, false, false, View.List, null, 0, 0 };
                 yield return new object[] { true, checkBoxes, false, false, View.List, new ImageList(), 0, 0 };
-                yield return new object[] { true, checkBoxes, false, false, View.List, nonEmptyImageList, 0, 0 };
+                yield return new object[] { true, checkBoxes, false, false, View.List, CreateNonEmpty(), 0, 0 };
                 yield return new object[] { true, checkBoxes, false, false, View.SmallIcon, null, 0, 0 };
                 yield return new object[] { true, checkBoxes, false, false, View.SmallIcon, new ImageList(), 0, 0 };
-                yield return new object[] { true, checkBoxes, false, false, View.SmallIcon, nonEmptyImageList, 0, 0 };
+                yield return new object[] { true, checkBoxes, false, false, View.SmallIcon, CreateNonEmpty(), 0, 0 };
             }
 
             yield return new object[] { true, false, true, false, View.Tile, null, 0, 0 };
             yield return new object[] { true, false, true, false, View.Tile, new ImageList(), 0, 0 };
-            yield return new object[] { true, false, true, false, View.Tile, nonEmptyImageList, 0, 0 };
+            yield return new object[] { true, false, true, false, View.Tile, CreateNonEmpty(), 0, 0 };
 
             yield return new object[] { true, false, false, false, View.Tile, null, 0, 0 };
             yield return new object[] { true, false, false, false, View.Tile, new ImageList(), 0, 0 };
-            yield return new object[] { true, false, false, false, View.Tile, nonEmptyImageList, 0, 0 };
+            yield return new object[] { true, false, false, false, View.Tile, CreateNonEmpty(), 0, 0 };
 
             // UseCompatibleStateImageBehavior false, CheckBoxes true
             yield return new object[] { false, true, true, false, View.Details, null, 1, 1 };
             yield return new object[] { false, true, true, false, View.Details, new ImageList(), 1, 1 };
-            yield return new object[] { false, true, true, false, View.Details, nonEmptyImageList, 1, 1 };
+            yield return new object[] { false, true, true, false, View.Details, CreateNonEmpty(), 1, 1 };
             yield return new object[] { false, true, true, false, View.LargeIcon, null, 3, 1 };
             yield return new object[] { false, true, true, false, View.LargeIcon, new ImageList(), 3, 1 };
-            yield return new object[] { false, true, true, false, View.LargeIcon, nonEmptyImageList, 3, 1 };
+            yield return new object[] { false, true, true, false, View.LargeIcon, CreateNonEmpty(), 3, 1 };
             yield return new object[] { false, true, true, false, View.List, null, 1, 1 };
             yield return new object[] { false, true, true, false, View.List, new ImageList(), 1, 1 };
-            yield return new object[] { false, true, true, false, View.List, nonEmptyImageList, 1, 1 };
+            yield return new object[] { false, true, true, false, View.List, CreateNonEmpty(), 1, 1 };
             yield return new object[] { false, true, true, false, View.SmallIcon, null, 3, 1 };
             yield return new object[] { false, true, true, false, View.SmallIcon, new ImageList(), 3, 1 };
-            yield return new object[] { false, true, true, false, View.SmallIcon, nonEmptyImageList, 3, 1 };
+            yield return new object[] { false, true, true, false, View.SmallIcon, CreateNonEmpty(), 3, 1 };
 
             foreach (bool autoArrange in new bool[] { true, false })
             {
                 yield return new object[] { false, true, autoArrange, true, View.Details, null, 1, 1 };
                 yield return new object[] { false, true, autoArrange, true, View.Details, new ImageList(), 1, 1 };
-                yield return new object[] { false, true, autoArrange, true, View.Details, nonEmptyImageList, 1, 1 };
+                yield return new object[] { false, true, autoArrange, true, View.Details, CreateNonEmpty(), 1, 1 };
                 yield return new object[] { false, true, autoArrange, true, View.LargeIcon, null, 1, 1 };
                 yield return new object[] { false, true, autoArrange, true, View.LargeIcon, new ImageList(), 1, 1 };
-                yield return new object[] { false, true, autoArrange, true, View.LargeIcon, nonEmptyImageList, 1, 1 };
+                yield return new object[] { false, true, autoArrange, true, View.LargeIcon, CreateNonEmpty(), 1, 1 };
                 yield return new object[] { false, true, autoArrange, true, View.List, null, 1, 1 };
                 yield return new object[] { false, true, autoArrange, true, View.List, new ImageList(), 1, 1 };
-                yield return new object[] { false, true, autoArrange, true, View.List, nonEmptyImageList, 1, 1 };
+                yield return new object[] { false, true, autoArrange, true, View.List, CreateNonEmpty(), 1, 1 };
                 yield return new object[] { false, true, autoArrange, true, View.SmallIcon, null, 1, 1 };
                 yield return new object[] { false, true, autoArrange, true, View.SmallIcon, new ImageList(), 1, 1 };
-                yield return new object[] { false, true, autoArrange, true, View.SmallIcon, nonEmptyImageList, 1, 1 };
+                yield return new object[] { false, true, autoArrange, true, View.SmallIcon, CreateNonEmpty(), 1, 1 };
             }
 
             yield return new object[] { false, true, false, false, View.Details, null, 1, 1 };
             yield return new object[] { false, true, false, false, View.Details, new ImageList(), 1, 1 };
-            yield return new object[] { false, true, false, false, View.Details, nonEmptyImageList, 1, 1 };
+            yield return new object[] { false, true, false, false, View.Details, CreateNonEmpty(), 1, 1 };
             yield return new object[] { false, true, false, false, View.LargeIcon, null, 1, 1 };
             yield return new object[] { false, true, false, false, View.LargeIcon, new ImageList(), 1, 1 };
-            yield return new object[] { false, true, false, false, View.LargeIcon, nonEmptyImageList, 1, 1 };
+            yield return new object[] { false, true, false, false, View.LargeIcon, CreateNonEmpty(), 1, 1 };
             yield return new object[] { false, true, false, false, View.List, null, 1, 1 };
             yield return new object[] { false, true, false, false, View.List, new ImageList(), 1, 1 };
-            yield return new object[] { false, true, false, false, View.List, nonEmptyImageList, 1, 1 };
+            yield return new object[] { false, true, false, false, View.List, CreateNonEmpty(), 1, 1 };
             yield return new object[] { false, true, false, false, View.SmallIcon, null, 1, 1 };
             yield return new object[] { false, true, false, false, View.SmallIcon, new ImageList(), 1, 1 };
-            yield return new object[] { false, true, false, false, View.SmallIcon, nonEmptyImageList, 1, 1 };
+            yield return new object[] { false, true, false, false, View.SmallIcon, CreateNonEmpty(), 1, 1 };
 
             // UseCompatibleStateImageBehavior false, CheckBoxes false
             yield return new object[] { false, false, true, false, View.Details, null, 0, 0 };
             yield return new object[] { false, false, true, false, View.Details, new ImageList(), 0, 0 };
-            yield return new object[] { false, false, true, false, View.Details, nonEmptyImageList, 0, 0 };
+            yield return new object[] { false, false, true, false, View.Details, CreateNonEmpty(), 0, 0 };
             yield return new object[] { false, false, true, false, View.LargeIcon, null, 1, 0 };
             yield return new object[] { false, false, true, false, View.LargeIcon, new ImageList(), 1, 0 };
-            yield return new object[] { false, false, true, false, View.LargeIcon, nonEmptyImageList, 1, 0 };
+            yield return new object[] { false, false, true, false, View.LargeIcon, CreateNonEmpty(), 1, 0 };
             yield return new object[] { false, false, true, false, View.List, null, 0, 0 };
             yield return new object[] { false, false, true, false, View.List, new ImageList(), 0, 0 };
-            yield return new object[] { false, false, true, false, View.List, nonEmptyImageList, 0, 0 };
+            yield return new object[] { false, false, true, false, View.List, CreateNonEmpty(), 0, 0 };
             yield return new object[] { false, false, true, false, View.SmallIcon, null, 1, 0 };
             yield return new object[] { false, false, true, false, View.SmallIcon, new ImageList(), 1, 0 };
-            yield return new object[] { false, false, true, false, View.SmallIcon, nonEmptyImageList, 1, 0 };
+            yield return new object[] { false, false, true, false, View.SmallIcon, CreateNonEmpty(), 1, 0 };
             yield return new object[] { false, false, true, false, View.Tile, null, 0, 0 };
             yield return new object[] { false, false, true, false, View.Tile, new ImageList(), 0, 0 };
-            yield return new object[] { false, false, true, false, View.Tile, nonEmptyImageList, 0, 0 };
+            yield return new object[] { false, false, true, false, View.Tile, CreateNonEmpty(), 0, 0 };
 
             foreach (bool autoArrange in new bool[] { true, false })
             {
                 yield return new object[] { false, false, autoArrange, true, View.Details, null, 0, 0 };
                 yield return new object[] { false, false, autoArrange, true, View.Details, new ImageList(), 0, 0 };
-                yield return new object[] { false, false, autoArrange, true, View.Details, nonEmptyImageList, 0, 0 };
+                yield return new object[] { false, false, autoArrange, true, View.Details, CreateNonEmpty(), 0, 0 };
                 yield return new object[] { false, false, autoArrange, true, View.LargeIcon, null, 0, 0 };
                 yield return new object[] { false, false, autoArrange, true, View.LargeIcon, new ImageList(), 0, 0 };
-                yield return new object[] { false, false, autoArrange, true, View.LargeIcon, nonEmptyImageList, 0, 0 };
+                yield return new object[] { false, false, autoArrange, true, View.LargeIcon, CreateNonEmpty(), 0, 0 };
                 yield return new object[] { false, false, autoArrange, true, View.List, null, 0, 0 };
                 yield return new object[] { false, false, autoArrange, true, View.List, new ImageList(), 0, 0 };
-                yield return new object[] { false, false, autoArrange, true, View.List, nonEmptyImageList, 0, 0 };
+                yield return new object[] { false, false, autoArrange, true, View.List, CreateNonEmpty(), 0, 0 };
                 yield return new object[] { false, false, autoArrange, true, View.SmallIcon, null, 0, 0 };
                 yield return new object[] { false, false, autoArrange, true, View.SmallIcon, new ImageList(), 0, 0 };
-                yield return new object[] { false, false, autoArrange, true, View.SmallIcon, nonEmptyImageList, 0, 0 };
+                yield return new object[] { false, false, autoArrange, true, View.SmallIcon, CreateNonEmpty(), 0, 0 };
             }
 
             yield return new object[] { false, false, false, false, View.Details, null, 0, 0 };
             yield return new object[] { false, false, false, false, View.Details, new ImageList(), 0, 0 };
-            yield return new object[] { false, false, false, false, View.Details, nonEmptyImageList, 0, 0 };
+            yield return new object[] { false, false, false, false, View.Details, CreateNonEmpty(), 0, 0 };
             yield return new object[] { false, false, false, false, View.LargeIcon, null, 0, 0 };
             yield return new object[] { false, false, false, false, View.LargeIcon, new ImageList(), 0, 0 };
-            yield return new object[] { false, false, false, false, View.LargeIcon, nonEmptyImageList, 0, 0 };
+            yield return new object[] { false, false, false, false, View.LargeIcon, CreateNonEmpty(), 0, 0 };
             yield return new object[] { false, false, false, false, View.List, null, 0, 0 };
             yield return new object[] { false, false, false, false, View.List, new ImageList(), 0, 0 };
-            yield return new object[] { false, false, false, false, View.List, nonEmptyImageList, 0, 0 };
+            yield return new object[] { false, false, false, false, View.List, CreateNonEmpty(), 0, 0 };
             yield return new object[] { false, false, false, false, View.SmallIcon, null, 0, 0 };
             yield return new object[] { false, false, false, false, View.SmallIcon, new ImageList(), 0, 0 };
-            yield return new object[] { false, false, false, false, View.SmallIcon, nonEmptyImageList, 0, 0 };
+            yield return new object[] { false, false, false, false, View.SmallIcon, CreateNonEmpty(), 0, 0 };
             yield return new object[] { false, false, false, false, View.Tile, null, 0, 0 };
             yield return new object[] { false, false, false, false, View.Tile, new ImageList(), 0, 0 };
-            yield return new object[] { false, false, false, false, View.Tile, nonEmptyImageList, 0, 0 };
+            yield return new object[] { false, false, false, false, View.Tile, CreateNonEmpty(), 0, 0 };
         }
 
         [WinFormsTheory]
@@ -3822,8 +3785,10 @@ namespace System.Windows.Forms.Tests
                 AutoArrange = autoArrange,
                 VirtualMode = virtualMode,
                 View = view,
-                StateImageList = imageList
             };
+
+            listView.StateImageList = imageList;
+
             Assert.NotEqual(IntPtr.Zero, listView.Handle);
             int invalidatedCallCount = 0;
             listView.Invalidated += (sender, e) => invalidatedCallCount++;
@@ -4187,6 +4152,13 @@ namespace System.Windows.Forms.Tests
         {
             using var control = new SubListView();
             Assert.False(control.GetTopLevel());
+        }
+
+        private static ImageList CreateNonEmpty()
+        {
+            var nonEmptyImageList = new ImageList();
+            nonEmptyImageList.Images.Add(new Bitmap(10, 10));
+            return nonEmptyImageList;
         }
 
         private class SubListView : ListView


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

- Centralise lifetime management of native ImageList
   Move calls to Create, Duplicate and Destroy into NativeImageList to reduce a chance of interleaved calls to Win32 API.
- Track disposal of NativeImageList
- Dispose  and do not reuse `ImageList` instances in tests. 
    Quite likely the observe AVE were a result of use reusing a shared instance of an `ImageList` across theory runs. Quite likely xUnit would dispose the instance while another test was run, leading to a corrupt heap. Resolves #3358
- Prevent ImageList allocation disposing PropertyGrid. Resolves #3485
- Refactor `ToolStripItem.Animate` and `ToolStripItem.set_Image` methods to reduce nesting



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3526)