### PR TITLE
Workaround for bad ImageList ownership management

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.NativeImageList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.NativeImageList.cs
@@ -61,6 +61,9 @@ namespace System.Windows.Forms
 
             public void Dispose()
             {
+#if DEBUG
+                GC.SuppressFinalize(this);
+#endif
                 lock (s_syncLock)
                 {
                     if (Handle == IntPtr.Zero)
@@ -68,13 +71,10 @@ namespace System.Windows.Forms
                         return;
                     }
 
-                    ComCtl32.ImageList.Destroy(Handle);
+                    var result = ComCtl32.ImageList.Destroy(Handle);
+                    Debug.Assert(result.IsTrue());
                     Handle = IntPtr.Zero;
                 }
-
-#if DEBUG
-                GC.SuppressFinalize(this);
-#endif
             }
 
 #if DEBUG
@@ -90,6 +90,13 @@ namespace System.Windows.Forms
                 return;
             }
 #endif
+
+            internal IntPtr TransferOwnership()
+            {
+                var handle = Handle;
+                Handle = IntPtr.Zero;
+                return handle;
+            }
 
             internal NativeImageList Duplicate()
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
@@ -142,6 +142,17 @@ namespace System.Windows.Forms
             }
         }
 
+        internal IntPtr CreateUniqueHandle()
+        {
+            if (_nativeImageList == null)
+            {
+                CreateHandle();
+            }
+
+            using var iml = _nativeImageList.Duplicate();
+            return iml.TransferOwnership();
+        }
+
         /// <summary>
         ///  Whether or not the underlying Win32 handle has been created.
         /// </summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -579,11 +579,21 @@ namespace System.Windows.Forms
                         {
                             if (CheckBoxes)
                             { // we want custom checkboxes
-                                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, _imageListState.Handle);
+                                var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, _imageListState.CreateUniqueHandle());
+                                if (previousHandle != IntPtr.Zero)
+                                {
+                                    var result = ComCtl32.ImageList.Destroy(previousHandle);
+                                    Debug.Assert(result.IsTrue());
+                                }
                             }
                             else
                             {
-                                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, IntPtr.Zero);
+                                var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, IntPtr.Zero);
+                                if (previousHandle != IntPtr.Zero)
+                                {
+                                    var result = ComCtl32.ImageList.Destroy(previousHandle);
+                                    Debug.Assert(result.IsTrue());
+                                }
                             }
                         }
 
@@ -664,7 +674,9 @@ namespace System.Windows.Forms
                     cp.Style |= (currentStyle & (int)(User32.WS.HSCROLL | User32.WS.VSCROLL));
                 }
 
-                cp.Style |= (int)LVS.SHAREIMAGELISTS;
+                // disabled until ownership management of list handles is fixed
+                // https://github.com/dotnet/winforms/issues/3531
+                //cp.Style |= (int)LVS.SHAREIMAGELISTS;
 
                 switch (alignStyle)
                 {
@@ -966,8 +978,13 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.GROUPHEADER,
-                        value is null ? IntPtr.Zero : value.Handle);
+                var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.GROUPHEADER,
+                        value is null ? IntPtr.Zero : value.CreateUniqueHandle());
+                if (previousHandle != IntPtr.Zero)
+                {
+                    var result = ComCtl32.ImageList.Destroy(previousHandle);
+                    Debug.Assert(result.IsTrue());
+                }
             }
         }
 
@@ -1235,7 +1252,13 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.NORMAL, value is null ? IntPtr.Zero : value.Handle);
+                var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.NORMAL, value is null ? IntPtr.Zero : value.CreateUniqueHandle());
+                if (previousHandle != IntPtr.Zero)
+                {
+                    var result = ComCtl32.ImageList.Destroy(previousHandle);
+                    Debug.Assert(result.IsTrue());
+                }
+
                 if (AutoArrange && !listViewState1[LISTVIEWSTATE1_disposingImageLists])
                 {
                     UpdateListViewItemsLocations();
@@ -1474,7 +1497,12 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.SMALL, value is null ? IntPtr.Zero : value.Handle);
+                var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.SMALL, value is null ? IntPtr.Zero : value.CreateUniqueHandle());
+                if (previousHandle != IntPtr.Zero)
+                {
+                    var result = ComCtl32.ImageList.Destroy(previousHandle);
+                    Debug.Assert(result.IsTrue());
+                }
 
                 if (View == View.SmallIcon)
                 {
@@ -1582,7 +1610,12 @@ namespace System.Windows.Forms
 
                     if (IsHandleCreated)
                     {
-                        User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, value is null ? IntPtr.Zero : value.Handle);
+                        var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, value is null ? IntPtr.Zero : value.CreateUniqueHandle());
+                        if (previousHandle != IntPtr.Zero)
+                        {
+                            var result = ComCtl32.ImageList.Destroy(previousHandle);
+                            Debug.Assert(result.IsTrue());
+                        }
                     }
                 }
                 else
@@ -1597,7 +1630,12 @@ namespace System.Windows.Forms
                         // (Yes, it does exactly that even though our wrapper sets LVS_SHAREIMAGELISTS on the native listView.)
                         // So we make the native listView forget about its StateImageList just before we recreate the handle.
                         // Likely related to https://devblogs.microsoft.com/oldnewthing/20171128-00/?p=97475
-                        User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, IntPtr.Zero);
+                        var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, IntPtr.Zero);
+                        if (previousHandle != IntPtr.Zero)
+                        {
+                            var result = ComCtl32.ImageList.Destroy(previousHandle);
+                            Debug.Assert(result.IsTrue());
+                        }
                     }
 
                     _imageListState = value;
@@ -1615,8 +1653,13 @@ namespace System.Windows.Forms
                     }
                     else
                     {
-                        User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE,
-                            (_imageListState is null || _imageListState.Images.Count == 0) ? IntPtr.Zero : _imageListState.Handle);
+                        var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE,
+                            (_imageListState is null || _imageListState.Images.Count == 0) ? IntPtr.Zero : _imageListState.CreateUniqueHandle());
+                        if (previousHandle != IntPtr.Zero)
+                        {
+                            var result = ComCtl32.ImageList.Destroy(previousHandle);
+                            Debug.Assert(result.IsTrue());
+                        }
                     }
 
                     // Comctl should handle auto-arrange for us, but doesn't
@@ -3672,8 +3715,13 @@ namespace System.Windows.Forms
                 return;
             }
 
-            IntPtr handle = (GroupImageList is null) ? IntPtr.Zero : GroupImageList.Handle;
-            User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.GROUPHEADER, handle);
+            IntPtr handle = (GroupImageList is null) ? IntPtr.Zero : GroupImageList.CreateUniqueHandle();
+            var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.GROUPHEADER, handle);
+            if (previousHandle != IntPtr.Zero)
+            {
+                var result = ComCtl32.ImageList.Destroy(previousHandle);
+                Debug.Assert(result.IsTrue());
+            }
         }
 
         public ListViewHitTestInfo HitTest(Point point)
@@ -4243,8 +4291,13 @@ namespace System.Windows.Forms
                 return;
             }
 
-            IntPtr handle = (LargeImageList is null) ? IntPtr.Zero : LargeImageList.Handle;
-            User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.NORMAL, handle);
+            IntPtr handle = (LargeImageList is null) ? IntPtr.Zero : LargeImageList.CreateUniqueHandle();
+            var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.NORMAL, handle);
+            if (previousHandle != IntPtr.Zero)
+            {
+                var result = ComCtl32.ImageList.Destroy(previousHandle);
+                Debug.Assert(result.IsTrue());
+            }
 
             ForceCheckBoxUpdate();
         }
@@ -4587,6 +4640,34 @@ namespace System.Windows.Forms
 
         protected override void OnHandleDestroyed(EventArgs e)
         {
+            var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.NORMAL);
+            if (previousHandle != IntPtr.Zero)
+            {
+                var result = ComCtl32.ImageList.Destroy(previousHandle);
+                Debug.Assert(result.IsTrue());
+            }
+
+            previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.SMALL);
+            if (previousHandle != IntPtr.Zero)
+            {
+                var result = ComCtl32.ImageList.Destroy(previousHandle);
+                Debug.Assert(result.IsTrue());
+            }
+
+            previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE);
+            if (previousHandle != IntPtr.Zero)
+            {
+                var result = ComCtl32.ImageList.Destroy(previousHandle);
+                Debug.Assert(result.IsTrue());
+            }
+
+            previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.GROUPHEADER);
+            if (previousHandle != IntPtr.Zero)
+            {
+                var result = ComCtl32.ImageList.Destroy(previousHandle);
+                Debug.Assert(result.IsTrue());
+            }
+
             // don't save the list view items state when in virtual mode : it is the responsability of the
             // user to cache the list view items in virtual mode
             if (!Disposing && !VirtualMode)
@@ -4822,22 +4903,42 @@ namespace System.Windows.Forms
 
             if (_imageListLarge != null)
             {
-                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.NORMAL, _imageListLarge.Handle);
+                var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.NORMAL, _imageListLarge.CreateUniqueHandle());
+                if (previousHandle != IntPtr.Zero)
+                {
+                    var result = ComCtl32.ImageList.Destroy(previousHandle);
+                    Debug.Assert(result.IsTrue());
+                }
             }
 
             if (_imageListSmall != null)
             {
-                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.SMALL, _imageListSmall.Handle);
+                var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.SMALL, _imageListSmall.CreateUniqueHandle());
+                if (previousHandle != IntPtr.Zero)
+                {
+                    var result = ComCtl32.ImageList.Destroy(previousHandle);
+                    Debug.Assert(result.IsTrue());
+                }
             }
 
             if (_imageListState != null)
             {
-                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, _imageListState.Handle);
+                var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, _imageListState.CreateUniqueHandle());
+                if (previousHandle != IntPtr.Zero)
+                {
+                    var result = ComCtl32.ImageList.Destroy(previousHandle);
+                    Debug.Assert(result.IsTrue());
+                }
             }
 
             if (_imageListGroup != null)
             {
-                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.GROUPHEADER, _imageListGroup.Handle);
+                var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.GROUPHEADER, _imageListGroup.CreateUniqueHandle());
+                if (previousHandle != IntPtr.Zero)
+                {
+                    var result = ComCtl32.ImageList.Destroy(previousHandle);
+                    Debug.Assert(result.IsTrue());
+                }
             }
         }
 
@@ -5364,8 +5465,13 @@ namespace System.Windows.Forms
                 return;
             }
 
-            IntPtr handle = (SmallImageList is null) ? IntPtr.Zero : SmallImageList.Handle;
-            User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.SMALL, handle);
+            IntPtr handle = (SmallImageList is null) ? IntPtr.Zero : SmallImageList.CreateUniqueHandle();
+            var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.SMALL, handle);
+            if (previousHandle != IntPtr.Zero)
+            {
+                var result = ComCtl32.ImageList.Destroy(previousHandle);
+                Debug.Assert(result.IsTrue());
+            }
 
             ForceCheckBoxUpdate();
         }
@@ -5396,8 +5502,13 @@ namespace System.Windows.Forms
                 return;
             }
 
-            IntPtr handle = (StateImageList is null) ? IntPtr.Zero : StateImageList.Handle;
-            User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, handle);
+            IntPtr handle = (StateImageList is null) ? IntPtr.Zero : StateImageList.CreateUniqueHandle();
+            var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, handle);
+            if (previousHandle != IntPtr.Zero)
+            {
+                var result = ComCtl32.ImageList.Destroy(previousHandle);
+                Debug.Assert(result.IsTrue());
+            }
         }
 
         /// <summary>
@@ -6164,7 +6275,12 @@ namespace System.Windows.Forms
             // (Yes, it does exactly that even though our wrapper sets LVS_SHAREIMAGELISTS on the native listView.)
             if (IsHandleCreated && StateImageList != null)
             {
-                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, IntPtr.Zero);
+                var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, IntPtr.Zero);
+                if (previousHandle != IntPtr.Zero)
+                {
+                    var result = ComCtl32.ImageList.Destroy(previousHandle);
+                    Debug.Assert(result.IsTrue());
+                }
             }
 
             RecreateHandle();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -662,7 +662,7 @@ namespace System.Windows.Forms
                                     value == null ? IntPtr.Zero : value.Handle);
                         if (StateImageList != null && StateImageList.Images.Count > 0 && internalStateImageList != null)
                         {
-                            SetStateImageList(internalStateImageList.Handle);
+                            SetStateImageList(internalStateImageList.CreateUniqueHandle());
                         }
                     }
                     UpdateCheckedState(root, true);
@@ -1819,7 +1819,7 @@ namespace System.Windows.Forms
                 IntPtr handle = IntPtr.Zero;
                 if (internalStateImageList != null)
                 {
-                    handle = internalStateImageList.Handle;
+                    handle = internalStateImageList.CreateUniqueHandle();
                 }
                 SetStateImageList(handle);
             }
@@ -1859,7 +1859,7 @@ namespace System.Windows.Forms
                             internalStateImageList.ImageSize = (Size)ScaledStateImageSize;
                         }
 
-                        SetStateImageList(internalStateImageList.Handle);
+                        SetStateImageList(internalStateImageList.CreateUniqueHandle());
                     }
                 }
                 else //stateImageList == null || stateImageList.Images.Count = 0;
@@ -2050,7 +2050,7 @@ namespace System.Windows.Forms
                     images[i] = stateImageList.Images[i - 1];
                 }
                 newImageList.Images.AddRange(images);
-                User32.SendMessageW(this, (User32.WM)TVM.SETIMAGELIST, (IntPtr)TVSIL.STATE, newImageList.Handle);
+                User32.SendMessageW(this, (User32.WM)TVM.SETIMAGELIST, (IntPtr)TVSIL.STATE, newImageList.CreateUniqueHandle());
 
                 if (internalStateImageList != null)
                 {
@@ -2067,7 +2067,8 @@ namespace System.Windows.Forms
             IntPtr handleOld = User32.SendMessageW(this, (User32.WM)TVM.SETIMAGELIST, (IntPtr)TVSIL.STATE, handle);
             if ((handleOld != IntPtr.Zero) && (handleOld != handle))
             {
-                ComCtl32.ImageList.Destroy(new HandleRef(this, handleOld));
+                var result = ComCtl32.ImageList.Destroy(new HandleRef(this, handleOld));
+                Debug.Assert(result.IsTrue());
             }
         }
 
@@ -2078,7 +2079,8 @@ namespace System.Windows.Forms
             IntPtr handle = User32.SendMessageW(this, (User32.WM)TVM.GETIMAGELIST, (IntPtr)TVSIL.STATE);
             if (handle != IntPtr.Zero)
             {
-                ComCtl32.ImageList.Destroy(new HandleRef(this, handle));
+                var result = ComCtl32.ImageList.Destroy(new HandleRef(this, handle));
+                Debug.Assert(result.IsTrue());
                 if (reset)
                 {
                     User32.SendMessageW(this, (User32.WM)TVM.SETIMAGELIST, (IntPtr)TVSIL.STATE);
@@ -2619,7 +2621,7 @@ namespace System.Windows.Forms
                     // user's images.
                     if (internalStateImageList != null)
                     {
-                        SetStateImageList(internalStateImageList.Handle);
+                        SetStateImageList(internalStateImageList.CreateUniqueHandle());
                     }
                 }
             }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -170,7 +170,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(97, createParams.Height);
             Assert.Equal(IntPtr.Zero, createParams.Parent);
             Assert.Null(createParams.Param);
-            Assert.Equal(0x56010148, createParams.Style);
+            // LVS.SHAREIMAGELISTS is temporarily removed from style until ownership management is fixed
+            // https://github.com/dotnet/winforms/issues/3531
+            Assert.Equal(0x56010108, createParams.Style);
             Assert.Equal(121, createParams.Width);
             Assert.Equal(0, createParams.X);
             Assert.Equal(0, createParams.Y);


### PR DESCRIPTION
Fixes #3358

## Proposed changes

Disable sharing ImageList handles because they are implemented incorrectly and can double-free handles, which will crash if the handle was reused already (#3358). Instead of sharing ImageLists this PR creates an explicit duplicate when assigning an ImageList to the native control, and destroys the previous instance. This guarantees the handle used by the native control is always unique and can be safely destroyed. To avoid leaks all ImageLists are removed when the handle is destroyed.

#3531 is tracking proper implementation of ImageList ownership

For TreeViews the StateImageList is never shareable and it had similar bugs, so the correct solution is also to create unique handles and destroy them. Part of the logic already was there, but it was too eager and destroyed ImageLists it didn't own. By creating unique handles this problem is avoided.

## Customer Impact

- ImageLists don't get destroyed prematurely (see #3531)
- Usage of ImageLists on checkbox-enabled TreeView or ListView controls no longer risks double-free crashes
- Higher memory usage due to duplicating ImageLists

## Regression? 

- No, the memory corruption and ownership issues were also present in Desktop Framework

## Risk

- This changes semantics of how ImageLists are managed, users which send window messages directly to the native control may not be prepared to handle this.

### Before

- ImageLists were destroyed while still in use
- ImageLists were destroyed twice (risk of crashing if numeric handle value was reused)

### After

- ImageList destruction result is checked in debug builds to verify no double-free happened

## Test methodology

- Running the test suite in a debugger and ensure the asserts detected no double-frees

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3601)