### PR TITLE
Suppress warnings about obsolete types and members

### DIFF
--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
@@ -307,10 +307,12 @@ Namespace Microsoft.VisualBasic.ApplicationServices
             '(network gets created during event hookup) and we need the context in place for it to latch on to.  The WindowsFormsSynchronizationContext
             'won't otherwise get created until OnCreateMainForm() when the startup form is created and by then it is too late.
             'When the startup form gets created, WinForms is going to push our context into the previous context and then restore it when Application.Run() exits.
+#Disable Warning BC40000 ' Type or member is obsolete
             Call New UIPermission(UIPermissionWindow.AllWindows).Assert()
             _appSyncronizationContext = AsyncOperationManager.SynchronizationContext
             AsyncOperationManager.SynchronizationContext = New Windows.Forms.WindowsFormsSynchronizationContext()
             PermissionSet.RevertAssert() 'CLR also reverts if we throw or when we return from this function
+#Enable Warning BC40000 ' Type or member is obsolete
         End Sub
 
         ''' <summary>
@@ -511,7 +513,9 @@ Namespace Microsoft.VisualBasic.ApplicationServices
         Protected Overridable Sub OnStartupNextInstance(eventArgs As StartupNextInstanceEventArgs)
             RaiseEvent StartupNextInstance(Me, eventArgs)
             'Activate the original instance
+#Disable Warning BC40000 ' Type or member is obsolete
             Call New UIPermission(UIPermissionWindow.SafeSubWindows Or UIPermissionWindow.SafeTopLevelWindows).Assert()
+#Enable Warning BC40000 ' Type or member is obsolete
             If eventArgs.BringToForeground = True AndAlso MainForm IsNot Nothing Then
                 If MainForm.WindowState = Windows.Forms.FormWindowState.Minimized Then
                     MainForm.WindowState = Windows.Forms.FormWindowState.Normal
@@ -637,9 +641,11 @@ Namespace Microsoft.VisualBasic.ApplicationServices
                 '       swapping the order of the two If blocks). This is to fix the issue where the main form
                 '       doesn't come to the front after the Splash screen disappears
                 If MainForm IsNot Nothing Then
+#Disable Warning BC40000 ' Type or member is obsolete
                     Call New UIPermission(UIPermissionWindow.AllWindows).Assert()
                     MainForm.Activate()
                     PermissionSet.RevertAssert() 'CLR also reverts if we throw or when we return from this function
+#Enable Warning BC40000 ' Type or member is obsolete
                 End If
                 If _splashScreen IsNot Nothing AndAlso Not _splashScreen.IsDisposed Then
                     Dim TheBigGoodbye As New DisposeDelegate(AddressOf _splashScreen.Dispose)
@@ -775,9 +781,12 @@ Namespace Microsoft.VisualBasic.ApplicationServices
                 If _app.ShutdownStyle = ShutdownMode.AfterMainFormCloses Then
                     MyBase.OnMainFormClosed(sender, e)
                 Else 'identify a new main form so we can keep running
+#Disable Warning BC40000 ' Type or member is obsolete
                     Call New UIPermission(UIPermissionWindow.AllWindows).Assert()
                     Dim forms As Windows.Forms.FormCollection = Windows.Forms.Application.OpenForms
                     PermissionSet.RevertAssert() 'CLR also reverts if we throw or when we return from this function.
+#Enable Warning BC40000 ' Type or member is obsolete
+
                     If forms.Count > 0 Then
                         'Note: Initially I used Process::MainWindowHandle to obtain an open form.  But that is bad for two reasons:
                         '1 - It appears to be broken and returns NULL sometimes even when there is still a window around.  WinForms people are looking at that issue.

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Devices/Audio.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Devices/Audio.vb
@@ -147,11 +147,13 @@ Namespace Microsoft.VisualBasic
             Private Shared Sub InternalStop(sound As Media.SoundPlayer)
 
                 ' Stop requires unmanaged code permission. Stop demands SafeSubWindows permissions, so we don't need to do it here                     
+#Disable Warning BC40000 ' Type or member is obsolete
                 Call New Security.Permissions.SecurityPermission(System.Security.Permissions.SecurityPermissionFlag.UnmanagedCode).Assert()
                 Try
                     sound.Stop()
                 Finally
                     System.Security.CodeAccessPermission.RevertAssert()
+#Enable Warning BC40000 ' Type or member is obsolete
                 End Try
             End Sub
 

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Devices/Network.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Devices/Network.vb
@@ -392,7 +392,9 @@ Namespace Microsoft.VisualBasic.Devices
                 Dim dialog As ProgressDialog = Nothing
                 If showUI AndAlso System.Environment.UserInteractive Then
                     ' Do UI demand here rather than waiting for form.show so that exception is thrown as early as possible
+#Disable Warning BC40000 ' Type or member is obsolete
                     Dim UIPermission As New UIPermission(UIPermissionWindow.SafeSubWindows)
+#Enable Warning BC40000 ' Type or member is obsolete
                     UIPermission.Demand()
 
                     dialog = New ProgressDialog With {

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Interaction.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Interaction.vb
@@ -1,4 +1,4 @@
-' Licensed to the .NET Foundation under one or more agreements.
+﻿' Licensed to the .NET Foundation under one or more agreements.
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
@@ -45,7 +45,9 @@ Namespace Microsoft.VisualBasic
                 'free the string fields since the API manages it instead.  But its OK here because we are just passing along the memory
                 'that GetStartupInfo() allocated along to CreateProcess() which just reads the string fields.
 
+#Disable Warning BC40000 ' Type or member is obsolete
                 RuntimeHelpers.PrepareConstrainedRegions()
+#Enable Warning BC40000 ' Type or member is obsolete
                 Try
                 Finally
                     ok = NativeMethods.CreateProcess(Nothing, PathName, Nothing, Nothing, False, NativeTypes.NORMAL_PRIORITY_CLASS, Nothing, Nothing, StartupInfo, ProcessInfo)

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Logging/FileLogTraceListener.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Logging/FileLogTraceListener.vb
@@ -233,7 +233,9 @@ Namespace Microsoft.VisualBasic.Logging
 
                 ' We shouldn't use fields for demands so we use a local variable
                 Dim returnPath As String = _fullFileName
+#Disable Warning BC40000 ' Type or member is obsolete
                 Dim filePermission As New FileIOPermission(FileIOPermissionAccess.PathDiscovery, returnPath)
+#Enable Warning BC40000 ' Type or member is obsolete
                 filePermission.Demand()
 
                 Return returnPath
@@ -371,7 +373,9 @@ Namespace Microsoft.VisualBasic.Logging
                 End If
 
                 Dim fileName As String = Path.GetFullPath(_customLocation)
+#Disable Warning BC40000 ' Type or member is obsolete
                 Dim filePermission As New FileIOPermission(FileIOPermissionAccess.PathDiscovery, fileName)
+#Enable Warning BC40000 ' Type or member is obsolete
                 filePermission.Demand()
                 Return fileName
             End Get
@@ -722,7 +726,9 @@ Namespace Microsoft.VisualBasic.Logging
                         Else
                             If Append Then
                                 ' We are handing off an already existing stream, so we need to make sure the caller has permissions to write to this stream
+#Disable Warning BC40000 ' Type or member is obsolete
                                 Dim filePermission As New FileIOPermission(FileIOPermissionAccess.Write, fileName)
+#Enable Warning BC40000 ' Type or member is obsolete
                                 filePermission.Demand()
 
                                 refStream.AddReference()
@@ -873,7 +879,9 @@ Namespace Microsoft.VisualBasic.Logging
             Dim TotalUserSpace As Long
             Dim TotalFreeSpace As Long
 
+#Disable Warning BC40000 ' Type or member is obsolete
             Dim discoveryPermission As New FileIOPermission(FileIOPermissionAccess.PathDiscovery, PathName)
+#Enable Warning BC40000 ' Type or member is obsolete
             discoveryPermission.Demand()
 
             If UnsafeNativeMethods.GetDiskFreeSpaceEx(PathName, FreeUserSpace, TotalUserSpace, TotalFreeSpace) Then
@@ -939,7 +947,9 @@ Namespace Microsoft.VisualBasic.Logging
         Private Sub DemandWritePermission()
             Debug.Assert(Not String.IsNullOrWhiteSpace(Path.GetDirectoryName(LogFileName)), "The log directory shouldn't be empty.")
             Dim fileName As String = Path.GetDirectoryName(LogFileName)
+#Disable Warning BC40000 ' Type or member is obsolete
             Dim filePermission As New FileIOPermission(FileIOPermissionAccess.Write, fileName)
+#Enable Warning BC40000 ' Type or member is obsolete
             filePermission.Demand()
         End Sub
 

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/MyServices/ClipboardProxy.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/MyServices/ClipboardProxy.vb
@@ -14,12 +14,14 @@ Imports System.Windows.Forms
 
 Namespace Microsoft.VisualBasic.MyServices
 
+#Disable Warning BC40000 ' Type or member is obsolete
     ''' <summary>
     ''' A class that wraps System.Windows.Forms.Clipboard so that
     ''' a clipboard can be instanced.
     ''' </summary>
     <EditorBrowsable(EditorBrowsableState.Never), HostProtection(Resources:=HostProtectionResource.ExternalProcessMgmt)>
     Public Class ClipboardProxy
+#Enable Warning BC40000 ' Type or member is obsolete
 
         ''' <summary>
         ''' Only Allows instantiation of the class

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationService.cs
@@ -406,7 +406,9 @@ namespace System.ComponentModel.Design.Serialization
                             BinaryFormatter formatter = new BinaryFormatter();
                             _resourceStream = new MemoryStream();
 
+#pragma warning disable CS0618 // Type or member is obsolete
                             formatter.Serialize(_resourceStream, _resources.Data);
+#pragma warning restore CS0618 // Type or member is obsolete
                         }
                     }
 
@@ -478,7 +480,9 @@ namespace System.ComponentModel.Design.Serialization
                 {
                     BinaryFormatter formatter = new BinaryFormatter();
                     _resourceStream.Seek(0, SeekOrigin.Begin);
+#pragma warning disable CS0618 // Type or member is obsolete
                     Hashtable resources = formatter.Deserialize(_resourceStream) as Hashtable;
+#pragma warning restore CS0618 // Type or member is obsolete
                     _resources = new LocalResourceManager(resources);
                 }
 
@@ -566,7 +570,9 @@ namespace System.ComponentModel.Design.Serialization
             internal static CodeDomSerializationStore Load(Stream stream)
             {
                 BinaryFormatter f = new BinaryFormatter();
+#pragma warning disable CS0618 // Type or member is obsolete
                 return (CodeDomSerializationStore)f.Deserialize(stream);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
@@ -1268,7 +1268,9 @@ namespace System.Windows.Forms.Design
                     object serializationData = ds.Serialize(selectedComponents);
                     MemoryStream stream = new MemoryStream();
                     BinaryFormatter formatter = new BinaryFormatter();
+#pragma warning disable CS0618 // Type or member is obsolete
                     formatter.Serialize(stream, serializationData);
+#pragma warning restore CS0618 // Type or member is obsolete
                     stream.Seek(0, SeekOrigin.Begin);
                     byte[] bytes = stream.GetBuffer();
                     IDataObject dataObj = new DataObject(CF_DESIGNER, bytes);
@@ -1305,7 +1307,9 @@ namespace System.Windows.Forms.Design
                     object serializationData = ds.Serialize(selectedComponents);
                     MemoryStream stream = new MemoryStream();
                     BinaryFormatter formatter = new BinaryFormatter();
+#pragma warning disable CS0618 // Type or member is obsolete
                     formatter.Serialize(stream, serializationData);
+#pragma warning restore CS0618 // Type or member is obsolete
                     stream.Seek(0, SeekOrigin.Begin);
                     byte[] bytes = stream.GetBuffer();
                     IDataObject dataObj = new DataObject(CF_DESIGNER, bytes);
@@ -1709,7 +1713,9 @@ namespace System.Windows.Forms.Design
                             {
                                 BinaryFormatter formatter = new BinaryFormatter();
                                 s.Seek(0, SeekOrigin.Begin);
+#pragma warning disable CS0618 // Type or member is obsolete
                                 object serializationData = formatter.Deserialize(s);
+#pragma warning restore CS0618 // Type or member is obsolete
                                 components = ds.Deserialize(serializationData);
                             }
                         }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ExceptionCollectionTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ExceptionCollectionTests.cs
@@ -45,7 +45,9 @@ namespace System.ComponentModel.Design.Tests
             {
                 var formatter = new BinaryFormatter();
                 var collection = new ExceptionCollection(new ArrayList());
+#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Throws<SerializationException>(() => formatter.Serialize(stream, collection));
+#pragma warning restore CS0618 // Type or member is obsolete
             }
         }
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationServiceTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationServiceTests.cs
@@ -804,7 +804,9 @@ namespace System.ComponentModel.Design.Serialization.Tests
             using (var stream = new MemoryStream())
             {
                 var formatter = new BinaryFormatter();
+#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Throws<SerializationException>(() => formatter.Serialize(stream, store));
+#pragma warning restore CS0618 // Type or member is obsolete
             }
         }
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/CodeDomSerializerExceptionTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/CodeDomSerializerExceptionTests.cs
@@ -95,7 +95,9 @@ namespace System.Windows.Forms.Design.Serialization.Tests
             {
                 var formatter = new BinaryFormatter();
                 var exception = new CodeDomSerializerException("message", new CodeLinePragma("fileName.cs", 11));
+#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Throws<SerializationException>(() => formatter.Serialize(stream, exception));
+#pragma warning restore CS0618 // Type or member is obsolete
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
@@ -351,7 +351,9 @@ namespace System.Resources
 
                     using (MemoryStream ms = new MemoryStream())
                     {
+#pragma warning disable CS0618 // Type or member is obsolete
                         _binaryFormatter.Serialize(ms, value);
+#pragma warning restore CS0618 // Type or member is obsolete
                         nodeInfo.ValueData = ToBase64WrappedString(ms.ToArray());
                     }
 
@@ -388,7 +390,9 @@ namespace System.Resources
                     IFormatter formatter = _binaryFormatter;
                     if (serializedData != null && serializedData.Length > 0)
                     {
+#pragma warning disable CS0618 // Type or member is obsolete
                         result = formatter.Deserialize(new MemoryStream(serializedData));
+#pragma warning restore CS0618 // Type or member is obsolete
                         if (result is ResXNullRef)
                         {
                             result = null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.PropertyBagStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.PropertyBagStream.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -23,7 +23,9 @@ namespace System.Windows.Forms
                 BinaryFormatter formatter = new BinaryFormatter();
                 try
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     bag = (Hashtable)formatter.Deserialize(stream);
+#pragma warning restore CS0618 // Type or member is obsolete
                 }
                 catch
                 {
@@ -68,7 +70,9 @@ namespace System.Windows.Forms
             internal void Write(Stream stream)
             {
                 BinaryFormatter formatter = new BinaryFormatter();
+#pragma warning disable CS0618 // Type or member is obsolete
                 formatter.Serialize(stream, bag);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -1123,7 +1123,9 @@ namespace System.Windows.Forms
                                     byte[] bytes = Convert.FromBase64String(obj.ToString());
                                     MemoryStream stream = new MemoryStream(bytes);
                                     BinaryFormatter formatter = new BinaryFormatter();
+#pragma warning disable CS0618 // Type or member is obsolete
                                     props[i].SetValue(_control, formatter.Deserialize(stream));
+#pragma warning restore CS0618 // Type or member is obsolete
                                 }
                                 else
                                 {
@@ -1526,7 +1528,9 @@ namespace System.Windows.Forms
                     public SafeIUnknown(object obj, bool addRefIntPtr, Guid iid)
                         : base(IntPtr.Zero, true)
                     {
+#pragma warning disable SYSLIB0004 // Type or member is obsolete
                         RuntimeHelpers.PrepareConstrainedRegions();
+#pragma warning restore SYSLIB0004 // Type or member is obsolete
                         try
                         {
                             // Set this.handle in a finally block to ensure the com ptr is set in the SafeHandle
@@ -1799,7 +1803,9 @@ namespace System.Windows.Forms
                             // Resource property.  Save this to the bag as a 64bit encoded string.
                             MemoryStream stream = new MemoryStream();
                             BinaryFormatter formatter = new BinaryFormatter();
+#pragma warning disable CS0618 // Type or member is obsolete
                             formatter.Serialize(stream, props[i].GetValue(_control));
+#pragma warning restore CS0618 // Type or member is obsolete
                             byte[] bytes = new byte[(int)stream.Length];
                             stream.Position = 0;
                             stream.Read(bytes, 0, bytes.Length);
@@ -2473,7 +2479,9 @@ namespace System.Windows.Forms
                     BinaryFormatter formatter = new BinaryFormatter();
                     try
                     {
+#pragma warning disable CS0618 // Type or member is obsolete
                         _bag = (Hashtable)formatter.Deserialize(stream);
+#pragma warning restore CS0618 // Type or member is obsolete
                     }
                     catch (Exception e)
                     {
@@ -2508,7 +2516,9 @@ namespace System.Windows.Forms
                 {
                     Stream stream = new DataStreamFromComStream(istream);
                     BinaryFormatter formatter = new BinaryFormatter();
+#pragma warning disable CS0618 // Type or member is obsolete
                     formatter.Serialize(stream, _bag);
+#pragma warning restore CS0618 // Type or member is obsolete
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
@@ -378,7 +378,9 @@ namespace System.Windows.Forms
                     formatter.Binder = new BitmapBinder();
                 }
                 formatter.AssemblyFormat = FormatterAssemblyStyle.Simple;
+#pragma warning disable CS0618 // Type or member is obsolete
                 return formatter.Deserialize(stream);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
@@ -825,7 +825,9 @@ namespace System.Windows.Forms
                 formatter.Binder = new BitmapBinder();
             }
 
+#pragma warning disable CS0618 // Type or member is obsolete
             formatter.Serialize(stream, data);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
@@ -596,7 +596,9 @@ namespace System.Windows.Forms
         ///  (because the classes are in use by the windows we can't destroy).  Instead,
         ///  we move the class and window procs to DefWndProc
         /// </summary>
+#pragma warning disable SYSLIB0004 // Type or member is obsolete
         [PrePrepareMethod]
+#pragma warning restore SYSLIB0004 // Type or member is obsolete
         private static void OnShutdown(object sender, EventArgs e)
         {
             // If we still have windows allocated, we must sling them to userDefWindowProc

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MergePropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MergePropertyDescriptor.cs
@@ -219,9 +219,11 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 BinaryFormatter f = new BinaryFormatter();
                 MemoryStream ms = new MemoryStream();
+#pragma warning disable CS0618 // Type or member is obsolete
                 f.Serialize(ms, value);
                 ms.Position = 0;
                 clonedValue = f.Deserialize(ms);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             if (clonedValue != null)

--- a/src/System.Windows.Forms/tests/TestUtilities/BinarySerialization.cs
+++ b/src/System.Windows.Forms/tests/TestUtilities/BinarySerialization.cs
@@ -81,9 +81,9 @@ namespace System
 
             using (var serializedStream = new MemoryStream(raw))
             {
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
                 return binaryFormatter.Deserialize(serializedStream);
-#pragma warning restore SYSLIB0011 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
             }
         }
 
@@ -97,9 +97,9 @@ namespace System
 
             using (MemoryStream ms = new MemoryStream())
             {
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
                 binaryFormatter.Serialize(ms, obj);
-#pragma warning restore SYSLIB0011 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
                 return ms.ToArray();
             }
         }

--- a/src/System.Windows.Forms/tests/TestUtilities/BinarySerialization.cs
+++ b/src/System.Windows.Forms/tests/TestUtilities/BinarySerialization.cs
@@ -81,7 +81,9 @@ namespace System
 
             using (var serializedStream = new MemoryStream(raw))
             {
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
                 return binaryFormatter.Deserialize(serializedStream);
+#pragma warning restore SYSLIB0011 // Type or member is obsolete
             }
         }
 
@@ -95,7 +97,9 @@ namespace System
 
             using (MemoryStream ms = new MemoryStream())
             {
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
                 binaryFormatter.Serialize(ms, obj);
+#pragma warning restore SYSLIB0011 // Type or member is obsolete
                 return ms.ToArray();
             }
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -448,9 +448,11 @@ namespace System.Windows.Forms.Tests
         {
             using var stream = new MemoryStream();
             var formatter = new BinaryFormatter();
+#pragma warning disable CS0618 // Type or member is obsolete
             formatter.Serialize(stream, source);
             stream.Position = 0;
             return (T)formatter.Deserialize(stream);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/TableLayoutSettingsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/TableLayoutSettingsTests.cs
@@ -1784,10 +1784,12 @@ namespace System.Windows.Forms.Layout.Tests
             using (var stream = new MemoryStream())
             {
                 var formatter = new BinaryFormatter();
+#pragma warning disable CS0618 // Type or member is obsolete
                 formatter.Serialize(stream, settings);
                 stream.Seek(0, SeekOrigin.Begin);
 
                 TableLayoutSettings result = Assert.IsType<TableLayoutSettings>(formatter.Deserialize(stream));
+#pragma warning restore CS0618 // Type or member is obsolete
                 Assert.Equal(columnStyle.SizeType, ((ColumnStyle)Assert.Single(result.ColumnStyles)).SizeType);
                 Assert.Equal(columnStyle.Width, ((ColumnStyle)Assert.Single(result.ColumnStyles)).Width);
                 Assert.Equal(rowStyle.SizeType, ((RowStyle)Assert.Single(result.RowStyles)).SizeType);
@@ -1811,10 +1813,12 @@ namespace System.Windows.Forms.Layout.Tests
             using (var stream = new MemoryStream())
             {
                 var formatter = new BinaryFormatter();
+#pragma warning disable CS0618 // Type or member is obsolete
                 formatter.Serialize(stream, settings);
                 stream.Seek(0, SeekOrigin.Begin);
 
                 Assert.Throws<SerializationException>(() => formatter.Deserialize(stream));
+#pragma warning restore CS0618 // Type or member is obsolete
             }
         }
 
@@ -1829,10 +1833,13 @@ namespace System.Windows.Forms.Layout.Tests
             using (var stream = new MemoryStream())
             {
                 var formatter = new BinaryFormatter();
+#pragma warning disable CS0618 // Type or member is obsolete
                 formatter.Serialize(stream, settings);
+
                 stream.Seek(0, SeekOrigin.Begin);
 
                 TableLayoutSettings result = Assert.IsType<TableLayoutSettings>(formatter.Deserialize(stream));
+#pragma warning restore CS0618 // Type or member is obsolete
                 Assert.NotNull(result.LayoutEngine);
                 Assert.Same(result.LayoutEngine, result.LayoutEngine);
                 Assert.Throws<NullReferenceException>(() => result.ColumnCount);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupTests.cs
@@ -1319,10 +1319,12 @@ namespace System.Windows.Forms.Tests
             using (var stream = new MemoryStream())
             {
                 var formatter = new BinaryFormatter();
+#pragma warning disable CS0618 // Type or member is obsolete
                 formatter.Serialize(stream, group);
                 stream.Seek(0, SeekOrigin.Begin);
 
                 ListViewGroup result = Assert.IsType<ListViewGroup>(formatter.Deserialize(stream));
+#pragma warning restore CS0618 // Type or member is obsolete
                 Assert.Equal(group.Header, result.Header);
                 Assert.Equal(group.HeaderAlignment, result.HeaderAlignment);
                 Assert.Equal(group.Items.Cast<ListViewItem>().Select(i => i.Text), result.Items.Cast<ListViewItem>().Select(i => i.Text));

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewSubItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewSubItemTests.cs
@@ -584,10 +584,12 @@ namespace System.Windows.Forms.Tests
             using (var stream = new MemoryStream())
             {
                 var formatter = new BinaryFormatter();
+#pragma warning disable CS0618 // Type or member is obsolete
                 formatter.Serialize(stream, subItem);
                 stream.Seek(0, SeekOrigin.Begin);
 
                 ListViewItem.ListViewSubItem result = Assert.IsType<ListViewItem.ListViewSubItem>(formatter.Deserialize(stream));
+#pragma warning restore CS0618 // Type or member is obsolete
                 Assert.Equal(subItem.BackColor, result.BackColor);
                 Assert.Equal(subItem.Font, result.Font);
                 Assert.Equal(subItem.ForeColor, result.ForeColor);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/OwnerDrawPropertyBagTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/OwnerDrawPropertyBagTests.cs
@@ -117,10 +117,12 @@ namespace System.Windows.Forms.Tests
             using (var stream = new MemoryStream())
             {
                 var formatter = new BinaryFormatter();
+#pragma warning disable CS0618 // Type or member is obsolete
                 formatter.Serialize(stream, original);
 
                 stream.Position = 0;
                 OwnerDrawPropertyBag bag = Assert.IsType<OwnerDrawPropertyBag>(formatter.Deserialize(stream));
+#pragma warning restore CS0618 // Type or member is obsolete
                 Assert.Equal(Color.Blue, bag.BackColor);
                 Assert.Equal(SystemFonts.MenuFont.Name, bag.Font.Name);
                 Assert.Equal(Color.Red, bag.ForeColor);


### PR DESCRIPTION
Some types and members were recently made obsolete in dotnet/runtime, and dependency flow into dotnet/winforms is broken because of it.

To keep darc running smoothly, I've suppressed these warnings individually.
I've built locally from both command line and VS, and all errors are now gone.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3611)