### PR TITLE
Fixing issue with read the state of the CheckBox as checked/unchecked after selection in DataGridViewCheckBoxColumn by Narrator

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -84,7 +84,6 @@ System.Windows.Forms.AccessibleNavigation.Right = 4 -> System.Windows.Forms.Acce
 System.Windows.Forms.AccessibleNavigation.Up = 1 -> System.Windows.Forms.AccessibleNavigation
 System.Windows.Forms.AccessibleObject
 System.Windows.Forms.AccessibleObject.AccessibleObject() -> void
-System.Windows.Forms.AccessibleObject.RaiseAutomationNotification(System.Windows.Forms.Automation.AutomationNotificationKind notificationKind, System.Windows.Forms.Automation.AutomationNotificationProcessing notificationProcessing, string! notificationText) -> bool
 System.Windows.Forms.AccessibleObject.UseStdAccessibleObjects(System.IntPtr handle) -> void
 System.Windows.Forms.AccessibleObject.UseStdAccessibleObjects(System.IntPtr handle, int objid) -> void
 System.Windows.Forms.AccessibleRole

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+virtual System.Windows.Forms.AccessibleObject.RaiseAutomationNotification(System.Windows.Forms.Automation.AutomationNotificationKind notificationKind, System.Windows.Forms.Automation.AutomationNotificationProcessing notificationProcessing, string! notificationText) -> bool

--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -1,5 +1,64 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -53,10 +112,10 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=42.42.42.42, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=42.42.42.42, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AboutBoxDesc" xml:space="preserve">
     <value>Displays the 'About' box for this component</value>
@@ -5866,6 +5925,12 @@ Stack trace where the illegal operation occurred was:
   </data>
   <data name="ToolStripLabelIsLinkDescr" xml:space="preserve">
     <value>Specifies whether the label acts as a link.</value>
+  </data>
+  <data name="DataGridViewCheckBoxCell_Checked" xml:space="preserve">
+    <value>Checked</value>
+  </data>
+  <data name="DataGridViewCheckBoxCell_Unchecked" xml:space="preserve">
+    <value>Unchecked</value>
   </data>
   <data name="ToolStripLabelLinkBehaviorDescr" xml:space="preserve">
     <value>The underlining behavior of the link.</value>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">Vlastnost ValueType buňky v mřížce nemůže mít hodnotu Null.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Checked">
+        <source>Checked</source>
+        <target state="new">Checked</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataGridViewCheckBoxCell_ClipboardChecked">
         <source>Selected</source>
         <target state="translated">Vybráno</target>
@@ -2240,6 +2245,11 @@
       <trans-unit id="DataGridViewCheckBoxCell_InvalidValueType">
         <source>The value provided for the DataGridViewCheckBoxCell has the wrong type.</source>
         <target state="translated">Hodnota zadaná pro vlastnost DataGridViewCheckBoxCell má nesprávný typ.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Unchecked">
+        <source>Unchecked</source>
+        <target state="new">Unchecked</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridViewColumnCollection_ColumnNotFound">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">Die ValueType-Eigenschaft einer Zelle in einem Raster kann nicht NULL sein.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Checked">
+        <source>Checked</source>
+        <target state="new">Checked</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataGridViewCheckBoxCell_ClipboardChecked">
         <source>Selected</source>
         <target state="translated">Ausgewählt</target>
@@ -2240,6 +2245,11 @@
       <trans-unit id="DataGridViewCheckBoxCell_InvalidValueType">
         <source>The value provided for the DataGridViewCheckBoxCell has the wrong type.</source>
         <target state="translated">Der für die DataGridViewCheckBoxCell angegebene Wert hat den falschen Typ.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Unchecked">
+        <source>Unchecked</source>
+        <target state="new">Unchecked</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridViewColumnCollection_ColumnNotFound">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">La propiedad ValueType de la celda de una cuadrícula no puede ser nula.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Checked">
+        <source>Checked</source>
+        <target state="new">Checked</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataGridViewCheckBoxCell_ClipboardChecked">
         <source>Selected</source>
         <target state="translated">Seleccionado</target>
@@ -2240,6 +2245,11 @@
       <trans-unit id="DataGridViewCheckBoxCell_InvalidValueType">
         <source>The value provided for the DataGridViewCheckBoxCell has the wrong type.</source>
         <target state="translated">El valor proporcionado para DataGridViewCheckBoxCell tiene el tipo erróneo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Unchecked">
+        <source>Unchecked</source>
+        <target state="new">Unchecked</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridViewColumnCollection_ColumnNotFound">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">La propriété ValueType d'une cellule d'une grille ne peut pas avoir une valeur null.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Checked">
+        <source>Checked</source>
+        <target state="new">Checked</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataGridViewCheckBoxCell_ClipboardChecked">
         <source>Selected</source>
         <target state="translated">Sélectionné</target>
@@ -2240,6 +2245,11 @@
       <trans-unit id="DataGridViewCheckBoxCell_InvalidValueType">
         <source>The value provided for the DataGridViewCheckBoxCell has the wrong type.</source>
         <target state="translated">La valeur fournie pour DataGridViewCheckBoxCell est du type incorrect.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Unchecked">
+        <source>Unchecked</source>
+        <target state="new">Unchecked</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridViewColumnCollection_ColumnNotFound">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">La proprietà ValueType di una cella in una griglia non può essere null.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Checked">
+        <source>Checked</source>
+        <target state="new">Checked</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataGridViewCheckBoxCell_ClipboardChecked">
         <source>Selected</source>
         <target state="translated">Selezionato</target>
@@ -2240,6 +2245,11 @@
       <trans-unit id="DataGridViewCheckBoxCell_InvalidValueType">
         <source>The value provided for the DataGridViewCheckBoxCell has the wrong type.</source>
         <target state="translated">Tipo non corretto per il valore specificato per DataGridViewCheckBoxCell.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Unchecked">
+        <source>Unchecked</source>
+        <target state="new">Unchecked</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridViewColumnCollection_ColumnNotFound">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">グリッドにあるセルの ValueType プロパティは null にできません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Checked">
+        <source>Checked</source>
+        <target state="new">Checked</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataGridViewCheckBoxCell_ClipboardChecked">
         <source>Selected</source>
         <target state="translated">選択しました</target>
@@ -2240,6 +2245,11 @@
       <trans-unit id="DataGridViewCheckBoxCell_InvalidValueType">
         <source>The value provided for the DataGridViewCheckBoxCell has the wrong type.</source>
         <target state="translated">DataGridViewCheckBoxCell に指定された値は間違った型が指定されています。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Unchecked">
+        <source>Unchecked</source>
+        <target state="new">Unchecked</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridViewColumnCollection_ColumnNotFound">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">모눈에 있는 셀의 ValueType 속성은 null일 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Checked">
+        <source>Checked</source>
+        <target state="new">Checked</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataGridViewCheckBoxCell_ClipboardChecked">
         <source>Selected</source>
         <target state="translated">선택한 상태</target>
@@ -2240,6 +2245,11 @@
       <trans-unit id="DataGridViewCheckBoxCell_InvalidValueType">
         <source>The value provided for the DataGridViewCheckBoxCell has the wrong type.</source>
         <target state="translated">DataGridViewCheckBoxCell에 제공된 값의 형식이 잘못되었습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Unchecked">
+        <source>Unchecked</source>
+        <target state="new">Unchecked</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridViewColumnCollection_ColumnNotFound">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">Właściwość ValueType komórki w siatce nie może być zerowa.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Checked">
+        <source>Checked</source>
+        <target state="new">Checked</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataGridViewCheckBoxCell_ClipboardChecked">
         <source>Selected</source>
         <target state="translated">Wybrane</target>
@@ -2240,6 +2245,11 @@
       <trans-unit id="DataGridViewCheckBoxCell_InvalidValueType">
         <source>The value provided for the DataGridViewCheckBoxCell has the wrong type.</source>
         <target state="translated">Wartość podana dla elementu DataGridViewCheckBoxCell ma nieprawidłowy typ.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Unchecked">
+        <source>Unchecked</source>
+        <target state="new">Unchecked</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridViewColumnCollection_ColumnNotFound">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">A propriedade ValueType de uma célula em uma grade não pode ser nula.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Checked">
+        <source>Checked</source>
+        <target state="new">Checked</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataGridViewCheckBoxCell_ClipboardChecked">
         <source>Selected</source>
         <target state="translated">Selecionado</target>
@@ -2240,6 +2245,11 @@
       <trans-unit id="DataGridViewCheckBoxCell_InvalidValueType">
         <source>The value provided for the DataGridViewCheckBoxCell has the wrong type.</source>
         <target state="translated">O valor fornecido para DataGridViewCheckBoxCell é do tipo incorreto.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Unchecked">
+        <source>Unchecked</source>
+        <target state="new">Unchecked</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridViewColumnCollection_ColumnNotFound">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">Свойство ValueType ячейки в сетке не может принимать пустое значение.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Checked">
+        <source>Checked</source>
+        <target state="new">Checked</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataGridViewCheckBoxCell_ClipboardChecked">
         <source>Selected</source>
         <target state="translated">Выбрано</target>
@@ -2240,6 +2245,11 @@
       <trans-unit id="DataGridViewCheckBoxCell_InvalidValueType">
         <source>The value provided for the DataGridViewCheckBoxCell has the wrong type.</source>
         <target state="translated">Недопустимый тип значения для DataGridViewCheckBoxCell.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Unchecked">
+        <source>Unchecked</source>
+        <target state="new">Unchecked</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridViewColumnCollection_ColumnNotFound">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">Kılavuzdaki bir hücrenin ValueType özelliği null olamaz.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Checked">
+        <source>Checked</source>
+        <target state="new">Checked</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataGridViewCheckBoxCell_ClipboardChecked">
         <source>Selected</source>
         <target state="translated">Seçili</target>
@@ -2240,6 +2245,11 @@
       <trans-unit id="DataGridViewCheckBoxCell_InvalidValueType">
         <source>The value provided for the DataGridViewCheckBoxCell has the wrong type.</source>
         <target state="translated">DataGridViewCheckBoxCell için sağlanan değer yanlış türde.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Unchecked">
+        <source>Unchecked</source>
+        <target state="new">Unchecked</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridViewColumnCollection_ColumnNotFound">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">网格单元格的 ValueType 属性不能为空。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Checked">
+        <source>Checked</source>
+        <target state="new">Checked</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataGridViewCheckBoxCell_ClipboardChecked">
         <source>Selected</source>
         <target state="translated">已选定</target>
@@ -2240,6 +2245,11 @@
       <trans-unit id="DataGridViewCheckBoxCell_InvalidValueType">
         <source>The value provided for the DataGridViewCheckBoxCell has the wrong type.</source>
         <target state="translated">为 DataGridViewCheckBoxCell 提供的值的类型错误。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Unchecked">
+        <source>Unchecked</source>
+        <target state="new">Unchecked</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridViewColumnCollection_ColumnNotFound">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">方格中儲存格的 ValueType 屬性不可為 null。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Checked">
+        <source>Checked</source>
+        <target state="new">Checked</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataGridViewCheckBoxCell_ClipboardChecked">
         <source>Selected</source>
         <target state="translated">已選取</target>
@@ -2240,6 +2245,11 @@
       <trans-unit id="DataGridViewCheckBoxCell_InvalidValueType">
         <source>The value provided for the DataGridViewCheckBoxCell has the wrong type.</source>
         <target state="translated">提供給 DataGridViewCheckBoxCell 的值類型錯誤。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DataGridViewCheckBoxCell_Unchecked">
+        <source>Unchecked</source>
+        <target state="new">Unchecked</target>
         <note />
       </trans-unit>
       <trans-unit id="DataGridViewColumnCollection_ColumnNotFound">

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -1843,7 +1843,7 @@ namespace System.Windows.Forms
         ///  False if the underlying windows infrastructure is not available or the operation had failed.
         ///  Use Marshal.GetLastWin32Error for details.
         /// </returns>
-        public bool RaiseAutomationNotification(AutomationNotificationKind notificationKind, AutomationNotificationProcessing notificationProcessing, string notificationText)
+        public virtual bool RaiseAutomationNotification(AutomationNotificationKind notificationKind, AutomationNotificationProcessing notificationProcessing, string notificationText)
         {
             if (!notificationEventAvailable)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.cs
@@ -832,6 +832,26 @@ namespace System.Windows.Forms
         {
             flags |= (byte)DATAGRIDVIEWCHECKBOXCELL_valueChanged;
             DataGridView.NotifyCurrentCellDirty(true);
+            bool ret = false;
+
+            // UIA events:
+            switch (EditingCellFormattedValue)
+            {
+                case string stringValue:
+                    ret = stringValue == SR.DataGridViewCheckBoxCell_ClipboardChecked;
+                    break;
+                case CheckState checkStateValue:
+                    ret = checkStateValue == CheckState.Checked;
+                    break;
+                case bool boolValue:
+                    ret = boolValue;
+                    break;
+            }
+
+            AccessibilityObject?.RaiseAutomationNotification(
+                                    Automation.AutomationNotificationKind.Other,
+                                    Automation.AutomationNotificationProcessing.MostRecent,
+                                    ret ? SR.DataGridViewCheckBoxCell_Checked : SR.DataGridViewCheckBoxCell_Unchecked);
         }
 
         private void OnCommonContentClick(DataGridViewCellEventArgs e)
@@ -886,7 +906,7 @@ namespace System.Windows.Forms
                 UpdateButtonState(ButtonState & ~ButtonState.Checked, rowIndex);
                 if (!e.Alt && !e.Control && !e.Shift)
                 {
-                    RaiseCellClick(new DataGridViewCellEventArgs(ColumnIndex, rowIndex));
+                    //RaiseCellClick(new DataGridViewCellEventArgs(ColumnIndex, rowIndex));
                     if (DataGridView != null &&
                         ColumnIndex < DataGridView.Columns.Count &&
                         rowIndex < DataGridView.Rows.Count)


### PR DESCRIPTION
Fixes #3597


## Proposed changes
- Added logic for reading of state of the CheckBox by Narrator when user changes state of checkbox in DataGridViewCheckBoxColumn

## Customer Impact
- No

## Regression? 

- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Unit tests 
- CTI

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.18363.900]
- NET Core 5.0.100-rc.1.20411.10


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3748)