### PR TITLE
Add dependencies required for CPD strict

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -7,101 +7,149 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
 -->
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NETCore.App" Version="5.0.0-preview.8.20361.2">
+    <Dependency Name="Microsoft.NETCore.App" Version="5.0.0-preview.8.20363.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-preview.8.20361.2">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-preview.8.20363.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-preview.8.20361.2">
+    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-preview.8.20363.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-preview.8.20361.2">
+    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-preview.8.20363.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="5.0.0-preview.8.20361.2">
+    <Dependency Name="System.CodeDom" Version="5.0.0-preview.8.20363.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-preview.8.20361.2">
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-preview.8.20363.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="5.0.0-preview.8.20361.2">
+    <Dependency Name="System.Drawing.Common" Version="5.0.0-preview.8.20363.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="5.0.0-preview.8.20361.2">
+    <Dependency Name="System.Resources.Extensions" Version="5.0.0-preview.8.20363.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-preview.8.20361.2">
+    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-preview.8.20363.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="5.0.0-preview.8.20361.2">
+    <Dependency Name="System.Security.Permissions" Version="5.0.0-preview.8.20363.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
-    <Dependency Name="System.Windows.Extensions" Version="5.0.0-preview.8.20361.2">
+    <Dependency Name="System.Windows.Extensions" Version="5.0.0-preview.8.20363.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.IL" Version="5.0.0-preview.8.20361.2">
+    <Dependency Name="Microsoft.NET.Sdk.IL" Version="5.0.0-preview.8.20363.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.ILAsm" Version="5.0.0-preview.8.20361.2">
+    <Dependency Name="Microsoft.NETCore.ILAsm" Version="5.0.0-preview.8.20363.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
-    <Dependency Name="runtime.win-x64.Microsoft.NETCore.ILAsm" Version="5.0.0-preview.8.20361.2">
+    <Dependency Name="runtime.win-x64.Microsoft.NETCore.ILAsm" Version="5.0.0-preview.8.20363.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
-    <Dependency Name="runtime.win-x86.Microsoft.NETCore.ILAsm" Version="5.0.0-preview.8.20361.2">
+    <Dependency Name="runtime.win-x86.Microsoft.NETCore.ILAsm" Version="5.0.0-preview.8.20363.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-preview.8.20361.2">
+    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-preview.8.20363.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="5.0.0-preview.8.20361.2">
+    <Dependency Name="System.DirectoryServices" Version="5.0.0-preview.8.20363.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.MetadataLoadContext" Version="5.0.0-preview.8.20361.2">
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="5.0.0-preview.8.20363.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
-    <Dependency Name="System.Security.AccessControl" Version="5.0.0-preview.8.20361.2">
+    <Dependency Name="System.Security.AccessControl" Version="5.0.0-preview.8.20363.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-preview.8.20361.2">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-preview.8.20363.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-preview.8.20361.2">
+    <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-preview.8.20363.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Packaging" Version="5.0.0-preview.8.20361.2">
+    <Dependency Name="System.IO.Packaging" Version="5.0.0-preview.8.20363.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.ILDAsm" Version="5.0.0-preview.8.20361.2">
+    <Dependency Name="Microsoft.NETCore.ILDAsm" Version="5.0.0-preview.8.20363.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Internal" Version="5.0.0-preview.8.20361.2">
+    <Dependency Name="Microsoft.NETCore.App.Internal" Version="5.0.0-preview.8.20363.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.Targets" Version="5.0.0-preview.8.20363.2">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+    </Dependency>
+    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-preview.8.20363.2">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+    </Dependency>
+    <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-preview.8.20363.2">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+    </Dependency>
+    <Dependency Name="System.IO.Pipes.AccessControl" Version="5.0.0-preview.8.20363.2">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-preview.8.20363.2">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-preview.8.20363.2">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+    </Dependency>
+    <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-preview.8.20363.2">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+    </Dependency>
+    <Dependency Name="System.Text.Json" Version="5.0.0-preview.8.20363.2">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+    </Dependency>
+    <Dependency Name="System.Threading.AccessControl" Version="5.0.0-preview.8.20363.2">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Win32.Registry.AccessControl" Version="5.0.0-preview.8.20363.2">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-preview.8.20363.2">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-preview.8.20363.2">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,39 +9,44 @@
     <UsingToolMicrosoftNetCompilers>false</UsingToolMicrosoftNetCompilers>
   </PropertyGroup>
   <!-- Below have corresponding entries in Versions.Details.XML because they are updated via Maestro -->
-  <!-- Core Setup for coherency -->
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>5.0.0-preview.8.20361.2</MicrosoftNETCoreAppPackageVersion>
-    <SystemDiagnosticsEventLogPackageVersion>5.0.0-preview.8.20361.2</SystemDiagnosticsEventLogPackageVersion>
-    <SystemDirectoryServicesPackageVersion>5.0.0-preview.8.20361.2</SystemDirectoryServicesPackageVersion>
-    <SystemReflectionMetadataLoadContextPackageVersion>5.0.0-preview.8.20361.2</SystemReflectionMetadataLoadContextPackageVersion>
-    <SystemSecurityAccessControlPackageVersion>5.0.0-preview.8.20361.2</SystemSecurityAccessControlPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>5.0.0-preview.8.20361.2</SystemSecurityCryptographyXmlPackageVersion>
-    <SystemSecurityPrincipalWindowsPackageVersion>5.0.0-preview.8.20361.2</SystemSecurityPrincipalWindowsPackageVersion>
-    <SystemIOPackagingPackageVersion>5.0.0-preview.8.20361.2</SystemIOPackagingPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>5.0.0-preview.8.20363.2</MicrosoftNETCoreAppPackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>5.0.0-preview.8.20363.2</SystemDiagnosticsEventLogPackageVersion>
+    <SystemDirectoryServicesPackageVersion>5.0.0-preview.8.20363.2</SystemDirectoryServicesPackageVersion>
+    <SystemReflectionMetadataLoadContextPackageVersion>5.0.0-preview.8.20363.2</SystemReflectionMetadataLoadContextPackageVersion>
+    <SystemSecurityAccessControlPackageVersion>5.0.0-preview.8.20363.2</SystemSecurityAccessControlPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>5.0.0-preview.8.20363.2</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityPrincipalWindowsPackageVersion>5.0.0-preview.8.20363.2</SystemSecurityPrincipalWindowsPackageVersion>
+    <SystemIOPackagingPackageVersion>5.0.0-preview.8.20363.2</SystemIOPackagingPackageVersion>
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>5.0.0-preview.7.20320.5</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
-    <MicrosoftNETCoreILDAsmPackageVersion>5.0.0-preview.8.20361.2</MicrosoftNETCoreILDAsmPackageVersion>
-    <MicrosoftNETCoreAppInternalPackageVersion>5.0.0-preview.8.20361.2</MicrosoftNETCoreAppInternalPackageVersion>
-  </PropertyGroup>
-  <!-- CoreFX via Core Setup -->
-  <PropertyGroup>
-    <MicrosoftNETCorePlatformsPackageVersion>5.0.0-preview.8.20361.2</MicrosoftNETCorePlatformsPackageVersion>
-    <MicrosoftWin32RegistryPackageVersion>5.0.0-preview.8.20361.2</MicrosoftWin32RegistryPackageVersion>
-    <MicrosoftWin32SystemEventsPackageVersion>5.0.0-preview.8.20361.2</MicrosoftWin32SystemEventsPackageVersion>
-    <SystemCodeDomPackageVersion>5.0.0-preview.8.20361.2</SystemCodeDomPackageVersion>
-    <SystemConfigurationConfigurationManagerPackageVersion>5.0.0-preview.8.20361.2</SystemConfigurationConfigurationManagerPackageVersion>
-    <SystemDrawingCommonPackageVersion>5.0.0-preview.8.20361.2</SystemDrawingCommonPackageVersion>
-    <SystemResourcesExtensionsPackageVersion>5.0.0-preview.8.20361.2</SystemResourcesExtensionsPackageVersion>
-    <SystemSecurityCryptographyCngPackageVersion>5.0.0-preview.8.20361.2</SystemSecurityCryptographyCngPackageVersion>
-    <SystemSecurityPermissionsPackageVersion>5.0.0-preview.8.20361.2</SystemSecurityPermissionsPackageVersion>
-    <SystemWindowsExtensionsPackageVersion>5.0.0-preview.8.20361.2</SystemWindowsExtensionsPackageVersion>
-  </PropertyGroup>
-  <!-- CoreCLR via Core Setup -->
-  <PropertyGroup>
+    <MicrosoftNETCoreILDAsmPackageVersion>5.0.0-preview.8.20363.2</MicrosoftNETCoreILDAsmPackageVersion>
+    <MicrosoftNETCoreAppInternalPackageVersion>5.0.0-preview.8.20363.2</MicrosoftNETCoreAppInternalPackageVersion>
+    <MicrosoftNETCoreTargetsPackageVersion>5.0.0-preview.8.20363.2</MicrosoftNETCoreTargetsPackageVersion>
+    <SystemDiagnosticsPerformanceCounterPackageVersion>5.0.0-preview.8.20363.2</SystemDiagnosticsPerformanceCounterPackageVersion>
+    <SystemIOFileSystemAccessControlPackageVersion>5.0.0-preview.8.20363.2</SystemIOFileSystemAccessControlPackageVersion>
+    <SystemIOPipesAccessControlPackageVersion>5.0.0-preview.8.20363.2</SystemIOPipesAccessControlPackageVersion>
+    <SystemSecurityCryptographyPkcsPackageVersion>5.0.0-preview.8.20363.2</SystemSecurityCryptographyPkcsPackageVersion>
+    <SystemSecurityCryptographyProtectedDataPackageVersion>5.0.0-preview.8.20363.2</SystemSecurityCryptographyProtectedDataPackageVersion>
+    <SystemTextEncodingsWebPackageVersion>5.0.0-preview.8.20363.2</SystemTextEncodingsWebPackageVersion>
+    <SystemTextJsonPackageVersion>5.0.0-preview.8.20363.2</SystemTextJsonPackageVersion>
+    <SystemThreadingAccessControlPackageVersion>5.0.0-preview.8.20363.2</SystemThreadingAccessControlPackageVersion>
+    <MicrosoftWin32RegistryAccessControlPackageVersion>5.0.0-preview.8.20363.2</MicrosoftWin32RegistryAccessControlPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>5.0.0-preview.8.20363.2</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>5.0.0-preview.8.20363.2</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>5.0.0-preview.8.20363.2</MicrosoftNETCorePlatformsPackageVersion>
+    <MicrosoftWin32RegistryPackageVersion>5.0.0-preview.8.20363.2</MicrosoftWin32RegistryPackageVersion>
+    <MicrosoftWin32SystemEventsPackageVersion>5.0.0-preview.8.20363.2</MicrosoftWin32SystemEventsPackageVersion>
+    <SystemCodeDomPackageVersion>5.0.0-preview.8.20363.2</SystemCodeDomPackageVersion>
+    <SystemConfigurationConfigurationManagerPackageVersion>5.0.0-preview.8.20363.2</SystemConfigurationConfigurationManagerPackageVersion>
+    <SystemDrawingCommonPackageVersion>5.0.0-preview.8.20363.2</SystemDrawingCommonPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>5.0.0-preview.8.20363.2</SystemResourcesExtensionsPackageVersion>
+    <SystemSecurityCryptographyCngPackageVersion>5.0.0-preview.8.20363.2</SystemSecurityCryptographyCngPackageVersion>
+    <SystemSecurityPermissionsPackageVersion>5.0.0-preview.8.20363.2</SystemSecurityPermissionsPackageVersion>
+    <SystemWindowsExtensionsPackageVersion>5.0.0-preview.8.20363.2</SystemWindowsExtensionsPackageVersion>
     <MicrosoftNETCoreILPackageVersion>3.0.0-preview5-27616-73</MicrosoftNETCoreILPackageVersion>
-    <MicrosoftNETCoreILAsmPackageVersion>5.0.0-preview.8.20361.2</MicrosoftNETCoreILAsmPackageVersion>
-    <runtimewinx64MicrosoftNETCoreILAsmPackageVersion>5.0.0-preview.8.20361.2</runtimewinx64MicrosoftNETCoreILAsmPackageVersion>
-    <runtimewinx86MicrosoftNETCoreILAsmPackageVersion>5.0.0-preview.8.20361.2</runtimewinx86MicrosoftNETCoreILAsmPackageVersion>
+    <MicrosoftNETCoreILAsmPackageVersion>5.0.0-preview.8.20363.2</MicrosoftNETCoreILAsmPackageVersion>
+    <runtimewinx64MicrosoftNETCoreILAsmPackageVersion>5.0.0-preview.8.20363.2</runtimewinx64MicrosoftNETCoreILAsmPackageVersion>
+    <runtimewinx86MicrosoftNETCoreILAsmPackageVersion>5.0.0-preview.8.20363.2</runtimewinx86MicrosoftNETCoreILAsmPackageVersion>
     <!-- 
       Microsoft.NET.Sdk.IL.targets requires definition of MicrosoftNETCoreILAsmVersion
     -->

--- a/global.json
+++ b/global.json
@@ -18,7 +18,7 @@
     "Microsoft.DotNet.CMake.Sdk": "5.0.0-beta.20256.5",
     "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20330.3",
     "FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
-    "Microsoft.NET.Sdk.IL": "5.0.0-preview.8.20361.2"
+    "Microsoft.NET.Sdk.IL": "5.0.0-preview.8.20363.2"
   },
   "native-tools": {
     "cmake": "3.14.2",


### PR DESCRIPTION
Also run a general update
CPD strict means the following:
```
<Dependency Name="Microsoft.Win32.Registry.AccessControl" Version="5.0.0-preview.8.20361.2" CoherentParentDependency="Microsoft.Private.Winforms">
    <Uri>https://github.com/dotnet/runtime</Uri>
    <Sha>f37dd6fc8595e130909dcb3085a56342d04aa20c</Sha>
</Dependency>
```
This is from windowdesktop. In this case, Maestro will look up to find a direct dependency on Microsoft.Win32.Registry.AccessControl in runtime@f37dd6fc8595e130909dcb3085a56342d04aa20c.
If none exists, it fails. This contrasts to the current CPD algorithm which will attempt to find the newest Microsoft.Win32.Registry.AccessControl in any build within the graph below runtime@f37dd6fc8595e130909dcb3085a56342d04aa20c.
This is prone to error in some servicing cases, is slow, and requires the use of external data sources.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3577)