### PR TITLE
Use proper size rectangle with GDI

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
@@ -1152,10 +1152,11 @@ namespace System.Windows.Forms
             if (context is null)
                 throw new ArgumentNullException(nameof(context));
 
-            bounds = new Rectangle(bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);
-
             if (color.HasTransparency() || style != ButtonBorderStyle.Solid)
             {
+                // Gdi+ right and bottom DrawRectangle border are 1 greater than Gdi
+                bounds = new Rectangle(bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);
+
                 Graphics graphics = context.TryGetGraphics(create: true);
                 if (graphics != null)
                 {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonRenderingTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonRenderingTests.cs
@@ -113,7 +113,7 @@ namespace System.Windows.Forms.Tests
                 Validate.SkipType(Gdi32.EMR.BITBLT),
                 Validate.TextOut("Flat Style"),
                 Validate.Rectangle(
-                    new Rectangle(0, 0, button.Width - 2, button.Height - 2),
+                    new Rectangle(0, 0, button.Width - 1, button.Height - 1),
                     penColor: Color.Black,
                     penStyle: Gdi32.PS.ENDCAP_ROUND,
                     brushColor: Color.Empty,        // Color doesn't really matter as we're using a null brush


### PR DESCRIPTION
GDI renders rectangle outlines different than GDI+ (System.Drawing). Adding the GDI code path to ControlPaint.DrawBorderSimple did not need the adjustment to the bounds rect.

Validated rendering to the pixel and wrote standalone tests to validate GDI+ behavior.

Fixes #3789

## Customer Impact

- Border rendering for some variants of buttons and checkboxes are off by one pixel. Sometimes this is very visible as it leaves a 1 pixel gap in the UI.

## Regression? 

- Yes

## Risk

- Low. Worst case is that we introduce a 1 pixel off problem somewhere else, but this is unlikely.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/8184940/91895464-245d8600-ec4c-11ea-8e17-c9422fac58a2.png)

### After

![image](https://user-images.githubusercontent.com/8184940/91895548-49ea8f80-ec4c-11ea-808d-e069495159de.png)

## Test methodology

- Wrote direct GDI/GDI+ rectangle code to validate behavior
- Updated existing test to correct coordinates


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3815)