### PR TITLE
Throw if we're given a null HDC in a message.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Internal/DrawingEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Internal/DrawingEventArgs.cs
@@ -53,6 +53,14 @@ namespace System.Windows.Forms
             if (dc.IsNull)
                 throw new ArgumentNullException(nameof(dc));
 
+#if DEBUG
+            Gdi32.OBJ type = Gdi32.GetObjectType(dc);
+            Debug.Assert(type == Gdi32.OBJ.DC
+                || type == Gdi32.OBJ.ENHMETADC
+                || type == Gdi32.OBJ.MEMDC
+                || type == Gdi32.OBJ.METADC);
+#endif
+
             _hdc = dc;
             _graphics = null;
             _oldPalette = default;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Internal/DrawingEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Internal/DrawingEventArgs.cs
@@ -50,6 +50,9 @@ namespace System.Windows.Forms
             Rectangle clipRect,
             DrawingEventFlags flags)
         {
+            if (dc.IsNull)
+                throw new ArgumentNullException(nameof(dc));
+
             _hdc = dc;
             _graphics = null;
             _oldPalette = default;


### PR DESCRIPTION
If we try to create a `Graphics` object from it we'll get an `OutOfMemoryException` which is not actually what is happening- GDI+ just reports that whenever you don't pass a valid HDC. Throwing when we see this so we don't chase down the wrong rabbit hole.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3668)