### PR TITLE
[Port to 3.1 servicing]: Adding Form subtype in WinForms C# template

### DIFF
--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/template.json
@@ -61,6 +61,11 @@
       "path": "Form1.cs"
     }
   ],
+  "sources": [
+    {
+      "exclude": [ "**/[Bb]in/**", "**/[Oo]bj/**", ".template.config/**/*", "**/*.filelist", "**/*.lock.json" ]
+    }
+  ],
   "defaultName": "WinFormsApp1",
   "postActions": [
     {

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/Company.WinFormsApplication1.csproj.user
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/Company.WinFormsApplication1.csproj.user
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <ItemGroup>
+        <Compile Update="Form1.cs">
+            <SubType>Form</SubType>
+        </Compile>
+    </ItemGroup>
+</Project>


### PR DESCRIPTION
Porting fix for bug #3510 to 3.1 servicing release.
Master branch commit: #3527 

Changes:

1. Added *.user file so as to add Form subtype.
2. By default template engine removes *.user files.
    To override it, I have added sources in template.json to remove *.user from "exclude"

Verified that:

1. .user file gets dropped on creating new project from dotnet CLI
2. It works when project gets created from VS. Now Form1.cs opens directly in designer
3. .user file has BOM (0xEF, 0xBB, 0xBF) characters in the beginning and the files have UTF 8 encoding
4. On adding a new Form to an existing project, the new Form opens directly in designer

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3594)