### PR TITLE
Fix porting regression in ToolStripDropDown

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
@@ -969,15 +969,11 @@ namespace System.Windows.Forms
             set => base.Visible = value;
         }
 
-        // internally we use not so we don't have to initialize it.
+        // internally we store the negated value so we don't have to initialize it.
         internal bool WorkingAreaConstrained
         {
-            get => true;
-            set
-            {
-                bool notConstrained = !value;
-                state[stateNotWorkingAreaConstrained] = !value;
-            }
+            get => !state[stateNotWorkingAreaConstrained];
+            set => state[stateNotWorkingAreaConstrained] = !value;
         }
 
         internal void AssignToDropDownItem()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripDropDownTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripDropDownTests.cs
@@ -4912,6 +4912,22 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, actual);
         }
 
+        [WinFormsFact]
+        public void ToolStripDropDown_WorkingAreaConstrained_DefaultValueTest()
+        {
+            using var control = new ToolStripDropDown();
+            Assert.True(control.WorkingAreaConstrained);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void ToolStripDropDown_WorkingAreaConstrained_AssignmentTest(bool value)
+        {
+            using var control = new ToolStripDropDown();
+            control.WorkingAreaConstrained = value;
+            Assert.Equal(value, control.WorkingAreaConstrained);
+        }
+
         private class SubAxHost : AxHost
         {
             public SubAxHost(string clsid) : base(clsid)


### PR DESCRIPTION
Fixes #2058

## Proposed changes

- Fix porting regression. Context menus for NotifyIcon are allowed to cover the taskbar, the corresponding property stored the setting but did not read it out.

## Customer Impact

- Allow context menus for taskbar icons to cover the taskbar (instead of getting shifted off the taskbar)

## Regression? 

- Yes

## Risk

- Minimal. The property was internal and only set by `NotifyIcon` caller.

## Screenshots

### Before

- context menu for NotifyIcon is moved off the taskbar and does not appear where the user clicked

![grafik](https://user-images.githubusercontent.com/5845814/88842292-8d7e5380-d1df-11ea-8f8a-808449251843.png)

### After

- context menu for NotifyIcon is allowed to cover the taskbar, depending where the user clicked (same as Desktop Framework)

![grafik](https://user-images.githubusercontent.com/5845814/88842445-c1f20f80-d1df-11ea-8fcf-2df9359c03a1.png)

## Test methodology <!-- How did you ensure quality? -->

- added unit test to verify the property returns the value stored in it (test fails without fix)
- manual testing to verify the reported behavior was fixed (cannot automate this test as it requires nontrivial user interaction to ensure the icon is actually shown in a location where the behaviore can be reproduced reliably)

For the manual test the following code was added to a new projects form. In addition the taskbar must be manually reconfigured to allow the icon to appear in the taskbar (by default it appears in the popup so the click position may already be off the taskbar)
```csharp
components ??= new System.ComponentModel.Container();
var ni = new NotifyIcon(components);
ni.ContextMenuStrip = new ContextMenuStrip
{
    Items =
    {
        new ToolStripButton("Hello"),
        new ToolStripButton("World"),
    }
};
ni.Icon = SystemIcons.Application;
ni.Visible = true;
```


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3665)