### PR TITLE
Set right SplitterDistance when setting SplitContainer.Panel2MinSize

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
@@ -1380,6 +1380,7 @@ namespace System.Windows.Forms
             {
                 throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgument, nameof(Panel2MinSize), value, 0));
             }
+
             if (Orientation == Orientation.Vertical)
             {
                 if (DesignMode && Width != DefaultSize.Width && value + Panel1MinSize + SplitterWidth > Width)
@@ -1394,10 +1395,23 @@ namespace System.Windows.Forms
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidArgument, nameof(Panel2MinSize), value));
                 }
             }
+
             panel2MinSize = value;
-            if (value > Panel2.Width)
+            if (Orientation == Orientation.Vertical)
             {
-                SplitterDistanceInternal = Panel2.Width + SplitterWidthInternal;  //Set the Splitter Distance to the start of Panel2
+                if (Panel2.Width < value)
+                {
+                    // Set the Splitter Distance to the start of Panel2
+                    SplitterDistanceInternal = Math.Max(Width - value - SplitterWidthInternal, 0);
+                }
+            }
+            else
+            {
+                if (Panel2.Height < value)
+                {
+                    // Set the Splitter Distance to the start of Panel2
+                    SplitterDistanceInternal = Math.Max(Height - value - SplitterWidthInternal, 0);
+                }
             }
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/SplitContainerTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/SplitContainerTests.cs
@@ -20,5 +20,61 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(sc, sc.Panel2.Owner);
             Assert.False(sc.SplitterRectangle.IsEmpty);
         }
+
+        [WinFormsTheory]
+        [InlineData(150, 100, 120)]
+        [InlineData(150, 100, 80)]
+        public void SplitContainer_Panel2MinSize_SetLargerThanPanel2SizeWithVerticalOrientation_SetsSplitterDistance(int width, int height, int panel2MinSize)
+        {
+            using var sc = new SplitContainer()
+            {
+                Orientation = Orientation.Vertical,
+                Width = width,
+                Height = height,
+                SplitterDistance = width / 2
+            };
+
+            sc.Panel2MinSize = panel2MinSize;
+
+            Assert.Equal(panel2MinSize, sc.Panel2.Width);
+        }
+
+        [WinFormsTheory]
+        [InlineData(100, 150, 120)]
+        [InlineData(100, 150, 80)]
+        public void SplitContainer_Panel2MinSize_SetLargerThanPanel2SizeWithHorizontalOrientation_SetsSplitterDistance(int width, int height, int panel2MinSize)
+        {
+            using var sc = new SplitContainer()
+            {
+                Orientation = Orientation.Horizontal,
+                Width = width,
+                Height = height,
+                SplitterDistance = height / 2
+            };
+
+            sc.Panel2MinSize = panel2MinSize;
+
+            Assert.Equal(panel2MinSize, sc.Panel2.Height);
+        }
+
+        [WinFormsTheory]
+        [InlineData(Orientation.Vertical, 150, 100, 75, 50)]
+        [InlineData(Orientation.Vertical, 300, 100, 150, 120)]
+        [InlineData(Orientation.Horizontal, 100, 150, 75, 50)]
+        [InlineData(Orientation.Horizontal, 100, 300, 150, 120)]
+        public void SplitContainer_Panel2MinSize_SetLessOrEqualPanel2Size_DoesNotSetSplitterDistance(Orientation orientation, int width, int height, int splitterDistance, int panel2MinSize)
+        {
+            using var sc = new SplitContainer()
+            {
+                Orientation = orientation,
+                Width = width,
+                Height = height,
+                SplitterDistance = splitterDistance
+            };
+
+            sc.Panel2MinSize = panel2MinSize;
+
+            Assert.Equal(splitterDistance, sc.SplitterDistance);
+        }
     }
 }


### PR DESCRIPTION
Respect the SplitContainer orientation in ApplyPanel2MinSize. Adjust
the splitter distance to accommodate Panel2 if Panel2 is smaller than
Panel2MinSize.

Fixes #3568


## Proposed changes

- When setting Panel2MinSize in a SplitContainer with Orientation = Orientation.Horizontal, consider Panel2.Height instead of Panel2.Width to determine wether changing SplitterDistance is required.
- If changing Panel2MinSize requires increasing the size of Panel2, change SplitterDistance in such a way that Panel2 size matches Panel2MinSize.
- Add tests.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- SplitContainer moves splitter (if necessary) to make sure that Panel2 is not smaller than Panel2MinSize.
- SplitContainer does not move the splitter unnecessarily when setting Panel2MinSize.

## Regression? 

- No

## Risk

- Low (I guess)

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

- Added unit tests.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Does not make changes that affect accessibility.
 

## Test environment(s) <!-- Remove any that don't apply -->

- 5.0.100-preview.6.20310.4


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3582)