### PR TITLE
fix: RTB retrieve hidden text

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.GETTEXTEX.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.GETTEXTEX.cs
@@ -2,14 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Runtime.InteropServices;
+
 internal partial class Interop
 {
     internal static partial class Richedit
     {
-        public struct GETTEXTLENGTHEX
+        [StructLayout(LayoutKind.Sequential)]
+        public struct GETTEXTEX
         {
-            public GTL flags;
+            public uint cb;
+            public GT flags;
             public uint codepage;
+            public IntPtr lpDefaultChar;
+            public IntPtr lpUsedDefChar;
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.GT.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.GT.cs
@@ -2,14 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 internal partial class Interop
 {
     internal static partial class Richedit
     {
-        public struct GETTEXTLENGTHEX
+        [Flags]
+        public enum GT : uint
         {
-            public GTL flags;
-            public uint codepage;
+            DEFAULT         = 0,
+            USECRLF         = 1,
+            SELECTION       = 2,
+            RAWTEXT         = 4,
+            NOHIDDENTEXT    = 8
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EM.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EM.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -50,6 +50,8 @@ internal static partial class Interop
             SETIMESTATUS = 0x00D8,
             GETIMESTATUS = 0x00D9,
             ENABLEFEATURE = 0x00DA,
+            GETTEXTEX = WM.USER + 94,
+            GETTEXTLENGTHEX = WM.USER + 95,
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
@@ -2568,7 +2568,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(64000, 0)]
         [InlineData(0x7FFFFFFE, 0)]
         [InlineData(int.MaxValue, 0)]
-        public void RichTextBox_RightMargin_SetWithCustomOldValueWithHandle_GetReturnsExpected(int value,  int expectedCreatedCallCount)
+        public void RichTextBox_RightMargin_SetWithCustomOldValueWithHandle_GetReturnsExpected(int value, int expectedCreatedCallCount)
         {
             using var control = new RichTextBox
             {
@@ -2727,6 +2727,23 @@ namespace System.Windows.Forms.Tests
             rtf = control.Rtf;
             Assert.StartsWith("{\\rtf", rtf);
             Assert.Empty(control.Text);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData("{\\rtf1Hello World}", "Hello World")]
+        [InlineData(@"{\rtf1\ansi{Sample for {\v HIDDEN }text}}", "Sample for HIDDEN text")]
+        public void RichTextBox_Rtf_Set_GetTextExpected(string rtf, string plainText)
+        {
+            using var control = new RichTextBox
+            {
+                Rtf = rtf
+            };
+
+            string readRtf = control.Rtf;
+            Assert.StartsWith("{\\rtf", readRtf);
+            Assert.NotSame(readRtf, control.Rtf);
+            Assert.Equal(plainText, control.Text);
             Assert.True(control.IsHandleCreated);
         }
 
@@ -3491,14 +3508,6 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void RichTextBox_SelectedText_GetCantCreateHandle_GetReturnsExpected()
-        {
-            using var control = new CantCreateHandleRichTextBox();
-            Assert.Empty(control.SelectedText);
-            Assert.False(control.IsHandleCreated);
-        }
-
-        [WinFormsFact]
         public void RichTextBox_SelectedText_GetDisposed_ThrowsObjectDisposedException()
         {
             using var control = new RichTextBox();
@@ -3618,21 +3627,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-        }
-
-        [WinFormsTheory]
-        [CommonMemberData(nameof(CommonTestHelper.GetStringTheoryData))]
-        public void RichTextBox_SelectedText_SetCantCreateHandle_GetReturnsExpected(string value)
-        {
-            using var control = new CantCreateHandleRichTextBox();
-            control.SelectedText = value;
-            Assert.Empty(control.SelectedText);
-            Assert.False(control.IsHandleCreated);
-
-            // Set same.
-            control.SelectedText = value;
-            Assert.Empty(control.SelectedText);
-            Assert.False(control.IsHandleCreated);
         }
 
         [WinFormsTheory]
@@ -6815,14 +6809,14 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void RichTextBox_Text_GetCantCreateHandleWithRtf_ReturnsExpected()
+        public void RichTextBox_Text_GetWithRtf_ReturnsExpected()
         {
-            using var control = new CantCreateHandleRichTextBox
+            using var control = new RichTextBox
             {
                 Rtf = "{\\rtf Hello World}"
             };
-            Assert.Empty(control.Text);
-            Assert.False(control.IsHandleCreated);
+            Assert.Equal("Hello World", control.Text);
+            Assert.True(control.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -8077,13 +8071,13 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { string.Empty, new char[] { 'a', 'b', 'c' }, 0, -1 };
 
             yield return new object[] { "abc", Array.Empty<char>(), 0, -1 };
-            yield return new object[] { "abc", new char[] { 'a' },0,  0 };
-            yield return new object[] { "abc", new char[] { 'a', 'b' },0,  0 };
-            yield return new object[] { "abc", new char[] { 'a', 'b', 'c' },0,  0 };
-            yield return new object[] { "abc", new char[] { 'a', 'b', 'c', 'd' },0,  0 };
-            yield return new object[] { "abc", new char[] { 'c', 'b', 'a' },0,  0 };
-            yield return new object[] { "abc", new char[] { 'c', 'b' },0,  1 };
-            yield return new object[] { "abc", new char[] { 'b' },0,  1 };
+            yield return new object[] { "abc", new char[] { 'a' }, 0, 0 };
+            yield return new object[] { "abc", new char[] { 'a', 'b' }, 0, 0 };
+            yield return new object[] { "abc", new char[] { 'a', 'b', 'c' }, 0, 0 };
+            yield return new object[] { "abc", new char[] { 'a', 'b', 'c', 'd' }, 0, 0 };
+            yield return new object[] { "abc", new char[] { 'c', 'b', 'a' }, 0, 0 };
+            yield return new object[] { "abc", new char[] { 'c', 'b' }, 0, 1 };
+            yield return new object[] { "abc", new char[] { 'b' }, 0, 1 };
             yield return new object[] { "abc", new char[] { 'd' }, 0, -1 };
             yield return new object[] { "abc", new char[] { 'A', 'B', 'C' }, 0, -1 };
 
@@ -8121,13 +8115,13 @@ namespace System.Windows.Forms.Tests
                 yield return new object[] { string.Empty, new char[] { 'a', 'b', 'c' }, 0, end, -1 };
 
                 yield return new object[] { "abc", Array.Empty<char>(), 0, end, -1 };
-                yield return new object[] { "abc", new char[] { 'a' },0, end,  0 };
-                yield return new object[] { "abc", new char[] { 'a', 'b' },0, end,  0 };
-                yield return new object[] { "abc", new char[] { 'a', 'b', 'c' },0, end,  0 };
-                yield return new object[] { "abc", new char[] { 'a', 'b', 'c', 'd' },0, end,  0 };
-                yield return new object[] { "abc", new char[] { 'c', 'b', 'a' },0, end,  0 };
-                yield return new object[] { "abc", new char[] { 'c', 'b' },0, end,  1 };
-                yield return new object[] { "abc", new char[] { 'b' },0, end,  1 };
+                yield return new object[] { "abc", new char[] { 'a' }, 0, end, 0 };
+                yield return new object[] { "abc", new char[] { 'a', 'b' }, 0, end, 0 };
+                yield return new object[] { "abc", new char[] { 'a', 'b', 'c' }, 0, end, 0 };
+                yield return new object[] { "abc", new char[] { 'a', 'b', 'c', 'd' }, 0, end, 0 };
+                yield return new object[] { "abc", new char[] { 'c', 'b', 'a' }, 0, end, 0 };
+                yield return new object[] { "abc", new char[] { 'c', 'b' }, 0, end, 1 };
+                yield return new object[] { "abc", new char[] { 'b' }, 0, end, 1 };
                 yield return new object[] { "abc", new char[] { 'd' }, 0, end, -1 };
                 yield return new object[] { "abc", new char[] { 'A', 'B', 'C' }, 0, end, -1 };
 
@@ -10332,6 +10326,50 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, createdCallCount);
         }
 
+        [WinFormsFact]
+        public void RichTextBox_CheckDefaultNativeControlVersions()
+        {
+            using var control = new RichTextBox();
+            control.CreateControl();
+
+            Assert.Contains("RICHEDIT50W", GetClassName(control.Handle), StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        [WinFormsFact]
+        public void RichTextBox_CheckRichEditWithVersionCanCreateOldVersions()
+        {
+            using (var riched32 = new RichEditWithVersion("riched32.dll", "RichEdit"))
+            {
+                riched32.CreateControl();
+                Assert.Contains(".RichEdit.", GetClassName(riched32.Handle), StringComparison.InvariantCultureIgnoreCase);
+            }
+
+            using (var riched20 = new RichEditWithVersion("riched20.dll", "RichEdit20W"))
+            {
+                riched20.CreateControl();
+                Assert.Contains(".RichEdit20W.", GetClassName(riched20.Handle), StringComparison.InvariantCultureIgnoreCase);
+
+                string rtfString = @"{\rtf1\ansi{" +
+                    @"The next line\par " +
+                    @"is {\v ###NOT### }hidden\par in plain text!}}";
+
+                riched20.Rtf = rtfString;
+
+                using var richTextBox = new RichTextBox();
+                richTextBox.CreateControl();
+                richTextBox.Rtf = rtfString;
+
+                Assert.Equal(riched20.TextLength, richTextBox.TextLength);
+                Assert.Equal(riched20.Text, richTextBox.Text);
+                Assert.Equal(richTextBox.Text.Length, richTextBox.TextLength);
+
+                int startOfIs = riched20.Text.IndexOf("is");
+                int endOfHidden = riched20.Text.IndexOf("hidden") + "hidden".Length;
+                richTextBox.Select(startOfIs, endOfHidden - startOfIs);
+                Assert.Equal("is ###NOT### hidden", richTextBox.SelectedText);
+            }
+        }
+
         private class CustomGetParaFormatRichTextBox : RichTextBox
         {
             public bool MakeCustom { get; set; }
@@ -10382,7 +10420,7 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        public class SubRichTextBox : RichTextBox
+        private class SubRichTextBox : RichTextBox
         {
             public new bool CanEnableIme => base.CanEnableIme;
 
@@ -10461,6 +10499,59 @@ namespace System.Windows.Forms.Tests
             public new void SetStyle(ControlStyles flag, bool value) => base.SetStyle(flag, value);
 
             public new void WndProc(ref Message m) => base.WndProc(ref m);
+        }
+
+        private static string GetClassName(IntPtr hWnd)
+        {
+            const int MaxClassName = 256;
+            StringBuilder sb = new StringBuilder(MaxClassName);
+            UnsafeNativeMethods.GetClassName(new HandleRef(null, hWnd), sb, MaxClassName);
+            return sb.ToString();
+        }
+
+        private class RichEditWithVersion : RichTextBox
+        {
+            public RichEditWithVersion(string nativeDll, string windowClassName)
+            {
+                this.nativeDll = nativeDll;
+                this.windowClassName = windowClassName;
+            }
+
+            private IntPtr _nativeDllHandle = IntPtr.Zero;
+            protected string nativeDll;
+            protected string windowClassName;
+
+            protected override CreateParams CreateParams
+            {
+                get
+                {
+                    CreateParams cp = base.CreateParams;
+
+                    if (_nativeDllHandle == IntPtr.Zero &&
+                        !string.IsNullOrEmpty(nativeDll)) // CreateParams is called in the base class constructor, before nativeDll is assigned.
+                    {
+                        _nativeDllHandle = NativeLibrary.Load(nativeDll);
+                    }
+
+                    if (!string.IsNullOrEmpty(windowClassName))
+                    {
+                        cp.ClassName = windowClassName;
+                    }
+
+                    return cp;
+                }
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                base.Dispose(disposing);
+
+                if (_nativeDllHandle != IntPtr.Zero)
+                {
+                    NativeLibrary.Free(_nativeDllHandle);
+                    _nativeDllHandle = IntPtr.Zero;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Resolves #3399


<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

In .NET 4.7 instead of using the old RichEdit2.0/3.0 a new version of RichEdit4.1 was used, which no longer allows to provide hidden text via the existing mechanics of EM_STREAMOUT.
However in .NET Desktop allowed switching to the old RichEdit control via configuration quirks.

In .NET Core 3.0 we have deprecated the old control, which essentially
breaks certain scenarios.

Restore the ability to read hidden text.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Customers relying on RichTextBox's behaviour to retrieve hidden text can now migrate to .NET 5.0

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->



## Test methodology <!-- How did you ensure quality? -->

- Manual
- Unit tests


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3726)


Co-authored-by: mavnorthwind <mavnorthwind@users.noreply.github.com>
