### PR TITLE
Extract and clean `DataGridViewTextBoxEditingControlAccessibleObject` up

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -522,7 +522,7 @@ namespace System.Windows.Forms
         ///  Sets the parent accessible object for the node which can be added or removed to/from hierachy nodes.
         /// </summary>
         /// <param name="parent">The parent accessible object.</param>
-        internal virtual void SetParent(AccessibleObject parent)
+        internal virtual void SetParent(AccessibleObject? parent)
         {
         }
 
@@ -530,7 +530,7 @@ namespace System.Windows.Forms
         ///  Sets the detachable child accessible object which may be added or removed to/from hierachy nodes.
         /// </summary>
         /// <param name="child">The child accessible object.</param>
-        internal virtual void SetDetachableChild(AccessibleObject child)
+        internal virtual void SetDetachableChild(AccessibleObject? child)
         {
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms
@@ -18,21 +16,21 @@ namespace System.Windows.Forms
             /// <summary>
             ///  The parent is changed when the editing control is attached to another editing cell.
             /// </summary>
-            private AccessibleObject _parentAccessibleObject;
+            private AccessibleObject? _parentAccessibleObject;
 
             public DataGridViewTextBoxEditingControlAccessibleObject(DataGridViewTextBoxEditingControl ownerControl) : base(ownerControl)
             {
             }
 
-            public override AccessibleObject Parent => _parentAccessibleObject;
+            public override AccessibleObject? Parent => _parentAccessibleObject;
 
-            public override string Name
+            public override string? Name
             {
                 get => Owner.AccessibleName ?? SR.DataGridView_AccEditingControlAccName;
                 set => base.Name = value;
             }
 
-            internal override UiaCore.IRawElementProviderFragment FragmentNavigate(UiaCore.NavigateDirection direction)
+            internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
                 => direction switch
                 {
                     UiaCore.NavigateDirection.Parent => (Owner is IDataGridViewEditingControl owner && owner.EditingControlDataGridView.EditingControl == owner)
@@ -41,10 +39,10 @@ namespace System.Windows.Forms
                     _ => base.FragmentNavigate(direction),
                 };
 
-            internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot
+            internal override UiaCore.IRawElementProviderFragmentRoot? FragmentRoot
                 => (Owner as IDataGridViewEditingControl)?.EditingControlDataGridView?.AccessibilityObject;
 
-            internal override object GetPropertyValue(UiaCore.UIA propertyID)
+            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.EditControlTypeId,
@@ -64,7 +62,7 @@ namespace System.Windows.Forms
             ///  Sets the parent accessible object for the node which can be added or removed to/from hierachy nodes.
             /// </summary>
             /// <param name="parent">The parent accessible object.</param>
-            internal override void SetParent(AccessibleObject parent) => _parentAccessibleObject = parent;
+            internal override void SetParent(AccessibleObject? parent) => _parentAccessibleObject = parent;
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObject.cs
@@ -1,0 +1,114 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    partial class DataGridViewTextBoxEditingControl
+    {
+        /// <summary>
+        ///  Defines the DataGridView TextBox EditingControl accessible object.
+        /// </summary>
+        internal class DataGridViewTextBoxEditingControlAccessibleObject : Control.ControlAccessibleObject
+        {
+            private readonly DataGridViewTextBoxEditingControl ownerControl;
+
+            /// <summary>
+            ///  The parent is changed when the editing control is attached to another editing cell.
+            /// </summary>
+            private AccessibleObject _parentAccessibleObject;
+
+            public DataGridViewTextBoxEditingControlAccessibleObject(DataGridViewTextBoxEditingControl ownerControl) : base(ownerControl)
+            {
+                this.ownerControl = ownerControl;
+            }
+
+            public override AccessibleObject Parent
+            {
+                get
+                {
+                    return _parentAccessibleObject;
+                }
+            }
+
+            public override string Name
+            {
+                get
+                {
+                    string name = Owner.AccessibleName;
+                    if (name != null)
+                    {
+                        return name;
+                    }
+                    else
+                    {
+                        return SR.DataGridView_AccEditingControlAccName;
+                    }
+                }
+                set => base.Name = value;
+            }
+
+            internal override UiaCore.IRawElementProviderFragment FragmentNavigate(UiaCore.NavigateDirection direction)
+            {
+                switch (direction)
+                {
+                    case UiaCore.NavigateDirection.Parent:
+                        if (Owner is IDataGridViewEditingControl owner && owner.EditingControlDataGridView.EditingControl == owner)
+                        {
+                            return _parentAccessibleObject;
+                        }
+
+                        return null;
+                }
+
+                return base.FragmentNavigate(direction);
+            }
+
+            internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot
+            {
+                get
+                {
+                    return (Owner as IDataGridViewEditingControl)?.EditingControlDataGridView?.AccessibilityObject;
+                }
+            }
+
+            internal override object GetPropertyValue(UiaCore.UIA propertyID)
+            {
+                switch (propertyID)
+                {
+                    case UiaCore.UIA.ControlTypePropertyId:
+                        return UiaCore.UIA.EditControlTypeId;
+                    case UiaCore.UIA.NamePropertyId:
+                        return Name;
+                    case UiaCore.UIA.IsValuePatternAvailablePropertyId:
+                        return true;
+                }
+
+                return base.GetPropertyValue(propertyID);
+            }
+
+            internal override bool IsPatternSupported(UiaCore.UIA patternId)
+            {
+                if (patternId == UiaCore.UIA.ValuePatternId)
+                {
+                    return true;
+                }
+
+                return base.IsPatternSupported(patternId);
+            }
+
+            /// <summary>
+            ///  Sets the parent accessible object for the node which can be added or removed to/from hierachy nodes.
+            /// </summary>
+            /// <param name="parent">The parent accessible object.</param>
+            internal override void SetParent(AccessibleObject parent)
+            {
+                _parentAccessibleObject = parent;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObject.cs
@@ -15,8 +15,6 @@ namespace System.Windows.Forms
         /// </summary>
         internal class DataGridViewTextBoxEditingControlAccessibleObject : Control.ControlAccessibleObject
         {
-            private readonly DataGridViewTextBoxEditingControl ownerControl;
-
             /// <summary>
             ///  The parent is changed when the editing control is attached to another editing cell.
             /// </summary>
@@ -24,91 +22,49 @@ namespace System.Windows.Forms
 
             public DataGridViewTextBoxEditingControlAccessibleObject(DataGridViewTextBoxEditingControl ownerControl) : base(ownerControl)
             {
-                this.ownerControl = ownerControl;
             }
 
-            public override AccessibleObject Parent
-            {
-                get
-                {
-                    return _parentAccessibleObject;
-                }
-            }
+            public override AccessibleObject Parent => _parentAccessibleObject;
 
             public override string Name
             {
-                get
-                {
-                    string name = Owner.AccessibleName;
-                    if (name != null)
-                    {
-                        return name;
-                    }
-                    else
-                    {
-                        return SR.DataGridView_AccEditingControlAccName;
-                    }
-                }
+                get => Owner.AccessibleName ?? SR.DataGridView_AccEditingControlAccName;
                 set => base.Name = value;
             }
 
             internal override UiaCore.IRawElementProviderFragment FragmentNavigate(UiaCore.NavigateDirection direction)
-            {
-                switch (direction)
+                => direction switch
                 {
-                    case UiaCore.NavigateDirection.Parent:
-                        if (Owner is IDataGridViewEditingControl owner && owner.EditingControlDataGridView.EditingControl == owner)
-                        {
-                            return _parentAccessibleObject;
-                        }
-
-                        return null;
-                }
-
-                return base.FragmentNavigate(direction);
-            }
+                    UiaCore.NavigateDirection.Parent => (Owner is IDataGridViewEditingControl owner && owner.EditingControlDataGridView.EditingControl == owner)
+                                               ? _parentAccessibleObject
+                                               : null,
+                    _ => base.FragmentNavigate(direction),
+                };
 
             internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot
-            {
-                get
-                {
-                    return (Owner as IDataGridViewEditingControl)?.EditingControlDataGridView?.AccessibilityObject;
-                }
-            }
+                => (Owner as IDataGridViewEditingControl)?.EditingControlDataGridView?.AccessibilityObject;
 
             internal override object GetPropertyValue(UiaCore.UIA propertyID)
-            {
-                switch (propertyID)
+                => propertyID switch
                 {
-                    case UiaCore.UIA.ControlTypePropertyId:
-                        return UiaCore.UIA.EditControlTypeId;
-                    case UiaCore.UIA.NamePropertyId:
-                        return Name;
-                    case UiaCore.UIA.IsValuePatternAvailablePropertyId:
-                        return true;
-                }
-
-                return base.GetPropertyValue(propertyID);
-            }
+                    UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.EditControlTypeId,
+                    UiaCore.UIA.NamePropertyId => Name,
+                    UiaCore.UIA.IsValuePatternAvailablePropertyId => true,
+                    _ => base.GetPropertyValue(propertyID),
+                };
 
             internal override bool IsPatternSupported(UiaCore.UIA patternId)
-            {
-                if (patternId == UiaCore.UIA.ValuePatternId)
+                => patternId switch
                 {
-                    return true;
-                }
-
-                return base.IsPatternSupported(patternId);
-            }
+                    UiaCore.UIA.ValuePatternId => true,
+                    _ => base.IsPatternSupported(patternId)
+                };
 
             /// <summary>
             ///  Sets the parent accessible object for the node which can be added or removed to/from hierachy nodes.
             /// </summary>
             /// <param name="parent">The parent accessible object.</param>
-            internal override void SetParent(AccessibleObject parent)
-            {
-                _parentAccessibleObject = parent;
-            }
+            internal override void SetParent(AccessibleObject parent) => _parentAccessibleObject = parent;
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
@@ -9,7 +9,7 @@ using static Interop;
 
 namespace System.Windows.Forms
 {
-    public class DataGridViewTextBoxEditingControl : TextBox, IDataGridViewEditingControl
+    public partial class DataGridViewTextBoxEditingControl : TextBox, IDataGridViewEditingControl
     {
         private const DataGridViewContentAlignment AnyTop = DataGridViewContentAlignment.TopLeft | DataGridViewContentAlignment.TopCenter | DataGridViewContentAlignment.TopRight;
         private const DataGridViewContentAlignment AnyRight = DataGridViewContentAlignment.TopRight | DataGridViewContentAlignment.MiddleRight | DataGridViewContentAlignment.BottomRight;
@@ -308,107 +308,6 @@ namespace System.Windows.Forms
             {
                 _dataGridView?.SetAccessibleObjectParent(this.AccessibilityObject);
             }
-        }
-    }
-
-    /// <summary>
-    ///  Defines the DataGridView TextBox EditingControl accessible object.
-    /// </summary>
-    internal class DataGridViewTextBoxEditingControlAccessibleObject : Control.ControlAccessibleObject
-    {
-        private readonly DataGridViewTextBoxEditingControl ownerControl;
-
-        /// <summary>
-        ///  The parent is changed when the editing control is attached to another editing cell.
-        /// </summary>
-        private AccessibleObject _parentAccessibleObject;
-
-        public DataGridViewTextBoxEditingControlAccessibleObject(DataGridViewTextBoxEditingControl ownerControl) : base(ownerControl)
-        {
-            this.ownerControl = ownerControl;
-        }
-
-        public override AccessibleObject Parent
-        {
-            get
-            {
-                return _parentAccessibleObject;
-            }
-        }
-
-        public override string Name
-        {
-            get
-            {
-                string name = Owner.AccessibleName;
-                if (name != null)
-                {
-                    return name;
-                }
-                else
-                {
-                    return SR.DataGridView_AccEditingControlAccName;
-                }
-            }
-            set => base.Name = value;
-        }
-
-        internal override UiaCore.IRawElementProviderFragment FragmentNavigate(UiaCore.NavigateDirection direction)
-        {
-            switch (direction)
-            {
-                case UiaCore.NavigateDirection.Parent:
-                    if (Owner is IDataGridViewEditingControl owner && owner.EditingControlDataGridView.EditingControl == owner)
-                    {
-                        return _parentAccessibleObject;
-                    }
-
-                    return null;
-            }
-
-            return base.FragmentNavigate(direction);
-        }
-
-        internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot
-        {
-            get
-            {
-                return (Owner as IDataGridViewEditingControl)?.EditingControlDataGridView?.AccessibilityObject;
-            }
-        }
-
-        internal override object GetPropertyValue(UiaCore.UIA propertyID)
-        {
-            switch (propertyID)
-            {
-                case UiaCore.UIA.ControlTypePropertyId:
-                    return UiaCore.UIA.EditControlTypeId;
-                case UiaCore.UIA.NamePropertyId:
-                    return Name;
-                case UiaCore.UIA.IsValuePatternAvailablePropertyId:
-                    return true;
-            }
-
-            return base.GetPropertyValue(propertyID);
-        }
-
-        internal override bool IsPatternSupported(UiaCore.UIA patternId)
-        {
-            if (patternId == UiaCore.UIA.ValuePatternId)
-            {
-                return true;
-            }
-
-            return base.IsPatternSupported(patternId);
-        }
-
-        /// <summary>
-        ///  Sets the parent accessible object for the node which can be added or removed to/from hierachy nodes.
-        /// </summary>
-        /// <param name="parent">The parent accessible object.</param>
-        internal override void SetParent(AccessibleObject parent)
-        {
-            _parentAccessibleObject = parent;
         }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->



## Proposed changes

- Extract `DataGridViewTextBoxEditingControlAccessibleObject` and nest under `DataGridViewTextBoxEditingControl`
- Clean `DataGridViewTextBoxEditingControlAccessibleObject`
- Apply NRT



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3688)