### PR TITLE
Move PRINTPAGERANGE to Interop Comdlg32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Comdlg32/Interop.PRINTPAGERANGE.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Comdlg32/Interop.PRINTPAGERANGE.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Comdlg32
+    {
+        // x86 requires EXPLICIT packing of 1.
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        public struct PRINTPAGERANGE
+        {
+            public uint nFromPage;
+            public uint nToPage;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -137,14 +137,6 @@ namespace System.Windows.Forms
             public Comdlg32.PD_RESULT dwResultAction;
         }
 
-        // x86 requires EXPLICIT packing of 1.
-        [StructLayout(LayoutKind.Sequential, Pack = 1, CharSet = CharSet.Auto)]
-        public class PRINTPAGERANGE
-        {
-            public int nFromPage;
-            public int nToPage;
-        }
-
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
         public class OPENFILENAME_I
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintDialog.cs
@@ -273,7 +273,7 @@ namespace System.Windows.Forms
             showNetwork = true;
         }
 
-        internal static NativeMethods.PRINTDLGEX CreatePRINTDLGEX()
+        internal unsafe static NativeMethods.PRINTDLGEX CreatePRINTDLGEX()
         {
             NativeMethods.PRINTDLGEX data = new NativeMethods.PRINTDLGEX();
             data.lStructSize = Marshal.SizeOf(data);
@@ -286,7 +286,7 @@ namespace System.Windows.Forms
             data.ExclusionFlags = 0;
             data.nPageRanges = 0;
             data.nMaxPageRanges = 1;
-            data.pageRanges = Kernel32.GlobalAlloc(Kernel32.GMEM.GPTR, (uint)(data.nMaxPageRanges * Marshal.SizeOf<NativeMethods.PRINTPAGERANGE>()));
+            data.pageRanges = Kernel32.GlobalAlloc(Kernel32.GMEM.GPTR, (uint)(data.nMaxPageRanges * sizeof(PRINTPAGERANGE)));
             data.nMinPage = 0;
             data.nMaxPage = 9999;
             data.nCopies = 1;


### PR DESCRIPTION
## Proposed changes

- Move PRINTPAGERANGE to Interop Comdlg32.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3604)