### PR TITLE
Fix string interpolation in ScrollBar

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.cs
@@ -353,7 +353,7 @@ namespace System.Windows.Forms
                 {
                     if (value < _minimum || value > _maximum)
                     {
-                        throw new ArgumentOutOfRangeException(nameof(value), string.Format(SR.InvalidBoundArgument, nameof(Value), value, $"'{nameof(Minimum)}'", "'{nameof(Maximum)}'"));
+                        throw new ArgumentOutOfRangeException(nameof(value), string.Format(SR.InvalidBoundArgument, nameof(Value), value, $"'{nameof(Minimum)}'", $"'{nameof(Maximum)}'"));
                     }
 
                     _value = value;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBarTests.cs
@@ -1752,7 +1752,10 @@ namespace System.Windows.Forms.Tests
         public void ScrollBar_Value_SetOutOfRange_ThrowsArgumentOutOfRangeException(int value)
         {
             using var control = new SubScrollBar();
-            Assert.Throws<ArgumentOutOfRangeException>("value", () => control.Value = value);
+            var paramName = "value";
+            ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(paramName, () => control.Value = value);
+            string expectedMessage = new ArgumentOutOfRangeException(paramName, string.Format(SR.InvalidBoundArgument, nameof(control.Value), value, $"'{nameof(control.Minimum)}'", $"'{nameof(control.Maximum)}'")).Message;
+            Assert.Equal(expectedMessage, ex.Message);
             Assert.Equal(0, control.Value);
         }
 


### PR DESCRIPTION
Just fixed string interpolation in ScrollBar.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3752)