### PR TITLE
[Port to 3.1 servicing] Fix regression in accessible name for data-bound combo box items

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -4867,7 +4867,7 @@ namespace System.Windows.Forms
                 {
                     if (_owningComboBox != null)
                     {
-                        return _owningItem.ToString();
+                        return _owningComboBox.GetItemText(_owningItem);
                     }
 
                     return base.Name;
@@ -5048,15 +5048,15 @@ namespace System.Windows.Forms
                     {
                         return false;
                     }
+
                     return true;
                 }
-                else
+
+                if (patternId == NativeMethods.UIA_ValuePatternId)
                 {
-                    if (patternId == NativeMethods.UIA_ValuePatternId)
-                    {
-                        return true;
-                    }
+                    return true;
                 }
+
                 return base.IsPatternSupported(patternId);
             }
 
@@ -5075,6 +5075,7 @@ namespace System.Windows.Forms
                         runtimeId[0] = RuntimeIDFirstItem;
                         runtimeId[1] = (int)(long)_owningComboBox.Handle;
                         runtimeId[2] = _owningComboBox.GetHashCode();
+
                         return runtimeId;
                     }
 
@@ -5108,10 +5109,8 @@ namespace System.Windows.Forms
                 {
                     return Name;
                 }
-                else
-                {
-                    return base.get_accNameInternal(childID);
-                }
+
+                return base.get_accNameInternal(childID);
             }
 
             internal override string get_accKeyboardShortcutInternal(object childID)
@@ -5121,10 +5120,8 @@ namespace System.Windows.Forms
                 {
                     return KeyboardShortcut;
                 }
-                else
-                {
-                    return base.get_accKeyboardShortcutInternal(childID);
-                }
+
+                return base.get_accKeyboardShortcutInternal(childID);
             }
 
             /// <summary>

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/Person.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/Person.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.IntegrationTests.Common
+{
+    public class Person
+    {
+        public Person(int id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/TestDataSources.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/TestDataSources.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace System.Windows.Forms.IntegrationTests.Common
+{
+    public static class TestDataSources
+    {
+        public static List<Person> GetPersons()
+            => new List<Person>()
+            {
+                new Person(1, "Name 1"),
+                new Person(2, "Name 2"),
+                new Person(3, "Name 3"),
+                new Person(4, "Name 4"),
+                new Person(5, "Name 5"),
+            };
+
+        public const string PersonDisplayMember = "Name";
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests/System.Windows.Forms.IntegrationTests.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests/System.Windows.Forms.IntegrationTests.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\System.Windows.Forms.csproj" />
-    <ProjectReference Include="..\System.Windows.Forms.IntegrationTests.Common\System.Windows.Forms.IntegrationTests.Common.csproj" />
     <ProjectReference Include="..\WinformsControlsTest\WinformsControlsTest.csproj" />
   </ItemGroup>
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinFormsControlsClassicTests/WinFormsControlsClassicTests.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinFormsControlsClassicTests/WinFormsControlsClassicTests.csproj
@@ -93,6 +93,12 @@
     <Compile Include="..\System.Windows.Forms.IntegrationTests.Common\TestHelpers.cs">
       <Link>TestHelpers.cs</Link>
     </Compile>
+    <Compile Include="..\System.Windows.Forms.IntegrationTests.Common\Person.cs">
+      <Link>Person.cs</Link>
+    </Compile>
+    <Compile Include="..\System.Windows.Forms.IntegrationTests.Common\TestDataSources.cs">
+      <Link>TestDataSources.cs</Link>
+    </Compile>
     <Compile Include="..\WinformsControlsTest\Buttons.cs">
       <Link>Buttons.cs</Link>
       <SubType>Form</SubType>

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ComboBoxes.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ComboBoxes.Designer.cs
@@ -44,8 +44,10 @@ namespace WinformsControlsTest
             this.comboBox10 = new System.Windows.Forms.ComboBox();
             this.comboBox11 = new System.Windows.Forms.ComboBox();
             this.comboBox12 = new System.Windows.Forms.ComboBox();
+            this.dataBoundComboBox = new System.Windows.Forms.ComboBox();
             this.currentDPILabel1 = new WinformsControlsTest.CurrentDPILabel();
             this.label1 = new System.Windows.Forms.Label();
+            this.dataBoundLabel = new System.Windows.Forms.Label();
             this.SuspendLayout();
             //
             // comboBox1
@@ -211,6 +213,15 @@ namespace WinformsControlsTest
             this.comboBox12.Size = new System.Drawing.Size(121, 150);
             this.comboBox12.TabIndex = 11;
             //
+            // dataBoundComboBox
+            //
+            this.dataBoundComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.Simple;
+            this.dataBoundComboBox.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.dataBoundComboBox.Location = new System.Drawing.Point(836, 22);
+            this.dataBoundComboBox.Name = "DataBoundComboBox";
+            this.dataBoundComboBox.Size = new System.Drawing.Size(121, 150);
+            this.dataBoundComboBox.TabIndex = 13;
+            //
             // currentDPILabel1
             //
             this.currentDPILabel1.AutoSize = true;
@@ -229,14 +240,25 @@ namespace WinformsControlsTest
             this.label1.Size = new System.Drawing.Size(35, 13);
             this.label1.TabIndex = 15;
             this.label1.Text = "label1";
+            //
+            // dataBoundLabel
+            // 
+            this.dataBoundLabel.AutoSize = true;
+            this.dataBoundLabel.Location = new System.Drawing.Point(836, 6);
+            this.dataBoundLabel.Name = "dataBoundLabel";
+            this.dataBoundLabel.Size = new System.Drawing.Size(65, 13);
+            this.dataBoundLabel.TabIndex = 16; 
+            this.dataBoundLabel.Text = "data-bound";
             // 
             // ComboBoxes
             //
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(831, 198);
+            this.ClientSize = new System.Drawing.Size(975, 198);
             this.Controls.Add(this.currentDPILabel1);
             this.Controls.Add(this.label1);
+            this.Controls.Add(this.dataBoundLabel);
+            this.Controls.Add(this.dataBoundComboBox);
             this.Controls.Add(this.comboBox9);
             this.Controls.Add(this.comboBox10);
             this.Controls.Add(this.comboBox11);
@@ -270,7 +292,9 @@ namespace WinformsControlsTest
         private System.Windows.Forms.ComboBox comboBox10;
         private System.Windows.Forms.ComboBox comboBox11;
         private System.Windows.Forms.ComboBox comboBox12;
+        private System.Windows.Forms.ComboBox dataBoundComboBox;
         private CurrentDPILabel currentDPILabel1;
         private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label dataBoundLabel;
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ComboBoxes.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ComboBoxes.cs
@@ -3,12 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Text;
 using System.Windows.Forms;
+using System.Windows.Forms.IntegrationTests.Common;
 
 namespace WinformsControlsTest
 {
@@ -17,7 +13,11 @@ namespace WinformsControlsTest
         public ComboBoxes()
         {
             InitializeComponent();
+
             comboBox1.SelectedIndex = 0;
+
+            dataBoundComboBox.DataSource = TestDataSources.GetPersons();
+            dataBoundComboBox.DisplayMember = TestDataSources.PersonDisplayMember;
         }
 
         private void ComboBox1_SelectedIndexChanged(object sender, EventArgs e)

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/WinformsControlsTest.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/WinformsControlsTest.csproj
@@ -23,61 +23,7 @@
     <ProjectReference Include="..\..\..\src\System.Windows.Forms.csproj" />
     <ProjectReference Include="..\System.Windows.Forms.IntegrationTests.Common\System.Windows.Forms.IntegrationTests.Common.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Compile Update="Buttons.Designer.cs">
-      <DependentUpon>Buttons.cs</DependentUpon>
-    </Compile>
-    <Compile Update="Calendar.Designer.cs">
-      <DependentUpon>Calendar.cs</DependentUpon>
-    </Compile>
-    <Compile Update="ComboBoxes.Designer.cs">
-      <DependentUpon>ComboBoxes.cs</DependentUpon>
-    </Compile>
-    <Compile Update="DataGridViewHeaders.Designer.cs">
-      <DependentUpon>DataGridViewHeaders.cs</DependentUpon>
-    </Compile>
-    <Compile Update="DateTimePicker.Designer.cs">
-      <DependentUpon>DateTimePicker.cs</DependentUpon>
-    </Compile>
-    <Compile Update="DesignTimeAligned.Designer.cs">
-      <DependentUpon>DesignTimeAligned.cs</DependentUpon>
-    </Compile>
-    <Compile Update="ListViewTest.Designer.cs">
-      <DependentUpon>ListViewTest.cs</DependentUpon>
-    </Compile>
-    <Compile Update="MainForm.Designer.cs">
-      <DependentUpon>MainForm.cs</DependentUpon>
-    </Compile>
-    <Compile Update="MdiChild.Designer.cs">
-      <DependentUpon>MdiChild.cs</DependentUpon>
-    </Compile>
-    <Compile Update="MDIParent.Designer.cs">
-      <DependentUpon>MDIParent.cs</DependentUpon>
-    </Compile>
-    <Compile Update="MenuStripAndCheckedListBox.Designer.cs">
-      <DependentUpon>MenuStripAndCheckedListBox.cs</DependentUpon>
-    </Compile>
-    <Compile Update="MultipleControls.Designer.cs">
-      <DependentUpon>MultipleControls.cs</DependentUpon>
-    </Compile>
-    <Compile Update="Panels.Designer.cs">
-      <DependentUpon>Panels.cs</DependentUpon>
-    </Compile>
-    <Compile Update="PropertyGrid.Designer.cs">
-      <DependentUpon>PropertyGrid.cs</DependentUpon>
-    </Compile>
-    <Compile Update="ScalingBeforeChanges.Designer.cs">
-      <DependentUpon>ScalingBeforeChanges.cs</DependentUpon>
-    </Compile>
-    <Compile Update="Splitter.Designer.cs">
-      <DependentUpon>Splitter.cs</DependentUpon>
-    </Compile>
-    <Compile Update="TreeViewTest.Designer.cs">
-      <DependentUpon>TreeViewTest.cs</DependentUpon>
-    </Compile>
-  </ItemGroup>
-
+ 
   <ItemGroup>
     <EmbeddedResource Include="Images\SmallA.bmp">
       <LogicalName>WinformsControlsTest.SmallA.bmp</LogicalName>
@@ -99,54 +45,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Management" Version="4.5.0-preview1-25914-04" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Update="Buttons.resx">
-      <DependentUpon>Buttons.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Update="Calendar.resx">
-      <DependentUpon>Calendar.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Update="ComboBoxes.resx">
-      <DependentUpon>ComboBoxes.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Update="DataGridViewHeaders.resx">
-      <DependentUpon>DataGridViewHeaders.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Update="DesignTimeAligned.resx">
-      <DependentUpon>DesignTimeAligned.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Update="ListViewTest.resx">
-      <DependentUpon>ListViewTest.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Update="MdiChild.resx">
-      <DependentUpon>MdiChild.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Update="MDIParent.resx">
-      <DependentUpon>MDIParent.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Update="MenuStripAndCheckedListBox.resx">
-      <DependentUpon>MenuStripAndCheckedListBox.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Update="MultipleControls.resx">
-      <DependentUpon>MultipleControls.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Update="Panels.resx">
-      <DependentUpon>Panels.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Update="PropertyGrid.resx">
-      <DependentUpon>PropertyGrid.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Update="ScalingBeforeChanges.resx">
-      <DependentUpon>ScalingBeforeChanges.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Update="Splitter.resx">
-      <DependentUpon>Splitter.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Update="TreeViewTest.resx">
-      <DependentUpon>TreeViewTest.cs</DependentUpon>
-    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
+++ b/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\System.Windows.Forms.csproj" />
     <ProjectReference Include="..\..\..\Common\tests\InternalUtilitiesForTests\InternalUtilitiesForTests.csproj" />
+    <ProjectReference Include="..\IntegrationTests\System.Windows.Forms.IntegrationTests.Common\System.Windows.Forms.IntegrationTests.Common.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxAccessibleObjectTests.cs
@@ -5,9 +5,9 @@
 using System.Collections.Generic;
 using Xunit;
 
-namespace System.Windows.Forms.Tests.AccessibleObjects
+namespace System.Windows.Forms.Tests
 {
-    public class ComboBoxAccessibleObjectTests
+    public class ComboBox_ComboBoxAccessibleObjectTests
     {
         public static IEnumerable<object[]> Ctor_ComboBox_TestData()
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObjectTests.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Forms.IntegrationTests.Common;
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    public class ComboBox_ComboBoxItemAccessibleObjectTests
+    {
+        [WinFormsFact]
+        public void ComboBoxItemAccessibleObject_Get_Not_ThrowsException()
+        {
+            using var control = new ComboBox();
+
+            var item1 = new HashNotImplementedObject();
+            var item2 = new HashNotImplementedObject();
+            var item3 = new HashNotImplementedObject();
+
+            control.Items.AddRange(new[] { item1, item2, item3 });
+
+            var comboBoxAccessibleObject = (ComboBox.ComboBoxAccessibleObject)control.AccessibilityObject;
+
+            var exceptionThrown = false;
+
+            try
+            {
+                var item1AccessibleObject= comboBoxAccessibleObject.ItemAccessibleObjects[item1];
+                var item2AccessibleObject = comboBoxAccessibleObject.ItemAccessibleObjects[item2];
+                var item3AccessibleObject = comboBoxAccessibleObject.ItemAccessibleObjects[item3];
+            }
+            catch
+            {
+                exceptionThrown = true;
+            }
+
+            Assert.False(exceptionThrown, "Getting accessible object for ComboBox item has thrown an exception.");
+        }
+
+        public class HashNotImplementedObject
+        {
+            public override int GetHashCode()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [WinFormsFact]
+        public void ComboBoxItemAccessibleObject_DataBoundAccessibleName()
+        {
+            // Regression test for https://github.com/dotnet/winforms/issues/3584
+
+            using var control = new ComboBox()
+            {
+                DataSource = TestDataSources.GetPersons(),
+                DisplayMember = TestDataSources.PersonDisplayMember
+            };
+
+            ComboBox.ComboBoxAccessibleObject accessibleObject = Assert.IsType<ComboBox.ComboBoxAccessibleObject>(control.AccessibilityObject);
+
+            foreach (Person person in TestDataSources.GetPersons())
+            {
+                var item = accessibleObject.ItemAccessibleObjects[person];
+                AccessibleObject itemAccessibleObject = Assert.IsType<ComboBox.ComboBoxItemAccessibleObject>(item);
+                Assert.Equal(person.Name, itemAccessibleObject.Name);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -924,35 +924,6 @@ namespace System.Windows.Forms.Tests
         }
 
         [Fact]
-        public void GettingComboBoxItemAccessibleObject_Not_ThrowsException()
-        {
-            var control = new ComboBox();
-
-            var h1 = new HashNotImplementedObject();
-            var h2 = new HashNotImplementedObject();
-            var h3 = new HashNotImplementedObject();
-
-            control.Items.AddRange(new[] { h1, h2, h3 });
-
-            var comboBoxAccObj = (ComboBox.ComboBoxAccessibleObject)control.AccessibilityObject;
-
-            var exceptionThrown = false;
-
-            try
-            {
-                var itemAccObj1 = comboBoxAccObj.ItemAccessibleObjects[h1];
-                var itemAccObj2 = comboBoxAccObj.ItemAccessibleObjects[h2];
-                var itemAccObj3 = comboBoxAccObj.ItemAccessibleObjects[h3];
-            }
-            catch
-            {
-                exceptionThrown = true;
-            }
-
-            Assert.False(exceptionThrown, "Getting accessible object for ComboBox item has thrown an exception.");
-        }
-
-        [Fact]
         public void ComboBox_SelectedIndexChanged_Doesnt_force_Handle_creating()
         {
             string[] items = new[] { "Item 1", "Item 2", "Item 3" };
@@ -963,14 +934,7 @@ namespace System.Windows.Forms.Tests
             comboBox.Items.AddRange(items);
             comboBox.SelectedItem = items[1];
             Assert.False(comboBox.IsHandleCreated);
-        }
 
-        public class HashNotImplementedObject
-        {
-            public override int GetHashCode()
-            {
-                throw new NotImplementedException();
-            }
         }
     }
 }


### PR DESCRIPTION
This is a regression from .NET Framework version 4.7.2. AccessibleObject.Name property for data-driven ComboBox items was broken because it was invoking ToString method instead of reading content of property that is named in DisplayMember databinding property.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3584


## Proposed changes

use method that accesses DisplayMember property

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

* User of accessible technologies does not have access to values of combo box items, when these items are data-bound.
* Automation tests that rely on UIA accessible name would not work

## Regression? 

- Yes, from  .NET Framework 4.7.2

## Risk

Low - we now use an existing method that is used to populate combobox drop down UI 
PR in Core 5.0: https://github.com/dotnet/winforms/issues/3549
Fix is a port from the .NET Framework and is cherry-picked from Core 5.0:
git cherry-pick f981c1216f6471534e01222b8fa192f805a3014e

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/15823268/88878116-08de0600-d1dc-11ea-9e4a-2af8d8ba6400.png)


### After
Inspect should display the same text as is contained in the drop down:

![image](https://user-images.githubusercontent.com/15823268/88878131-14313180-d1dc-11ea-8b69-f74ce3e34547.png)



## Test methodology <!-- How did you ensure quality? -->

manual test using the inspect tool, unit tests



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3669)