### PR TITLE
Set the color when drawing text in CheckedListBox.

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/DeviceContextExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/DeviceContextExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
 using System.Diagnostics;
 using System.Drawing;
 using static Interop;
@@ -46,6 +45,7 @@ namespace System.Windows.Forms
 
         internal static void FillRectangle(this Gdi32.HDC hdc, Rectangle rectangle, Gdi32.HBRUSH hbrush)
         {
+            Debug.Assert(!hbrush.IsNull);
             RECT rect = rectangle;
             User32.FillRect(
                 hdc,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
@@ -682,7 +682,7 @@ namespace System.Windows.Forms
                 if (!backColor.HasTransparency())
                 {
                     using var hdc = new DeviceContextHdcScope(e);
-                    using var hbrush = new Gdi32.CreateBrushScope();
+                    using var hbrush = new Gdi32.CreateBrushScope(backColor);
                     hdc.FillRectangle(textBounds, hbrush);
                 }
                 else


### PR DESCRIPTION
Didn't actually set a color for the GDI case. Add an assert to FillRectangle to try and flush out this sort of mistake earlier.

Fixes #3628

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3629)