### PR TITLE
Fix rendering text with a transparent background

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.GetBkColor.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.GetBkColor.cs
@@ -4,20 +4,12 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Windows.Forms;
 
 internal static partial class Interop
 {
     internal static partial class Gdi32
     {
         [DllImport(Libraries.Gdi32, ExactSpelling = true)]
-        public static extern int GetBkColor(HDC hdc);
-
-        public static int GetBkColor(IHandle hdc)
-        {
-            int result = GetBkColor((HDC)hdc.Handle);
-            GC.KeepAlive(hdc);
-            return result;
-        }
+        public static extern COLORREF GetBkColor(HDC hdc);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.GetBrushOrgEx.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.GetBrushOrgEx.cs
@@ -3,14 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Drawing;
 using System.Runtime.InteropServices;
-using System.Windows.Forms;
 
 internal static partial class Interop
 {
     internal static partial class Gdi32
     {
         [DllImport(Libraries.Gdi32, ExactSpelling = true)]
-        public static extern TA SetTextAlign(Gdi32.HDC hdc, TA align);
+        public static extern BOOL GetBrushOrgEx(HDC hdc, ref Point lppt);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.GetTextAlign.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.GetTextAlign.cs
@@ -4,18 +4,17 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Windows.Forms;
 
 internal static partial class Interop
 {
     internal static partial class Gdi32
     {
         [DllImport(Libraries.Gdi32, ExactSpelling = true)]
-        public static extern TA GetTextAlign(IntPtr hdc);
+        public static extern TA GetTextAlign(HDC hdc);
 
         public static TA GetTextAlign(IHandle hdc)
         {
-            TA result = GetTextAlign(hdc.Handle);
+            TA result = GetTextAlign((HDC)hdc.Handle);
             GC.KeepAlive(hdc);
             return result;
         }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.GetTextColor.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.GetTextColor.cs
@@ -4,20 +4,12 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Windows.Forms;
 
 internal static partial class Interop
 {
     internal static partial class Gdi32
     {
         [DllImport(Libraries.Gdi32, ExactSpelling = true)]
-        public static extern int GetTextColor(HDC hdc);
-
-        public static int GetTextColor(IHandle hdc)
-        {
-            int result = GetTextColor((HDC)hdc.Handle);
-            GC.KeepAlive(hdc);
-            return result;
-        }
+        public static extern COLORREF GetTextColor(HDC hdc);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EXTLOGFONTW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EXTLOGFONTW.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public unsafe struct EXTLOGFONTW
+        {
+            public const int LF_FULLFACESIZE = 64;
+            public const int ELF_VENDOR_SIZE = 4;
+
+            public LOGFONTW elfLogFont;
+            private fixed char _elfFullName[LF_FULLFACESIZE];
+            private fixed char _elfStyle[LOGFONTW.LF_FACESIZE];
+            public uint elfVersion;
+            public uint elfStyleSize;
+            public uint elfMatch;
+            public uint elfReserved;
+            public fixed char _elfVendorId[ELF_VENDOR_SIZE];
+            public uint elfCulture;
+            public PANOSE elfPanose;
+
+            public ReadOnlySpan<char> elfFullName
+            {
+                get { fixed (char* c = _elfFullName) { return new Span<char>(c, LF_FULLFACESIZE).SliceAtFirstNull(); } }
+            }
+
+            public ReadOnlySpan<char> elfStyle
+            {
+                get { fixed (char* c = _elfStyle) { return new Span<char>(c, LOGFONTW.LF_FACESIZE).SliceAtFirstNull(); } }
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.LOGFONTW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.LOGFONTW.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Drawing;
 using System.Runtime.InteropServices;
-using System.Windows.Forms;
 
 internal static partial class Interop
 {
@@ -14,7 +13,7 @@ internal static partial class Interop
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
         public unsafe struct LOGFONTW
         {
-            private const int LF_FACESIZE = 32;
+            public const int LF_FACESIZE = 32;
 
             public int lfHeight;
             public int lfWidth;

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.PANOSE.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.PANOSE.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        public struct PANOSE
+        {
+            public byte bFamilyType;
+            public byte bSerifStyle;
+            public byte bWeight;
+            public byte bProportion;
+            public byte bContrast;
+            public byte bStrokeVariation;
+            public byte bArmStyle;
+            public byte bLetterform;
+            public byte bMidline;
+            public byte bXHeight;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/SpanHelpers.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/SpanHelpers.cs
@@ -4,7 +4,7 @@
 
 using System.Diagnostics;
 
-namespace System.Windows.Forms
+namespace System
 {
     internal static class SpanHelpers
     {

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/DeviceContextState.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/DeviceContextState.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using static Interop;
+
+namespace System
+{
+    /// <summary>
+    ///  Holder for tracking HDC state.
+    /// </summary>
+    internal unsafe class DeviceContextState
+    {
+        // Not all state is handled yet. Backfilling in as we write specific tests. Of special note is that we don't
+        // have tracking for Save/RestoreDC yet.
+
+        /// <summary>
+        ///  Initialize the current state of <paramref name="hdc"/>.
+        /// </summary>
+        public DeviceContextState(Gdi32.HDC hdc)
+        {
+            MapMode = Gdi32.GetMapMode(hdc);
+            BackColor = Gdi32.GetBkColor(hdc);
+            TextColor = Gdi32.GetTextColor(hdc);
+            Point point = default;
+            Gdi32.GetBrushOrgEx(hdc, ref point);
+            BrushOrigin = point;
+            TextAlign = Gdi32.GetTextAlign(hdc);
+            BackgroundMode = Gdi32.GetBkMode(hdc);
+        }
+
+        public Gdi32.MM MapMode { get; set; }
+        public COLORREF BackColor { get; set; }
+        public COLORREF TextColor { get; set; }
+        public Point BrushOrigin { get; set; }
+        public Gdi32.TA TextAlign { get; set; }
+        public Gdi32.BKMODE BackgroundMode { get; set; }
+        public string SelectedFont { get; set; }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/HdcDeviceContextAdapter.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/HdcDeviceContextAdapter.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using static Interop;
+
+namespace System
+{
+    /// <summary>
+    ///  Simple adapter for passing <see cref="Gdi32.HDC"/> as <see cref="IDeviceContext"/>. Does not manage HDC
+    ///  lifetime.
+    /// </summary>
+    internal class HdcDeviceContextAdapter : IDeviceContext
+    {
+        private readonly Gdi32.HDC _hdc;
+
+        public HdcDeviceContextAdapter(Gdi32.HDC hdc) => _hdc = hdc;
+
+        public IntPtr GetHdc() => (IntPtr)_hdc;
+        public void ReleaseHdc() { }
+        public void Dispose() { }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EMRENUMRECORD.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EMRENUMRECORD.cs
@@ -27,6 +27,6 @@ namespace System.Windows.Forms.Metafiles
         public EMR emr;
         public T iMode;
 
-        public override string ToString() => $"[EMR{emr.iType}] Mode: {iMode}";
+        public override string ToString() => $"[EMR{emr.iType}] Mode: {typeof(T).Name}_{iMode}";
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EMREXTCREATEFONTINDIRECTW.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EMREXTCREATEFONTINDIRECTW.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using static Interop;
+
+namespace System.Windows.Forms.Metafiles
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct EMREXTCREATEFONTINDIRECTW
+    {
+        public EMR emr;
+        public uint ihFont;
+        public User32.EXTLOGFONTW elfw;
+
+        public override string ToString()
+            => $@"[{nameof(EMREXTCREATEFONTINDIRECTW)}] Index: {ihFont} FaceName: '{elfw.elfLogFont.FaceName.ToString()
+                }' Height: {elfw.elfLogFont.lfHeight} Weight: FW_{elfw.elfLogFont.lfWeight}";
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EMREXTTEXTOUTW.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EMREXTTEXTOUTW.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using static Interop;
+
+namespace System.Windows.Forms.Metafiles
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct EMREXTTEXTOUTW
+    {
+        public EMR emr;
+        public RECT rclBounds;           // Inclusive-inclusive bounds in device units
+        public GM iGraphicsMode;         // Current graphics mode
+        public float exScale;            // X and Y scales from Page units to .01mm units
+        public float eyScale;            //   if graphics mode is GM_COMPATIBLE.
+        public EMRTEXT emrtext;          // This is followed by the string and spacing
+
+        public override string ToString()
+            => $@"[{nameof(EMREXTTEXTOUTW)}] Bounds: {rclBounds} Text: '{emrtext.GetString().ToString()}'";
+
+        internal enum GM : uint
+        {
+            COMPATIBLE = 0x00000001,
+            ADVANCED = 0x00000002
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EMRTEXT.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EMRTEXT.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using System.Runtime.InteropServices;
+using static Interop;
+
+namespace System.Windows.Forms.Metafiles
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct EMRTEXT
+    {
+        public Point ptlReference;
+        public uint nChars;
+        public uint offString;          // Offset to the string
+        public uint fOptions;
+        public RECT rcl;
+        public uint offDx;              // Offset to the inter-character spacing array.
+
+        public unsafe ReadOnlySpan<char> GetString()
+        {
+            int offset = (int)offString - sizeof(EMREXTTEXTOUTW) + sizeof(EMRTEXT);
+            fixed (Point* p = &ptlReference)
+            {
+                byte* b = (byte*)(void*)p;
+                b += offset;
+                return new ReadOnlySpan<char>((void*)b, (int)nChars);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EmfRecord.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EmfRecord.cs
@@ -6,7 +6,7 @@ using static Interop;
 
 namespace System.Windows.Forms.Metafiles
 {
-    internal unsafe readonly ref struct EmfRecord
+    internal unsafe readonly struct EmfRecord
     {
         public Gdi32.HDC HDC { get; }
         private readonly Gdi32.HGDIOBJ* _lpht;
@@ -81,9 +81,18 @@ namespace System.Windows.Forms.Metafiles
             => Type == Gdi32.EMR.SETTEXTCOLOR ? (EMRSETCOLOR*)_lpmr : null;
         public EMRCREATEDIBPATTERNBRUSHPT* CreateDibPatternBrushPtRecord
             => Type == Gdi32.EMR.CREATEDIBPATTERNBRUSHPT ? (EMRCREATEDIBPATTERNBRUSHPT*)_lpmr : null;
+        public EMRENUMRECORD<Gdi32.TA>* SetTextAlignRecord
+            => Type == Gdi32.EMR.SETTEXTALIGN ? (EMRENUMRECORD<Gdi32.TA>*)_lpmr : null;
+        public EMREXTCREATEFONTINDIRECTW* ExtCreateFontIndirectWRecord
+            => Type == Gdi32.EMR.EXTCREATEFONTINDIRECTW ? (EMREXTCREATEFONTINDIRECTW*)_lpmr : null;
+        public EMREXTTEXTOUTW* ExtTextOutWRecord
+            => Type == Gdi32.EMR.EXTTEXTOUTW ? (EMREXTTEXTOUTW*)_lpmr : null;
+        public EMRENUMRECORD<Gdi32.MM>* SetMapModeRecord
+            => Type == Gdi32.EMR.SETMAPMODE ? (EMRENUMRECORD<Gdi32.MM>*)_lpmr : null;
 
         public override string ToString() => Type switch
         {
+            // Note that not all records have special handling yet- we're filling these in as we go.
             Gdi32.EMR.HEADER => HeaderRecord->ToString(),
             Gdi32.EMR.EXTSELECTCLIPRGN => ExtSelectClipRgnRecord->ToString(),
             Gdi32.EMR.SETVIEWPORTORGEX => SetViewportOrgExRecord->ToString(),
@@ -104,6 +113,10 @@ namespace System.Windows.Forms.Metafiles
             Gdi32.EMR.SETTEXTCOLOR => SetTextColorRecord->ToString(),
             Gdi32.EMR.SETBKCOLOR => SetBkColorRecord->ToString(),
             Gdi32.EMR.CREATEDIBPATTERNBRUSHPT => CreateDibPatternBrushPtRecord->ToString(),
+            Gdi32.EMR.SETTEXTALIGN => SetTextAlignRecord->ToString(),
+            Gdi32.EMR.EXTCREATEFONTINDIRECTW => ExtCreateFontIndirectWRecord->ToString(),
+            Gdi32.EMR.EXTTEXTOUTW => ExtTextOutWRecord->ToString(),
+            Gdi32.EMR.SETMAPMODE => SetMapModeRecord->ToString(),
             _ => $"[EMR{Type}]"
         };
     }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EmfScope.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EmfScope.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using static Interop;
 
@@ -58,6 +60,95 @@ namespace System.Windows.Forms.Metafiles
             }
         }
 
+        public delegate bool ProcessRecordWithStateDelegate(ref EmfRecord record, DeviceContextState state);
+
+        /// <summary>
+        ///  Allows enumerating the metafile records while tracking state. <paramref name="state"/> should be
+        ///  initialized to the metafile DC state before any drawing has begun.
+        /// </summary>
+        public unsafe void EnumerateWithState(ProcessRecordWithStateDelegate enumerator, DeviceContextState state)
+        {
+            List<EmfRecord> gdiObjects = new List<EmfRecord>();
+            Enumerate(stateTracker);
+
+            bool stateTracker(ref EmfRecord record)
+            {
+                int index;
+                switch (record.Type)
+                {
+                    // Not all records are handled yet. Backfilling in as we write specific tests.
+                    case Gdi32.EMR.SETTEXTALIGN:
+                        state.TextAlign = record.SetTextAlignRecord->iMode;
+                        break;
+                    case Gdi32.EMR.SETMAPMODE:
+                        state.MapMode = record.SetMapModeRecord->iMode;
+                        break;
+                    case Gdi32.EMR.SETBKMODE:
+                        state.BackgroundMode = record.SetBkModeRecord->iMode;
+                        break;
+                    case Gdi32.EMR.SETTEXTCOLOR:
+                        state.TextColor = record.SetTextColorRecord->crColor;
+                        break;
+                    case Gdi32.EMR.SETBKCOLOR:
+                        state.BackColor = record.SetBkColorRecord->crColor;
+                        break;
+                    case Gdi32.EMR.MOVETOEX:
+                        state.BrushOrigin = record.MoveToExRecord->point;
+                        break;
+                    case Gdi32.EMR.EXTCREATEFONTINDIRECTW:
+                        index = (int)record.ExtCreateFontIndirectWRecord->ihFont;
+                        AddGdiObject(ref record, index);
+                        break;
+                    case Gdi32.EMR.SELECTOBJECT:
+                        SelectGdiObject((int)record.SelectObjectRecord->index);
+                        break;
+                }
+
+                return enumerator(ref record, state);
+            }
+
+            void AddGdiObject(ref EmfRecord record, int index)
+            {
+                if (gdiObjects.Capacity <= index)
+                {
+                    gdiObjects.Capacity = index + 1;
+                }
+
+                while (gdiObjects.Count <= index)
+                {
+                    gdiObjects.Add(default);
+                }
+
+                gdiObjects[index] = record;
+            }
+
+            void SelectGdiObject(int index)
+            {
+                // WARNING: You can not use fields that index out of the struct's contents here.
+
+                // Not all records are handled yet. Backfilling in as we write specific tests.
+                EmfRecord record = gdiObjects[index];
+                switch (record.Type)
+                {
+                    case Gdi32.EMR.EXTCREATEFONTINDIRECTW:
+                        state.SelectedFont = record.ExtCreateFontIndirectWRecord->elfw.elfLogFont.FaceName.ToString();
+                        break;
+                }
+            }
+        }
+
+        public List<string> RecordsToString()
+        {
+            var strings = new List<string>();
+            Enumerate((ref EmfRecord record) =>
+            {
+                strings.Add(record.ToString());
+                return true;
+            });
+
+            return strings;
+        }
+
         private static unsafe BOOL CallBack(
             Gdi32.HDC hdc,
             Gdi32.HGDIOBJ* lpht,
@@ -65,11 +156,14 @@ namespace System.Windows.Forms.Metafiles
             int nHandles,
             IntPtr data)
         {
+            // Note that the record pointer is *only* valid during the callback
             GCHandle enumeratorHandle = GCHandle.FromIntPtr(data);
             ProcessRecordDelegate enumerator = enumeratorHandle.Target as ProcessRecordDelegate;
             var record = new EmfRecord(hdc, lpht, lpmr, nHandles, data);
             return enumerator(ref record).ToBOOL();
         }
+
+        public static implicit operator Gdi32.HDC(in EmfScope scope) => scope.HDC;
 
         public void Dispose()
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -5880,8 +5880,8 @@ namespace System.Windows.Forms
                         case CDDS.ITEMPREPAINT:
                             {
                                 using Graphics g = nmcd->hdc.CreateGraphics();
-                                Color foreColor = ColorTranslator.FromWin32(Gdi32.GetTextColor(nmcd->hdc));
-                                Color backColor = ColorTranslator.FromWin32(Gdi32.GetBkColor(nmcd->hdc));
+                                Color foreColor = Gdi32.GetTextColor(nmcd->hdc);
+                                Color backColor = Gdi32.GetBkColor(nmcd->hdc);
                                 Font font = GetListHeaderFont();
                                 var e = new DrawListViewColumnHeaderEventArgs(
                                     g,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextRenderer.cs
@@ -21,7 +21,7 @@ namespace System.Windows.Forms
         internal static Size MaxSize { get; } = new Size(int.MaxValue, int.MaxValue);
 
         public static void DrawText(IDeviceContext dc, string? text, Font? font, Point pt, Color foreColor)
-            => DrawTextInternal(dc, text, font, pt, foreColor);
+            => DrawTextInternal(dc, text, font, pt, foreColor, Color.Empty);
 
         public static void DrawText(IDeviceContext dc, string? text, Font? font, Point pt, Color foreColor, Color backColor)
             => DrawTextInternal(dc, text, font, pt, foreColor, backColor);
@@ -33,7 +33,7 @@ namespace System.Windows.Forms
             Point pt,
             Color foreColor,
             TextFormatFlags flags)
-            => DrawTextInternal(dc, text, font, pt, foreColor, flags: GetTextFormatFlags(flags));
+            => DrawTextInternal(dc, text, font, pt, foreColor, Color.Empty, flags: GetTextFormatFlags(flags));
 
         public static void DrawText(
             IDeviceContext dc,
@@ -46,7 +46,7 @@ namespace System.Windows.Forms
             => DrawTextInternal(dc, text, font, pt, foreColor, backColor, flags: GetTextFormatFlags(flags));
 
         public static void DrawText(IDeviceContext dc, string? text, Font? font, Rectangle bounds, Color foreColor)
-            => DrawTextInternal(dc, text, font, bounds, foreColor);
+            => DrawTextInternal(dc, text, font, bounds, foreColor, Color.Empty);
 
         public static void DrawText(
             IDeviceContext dc,
@@ -63,7 +63,7 @@ namespace System.Windows.Forms
             Rectangle bounds,
             Color foreColor,
             TextFormatFlags flags)
-            => DrawTextInternal(dc, text, font, bounds, foreColor, flags: GetTextFormatFlags(flags));
+            => DrawTextInternal(dc, text, font, bounds, foreColor, Color.Empty, flags: GetTextFormatFlags(flags));
 
         public static void DrawText(
             IDeviceContext dc,
@@ -81,7 +81,7 @@ namespace System.Windows.Forms
             Font? font,
             Point pt,
             Color foreColor,
-            Color backColor = default,
+            Color backColor,
             User32.DT flags = User32.DT.DEFAULT)
             => DrawTextInternal(dc, text, font, new Rectangle(pt, MaxSize), foreColor, backColor, flags);
 
@@ -91,7 +91,7 @@ namespace System.Windows.Forms
             Font? font,
             Rectangle bounds,
             Color foreColor,
-            Color backColor = default,
+            Color backColor,
             User32.DT flags = User32.DT.CENTER | User32.DT.VCENTER)
         {
             if (dc is null)
@@ -116,7 +116,7 @@ namespace System.Windows.Forms
             Rectangle bounds,
             Color foreColor,
             TextFormatFlags flags)
-            => DrawTextInternal(e, text, font, bounds, foreColor, flags: GetTextFormatFlags(flags));
+            => DrawTextInternal(e, text, font, bounds, foreColor, Color.Empty, flags: GetTextFormatFlags(flags));
 
         internal static void DrawTextInternal(
             PaintEventArgs e,
@@ -124,7 +124,7 @@ namespace System.Windows.Forms
             Font? font,
             Rectangle bounds,
             Color foreColor,
-            Color backColor = default,
+            Color backColor,
             User32.DT flags = User32.DT.CENTER | User32.DT.VCENTER)
         {
             Gdi32.HDC hdc = e.HDC;
@@ -150,7 +150,7 @@ namespace System.Windows.Forms
             Color foreColor,
             Gdi32.QUALITY fontQuality,
             TextFormatFlags flags)
-            => DrawTextInternal(hdc, text, font, bounds, foreColor, fontQuality, default, GetTextFormatFlags(flags));
+            => DrawTextInternal(hdc, text, font, bounds, foreColor, fontQuality, Color.Empty, GetTextFormatFlags(flags));
 
         internal static void DrawTextInternal(
             Gdi32.HDC hdc,


### PR DESCRIPTION
`(Color)default` is not the same as `Color.Empty`. `Color.Empty` is used to determine that we should not be writing opaque. Adds regression test.

This change starts introducing another layer on the metafile parsing to allow accumulating state. It also adds additional records.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3657)