### PR TITLE
Fixing issue when keyboard focus cannot use alt+right arrow to leave ComboBox/TextBox clockwise

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripComboBox.cs
@@ -663,11 +663,17 @@ namespace System.Windows.Forms
             {
                 if ((keyData & Keys.Alt) == Keys.Alt)
                 {
-                    if ((keyData & Keys.Down) == Keys.Down || (keyData & Keys.Up) == Keys.Up)
+                    // This condition is required because (keyData & Keys.Up) == Keys.Up returns true for Keys.Right
+                    if ((keyData & Keys.Right) == Keys.Right)
+                    {
+                        return false;
+                    }
+                    else if ((keyData & Keys.Down) == Keys.Down || (keyData & Keys.Up) == Keys.Up)
                     {
                         return true;
                     }
                 }
+
                 return base.IsInputKey(keyData);
             }
 


### PR DESCRIPTION
Fixes #3661


## Proposed changes
- Fixed invalid condition for right arrow on keyboard.

## Customer Impact
- No

## Regression? 
- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- CTI 

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.18363.900]
- NET Core 5.0.100-rc.1.20411.10


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3751)