### PR TITLE
Revert "DataGridView-related NRT annotations"

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -9571,13 +9571,13 @@ System.Windows.Forms.CheckBox.CheckBoxAccessibleObject.CheckBoxAccessibleObject(
 ~System.Windows.Forms.DataGridViewAutoSizeColumnModeEventArgs.DataGridViewAutoSizeColumnModeEventArgs(System.Windows.Forms.DataGridViewColumn dataGridViewColumn, System.Windows.Forms.DataGridViewAutoSizeColumnMode previousMode) -> void
 ~System.Windows.Forms.DataGridViewAutoSizeColumnsModeEventArgs.DataGridViewAutoSizeColumnsModeEventArgs(System.Windows.Forms.DataGridViewAutoSizeColumnMode[] previousModes) -> void
 ~System.Windows.Forms.DataGridViewAutoSizeColumnsModeEventArgs.PreviousModes.get -> System.Windows.Forms.DataGridViewAutoSizeColumnMode[]
-System.Windows.Forms.DataGridViewButtonCell.DataGridViewButtonCellAccessibleObject.DataGridViewButtonCellAccessibleObject(System.Windows.Forms.DataGridViewCell? owner) -> void
+~System.Windows.Forms.DataGridViewButtonCell.DataGridViewButtonCellAccessibleObject.DataGridViewButtonCellAccessibleObject(System.Windows.Forms.DataGridViewCell owner) -> void
 ~System.Windows.Forms.DataGridViewButtonColumn.Text.get -> string
 ~System.Windows.Forms.DataGridViewButtonColumn.Text.set -> void
 ~System.Windows.Forms.DataGridViewCell.AccessibilityObject.get -> System.Windows.Forms.AccessibleObject
-System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.DataGridViewCellAccessibleObject(System.Windows.Forms.DataGridViewCell? owner) -> void
-System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner.get -> System.Windows.Forms.DataGridViewCell?
-System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner.set -> void
+~System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.DataGridViewCellAccessibleObject(System.Windows.Forms.DataGridViewCell owner) -> void
+~System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner.get -> System.Windows.Forms.DataGridViewCell
+~System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner.set -> void
 ~System.Windows.Forms.DataGridViewCell.EditedFormattedValue.get -> object
 ~System.Windows.Forms.DataGridViewCell.ErrorText.get -> string
 ~System.Windows.Forms.DataGridViewCell.ErrorText.set -> void
@@ -9641,7 +9641,7 @@ System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner.set
 ~System.Windows.Forms.DataGridViewCellValidatingEventArgs.FormattedValue.get -> object
 ~System.Windows.Forms.DataGridViewCellValueEventArgs.Value.get -> object
 ~System.Windows.Forms.DataGridViewCellValueEventArgs.Value.set -> void
-System.Windows.Forms.DataGridViewCheckBoxCell.DataGridViewCheckBoxCellAccessibleObject.DataGridViewCheckBoxCellAccessibleObject(System.Windows.Forms.DataGridViewCell? owner) -> void
+~System.Windows.Forms.DataGridViewCheckBoxCell.DataGridViewCheckBoxCellAccessibleObject.DataGridViewCheckBoxCellAccessibleObject(System.Windows.Forms.DataGridViewCell owner) -> void
 ~System.Windows.Forms.DataGridViewCheckBoxCell.FalseValue.get -> object
 ~System.Windows.Forms.DataGridViewCheckBoxCell.FalseValue.set -> void
 ~System.Windows.Forms.DataGridViewCheckBoxCell.IndeterminateValue.get -> object
@@ -9684,10 +9684,10 @@ System.Windows.Forms.DataGridViewCheckBoxCell.DataGridViewCheckBoxCellAccessible
 ~System.Windows.Forms.DataGridViewColumnDividerDoubleClickEventArgs.DataGridViewColumnDividerDoubleClickEventArgs(int columnIndex, System.Windows.Forms.HandledMouseEventArgs e) -> void
 ~System.Windows.Forms.DataGridViewColumnEventArgs.Column.get -> System.Windows.Forms.DataGridViewColumn
 ~System.Windows.Forms.DataGridViewColumnEventArgs.DataGridViewColumnEventArgs(System.Windows.Forms.DataGridViewColumn dataGridViewColumn) -> void
-System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.DataGridViewColumnHeaderCellAccessibleObject(System.Windows.Forms.DataGridViewColumnHeaderCell? owner) -> void
+~System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.DataGridViewColumnHeaderCellAccessibleObject(System.Windows.Forms.DataGridViewColumnHeaderCell owner) -> void
 ~System.Windows.Forms.DataGridViewColumnStateChangedEventArgs.Column.get -> System.Windows.Forms.DataGridViewColumn
 ~System.Windows.Forms.DataGridViewColumnStateChangedEventArgs.DataGridViewColumnStateChangedEventArgs(System.Windows.Forms.DataGridViewColumn dataGridViewColumn, System.Windows.Forms.DataGridViewElementStates stateChanged) -> void
-System.Windows.Forms.DataGridViewComboBoxCell.DataGridViewComboBoxCellAccessibleObject.DataGridViewComboBoxCellAccessibleObject(System.Windows.Forms.DataGridViewCell? owner) -> void
+~System.Windows.Forms.DataGridViewComboBoxCell.DataGridViewComboBoxCellAccessibleObject.DataGridViewComboBoxCellAccessibleObject(System.Windows.Forms.DataGridViewCell owner) -> void
 ~System.Windows.Forms.DataGridViewComboBoxCell.ObjectCollection.Add(object item) -> int
 ~System.Windows.Forms.DataGridViewComboBoxCell.ObjectCollection.AddRange(System.Windows.Forms.DataGridViewComboBoxCell.ObjectCollection value) -> void
 ~System.Windows.Forms.DataGridViewComboBoxCell.ObjectCollection.AddRange(params object[] items) -> void
@@ -9711,7 +9711,7 @@ System.Windows.Forms.DataGridViewComboBoxCell.DataGridViewComboBoxCellAccessible
 ~System.Windows.Forms.DataGridViewEditingControlShowingEventArgs.CellStyle.set -> void
 ~System.Windows.Forms.DataGridViewEditingControlShowingEventArgs.Control.get -> System.Windows.Forms.Control
 ~System.Windows.Forms.DataGridViewEditingControlShowingEventArgs.DataGridViewEditingControlShowingEventArgs(System.Windows.Forms.Control control, System.Windows.Forms.DataGridViewCellStyle cellStyle) -> void
-System.Windows.Forms.DataGridViewImageCell.DataGridViewImageCellAccessibleObject.DataGridViewImageCellAccessibleObject(System.Windows.Forms.DataGridViewCell? owner) -> void
+~System.Windows.Forms.DataGridViewImageCell.DataGridViewImageCellAccessibleObject.DataGridViewImageCellAccessibleObject(System.Windows.Forms.DataGridViewCell owner) -> void
 ~System.Windows.Forms.DataGridViewImageCell.Description.get -> string
 ~System.Windows.Forms.DataGridViewImageCell.Description.set -> void
 ~System.Windows.Forms.DataGridViewImageColumn.Description.get -> string
@@ -9720,7 +9720,7 @@ System.Windows.Forms.DataGridViewImageCell.DataGridViewImageCellAccessibleObject
 ~System.Windows.Forms.DataGridViewImageColumn.Icon.set -> void
 ~System.Windows.Forms.DataGridViewImageColumn.Image.get -> System.Drawing.Image
 ~System.Windows.Forms.DataGridViewImageColumn.Image.set -> void
-System.Windows.Forms.DataGridViewLinkCell.DataGridViewLinkCellAccessibleObject.DataGridViewLinkCellAccessibleObject(System.Windows.Forms.DataGridViewCell? owner) -> void
+~System.Windows.Forms.DataGridViewLinkCell.DataGridViewLinkCellAccessibleObject.DataGridViewLinkCellAccessibleObject(System.Windows.Forms.DataGridViewCell owner) -> void
 ~System.Windows.Forms.DataGridViewLinkColumn.Text.get -> string
 ~System.Windows.Forms.DataGridViewLinkColumn.Text.set -> void
 ~System.Windows.Forms.DataGridViewRow.AccessibilityObject.get -> System.Windows.Forms.AccessibleObject
@@ -9755,7 +9755,7 @@ System.Windows.Forms.DataGridViewLinkCell.DataGridViewLinkCellAccessibleObject.D
 ~System.Windows.Forms.DataGridViewRowErrorTextNeededEventArgs.ErrorText.set -> void
 ~System.Windows.Forms.DataGridViewRowEventArgs.DataGridViewRowEventArgs(System.Windows.Forms.DataGridViewRow dataGridViewRow) -> void
 ~System.Windows.Forms.DataGridViewRowEventArgs.Row.get -> System.Windows.Forms.DataGridViewRow
-System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.DataGridViewRowHeaderCellAccessibleObject(System.Windows.Forms.DataGridViewRowHeaderCell? owner) -> void
+~System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.DataGridViewRowHeaderCellAccessibleObject(System.Windows.Forms.DataGridViewRowHeaderCell owner) -> void
 ~System.Windows.Forms.DataGridViewRowPostPaintEventArgs.DataGridViewRowPostPaintEventArgs(System.Windows.Forms.DataGridView dataGridView, System.Drawing.Graphics graphics, System.Drawing.Rectangle clipBounds, System.Drawing.Rectangle rowBounds, int rowIndex, System.Windows.Forms.DataGridViewElementStates rowState, string errorText, System.Windows.Forms.DataGridViewCellStyle inheritedRowStyle, bool isFirstDisplayedRow, bool isLastVisibleRow) -> void
 ~System.Windows.Forms.DataGridViewRowPostPaintEventArgs.ErrorText.get -> string
 ~System.Windows.Forms.DataGridViewRowPostPaintEventArgs.Graphics.get -> System.Drawing.Graphics
@@ -9782,7 +9782,7 @@ System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessib
 ~System.Windows.Forms.DataGridViewSortCompareEventArgs.CellValue2.get -> object
 ~System.Windows.Forms.DataGridViewSortCompareEventArgs.Column.get -> System.Windows.Forms.DataGridViewColumn
 ~System.Windows.Forms.DataGridViewSortCompareEventArgs.DataGridViewSortCompareEventArgs(System.Windows.Forms.DataGridViewColumn dataGridViewColumn, object cellValue1, object cellValue2, int rowIndex1, int rowIndex2) -> void
-System.Windows.Forms.DataGridViewTextBoxCell.DataGridViewTextBoxCellAccessibleObject.DataGridViewTextBoxCellAccessibleObject(System.Windows.Forms.DataGridViewCell? owner) -> void
+~System.Windows.Forms.DataGridViewTextBoxCell.DataGridViewTextBoxCellAccessibleObject.DataGridViewTextBoxCellAccessibleObject(System.Windows.Forms.DataGridViewCell owner) -> void
 ~System.Windows.Forms.DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.DataGridViewTopLeftHeaderCellAccessibleObject(System.Windows.Forms.DataGridViewTopLeftHeaderCell owner) -> void
 ~System.Windows.Forms.DataObject.DataObject(object data) -> void
 ~System.Windows.Forms.DataObject.DataObject(string format, object data) -> void
@@ -11218,7 +11218,7 @@ override System.Windows.Forms.CheckBox.CheckBoxAccessibleObject.DefaultAction.ge
 ~override System.Windows.Forms.DataGridViewAdvancedBorderStyle.ToString() -> string
 ~override System.Windows.Forms.DataGridViewButtonCell.Clone() -> object
 ~override System.Windows.Forms.DataGridViewButtonCell.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
-override System.Windows.Forms.DataGridViewButtonCell.DataGridViewButtonCellAccessibleObject.DefaultAction.get -> string!
+~override System.Windows.Forms.DataGridViewButtonCell.DataGridViewButtonCellAccessibleObject.DefaultAction.get -> string
 ~override System.Windows.Forms.DataGridViewButtonCell.EditType.get -> System.Type
 ~override System.Windows.Forms.DataGridViewButtonCell.FormattedValueType.get -> System.Type
 ~override System.Windows.Forms.DataGridViewButtonCell.GetContentBounds(System.Drawing.Graphics graphics, System.Windows.Forms.DataGridViewCellStyle cellStyle, int rowIndex) -> System.Drawing.Rectangle
@@ -11243,15 +11243,15 @@ override System.Windows.Forms.DataGridViewButtonCell.DataGridViewButtonCellAcces
 ~override System.Windows.Forms.DataGridViewButtonColumn.DefaultCellStyle.get -> System.Windows.Forms.DataGridViewCellStyle
 ~override System.Windows.Forms.DataGridViewButtonColumn.DefaultCellStyle.set -> void
 ~override System.Windows.Forms.DataGridViewButtonColumn.ToString() -> string
-override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.DefaultAction.get -> string!
-override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.GetChild(int index) -> System.Windows.Forms.AccessibleObject?
-override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.GetFocused() -> System.Windows.Forms.AccessibleObject?
-override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.GetSelected() -> System.Windows.Forms.AccessibleObject?
-override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Name.get -> string?
-override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Navigate(System.Windows.Forms.AccessibleNavigation navigationDirection) -> System.Windows.Forms.AccessibleObject?
-override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Parent.get -> System.Windows.Forms.AccessibleObject?
-override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Value.get -> string?
-override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Value.set -> void
+~override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.DefaultAction.get -> string
+~override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.GetChild(int index) -> System.Windows.Forms.AccessibleObject
+~override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.GetFocused() -> System.Windows.Forms.AccessibleObject
+~override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.GetSelected() -> System.Windows.Forms.AccessibleObject
+~override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Name.get -> string
+~override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Navigate(System.Windows.Forms.AccessibleNavigation navigationDirection) -> System.Windows.Forms.AccessibleObject
+~override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Parent.get -> System.Windows.Forms.AccessibleObject
+~override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Value.get -> string
+~override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Value.set -> void
 ~override System.Windows.Forms.DataGridViewCell.ToString() -> string
 ~override System.Windows.Forms.DataGridViewCellCollection.List.get -> System.Collections.ArrayList
 ~override System.Windows.Forms.DataGridViewCellStyle.Equals(object o) -> bool
@@ -11262,7 +11262,7 @@ override System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.
 ~override System.Windows.Forms.DataGridViewCheckBoxCell.ContentClickUnsharesRow(System.Windows.Forms.DataGridViewCellEventArgs e) -> bool
 ~override System.Windows.Forms.DataGridViewCheckBoxCell.ContentDoubleClickUnsharesRow(System.Windows.Forms.DataGridViewCellEventArgs e) -> bool
 ~override System.Windows.Forms.DataGridViewCheckBoxCell.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
-override System.Windows.Forms.DataGridViewCheckBoxCell.DataGridViewCheckBoxCellAccessibleObject.DefaultAction.get -> string!
+~override System.Windows.Forms.DataGridViewCheckBoxCell.DataGridViewCheckBoxCellAccessibleObject.DefaultAction.get -> string
 ~override System.Windows.Forms.DataGridViewCheckBoxCell.EditType.get -> System.Type
 ~override System.Windows.Forms.DataGridViewCheckBoxCell.FormattedValueType.get -> System.Type
 ~override System.Windows.Forms.DataGridViewCheckBoxCell.GetContentBounds(System.Drawing.Graphics graphics, System.Windows.Forms.DataGridViewCellStyle cellStyle, int rowIndex) -> System.Drawing.Rectangle
@@ -11301,11 +11301,11 @@ override System.Windows.Forms.DataGridViewCheckBoxCell.DataGridViewCheckBoxCellA
 ~override System.Windows.Forms.DataGridViewColumnDesignTimeVisibleAttribute.Equals(object obj) -> bool
 ~override System.Windows.Forms.DataGridViewColumnHeaderCell.Clone() -> object
 ~override System.Windows.Forms.DataGridViewColumnHeaderCell.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
-override System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.DefaultAction.get -> string!
-override System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.Name.get -> string!
-override System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.Navigate(System.Windows.Forms.AccessibleNavigation navigationDirection) -> System.Windows.Forms.AccessibleObject?
-override System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.Parent.get -> System.Windows.Forms.AccessibleObject?
-override System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.Value.get -> string!
+~override System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.DefaultAction.get -> string
+~override System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.Name.get -> string
+~override System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.Navigate(System.Windows.Forms.AccessibleNavigation navigationDirection) -> System.Windows.Forms.AccessibleObject
+~override System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.Parent.get -> System.Windows.Forms.AccessibleObject
+~override System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.Value.get -> string
 ~override System.Windows.Forms.DataGridViewColumnHeaderCell.GetClipboardContent(int rowIndex, bool firstCell, bool lastCell, bool inFirstRow, bool inLastRow, string format) -> object
 ~override System.Windows.Forms.DataGridViewColumnHeaderCell.GetContentBounds(System.Drawing.Graphics graphics, System.Windows.Forms.DataGridViewCellStyle cellStyle, int rowIndex) -> System.Drawing.Rectangle
 ~override System.Windows.Forms.DataGridViewColumnHeaderCell.GetInheritedContextMenuStrip(int rowIndex) -> System.Windows.Forms.ContextMenuStrip
@@ -11352,10 +11352,10 @@ override System.Windows.Forms.DataGridViewColumnHeaderCell.DataGridViewColumnHea
 ~override System.Windows.Forms.DataGridViewHeaderCell.ValueType.set -> void
 ~override System.Windows.Forms.DataGridViewImageCell.Clone() -> object
 ~override System.Windows.Forms.DataGridViewImageCell.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
-override System.Windows.Forms.DataGridViewImageCell.DataGridViewImageCellAccessibleObject.DefaultAction.get -> string!
-override System.Windows.Forms.DataGridViewImageCell.DataGridViewImageCellAccessibleObject.Description.get -> string?
-override System.Windows.Forms.DataGridViewImageCell.DataGridViewImageCellAccessibleObject.Value.get -> string?
-override System.Windows.Forms.DataGridViewImageCell.DataGridViewImageCellAccessibleObject.Value.set -> void
+~override System.Windows.Forms.DataGridViewImageCell.DataGridViewImageCellAccessibleObject.DefaultAction.get -> string
+~override System.Windows.Forms.DataGridViewImageCell.DataGridViewImageCellAccessibleObject.Description.get -> string
+~override System.Windows.Forms.DataGridViewImageCell.DataGridViewImageCellAccessibleObject.Value.get -> string
+~override System.Windows.Forms.DataGridViewImageCell.DataGridViewImageCellAccessibleObject.Value.set -> void
 ~override System.Windows.Forms.DataGridViewImageCell.DefaultNewRowValue.get -> object
 ~override System.Windows.Forms.DataGridViewImageCell.EditType.get -> System.Type
 ~override System.Windows.Forms.DataGridViewImageCell.FormattedValueType.get -> System.Type
@@ -11376,7 +11376,7 @@ override System.Windows.Forms.DataGridViewImageCell.DataGridViewImageCellAccessi
 ~override System.Windows.Forms.DataGridViewImageColumn.ToString() -> string
 ~override System.Windows.Forms.DataGridViewLinkCell.Clone() -> object
 ~override System.Windows.Forms.DataGridViewLinkCell.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
-override System.Windows.Forms.DataGridViewLinkCell.DataGridViewLinkCellAccessibleObject.DefaultAction.get -> string!
+~override System.Windows.Forms.DataGridViewLinkCell.DataGridViewLinkCellAccessibleObject.DefaultAction.get -> string
 ~override System.Windows.Forms.DataGridViewLinkCell.EditType.get -> System.Type
 ~override System.Windows.Forms.DataGridViewLinkCell.FormattedValueType.get -> System.Type
 ~override System.Windows.Forms.DataGridViewLinkCell.GetContentBounds(System.Drawing.Graphics graphics, System.Windows.Forms.DataGridViewCellStyle cellStyle, int rowIndex) -> System.Drawing.Rectangle
@@ -11414,11 +11414,11 @@ override System.Windows.Forms.DataGridViewLinkCell.DataGridViewLinkCellAccessibl
 ~override System.Windows.Forms.DataGridViewRow.ToString() -> string
 ~override System.Windows.Forms.DataGridViewRowHeaderCell.Clone() -> object
 ~override System.Windows.Forms.DataGridViewRowHeaderCell.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
-override System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.DefaultAction.get -> string!
-override System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.Name.get -> string?
-override System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.Navigate(System.Windows.Forms.AccessibleNavigation navigationDirection) -> System.Windows.Forms.AccessibleObject?
-override System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.Parent.get -> System.Windows.Forms.AccessibleObject?
-override System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.Value.get -> string!
+~override System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.DefaultAction.get -> string
+~override System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.Name.get -> string
+~override System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.Navigate(System.Windows.Forms.AccessibleNavigation navigationDirection) -> System.Windows.Forms.AccessibleObject
+~override System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.Parent.get -> System.Windows.Forms.AccessibleObject
+~override System.Windows.Forms.DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.Value.get -> string
 ~override System.Windows.Forms.DataGridViewRowHeaderCell.GetClipboardContent(int rowIndex, bool firstCell, bool lastCell, bool inFirstRow, bool inLastRow, string format) -> object
 ~override System.Windows.Forms.DataGridViewRowHeaderCell.GetContentBounds(System.Drawing.Graphics graphics, System.Windows.Forms.DataGridViewCellStyle cellStyle, int rowIndex) -> System.Drawing.Rectangle
 ~override System.Windows.Forms.DataGridViewRowHeaderCell.GetErrorIconBounds(System.Drawing.Graphics graphics, System.Windows.Forms.DataGridViewCellStyle cellStyle, int rowIndex) -> System.Drawing.Rectangle

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.DataGridViewButtonCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.DataGridViewButtonCellAccessibleObject.cs
@@ -1,6 +1,8 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+#nullable disable
 
 using static Interop;
 
@@ -10,7 +12,7 @@ namespace System.Windows.Forms
     {
         protected class DataGridViewButtonCellAccessibleObject : DataGridViewCellAccessibleObject
         {
-            public DataGridViewButtonCellAccessibleObject(DataGridViewCell? owner) : base(owner)
+            public DataGridViewButtonCellAccessibleObject(DataGridViewCell owner) : base(owner)
             {
             }
 
@@ -24,25 +26,12 @@ namespace System.Windows.Forms
 
             public override void DoDefaultAction()
             {
-                if (Owner is null)
-                {
-                    throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
-                }
+                DataGridViewButtonCell dataGridViewCell = (DataGridViewButtonCell)Owner;
+                DataGridView dataGridView = dataGridViewCell.DataGridView;
 
-                if (!(Owner is DataGridViewButtonCell dataGridViewCell))
-                {
-                    return;
-                }
-
-                if (dataGridViewCell.RowIndex == -1)
+                if (dataGridView != null && dataGridViewCell.RowIndex == -1)
                 {
                     throw new InvalidOperationException(SR.DataGridView_InvalidOperationOnSharedCell);
-                }
-
-                DataGridView? dataGridView = dataGridViewCell.DataGridView;
-                if (dataGridView?.IsHandleCreated != true)
-                {
-                    return;
                 }
 
                 if (dataGridViewCell.OwningColumn != null && dataGridViewCell.OwningRow != null)
@@ -52,14 +41,22 @@ namespace System.Windows.Forms
                 }
             }
 
-            public override int GetChildCount() => 0;
+            public override int GetChildCount()
+            {
+                return 0;
+            }
 
             internal override bool IsIAccessibleExSupported() => true;
 
-            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
-                => propertyID == UiaCore.UIA.ControlTypePropertyId
-                    ? UiaCore.UIA.ButtonControlTypeId
-                    : base.GetPropertyValue(propertyID);
+            internal override object GetPropertyValue(UiaCore.UIA propertyID)
+            {
+                if (propertyID == UiaCore.UIA.ControlTypePropertyId)
+                {
+                    return UiaCore.UIA.ButtonControlTypeId;
+                }
+
+                return base.GetPropertyValue(propertyID);
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
@@ -13,20 +15,26 @@ namespace System.Windows.Forms
     {
         protected class DataGridViewCellAccessibleObject : AccessibleObject
         {
-            private int[] _runtimeId = null!; // Used by UIAutomation
-            private AccessibleObject? _child;
-            private DataGridViewCell? _owner;
+            private int[] _runtimeId; // Used by UIAutomation
+            private AccessibleObject _child;
+            private DataGridViewCell _owner;
 
             public DataGridViewCellAccessibleObject()
             {
             }
 
-            public DataGridViewCellAccessibleObject(DataGridViewCell? owner)
+            public DataGridViewCellAccessibleObject(DataGridViewCell owner)
             {
                 _owner = owner;
             }
 
-            public override Rectangle Bounds => GetAccessibleObjectBounds(GetAccessibleObjectParent());
+            public override Rectangle Bounds
+            {
+                get
+                {
+                    return GetAccessibleObjectBounds(GetAccessibleObjectParent());
+                }
+            }
 
             public override string DefaultAction
             {
@@ -36,12 +44,18 @@ namespace System.Windows.Forms
                     {
                         throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                     }
-
-                    return !Owner.ReadOnly ? SR.DataGridView_AccCellDefaultAction : string.Empty;
+                    if (!Owner.ReadOnly)
+                    {
+                        return SR.DataGridView_AccCellDefaultAction;
+                    }
+                    else
+                    {
+                        return string.Empty;
+                    }
                 }
             }
 
-            public override string? Name
+            public override string Name
             {
                 get
                 {
@@ -49,54 +63,62 @@ namespace System.Windows.Forms
                     {
                         throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                     }
+                    if (_owner.OwningColumn != null)
+                    {
+                        string name = string.Format(SR.DataGridView_AccDataGridViewCellName, _owner.OwningColumn.HeaderText, _owner.OwningRow.Index);
 
-                    if (_owner.OwningColumn is null)
+                        if (_owner.OwningColumn.SortMode != DataGridViewColumnSortMode.NotSortable)
+                        {
+                            DataGridViewCell dataGridViewCell = Owner;
+                            DataGridView dataGridView = dataGridViewCell.DataGridView;
+
+                            if (dataGridViewCell.OwningColumn != null &&
+                                dataGridViewCell.OwningColumn == dataGridView.SortedColumn)
+                            {
+                                name += ", " + (dataGridView.SortOrder == SortOrder.Ascending
+                                    ? SR.SortedAscendingAccessibleStatus
+                                    : SR.SortedDescendingAccessibleStatus);
+                            }
+                            else
+                            {
+                                name += ", " + SR.NotSortedAccessibleStatus;
+                            }
+                        }
+
+                        return name;
+                    }
+                    else
                     {
                         return string.Empty;
                     }
-
-                    string name = string.Format(SR.DataGridView_AccDataGridViewCellName, _owner.OwningColumn.HeaderText, _owner.OwningRow.Index);
-
-                    if (_owner.OwningColumn.SortMode != DataGridViewColumnSortMode.NotSortable)
-                    {
-                        DataGridViewCell dataGridViewCell = _owner;
-                        DataGridView? dataGridView = dataGridViewCell.DataGridView;
-
-                        if (dataGridView != null &&
-                            dataGridViewCell.OwningColumn != null &&
-                            dataGridViewCell.OwningColumn == dataGridView.SortedColumn)
-                        {
-                            name += ", " + (dataGridView.SortOrder == SortOrder.Ascending
-                                ? SR.SortedAscendingAccessibleStatus
-                                : SR.SortedDescendingAccessibleStatus);
-                        }
-                        else
-                        {
-                            name += $", {SR.NotSortedAccessibleStatus}";
-                        }
-                    }
-
-                    return name;
                 }
             }
 
-            public DataGridViewCell? Owner
+            public DataGridViewCell Owner
             {
-                get => _owner;
+                get
+                {
+                    return _owner;
+                }
                 set
                 {
                     if (_owner != null)
                     {
                         throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerAlreadySet);
                     }
-
                     _owner = value;
                 }
             }
 
-            public override AccessibleObject? Parent => ParentPrivate;
+            public override AccessibleObject Parent
+            {
+                get
+                {
+                    return ParentPrivate;
+                }
+            }
 
-            private AccessibleObject? ParentPrivate
+            private AccessibleObject ParentPrivate
             {
                 get
                 {
@@ -109,7 +131,13 @@ namespace System.Windows.Forms
                 }
             }
 
-            public override AccessibleRole Role => AccessibleRole.Cell;
+            public override AccessibleRole Role
+            {
+                get
+                {
+                    return AccessibleRole.Cell;
+                }
+            }
 
             public override AccessibleStates State
             {
@@ -136,39 +164,37 @@ namespace System.Windows.Forms
                         state |= AccessibleStates.ReadOnly;
                     }
 
-                    if (_owner.DataGridView?.IsHandleCreated != true)
+                    if (Owner.DataGridView != null)
                     {
-                        return state;
-                    }
+                        Rectangle cellBounds;
+                        if (_owner.OwningColumn != null && _owner.OwningRow != null)
+                        {
+                            cellBounds = _owner.DataGridView.GetCellDisplayRectangle(_owner.OwningColumn.Index, _owner.OwningRow.Index, false /*cutOverflow*/);
+                        }
+                        else if (_owner.OwningRow != null)
+                        {
+                            cellBounds = _owner.DataGridView.GetCellDisplayRectangle(-1, _owner.OwningRow.Index, false /*cutOverflow*/);
+                        }
+                        else if (_owner.OwningColumn != null)
+                        {
+                            cellBounds = _owner.DataGridView.GetCellDisplayRectangle(_owner.OwningColumn.Index, -1, false /*cutOverflow*/);
+                        }
+                        else
+                        {
+                            cellBounds = _owner.DataGridView.GetCellDisplayRectangle(-1, -1, false /*cutOverflow*/);
+                        }
 
-                    Rectangle cellBounds;
-                    if (_owner.OwningColumn != null && _owner.OwningRow != null)
-                    {
-                        cellBounds = _owner.DataGridView.GetCellDisplayRectangle(_owner.OwningColumn.Index, _owner.OwningRow.Index, cutOverflow: false);
-                    }
-                    else if (_owner.OwningRow != null)
-                    {
-                        cellBounds = _owner.DataGridView.GetCellDisplayRectangle(-1, _owner.OwningRow.Index, cutOverflow: false);
-                    }
-                    else if (_owner.OwningColumn != null)
-                    {
-                        cellBounds = _owner.DataGridView.GetCellDisplayRectangle(_owner.OwningColumn.Index, -1, cutOverflow: false);
-                    }
-                    else
-                    {
-                        cellBounds = _owner.DataGridView.GetCellDisplayRectangle(-1, -1, cutOverflow: false);
-                    }
-
-                    if (!cellBounds.IntersectsWith(_owner.DataGridView.ClientRectangle))
-                    {
-                        state |= AccessibleStates.Offscreen;
+                        if (!cellBounds.IntersectsWith(_owner.DataGridView.ClientRectangle))
+                        {
+                            state |= AccessibleStates.Offscreen;
+                        }
                     }
 
                     return state;
                 }
             }
 
-            public override string? Value
+            public override string Value
             {
                 get
                 {
@@ -177,8 +203,8 @@ namespace System.Windows.Forms
                         throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                     }
 
-                    object? formattedValue = _owner.FormattedValue;
-                    string? formattedValueAsString = formattedValue as string;
+                    object formattedValue = _owner.FormattedValue;
+                    string formattedValueAsString = formattedValue as string;
                     if (formattedValue is null || (formattedValueAsString != null && string.IsNullOrEmpty(formattedValueAsString)))
                     {
                         return SR.DataGridView_AccNullValue;
@@ -204,14 +230,20 @@ namespace System.Windows.Forms
                         return string.Empty;
                     }
                 }
+
                 set
                 {
-                    if (_owner is null)
+                    if (_owner is DataGridViewHeaderCell)
                     {
-                        throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
+                        return;
                     }
 
-                    if (_owner is DataGridViewHeaderCell || _owner.ReadOnly || _owner.DataGridView is null || _owner.OwningRow is null)
+                    if (_owner.ReadOnly)
+                    {
+                        return;
+                    }
+
+                    if (_owner.OwningRow is null)
                     {
                         return;
                     }
@@ -226,17 +258,17 @@ namespace System.Windows.Forms
                     DataGridViewCellStyle dataGridViewCellStyle = _owner.InheritedStyle;
 
                     // Format string "True" to boolean True.
-                    object? formattedValue = _owner.GetFormattedValue(value,
-                                                                      _owner.OwningRow.Index,
-                                                                      ref dataGridViewCellStyle,
-                                                                      valueTypeConverter: null,
-                                                                      formattedValueTypeConverter: null,
-                                                                      DataGridViewDataErrorContexts.Formatting);
+                    object formattedValue = _owner.GetFormattedValue(value,
+                                                                         _owner.OwningRow.Index,
+                                                                         ref dataGridViewCellStyle,
+                                                                         null /*formattedValueTypeConverter*/ ,
+                                                                         null /*valueTypeConverter*/,
+                                                                         DataGridViewDataErrorContexts.Formatting);
                     // Parse the formatted value and push it into the back end.
                     _owner.Value = _owner.ParseFormattedValue(formattedValue,
-                                                               dataGridViewCellStyle,
-                                                               formattedValueTypeConverter: null,
-                                                               valueTypeConverter: null);
+                                                                 dataGridViewCellStyle,
+                                                                 null /*formattedValueTypeConverter*/,
+                                                                 null /*valueTypeConverter*/);
                 }
             }
 
@@ -247,14 +279,15 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                 }
 
-                DataGridViewCell dataGridViewCell = _owner;
-                DataGridView? dataGridView = dataGridViewCell.DataGridView;
-                if (dataGridViewCell is DataGridViewHeaderCell || dataGridView?.IsHandleCreated != true)
+                DataGridViewCell dataGridViewCell = (DataGridViewCell)Owner;
+                DataGridView dataGridView = dataGridViewCell.DataGridView;
+
+                if (dataGridViewCell is DataGridViewHeaderCell)
                 {
                     return;
                 }
 
-                if (dataGridViewCell.RowIndex == -1)
+                if (dataGridView != null && dataGridViewCell.RowIndex == -1)
                 {
                     throw new InvalidOperationException(SR.DataGridView_InvalidOperationOnSharedCell);
                 }
@@ -289,25 +322,21 @@ namespace System.Windows.Forms
                 }
             }
 
-            internal Rectangle GetAccessibleObjectBounds(AccessibleObject? parentAccObject)
+            internal Rectangle GetAccessibleObjectBounds(AccessibleObject parentAccObject)
             {
                 if (_owner is null)
                 {
                     throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                 }
 
-                if (parentAccObject is null
-                    || _owner.DataGridView is null
-                    || !_owner.DataGridView.IsHandleCreated
-                    || _owner.OwningColumn is null)
+                if (_owner.OwningColumn is null)
                 {
                     return Rectangle.Empty;
                 }
 
                 Rectangle rowRect = parentAccObject.Bounds;
                 Rectangle cellRect = rowRect;
-                Rectangle columnRect = _owner.DataGridView.RectangleToScreen(
-                    _owner.DataGridView.GetColumnDisplayRectangle(_owner.ColumnIndex, cutOverflow: false));
+                Rectangle columnRect = _owner.DataGridView.RectangleToScreen(_owner.DataGridView.GetColumnDisplayRectangle(_owner.ColumnIndex, false /*cutOverflow*/));
 
                 var cellRight = columnRect.Left + columnRect.Width;
                 var cellLeft = columnRect.Left;
@@ -349,7 +378,7 @@ namespace System.Windows.Forms
                 return cellRect;
             }
 
-            private AccessibleObject? GetAccessibleObjectParent()
+            private AccessibleObject GetAccessibleObjectParent()
             {
                 // If this is one of our types, use the shortcut provided by ParentPrivate property.
                 // Otherwise, use the Parent property.
@@ -368,7 +397,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            public override AccessibleObject? GetChild(int index)
+            public override AccessibleObject GetChild(int index)
             {
                 if (_owner is null)
                 {
@@ -409,18 +438,24 @@ namespace System.Windows.Forms
                 }
             }
 
-            public override AccessibleObject? GetFocused() => null;
+            public override AccessibleObject GetFocused()
+            {
+                return null;
+            }
 
-            public override AccessibleObject? GetSelected() => null;
+            public override AccessibleObject GetSelected()
+            {
+                return null;
+            }
 
-            public override AccessibleObject? Navigate(AccessibleNavigation navigationDirection)
+            public override AccessibleObject Navigate(AccessibleNavigation navigationDirection)
             {
                 if (_owner is null)
                 {
                     throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                 }
 
-                if (_owner.DataGridView?.IsHandleCreated != true || _owner.OwningColumn is null || _owner.OwningRow is null)
+                if (_owner.OwningColumn is null || _owner.OwningRow is null)
                 {
                     return null;
                 }
@@ -428,34 +463,45 @@ namespace System.Windows.Forms
                 switch (navigationDirection)
                 {
                     case AccessibleNavigation.Right:
-                        return _owner.DataGridView.RightToLeft == RightToLeft.No
-                            ? NavigateForward(wrapAround: true)
-                            : NavigateBackward(wrapAround: true);
-
+                        if (_owner.DataGridView.RightToLeft == RightToLeft.No)
+                        {
+                            return NavigateForward(true /*wrapAround*/);
+                        }
+                        else
+                        {
+                            return NavigateBackward(true /*wrapAround*/);
+                        }
                     case AccessibleNavigation.Next:
-                        return NavigateForward(wrapAround: false);
-
+                        return NavigateForward(false /*wrapAround*/);
                     case AccessibleNavigation.Left:
-                        return _owner.DataGridView.RightToLeft == RightToLeft.No
-                            ? NavigateBackward(wrapAround: true)
-                            : NavigateForward(wrapAround: true);
-
+                        if (_owner.DataGridView.RightToLeft == RightToLeft.No)
+                        {
+                            return NavigateBackward(true /*wrapAround*/);
+                        }
+                        else
+                        {
+                            return NavigateForward(true /*wrapAround*/);
+                        }
                     case AccessibleNavigation.Previous:
-                        return NavigateBackward(wrapAround: false);
-
+                        return NavigateBackward(false /*wrapAround*/);
                     case AccessibleNavigation.Up:
                         if (_owner.OwningRow.Index == _owner.DataGridView.Rows.GetFirstRow(DataGridViewElementStates.Visible))
                         {
-                            return _owner.DataGridView.ColumnHeadersVisible
-                                ? _owner.OwningColumn.HeaderCell.AccessibilityObject // Return the column header accessible object
-                                : null;
+                            if (_owner.DataGridView.ColumnHeadersVisible)
+                            {
+                                // Return the column header accessible object.
+                                return _owner.OwningColumn.HeaderCell.AccessibilityObject;
+                            }
+                            else
+                            {
+                                return null;
+                            }
                         }
                         else
                         {
                             int previousVisibleRow = _owner.DataGridView.Rows.GetPreviousRow(_owner.OwningRow.Index, DataGridViewElementStates.Visible);
                             return _owner.DataGridView.Rows[previousVisibleRow].Cells[_owner.OwningColumn.Index].AccessibilityObject;
                         }
-
                     case AccessibleNavigation.Down:
                         if (_owner.OwningRow.Index == _owner.DataGridView.Rows.GetLastRow(DataGridViewElementStates.Visible))
                         {
@@ -466,75 +512,86 @@ namespace System.Windows.Forms
                             int nextVisibleRow = _owner.DataGridView.Rows.GetNextRow(_owner.OwningRow.Index, DataGridViewElementStates.Visible);
                             return _owner.DataGridView.Rows[nextVisibleRow].Cells[_owner.OwningColumn.Index].AccessibilityObject;
                         }
-
                     default:
                         return null;
                 }
             }
 
-            private AccessibleObject? NavigateBackward(bool wrapAround)
+            private AccessibleObject NavigateBackward(bool wrapAround)
             {
-                Debug.Assert(_owner != null);
-                Debug.Assert(_owner.DataGridView != null);
-                Debug.Assert(_owner.OwningColumn != null);
-                Debug.Assert(_owner.OwningRow != null);
-
                 if (_owner.OwningColumn == _owner.DataGridView.Columns.GetFirstColumn(DataGridViewElementStates.Visible))
                 {
                     if (wrapAround)
                     {
                         // Return the last accessible object in the previous row
-                        AccessibleObject? previousRow = _owner.OwningRow.AccessibilityObject.Navigate(AccessibleNavigation.Previous);
-                        if (previousRow is null)
+                        AccessibleObject previousRow = Owner.OwningRow.AccessibilityObject.Navigate(AccessibleNavigation.Previous);
+                        if (previousRow != null && previousRow.GetChildCount() > 0)
+                        {
+                            return previousRow.GetChild(previousRow.GetChildCount() - 1);
+                        }
+                        else
                         {
                             return null;
                         }
-
-                        int childCount = previousRow.GetChildCount();
-                        return childCount > 0 ? previousRow.GetChild(childCount - 1) : null;
                     }
                     else
                     {
                         // return the row header cell if the row headers are visible.
-                        return _owner.DataGridView.RowHeadersVisible ? _owner.OwningRow.AccessibilityObject.GetChild(0) : null;
+                        if (_owner.DataGridView.RowHeadersVisible)
+                        {
+                            return _owner.OwningRow.AccessibilityObject.GetChild(0);
+                        }
+                        else
+                        {
+                            return null;
+                        }
                     }
                 }
                 else
                 {
                     int previousVisibleColumnIndex = _owner.DataGridView.Columns.GetPreviousColumn(_owner.OwningColumn,
-                                                                                                   DataGridViewElementStates.Visible,
-                                                                                                   DataGridViewElementStates.None).Index;
+                                                                                                       DataGridViewElementStates.Visible,
+                                                                                                       DataGridViewElementStates.None).Index;
                     return _owner.OwningRow.Cells[previousVisibleColumnIndex].AccessibilityObject;
                 }
             }
 
-            private AccessibleObject? NavigateForward(bool wrapAround)
+            private AccessibleObject NavigateForward(bool wrapAround)
             {
-                Debug.Assert(_owner != null);
-                Debug.Assert(_owner.DataGridView != null);
-                Debug.Assert(_owner.OwningColumn != null);
-                Debug.Assert(_owner.OwningRow != null);
-
                 if (_owner.OwningColumn == _owner.DataGridView.Columns.GetLastColumn(DataGridViewElementStates.Visible,
-                                                                                        DataGridViewElementStates.None))
+                                                                                             DataGridViewElementStates.None))
                 {
                     if (wrapAround)
                     {
                         // Return the first cell in the next visible row.
-                        AccessibleObject? nextRow = _owner.OwningRow.AccessibilityObject.Navigate(AccessibleNavigation.Next);
+                        //
+                        AccessibleObject nextRow = Owner.OwningRow.AccessibilityObject.Navigate(AccessibleNavigation.Next);
                         if (nextRow != null && nextRow.GetChildCount() > 0)
                         {
-                            return _owner.DataGridView.RowHeadersVisible ? nextRow.GetChild(1) : nextRow.GetChild(0);
+                            if (Owner.DataGridView.RowHeadersVisible)
+                            {
+                                return nextRow.GetChild(1);
+                            }
+                            else
+                            {
+                                return nextRow.GetChild(0);
+                            }
+                        }
+                        else
+                        {
+                            return null;
                         }
                     }
-
-                    return null;
+                    else
+                    {
+                        return null;
+                    }
                 }
                 else
                 {
                     int nextVisibleColumnIndex = _owner.DataGridView.Columns.GetNextColumn(_owner.OwningColumn,
-                                                                                           DataGridViewElementStates.Visible,
-                                                                                           DataGridViewElementStates.None).Index;
+                                                                                               DataGridViewElementStates.Visible,
+                                                                                               DataGridViewElementStates.None).Index;
                     return _owner.OwningRow.Cells[nextVisibleColumnIndex].AccessibilityObject;
                 }
             }
@@ -545,20 +602,17 @@ namespace System.Windows.Forms
                 {
                     throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                 }
-
-                if (_owner.DataGridView?.IsHandleCreated != true)
-                {
-                    return;
-                }
-
                 if ((flags & AccessibleSelection.TakeFocus) == AccessibleSelection.TakeFocus)
                 {
-                    _owner.DataGridView.Focus();
+                    _owner.DataGridView?.Focus();
                 }
                 if ((flags & AccessibleSelection.TakeSelection) == AccessibleSelection.TakeSelection)
                 {
                     _owner.Selected = true;
-                    _owner.DataGridView.CurrentCell = _owner; // Do not change old selection
+                    if (_owner.DataGridView != null)
+                    {
+                        _owner.DataGridView.CurrentCell = _owner; // Do not change old selection
+                    }
                 }
                 if ((flags & AccessibleSelection.AddSelection) == AccessibleSelection.AddSelection)
                 {
@@ -576,18 +630,13 @@ namespace System.Windows.Forms
             ///  Sets the detachable child accessible object which may be added or removed to/from hierachy nodes.
             /// </summary>
             /// <param name="child">The child accessible object.</param>
-            internal override void SetDetachableChild(AccessibleObject? child)
+            internal override void SetDetachableChild(AccessibleObject child)
             {
                 _child = child;
             }
 
             internal override void SetFocus()
             {
-                if (_owner?.DataGridView?.IsHandleCreated != true)
-                {
-                    return;
-                }
-
                 base.SetFocus();
 
                 RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
@@ -626,19 +675,30 @@ namespace System.Windows.Forms
 
             #region IRawElementProviderFragment Implementation
 
-            internal override Rectangle BoundingRectangle => Bounds;
+            internal override Rectangle BoundingRectangle
+            {
+                get
+                {
+                    return Bounds;
+                }
+            }
 
-            internal override UiaCore.IRawElementProviderFragmentRoot? FragmentRoot
-                => _owner?.DataGridView?.AccessibilityObject;
+            internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot
+            {
+                get
+                {
+                    return _owner.DataGridView.AccessibilityObject;
+                }
+            }
 
-            internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
+            internal override UiaCore.IRawElementProviderFragment FragmentNavigate(UiaCore.NavigateDirection direction)
             {
                 if (_owner is null)
                 {
                     throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                 }
 
-                if (_owner.DataGridView?.IsHandleCreated != true || _owner.OwningColumn is null || _owner.OwningRow is null)
+                if (_owner.OwningColumn is null || _owner.OwningRow is null)
                 {
                     return null;
                 }
@@ -647,13 +707,10 @@ namespace System.Windows.Forms
                 {
                     case UiaCore.NavigateDirection.Parent:
                         return _owner.OwningRow.AccessibilityObject;
-
                     case UiaCore.NavigateDirection.NextSibling:
-                        return NavigateForward(wrapAround: false);
-
+                        return NavigateForward(false);
                     case UiaCore.NavigateDirection.PreviousSibling:
-                        return NavigateBackward(wrapAround: false);
-
+                        return NavigateBackward(false);
                     case UiaCore.NavigateDirection.FirstChild:
                     case UiaCore.NavigateDirection.LastChild:
                         if (_owner.DataGridView.CurrentCell == _owner &&
@@ -663,7 +720,6 @@ namespace System.Windows.Forms
                             return _child;
                         }
                         break;
-
                     default:
                         return null;
                 }
@@ -675,23 +731,38 @@ namespace System.Windows.Forms
 
             #region IRawElementProviderSimple Implementation
 
-            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
-                => propertyID switch
+            internal override object GetPropertyValue(UiaCore.UIA propertyID)
+            {
+                switch (propertyID)
                 {
-                    UiaCore.UIA.NamePropertyId => Name,
-                    UiaCore.UIA.HasKeyboardFocusPropertyId => (State & AccessibleStates.Focused) == AccessibleStates.Focused,// Announce the cell when focusing.
-                    UiaCore.UIA.IsEnabledPropertyId => _owner?.DataGridView?.Enabled ?? false,
-                    UiaCore.UIA.AutomationIdPropertyId => AutomationId,
-                    UiaCore.UIA.HelpTextPropertyId => Help ?? string.Empty,
-                    UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
-                    UiaCore.UIA.IsPasswordPropertyId => false,
-                    UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
-                    UiaCore.UIA.AccessKeyPropertyId => string.Empty,
-                    UiaCore.UIA.GridItemContainingGridPropertyId => _owner?.DataGridView?.AccessibilityObject,
-                    UiaCore.UIA.IsTableItemPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.TableItemPatternId),
-                    UiaCore.UIA.IsGridItemPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.GridItemPatternId),
-                    _ => base.GetPropertyValue(propertyID),
-                };
+                    case UiaCore.UIA.NamePropertyId:
+                        return Name;
+                    case UiaCore.UIA.HasKeyboardFocusPropertyId:
+                        return (State & AccessibleStates.Focused) == AccessibleStates.Focused; // Announce the cell when focusing.
+                    case UiaCore.UIA.IsEnabledPropertyId:
+                        return _owner.DataGridView.Enabled;
+                    case UiaCore.UIA.AutomationIdPropertyId:
+                        return AutomationId;
+                    case UiaCore.UIA.HelpTextPropertyId:
+                        return Help ?? string.Empty;
+                    case UiaCore.UIA.IsKeyboardFocusablePropertyId:
+                        return (State & AccessibleStates.Focusable) == AccessibleStates.Focusable;
+                    case UiaCore.UIA.IsPasswordPropertyId:
+                        return false;
+                    case UiaCore.UIA.IsOffscreenPropertyId:
+                        return (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen;
+                    case UiaCore.UIA.AccessKeyPropertyId:
+                        return string.Empty;
+                    case UiaCore.UIA.GridItemContainingGridPropertyId:
+                        return Owner.DataGridView.AccessibilityObject;
+                    case UiaCore.UIA.IsTableItemPatternAvailablePropertyId:
+                        return IsPatternSupported(UiaCore.UIA.TableItemPatternId);
+                    case UiaCore.UIA.IsGridItemPatternAvailablePropertyId:
+                        return IsPatternSupported(UiaCore.UIA.GridItemPatternId);
+                }
+
+                return base.GetPropertyValue(propertyID);
+            }
 
             internal override bool IsPatternSupported(UiaCore.UIA patternId)
             {
@@ -702,9 +773,10 @@ namespace System.Windows.Forms
                     return true;
                 }
 
-                if ((patternId == UiaCore.UIA.TableItemPatternId || patternId == UiaCore.UIA.GridItemPatternId)
+                if ((patternId == UiaCore.UIA.TableItemPatternId ||
+                    patternId == UiaCore.UIA.GridItemPatternId) &&
                     // We don't want to implement patterns for header cells
-                    && _owner?.ColumnIndex != -1 && _owner?.RowIndex != -1)
+                    _owner.ColumnIndex != -1 && _owner.RowIndex != -1)
                 {
                     return true;
                 }
@@ -714,9 +786,9 @@ namespace System.Windows.Forms
 
             #endregion
 
-            internal override UiaCore.IRawElementProviderSimple[]? GetRowHeaderItems()
+            internal override UiaCore.IRawElementProviderSimple[] GetRowHeaderItems()
             {
-                if (_owner?.DataGridView?.IsHandleCreated is true && _owner.DataGridView.RowHeadersVisible && _owner.OwningRow.HasHeaderCell)
+                if (_owner.DataGridView.RowHeadersVisible && _owner.OwningRow.HasHeaderCell)
                 {
                     return new UiaCore.IRawElementProviderSimple[1] { _owner.OwningRow.HeaderCell.AccessibilityObject };
                 }
@@ -724,9 +796,9 @@ namespace System.Windows.Forms
                 return null;
             }
 
-            internal override UiaCore.IRawElementProviderSimple[]? GetColumnHeaderItems()
+            internal override UiaCore.IRawElementProviderSimple[] GetColumnHeaderItems()
             {
-                if (_owner?.DataGridView?.IsHandleCreated is true && _owner.DataGridView.ColumnHeadersVisible && _owner.OwningColumn.HasHeaderCell)
+                if (_owner.DataGridView.ColumnHeadersVisible && _owner.OwningColumn.HasHeaderCell)
                 {
                     return new UiaCore.IRawElementProviderSimple[1] { _owner.OwningColumn.HeaderCell.AccessibilityObject };
                 }
@@ -734,13 +806,31 @@ namespace System.Windows.Forms
                 return null;
             }
 
-            internal override int Row => _owner?.OwningRow != null ? _owner.OwningRow.Index : -1;
+            internal override int Row
+            {
+                get
+                {
+                    return _owner.OwningRow != null ? _owner.OwningRow.Index : -1;
+                }
+            }
 
-            internal override int Column => _owner?.OwningColumn != null ? _owner.OwningColumn.Index : -1;
+            internal override int Column
+            {
+                get
+                {
+                    return _owner.OwningColumn != null ? _owner.OwningColumn.Index : -1;
+                }
+            }
 
-            internal override UiaCore.IRawElementProviderSimple? ContainingGrid => _owner?.DataGridView?.AccessibilityObject;
+            internal override UiaCore.IRawElementProviderSimple ContainingGrid
+            {
+                get
+                {
+                    return _owner.DataGridView.AccessibilityObject;
+                }
+            }
 
-            internal override bool IsReadOnly => _owner?.ReadOnly ?? false;
+            internal override bool IsReadOnly => _owner.ReadOnly;
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.cs
@@ -1,9 +1,10 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Drawing;
 using static Interop;
 
@@ -13,61 +14,89 @@ namespace System.Windows.Forms
     {
         protected class DataGridViewColumnHeaderCellAccessibleObject : DataGridViewCellAccessibleObject
         {
-            public DataGridViewColumnHeaderCellAccessibleObject(DataGridViewColumnHeaderCell? owner) : base(owner)
+            public DataGridViewColumnHeaderCellAccessibleObject(DataGridViewColumnHeaderCell owner) : base(owner)
             {
             }
 
-            public override Rectangle Bounds => Owner is null
-                ? throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet)
-                : (Owner.DataGridView?.IsHandleCreated == true) ? GetAccessibleObjectBounds(Parent) : Rectangle.Empty;
+            public override Rectangle Bounds
+            {
+                get
+                {
+                    return GetAccessibleObjectBounds(ParentPrivate);
+                }
+            }
 
             public override string DefaultAction
             {
                 get
                 {
-                    if (Owner is null)
-                    {
-                        throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
-                    }
-
                     if (Owner.OwningColumn != null)
                     {
                         if (Owner.OwningColumn.SortMode == DataGridViewColumnSortMode.Automatic)
                         {
                             return SR.DataGridView_AccColumnHeaderCellDefaultAction;
                         }
-                        else if (Owner.DataGridView != null && (
-                                Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.FullColumnSelect ||
-                                Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.ColumnHeaderSelect))
+                        else if (Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.FullColumnSelect ||
+                                 Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.ColumnHeaderSelect)
                         {
                             return SR.DataGridView_AccColumnHeaderCellSelectDefaultAction;
                         }
+                        else
+                        {
+                            return string.Empty;
+                        }
                     }
-
-                    return string.Empty;
+                    else
+                    {
+                        return string.Empty;
+                    }
                 }
             }
 
-            public override string Name => Owner is null
-                ? throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet)
-                : Owner.OwningColumn?.HeaderText ?? string.Empty;
+            public override string Name
+            {
+                get
+                {
+                    if (Owner.OwningColumn != null)
+                    {
+                        return Owner.OwningColumn.HeaderText;
+                    }
+                    else
+                    {
+                        return string.Empty;
+                    }
+                }
+            }
 
-            // return the top header row accessible object
-            public override AccessibleObject? Parent => Owner is null
-                ? throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet)
-                : Owner.DataGridView?.AccessibilityObject?.GetChild(0);
+            public override AccessibleObject Parent
+            {
+                get
+                {
+                    return ParentPrivate;
+                }
+            }
 
-            public override AccessibleRole Role => AccessibleRole.ColumnHeader;
+            private AccessibleObject ParentPrivate
+            {
+                get
+                {
+                    // return the top header row accessible object
+                    return Owner.DataGridView.AccessibilityObject.GetChild(0);
+                }
+            }
+
+            public override AccessibleRole Role
+            {
+                get
+                {
+                    return AccessibleRole.ColumnHeader;
+                }
+            }
 
             public override AccessibleStates State
             {
                 get
                 {
-                    if (Owner is null)
-                    {
-                        throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
-                    }
-
                     AccessibleStates resultState = AccessibleStates.Selectable;
 
                     // get the Offscreen state from the base method.
@@ -77,10 +106,10 @@ namespace System.Windows.Forms
                         resultState |= AccessibleStates.Offscreen;
                     }
 
-                    if (Owner.DataGridView != null && Owner.OwningColumn != null && Owner.OwningColumn.Selected)
-                    {
-                        if (Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.FullColumnSelect ||
+                    if (Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.FullColumnSelect ||
                         Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.ColumnHeaderSelect)
+                    {
+                        if (Owner.OwningColumn != null && Owner.OwningColumn.Selected)
                         {
                             resultState |= AccessibleStates.Selected;
                         }
@@ -90,49 +119,41 @@ namespace System.Windows.Forms
                 }
             }
 
-            public override string Value => Name;
-
-            public override void DoDefaultAction()
+            public override string Value
             {
-                if (Owner is null)
+                get
                 {
-                    throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
-                }
-
-                if (!(Owner is DataGridViewColumnHeaderCell dataGridViewCell))
-                {
-                    return;
-                }
-
-                DataGridView? dataGridView = dataGridViewCell.DataGridView;
-                if (dataGridView?.IsHandleCreated != true || dataGridViewCell.OwningColumn is null)
-                {
-                    return;
-                }
-
-                if (dataGridViewCell.OwningColumn.SortMode == DataGridViewColumnSortMode.Automatic)
-                {
-                    ListSortDirection listSortDirection = dataGridView.SortedColumn == dataGridViewCell.OwningColumn && dataGridView.SortOrder == SortOrder.Ascending
-                        ? ListSortDirection.Descending
-                        : ListSortDirection.Ascending;
-
-                    dataGridView.Sort(dataGridViewCell.OwningColumn, listSortDirection);
-                }
-                else if (dataGridView.SelectionMode == DataGridViewSelectionMode.FullColumnSelect ||
-                         dataGridView.SelectionMode == DataGridViewSelectionMode.ColumnHeaderSelect)
-                {
-                    dataGridViewCell.OwningColumn.Selected = true;
+                    return Name;
                 }
             }
 
-            public override AccessibleObject? Navigate(AccessibleNavigation navigationDirection)
+            public override void DoDefaultAction()
             {
-                if (Owner is null)
-                {
-                    throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
-                }
+                DataGridViewColumnHeaderCell dataGridViewCell = (DataGridViewColumnHeaderCell)Owner;
+                DataGridView dataGridView = dataGridViewCell.DataGridView;
 
-                if (Owner.OwningColumn is null || Owner.DataGridView is null)
+                if (dataGridViewCell.OwningColumn != null)
+                {
+                    if (dataGridViewCell.OwningColumn.SortMode == DataGridViewColumnSortMode.Automatic)
+                    {
+                        ListSortDirection listSortDirection = ListSortDirection.Ascending;
+                        if (dataGridView.SortedColumn == dataGridViewCell.OwningColumn && dataGridView.SortOrder == SortOrder.Ascending)
+                        {
+                            listSortDirection = ListSortDirection.Descending;
+                        }
+                        dataGridView.Sort(dataGridViewCell.OwningColumn, listSortDirection);
+                    }
+                    else if (dataGridView.SelectionMode == DataGridViewSelectionMode.FullColumnSelect ||
+                             dataGridView.SelectionMode == DataGridViewSelectionMode.ColumnHeaderSelect)
+                    {
+                        dataGridViewCell.OwningColumn.Selected = true;
+                    }
+                }
+            }
+
+            public override AccessibleObject Navigate(AccessibleNavigation navigationDirection)
+            {
+                if (Owner.OwningColumn is null)
                 {
                     return null;
                 }
@@ -140,74 +161,96 @@ namespace System.Windows.Forms
                 switch (navigationDirection)
                 {
                     case AccessibleNavigation.Right:
-                        return Owner.DataGridView.RightToLeft == RightToLeft.No ? NavigateForward() : NavigateBackward();
+                        if (Owner.DataGridView.RightToLeft == RightToLeft.No)
+                        {
+                            return NavigateForward();
+                        }
+                        else
+                        {
+                            return NavigateBackward();
+                        }
                     case AccessibleNavigation.Next:
                         return NavigateForward();
                     case AccessibleNavigation.Left:
-                        return Owner.DataGridView.RightToLeft == RightToLeft.No ? NavigateBackward() : NavigateForward();
+                        if (Owner.DataGridView.RightToLeft == RightToLeft.No)
+                        {
+                            return NavigateBackward();
+                        }
+                        else
+                        {
+                            return NavigateForward();
+                        }
                     case AccessibleNavigation.Previous:
                         return NavigateBackward();
                     case AccessibleNavigation.FirstChild:
                         // return the top left header cell accessible object
-                        return Parent?.GetChild(0);
+                        return Owner.DataGridView.AccessibilityObject.GetChild(0).GetChild(0);
                     case AccessibleNavigation.LastChild:
                         // return the last column header cell in the top row header accessible object
-                        AccessibleObject? topRowHeaderAccessibleObject = Parent;
-                        return topRowHeaderAccessibleObject?.GetChild(topRowHeaderAccessibleObject.GetChildCount() - 1);
+                        AccessibleObject topRowHeaderAccessibleObject = Owner.DataGridView.AccessibilityObject.GetChild(0);
+                        return topRowHeaderAccessibleObject.GetChild(topRowHeaderAccessibleObject.GetChildCount() - 1);
                     default:
                         return null;
                 }
             }
 
-            private AccessibleObject? NavigateBackward()
+            private AccessibleObject NavigateBackward()
             {
-                Debug.Assert(Owner != null);
-
-                // This method is called after _owner and its properties are validated
-                if (Owner.OwningColumn is null || Owner.DataGridView is null)
-                {
-                    return null;
-                }
-
                 if (Owner.OwningColumn == Owner.DataGridView.Columns.GetFirstColumn(DataGridViewElementStates.Visible))
                 {
-                    // return the row header cell accessible object for the current row if Owner.DataGridView.RowHeadersVisible == false
-                    return Owner.DataGridView.RowHeadersVisible ? Parent?.GetChild(0) : null;
+                    if (Owner.DataGridView.RowHeadersVisible)
+                    {
+                        // return the row header cell accessible object for the current row
+                        return Parent.GetChild(0);
+                    }
+                    else
+                    {
+                        return null;
+                    }
                 }
                 else
                 {
                     int previousVisibleColumnIndex = Owner.DataGridView.Columns.GetPreviousColumn(Owner.OwningColumn,
-                                                                                                  DataGridViewElementStates.Visible,
-                                                                                                  DataGridViewElementStates.None).Index;
+                                                                                                                DataGridViewElementStates.Visible,
+                                                                                                                DataGridViewElementStates.None).Index;
                     int actualDisplayIndex = Owner.DataGridView.Columns.ColumnIndexToActualDisplayIndex(previousVisibleColumnIndex,
-                                                                                                  DataGridViewElementStates.Visible);
-
-                    return Owner.DataGridView.RowHeadersVisible ? Parent?.GetChild(actualDisplayIndex + 1) : Parent?.GetChild(actualDisplayIndex);
+                                                                                                             DataGridViewElementStates.Visible);
+                    if (Owner.DataGridView.RowHeadersVisible)
+                    {
+                        return Parent.GetChild(actualDisplayIndex + 1);
+                    }
+                    else
+                    {
+                        return Parent.GetChild(actualDisplayIndex);
+                    }
                 }
             }
 
-            private AccessibleObject? NavigateForward()
+            private AccessibleObject NavigateForward()
             {
-                Debug.Assert(Owner != null);
-
-                // This method is called after _owner and its properties are validated
-                if (Owner.OwningColumn is null ||
-                    Owner.DataGridView is null ||
-                    Owner.OwningColumn == Owner.DataGridView.Columns.GetLastColumn(DataGridViewElementStates.Visible,
-                                                                                   DataGridViewElementStates.None))
+                if (Owner.OwningColumn == Owner.DataGridView.Columns.GetLastColumn(DataGridViewElementStates.Visible,
+                                                                                                      DataGridViewElementStates.None))
                 {
                     return null;
                 }
+                else
+                {
+                    int nextVisibleColumnIndex = Owner.DataGridView.Columns.GetNextColumn(Owner.OwningColumn,
+                                                                                                        DataGridViewElementStates.Visible,
+                                                                                                        DataGridViewElementStates.None).Index;
+                    int actualDisplayIndex = Owner.DataGridView.Columns.ColumnIndexToActualDisplayIndex(nextVisibleColumnIndex,
+                                                                                                             DataGridViewElementStates.Visible);
 
-                int nextVisibleColumnIndex = Owner.DataGridView.Columns.GetNextColumn(Owner.OwningColumn,
-                                                                                      DataGridViewElementStates.Visible,
-                                                                                      DataGridViewElementStates.None).Index;
-
-                int actualDisplayIndex = Owner.DataGridView.Columns.ColumnIndexToActualDisplayIndex(nextVisibleColumnIndex,
-                                                                                      DataGridViewElementStates.Visible);
-
-                // Add 1 because the top header row accessible object has the top left header cell accessible object at the beginning
-                return Owner.DataGridView.RowHeadersVisible ? Parent?.GetChild(actualDisplayIndex + 1) : Parent?.GetChild(actualDisplayIndex);
+                    if (Owner.DataGridView.RowHeadersVisible)
+                    {
+                        // + 1 because the top header row accessible object has the top left header cell accessible object at the beginning
+                        return Parent.GetChild(actualDisplayIndex + 1);
+                    }
+                    else
+                    {
+                        return Parent.GetChild(actualDisplayIndex);
+                    }
+                }
             }
 
             public override void Select(AccessibleSelection flags)
@@ -217,22 +260,17 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                 }
 
-                if (!(Owner is DataGridViewColumnHeaderCell dataGridViewCell))
+                DataGridViewColumnHeaderCell dataGridViewCell = (DataGridViewColumnHeaderCell)Owner;
+                DataGridView dataGridView = dataGridViewCell.DataGridView;
+
+                if (dataGridView is null)
                 {
                     return;
                 }
-
-                DataGridView? dataGridView = dataGridViewCell.DataGridView;
-                if (dataGridView?.IsHandleCreated != true)
-                {
-                    return;
-                }
-
                 if ((flags & AccessibleSelection.TakeFocus) == AccessibleSelection.TakeFocus)
                 {
                     dataGridView.Focus();
                 }
-
                 if (dataGridViewCell.OwningColumn != null &&
                     (dataGridView.SelectionMode == DataGridViewSelectionMode.FullColumnSelect ||
                      dataGridView.SelectionMode == DataGridViewSelectionMode.ColumnHeaderSelect))
@@ -250,20 +288,24 @@ namespace System.Windows.Forms
 
             #region IRawElementProviderFragment Implementation
 
-            internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
+            internal override UiaCore.IRawElementProviderFragment FragmentNavigate(UiaCore.NavigateDirection direction)
             {
-                if (Owner is null)
+                if (Owner.OwningColumn is null)
                 {
-                    throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
+                    return null;
                 }
 
-                return direction switch
+                switch (direction)
                 {
-                    UiaCore.NavigateDirection.Parent => Parent,
-                    UiaCore.NavigateDirection.NextSibling => NavigateForward(),
-                    UiaCore.NavigateDirection.PreviousSibling => NavigateBackward(),
-                    _ => null
-                };
+                    case UiaCore.NavigateDirection.Parent:
+                        return Parent;
+                    case UiaCore.NavigateDirection.NextSibling:
+                        return NavigateForward();
+                    case UiaCore.NavigateDirection.PreviousSibling:
+                        return NavigateBackward();
+                    default:
+                        return null;
+                }
             }
 
             #endregion
@@ -271,22 +313,36 @@ namespace System.Windows.Forms
             #region IRawElementProviderSimple Implementation
 
             internal override bool IsPatternSupported(UiaCore.UIA patternId)
-                => patternId.Equals(UiaCore.UIA.LegacyIAccessiblePatternId) ||
+            {
+                return patternId.Equals(UiaCore.UIA.LegacyIAccessiblePatternId) ||
                     patternId.Equals(UiaCore.UIA.InvokePatternId);
+            }
 
-            internal override object? GetPropertyValue(UiaCore.UIA propertyId)
-                => propertyId switch
+            internal override object GetPropertyValue(UiaCore.UIA propertyId)
+            {
+                switch (propertyId)
                 {
-                    UiaCore.UIA.NamePropertyId => Name,
-                    UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.HeaderControlTypeId,
-                    UiaCore.UIA.IsEnabledPropertyId => Owner?.DataGridView?.Enabled ?? false,
-                    UiaCore.UIA.HelpTextPropertyId => Help ?? string.Empty,
-                    UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
-                    var x when x == UiaCore.UIA.HasKeyboardFocusPropertyId || x == UiaCore.UIA.IsPasswordPropertyId => false,
-                    UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
-                    UiaCore.UIA.AccessKeyPropertyId => string.Empty,
-                    _ => base.GetPropertyValue(propertyId)
-                };
+                    case UiaCore.UIA.NamePropertyId:
+                        return Name;
+                    case UiaCore.UIA.ControlTypePropertyId:
+                        return UiaCore.UIA.HeaderControlTypeId;
+                    case UiaCore.UIA.IsEnabledPropertyId:
+                        return Owner.DataGridView.Enabled;
+                    case UiaCore.UIA.HelpTextPropertyId:
+                        return Help ?? string.Empty;
+                    case UiaCore.UIA.IsKeyboardFocusablePropertyId:
+                        return (State & AccessibleStates.Focusable) == AccessibleStates.Focusable;
+                    case UiaCore.UIA.HasKeyboardFocusPropertyId:
+                    case UiaCore.UIA.IsPasswordPropertyId:
+                        return false;
+                    case UiaCore.UIA.IsOffscreenPropertyId:
+                        return (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen;
+                    case UiaCore.UIA.AccessKeyPropertyId:
+                        return string.Empty;
+                }
+
+                return base.GetPropertyValue(propertyId);
+            }
 
             #endregion
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.DataGridViewComboBoxCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.DataGridViewComboBoxCellAccessibleObject.cs
@@ -1,6 +1,8 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+#nullable disable
 
 using static Interop;
 
@@ -10,33 +12,41 @@ namespace System.Windows.Forms
     {
         protected class DataGridViewComboBoxCellAccessibleObject : DataGridViewCellAccessibleObject
         {
-            public DataGridViewComboBoxCellAccessibleObject(DataGridViewCell? owner) : base(owner)
+            public DataGridViewComboBoxCellAccessibleObject(DataGridViewCell owner) : base(owner)
             {
             }
 
             internal override bool IsIAccessibleExSupported() => true;
 
-            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
-                => propertyID switch
+            internal override object GetPropertyValue(UiaCore.UIA propertyID)
+            {
+                switch (propertyID)
                 {
-                    UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ComboBoxControlTypeId,
-                    UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ExpandCollapsePatternId),
-                    _ => base.GetPropertyValue(propertyID)
-                };
+                    case UiaCore.UIA.ControlTypePropertyId:
+                        return UiaCore.UIA.ComboBoxControlTypeId;
+                    case UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId:
+                        return IsPatternSupported(UiaCore.UIA.ExpandCollapsePatternId);
+                }
+
+                return base.GetPropertyValue(propertyID);
+            }
 
             internal override bool IsPatternSupported(UiaCore.UIA patternId)
-                => patternId == UiaCore.UIA.ExpandCollapsePatternId ? true : base.IsPatternSupported(patternId);
+            {
+                if (patternId == UiaCore.UIA.ExpandCollapsePatternId)
+                {
+                    return true;
+                }
+
+                return base.IsPatternSupported(patternId);
+            }
 
             internal override UiaCore.ExpandCollapseState ExpandCollapseState
             {
                 get
                 {
-                    if (Owner is null)
-                    {
-                        throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
-                    }
-
-                    if (Owner.Properties.GetObject(s_propComboBoxCellEditingComboBox) is DataGridViewComboBoxEditingControl comboBox && comboBox.IsHandleCreated)
+                    DataGridViewComboBoxEditingControl comboBox = Owner.Properties.GetObject(s_propComboBoxCellEditingComboBox) as DataGridViewComboBoxEditingControl;
+                    if (comboBox != null)
                     {
                         return comboBox.DroppedDown ? UiaCore.ExpandCollapseState.Expanded : UiaCore.ExpandCollapseState.Collapsed;
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewImageCell.DataGridViewImageCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewImageCell.DataGridViewImageCellAccessibleObject.cs
@@ -1,6 +1,8 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+#nullable disable
 
 using static Interop;
 
@@ -10,7 +12,7 @@ namespace System.Windows.Forms
     {
         protected class DataGridViewImageCellAccessibleObject : DataGridViewCellAccessibleObject
         {
-            public DataGridViewImageCellAccessibleObject(DataGridViewCell? owner) : base(owner)
+            public DataGridViewImageCellAccessibleObject(DataGridViewCell owner) : base(owner)
             {
             }
 
@@ -22,11 +24,25 @@ namespace System.Windows.Forms
                 }
             }
 
-            public override string? Description => Owner is DataGridViewImageCell imageCell ? imageCell.Description : null;
+            public override string Description
+            {
+                get
+                {
+                    if (Owner is DataGridViewImageCell imageCell)
+                    {
+                        return imageCell.Description;
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                }
+            }
 
-            public override string? Value
+            public override string Value
             {
                 get => base.Value;
+
                 set
                 {
                     // do nothing.
@@ -35,41 +51,47 @@ namespace System.Windows.Forms
 
             public override void DoDefaultAction()
             {
-                if (Owner is null)
-                {
-                    throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
-                }
+                DataGridViewImageCell dataGridViewCell = (DataGridViewImageCell)Owner;
+                DataGridView dataGridView = dataGridViewCell.DataGridView;
 
-                if (!(Owner is DataGridViewImageCell dataGridViewCell))
-                {
-                    return;
-                }
-
-                DataGridView? dataGridView = dataGridViewCell.DataGridView;
-                if (dataGridView != null &&
-                    dataGridView.IsHandleCreated &&
-                    dataGridViewCell.RowIndex != -1 &&
-                    dataGridViewCell.OwningColumn != null &&
-                    dataGridViewCell.OwningRow != null)
+                if (dataGridView != null && dataGridViewCell.RowIndex != -1 &&
+                    dataGridViewCell.OwningColumn != null && dataGridViewCell.OwningRow != null)
                 {
                     dataGridView.OnCellContentClickInternal(new DataGridViewCellEventArgs(dataGridViewCell.ColumnIndex, dataGridViewCell.RowIndex));
                 }
             }
 
-            public override int GetChildCount() => 0;
+            public override int GetChildCount()
+            {
+                return 0;
+            }
 
             internal override bool IsIAccessibleExSupported() => true;
 
-            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
-                => propertyID switch
+            internal override object GetPropertyValue(UiaCore.UIA propertyID)
+            {
+                if (propertyID == UiaCore.UIA.ControlTypePropertyId)
                 {
-                    UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ImageControlTypeId,
-                    UiaCore.UIA.IsInvokePatternAvailablePropertyId => true,
-                    _ => base.GetPropertyValue(propertyID)
-                };
+                    return UiaCore.UIA.ImageControlTypeId;
+                }
+
+                if (propertyID == UiaCore.UIA.IsInvokePatternAvailablePropertyId)
+                {
+                    return true;
+                }
+
+                return base.GetPropertyValue(propertyID);
+            }
 
             internal override bool IsPatternSupported(UiaCore.UIA patternId)
-                => patternId == UiaCore.UIA.InvokePatternId ? true : base.IsPatternSupported(patternId);
+            {
+                if (patternId == UiaCore.UIA.InvokePatternId)
+                {
+                    return true;
+                }
+
+                return base.IsPatternSupported(patternId);
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.DataGridViewLinkCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.DataGridViewLinkCellAccessibleObject.cs
@@ -1,6 +1,8 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+#nullable disable
 
 using static Interop;
 
@@ -10,7 +12,7 @@ namespace System.Windows.Forms
     {
         protected class DataGridViewLinkCellAccessibleObject : DataGridViewCellAccessibleObject
         {
-            public DataGridViewLinkCellAccessibleObject(DataGridViewCell? owner) : base(owner)
+            public DataGridViewLinkCellAccessibleObject(DataGridViewCell owner) : base(owner)
             {
             }
 
@@ -24,25 +26,12 @@ namespace System.Windows.Forms
 
             public override void DoDefaultAction()
             {
-                if (Owner is null)
-                {
-                    throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
-                }
+                DataGridViewLinkCell dataGridViewCell = (DataGridViewLinkCell)Owner;
+                DataGridView dataGridView = dataGridViewCell.DataGridView;
 
-                if (!(Owner is DataGridViewLinkCell dataGridViewCell))
-                {
-                    return;
-                }
-
-                if (dataGridViewCell.RowIndex == -1)
+                if (dataGridView != null && dataGridViewCell.RowIndex == -1)
                 {
                     throw new InvalidOperationException(SR.DataGridView_InvalidOperationOnSharedCell);
-                }
-
-                DataGridView? dataGridView = dataGridViewCell.DataGridView;
-                if (dataGridView?.IsHandleCreated != true)
-                {
-                    return;
                 }
 
                 if (dataGridViewCell.OwningColumn != null && dataGridViewCell.OwningRow != null)
@@ -51,16 +40,22 @@ namespace System.Windows.Forms
                 }
             }
 
-            public override int GetChildCount() => 0;
+            public override int GetChildCount()
+            {
+                return 0;
+            }
 
             internal override bool IsIAccessibleExSupported() => true;
 
-            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
-                => propertyID switch
+            internal override object GetPropertyValue(UiaCore.UIA propertyID)
+            {
+                if (propertyID == UiaCore.UIA.ControlTypePropertyId)
                 {
-                    UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.HyperlinkControlTypeId,
-                    _ => base.GetPropertyValue(propertyID)
-                };
+                    return UiaCore.UIA.HyperlinkControlTypeId;
+                }
+
+                return base.GetPropertyValue(propertyID);
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.cs
@@ -1,6 +1,8 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+#nullable disable
 
 using System.Diagnostics;
 using System.Drawing;
@@ -12,7 +14,7 @@ namespace System.Windows.Forms
     {
         protected class DataGridViewRowHeaderCellAccessibleObject : DataGridViewCellAccessibleObject
         {
-            public DataGridViewRowHeaderCellAccessibleObject(DataGridViewRowHeaderCell? owner) : base(owner)
+            public DataGridViewRowHeaderCellAccessibleObject(DataGridViewRowHeaderCell owner) : base(owner)
             {
             }
 
@@ -20,12 +22,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (Owner is null)
-                    {
-                        throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
-                    }
-
-                    if (Owner.DataGridView is null || Owner.OwningRow is null || ParentPrivate is null)
+                    if (Owner.OwningRow is null)
                     {
                         return Rectangle.Empty;
                     }
@@ -47,50 +44,68 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (Owner is null)
-                    {
-                        throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
-                    }
-
-                    if (Owner.DataGridView != null &&
-                        (Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.FullRowSelect ||
-                         Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.RowHeaderSelect))
+                    if (Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.FullRowSelect ||
+                        Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.RowHeaderSelect)
                     {
                         return SR.DataGridView_RowHeaderCellAccDefaultAction;
                     }
-
-                    return string.Empty;
+                    else
+                    {
+                        return string.Empty;
+                    }
                 }
             }
 
-            public override string? Name => ParentPrivate?.Name ?? string.Empty;
-
-            public override AccessibleObject? Parent => ParentPrivate;
-
-            private AccessibleObject? ParentPrivate
+            public override string Name
             {
                 get
                 {
-                    if (Owner is null)
+                    if (ParentPrivate != null)
                     {
-                        throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
+                        return ParentPrivate.Name;
                     }
-
-                    return Owner.OwningRow?.AccessibilityObject;
+                    else
+                    {
+                        return string.Empty;
+                    }
                 }
             }
 
-            public override AccessibleRole Role => AccessibleRole.RowHeader;
+            public override AccessibleObject Parent
+            {
+                get
+                {
+                    return ParentPrivate;
+                }
+            }
+
+            private AccessibleObject ParentPrivate
+            {
+                get
+                {
+                    if (Owner.OwningRow is null)
+                    {
+                        return null;
+                    }
+                    else
+                    {
+                        return Owner.OwningRow.AccessibilityObject;
+                    }
+                }
+            }
+
+            public override AccessibleRole Role
+            {
+                get
+                {
+                    return AccessibleRole.RowHeader;
+                }
+            }
 
             public override AccessibleStates State
             {
                 get
                 {
-                    if (Owner is null)
-                    {
-                        throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
-                    }
-
                     AccessibleStates resultState = AccessibleStates.Selectable;
 
                     // get the Offscreen state from the base method.
@@ -100,9 +115,8 @@ namespace System.Windows.Forms
                         resultState |= AccessibleStates.Offscreen;
                     }
 
-                    if (Owner.DataGridView != null &&
-                        (Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.FullRowSelect ||
-                         Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.RowHeaderSelect))
+                    if (Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.FullRowSelect ||
+                        Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.RowHeaderSelect)
                     {
                         if (Owner.OwningRow != null && Owner.OwningRow.Selected)
                         {
@@ -114,74 +128,87 @@ namespace System.Windows.Forms
                 }
             }
 
-            public override string Value => string.Empty;
+            public override string Value
+            {
+                get
+                {
+                    return string.Empty;
+                }
+            }
 
             public override void DoDefaultAction()
             {
-                if (Owner is null)
-                {
-                    throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
-                }
-
-                if (Owner.DataGridView?.IsHandleCreated == true &&
-                    Owner.OwningRow != null &&
-                    (Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.FullRowSelect ||
-                     Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.RowHeaderSelect))
+                if ((Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.FullRowSelect ||
+                    Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.RowHeaderSelect) &&
+                    Owner.OwningRow != null)
                 {
                     Owner.OwningRow.Selected = true;
                 }
             }
 
-            public override AccessibleObject? Navigate(AccessibleNavigation navigationDirection)
+            public override AccessibleObject Navigate(AccessibleNavigation navigationDirection)
             {
-                if (Owner is null)
-                {
-                    throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
-                }
-
-                if (Owner.OwningRow is null || Owner.DataGridView is null)
-                {
-                    return null;
-                }
-
+                Debug.Assert(Owner.DataGridView.RowHeadersVisible, "if the rows are not visible how did you get the row headers acc obj?");
                 switch (navigationDirection)
                 {
                     case AccessibleNavigation.Next:
-                        return (Owner.DataGridView.Columns.GetColumnCount(DataGridViewElementStates.Visible) > 0)
-                            ? ParentPrivate?.GetChild(1) // go to the next sibling
-                            : null;
-
+                        if (Owner.OwningRow != null && Owner.DataGridView.Columns.GetColumnCount(DataGridViewElementStates.Visible) > 0)
+                        {
+                            // go to the next sibling
+                            return ParentPrivate.GetChild(1);
+                        }
+                        else
+                        {
+                            return null;
+                        }
                     case AccessibleNavigation.Down:
+                        if (Owner.OwningRow is null)
+                        {
+                            return null;
+                        }
+                        else
                         {
                             if (Owner.OwningRow.Index == Owner.DataGridView.Rows.GetLastRow(DataGridViewElementStates.Visible))
                             {
                                 return null;
                             }
-
-                            int nextVisibleRow = Owner.DataGridView.Rows.GetNextRow(Owner.OwningRow.Index, DataGridViewElementStates.Visible);
-                            int actualDisplayIndex = Owner.DataGridView.Rows.GetRowCount(DataGridViewElementStates.Visible, 0, nextVisibleRow);
-
-                            if (Owner.DataGridView.ColumnHeadersVisible)
+                            else
                             {
-                                // Add 1 because the first child in the data grid view acc obj is the top row header acc obj
-                                actualDisplayIndex++;
+                                int nextVisibleRow = Owner.DataGridView.Rows.GetNextRow(Owner.OwningRow.Index, DataGridViewElementStates.Visible);
+                                int actualDisplayIndex = Owner.DataGridView.Rows.GetRowCount(DataGridViewElementStates.Visible, 0, nextVisibleRow);
+
+                                if (Owner.DataGridView.ColumnHeadersVisible)
+                                {
+                                    // + 1 because the first child in the data grid view acc obj is the top row header acc obj
+                                    return Owner.DataGridView.AccessibilityObject.GetChild(1 + actualDisplayIndex).GetChild(0);
+                                }
+                                else
+                                {
+                                    return Owner.DataGridView.AccessibilityObject.GetChild(actualDisplayIndex).GetChild(0);
+                                }
                             }
-
-                            return Owner.DataGridView.AccessibilityObject.GetChild(actualDisplayIndex)?.GetChild(0);
                         }
-
+                    case AccessibleNavigation.Previous:
+                        return null;
                     case AccessibleNavigation.Up:
+                        if (Owner.OwningRow is null)
+                        {
+                            return null;
+                        }
+                        else
                         {
                             if (Owner.OwningRow.Index == Owner.DataGridView.Rows.GetFirstRow(DataGridViewElementStates.Visible))
                             {
-                                if (!Owner.DataGridView.ColumnHeadersVisible)
+                                if (Owner.DataGridView.ColumnHeadersVisible)
+                                {
+                                    // Return the top left header cell accessible object.
+                                    Debug.Assert(Owner.DataGridView.TopLeftHeaderCell.AccessibilityObject == Owner.DataGridView.AccessibilityObject.GetChild(0).GetChild(0));
+                                    return Owner.DataGridView.AccessibilityObject.GetChild(0).GetChild(0);
+                                }
+                                else
                                 {
                                     return null;
                                 }
-
-                                // Return the top left header cell accessible object.
-                                Debug.Assert(Owner.DataGridView.TopLeftHeaderCell.AccessibilityObject == Owner.DataGridView.AccessibilityObject.GetChild(0)!.GetChild(0));
-                                return Owner.DataGridView.AccessibilityObject.GetChild(0)?.GetChild(0);
                             }
                             else
                             {
@@ -189,15 +216,15 @@ namespace System.Windows.Forms
                                 int actualDisplayIndex = Owner.DataGridView.Rows.GetRowCount(DataGridViewElementStates.Visible, 0, previousVisibleRow);
                                 if (Owner.DataGridView.ColumnHeadersVisible)
                                 {
-                                    // Add 1 because the first child in the data grid view acc obj is the top row header acc obj
-                                    actualDisplayIndex++;
+                                    // + 1 because the first child in the data grid view acc obj is the top row header acc obj
+                                    return Owner.DataGridView.AccessibilityObject.GetChild(actualDisplayIndex + 1).GetChild(0);
                                 }
-
-                                return Owner.DataGridView.AccessibilityObject.GetChild(actualDisplayIndex)?.GetChild(0);
+                                else
+                                {
+                                    return Owner.DataGridView.AccessibilityObject.GetChild(actualDisplayIndex).GetChild(0);
+                                }
                             }
                         }
-
-                    case AccessibleNavigation.Previous:
                     default:
                         return null;
                 }
@@ -210,22 +237,17 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                 }
 
-                if (!(Owner is DataGridViewRowHeaderCell dataGridViewCell))
+                DataGridViewRowHeaderCell dataGridViewCell = (DataGridViewRowHeaderCell)Owner;
+                DataGridView dataGridView = dataGridViewCell.DataGridView;
+
+                if (dataGridView is null)
                 {
                     return;
                 }
-
-                DataGridView? dataGridView = dataGridViewCell.DataGridView;
-                if (dataGridView?.IsHandleCreated != true)
-                {
-                    return;
-                }
-
                 if ((flags & AccessibleSelection.TakeFocus) == AccessibleSelection.TakeFocus)
                 {
                     dataGridView.Focus();
                 }
-
                 if (dataGridViewCell.OwningRow != null &&
                     (dataGridView.SelectionMode == DataGridViewSelectionMode.FullRowSelect ||
                      dataGridView.SelectionMode == DataGridViewSelectionMode.RowHeaderSelect))
@@ -243,47 +265,62 @@ namespace System.Windows.Forms
 
             #region IRawElementProviderFragment Implementation
 
-            internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
+            internal override UiaCore.IRawElementProviderFragment FragmentNavigate(UiaCore.NavigateDirection direction)
             {
-                if (Owner is null)
-                {
-                    throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
-                }
-
                 if (Owner.OwningRow is null)
                 {
                     return null;
                 }
 
-                return direction switch
+                switch (direction)
                 {
-                    UiaCore.NavigateDirection.Parent => Owner.OwningRow.AccessibilityObject,
-                    UiaCore.NavigateDirection.NextSibling =>
-                            (Owner.DataGridView != null && Owner.DataGridView.Columns.GetColumnCount(DataGridViewElementStates.Visible) > 0)
-                                ? Owner.OwningRow.AccessibilityObject.GetChild(1) // go to the next sibling
-                                : null,
-                    _ => null,
-                };
+                    case UiaCore.NavigateDirection.Parent:
+                        return Owner.OwningRow.AccessibilityObject;
+                    case UiaCore.NavigateDirection.NextSibling:
+                        if (Owner.DataGridView.Columns.GetColumnCount(DataGridViewElementStates.Visible) > 0)
+                        {
+                            // go to the next sibling
+                            return Owner.OwningRow.AccessibilityObject.GetChild(1);
+                        }
+                        else
+                        {
+                            return null;
+                        }
+                    case UiaCore.NavigateDirection.PreviousSibling:
+                    default:
+                        return null;
+                }
             }
 
             #endregion
 
             #region IRawElementProviderSimple Implementation
 
-            internal override object? GetPropertyValue(UiaCore.UIA propertyId)
-                => propertyId switch
+            internal override object GetPropertyValue(UiaCore.UIA propertyId)
+            {
+                switch (propertyId)
                 {
-                    UiaCore.UIA.NamePropertyId => Name,
-                    UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.HeaderControlTypeId,
-                    UiaCore.UIA.IsEnabledPropertyId => Owner?.DataGridView?.Enabled ?? false,
-                    UiaCore.UIA.HelpTextPropertyId => Help ?? string.Empty,
-                    UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
-                    UiaCore.UIA.HasKeyboardFocusPropertyId => false,
-                    UiaCore.UIA.IsPasswordPropertyId => false,
-                    UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
-                    UiaCore.UIA.AccessKeyPropertyId => string.Empty,
-                    _ => base.GetPropertyValue(propertyId),
-                };
+                    case UiaCore.UIA.NamePropertyId:
+                        return Name;
+                    case UiaCore.UIA.ControlTypePropertyId:
+                        return UiaCore.UIA.HeaderControlTypeId;
+                    case UiaCore.UIA.IsEnabledPropertyId:
+                        return Owner.DataGridView.Enabled;
+                    case UiaCore.UIA.HelpTextPropertyId:
+                        return Help ?? string.Empty;
+                    case UiaCore.UIA.IsKeyboardFocusablePropertyId:
+                        return (State & AccessibleStates.Focusable) == AccessibleStates.Focusable;
+                    case UiaCore.UIA.HasKeyboardFocusPropertyId:
+                    case UiaCore.UIA.IsPasswordPropertyId:
+                        return false;
+                    case UiaCore.UIA.IsOffscreenPropertyId:
+                        return (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen;
+                    case UiaCore.UIA.AccessKeyPropertyId:
+                        return string.Empty;
+                }
+
+                return base.GetPropertyValue(propertyId);
+            }
 
             #endregion
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxCell.DataGridViewTextBoxCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxCell.DataGridViewTextBoxCellAccessibleObject.cs
@@ -1,6 +1,8 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+#nullable disable
 
 using static Interop;
 
@@ -10,18 +12,21 @@ namespace System.Windows.Forms
     {
         protected class DataGridViewTextBoxCellAccessibleObject : DataGridViewCellAccessibleObject
         {
-            public DataGridViewTextBoxCellAccessibleObject(DataGridViewCell? owner) : base(owner)
+            public DataGridViewTextBoxCellAccessibleObject(DataGridViewCell owner) : base(owner)
             {
             }
 
             internal override bool IsIAccessibleExSupported() => true;
 
-            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
-                => propertyID switch
+            internal override object GetPropertyValue(UiaCore.UIA propertyID)
+            {
+                if (propertyID == UiaCore.UIA.ControlTypePropertyId)
                 {
-                    UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.EditControlTypeId,
-                    _ => base.GetPropertyValue(propertyID)
-                };
+                    return UiaCore.UIA.EditControlTypeId;
+                }
+
+                return base.GetPropertyValue(propertyID);
+            }
         }
     }
 }


### PR DESCRIPTION
This reverts commit 63f0ca1525151312b065375daaf50d692c95b73b.

The original commit did not come through a PR and fails tests consistently.

Tests that fail:

- DataGridViewCellAccessibleObject_Select_HasSelectionFlagsWithoutDataGridView_ThrowsInvalidOperationException
- DataGridViewCellAccessibleObject_DoDefaultAction_NoDataGridView_ThrowsInvalidOperationException


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3817)