### PR TITLE
Use generic hash sets in DataObject

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.DataStore.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.DataStore.cs
@@ -5,12 +5,14 @@
 #nullable disable
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Runtime.Serialization;
 
 namespace System.Windows.Forms
@@ -225,8 +227,10 @@ namespace System.Windows.Forms
                 {
                     Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "DataStore: applying autoConvert");
 
-                    ArrayList formats = new ArrayList();
-                    for (int i = 0; i < baseVar.Length; i++)
+                    // Since we are only adding elements to the HashSet, the order will be preserved.
+                    int baseVarLength = baseVar.Length;
+                    HashSet<string> distinctFormats = new HashSet<string>(baseVarLength);
+                    for (int i = 0; i < baseVarLength; i++)
                     {
                         Debug.Assert(data[baseVar[i]] != null, "Null item in data collection with key '" + baseVar[i] + "'");
                         if (((DataStoreEntry)data[baseVar[i]]).autoConvert)
@@ -235,18 +239,16 @@ namespace System.Windows.Forms
                             Debug.Assert(cur != null, "GetMappedFormats returned null for '" + baseVar[i] + "'");
                             for (int j = 0; j < cur.Length; j++)
                             {
-                                formats.Add(cur[j]);
+                                distinctFormats.Add(cur[j]);
                             }
                         }
                         else
                         {
-                            formats.Add(baseVar[i]);
+                            distinctFormats.Add(baseVar[i]);
                         }
                     }
 
-                    string[] temp = new string[formats.Count];
-                    formats.CopyTo(temp, 0);
-                    baseVar = GetDistinctStrings(temp);
+                    baseVar = distinctFormats.ToArray();
                 }
                 Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "DataStore: returing " + baseVar.Length.ToString(CultureInfo.InvariantCulture) + " formats from GetFormats");
                 return baseVar;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
@@ -4,11 +4,12 @@
 
 #nullable disable
 
-using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using System.Runtime.Serialization;
@@ -599,7 +600,9 @@ namespace System.Windows.Forms
                 Debug.Assert(innerData != null, "You must have an innerData on all DataObjects");
 
                 IEnumFORMATETC enumFORMATETC = null;
-                ArrayList formats = new ArrayList();
+
+                // Since we are only adding elements to the HashSet, the order will be preserved.
+                HashSet<string> distinctFormats = new HashSet<string>();
                 try
                 {
                     enumFORMATETC = innerData.EnumFormatEtc(DATADIR.DATADIR_GET);
@@ -634,20 +637,18 @@ namespace System.Windows.Forms
                                 string[] mappedFormats = GetMappedFormats(name);
                                 for (int i = 0; i < mappedFormats.Length; i++)
                                 {
-                                    formats.Add(mappedFormats[i]);
+                                    distinctFormats.Add(mappedFormats[i]);
                                 }
                             }
                             else
                             {
-                                formats.Add(name);
+                                distinctFormats.Add(name);
                             }
                         }
                     }
                 }
 
-                string[] temp = new string[formats.Count];
-                formats.CopyTo(temp, 0);
-                return GetDistinctStrings(temp);
+                return distinctFormats.ToArray();
             }
 
             public virtual string[] GetFormats()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-using System.Collections;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -410,26 +409,6 @@ namespace System.Windows.Forms
         }
 
         // END - WHIDBEY ADDITIONS -->
-
-        /// <summary>
-        ///  Retrieves a list of distinct strings from the array.
-        /// </summary>
-        private static string[] GetDistinctStrings(string[] formats)
-        {
-            ArrayList distinct = new ArrayList();
-            for (int i = 0; i < formats.Length; i++)
-            {
-                string s = formats[i];
-                if (!distinct.Contains(s))
-                {
-                    distinct.Add(s);
-                }
-            }
-
-            string[] temp = new string[distinct.Count];
-            distinct.CopyTo(temp, 0);
-            return temp;
-        }
 
         /// <summary>
         ///  Returns all the "synonyms" for the specified format.


### PR DESCRIPTION
## Proposed changes

- Use generic hash sets in DataObject.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3643)