### PR TITLE
Fix getting stock objects (#3774)

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.StockObject.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.StockObject.cs
@@ -6,27 +6,33 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        internal enum StockObject : uint
+        /// <summary>
+        ///  Stock GDI object identifiers.
+        /// </summary>
+        /// <remarks>
+        ///  Note that in metafile records these values are OR'ed with 0x80000000.
+        /// </remarks>
+        internal enum StockObject : int
         {
-            WHITE_BRUSH             = 0x80000000,   // 0x00FFFFFF
-            LTGRAY_BRUSH            = 0x80000001,   // 0x00C0C0C0
-            GRAY_BRUSH              = 0x80000002,   // 0x00808080
-            DKGRAY_BRUSH            = 0x80000003,   // 0x00404040
-            BLACK_BRUSH             = 0x80000004,   // 0x00404040
-            NULL_BRUSH              = 0x80000005,   // Same as HOLLOW_BRUSH
-            WHITE_PEN               = 0x80000006,   // 0x00FFFFFF
-            BLACK_PEN               = 0x80000007,   // 0x00000000
-            NULL_PEN                = 0x80000008,
-            OEM_FIXED_FONT          = 0x8000000A,
-            ANSI_FIXED_FONT         = 0x8000000B,
-            ANSI_VAR_FONT           = 0x8000000C,
-            SYSTEM_FONT             = 0x8000000D,
-            DEVICE_DEFAULT_FONT     = 0x8000000E,
-            DEFAULT_PALETTE         = 0x8000000F,
-            SYSTEM_FIXED_FONT       = 0x80000010,
-            DEFAULT_GUI_FONT        = 0x80000011,
-            DC_BRUSH                = 0x80000012,
-            DC_PEN                  = 0x80000013
+            WHITE_BRUSH             = 0x00000000,   // 0x00FFFFFF
+            LTGRAY_BRUSH            = 0x00000001,   // 0x00C0C0C0
+            GRAY_BRUSH              = 0x00000002,   // 0x00808080
+            DKGRAY_BRUSH            = 0x00000003,   // 0x00404040
+            BLACK_BRUSH             = 0x00000004,   // 0x00000000
+            NULL_BRUSH              = 0x00000005,   // Same as HOLLOW_BRUSH
+            WHITE_PEN               = 0x00000006,   // 0x00FFFFFF
+            BLACK_PEN               = 0x00000007,   // 0x00000000
+            NULL_PEN                = 0x00000008,
+            OEM_FIXED_FONT          = 0x0000000A,
+            ANSI_FIXED_FONT         = 0x0000000B,
+            ANSI_VAR_FONT           = 0x0000000C,
+            SYSTEM_FONT             = 0x0000000D,
+            DEVICE_DEFAULT_FONT     = 0x0000000E,
+            DEFAULT_PALETTE         = 0x0000000F,
+            SYSTEM_FIXED_FONT       = 0x00000010,
+            DEFAULT_GUI_FONT        = 0x00000011,
+            DC_BRUSH                = 0x00000012,
+            DC_PEN                  = 0x00000013
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EmfRecord.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EmfRecord.cs
@@ -91,6 +91,20 @@ namespace System.Windows.Forms.Metafiles
             => Type == Gdi32.EMR.EXTTEXTOUTW ? (EMREXTTEXTOUTW*)_lpmr : null;
         public EMRENUMRECORD<Gdi32.MM>* SetMapModeRecord
             => Type == Gdi32.EMR.SETMAPMODE ? (EMRENUMRECORD<Gdi32.MM>*)_lpmr : null;
+        public EMRRECTRECORD* FillPathRecord
+            => Type == Gdi32.EMR.FILLPATH ? (EMRRECTRECORD*)_lpmr : null;
+        public EMRRECTRECORD* StrokeAndFillPathRecord
+            => Type == Gdi32.EMR.STROKEANDFILLPATH ? (EMRRECTRECORD*)_lpmr : null;
+        public EMRRECTRECORD* StrokePathRecord
+            => Type == Gdi32.EMR.STROKEPATH ? (EMRRECTRECORD*)_lpmr : null;
+        public EMRRECTRECORD* ExcludeClipRectRecord
+            => Type == Gdi32.EMR.EXCLUDECLIPRECT ? (EMRRECTRECORD*)_lpmr : null;
+        public EMRRECTRECORD* IntersetClipRectRecord
+            => Type == Gdi32.EMR.INTERSECTCLIPRECT ? (EMRRECTRECORD*)_lpmr : null;
+        public EMRRECTRECORD* EllipseRecord
+            => Type == Gdi32.EMR.ELLIPSE ? (EMRRECTRECORD*)_lpmr : null;
+        public EMRRECTRECORD* RectangleRecord
+            => Type == Gdi32.EMR.RECTANGLE ? (EMRRECTRECORD*)_lpmr : null;
 
         public override string ToString() => Type switch
         {
@@ -119,6 +133,13 @@ namespace System.Windows.Forms.Metafiles
             Gdi32.EMR.EXTCREATEFONTINDIRECTW => ExtCreateFontIndirectWRecord->ToString(),
             Gdi32.EMR.EXTTEXTOUTW => ExtTextOutWRecord->ToString(),
             Gdi32.EMR.SETMAPMODE => SetMapModeRecord->ToString(),
+            Gdi32.EMR.FILLPATH => FillPathRecord->ToString(),
+            Gdi32.EMR.STROKEANDFILLPATH => StrokeAndFillPathRecord->ToString(),
+            Gdi32.EMR.STROKEPATH => StrokePathRecord->ToString(),
+            Gdi32.EMR.EXCLUDECLIPRECT => ExcludeClipRectRecord->ToString(),
+            Gdi32.EMR.INTERSECTCLIPRECT => IntersetClipRectRecord->ToString(),
+            Gdi32.EMR.ELLIPSE => EllipseRecord->ToString(),
+            Gdi32.EMR.RECTANGLE => RectangleRecord->ToString(),
             _ => $"[EMR{Type}]"
         };
     }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMRRECTRECORD.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMRRECTRECORD.cs
@@ -4,33 +4,32 @@
 
 #nullable enable
 
+using System.Drawing;
 using System.Runtime.InteropServices;
 using static Interop;
 
 namespace System.Windows.Forms.Metafiles
 {
     /// <summary>
-    ///  Record that represents an index.
+    ///  Record that just has a single <see cref="RECT"/> value.
     /// </summary>
     /// <remarks>
     ///   Not an actual Win32 define, encapsulates:
     ///
-    ///   - EMRSELECTOBJECT
-    ///   - EMRDELETEOBJECT
-    ///   - EMRSELECTPALETTE
+    ///    - EMRFILLPATH
+    ///    - EMRSTROKEANDFILLPATH
+    ///    - EMRSTROKEPATH
+    ///    - EMREXCLUDECLIPRECT
+    ///    - EMRINTERSECTCLIPRECT
+    ///    - EMRELLIPSE
+    ///    - EMRRECTANGLE
     /// </remarks>
     [StructLayout(LayoutKind.Sequential)]
-    internal struct EMRINDEXRECORD
+    internal struct EMRRECTRECORD
     {
         public EMR emr;
-        public uint index;
+        public RECT rect;
 
-        public bool IsStockObject => (index & 0x80000000) != 0;
-        public Gdi32.StockObject StockObject => (Gdi32.StockObject)(index & ~0x80000000);
-
-        public override string ToString()
-            => IsStockObject
-                ? $"[EMR{emr.iType}] StockObject: {StockObject}"
-                : $"[EMR{emr.iType}] Index: {index}";
+        public override string ToString() => $"[EMR{emr.iType}] RECT: {rect}";
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/RectangleValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/RectangleValidator.cs
@@ -1,0 +1,143 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Drawing;
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.Metafiles
+{
+    internal sealed class RectangleValidator : IEmfValidator
+    {
+        private readonly Flags _validate;
+        private readonly Rectangle _bounds;
+        private readonly int _penWidth;
+        private readonly Color _penColor;
+        private readonly Gdi32.PS _penStyle;
+        private readonly Gdi32.R2 _rop2;
+        private readonly Gdi32.BKMODE _backgroundMode;
+        private readonly Gdi32.BS _brushStyle;
+        private readonly Color _brushColor;
+
+        public RectangleValidator(
+            RECT bounds,
+            Color penColor,
+            Color brushColor,
+            int penWidth = 1,
+            Gdi32.PS penStyle = default,
+            Gdi32.R2 rop2 = Gdi32.R2.COPYPEN,
+            Gdi32.BKMODE backgroundMode = Gdi32.BKMODE.TRANSPARENT,
+            Gdi32.BS brushStyle = default,
+            Flags validate = default)
+        {
+            _bounds = bounds;
+            _brushColor = brushColor;
+            _brushStyle = brushStyle;
+            _penWidth = penWidth;
+            _penColor = penColor;
+            _penStyle = penStyle;
+            _rop2 = rop2;
+            _backgroundMode = backgroundMode;
+
+            if (validate != default)
+            {
+                _validate = validate;
+                return;
+            }
+
+            // Default values for all of these are valid expectations so we always turn them on.
+            _validate = Flags.Bounds | Flags.PenStyle | Flags.BrushStyle;
+
+            if (penWidth != 0)
+            {
+                _validate |= Flags.PenWidth;
+            }
+
+            if (!penColor.IsEmpty)
+            {
+                _validate |= Flags.PenColor;
+            }
+
+            if (!brushColor.IsEmpty)
+            {
+                _validate |= Flags.BrushColor;
+            }
+
+            if (backgroundMode != default)
+            {
+                _validate |= Flags.BackgroundMode;
+            }
+
+            if (_rop2 != default)
+            {
+                _validate |= Flags.RopMode;
+            }
+        }
+
+        public bool ShouldValidate(Gdi32.EMR recordType) => recordType == Gdi32.EMR.RECTANGLE;
+
+        public unsafe void Validate(ref EmfRecord record, DeviceContextState state, out bool complete)
+        {
+            // We're only checking one TextOut record, so this call completes our work.
+            complete = true;
+
+            EMRRECTRECORD* rectangle = record.RectangleRecord;
+
+            if (_validate.HasFlag(Flags.Bounds))
+            {
+                Assert.Equal(_bounds, (Rectangle)rectangle->rect);
+            }
+
+            if (_validate.HasFlag(Flags.BrushColor))
+            {
+                Assert.Equal((COLORREF)_brushColor, state.SelectedBrush.lbColor);
+            }
+
+            if (_validate.HasFlag(Flags.BrushStyle))
+            {
+                Assert.Equal(_brushStyle, state.SelectedBrush.lbStyle);
+            }
+
+            if (_validate.HasFlag(Flags.PenColor))
+            {
+                Assert.Equal((COLORREF)_penColor, state.SelectedPen.lopnColor);
+            }
+
+            if (_validate.HasFlag(Flags.PenWidth))
+            {
+                Assert.Equal(_penWidth, state.SelectedPen.lopnWidth.X);
+            }
+
+            if (_validate.HasFlag(Flags.PenStyle))
+            {
+                Assert.Equal(_penStyle, state.SelectedPen.lopnStyle);
+            }
+
+            if (_validate.HasFlag(Flags.BackgroundMode))
+            {
+                Assert.Equal(_backgroundMode, state.BackgroundMode);
+            }
+
+            if (_validate.HasFlag(Flags.RopMode))
+            {
+                Assert.Equal(_rop2, state.Rop2Mode);
+            }
+        }
+
+        [Flags]
+        public enum Flags : uint
+        {
+            Bounds              = 0b00000000_00000000_00000000_00000001,
+            PenColor            = 0b00000000_00000000_00000000_00000100,
+            PenWidth            = 0b00000000_00000000_00000000_00001000,
+            PenStyle            = 0b00000000_00000000_00000000_00010000,
+            RopMode             = 0b00000000_00000000_00000000_00100000,
+            BackgroundMode      = 0b00000000_00000000_00000000_01000000,
+            BrushColor          = 0b00000000_00000000_00000000_10000000,
+            BrushStyle          = 0b00000000_00000000_00000001_00000000
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/Validate.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/Validate.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System.Drawing;
+using System.Net;
 using static Interop;
 
 namespace System.Windows.Forms.Metafiles
@@ -54,6 +55,26 @@ namespace System.Windows.Forms.Metafiles
                 penStyle,
                 rop2Mode,
                 backgroundMode,
+                validate);
+
+        internal static IEmfValidator Rectangle(
+            RECT bounds,
+            Color penColor,
+            Color brushColor,
+            int penWidth = 1,
+            Gdi32.PS penStyle = default,
+            Gdi32.R2 rop2 = Gdi32.R2.COPYPEN,
+            Gdi32.BKMODE backgroundMode = Gdi32.BKMODE.TRANSPARENT,
+            Gdi32.BS brushStyle = default,
+            RectangleValidator.Flags validate = default) => new RectangleValidator(
+                bounds,
+                penColor,
+                brushColor,
+                penWidth,
+                penStyle,
+                rop2,
+                backgroundMode,
+                brushStyle,
                 validate);
 
         /// <summary>

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Gdi32/GetStockObjectTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Gdi32/GetStockObjectTests.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.Gdi32Tests
+{
+    public class GetStockObjectTests
+    {
+        [Theory]
+        [InlineData((int)Gdi32.StockObject.BLACK_BRUSH, 0x00000000, (uint)Gdi32.BS.SOLID)]
+        [InlineData((int)Gdi32.StockObject.NULL_BRUSH, 0x00000000, (uint)Gdi32.BS.HOLLOW)]
+        [InlineData((int)Gdi32.StockObject.WHITE_BRUSH, 0x00FFFFFF, (uint)Gdi32.BS.SOLID)]
+        public void GetStockBrushes(int id, uint color, uint brushStyle)
+        {
+            Gdi32.HGDIOBJ hgdiobj = Gdi32.GetStockObject((Gdi32.StockObject)id);
+            Assert.False(hgdiobj.IsNull);
+
+            Gdi32.GetObjectW(hgdiobj, out Gdi32.LOGBRUSH logBrush);
+            Assert.Equal(color, logBrush.lbColor);
+            Assert.Equal((Gdi32.BS)brushStyle, logBrush.lbStyle);
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonRenderingTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonRenderingTests.cs
@@ -91,5 +91,34 @@ namespace System.Windows.Forms.Tests
 
             var details = emf.RecordsToString();
         }
+
+        [WinFormsFact]
+        public unsafe void Button_FlatStyle_WithText_Rectangle()
+        {
+            using Button button = new Button
+            {
+                Text = "Flat Style",
+                FlatStyle = FlatStyle.Flat,
+            };
+
+            using var emf = new EmfScope();
+            DeviceContextState state = new DeviceContextState(emf);
+
+            Rectangle bounds = button.Bounds;
+
+            button.PrintToMetafile(emf);
+
+            emf.Validate(
+                state,
+                Validate.SkipType(Gdi32.EMR.BITBLT),
+                Validate.TextOut("Flat Style"),
+                Validate.Rectangle(
+                    new Rectangle(0, 0, button.Width - 2, button.Height - 2),
+                    penColor: Color.Black,
+                    penStyle: Gdi32.PS.ENDCAP_ROUND,
+                    brushColor: Color.Empty,        // Color doesn't really matter as we're using a null brush
+                    brushStyle: Gdi32.BS.NULL,      // Regressed in https://github.com/dotnet/winforms/pull/3667
+                    rop2: Gdi32.R2.COPYPEN));
+        }
     }
 }


### PR DESCRIPTION
Stock objects have a different define in metafile records. Correct values for API usage.

Add rectangle validation to the EMF validator and add regression tests for button and the Interop definitions.

Ported from https://github.com/dotnet/winforms/pull/3774 / https://github.com/dotnet/winforms/commit/6f4b818cdc3fd3a76492cfd1fb6947a3482635c9

## Customer Impact

- Flat style buttons and other controls that use a null/hollow brush don't render correctly.

## Regression? 

- Yes

## Risk

- Low


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3776)