### PR TITLE
Use native-sized integers to avoid overhead for 32-bit platforms

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Interop.PARAM.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Interop.PARAM.cs
@@ -31,17 +31,19 @@ internal partial class Interop
         public static int LOWORD(int n)
             => n & 0xffff;
 
+#pragma warning disable IDE0004 // (nint) cast in (int)(nint)IntPtr is not actually redundant
         public static int LOWORD(IntPtr n)
-            => LOWORD(unchecked((int)(long)n));
+            => LOWORD(unchecked((int)(nint)n));
 
         public static int HIWORD(IntPtr n)
-            => HIWORD(unchecked((int)(long)n));
+            => HIWORD(unchecked((int)(nint)n));
 
         public static int SignedHIWORD(IntPtr n)
-            => SignedHIWORD(unchecked((int)(long)n));
+            => SignedHIWORD(unchecked((int)(nint)n));
 
         public static int SignedLOWORD(IntPtr n)
-            => SignedLOWORD(unchecked((int)(long)n));
+            => SignedLOWORD(unchecked((int)(nint)n));
+#pragma warning restore IDE0004
 
         public static int SignedHIWORD(int n)
             => (int)(short)HIWORD(n);
@@ -55,15 +57,17 @@ internal partial class Interop
         public static IntPtr FromColor(Color color)
             => (IntPtr)ColorTranslator.ToWin32(color);
 
+#pragma warning disable IDE0004 // (int) cast in (nint)(nint)IntPtr is not actually redundant
         /// <summary>
         ///  Hard casts to <see langword="int" /> without bounds checks.
         /// </summary>
-        public static int ToInt(IntPtr param) => (int)(long)param;
+        public static int ToInt(IntPtr param) => (int)(nint)param;
 
         /// <summary>
         ///  Hard casts to <see langword="uint" /> without bounds checks.
         /// </summary>
-        public static uint ToUInt(IntPtr param) => (uint)(long)param;
+        public static uint ToUInt(IntPtr param) => (uint)(nint)param;
+#pragma warning restore IDE0004
 
         /// <summary>
         ///  Hard casts to <see langword="long" /> without bounds checks.

--- a/src/System.Windows.Forms.Primitives/src/Interop/Interop.PARAM.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Interop.PARAM.cs
@@ -31,19 +31,17 @@ internal partial class Interop
         public static int LOWORD(int n)
             => n & 0xffff;
 
-#pragma warning disable IDE0004 // (nint) cast is not actually redundant
-        public static int LOWORD(IntPtr n)
-            => LOWORD(unchecked((int)(nint)n));
+        public static int LOWORD(nint n)
+            => LOWORD(unchecked((int)n));
 
-        public static int HIWORD(IntPtr n)
-            => HIWORD(unchecked((int)(nint)n));
+        public static int HIWORD(nint n)
+            => HIWORD(unchecked((int)n));
 
-        public static int SignedHIWORD(IntPtr n)
-            => SignedHIWORD(unchecked((int)(nint)n));
+        public static int SignedHIWORD(nint n)
+            => SignedHIWORD(unchecked((int)n));
 
-        public static int SignedLOWORD(IntPtr n)
-            => SignedLOWORD(unchecked((int)(nint)n));
-#pragma warning restore IDE0004
+        public static int SignedLOWORD(nint n)
+            => SignedLOWORD(unchecked((int)n));
 
         public static int SignedHIWORD(int n)
             => (int)(short)HIWORD(n);
@@ -57,17 +55,15 @@ internal partial class Interop
         public static IntPtr FromColor(Color color)
             => (IntPtr)ColorTranslator.ToWin32(color);
 
-#pragma warning disable IDE0004 // (nint) cast is not actually redundant
         /// <summary>
         ///  Hard casts to <see langword="int" /> without bounds checks.
         /// </summary>
-        public static int ToInt(IntPtr param) => (int)(nint)param;
+        public static int ToInt(nint param) => (int)param;
 
         /// <summary>
         ///  Hard casts to <see langword="uint" /> without bounds checks.
         /// </summary>
-        public static uint ToUInt(IntPtr param) => (uint)(nint)param;
-#pragma warning restore IDE0004
+        public static uint ToUInt(nint param) => (uint)param;
 
         /// <summary>
         ///  Hard casts to <see langword="long" /> without bounds checks.
@@ -75,11 +71,11 @@ internal partial class Interop
         /// <remarks>
         ///  Technically not needed, but here for completeness.
         /// </remarks>
-        public static long ToLong(IntPtr param) => (long)param;
+        public static long ToLong(nint param) => param;
 
         /// <summary>
         ///  Hard casts to <see langword="ulong" /> without bounds checks.
         /// </summary>
-        public static ulong ToULong(IntPtr param) => (ulong)(long)param;
+        public static ulong ToULong(nint param) => (ulong)param;
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Interop.PARAM.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Interop.PARAM.cs
@@ -57,7 +57,7 @@ internal partial class Interop
         public static IntPtr FromColor(Color color)
             => (IntPtr)ColorTranslator.ToWin32(color);
 
-//#pragma warning disable IDE0004 // (nint) cast is not actually redundant
+#pragma warning disable IDE0004 // (nint) cast is not actually redundant
         /// <summary>
         ///  Hard casts to <see langword="int" /> without bounds checks.
         /// </summary>

--- a/src/System.Windows.Forms.Primitives/src/Interop/Interop.PARAM.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Interop.PARAM.cs
@@ -31,7 +31,7 @@ internal partial class Interop
         public static int LOWORD(int n)
             => n & 0xffff;
 
-#pragma warning disable IDE0004 // (nint) cast in (int)(nint)IntPtr is not actually redundant
+#pragma warning disable IDE0004 // (nint) cast is not actually redundant
         public static int LOWORD(IntPtr n)
             => LOWORD(unchecked((int)(nint)n));
 
@@ -57,7 +57,7 @@ internal partial class Interop
         public static IntPtr FromColor(Color color)
             => (IntPtr)ColorTranslator.ToWin32(color);
 
-#pragma warning disable IDE0004 // (int) cast in (nint)(nint)IntPtr is not actually redundant
+//#pragma warning disable IDE0004 // (nint) cast is not actually redundant
         /// <summary>
         ///  Hard casts to <see langword="int" /> without bounds checks.
         /// </summary>

--- a/src/System.Windows.Forms.Primitives/src/Interop/Interop.PARAM.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Interop.PARAM.cs
@@ -15,13 +15,12 @@ internal partial class Interop
         public static IntPtr FromLowHigh(int low, int high)
             => (IntPtr)ToInt(low, high);
 
-        public static unsafe IntPtr FromLowHighUnsigned(int low, int high)
+        public static IntPtr FromLowHighUnsigned(int low, int high)
             // Convert the int to an uint before converting it to a pointer type,
             // which ensures the high dword being zero for 64-bit pointers.
             // This corresponds to the logic of the MAKELPARAM/MAKEWPARAM/MAKELRESULT
             // macros.
-            // TODO: Use nint (with 'unchecked') instead of void* when it is available.
-            => (IntPtr)(void*)unchecked((uint)ToInt(low, high));
+            => unchecked((nint)(uint)ToInt(low, high));
 
         public static int ToInt(int low, int high)
             => (high << 16) | (low & 0xffff);

--- a/src/System.Windows.Forms.Primitives/src/Interop/Interop.PARAM.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Interop.PARAM.cs
@@ -20,7 +20,7 @@ internal partial class Interop
             // which ensures the high dword being zero for 64-bit pointers.
             // This corresponds to the logic of the MAKELPARAM/MAKEWPARAM/MAKELRESULT
             // macros.
-            => unchecked((nint)(uint)ToInt(low, high));
+            => unchecked((nint)(nuint)(uint)ToInt(low, high));
 
         public static int ToInt(int low, int high)
             => (high << 16) | (low & 0xffff);

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/PARAMTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/PARAMTests.cs
@@ -1,0 +1,124 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.Primitives.Tests.Interop
+{
+    public class PARAMTests
+    {
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is32bit))]
+        public unsafe void FromLowHigh_x32_Result()
+        {
+            Assert.Equal(unchecked((int)0x03040102), (int)PARAM.FromLowHigh(0x0102, 0x0304));
+            Assert.Equal(unchecked((int)0xF3F4F1F2), (int)PARAM.FromLowHigh(0xF1F2, 0xF3F4));
+        }
+
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is64bit))]
+        public unsafe void FromLowHigh_x64_Result()
+        {
+            Assert.Equal(unchecked((long)0x0000000003040102), (long)PARAM.FromLowHigh(0x0102, 0x0304));
+            Assert.Equal(unchecked((long)0xFFFFFFFFF3F4F1F2), (long)PARAM.FromLowHigh(0xF1F2, 0xF3F4));
+        }
+
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is32bit))]
+        public unsafe void FromLowHighUnsigned_x32_Result()
+        {
+            Assert.Equal(unchecked((int)0x03040102), (int)PARAM.FromLowHighUnsigned(0x0102, 0x0304));
+            Assert.Equal(unchecked((int)0xF3F4F1F2), (int)PARAM.FromLowHighUnsigned(0xF1F2, 0xF3F4));
+        }
+
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is64bit))]
+        public unsafe void FromLowHighUnsigned_x64_Result()
+        {
+            Assert.Equal(unchecked((long)0x0000000003040102), (long)PARAM.FromLowHighUnsigned(0x0102, 0x0304));
+            Assert.Equal(unchecked((long)0x00000000F3F4F1F2), (long)PARAM.FromLowHighUnsigned(0xF1F2, 0xF3F4));
+        }
+
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is32bit))]
+        public unsafe void LOWORD_x32_Result()
+        {
+            Assert.Equal(0x0304, PARAM.LOWORD((IntPtr)unchecked((int)0x01020304)));
+            Assert.Equal(0xF3F4, PARAM.LOWORD((IntPtr)unchecked((int)0xF1F2F3F4)));
+        }
+
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is64bit))]
+        public unsafe void LOWORD_x64_Result()
+        {
+            Assert.Equal(0x0304, PARAM.LOWORD((IntPtr)unchecked((long)0x0506070801020304)));
+            Assert.Equal(0xF3F4, PARAM.LOWORD((IntPtr)unchecked((long)0xF5F6F7F8F1F2F3F4)));
+        }
+
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is32bit))]
+        public unsafe void HIWORD_x32_Result()
+        {
+            Assert.Equal(0x0102, PARAM.HIWORD((IntPtr)unchecked((int)0x01020304)));
+            Assert.Equal(0xF1F2, PARAM.HIWORD((IntPtr)unchecked((int)0xF1F2F3F4)));
+        }
+
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is64bit))]
+        public unsafe void HIWORD_x64_Result()
+        {
+            Assert.Equal(0x0102, PARAM.HIWORD((IntPtr)unchecked((long)0x0506070801020304)));
+            Assert.Equal(0xF1F2, PARAM.HIWORD((IntPtr)unchecked((long)0xF5F6F7F8F1F2F3F4)));
+        }
+
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is32bit))]
+        public unsafe void SignedLOWORD_x32_Result()
+        {
+            Assert.Equal(unchecked((short)0x0304), PARAM.SignedLOWORD((IntPtr)unchecked((int)0x01020304)));
+            Assert.Equal(unchecked((short)0xF3F4), PARAM.SignedLOWORD((IntPtr)unchecked((int)0xF1F2F3F4)));
+        }
+
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is64bit))]
+        public unsafe void SignedLOWORD_x64_Result()
+        {
+            Assert.Equal(unchecked((short)0x0304), PARAM.SignedLOWORD((IntPtr)unchecked((long)0x0506070801020304)));
+            Assert.Equal(unchecked((short)0xF3F4), PARAM.SignedLOWORD((IntPtr)unchecked((long)0xF5F6F7F8F1F2F3F4)));
+        }
+
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is32bit))]
+        public unsafe void SignedHIWORD_x32_Result()
+        {
+            Assert.Equal(unchecked((short)0x0102), PARAM.SignedHIWORD((IntPtr)unchecked((int)0x01020304)));
+            Assert.Equal(unchecked((short)0xF1F2), PARAM.SignedHIWORD((IntPtr)unchecked((int)0xF1F2F3F4)));
+        }
+
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is64bit))]
+        public unsafe void SignedHIWORD_x64_Result()
+        {
+            Assert.Equal(unchecked((short)0x0102), PARAM.SignedHIWORD((IntPtr)unchecked((long)0x0506070801020304)));
+            Assert.Equal(unchecked((short)0xF1F2), PARAM.SignedHIWORD((IntPtr)unchecked((long)0xF5F6F7F8F1F2F3F4)));
+        }
+
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is32bit))]
+        public unsafe void ToInt_x32_Result()
+        {
+            Assert.Equal(unchecked((int)0x01020304), PARAM.ToInt((IntPtr)unchecked((int)0x01020304)));
+            Assert.Equal(unchecked((int)0xF1F2F3F4), PARAM.ToInt((IntPtr)unchecked((int)0xF1F2F3F4)));
+        }
+
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is64bit))]
+        public unsafe void ToInt_x64_Result()
+        {
+            Assert.Equal(unchecked((int)0x01020304), PARAM.ToInt((IntPtr)unchecked((long)0x0506070801020304)));
+            Assert.Equal(unchecked((int)0xF1F2F3F4), PARAM.ToInt((IntPtr)unchecked((long)0xF5F6F7F8F1F2F3F4)));
+        }
+
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is32bit))]
+        public unsafe void ToUInt_x32_Result()
+        {
+            Assert.Equal((uint)0x01020304, PARAM.ToUInt((IntPtr)unchecked((int)0x01020304)));
+            Assert.Equal((uint)0xF1F2F3F4, PARAM.ToUInt((IntPtr)unchecked((int)0xF1F2F3F4)));
+        }
+
+        [ConditionalFact(typeof(ArchitectureDetection), nameof(ArchitectureDetection.Is64bit))]
+        public unsafe void ToUInt_x64_Result()
+        {
+            Assert.Equal((uint)0x01020304, PARAM.ToUInt((IntPtr)unchecked((long)0x0506070801020304)));
+            Assert.Equal((uint)0xF1F2F3F4, PARAM.ToUInt((IntPtr)unchecked((long)0xF5F6F7F8F1F2F3F4)));
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialog.cs
@@ -1491,10 +1491,8 @@ namespace System.Windows.Forms
 
                 // Align the pointer to the next align size. If not specified,
                 // we will use the pointer (register) size.
-                // TODO: Use nuint (System.UIntN) once available instead of
-                // ulong to avoid the overhead for 32-bit platforms.
-                ulong add = (ulong)(alignment ?? IntPtr.Size) - 1;
-                currentPtr = (byte*)(((ulong)currentPtr + add) & ~add);
+                nuint add = (nuint)(alignment ?? IntPtr.Size) - 1;
+                currentPtr = (byte*)(((nuint)currentPtr + add) & ~add);
             }
 
             static long SizeOfString(string? str)


### PR DESCRIPTION
## Proposed changes

- Resolve TODOs in the TaskDialog code by using native-sized integers (`nint`/`nuint`) where applicable, to reduce overhead for 32-bit platforms and to avoid having to use the `unsafe` keyword.
- In class `PARAM`, cast `IntPtr` to `nint` instead of `long` where applicable.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- None

## Regression? 

- No

## Risk

-

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

- Testing the changed code running as `x86` and `x64` with various inputs, including values where an overflow could happen, to make sure it behaves the same as the previous code.
- Added tests for `PARAM`.

 

## Test environment(s) <!-- Remove any that don't apply -->

.NET SDK (reflecting any global.json):
 Version:   6.0.100-alpha.1.20472.11
 Commit:    e55929c5a5

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.18363
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\6.0.100-alpha.1.20472.11\

Host (useful for support):
  Version: 6.0.0-alpha.1.20468.7
  Commit:  a820ca1c4f

.NET SDKs installed:
  5.0.100-rc.1.20452.10 [C:\Program Files\dotnet\sdk]
  6.0.100-alpha.1.20472.11 [C:\Program Files\dotnet\sdk]

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3603)