### PR TITLE
Several fixes to Control.AccessibleName property

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -11155,7 +11155,6 @@ override System.Windows.Forms.CheckBox.CheckBoxAccessibleObject.DefaultAction.ge
 ~override System.Windows.Forms.DataGridView.DataGridViewAccessibleObject.GetFocused() -> System.Windows.Forms.AccessibleObject
 ~override System.Windows.Forms.DataGridView.DataGridViewAccessibleObject.GetSelected() -> System.Windows.Forms.AccessibleObject
 ~override System.Windows.Forms.DataGridView.DataGridViewAccessibleObject.HitTest(int x, int y) -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridView.DataGridViewAccessibleObject.Name.get -> string
 ~override System.Windows.Forms.DataGridView.DataGridViewAccessibleObject.Navigate(System.Windows.Forms.AccessibleNavigation navigationDirection) -> System.Windows.Forms.AccessibleObject
 ~override System.Windows.Forms.DataGridView.DataGridViewControlCollection.Remove(System.Windows.Forms.Control value) -> void
 ~override System.Windows.Forms.DataGridView.DataGridViewTopRowAccessibleObject.GetChild(int index) -> System.Windows.Forms.AccessibleObject
@@ -11478,8 +11477,6 @@ override System.Windows.Forms.CheckBox.CheckBoxAccessibleObject.DefaultAction.ge
 ~override System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject.Parent.get -> System.Windows.Forms.AccessibleObject
 ~override System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject.Value.get -> string
 ~override System.Windows.Forms.DomainUpDown.DomainUpDownAccessibleObject.GetChild(int index) -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DomainUpDown.DomainUpDownAccessibleObject.Name.get -> string
-~override System.Windows.Forms.DomainUpDown.DomainUpDownAccessibleObject.Name.set -> void
 ~override System.Windows.Forms.DomainUpDown.DomainUpDownItemCollection.Add(object item) -> int
 ~override System.Windows.Forms.DomainUpDown.DomainUpDownItemCollection.Insert(int index, object item) -> void
 ~override System.Windows.Forms.DomainUpDown.DomainUpDownItemCollection.Remove(object item) -> void

--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6530,9 +6530,6 @@ Stack trace where the illegal operation occurred was:
   <data name="DateTimePickerLocalizedControlType" xml:space="preserve">
     <value>date and time picker</value>
   </data>
-  <data name="SpinnerAccessibleName" xml:space="preserve">
-    <value>Spinner</value>
-  </data>
   <data name="LiveRegionAutomationLiveSettingDescr" xml:space="preserve">
     <value>The politeness level that a client should use to notify the user of changes to this live region.</value>
   </data>
@@ -6592,9 +6589,6 @@ Stack trace where the illegal operation occurred was:
   </data>
   <data name="DefaultNumericUpDownAccessibleName" xml:space="preserve">
     <value>NumericUpDown</value>
-  </data>
-  <data name="DefaultDomainUpDownAccessibleName" xml:space="preserve">
-    <value>DomainUpDown</value>
   </data>
   <data name="DefaultUpDownButtonsAccessibleName" xml:space="preserve">
     <value>UpDown</value>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -4214,11 +4214,6 @@ Chcete-li nahradit toto výchozí dialogové okno, nastavte popisovač události
         <target state="translated">Upravit</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDomainUpDownAccessibleName">
-        <source>DomainUpDown</source>
-        <target state="translated">DomainUpDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DefaultNumericUpDownAccessibleName">
         <source>NumericUpDown</source>
         <target state="translated">NumericUpDown</target>
@@ -8739,11 +8734,6 @@ Trasování zásobníku, kde došlo k neplatné operaci:
       <trans-unit id="SortedDescendingAccessibleStatus">
         <source>Sorted descending.</source>
         <target state="translated">Seřazeno sestupně</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SpinnerAccessibleName">
-        <source>Spinner</source>
-        <target state="translated">Číselník</target>
         <note />
       </trans-unit>
       <trans-unit id="SplitContainerFixedPanelDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -4214,11 +4214,6 @@ Behandeln Sie das DataError-Ereignis, um dieses Standarddialogfeld zu ersetzen.<
         <target state="translated">Bearbeiten</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDomainUpDownAccessibleName">
-        <source>DomainUpDown</source>
-        <target state="translated">DomainUpDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DefaultNumericUpDownAccessibleName">
         <source>NumericUpDown</source>
         <target state="translated">NumericUpDown</target>
@@ -8739,11 +8734,6 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
       <trans-unit id="SortedDescendingAccessibleStatus">
         <source>Sorted descending.</source>
         <target state="translated">Absteigend sortiert.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SpinnerAccessibleName">
-        <source>Spinner</source>
-        <target state="translated">Wartekreisel</target>
         <note />
       </trans-unit>
       <trans-unit id="SplitContainerFixedPanelDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -4214,11 +4214,6 @@ Para reemplazar este cuadro de diálogo predeterminado controle el evento DataEr
         <target state="translated">Editar</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDomainUpDownAccessibleName">
-        <source>DomainUpDown</source>
-        <target state="translated">DomainUpDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DefaultNumericUpDownAccessibleName">
         <source>NumericUpDown</source>
         <target state="translated">NumericUpDown</target>
@@ -8739,11 +8734,6 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
       <trans-unit id="SortedDescendingAccessibleStatus">
         <source>Sorted descending.</source>
         <target state="translated">Orden descendente.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SpinnerAccessibleName">
-        <source>Spinner</source>
-        <target state="translated">Indicador giratorio</target>
         <note />
       </trans-unit>
       <trans-unit id="SplitContainerFixedPanelDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -4214,11 +4214,6 @@ Pour remplacer cette boîte de dialogue par défaut, traitez l'événement DataE
         <target state="translated">Modifier</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDomainUpDownAccessibleName">
-        <source>DomainUpDown</source>
-        <target state="translated">DomainUpDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DefaultNumericUpDownAccessibleName">
         <source>NumericUpDown</source>
         <target state="translated">NumericUpDown</target>
@@ -8739,11 +8734,6 @@ Cette opération non conforme s'est produite sur la trace de la pile :
       <trans-unit id="SortedDescendingAccessibleStatus">
         <source>Sorted descending.</source>
         <target state="translated">Trié en ordre décroissant.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SpinnerAccessibleName">
-        <source>Spinner</source>
-        <target state="translated">Compteur</target>
         <note />
       </trans-unit>
       <trans-unit id="SplitContainerFixedPanelDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -4214,11 +4214,6 @@ Per sostituire questa finestra di dialogo predefinita, gestire l'evento DataErro
         <target state="translated">Modifica</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDomainUpDownAccessibleName">
-        <source>DomainUpDown</source>
-        <target state="translated">DomainUpDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DefaultNumericUpDownAccessibleName">
         <source>NumericUpDown</source>
         <target state="translated">NumericUpDown</target>
@@ -8739,11 +8734,6 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
       <trans-unit id="SortedDescendingAccessibleStatus">
         <source>Sorted descending.</source>
         <target state="translated">Ordinamento decrescente.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SpinnerAccessibleName">
-        <source>Spinner</source>
-        <target state="translated">Casella di selezione</target>
         <note />
       </trans-unit>
       <trans-unit id="SplitContainerFixedPanelDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -4214,11 +4214,6 @@ To replace this default dialog please handle the DataError event.</source>
         <target state="translated">編集</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDomainUpDownAccessibleName">
-        <source>DomainUpDown</source>
-        <target state="translated">DomainUpDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DefaultNumericUpDownAccessibleName">
         <source>NumericUpDown</source>
         <target state="translated">NumericUpDown</target>
@@ -8739,11 +8734,6 @@ Stack trace where the illegal operation occurred was:
       <trans-unit id="SortedDescendingAccessibleStatus">
         <source>Sorted descending.</source>
         <target state="translated">並べ替え済み (降順)。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SpinnerAccessibleName">
-        <source>Spinner</source>
-        <target state="translated">スピナー</target>
         <note />
       </trans-unit>
       <trans-unit id="SplitContainerFixedPanelDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -4214,11 +4214,6 @@ To replace this default dialog please handle the DataError event.</source>
         <target state="translated">편집</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDomainUpDownAccessibleName">
-        <source>DomainUpDown</source>
-        <target state="translated">DomainUpDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DefaultNumericUpDownAccessibleName">
         <source>NumericUpDown</source>
         <target state="translated">NumericUpDown</target>
@@ -8739,11 +8734,6 @@ Stack trace where the illegal operation occurred was:
       <trans-unit id="SortedDescendingAccessibleStatus">
         <source>Sorted descending.</source>
         <target state="translated">내림차순으로 정렬했습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SpinnerAccessibleName">
-        <source>Spinner</source>
-        <target state="translated">회전자</target>
         <note />
       </trans-unit>
       <trans-unit id="SplitContainerFixedPanelDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -4214,11 +4214,6 @@ Aby zamienić to domyślne okno dialogowe, obsłuż zdarzenie DataError.</target
         <target state="translated">Edytuj</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDomainUpDownAccessibleName">
-        <source>DomainUpDown</source>
-        <target state="translated">DomainUpDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DefaultNumericUpDownAccessibleName">
         <source>NumericUpDown</source>
         <target state="translated">NumericUpDown</target>
@@ -8739,11 +8734,6 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
       <trans-unit id="SortedDescendingAccessibleStatus">
         <source>Sorted descending.</source>
         <target state="translated">Posortowano malejąco.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SpinnerAccessibleName">
-        <source>Spinner</source>
-        <target state="translated">Pokrętło</target>
         <note />
       </trans-unit>
       <trans-unit id="SplitContainerFixedPanelDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -4214,11 +4214,6 @@ Para substituir a caixa de diálogo padrão, manipule o evento DataError.</targe
         <target state="translated">Editar</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDomainUpDownAccessibleName">
-        <source>DomainUpDown</source>
-        <target state="translated">DomainUpDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DefaultNumericUpDownAccessibleName">
         <source>NumericUpDown</source>
         <target state="translated">NumericUpDown</target>
@@ -8739,11 +8734,6 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
       <trans-unit id="SortedDescendingAccessibleStatus">
         <source>Sorted descending.</source>
         <target state="translated">Classificado em ordem decrescente.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SpinnerAccessibleName">
-        <source>Spinner</source>
-        <target state="translated">Controle giratório</target>
         <note />
       </trans-unit>
       <trans-unit id="SplitContainerFixedPanelDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -4214,11 +4214,6 @@ To replace this default dialog please handle the DataError event.</source>
         <target state="translated">Изменить</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDomainUpDownAccessibleName">
-        <source>DomainUpDown</source>
-        <target state="translated">DomainUpDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DefaultNumericUpDownAccessibleName">
         <source>NumericUpDown</source>
         <target state="translated">NumericUpDown</target>
@@ -8740,11 +8735,6 @@ Stack trace where the illegal operation occurred was:
       <trans-unit id="SortedDescendingAccessibleStatus">
         <source>Sorted descending.</source>
         <target state="translated">Отсортировано по убыванию.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SpinnerAccessibleName">
-        <source>Spinner</source>
-        <target state="translated">Вертушка</target>
         <note />
       </trans-unit>
       <trans-unit id="SplitContainerFixedPanelDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -4214,11 +4214,6 @@ Bu varsayılan iletişim kutusunu değiştirmek için, lütfen DataError olayın
         <target state="translated">Düzenle</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDomainUpDownAccessibleName">
-        <source>DomainUpDown</source>
-        <target state="translated">DomainUpDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DefaultNumericUpDownAccessibleName">
         <source>NumericUpDown</source>
         <target state="translated">NumericUpDown</target>
@@ -8739,11 +8734,6 @@ Geçersiz işlemin gerçekleştiği yığın izi:
       <trans-unit id="SortedDescendingAccessibleStatus">
         <source>Sorted descending.</source>
         <target state="translated">Azalan düzende sıralı.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SpinnerAccessibleName">
-        <source>Spinner</source>
-        <target state="translated">Değer Değiştirici</target>
         <note />
       </trans-unit>
       <trans-unit id="SplitContainerFixedPanelDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -4214,11 +4214,6 @@ To replace this default dialog please handle the DataError event.</source>
         <target state="translated">编辑</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDomainUpDownAccessibleName">
-        <source>DomainUpDown</source>
-        <target state="translated">DomainUpDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DefaultNumericUpDownAccessibleName">
         <source>NumericUpDown</source>
         <target state="translated">NumericUpDown</target>
@@ -8739,11 +8734,6 @@ Stack trace where the illegal operation occurred was:
       <trans-unit id="SortedDescendingAccessibleStatus">
         <source>Sorted descending.</source>
         <target state="translated">已排序，降序。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SpinnerAccessibleName">
-        <source>Spinner</source>
-        <target state="translated">旋转图标</target>
         <note />
       </trans-unit>
       <trans-unit id="SplitContainerFixedPanelDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -4214,11 +4214,6 @@ To replace this default dialog please handle the DataError event.</source>
         <target state="translated">編輯</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDomainUpDownAccessibleName">
-        <source>DomainUpDown</source>
-        <target state="translated">DomainUpDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DefaultNumericUpDownAccessibleName">
         <source>NumericUpDown</source>
         <target state="translated">NumericUpDown</target>
@@ -8739,11 +8734,6 @@ Stack trace where the illegal operation occurred was:
       <trans-unit id="SortedDescendingAccessibleStatus">
         <source>Sorted descending.</source>
         <target state="translated">已遞減排序。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SpinnerAccessibleName">
-        <source>Spinner</source>
-        <target state="translated">進度環</target>
         <note />
       </trans-unit>
       <trans-unit id="SplitContainerFixedPanelDescr">

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
@@ -27,11 +27,6 @@ namespace System.Windows.Forms
 
             internal override bool IsReadOnly => owner.ReadOnly;
 
-            public override string Name
-            {
-                get => base.Name;
-            }
-
             public override AccessibleRole Role
             {
                 get

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
@@ -29,19 +29,7 @@ namespace System.Windows.Forms
 
             public override string Name
             {
-                get
-                {
-                    string name = Owner.AccessibleName;
-                    if (!string.IsNullOrEmpty(name))
-                    {
-                        return name;
-                    }
-                    else
-                    {
-                        // The default name should not be localized.
-                        return "DataGridView";
-                    }
-                }
+                get => base.Name;
             }
 
             public override AccessibleRole Role

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.DataGridViewEditingPanelAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.DataGridViewEditingPanelAccessibleObject.cs
@@ -79,11 +79,6 @@ namespace System.Windows.Forms
 
             #region IRawElementProviderSimple Implementation
 
-            internal override bool IsPatternSupported(UiaCore.UIA patternId)
-            {
-                return patternId.Equals(UiaCore.UIA.LegacyIAccessiblePatternId);
-            }
-
             internal override object GetPropertyValue(UiaCore.UIA propertyId)
             {
                 switch (propertyId)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.cs
@@ -707,7 +707,7 @@ namespace System.Windows.Forms
             /// </summary>
             public override string Name
             {
-                get => base.Name ?? SR.DefaultDomainUpDownAccessibleName;
+                get => base.Name;
                 set => base.Name = value;
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.cs
@@ -702,15 +702,6 @@ namespace System.Windows.Forms
                 }
             }
 
-            /// <summary>
-            ///  Gets or sets the accessible name.
-            /// </summary>
-            public override string Name
-            {
-                get => base.Name;
-                set => base.Name = value;
-            }
-
             private DomainItemListAccessibleObject ItemList
             {
                 get

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.AccessibleObject.cs
@@ -29,6 +29,13 @@ namespace System.Windows.Forms
 
             internal override Rectangle BoundingRectangle => _owner.Bounds;
 
+            internal override object GetPropertyValue(UiaCore.UIA propertyID)
+            {
+                return propertyID == UiaCore.UIA.NamePropertyId
+                    ? Name
+                    : base.GetPropertyValue(propertyID);
+            }
+
             internal override bool IsIAccessibleExSupported()
             {
                 if (_owner != null)
@@ -38,13 +45,6 @@ namespace System.Windows.Forms
 
                 return base.IsIAccessibleExSupported();
             }
-
-            internal override bool IsPatternSupported(UiaCore.UIA patternId)
-                => patternId switch
-                {
-                    UiaCore.UIA.LegacyIAccessiblePatternId => true,
-                    _ => base.IsPatternSupported(patternId),
-                };
 
             internal override void SetValue(string newValue)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.AccessibleObject.cs
@@ -177,8 +177,7 @@ namespace System.Windows.Forms
             internal override bool IsPatternSupported(UiaCore.UIA patternId)
             {
                 if (patternId == UiaCore.UIA.ScrollPatternId ||
-                    patternId == UiaCore.UIA.SelectionPatternId ||
-                    patternId == UiaCore.UIA.LegacyIAccessiblePatternId)
+                    patternId == UiaCore.UIA.SelectionPatternId)
                 {
                     return true;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
@@ -564,8 +564,7 @@ namespace System.Windows.Forms
                     var p when
                         p == UiaCore.UIA.ValuePatternId ||
                         p == UiaCore.UIA.GridPatternId ||
-                        p == UiaCore.UIA.TablePatternId ||
-                        p == UiaCore.UIA.LegacyIAccessiblePatternId => true,
+                        p == UiaCore.UIA.TablePatternId => true,
                     _ => base.IsPatternSupported(patternId)
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDown.cs
@@ -940,15 +940,6 @@ namespace System.Windows.Forms
                 }
             }
 
-            /// <summary>
-            ///  Gets or sets the accessible name.
-            /// </summary>
-            public override string Name
-            {
-                get => base.Name ?? SR.DefaultNumericUpDownAccessibleName;
-                set => base.Name = value;
-            }
-
             public override AccessibleRole Role
             {
                 get

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ProgressBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ProgressBar.cs
@@ -713,12 +713,6 @@ namespace System.Windows.Forms
             {
             }
 
-            public override string Name
-            {
-                get => base.Name ?? SR.ProgressBarDefaultAccessibleName;
-                set => base.Name = value;
-            }
-
             private ProgressBar OwningProgressBar => Owner as ProgressBar;
 
             internal override bool IsIAccessibleExSupported() => true;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -163,6 +163,8 @@ namespace System.Windows.Forms
             SuspendLayout();
             AutoScaleMode = AutoScaleMode.None;
 
+            SetStyle(ControlStyles.UseTextForAccessibility, false);
+
             // static variables are problem in a child level mixed mode scenario. Changing static variables cause compatibility issue.
             // So, recalculate static variables everytime property grid initialized.
             if (DpiHelper.IsPerMonitorV2Awareness)
@@ -5667,25 +5669,6 @@ namespace System.Windows.Forms
                 UiaCore.UIA.NamePropertyId => Name,
                 _ => base.GetPropertyValue(propertyID),
             };
-
-        public override string Name
-        {
-            get
-            {
-                string name = Owner?.AccessibleName;
-                if (name != null)
-                {
-                    return name;
-                }
-
-                return Owner.Name;
-            }
-
-            set
-            {
-                Owner.AccessibleName = value;
-            }
-        }
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -249,7 +249,6 @@ namespace System.Windows.Forms
                 _toolStrip.ResumeLayout(false);  // SetupToolbar should perform the layout
                 SetupToolbar();
                 PropertySort = PropertySort.Categorized | PropertySort.Alphabetical;
-                Text = "PropertyGrid";
                 SetSelectState(0);
             }
             catch (Exception ex)
@@ -5764,7 +5763,7 @@ namespace System.Windows.Forms
                     return name;
                 }
 
-                return _parentPropertyGrid?.Name;
+                return _parentPropertyGrid?.AccessibilityObject.Name;
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DocComment.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DocComment.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -314,7 +314,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return name;
                 }
 
-                return string.Format(SR.PropertyGridDocCommentAccessibleNameTemplate, _parentPropertyGrid?.Name);
+                return string.Format(SR.PropertyGridDocCommentAccessibleNameTemplate, _parentPropertyGrid?.AccessibilityObject.Name);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.cs
@@ -306,14 +306,6 @@ namespace System.Windows.Forms.PropertyGridInternal
         };
 
         /// <summary>
-        ///  Indicates whether the specified pattern is supported.
-        /// </summary>
-        /// <param name="patternId">The pattern ID.</param>
-        /// <returns>True if specified pattern is supported, otherwise false.</returns>
-        internal override bool IsPatternSupported(UiaCore.UIA patternId)
-            => patternId == UiaCore.UIA.LegacyIAccessiblePatternId || base.IsPatternSupported(patternId);
-
-        /// <summary>
         ///  Gets the accessible role.
         /// </summary>
         public override AccessibleRole Role => AccessibleRole.PushButton;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/HotCommands.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/HotCommands.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -309,7 +309,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return name;
                 }
 
-                return _parentPropertyGrid?.Name;
+                return _parentPropertyGrid?.AccessibilityObject.Name;
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewListBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewListBoxAccessibleObject.cs
@@ -45,7 +45,8 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     return _owningPropertyGridView.SelectedGridEntry.AccessibilityObject;
                 }
-                else if (direction == UiaCore.NavigateDirection.NextSibling)
+
+                if (direction == UiaCore.NavigateDirection.NextSibling)
                 {
                     return _owningPropertyGridView.Edit.AccessibilityObject;
                 }
@@ -56,7 +57,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             public override string? Name
             {
                 get => base.Name ?? SR.PropertyGridEntryValuesListDefaultAccessibleName;
-                set => base.Name = value;
             }
 
             /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewListBoxItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewListBoxItemAccessibleObject.cs
@@ -69,7 +69,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     return base.Name;
                 }
-                set => base.Name = value;
             }
 
             /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -6413,7 +6413,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         return name;
                     }
 
-                    return string.Format(SR.PropertyGridDefaultAccessibleNameTemplate, _owningPropertyGridView?.OwnerGrid?.Name);
+                    return string.Format(SR.PropertyGridDefaultAccessibleNameTemplate, _owningPropertyGridView?.OwnerGrid?.AccessibilityObject.Name);
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/SingleSelectRootGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/SingleSelectRootGridEntry.cs
@@ -225,15 +225,15 @@ namespace System.Windows.Forms.PropertyGridInternal
                     {
                         return objValue.GetType().Name;
                     }
-                    else
-                    {
-                        return site.Name;
-                    }
+
+                    return site.Name;
                 }
-                else if (objValue != null)
+
+                if (objValue != null)
                 {
                     return objValue.ToString();
                 }
+
                 return null;
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -2099,6 +2099,8 @@ namespace System.Windows.Forms
                     }
 
                     ToolStripManager.ToolStrips.Remove(this);
+
+                    _imageList?.Dispose();
                 }
                 finally
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
@@ -463,21 +463,6 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Gets an accessible name.
-        /// </summary>
-        /// <param name="baseName">The base name.</param>
-        /// <returns>The accessible name.</returns>
-        internal string GetAccessibleName(string baseName)
-        {
-            if (baseName is null)
-            {
-                return SR.SpinnerAccessibleName;
-            }
-
-            return baseName;
-        }
-
-        /// <summary>
         ///  When overridden in a derived class, handles rescaling of any magic numbers used in control painting.
         ///  For UpDown controls, scale the width of the up/down buttons.
         ///  Must call the base class method to get the current DPI values. This method is invoked only when

--- a/src/System.Windows.Forms/tests/TestUtilities/ReflectionHelper.cs
+++ b/src/System.Windows.Forms/tests/TestUtilities/ReflectionHelper.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace System
+{
+    public static class ReflectionHelper
+    {
+        public static IEnumerable<object[]> GetPublicNotAbstractClasses<T>()
+        {
+            var types = typeof(T).Assembly.GetTypes().Where(type => IsPublicNonAbstract<T>(type));
+            foreach (var type in types)
+            {
+                if (type.GetConstructor(
+                bindingAttr: BindingFlags.Public | BindingFlags.Instance,
+                binder: null,
+                types: Array.Empty<Type>(),
+                modifiers: null) == null)
+                {
+                    continue;
+                }
+
+                yield return new object[] { type };
+            }
+        }
+
+        public static T InvokePublicConstructor<T>(Type type)
+        {
+            var ctor = type.GetConstructor(
+                bindingAttr: BindingFlags.Public | BindingFlags.Instance,
+                binder: null,
+                types: Array.Empty<Type>(),
+                modifiers: null);
+
+            if (ctor == null)
+            {
+                return default;
+            }
+
+            return (T)ctor.Invoke(Array.Empty<object>());
+        }
+
+        public static bool IsPublicNonAbstract<T>(Type type)
+        {
+            return !type.IsAbstract && type.IsPublic && typeof(T).IsAssignableFrom(type);
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/TestUtilities/ReflectionHelper.cs
+++ b/src/System.Windows.Forms/tests/TestUtilities/ReflectionHelper.cs
@@ -11,7 +11,7 @@ namespace System
 {
     public static class ReflectionHelper
     {
-        public static IEnumerable<object[]> GetPublicNotAbstractClasses<T>()
+        public static IEnumerable<Type> GetPublicNotAbstractClasses<T>()
         {
             var types = typeof(T).Assembly.GetTypes().Where(type => IsPublicNonAbstract<T>(type));
             foreach (var type in types)
@@ -20,12 +20,12 @@ namespace System
                     bindingAttr: BindingFlags.Public | BindingFlags.Instance,
                     binder: null,
                     types: Array.Empty<Type>(),
-                    modifiers: null) == null)
+                    modifiers: null) is null)
                 {
                     continue;
                 }
 
-                yield return new object[] { type };
+                yield return type;
             }
         }
 
@@ -37,12 +37,12 @@ namespace System
                 types: Array.Empty<Type>(),
                 modifiers: null);
 
-            if (ctor == null)
+            if (ctor is null)
             {
                 return default;
             }
 
-            T obj= (T)ctor.Invoke(Array.Empty<object>());
+            T obj = (T)ctor.Invoke(Array.Empty<object>());
             Assert.NotNull(obj);
             return obj;
         }

--- a/src/System.Windows.Forms/tests/TestUtilities/ReflectionHelper.cs
+++ b/src/System.Windows.Forms/tests/TestUtilities/ReflectionHelper.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Xunit;
 
 namespace System
 {
@@ -16,10 +17,10 @@ namespace System
             foreach (var type in types)
             {
                 if (type.GetConstructor(
-                bindingAttr: BindingFlags.Public | BindingFlags.Instance,
-                binder: null,
-                types: Array.Empty<Type>(),
-                modifiers: null) == null)
+                    bindingAttr: BindingFlags.Public | BindingFlags.Instance,
+                    binder: null,
+                    types: Array.Empty<Type>(),
+                    modifiers: null) == null)
                 {
                     continue;
                 }
@@ -41,7 +42,9 @@ namespace System
                 return default;
             }
 
-            return (T)ctor.Invoke(Array.Empty<object>());
+            T obj= (T)ctor.Invoke(Array.Empty<object>());
+            Assert.NotNull(obj);
+            return obj;
         }
 
         public static bool IsPublicNonAbstract<T>(Type type)

--- a/src/System.Windows.Forms/tests/TestUtilities/ReflectionHelper.cs
+++ b/src/System.Windows.Forms/tests/TestUtilities/ReflectionHelper.cs
@@ -47,7 +47,7 @@ namespace System
             return obj;
         }
 
-        public static bool IsPublicNonAbstract<T>(Type type)
+        private static bool IsPublicNonAbstract<T>(Type type)
         {
             return !type.IsAbstract && type.IsPublic && typeof(T).IsAssignableFrom(type);
         }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DomainUpDownAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DomainUpDownAccessibleObjectTests.cs
@@ -15,15 +15,5 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             AccessibleObject accessibleObject = numericUpDown.AccessibilityObject;
             Assert.NotNull(accessibleObject);
         }
-
-        [WinFormsFact]
-        public void DomainUpDownAccessibleObject_NameIsNotEqualControlType()
-        {
-            using DomainUpDown numericUpDown = new DomainUpDown();
-            string accessibleName = numericUpDown.AccessibilityObject.Name;
-
-            // Control should have null AccessibleName by default
-            Assert.Null(accessibleName);
-        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DomainUpDownAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DomainUpDownAccessibleObjectTests.cs
@@ -28,7 +28,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             // So we need to check if these properties are not equal.
             // In this specific case, we can't have some positive Assert.
             // ToLower method used to be case insensitive.
-            Assert.NotEqual(accessibleName.ToLower(), controlType.ToLower());
+            Assert.Null(accessibleName);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DomainUpDownAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DomainUpDownAccessibleObjectTests.cs
@@ -21,13 +21,8 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
         {
             using DomainUpDown numericUpDown = new DomainUpDown();
             string accessibleName = numericUpDown.AccessibilityObject.Name;
-            string controlType = SR.SpinnerAccessibleName;
 
-            // Mas requires us to have no same AccessibleName and LocalizedControlType,
-            // please see the requirement (Section 508 502.3.1).
-            // So we need to check if these properties are not equal.
-            // In this specific case, we can't have some positive Assert.
-            // ToLower method used to be case insensitive.
+            // Control should have null AccessibleName by default
             Assert.Null(accessibleName);
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/NumericUpDownAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/NumericUpDownAccessibleObjectTests.cs
@@ -21,14 +21,13 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
         {
             using NumericUpDown numericUpDown = new NumericUpDown();
             string accessibleName = numericUpDown.AccessibilityObject.Name;
-            string controlType = SR.SpinnerAccessibleName;
 
             // Mas requires us to have no same AccessibleName and LocalizedControlType,
             // please see the requirement (Section 508 502.3.1).
             // So we need to check if these properties are not equal.
             // In this specific case, we can't have some positive Assert.
             // ToLower method used to be case insensitive.
-            Assert.NotEqual(accessibleName.ToLower(), controlType.ToLower());
+            Assert.Null(accessibleName);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/NumericUpDownAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/NumericUpDownAccessibleObjectTests.cs
@@ -15,15 +15,5 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             AccessibleObject accessibleObject = numericUpDown.AccessibilityObject;
             Assert.NotNull(accessibleObject);
         }
-
-        [WinFormsFact]
-        public void NumericUpDownAccessibleObject_NameIsNotEqualControlType()
-        {
-            using NumericUpDown numericUpDown = new NumericUpDown();
-            string accessibleName = numericUpDown.AccessibilityObject.Name;
-
-            // Control should have null AccessibleName by default
-            Assert.Null(accessibleName);
-        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/NumericUpDownAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/NumericUpDownAccessibleObjectTests.cs
@@ -22,11 +22,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             using NumericUpDown numericUpDown = new NumericUpDown();
             string accessibleName = numericUpDown.AccessibilityObject.Name;
 
-            // Mas requires us to have no same AccessibleName and LocalizedControlType,
-            // please see the requirement (Section 508 502.3.1).
-            // So we need to check if these properties are not equal.
-            // In this specific case, we can't have some positive Assert.
-            // ToLower method used to be case insensitive.
+            // Control should have null AccessibleName by default
             Assert.Null(accessibleName);
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ProgressBarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ProgressBarAccessibleObjectTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -23,7 +23,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(ownerControl.Handle, accessibilityObject.Handle);
             Assert.Null(accessibilityObject.Help);
             Assert.Null(accessibilityObject.KeyboardShortcut);
-            Assert.Equal(SR.ProgressBarDefaultAccessibleName, accessibilityObject.Name);
+            Assert.Null(accessibilityObject.Name);
             Assert.Equal(AccessibleRole.ProgressBar, accessibilityObject.Role);
             Assert.Same(ownerControl, accessibilityObject.Owner);
             Assert.NotNull(accessibilityObject.Parent);

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ToolStripItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ToolStripItemAccessibleObjectTests.cs
@@ -46,15 +46,11 @@ namespace System.Windows.Forms.Tests
             return ReflectionHelper.GetPublicNotAbstractClasses<ToolStripItem>();
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(ToolStripItemAccessibleObject_TestData))]
         public void ToolStripItemAccessibleObject_LegacyIAccessible_Custom_Role_ReturnsExpected(Type type)
         {
             using ToolStripItem item = ReflectionHelper.InvokePublicConstructor<ToolStripItem>(type);
-            if (item == null)
-            {
-                return;
-            }
             item.AccessibleRole = AccessibleRole.Link;
             AccessibleObject toolStripItemAccessibleObject = item.AccessibilityObject;
 
@@ -68,10 +64,6 @@ namespace System.Windows.Forms.Tests
         public void ToolStripItemAccessibleObject_IsPatternSupported_LegacyIAccessible_ReturnsTrue(Type type)
         {
             using ToolStripItem item = ReflectionHelper.InvokePublicConstructor<ToolStripItem>(type);
-            if (item == null)
-            {
-                return;
-            }
             AccessibleObject toolStripItemAccessibleObject = item.AccessibilityObject;
 
             bool supportsLegacyIAccessiblePatternId = toolStripItemAccessibleObject.IsPatternSupported(UIA.LegacyIAccessiblePatternId);
@@ -84,11 +76,6 @@ namespace System.Windows.Forms.Tests
         public void ToolStripItemAccessibleObject_LegacyIAccessible_Custom_Description_ReturnsExpected(Type type)
         {
             using ToolStripItem item = ReflectionHelper.InvokePublicConstructor<ToolStripItem>(type);
-            if (item == null)
-            {
-                return;
-            }
-
             item.AccessibleDescription = "Test Accessible Description";
             AccessibleObject toolStripItemAccessibleObject = item.AccessibilityObject;
 
@@ -102,11 +89,6 @@ namespace System.Windows.Forms.Tests
         public void ToolStripItemAccessibleObject_GetPropertyValue_Custom_Name_ReturnsExpected(Type type)
         {
             using ToolStripItem item = ReflectionHelper.InvokePublicConstructor<ToolStripItem>(type);
-            if (item == null)
-            {
-                return;
-            }
-
             AccessibleObject toolStripItemAccessibleObject = item.AccessibilityObject;
             Assert.Equal(string.Empty, toolStripItemAccessibleObject.GetPropertyValue(UIA.NamePropertyId));
 

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ToolStripItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ToolStripItemAccessibleObjectTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using Xunit;
 using static Interop.UiaCore;
 
@@ -43,7 +44,7 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> ToolStripItemAccessibleObject_TestData()
         {
-            return ReflectionHelper.GetPublicNotAbstractClasses<ToolStripItem>();
+            return ReflectionHelper.GetPublicNotAbstractClasses<ToolStripItem>().Select(type => new object[] { type });
         }
 
         [WinFormsTheory]
@@ -90,6 +91,9 @@ namespace System.Windows.Forms.Tests
         {
             using ToolStripItem item = ReflectionHelper.InvokePublicConstructor<ToolStripItem>(type);
             AccessibleObject toolStripItemAccessibleObject = item.AccessibilityObject;
+
+            // By default Name has string.Empty value, because if AccessibleName is not defined
+            // then control uses the value of "Text" property from owner Item (by default an empty string)
             Assert.Equal(string.Empty, toolStripItemAccessibleObject.GetPropertyValue(UIA.NamePropertyId));
 
             item.Name = "Name1";

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ToolStripItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ToolStripItemAccessibleObjectTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Drawing;
 using Xunit;
 using static Interop.UiaCore;
@@ -40,15 +41,81 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<ArgumentNullException>("ownerItem", () => new ToolStripItem.ToolStripItemAccessibleObject(null));
         }
 
-        [WinFormsFact]
-        public void ToolStripItemAccessibleObject_IsPatternSupported_LegacyIAccessible_ReturnsTrue()
+        public static IEnumerable<object[]> ToolStripItemAccessibleObject_TestData()
         {
-            using var toolStripItem = new SubToolStripItem();
-            AccessibleObject toolStripItemAccessibleObject = toolStripItem.AccessibilityObject;
+            return ReflectionHelper.GetPublicNotAbstractClasses<ToolStripItem>();
+        }
+
+        [Theory]
+        [MemberData(nameof(ToolStripItemAccessibleObject_TestData))]
+        public void ToolStripItemAccessibleObject_LegacyIAccessible_Custom_Role_ReturnsExpected(Type type)
+        {
+            using ToolStripItem item = ReflectionHelper.InvokePublicConstructor<ToolStripItem>(type);
+            if (item == null)
+            {
+                return;
+            }
+            item.AccessibleRole = AccessibleRole.Link;
+            AccessibleObject toolStripItemAccessibleObject = item.AccessibilityObject;
+
+            var accessibleObjectRole = toolStripItemAccessibleObject.Role;
+
+            Assert.Equal(AccessibleRole.Link, accessibleObjectRole);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ToolStripItemAccessibleObject_TestData))]
+        public void ToolStripItemAccessibleObject_IsPatternSupported_LegacyIAccessible_ReturnsTrue(Type type)
+        {
+            using ToolStripItem item = ReflectionHelper.InvokePublicConstructor<ToolStripItem>(type);
+            if (item == null)
+            {
+                return;
+            }
+            AccessibleObject toolStripItemAccessibleObject = item.AccessibilityObject;
 
             bool supportsLegacyIAccessiblePatternId = toolStripItemAccessibleObject.IsPatternSupported(UIA.LegacyIAccessiblePatternId);
 
             Assert.True(supportsLegacyIAccessiblePatternId);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ToolStripItemAccessibleObject_TestData))]
+        public void ToolStripItemAccessibleObject_LegacyIAccessible_Custom_Description_ReturnsExpected(Type type)
+        {
+            using ToolStripItem item = ReflectionHelper.InvokePublicConstructor<ToolStripItem>(type);
+            if (item == null)
+            {
+                return;
+            }
+
+            item.AccessibleDescription = "Test Accessible Description";
+            AccessibleObject toolStripItemAccessibleObject = item.AccessibilityObject;
+
+            var accessibleObjectDescription = toolStripItemAccessibleObject.Description;
+
+            Assert.Equal("Test Accessible Description", accessibleObjectDescription);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ToolStripItemAccessibleObject_TestData))]
+        public void ToolStripItemAccessibleObject_GetPropertyValue_Custom_Name_ReturnsExpected(Type type)
+        {
+            using ToolStripItem item = ReflectionHelper.InvokePublicConstructor<ToolStripItem>(type);
+            if (item == null)
+            {
+                return;
+            }
+
+            AccessibleObject toolStripItemAccessibleObject = item.AccessibilityObject;
+            Assert.Equal(string.Empty, toolStripItemAccessibleObject.GetPropertyValue(UIA.NamePropertyId));
+
+            item.Name = "Name1";
+            item.AccessibleName = "Test Name";
+
+            var accessibleName = toolStripItemAccessibleObject.GetPropertyValue(UIA.NamePropertyId);
+
+            Assert.Equal("Test Name", accessibleName);
         }
 
         private class SubToolStripItem : ToolStripItem

--- a/src/System.Windows.Forms/tests/UnitTests/PropertyGridTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/PropertyGridTests.cs
@@ -153,7 +153,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(new Size(130, 130), control.Size);
             Assert.Equal(0, control.TabIndex);
             Assert.True(control.TabStop);
-            Assert.Equal("PropertyGrid", control.Text);
+            Assert.Empty(control.Text);
             Assert.True(control.ToolbarVisible);
             Assert.NotNull(control.ToolStripRenderer);
             Assert.Same(control.ToolStripRenderer, control.ToolStripRenderer);
@@ -177,7 +177,7 @@ namespace System.Windows.Forms.Tests
         {
             using var control = new SubPropertyGrid();
             CreateParams createParams = control.CreateParams;
-            Assert.Equal("PropertyGrid", createParams.Caption);
+            Assert.Null(createParams.Caption);
             Assert.Null(createParams.ClassName);
             Assert.Equal(0x8, createParams.ClassStyle);
             Assert.Equal(0x10000, createParams.ExStyle);

--- a/src/System.Windows.Forms/tests/UnitTests/PropertyGridTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/PropertyGridTests.cs
@@ -3369,7 +3369,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(ControlStyles.EnableNotifyMessage, false)]
         [InlineData(ControlStyles.DoubleBuffer, false)]
         [InlineData(ControlStyles.OptimizedDoubleBuffer, false)]
-        [InlineData(ControlStyles.UseTextForAccessibility, true)]
+        [InlineData(ControlStyles.UseTextForAccessibility, false)]
         [InlineData((ControlStyles)0, true)]
         [InlineData((ControlStyles)int.MaxValue, false)]
         [InlineData((ControlStyles)(-1), false)]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -1123,8 +1123,8 @@ namespace System.Windows.Forms.Tests
             // These controls have AccessibleName defined.
             // MonthCalendar has "Month" view by default and returns current date as AccessibleName
             var typeDefaultValues = new Dictionary<Type, string> {
-                { typeof(DataGridViewTextBoxEditingControl), "Editing Control"},
-                { typeof(PrintPreviewDialog), "Print preview"},
+                { typeof(DataGridViewTextBoxEditingControl), SR.DataGridView_AccEditingControlAccName},
+                { typeof(PrintPreviewDialog), SR.PrintPreviewDialog_PrintPreview},
                 { typeof(MonthCalendar), string.Format(SR.MonthCalendarSingleDateSelected, DateTime.Now.ToLongDateString())}
             };
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -1044,7 +1044,7 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [MemberData(nameof(ControlAccessibleObject_TestData))]
-        public void ControlAccessibleObject_LegacyIAccessible_Custom_Role_ReturnsExpected(Type type)
+        public void ControlAccessibleObject_Custom_Role_ReturnsExpected(Type type)
         {
             using Control control = ReflectionHelper.InvokePublicConstructor<Control>(type);
 
@@ -1081,7 +1081,7 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [MemberData(nameof(ControlAccessibleObject_TestData))]
-        public void ControlAccessibleObject_LegacyIAccessible_Custom_Description_ReturnsExpected(Type type)
+        public void ControlAccessibleObject_Custom_Description_ReturnsExpected(Type type)
         {
             using Control control = ReflectionHelper.InvokePublicConstructor<Control>(type);
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Drawing;
 using System.Runtime.Serialization;
 using System.Windows.Forms.Automation;
 using Accessibility;
@@ -1042,13 +1041,13 @@ namespace System.Windows.Forms.Tests
             return ReflectionHelper.GetPublicNotAbstractClasses<Control>();
         }
 
-        [StaTheory]
+        [WinFormsTheory]
         [MemberData(nameof(ControlAccessibleObject_TestData))]
         public void ControlAccessibleObject_LegacyIAccessible_Custom_Role_ReturnsExpected(Type type)
         {
             using Control control = ReflectionHelper.InvokePublicConstructor<Control>(type);
 
-            if (control == null || !control.SupportsUiaProviders)
+            if (!control.SupportsUiaProviders)
             {
                 return;
             }
@@ -1061,13 +1060,13 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(AccessibleRole.Link, accessibleObjectRole);
         }
 
-        [StaTheory]
+        [WinFormsTheory]
         [MemberData(nameof(ControlAccessibleObject_TestData))]
         public void ControlAccessibleObject_IsPatternSupported_LegacyIAccessible_ReturnsTrue(Type type)
         {
             using Control control = ReflectionHelper.InvokePublicConstructor<Control>(type);
 
-            if (control == null || !control.SupportsUiaProviders)
+            if (!control.SupportsUiaProviders)
             {
                 return;
             }
@@ -1079,13 +1078,13 @@ namespace System.Windows.Forms.Tests
             Assert.True(supportsLegacyIAccessiblePatternId);
         }
 
-        [StaTheory]
+        [WinFormsTheory]
         [MemberData(nameof(ControlAccessibleObject_TestData))]
         public void ControlAccessibleObject_LegacyIAccessible_Custom_Description_ReturnsExpected(Type type)
         {
             using Control control = ReflectionHelper.InvokePublicConstructor<Control>(type);
 
-            if (control == null || !control.SupportsUiaProviders)
+            if (!control.SupportsUiaProviders)
             {
                 return;
             }
@@ -1098,13 +1097,13 @@ namespace System.Windows.Forms.Tests
             Assert.Equal("Test Accessible Description", accessibleObjectDescription);
         }
 
-        [StaTheory]
+        [WinFormsTheory]
         [MemberData(nameof(ControlAccessibleObject_TestData))]
         public void ControlAccessibleObject_GetPropertyValue_Custom_Name_ReturnsExpected(Type type)
         {
             using Control control = ReflectionHelper.InvokePublicConstructor<Control>(type);
 
-            if (control == null || !control.SupportsUiaProviders)
+            if (!control.SupportsUiaProviders)
             {
                 return;
             }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -1037,6 +1037,88 @@ namespace System.Windows.Forms.Tests
             Assert.True(actual);
         }
 
+        public static IEnumerable<object[]> ControlAccessibleObject_TestData()
+        {
+            return ReflectionHelper.GetPublicNotAbstractClasses<Control>();
+        }
+
+        [StaTheory]
+        [MemberData(nameof(ControlAccessibleObject_TestData))]
+        public void ControlAccessibleObject_LegacyIAccessible_Custom_Role_ReturnsExpected(Type type)
+        {
+            using Control control = ReflectionHelper.InvokePublicConstructor<Control>(type);
+
+            if (control == null || !control.SupportsUiaProviders)
+            {
+                return;
+            }
+
+            control.AccessibleRole = AccessibleRole.Link;
+            AccessibleObject controlAccessibleObject = control.AccessibilityObject;
+
+            var accessibleObjectRole = controlAccessibleObject.Role;
+
+            Assert.Equal(AccessibleRole.Link, accessibleObjectRole);
+        }
+
+        [StaTheory]
+        [MemberData(nameof(ControlAccessibleObject_TestData))]
+        public void ControlAccessibleObject_IsPatternSupported_LegacyIAccessible_ReturnsTrue(Type type)
+        {
+            using Control control = ReflectionHelper.InvokePublicConstructor<Control>(type);
+
+            if (control == null || !control.SupportsUiaProviders)
+            {
+                return;
+            }
+
+            AccessibleObject controlAccessibleObject = control.AccessibilityObject;
+
+            bool supportsLegacyIAccessiblePatternId = controlAccessibleObject.IsPatternSupported(UiaCore.UIA.LegacyIAccessiblePatternId);
+
+            Assert.True(supportsLegacyIAccessiblePatternId);
+        }
+
+        [StaTheory]
+        [MemberData(nameof(ControlAccessibleObject_TestData))]
+        public void ControlAccessibleObject_LegacyIAccessible_Custom_Description_ReturnsExpected(Type type)
+        {
+            using Control control = ReflectionHelper.InvokePublicConstructor<Control>(type);
+
+            if (control == null || !control.SupportsUiaProviders)
+            {
+                return;
+            }
+
+            control.AccessibleDescription = "Test Accessible Description";
+            AccessibleObject controlAccessibleObject = control.AccessibilityObject;
+
+            var accessibleObjectDescription = controlAccessibleObject.Description;
+
+            Assert.Equal("Test Accessible Description", accessibleObjectDescription);
+        }
+
+        [StaTheory]
+        [MemberData(nameof(ControlAccessibleObject_TestData))]
+        public void ControlAccessibleObject_GetPropertyValue_Custom_Name_ReturnsExpected(Type type)
+        {
+            using Control control = ReflectionHelper.InvokePublicConstructor<Control>(type);
+
+            if (control == null || !control.SupportsUiaProviders)
+            {
+                return;
+            }
+
+            AccessibleObject controlAccessibleObject = control.AccessibilityObject;
+            Assert.Null(controlAccessibleObject.GetPropertyValue(UiaCore.UIA.NamePropertyId));
+            control.Name = "Name1";
+            control.AccessibleName = "Test Name";
+
+            var accessibleName = controlAccessibleObject.GetPropertyValue(UiaCore.UIA.NamePropertyId);
+
+            Assert.Equal("Test Name", accessibleName);
+        }
+
         private class AutomationLiveRegionControl : Control, IAutomationLiveRegion
         {
             public AutomationLiveSetting LiveSetting { get; set; }


### PR DESCRIPTION
Fixes #3673


## Proposed changes
- Added supporting of custom AccessibleName for Form control
- Removed unneeded using "LegacyIAccessible" pattern from controls.
- Removed default names for several controls, where default names were synonyms of the control type

## Customer Impact
Customers have ability to set custom accessible name for Form control.
Now, It's app developer responsibility to set default name for several controls, and AI tooling correctly reports errors if developer had not provided AccessibleName.
- DomainUpDown;
- NumericUpdown;
- ProgressBar;
- DataGridView;
- PropertyGrid;


## Regression? 

- Yes, from .Net Framework 4.8

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->

- Unit tests
- Manual testing

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.18363.900]
- .NET Core 5.0: 5.0.100-rc.1.20379.24

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3676)