### PR TITLE
Print preview dialog incorrect focus after pressing 'Enter' on any button

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewDialog.PrintPreviewDialogToolStripButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewDialog.PrintPreviewDialogToolStripButton.cs
@@ -9,7 +9,7 @@ namespace System.Windows.Forms
         internal class PrintPreviewDialogToolStripButton : ToolStripButton
         {
             /// <summary>
-            ///  See Control.ProcessDialogKey for more info.
+            ///  See <see cref="Control.ProcessDialogKey"/> for more info.
             /// </summary>
             protected internal override bool ProcessDialogKey(Keys keyData)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewDialog.PrintPreviewDialogToolStripButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewDialog.PrintPreviewDialogToolStripButton.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms
+{
+    public partial class PrintPreviewDialog
+    {
+        internal class PrintPreviewDialogToolStripButton : ToolStripButton
+        {
+            /// <summary>
+            ///  See Control.ProcessDialogKey for more info.
+            /// </summary>
+            protected internal override bool ProcessDialogKey(Keys keyData)
+            {
+                if (keyData == Keys.Enter || (SupportsSpaceKey && keyData == Keys.Space))
+                {
+                    FireEvent(ToolStripItemEventType.Click);
+                    return true;
+                }
+
+                return false;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewDialog.cs
@@ -7,7 +7,6 @@
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Printing;
-using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms
 {
@@ -21,7 +20,7 @@ namespace System.Windows.Forms
     [ToolboxItemFilter("System.Windows.Forms.Control.TopLevel")]
     [ToolboxItem(true)]
     [SRDescription(nameof(SR.DescriptionPrintPreviewDialog))]
-    public class PrintPreviewDialog : Form
+    public partial class PrintPreviewDialog : Form
     {
         readonly PrintPreviewControl previewControl;
         private System.Windows.Forms.ToolStrip toolStrip1;
@@ -39,11 +38,11 @@ namespace System.Windows.Forms
         private ToolStripMenuItem toolStripMenuItem7;
         private ToolStripMenuItem toolStripMenuItem8;
         private ToolStripSeparator separatorToolStripSeparator;
-        private ToolStripButton onepageToolStripButton;
-        private ToolStripButton twopagesToolStripButton;
-        private ToolStripButton threepagesToolStripButton;
-        private ToolStripButton fourpagesToolStripButton;
-        private ToolStripButton sixpagesToolStripButton;
+        private PrintPreviewDialogToolStripButton onepageToolStripButton;
+        private PrintPreviewDialogToolStripButton twopagesToolStripButton;
+        private PrintPreviewDialogToolStripButton threepagesToolStripButton;
+        private PrintPreviewDialogToolStripButton fourpagesToolStripButton;
+        private PrintPreviewDialogToolStripButton sixpagesToolStripButton;
         private ToolStripSeparator separatorToolStripSeparator1;
         private ToolStripButton closeToolStripButton;
         private ToolStripLabel pageToolStripLabel;
@@ -952,11 +951,11 @@ namespace System.Windows.Forms
             toolStripMenuItem7 = new ToolStripMenuItem();
             toolStripMenuItem8 = new ToolStripMenuItem();
             separatorToolStripSeparator = new ToolStripSeparator();
-            onepageToolStripButton = new ToolStripButton();
-            twopagesToolStripButton = new ToolStripButton();
-            threepagesToolStripButton = new ToolStripButton();
-            fourpagesToolStripButton = new ToolStripButton();
-            sixpagesToolStripButton = new ToolStripButton();
+            onepageToolStripButton = new PrintPreviewDialogToolStripButton();
+            twopagesToolStripButton = new PrintPreviewDialogToolStripButton();
+            threepagesToolStripButton = new PrintPreviewDialogToolStripButton();
+            fourpagesToolStripButton = new PrintPreviewDialogToolStripButton();
+            sixpagesToolStripButton = new PrintPreviewDialogToolStripButton();
             separatorToolStripSeparator1 = new ToolStripSeparator();
             closeToolStripButton = new ToolStripButton();
             pageCounterItem = new ToolStripNumericUpDown();


### PR DESCRIPTION
Fixes #3598


## Proposed changes
- Added special control that doesn't remove focus when user clicks Page buttons on PrintPreviewDialog

## Customer Impact

- No

## Regression? 

- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- CTI 

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.18363.900]
- NET Core 5.0.100-rc.1.20411.10

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3793)