### PR TITLE
Replace Dev10 with .NET Framework 4.0 in comments

### DIFF
--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
@@ -637,7 +637,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
         <SecuritySafeCritical()>
         Protected Sub HideSplashScreen()
             SyncLock _splashLock 'This ultimately wasn't necessary.  I suppose we better keep it for backwards compatibility
-                'Dev10 590587 - we now activate the main form before calling Dispose on the Splash screen. (we're just
+                '.NET Framework 4.0 (Dev10 #590587) - we now activate the main form before calling Dispose on the Splash screen. (we're just
                 '       swapping the order of the two If blocks). This is to fix the issue where the main form
                 '       doesn't come to the front after the Splash screen disappears
                 If MainForm IsNot Nothing Then

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.cs
@@ -660,8 +660,8 @@ namespace System.ComponentModel.Design.Serialization
                     culture = ReadCulture;
                 }
 
-                // Dev10 Bug 425129: Control location moves due to incorrect anchor info when  resource files are reloaded.
-                System.Windows.Forms.Control control = value as System.Windows.Forms.Control;
+                // .NET Framework 4.0 (Dev10 #425129): Control location moves due to incorrect anchor info when resource files are reloaded.
+                Windows.Forms.Control control = value as Windows.Forms.Control;
                 if (control != null)
                 {
                     control.SuspendLayout();

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCodeDomSerializer.cs
@@ -76,11 +76,11 @@ namespace System.Windows.Forms.Design
                 {
                     foreach (Control c in suspendedComponents)
                     {
-                        // Dev10 Bug #462211: Controls in design time may change their size due to incorrectly
+                        // .NET Framework 4.0 (Dev10 #462211): Controls in design time may change their size due to incorrectly
                         // calculated anchor info.
                         // UNDONE: c.ResumeLayout(false) because it regressed layouts with Dock property
                         // see Dev11 bug 117530 DTS Winforms: Upgraded project -Control location and size are changed in the designer gen'd code
-                        c.ResumeLayout(true /*performLayout*/);
+                        c.ResumeLayout(performLayout: true);
                     }
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -2915,8 +2915,7 @@ namespace System.Windows.Forms
                     Array.Copy(_currentObjects, 0, newObjects, 0, i);
                     if (i < newObjects.Length)
                     {
-                        // Dev10
-
+                        // Fixed for .NET Framework 4.0
                         Array.Copy(_currentObjects, i + 1, newObjects, i, newObjects.Length - i);
                     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -897,9 +897,8 @@ namespace System.Windows.Forms
             // Reduce constraints by border/padding size
             proposedConstraints -= bordersAndPadding;
 
-            // Fit the text to the remaining space
-            // Fix for Dev10
-
+            // Fit the text to the remaining space.
+            // Fixed for .NET Framework 4.0
             TextFormatFlags format = TextFormatFlags.NoPrefix;
             if (!Multiline)
             {


### PR DESCRIPTION
Contributes to #3546


## Proposed changes

- Replace Dev10 with .NET Framework 4.0 in comments.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3565)