### PR TITLE
Convert GetWordBoundaryStart to take string not char[]

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ClientUtils.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ClientUtils.cs
@@ -11,9 +11,6 @@ namespace System.Windows.Forms
 {
     static internal class ClientUtils
     {
-        private const int SurrogateRangeStart = 0xD800;
-        private const int SurrogateRangeEnd = 0xDFFF;
-
         // ExecutionEngineException is obsolete and shouldn't be used (to catch, throw or reference) anymore.
         // Pragma added to prevent converting the "type is obsolete" warning into build error.
         // File owner should fix this.
@@ -110,11 +107,13 @@ namespace System.Windows.Forms
             NonWord
         }
 
-        // Imitates the backwards word selection logic of the native SHAutoComplete Ctrl+Backspace handler.
-        // The selection will consist of any run of word characters and any run of non-word characters at the end of that word.
-        // If the selection reaches the second character in the input, and the first character is non-word, it is also selected.
-        // Here, word characters are equivalent to the "\w" regex class but with UnicodeCategory.ConnectorPunctuation excluded.
-        public static int GetWordBoundaryStart(char[] text, int endIndex)
+        /// <summary>
+        ///  Imitates the backwards word selection logic of the native SHAutoComplete Ctrl+Backspace handler.
+        ///  The selection will consist of any run of word characters and any run of non-word characters at the end of that word.
+        ///  If the selection reaches the second character in the input, and the first character is non-word, it is also selected.
+        ///  Here, word characters are equivalent to the "\w" regex class but with UnicodeCategory.ConnectorPunctuation excluded.
+        /// </summary>
+        public static int GetWordBoundaryStart(string text, int endIndex)
         {
             bool seenWord = false;
             CharType lastSeen = CharType.None;
@@ -122,10 +121,11 @@ namespace System.Windows.Forms
             for (; index >= 0; index--)
             {
                 char character = text[index];
-                if (character >= SurrogateRangeStart && character <= SurrogateRangeEnd)
+                if (char.IsSurrogate(character))
                 {
                     break;
                 }
+
                 bool isWord = char.IsLetterOrDigit(character) ||
                     CharUnicodeInfo.GetUnicodeCategory(character) == UnicodeCategory.NonSpacingMark;
                 if ((isWord && lastSeen == CharType.NonWord && seenWord) ||
@@ -133,9 +133,11 @@ namespace System.Windows.Forms
                 {
                     break;
                 }
+
                 seenWord |= isWord;
                 lastSeen = isWord ? CharType.Word : CharType.NonWord;
             }
+
             return index + 1;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -3022,17 +3022,17 @@ namespace System.Windows.Forms
             {
                 if (SelectionLength != 0)
                 {
-                    SelectedText = "";
+                    SelectedText = string.Empty;
                 }
                 else if (SelectionStart != 0)
                 {
-                    int boundaryStart = ClientUtils.GetWordBoundaryStart(Text.ToCharArray(), SelectionStart);
+                    int boundaryStart = ClientUtils.GetWordBoundaryStart(Text, SelectionStart);
                     int length = SelectionStart - boundaryStart;
                     BeginUpdateInternal();
                     SelectionStart = boundaryStart;
                     SelectionLength = length;
                     EndUpdateInternal();
-                    SelectedText = "";
+                    SelectedText = string.Empty;
                 }
                 return true;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -210,17 +210,17 @@ namespace System.Windows.Forms
             {
                 if (SelectionLength != 0)
                 {
-                    SetSelectedTextInternal("", clearUndo: false);
+                    SetSelectedTextInternal(string.Empty, clearUndo: false);
                 }
                 else if (SelectionStart != 0)
                 {
-                    int boundaryStart = ClientUtils.GetWordBoundaryStart(Text.ToCharArray(), SelectionStart);
+                    int boundaryStart = ClientUtils.GetWordBoundaryStart(Text, SelectionStart);
                     int length = SelectionStart - boundaryStart;
                     BeginUpdateInternal();
                     SelectionStart = boundaryStart;
                     SelectionLength = length;
                     EndUpdateInternal();
-                    SetSelectedTextInternal("", clearUndo: false);
+                    SetSelectedTextInternal(string.Empty, clearUndo: false);
                 }
                 return true;
             }


### PR DESCRIPTION
And simplify a little

Remaining question: we should move this out of ClientUtils -where to?

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3735)