### PR TITLE
Add scope tracking

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -2025,7 +2025,7 @@ namespace System.Windows.Forms.Design
                         }
                         else
                         {
-                            using (var scope = new User32.BeginPaintScope())
+                            using (var scope = new User32.BeginPaintScope(m.HWnd))
                             {
                                 PaintException(pevent, _thrownException);
                             }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.CreateBitmapScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.CreateBitmapScope.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 
 internal static partial class Interop
 {
@@ -16,7 +17,11 @@ internal static partial class Interop
         ///  Use in a <see langword="using" /> statement. If you must pass this around, always pass
         ///  by <see langword="ref" /> to avoid duplicating the handle and risking a double delete.
         /// </remarks>
-        public readonly ref struct CreateBitmapScope
+#if DEBUG
+        internal class CreateBitmapScope : DisposalTracking.Tracker, IDisposable
+#else
+        internal readonly ref struct CreateBitmapScope
+#endif
         {
             public HBITMAP HBitmap { get; }
 
@@ -48,6 +53,10 @@ internal static partial class Interop
                 {
                     DeleteObject(HBitmap);
                 }
+
+#if DEBUG
+                GC.SuppressFinalize(this);
+#endif
             }
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.CreateBrushScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.CreateBrushScope.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Drawing;
+using System.Diagnostics;
 
 internal static partial class Interop
 {
@@ -16,7 +17,11 @@ internal static partial class Interop
         ///  Use in a <see langword="using" /> statement. If you must pass this around, always pass
         ///  by <see langword="ref" /> to avoid duplicating the handle and risking a double delete.
         /// </remarks>
-        public readonly ref struct CreateBrushScope
+#if DEBUG
+        internal class CreateBrushScope : DisposalTracking.Tracker, IDisposable
+#else
+        internal readonly ref struct CreateBrushScope
+#endif
         {
             public HBRUSH HBrush { get; }
 
@@ -42,6 +47,10 @@ internal static partial class Interop
                     // Note that this is a no-op if the original brush was a system brush
                     DeleteObject(HBrush);
                 }
+
+#if DEBUG
+                GC.SuppressFinalize(this);
+#endif
             }
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.CreateDcScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.CreateDcScope.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 
 internal static partial class Interop
 {
@@ -16,7 +17,11 @@ internal static partial class Interop
         ///  Use in a <see langword="using" /> statement. If you must pass this around, always pass
         ///  by <see langword="ref" /> to avoid duplicating the handle and risking a double delete.
         /// </remarks>
-        public readonly ref struct CreateDcScope
+#if DEBUG
+        internal class CreateDcScope : DisposalTracking.Tracker, IDisposable
+#else
+        internal readonly ref struct CreateDcScope
+#endif
         {
             public HDC HDC { get; }
 
@@ -55,6 +60,10 @@ internal static partial class Interop
                 {
                     DeleteDC(HDC);
                 }
+
+#if DEBUG
+                GC.SuppressFinalize(this);
+#endif
             }
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.CreatePenScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.CreatePenScope.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Drawing;
+using System.Diagnostics;
 
 internal static partial class Interop
 {
@@ -16,7 +17,11 @@ internal static partial class Interop
         ///  Use in a <see langword="using" /> statement. If you must pass this around, always pass
         ///  by <see langword="ref" /> to avoid duplicating the handle and risking a double delete.
         /// </remarks>
-        public readonly ref struct CreatePenScope
+#if DEBUG
+        internal class CreatePenScope : DisposalTracking.Tracker, IDisposable
+#else
+        internal readonly ref struct CreatePenScope
+#endif
         {
             public HPEN HPen { get; }
 
@@ -44,6 +49,10 @@ internal static partial class Interop
                 {
                     DeleteObject(HPen);
                 }
+
+#if DEBUG
+                GC.SuppressFinalize(this);
+#endif
             }
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.GetBkMode.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.GetBkMode.cs
@@ -4,20 +4,12 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Windows.Forms;
 
 internal static partial class Interop
 {
     internal static partial class Gdi32
     {
         [DllImport(Libraries.Gdi32, ExactSpelling = true)]
-        public static extern BKMODE GetBkMode(IntPtr hdc);
-
-        public static BKMODE GetBkMode(IHandle hdc)
-        {
-            BKMODE result = GetBkMode(hdc.Handle);
-            GC.KeepAlive(hdc);
-            return result;
-        }
+        public static extern BKMODE GetBkMode(HDC hdc);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.ObjectScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.ObjectScope.cs
@@ -15,7 +15,11 @@ internal static partial class Interop
         ///  Use in a <see langword="using" /> statement. If you must pass this around, always pass
         ///  by <see langword="ref" /> to avoid duplicating the handle and risking a double deletion.
         /// </remarks>
+#if DEBUG
+        internal class ObjectScope : DisposalTracking.Tracker, IDisposable
+#else
         internal readonly ref struct ObjectScope
+#endif
         {
             public HGDIOBJ Object { get; }
 
@@ -33,6 +37,8 @@ internal static partial class Interop
                 {
                     DeleteObject(Object);
                 }
+
+                DisposalTracking.SuppressFinalize(this!);
             }
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.RegionScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.RegionScope.cs
@@ -17,7 +17,11 @@ internal static partial class Interop
         ///  Use in a <see langword="using" /> statement. If you must pass this around, always pass
         ///  by <see langword="ref" /> to avoid duplicating the handle and risking a double deletion.
         /// </remarks>
-        public ref struct RegionScope
+#if DEBUG
+        internal class RegionScope : DisposalTracking.Tracker, IDisposable
+#else
+        internal ref struct RegionScope
+#endif
         {
             public HRGN Region { get; private set; }
 
@@ -113,6 +117,8 @@ internal static partial class Interop
                 {
                     DeleteObject(Region);
                 }
+
+                DisposalTracking.SuppressFinalize(this!);
             }
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.SelectPaletteScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.SelectPaletteScope.cs
@@ -16,7 +16,11 @@ internal static partial class Interop
         ///  Use in a <see langword="using" /> statement. If you must pass this around, always pass
         ///  by <see langword="ref" /> to avoid duplicating the handle and risking a double pallete reset.
         /// </remarks>
-        public readonly ref struct SelectPaletteScope
+#if DEBUG
+        internal class SelectPaletteScope : DisposalTracking.Tracker, IDisposable
+#else
+        internal readonly ref struct SelectPaletteScope
+#endif
         {
             public HDC HDC { get; }
             public HPALETTE HPalette { get; }
@@ -43,7 +47,7 @@ internal static partial class Interop
                     // Doing this is a bit pointless when the color depth is much higher (the normal scenario). As such
                     // we'll skip doing this unless we see 8bpp or less.
 
-                    return default;
+                    return new SelectPaletteScope();
                 }
 
                 return new SelectPaletteScope(
@@ -61,7 +65,13 @@ internal static partial class Interop
                 {
                     SelectPalette(HDC, HPalette, bForceBkgd: BOOL.FALSE);
                 }
+
+                DisposalTracking.SuppressFinalize(this);
             }
+
+#if DEBUG
+            public SelectPaletteScope() { }
+#endif
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.SelectionScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.SelectionScope.cs
@@ -16,7 +16,11 @@ internal static partial class Interop
         ///  Use in a <see langword="using" /> statement. If you must pass this around, always pass
         ///  by <see langword="ref" /> to avoid duplicating the handle and risking a double selection.
         /// </remarks>
+#if DEBUG
+        internal class SelectObjectScope : DisposalTracking.Tracker, IDisposable
+#else
         internal readonly ref struct SelectObjectScope
+#endif
         {
             private readonly HDC _hdc;
             public HGDIOBJ PreviousObject { get; }
@@ -31,7 +35,8 @@ internal static partial class Interop
 
                 if (@object.IsNull)
                 {
-                    this = default;
+                    _hdc = default;
+                    PreviousObject = default;
                 }
                 else
                 {
@@ -46,6 +51,10 @@ internal static partial class Interop
                 {
                     SelectObject(_hdc, PreviousObject);
                 }
+
+#if DEBUG
+                GC.SuppressFinalize(this);
+#endif
             }
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.SetBkModeScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.SetBkModeScope.cs
@@ -16,7 +16,11 @@ internal static partial class Interop
         ///  Use in a <see langword="using" /> statement. If you must pass this around, always pass by
         ///  <see langword="ref" /> to avoid duplicating the handle and resetting multiple times.
         /// </remarks>
+#if DEBUG
+        internal class SetBkModeScope : DisposalTracking.Tracker, IDisposable
+#else
         internal readonly ref struct SetBkModeScope
+#endif
         {
             private readonly BKMODE _previousMode;
             private readonly HDC _hdc;
@@ -38,6 +42,10 @@ internal static partial class Interop
                 {
                     SetBkMode(_hdc, _previousMode);
                 }
+
+#if DEBUG
+                GC.SuppressFinalize(this);
+#endif
             }
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.SetMapModeScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.SetMapModeScope.cs
@@ -17,7 +17,11 @@ internal static partial class Interop
         ///  Use in a <see langword="using" /> statement. If you must pass this around, always pass by
         ///  <see langword="ref" /> to avoid duplicating the handle and resetting multiple times.
         /// </remarks>
+#if DEBUG
+        internal class SetMapModeScope : DisposalTracking.Tracker, IDisposable
+#else
         internal readonly ref struct SetMapModeScope
+#endif
         {
             private readonly MM _previousMapMode;
             private readonly HDC _hdc;
@@ -40,6 +44,10 @@ internal static partial class Interop
                 {
                     SetMapMode(_hdc, _previousMapMode);
                 }
+
+#if DEBUG
+                GC.SuppressFinalize(this);
+#endif
             }
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.SetRop2Scope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.SetRop2Scope.cs
@@ -16,7 +16,11 @@ internal static partial class Interop
         ///  Use in a <see langword="using" /> statement. If you must pass this around, always pass by
         ///  <see langword="ref" /> to avoid duplicating the handle and resetting multiple times.
         /// </remarks>
+#if DEBUG
+        internal class SetRop2Scope : DisposalTracking.Tracker, IDisposable
+#else
         internal readonly ref struct SetRop2Scope
+#endif
         {
             private readonly R2 _previousRop;
             private readonly HDC _hdc;
@@ -38,6 +42,10 @@ internal static partial class Interop
                 {
                     SetROP2(_hdc, _previousRop);
                 }
+
+#if DEBUG
+                GC.SuppressFinalize(this);
+#endif
             }
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.SetTextAlignmentScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.SetTextAlignmentScope.cs
@@ -16,7 +16,11 @@ internal static partial class Interop
         ///  Use in a <see langword="using" /> statement. If you must pass this around, always pass by
         ///  <see langword="ref" /> to avoid duplicating the handle and resetting multiple times.
         /// </remarks>
+#if DEBUG
+        internal class SetTextAlignmentScope : DisposalTracking.Tracker, IDisposable
+#else
         internal readonly ref struct SetTextAlignmentScope
+#endif
         {
             private readonly TA _previousTa;
             private readonly HDC _hdc;
@@ -38,6 +42,10 @@ internal static partial class Interop
                 {
                     SetTextAlign(_hdc, _previousTa);
                 }
+
+#if DEBUG
+                GC.SuppressFinalize(this);
+#endif
             }
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.SetTextColorScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.SetTextColorScope.cs
@@ -17,7 +17,11 @@ internal static partial class Interop
         ///  Use in a <see langword="using" /> statement. If you must pass this around, always pass by
         ///  <see langword="ref" /> to avoid duplicating the handle and resetting multiple times.
         /// </remarks>
+#if DEBUG
+        internal class SetTextColorScope : DisposalTracking.Tracker, IDisposable
+#else
         internal readonly ref struct SetTextColorScope
+#endif
         {
             private readonly int _previousColor;
             private readonly HDC _hdc;
@@ -41,6 +45,10 @@ internal static partial class Interop
                 {
                     SetTextColor(_hdc, _previousColor);
                 }
+
+#if DEBUG
+                GC.SuppressFinalize(this);
+#endif
             }
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.BeginPaintScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.BeginPaintScope.cs
@@ -15,7 +15,11 @@ internal static partial class Interop
         ///  Use in a <see langword="using" /> statement. If you must pass this around, always pass
         ///  by <see langword="ref" /> to avoid duplicating the handle and risking a double EndPaint.
         /// </remarks>
-        public readonly ref struct BeginPaintScope
+#if DEBUG
+        internal class BeginPaintScope : DisposalTracking.Tracker, IDisposable
+#else
+        internal readonly ref struct BeginPaintScope
+#endif
         {
             public readonly PAINTSTRUCT _paintStruct;
 
@@ -42,6 +46,8 @@ internal static partial class Interop
                         EndPaint(HWND, ps);
                     }
                 }
+
+                DisposalTracking.SuppressFinalize(this);
             }
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Interop/UxTheme/Interop.OpenThemeDataScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UxTheme/Interop.OpenThemeDataScope.cs
@@ -15,7 +15,11 @@ internal static partial class Interop
         ///  Use in a <see langword="using" /> statement. If you must pass this around, always pass by
         ///  <see langword="ref" /> to avoid duplicating the handle and risking a double close.
         /// </remarks>
-        public readonly ref struct OpenThemeDataScope
+#if DEBUG
+        internal class OpenThemeDataScope : DisposalTracking.Tracker, IDisposable
+#else
+        internal readonly ref struct OpenThemeDataScope
+#endif
         {
             public IntPtr HTheme { get; }
 
@@ -37,6 +41,8 @@ internal static partial class Interop
                 {
                     CloseThemeData(HTheme);
                 }
+
+                DisposalTracking.SuppressFinalize(this);
             }
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/DisposalTracking.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/DisposalTracking.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace System
+{
+    internal static class DisposalTracking
+    {
+        /// <summary>
+        ///  Used to suppress finalization in debug builds only.
+        /// </summary>
+        /// <remarks>
+        ///  Unfortunately this can only be used when there is a single implicit conversion operator when called from
+        ///  a ref struct. C# tries to cast to anything that fits in object, which leads to an ambiguous error.
+        ///
+        ///  You need to add GC.SuppressFinalize under #ifdef when you don't have a single implicit conversion.
+        /// </remarks>
+        [Conditional("DEBUG")]
+        public static void SuppressFinalize(object @object)
+        {
+            GC.SuppressFinalize(@object);
+        }
+
+        /// <summary>
+        ///  Helper base class for tracking undisposed objects.
+        /// </summary>
+        /// <remarks>
+        ///  Fires if <see cref="GC.SuppressFinalize(object)"/> is not called on the class and the class is finalized.
+        ///  As such you must suppress finalization when disposing to "signal" that you've been disposed properly.
+        ///
+        ///  The debug only static <see cref="SuppressFinalize(object)"/> can be called when you only derive from this
+        ///  class in debug builds.
+        /// </remarks>
+        internal abstract class Tracker
+        {
+            private readonly string _originatingStack = new StackTrace().ToString();
+
+            ~Tracker()
+            {
+                Debug.Fail($"Did not dispose {GetType().Name}. Originating stack:\n{_originatingStack}");
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonBaseAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonBaseAdapter.cs
@@ -1361,13 +1361,11 @@ namespace System.Windows.Forms.ButtonInternal
                 if (useCompatibleTextRendering)
                 {
                     // GDI+ text rendering.
-                    using (var screen = GdiCache.GetScreenDCGraphics())
-                    using (StringFormat gdipStringFormat = StringFormat)
-                    {
-                        textSize = Size.Ceiling(
-                            screen.Graphics.MeasureString(text, font, new SizeF(proposedSize.Width, proposedSize.Height),
-                            gdipStringFormat));
-                    }
+                    using var screen = GdiCache.GetScreenDCGraphics();
+                    using StringFormat gdipStringFormat = StringFormat;
+                    textSize = Size.Ceiling(
+                        screen.Graphics.MeasureString(text, font, new SizeF(proposedSize.Width, proposedSize.Height),
+                        gdipStringFormat));
                 }
                 else if (!string.IsNullOrEmpty(text))
                 {
@@ -1490,10 +1488,8 @@ namespace System.Windows.Forms.ButtonInternal
             {
                 if (layout.useCompatibleTextRendering)
                 {
-                    using (StringFormat format = Control.CreateStringFormat())
-                    {
-                        layout.StringFormat = format;
-                    }
+                    using StringFormat format = Control.CreateStringFormat();
+                    layout.StringFormat = format;
                 }
                 else
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -3836,7 +3836,7 @@ namespace System.Windows.Forms
 
                         // Call the base class to do its painting (with a clipped DC).
                         bool useBeginPaint = m.WParam == IntPtr.Zero;
-                        var paintScope = useBeginPaint ? new BeginPaintScope(Handle) : default;
+                        using var paintScope = useBeginPaint ? new BeginPaintScope(Handle) : default;
 
                         Gdi32.HDC dc = useBeginPaint ? paintScope : (Gdi32.HDC)m.WParam;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -8195,16 +8195,13 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Inheriting classes should override this method to handle the erase
-        ///  background request from windows. It is not necessary to call
-        ///  base.onPaintBackground, however if you do not want the default
-        ///  Windows behavior you must set event.handled to true.
+        ///  Inheriting classes should override this method to handle the erase background request from windows. It is
+        ///  not necessary to call base.OnPaintBackground.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected virtual void OnPaintBackground(PaintEventArgs pevent)
         {
-            // We need the true client rectangle as clip rectangle causes
-            // problems on "Windows Classic" theme.
+            // We need the true client rectangle as clip rectangle causes problems on "Windows Classic" theme.
             RECT rect = new RECT();
             User32.GetClientRect(new HandleRef(_window, InternalHandle), ref rect);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -2922,31 +2922,29 @@ namespace System.Windows.Forms
                         {
                             DataGridViewCellStyle dataGridViewCellStyle = GetInheritedStyle(null, rowIndex, false);
 
-                            using (var screen = GdiCache.GetScreenDCGraphics())
+                            using var screen = GdiCache.GetScreenDCGraphics();
+                            Rectangle contentBounds = GetContentBounds(screen, dataGridViewCellStyle, rowIndex);
+
+                            bool widthTruncated = false;
+                            int preferredHeight = 0;
+                            if (contentBounds.Width > 0)
                             {
-                                Rectangle contentBounds = GetContentBounds(screen, dataGridViewCellStyle, rowIndex);
+                                preferredHeight = GetPreferredTextHeight(
+                                    screen,
+                                    DataGridView.RightToLeftInternal,
+                                    stringValue,
+                                    dataGridViewCellStyle,
+                                    contentBounds.Width,
+                                    out widthTruncated);
+                            }
+                            else
+                            {
+                                widthTruncated = true;
+                            }
 
-                                bool widthTruncated = false;
-                                int preferredHeight = 0;
-                                if (contentBounds.Width > 0)
-                                {
-                                    preferredHeight = GetPreferredTextHeight(
-                                        screen,
-                                        DataGridView.RightToLeftInternal,
-                                        stringValue,
-                                        dataGridViewCellStyle,
-                                        contentBounds.Width,
-                                        out widthTruncated);
-                                }
-                                else
-                                {
-                                    widthTruncated = true;
-                                }
-
-                                if (preferredHeight > contentBounds.Height || widthTruncated)
-                                {
-                                    toolTipText = TruncateToolTipText(stringValue);
-                                }
+                            if (preferredHeight > contentBounds.Height || widthTruncated)
+                            {
+                                toolTipText = TruncateToolTipText(stringValue);
                             }
                         }
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
@@ -1870,16 +1870,16 @@ namespace System.Windows.Forms
                         cellBounds,
                         rowIndex,
                         cellState,
-                        null /*formattedValue*/,            // dropDownButtonRect is independent of formattedValue
-                        null /*errorText*/,                 // dropDownButtonRect is independent of errorText
+                        formattedValue: null,            // dropDownButtonRect is independent of formattedValue
+                        errorText: null,                 // dropDownButtonRect is independent of errorText
                         cellStyle,
                         dgvabsEffective,
                         out dropDownButtonRect,
                         DataGridViewPaintParts.ContentForeground,
-                        false /*computeContentBounds*/,
-                        false /*computeErrorIconBounds*/,
-                        true  /*computeDropDownButtonRect*/,
-                        false /*paint*/);
+                        computeContentBounds: false,
+                        computeErrorIconBounds: false,
+                        computeDropDownButtonRect: true,
+                        paint: false);
                 }
 
                 bool newMouseInDropDownButtonBounds = dropDownButtonRect.Contains(DataGridView.PointToClient(Control.MousePosition));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxCell.cs
@@ -249,10 +249,8 @@ namespace System.Windows.Forms
                     }
                     TextFormatFlags flags = DataGridViewUtilities.ComputeTextFormatFlagsForCellStyleAlignment(DataGridView.RightToLeftInternal, cellStyle.Alignment, cellStyle.WrapMode);
 
-                    using (var screen = GdiCache.GetScreenDCGraphics())
-                    {
-                        preferredHeight = MeasureTextHeight(screen, editedFormattedValue, cellStyle.Font, originalWidth, flags);
-                    }
+                    using var screen = GdiCache.GetScreenDCGraphics();
+                    preferredHeight = MeasureTextHeight(screen, editedFormattedValue, cellStyle.Font, originalWidth, flags);
                 }
                 if (preferredHeight < editingControlBounds.Height)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
@@ -127,15 +127,15 @@ namespace System.Windows.Forms
             Gdi32.HBITMAP hBitmap = bm.GetHBITMAP();
 
             // Create a compatible DC to render the source bitmap.
-            var sourceDC = new Gdi32.CreateDcScope(screenDC);
-            var sourceBitmapSelection = new Gdi32.SelectObjectScope(sourceDC, hBitmap);
+            using var sourceDC = new Gdi32.CreateDcScope(screenDC);
+            using var sourceBitmapSelection = new Gdi32.SelectObjectScope(sourceDC, hBitmap);
 
             // Create a compatible DC and a new compatible bitmap.
-            var destinationDC = new Gdi32.CreateDcScope(screenDC);
+            using var destinationDC = new Gdi32.CreateDcScope(screenDC);
             Gdi32.HBITMAP bitmap = Gdi32.CreateCompatibleBitmap(screenDC, bm.Size.Width, bm.Size.Height);
 
             // Select the new bitmap into a compatible DC and render the blt the original bitmap.
-            var destinationBitmapSelection = new Gdi32.SelectObjectScope(destinationDC, bitmap);
+            using var destinationBitmapSelection = new Gdi32.SelectObjectScope(destinationDC, bitmap);
             Gdi32.BitBlt(
                 destinationDC,
                 0,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Internal/DrawingEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Internal/DrawingEventArgs.cs
@@ -96,6 +96,8 @@ namespace System.Windows.Forms
                     forceBackground: false,
                     realizePalette: false);
 
+                GC.SuppressFinalize(palleteScope);
+
                 _oldPalette = palleteScope.HPalette;
 
                 _graphics = Graphics.FromHdcInternal((IntPtr)_hdc);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Internal/GdiCache.ScreenGraphicsScope.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Internal/GdiCache.ScreenGraphicsScope.cs
@@ -12,7 +12,11 @@ namespace System.Windows.Forms
         ///  Scope that creates a wrapping <see cref="Drawing.Graphics"/> for a <see cref="ScreenDcCache.ScreenDcScope"/>
         ///  and manages disposal of the <see cref="Drawing.Graphics"/> and the scope.
         /// </summary>
+#if DEBUG
+        internal class ScreenGraphicsScope : DisposalTracking.Tracker, IDisposable
+#else
         internal readonly ref struct ScreenGraphicsScope
+#endif
         {
             private readonly ScreenDcCache.ScreenDcScope _dcScope;
             public Graphics Graphics { get; }
@@ -29,6 +33,7 @@ namespace System.Windows.Forms
             {
                 Graphics?.Dispose();
                 _dcScope.Dispose();
+                DisposalTracking.SuppressFinalize(this!);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Internal/ScreenDcCache.ScreenDcScope.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Internal/ScreenDcCache.ScreenDcScope.cs
@@ -11,7 +11,12 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Scope to ensure return of the device context back to the cache.
         /// </summary>
-        public readonly ref struct ScreenDcScope
+        ///
+#if DEBUG
+        internal class ScreenDcScope : DisposalTracking.Tracker, IDisposable
+#else
+        internal readonly ref struct ScreenDcScope
+#endif
         {
             public Gdi32.HDC HDC { get; }
             private readonly ScreenDcCache _cache;
@@ -27,6 +32,7 @@ namespace System.Windows.Forms
             public void Dispose()
             {
                 _cache.Release(HDC);
+                DisposalTracking.SuppressFinalize(this!);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Internal/ScreenDcCache.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Internal/ScreenDcCache.cs
@@ -144,6 +144,8 @@ namespace System.Windows.Forms
             Gdi32.GetViewportOrgEx(hdc, out Point point);
             Debug.Assert(point.IsEmpty, "Viewport origin shouldn't be shifted");
             Debug.Assert(Gdi32.GetMapMode(hdc) == Gdi32.MM.TEXT);
+            Debug.Assert(Gdi32.GetROP2(hdc) == Gdi32.R2.COPYPEN);
+            Debug.Assert(Gdi32.GetBkMode(hdc) == Gdi32.BKMODE.OPAQUE);
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
@@ -1216,13 +1216,12 @@ namespace System.Windows.Forms
             if (string.IsNullOrEmpty(Text))
             {
                 // empty labels return the font height + borders
-                using (var hfont = GdiCache.GetHFONT(Font))
-                using (var screen = GdiCache.GetScreenHdc())
-                {
-                    // this is the character that Windows uses to determine the extent
-                    requiredSize = screen.HDC.GetTextExtent("0", hfont);
-                    requiredSize.Width = 0;
-                }
+                using var hfont = GdiCache.GetHFONT(Font);
+                using var screen = GdiCache.GetScreenHdc();
+
+                // this is the character that Windows uses to determine the extent
+                requiredSize = screen.HDC.GetTextExtent("0", hfont);
+                requiredSize.Width = 0;
             }
             else if (UseGDIMeasuring())
             {
@@ -1232,15 +1231,13 @@ namespace System.Windows.Forms
             else
             {
                 // GDI+ rendering.
-                using (var screen = GdiCache.GetScreenDCGraphics())
-                using (StringFormat stringFormat = CreateStringFormat())
-                {
-                    SizeF bounds = (proposedConstraints.Width == 1) ?
-                        new SizeF(0, proposedConstraints.Height) :
-                        new SizeF(proposedConstraints.Width, proposedConstraints.Height);
+                using var screen = GdiCache.GetScreenDCGraphics();
+                using StringFormat stringFormat = CreateStringFormat();
+                SizeF bounds = (proposedConstraints.Width == 1) ?
+                    new SizeF(0, proposedConstraints.Height) :
+                    new SizeF(proposedConstraints.Width, proposedConstraints.Height);
 
-                    requiredSize = Size.Ceiling(screen.Graphics.MeasureString(Text, Font, bounds, stringFormat));
-                }
+                requiredSize = Size.Ceiling(screen.Graphics.MeasureString(Text, Font, bounds, stringFormat));
             }
 
             requiredSize += bordersAndPadding;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ProfessionalColorTable.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ProfessionalColorTable.cs
@@ -338,20 +338,18 @@ namespace System.Windows.Forms
             // FromARGB here. So we have a simple function which calculates the blending for us.
             if (!DisplayInformation.LowResolution)
             {
-                using (var screen = GdiCache.GetScreenDCGraphics())
-                {
-                    rgbTable[KnownColors.ButtonPressedHighlight] = GetAlphaBlendedColor(
-                        screen,
-                        SystemColors.Window,
-                        GetAlphaBlendedColor(screen, SystemColors.Highlight, SystemColors.Window, 160),
-                        50);
-                    rgbTable[KnownColors.ButtonCheckedHighlight] = GetAlphaBlendedColor(
-                        screen,
-                        SystemColors.Window,
-                        GetAlphaBlendedColor(screen, SystemColors.Highlight, SystemColors.Window, 80),
-                        20);
-                    rgbTable[KnownColors.ButtonSelectedHighlight] = rgbTable[KnownColors.ButtonCheckedHighlight];
-                }
+                using var screen = GdiCache.GetScreenDCGraphics();
+                rgbTable[KnownColors.ButtonPressedHighlight] = GetAlphaBlendedColor(
+                    screen,
+                    SystemColors.Window,
+                    GetAlphaBlendedColor(screen, SystemColors.Highlight, SystemColors.Window, 160),
+                    50);
+                rgbTable[KnownColors.ButtonCheckedHighlight] = GetAlphaBlendedColor(
+                    screen,
+                    SystemColors.Window,
+                    GetAlphaBlendedColor(screen, SystemColors.Highlight, SystemColors.Window, 80),
+                    20);
+                rgbTable[KnownColors.ButtonSelectedHighlight] = rgbTable[KnownColors.ButtonCheckedHighlight];
             }
             else
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBox.ObjectCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBox.ObjectCollectionTests.cs
@@ -2197,6 +2197,9 @@ namespace System.Windows.Forms.Tests
         [InlineData(-2)]
         public void ListBoxObjectCollection_Add_ErrorAdding_ThrowsOutOfMemoryException(int result)
         {
+            // Note that this is not an actual out of memory, we're artificially setting up an error case
+            // that we surface as `OutOfMemoryException` (see ListBox.NativeAdd(Object item))
+
             using var owner = new CustomAddStringListBox
             {
                 AddStringResult = (IntPtr)result
@@ -3666,6 +3669,9 @@ namespace System.Windows.Forms.Tests
         [InlineData(-2)]
         public void ListBoxObjectCollection_AddRange_ErrorAdding_ThrowsOutOfMemoryException(int result)
         {
+            // Note that this is not an actual out of memory, we're artificially setting up an error case
+            // that we surface as `OutOfMemoryException` (see ListBox.NativeAdd(Object item))
+
             using var owner = new CustomAddStringListBox
             {
                 AddStringResult = (IntPtr)result
@@ -3675,6 +3681,7 @@ namespace System.Windows.Forms.Tests
             using var otherOwner = new ListBox();
             var otherCollection = new ListBox.ObjectCollection(otherOwner);
             otherCollection.Add(1);
+
             Assert.Throws<OutOfMemoryException>(() => collection.AddRange(new object[] { 1 }));
             Assert.Throws<OutOfMemoryException>(() => collection.AddRange(otherCollection));
         }
@@ -5010,6 +5017,9 @@ namespace System.Windows.Forms.Tests
         [InlineData(-2)]
         public void ListBoxObjectCollection_Insert_ErrorAdding_ThrowsOutOfMemoryException(int result)
         {
+            // Note that this is not an actual out of memory, we're artificially setting up an error case
+            // that we surface as `OutOfMemoryException` (see ListBox.NativeAdd(Object item))
+
             using var owner = new CustomInsertStringListBox
             {
                 InsertStringResult = (IntPtr)result
@@ -8948,6 +8958,9 @@ namespace System.Windows.Forms.Tests
         [InlineData(-2)]
         public void ListBoxObjectCollection_IListAdd_ErrorAdding_ThrowsOutOfMemoryException(int result)
         {
+            // Note that this is not an actual out of memory, we're artificially setting up an error case
+            // that we surface as `OutOfMemoryException` (see ListBox.NativeAdd(Object item))
+
             using var owner = new CustomAddStringListBox
             {
                 AddStringResult = (IntPtr)result
@@ -10288,6 +10301,9 @@ namespace System.Windows.Forms.Tests
         [InlineData(-2)]
         public void ListBoxObjectCollection_IListInsert_ErrorAdding_ThrowsOutOfMemoryException(int result)
         {
+            // Note that this is not an actual out of memory, we're artificially setting up an error case
+            // that we surface as `OutOfMemoryException` (see ListBox.NativeAdd(Object item))
+
             using var owner = new CustomInsertStringListBox
             {
                 InsertStringResult = (IntPtr)result


### PR DESCRIPTION
In debug builds makes scopes classes instead of ref structs so we can track when we fail to close scopes.

Found a few places we were leaking and fixed them. Finally got annoyed enough to make CreateHBitmap16Bit not use native memory (as I had to change the HDC usage).

Simplified some usings (for easier review when finding all references). Fixed a few comments as I walked through the callers. Also added a few more screen dc cache validation steps.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3653)