### PR TITLE
Fix 3485 `PropertyGrid` allocates `ImageList` handles while disposing

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.NativeImageList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.NativeImageList.cs
@@ -1,9 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 #nullable disable
 
+using System.Diagnostics;
 using static Interop;
 
 namespace System.Windows.Forms
@@ -42,7 +43,13 @@ namespace System.Windows.Forms
                 }
             }
 
-            ~NativeImageList() => Dispose(false);
+            ~NativeImageList()
+            {
+#if DEBUG
+                Debug.Fail($"{nameof(NativeImageList)} was not disposed properly. Originating stack:\n{_callStack}");
+#endif
+                Dispose(false);
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -1018,7 +1018,7 @@ namespace System.Windows.Forms
             get
             {
                 Image image = (Image)Properties.GetObject(s_imageProperty);
-                if (image == null && (Owner != null) && (Owner.ImageList != null) && ImageIndexer.ActualIndex >= 0)
+                if (image == null && Owner?.ImageList?.HandleCreated == true && ImageIndexer.ActualIndex >= 0)
                 {
                     if (ImageIndexer.ActualIndex < Owner.ImageList.Images.Count)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -2056,25 +2056,27 @@ namespace System.Windows.Forms
 
         private void Animate(bool animate)
         {
-            if (animate != _state[s_stateCurrentlyAnimatingImage])
+            if (animate == _state[s_stateCurrentlyAnimatingImage])
             {
-                if (animate)
-                {
-                    if (Image != null)
-                    {
-                        ImageAnimator.Animate(Image, new EventHandler(OnAnimationFrameChanged));
-                        _state[s_stateCurrentlyAnimatingImage] = animate;
-                    }
-                }
-                else
-                {
-                    if (Image != null)
-                    {
-                        ImageAnimator.StopAnimate(Image, new EventHandler(OnAnimationFrameChanged));
-                        _state[s_stateCurrentlyAnimatingImage] = animate;
-                    }
-                }
+                return;
             }
+
+            Image image = Image;
+            if (image == null)
+            {
+                return;
+            }
+
+            if (animate)
+            {
+                ImageAnimator.Animate(image, new EventHandler(OnAnimationFrameChanged));
+            }
+            else
+            {
+                ImageAnimator.StopAnimate(image, new EventHandler(OnAnimationFrameChanged));
+            }
+
+            _state[s_stateCurrentlyAnimatingImage] = animate;
         }
 
         internal bool BeginDragForItemReorder()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Resolves #3485


## Proposed changes

- Refactor `ToolStripItem.Animate(bool)` method to reduce nesting
- Prevent `ImageList` allocation while disposing `PropertyGrid` by asserting `ImageList` has a valid handle.


## Test methodology <!-- How did you ensure quality? -->

- Manually as described in #3485

/cc: @weltkante 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3529)