### PR TITLE
Don't double apply Graphics transform

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.Rectangle.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.Rectangle.cs
@@ -11,12 +11,5 @@ internal static partial class Interop
     {
         [DllImport(Libraries.Gdi32, ExactSpelling = true)]
         public static extern BOOL Rectangle(HDC hdc, int left, int top, int right, int bottom);
-
-        public static BOOL Rectangle(HandleRef hdc, int left, int top, int right, int bottom)
-        {
-            BOOL result = Rectangle((HDC)hdc.Handle, left, top, right, bottom);
-            GC.KeepAlive(hdc.Wrapper);
-            return result;
-        }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.cs
@@ -679,7 +679,7 @@ namespace System.Windows.Forms
                 var hdc = (Gdi32.HDC)m.WParam;
                 using var hbrush = new Gdi32.CreateBrushScope(backColor);
                 using var selection = new Gdi32.SelectObjectScope(hdc, hbrush);
-                Gdi32.Rectangle(hdc, rect.left, rect.top, rect.right, rect.bottom);
+                User32.FillRect(hdc, ref rect, hbrush);
             }
 
             m.Result = (IntPtr)1;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.cs
@@ -678,7 +678,6 @@ namespace System.Windows.Forms
             {
                 var hdc = (Gdi32.HDC)m.WParam;
                 using var hbrush = new Gdi32.CreateBrushScope(backColor);
-                using var selection = new Gdi32.SelectObjectScope(hdc, hbrush);
                 User32.FillRect(hdc, ref rect, hbrush);
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
@@ -12,7 +12,6 @@ using System.Drawing;
 using System.Drawing.Design;
 using System.Drawing.Drawing2D;
 using System.Globalization;
-using System.Runtime.InteropServices;
 using System.Windows.Forms.Design;
 using System.Windows.Forms.VisualStyles;
 using static Interop;
@@ -76,7 +75,8 @@ namespace System.Windows.Forms.PropertyGridInternal
             None = 0,
             DrawSelected = 0x1,
             FetchValue = 0x2,
-            CheckShouldSerialize = 0x4
+            CheckShouldSerialize = 0x4,
+            PaintInPlace = 0x8
         }
 
         private class CacheItems
@@ -2382,11 +2382,21 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return;
             }
 
-            // Do actual drawing
+            // Do actual drawing, shifting to match the PropertyGridView.GridViewListbox content alignment
+
+            if (paintFlags.HasFlag(PaintValueFlags.PaintInPlace))
+            {
+                rect.Offset(1, 2);
+            }
+            else
+            {
+                // Only go down one pixel when we're painting in the listbox
+                rect.Offset(1, 1);
+            }
 
             Rectangle textRectangle = new Rectangle(
-                rect.X,
-                rect.Y + 1,
+                rect.X - 1,
+                rect.Y - 1,
                 rect.Width - 4,
                 rect.Height);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
@@ -2386,7 +2386,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             // Do actual drawing
 
             // Bump the text down 2 pixels and over 1 pixel.
-            if ((paintFlags & PaintValueFlags.PaintInPlace) != PaintValueFlags.None)
+            if (paintFlags.HasFlag(PaintValueFlags.PaintInPlace))
             {
                 rect.Offset(1, 1);
             }
@@ -2402,9 +2402,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 rect.Width - 4,
                 rect.Height);
 
-            Font font = GetFont(boldFont: valueModified);
-
-            Color backColor = ((paintFlags & PaintValueFlags.DrawSelected) != PaintValueFlags.None)
+            Color backColor = paintFlags.HasFlag(PaintValueFlags.DrawSelected)
                 ? GridEntryHost.GetSelectedItemWithFocusBackColor()
                 : GridEntryHost.BackColor;
 
@@ -2431,7 +2429,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             TextRenderer.DrawTextInternal(
                 g,
                 text,
-                font,
+                GetFont(boldFont: valueModified),
                 textRectangle,
                 textColor,
                 backColor,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
@@ -76,8 +76,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             None = 0,
             DrawSelected = 0x1,
             FetchValue = 0x2,
-            CheckShouldSerialize = 0x4,
-            PaintInPlace = 0x8
+            CheckShouldSerialize = 0x4
         }
 
         private class CacheItems
@@ -2385,20 +2384,9 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             // Do actual drawing
 
-            // Bump the text down 2 pixels and over 1 pixel.
-            if (paintFlags.HasFlag(PaintValueFlags.PaintInPlace))
-            {
-                rect.Offset(1, 1);
-            }
-            else
-            {
-                // Only go down one pixel when we're painting in the listbox
-                rect.Offset(1, 0);
-            }
-
             Rectangle textRectangle = new Rectangle(
                 rect.X,
-                rect.Y,
+                rect.Y + 1,
                 rect.Width - 4,
                 rect.Height);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
@@ -1992,18 +1992,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        protected IntPtr GetHfont(bool boldFont)
-        {
-            if (boldFont)
-            {
-                return GridEntryHost.GetBoldHfont();
-            }
-            else
-            {
-                return GridEntryHost.GetBaseHfont();
-            }
-        }
-
         /// <summary>
         ///  Retrieves the requested service.  This may
         ///  return null if the requested service is not
@@ -2290,40 +2278,36 @@ namespace System.Windows.Forms.PropertyGridInternal
         }
 
         /// <summary>
-        ///  Paints the value portion of this GridEntry into the given Graphics object.  This
-        ///  is called by the GridEntry host (the PropertyGridView) when this GridEntry is
-        ///  to be painted.
+        ///  Paints the value portion of this GridEntry into the given Graphics object. This is called by the GridEntry
+        ///  host (the PropertyGridView) when this GridEntry is to be painted.
         /// </summary>
         public virtual void PaintValue(object val, Graphics g, Rectangle rect, Rectangle clipRect, PaintValueFlags paintFlags)
         {
             PropertyGridView gridHost = GridEntryHost;
-            Debug.Assert(gridHost != null, "No propEntryHost");
-            int cPaint = 0;
+            Debug.Assert(gridHost != null);
 
-            Color textColor = gridHost.GetTextColor();
-            if (ShouldRenderReadOnly)
-            {
-                textColor = GridEntryHost.GrayTextColor;
-            }
+            Color textColor = ShouldRenderReadOnly ? GridEntryHost.GrayTextColor : gridHost.GetTextColor();
 
-            string strValue;
+            string text;
 
-            if ((paintFlags & PaintValueFlags.FetchValue) != PaintValueFlags.None)
+            if (paintFlags.HasFlag(PaintValueFlags.FetchValue))
             {
                 if (cacheItems != null && cacheItems.useValueString)
                 {
-                    strValue = cacheItems.lastValueString;
+                    text = cacheItems.lastValueString;
                     val = cacheItems.lastValue;
                 }
                 else
                 {
                     val = PropertyValue;
-                    strValue = GetPropertyTextValue(val);
+                    text = GetPropertyTextValue(val);
+
                     if (cacheItems == null)
                     {
                         cacheItems = new CacheItems();
                     }
-                    cacheItems.lastValueString = strValue;
+
+                    cacheItems.lastValueString = text;
                     cacheItems.useValueString = true;
                     cacheItems.lastValueTextWidth = -1;
                     cacheItems.lastValueFont = null;
@@ -2332,137 +2316,128 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             else
             {
-                strValue = GetPropertyTextValue(val);
+                text = GetPropertyTextValue(val);
             }
 
-            // paint out the main rect using the appropriate brush
-            Brush bkBrush = GetBackgroundBrush(g);
-            Debug.Assert(bkBrush != null, "We didn't find a good background brush for PaintValue");
+            // Paint out the main rect using the appropriate brush
+            Brush backBrush = GetBackgroundBrush(g);
+            Debug.Assert(backBrush != null, "We didn't find a good background brush for PaintValue");
 
-            if ((paintFlags & PaintValueFlags.DrawSelected) != PaintValueFlags.None)
+            if (paintFlags.HasFlag(PaintValueFlags.DrawSelected))
             {
-                bkBrush = gridHost.GetSelectedItemWithFocusBackBrush(g);
+                backBrush = gridHost.GetSelectedItemWithFocusBackBrush(g);
                 textColor = gridHost.GetSelectedItemWithFocusForeColor();
             }
 
-            Brush blank = bkBrush;
-            g.FillRectangle(blank, clipRect);
+            g.FillRectangle(backBrush, clipRect);
 
+            int paintIndent = 0;
             if (IsCustomPaint)
             {
-                cPaint = gridHost.GetValuePaintIndent();
-                Rectangle rectPaint = new Rectangle(rect.X + 1, rect.Y + 1, gridHost.GetValuePaintWidth(), gridHost.GetGridEntryHeight() - 2);
+                paintIndent = gridHost.GetValuePaintIndent();
+                Rectangle rectPaint = new Rectangle(
+                    rect.X + 1,
+                    rect.Y + 1,
+                    gridHost.GetValuePaintWidth(),
+                    gridHost.GetGridEntryHeight() - 2);
 
                 if (!Rectangle.Intersect(rectPaint, clipRect).IsEmpty)
                 {
-                    UITypeEditor uie = UITypeEditor;
-                    if (uie != null)
-                    {
-                        uie.PaintValue(new PaintValueEventArgs(this, val, g, rectPaint));
-                    }
+                    UITypeEditor?.PaintValue(new PaintValueEventArgs(this, val, g, rectPaint));
 
-                    // paint a border around the area
+                    // Paint a border around the area
                     rectPaint.Width--;
                     rectPaint.Height--;
                     g.DrawRectangle(SystemPens.WindowText, rectPaint);
                 }
             }
 
-            rect.X += cPaint + gridHost.GetValueStringIndent();
-            rect.Width -= cPaint + 2 * gridHost.GetValueStringIndent();
+            rect.X += paintIndent + gridHost.GetValueStringIndent();
+            rect.Width -= paintIndent + 2 * gridHost.GetValueStringIndent();
 
-            // bold the property if we need to persist it (e.g. it's not the default value)
-            bool valueModified = ((paintFlags & PaintValueFlags.CheckShouldSerialize) != PaintValueFlags.None) && ShouldSerializePropertyValue();
+            // Bold the property if we need to persist it (e.g. it's not the default value)
+            bool valueModified = paintFlags.HasFlag(PaintValueFlags.CheckShouldSerialize) && ShouldSerializePropertyValue();
 
             // If we have text to paint, paint it
-            if (strValue != null && strValue.Length > 0)
+            if (string.IsNullOrEmpty(text))
             {
-                Font f = GetFont(valueModified);
-
-                if (strValue.Length > maximumLengthOfPropertyString)
-                {
-                    strValue = strValue.Substring(0, maximumLengthOfPropertyString);
-                }
-                int textWidth = GetValueTextWidth(strValue, g, f);
-                bool doToolTip = false;
-
-                // Check if text contains multiple lines
-                if (textWidth >= rect.Width || GetMultipleLines(strValue))
-                {
-                    doToolTip = true;
-                }
-
-                if (Rectangle.Intersect(rect, clipRect).IsEmpty)
-                {
-                    return;
-                }
-
-                // Do actual drawing
-
-                // bump the text down 2 pixels and over 1 pixel.
-                if ((paintFlags & PaintValueFlags.PaintInPlace) != PaintValueFlags.None)
-                {
-                    rect.Offset(1, 2);
-                }
-                else
-                {
-                    // only go down one pixel when we're painting in the listbox
-                    rect.Offset(1, 1);
-                }
-
-                Matrix m = g.Transform;
-
-                using var hdc = new DeviceContextHdcScope(g);
-                RECT lpRect = new Rectangle(rect.X + (int)m.OffsetX + 2, rect.Y + (int)m.OffsetY - 1, rect.Width - 4, rect.Height);
-                Gdi32.HGDIOBJ hfont = (Gdi32.HGDIOBJ)GetHfont(valueModified);
-
-                int oldTextColor = 0;
-                int oldBkColor = 0;
-
-                Color bkColor = ((paintFlags & PaintValueFlags.DrawSelected) != PaintValueFlags.None) ? GridEntryHost.GetSelectedItemWithFocusBackColor() : GridEntryHost.BackColor;
-
-                try
-                {
-                    oldTextColor = Gdi32.SetTextColor(hdc, COLORREF.RgbToCOLORREF(textColor.ToArgb()));
-                    oldBkColor = Gdi32.SetBkColor(hdc, COLORREF.RgbToCOLORREF(bkColor.ToArgb()));
-                    using var fontSelection = new Gdi32.SelectObjectScope(hdc, hfont);
-                    User32.DT format = User32.DT.EDITCONTROL | User32.DT.EXPANDTABS | User32.DT.NOCLIP | User32.DT.SINGLELINE | User32.DT.NOPREFIX;
-                    if (gridHost.DrawValuesRightToLeft)
-                    {
-                        format |= User32.DT.RIGHT | User32.DT.RTLREADING;
-                    }
-
-                    // For password mode, replace the string value with a bullet.
-                    if (ShouldRenderPassword)
-                    {
-                        if (passwordReplaceChar == '\0')
-                        {
-                            // Bullet is 2022, but edit box uses round circle 25CF
-                            passwordReplaceChar = '\u25CF';
-                        }
-
-                        strValue = new string(passwordReplaceChar, strValue.Length);
-                    }
-
-                    User32.DrawTextW(hdc, strValue, strValue.Length, ref lpRect, format);
-                }
-                finally
-                {
-                    Gdi32.SetTextColor(hdc, oldTextColor);
-                    Gdi32.SetBkColor(hdc, oldBkColor);
-                }
-
-                if (doToolTip)
-                {
-                    ValueToolTipLocation = new Point(rect.X + 2, rect.Y - 1);
-                }
-                else
-                {
-                    ValueToolTipLocation = InvalidPoint;
-                }
+                return;
             }
 
-            return;
+            if (text.Length > maximumLengthOfPropertyString)
+            {
+                text = text.Substring(0, maximumLengthOfPropertyString);
+            }
+
+            int textWidth = GetValueTextWidth(text, g, GetFont(valueModified));
+            bool doToolTip = false;
+
+            // Check if text contains multiple lines
+            if (textWidth >= rect.Width || GetMultipleLines(text))
+            {
+                doToolTip = true;
+            }
+
+            if (Rectangle.Intersect(rect, clipRect).IsEmpty)
+            {
+                return;
+            }
+
+            // Do actual drawing
+
+            // Bump the text down 2 pixels and over 1 pixel.
+            if ((paintFlags & PaintValueFlags.PaintInPlace) != PaintValueFlags.None)
+            {
+                rect.Offset(1, 1);
+            }
+            else
+            {
+                // Only go down one pixel when we're painting in the listbox
+                rect.Offset(1, 0);
+            }
+
+            Rectangle textRectangle = new Rectangle(
+                rect.X,
+                rect.Y,
+                rect.Width - 4,
+                rect.Height);
+
+            Font font = GetFont(boldFont: valueModified);
+
+            Color backColor = ((paintFlags & PaintValueFlags.DrawSelected) != PaintValueFlags.None)
+                ? GridEntryHost.GetSelectedItemWithFocusBackColor()
+                : GridEntryHost.BackColor;
+
+            User32.DT format = User32.DT.EDITCONTROL | User32.DT.EXPANDTABS | User32.DT.NOCLIP
+                | User32.DT.SINGLELINE | User32.DT.NOPREFIX;
+
+            if (gridHost.DrawValuesRightToLeft)
+            {
+                format |= User32.DT.RIGHT | User32.DT.RTLREADING;
+            }
+
+            // For password mode, replace the string value with a bullet.
+            if (ShouldRenderPassword)
+            {
+                if (passwordReplaceChar == '\0')
+                {
+                    // Bullet is 2022, but edit box uses round circle 25CF
+                    passwordReplaceChar = '\u25CF';
+                }
+
+                text = new string(passwordReplaceChar, text.Length);
+            }
+
+            TextRenderer.DrawTextInternal(
+                g,
+                text,
+                font,
+                textRectangle,
+                textColor,
+                backColor,
+                format);
+
+            ValueToolTipLocation = doToolTip ? new Point(rect.X + 2, rect.Y - 1) : InvalidPoint;
         }
 
         public virtual bool OnComponentChanging()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -169,7 +169,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             ownerGrid = propertyGrid;
             this.serviceProvider = serviceProvider;
 
-            //SetStyle(ControlStyles.OptimizedDoubleBuffer, true);
+            SetStyle(ControlStyles.OptimizedDoubleBuffer, true);
             SetStyle(ControlStyles.ResizeRedraw, false);
             SetStyle(ControlStyles.UserMouse, true);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -146,8 +146,6 @@ namespace System.Windows.Forms.PropertyGridInternal
         private readonly GridEntryRecreateChildrenEventHandler ehRecreateChildren;
 
         private int cachedRowHeight = -1;
-        IntPtr _baseHfont;
-        IntPtr _boldHfont;
 
         public PropertyGridView(IServiceProvider serviceProvider, PropertyGrid propertyGrid)
         : base()
@@ -171,7 +169,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             ownerGrid = propertyGrid;
             this.serviceProvider = serviceProvider;
 
-            SetStyle(ControlStyles.OptimizedDoubleBuffer, true);
+            //SetStyle(ControlStyles.OptimizedDoubleBuffer, true);
             SetStyle(ControlStyles.ResizeRedraw, false);
             SetStyle(ControlStyles.UserMouse, true);
 
@@ -1190,9 +1188,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         protected override void Dispose(bool disposing)
         {
-            // Make sure we close any dangling font handles
-            ClearCachedFontInfo();
-
             if (disposing)
             {
                 Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:Dispose");
@@ -1609,15 +1604,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             return fontBold;
         }
 
-        internal IntPtr GetBaseHfont()
-        {
-            if (_baseHfont == IntPtr.Zero)
-            {
-                _baseHfont = GetBaseFont().ToHfont();
-            }
-            return _baseHfont;
-        }
-
         /// <summary>
         ///  Gets the element from point.
         /// </summary>
@@ -1647,15 +1633,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
 
             return null;
-        }
-
-        internal IntPtr GetBoldHfont()
-        {
-            if (_boldHfont == IntPtr.Zero)
-            {
-                _boldHfont = GetBoldFont().ToHfont();
-            }
-            return _boldHfont;
         }
 
         private bool GetFlag(short flag)
@@ -3935,10 +3912,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 Debug.Fail("Caught exception in OnPaint");
                 // Do nothing.
             }
-            finally
-            {
-                ClearCachedFontInfo();
-            }
         }
 
         private void OnGridEntryLabelDoubleClick(object s, EventArgs e)
@@ -4028,23 +4001,8 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        private void ClearCachedFontInfo()
-        {
-            if (_baseHfont != IntPtr.Zero)
-            {
-                Gdi32.DeleteObject(_baseHfont);
-                _baseHfont = IntPtr.Zero;
-            }
-            if (_boldHfont != IntPtr.Zero)
-            {
-                Gdi32.DeleteObject(_boldHfont);
-                _boldHfont = IntPtr.Zero;
-            }
-        }
-
         protected override void OnFontChanged(EventArgs e)
         {
-            ClearCachedFontInfo();
             cachedRowHeight = -1;
 
             if (Disposing || ParentInternal == null || ParentInternal.Disposing)
@@ -6093,7 +6051,6 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             if (DpiHelper.IsScalingRequirementMet)
             {
-                ClearCachedFontInfo();
                 cachedRowHeight = -1;
                 paintWidth = LogicalToDeviceUnits(PAINT_WIDTH);
                 paintIndent = LogicalToDeviceUnits(PAINT_INDENT);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -1439,7 +1439,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 try
                 {
-                    DrawValueEntry(g, r, cr, gridEntry, null, true);
+                    gridEntry.PaintValue(null, g, r, cr, GridEntry.PaintValueFlags.FetchValue);
                 }
                 catch
                 {
@@ -1449,37 +1449,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 ResetOrigin(g);
             }
-        }
-
-        private /*protected virtual*/ void DrawValueEntry(Graphics g, Rectangle rect, Rectangle clipRect, GridEntry gridEntry, object value, bool fetchValue)
-        {
-            DrawValue(g, rect, clipRect, gridEntry, value, false, true, fetchValue, true);
-        }
-        private void DrawValue(Graphics g, Rectangle rect, Rectangle clipRect, GridEntry gridEntry, object value, bool drawSelected, bool checkShouldSerialize, bool fetchValue, bool paintInPlace)
-        {
-            GridEntry.PaintValueFlags paintFlags = GridEntry.PaintValueFlags.None;
-
-            if (drawSelected)
-            {
-                paintFlags |= GridEntry.PaintValueFlags.DrawSelected;
-            }
-
-            if (checkShouldSerialize)
-            {
-                paintFlags |= GridEntry.PaintValueFlags.CheckShouldSerialize;
-            }
-
-            if (fetchValue)
-            {
-                paintFlags |= GridEntry.PaintValueFlags.FetchValue;
-            }
-
-            if (paintInPlace)
-            {
-                paintFlags |= GridEntry.PaintValueFlags.PaintInPlace;
-            }
-
-            gridEntry.PaintValue(value, g, rect, clipRect, paintFlags);
         }
 
         private void F4Selection(bool popupModalDialog)
@@ -2753,9 +2722,15 @@ namespace System.Windows.Forms.PropertyGridInternal
             drawBounds.X -= 1;
 
             GridEntry gridEntry = GetGridEntryFromRow(selectedRow);
+
             try
             {
-                DrawValue(die.Graphics, drawBounds, drawBounds, gridEntry, gridEntry.ConvertTextToValue(text), (int)(die.State & DrawItemState.Selected) != 0, false, false, false);
+                gridEntry.PaintValue(
+                    gridEntry.ConvertTextToValue(text),
+                    die.GraphicsInternal,
+                    drawBounds,
+                    drawBounds,
+                    die.State.HasFlag(DrawItemState.Selected) ? GridEntry.PaintValueFlags.DrawSelected : default);
             }
             catch (FormatException ex)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -1439,7 +1439,14 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 try
                 {
-                    gridEntry.PaintValue(null, g, r, cr, GridEntry.PaintValueFlags.FetchValue);
+                    gridEntry.PaintValue(
+                        null,
+                        g,
+                        r,
+                        cr,
+                        GridEntry.PaintValueFlags.FetchValue
+                            | GridEntry.PaintValueFlags.PaintInPlace
+                            | GridEntry.PaintValueFlags.CheckShouldSerialize);
                 }
                 catch
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextRenderer.cs
@@ -85,7 +85,7 @@ namespace System.Windows.Forms
             User32.DT flags = User32.DT.DEFAULT)
             => DrawTextInternal(dc, text, font, new Rectangle(pt, MaxSize), foreColor, backColor, flags);
 
-        private static void DrawTextInternal(
+        internal static void DrawTextInternal(
             IDeviceContext dc,
             string? text,
             Font? font,


### PR DESCRIPTION
Grid entry text was being shifted out of the control window as we were applying the Graphics transform manually when the centralized code now does this for us.

This change no longer double applies and changes the code to use TextRenderer, removing the local HFONT caching.

Also fix GroupBox to use FillRect instead of Rectangle. Remove an uncalled overload for Rectangle.

Fixes #3580


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3635)