### PR TITLE
Restore original RichTextBox.Text EoL

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -3173,6 +3173,24 @@ namespace System.Windows.Forms
             fixed (char* pText = text)
             {
                 int actualLength = PARAM.ToInt(User32.SendMessageW(Handle, (User32.WM)User32.EM.GETTEXTEX, (IntPtr)pGt, (IntPtr)pText));
+
+                // The default behaviour of EM_GETTEXTEX is to normalise line endings to '\r'
+                // (see: GT_DEFAULT, https://docs.microsoft.com/windows/win32/api/richedit/ns-richedit-gettextex#members),
+                // whereas previously we would normalise to '\n'. Unfortunately we can only ask for '\r\n' line endings via GT.USECRLF,
+                // but unable to ask for '\n'. Unless GT.USECRLF was set, convert '\r' with '\n' to retain the original behaviour.
+                if (!flags.HasFlag(GT.USECRLF))
+                {
+                    int index = 0;
+                    while (index < actualLength)
+                    {
+                        if (pText[index] == '\r')
+                        {
+                            pText[index] = '\n';
+                        }
+                        index++;
+                    }
+                }
+
                 result = new string(pText, 0, actualLength);
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -3150,6 +3150,11 @@ namespace System.Windows.Forms
                 flags = GTL.DEFAULT
             };
 
+            if (flags.HasFlag(GT.USECRLF))
+            {
+                gtl.flags |= GTL.USECRLF;
+            }
+
             GETTEXTLENGTHEX* pGtl = &gtl;
             int expectedLength = PARAM.ToInt(User32.SendMessageW(Handle, (User32.WM)User32.EM.GETTEXTLENGTHEX, (IntPtr)pGtl));
             if (expectedLength == (int)HRESULT.E_INVALIDARG)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
@@ -6808,6 +6808,13 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
+
+            // verify the old behaviour via StreamOut(SF.TEXT | SF.UNICODE)
+            string textOldWay = control.TestAccessor().Dynamic.StreamOut(SF.TEXT | SF.UNICODE);
+            Assert.Equal(expected, textOldWay);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
@@ -6701,7 +6701,7 @@ namespace System.Windows.Forms.Tests
         [InlineData("", 0)]
         [InlineData("a\0b", 1)]
         [InlineData("a", 1)]
-        [InlineData("\ud83c\udf09", 2)]
+        [InlineData("\ud83c\udf09", 2)] // emoji, surrogate pair https://charbase.com/1f309-unicode-bridge-at-night
         public void RichTextBox_TextLength_GetSetWithHandle_Success(string text, int expected)
         {
             using var control = new RichTextBox
@@ -6716,7 +6716,7 @@ namespace System.Windows.Forms.Tests
         [InlineData("", 0)]
         [InlineData("a\0b", 1)]
         [InlineData("a", 1)]
-        [InlineData("\ud83c\udf09", 2)]
+        [InlineData("\ud83c\udf09", 2)] // emoji, surrogate pair https://charbase.com/1f309-unicode-bridge-at-night
         public void RichTextBox_TextLength_GetWithHandle_ReturnsExpected(string text, int expected)
         {
             using var control = new RichTextBox();
@@ -6774,47 +6774,147 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [WinFormsTheory]
-        [InlineData(null, "")]
-        [InlineData("", "")]
-        [InlineData("abc", "abc")]
-        [InlineData("a\0b", "a")]
-        [InlineData("\ud83c\udf09", "\ud83c\udf09")]
-        [InlineData("\n\n", "\n\n")]
-        [InlineData("\r\r", "\n\n")]
-        [InlineData("\r\n\r\n", "\n\n")]
-        [InlineData("a\r\nb\r\nc\r\nd\r\n", "a\nb\nc\nd\n")]
-        [InlineData("a\nb\rc\r\n\n\rd\r\r\n", "a\nb\nc\n\n\nd")]
-        public void RichTextBox_Text_GetWithHandle_ReturnsExpected(string text, string expected)
+        public static IEnumerable<object[]> RichTextBox_Text_GetWithHandle_TestData()
         {
-            using var control = new RichTextBox();
-            control.CreateControl();
-            int invalidatedCallCount = 0;
-            control.Invalidated += (sender, e) => invalidatedCallCount++;
-            int styleChangedCallCount = 0;
-            control.StyleChanged += (sender, e) => styleChangedCallCount++;
-            int createdCallCount = 0;
-            control.HandleCreated += (sender, e) => createdCallCount++;
+            yield return new object[] { null, string.Empty };
+            yield return new object[] { string.Empty, string.Empty };
+            yield return new object[] { " ", " " };
+            yield return new object[] { "abc", "abc" };
+            yield return new object[] { "a\0b", "a" };
+            yield return new object[] { "\ud83c\udf09", "\ud83c\udf09" }; // emoji, surrogate pair https://charbase.com/1f309-unicode-bridge-at-night
+            yield return new object[] { "\n\n", "\n\n" };
+            yield return new object[] { "\r\r", "\n\n" };
+            yield return new object[] { "\n\r", "\n\n" };
+            yield return new object[] { "\r\n\r\n", "\n\n" };
+            yield return new object[] { "a6\r\nb\r\nc\r\nd\r\n", "a6\nb\nc\nd\n" };
+            yield return new object[] { "a7\nb\rc\r\n\n\rd\r\r\n", "a7\nb\nc\n\n\nd", SAME, "a7\nb\nc\n\n\nd " }; // RichEdit20W has a trailing space
 
-            Assert.Empty(control.Text);
-            Assert.True(control.IsHandleCreated);
-            Assert.Equal(0, invalidatedCallCount);
-            Assert.Equal(0, styleChangedCallCount);
-            Assert.Equal(0, createdCallCount);
+            // 0x0008 to 0x007F: https://www.unicode.org/charts/PDF/U0000.pdf
+            // 0x2000 to 0x2069: https://www.unicode.org/charts/PDF/U2000.pdf
 
-            control.Text = text;
+            var chars = Enumerable.Range(0x0008, /* 0x0008 to 0x007F */ 0x007F - 0x0008 + 1).Union(
+                        Enumerable.Range(0x2000, /* 0x2000 to 0x2069 */ 0x2069 - 0x2000 + 1));
 
-            Assert.Equal(expected, control.Text);
-            Assert.Equal(0, invalidatedCallCount);
-            Assert.Equal(0, styleChangedCallCount);
-            Assert.Equal(0, createdCallCount);
+            foreach (int i in chars)
+            {
+                if (i == 0x000B) // Vertical Tabulation
+                {
+                    // NB: The old control works the same, but StreamOut() substituted 0x000B with \n
+                    yield return new object[] { $"{(char)i}ab", "ab", "\nab" };
+                    yield return new object[] { $"a{(char)i}b", "ab", "a\nb" };
+                    yield return new object[] { $"ab\r\n{(char)i}\r\n", "ab\n\n", "ab\n\n\n" };
+                    yield return new object[] { $"ab{(char)i}", $"ab", "ab\n" };
+                    yield return new object[] { $"ab\r\n{(char)i}", "ab\n", "ab\n\n" };
 
-            // verify the old behaviour via StreamOut(SF.TEXT | SF.UNICODE)
-            string textOldWay = control.TestAccessor().Dynamic.StreamOut(SF.TEXT | SF.UNICODE);
-            Assert.Equal(expected, textOldWay);
-            Assert.Equal(0, invalidatedCallCount);
-            Assert.Equal(0, styleChangedCallCount);
-            Assert.Equal(0, createdCallCount);
+                    continue;
+                }
+
+                if (i == 0x000D) // Carriage Return (\r) gets replaced with Line Feed (\n)
+                {
+                    yield return new object[] { $"{(char)i}ab", "\nab" };
+                    yield return new object[] { $"a{(char)i}b", "a\nb" };
+                    yield return new object[] { $"ab\r\n{(char)i}\r\n", "ab\n", SAME, "ab\n " }; // RichEdit20W has a trailing space
+                    yield return new object[] { $"ab{(char)i}", "ab\n" };
+                    yield return new object[] { $"ab\r\n{(char)i}", "ab\n\n" };
+
+                    continue;
+                }
+
+                if (i == 0x2028) // Line Separator (\v)
+                {
+                    // NB: The old control works the same, but StreamOut() substituted 0x2028 with \n
+                    yield return new object[] { $"{(char)i}ab", "ab", "\nab" };
+                    yield return new object[] { $"a{(char)i}b", "ab", "a\nb" };
+                    yield return new object[] { $"ab\r\n{(char)i}\r\n", "ab\n\n", "ab\n\n\n" };
+                    yield return new object[] { $"ab{(char)i}", $"ab", "ab\n" };
+                    yield return new object[] { $"ab\r\n{(char)i}", "ab\n", "ab\n\n" };
+
+                    continue;
+                }
+
+                if (i == 0x2029) // Paragraph Separator
+                {
+                    yield return new object[] { $"{(char)i}ab", "\nab" };
+                    yield return new object[] { $"a{(char)i}b", "a\nb" };
+                    yield return new object[] { $"ab\r\n{(char)i}\r\n", "ab\n", SAME, "ab\n\n\n" }; // RichEdit20W has extra line feeds
+                    yield return new object[] { $"ab{(char)i}", $"ab\n" };
+                    yield return new object[] { $"ab\r\n{(char)i}", "ab\n\n" };
+
+                    continue;
+                }
+
+                yield return new object[] { $"{(char)i}ab", $"{(char)i}ab" };
+                yield return new object[] { $"a{(char)i}b", $"a{(char)i}b" };
+                yield return new object[] { $"ab\r\n{(char)i}\r\n", $"ab\n{(char)i}\n" };
+                yield return new object[] { $"ab{(char)i}", $"ab{(char)i}" };
+                yield return new object[] { $"ab\r\n{(char)i}", $"ab\n{(char)i}" };
+            }
+        }
+
+        private const string SAME = "SAME";
+
+        [WinFormsTheory]
+        [MemberData(nameof(RichTextBox_Text_GetWithHandle_TestData))]
+        public void RichTextBox_Text_GetWithHandle_ReturnsExpected(string text, string expectedText, string oldWayExpectedText = SAME, string oldControlExpectedText = SAME)
+        {
+            // NB: in certain scenarios the old way (using StreamOut() method) returned a different
+            // text value to the new way (via GetTextEx() method).
+            // If oldWayExpectedText is SAME, assume StreamOut() returned the same expectedText.
+            if (oldWayExpectedText is SAME)
+            {
+                oldWayExpectedText = expectedText;
+            }
+
+            // NB: in certain scenarios the old control returns a different text value to the new control.
+            // If oldControlExpectedText is SAME, assume the old control returns the same expectedText.
+            if (oldControlExpectedText is SAME)
+            {
+                oldControlExpectedText = expectedText;
+            }
+
+            using (var control = new RichTextBox())
+            {
+                control.CreateControl();
+                int invalidatedCallCount = 0;
+                control.Invalidated += (sender, e) => invalidatedCallCount++;
+                int styleChangedCallCount = 0;
+                control.StyleChanged += (sender, e) => styleChangedCallCount++;
+                int createdCallCount = 0;
+                control.HandleCreated += (sender, e) => createdCallCount++;
+
+                Assert.True(control.IsHandleCreated);
+                Assert.Empty(control.Text);
+                Assert.Equal(0, invalidatedCallCount);
+                Assert.Equal(0, styleChangedCallCount);
+                Assert.Equal(0, createdCallCount);
+
+                control.Text = text;
+
+                Assert.Equal(expectedText, control.Text);
+                Assert.Equal(0, invalidatedCallCount);
+                Assert.Equal(0, styleChangedCallCount);
+                Assert.Equal(0, createdCallCount);
+
+                // verify the old behaviour via StreamOut(SF.TEXT | SF.UNICODE)
+                string textOldWay = control.TestAccessor().Dynamic.StreamOut(SF.TEXT | SF.UNICODE);
+                Assert.Equal(oldWayExpectedText, textOldWay);
+                Assert.Equal(0, invalidatedCallCount);
+                Assert.Equal(0, styleChangedCallCount);
+                Assert.Equal(0, createdCallCount);
+            }
+
+            // verify against RichEdit20W
+            using (var riched20 = new RichEditWithVersion("riched20.dll", "RichEdit20W"))
+            {
+                riched20.CreateControl();
+
+                Assert.True(riched20.IsHandleCreated);
+                Assert.Empty(riched20.Text);
+
+                riched20.Text = text;
+
+                Assert.Equal(oldControlExpectedText, riched20.Text);
+            }
         }
 
         [WinFormsTheory]
@@ -6822,7 +6922,7 @@ namespace System.Windows.Forms.Tests
         [InlineData("", "")]
         [InlineData("abc", "abc")]
         [InlineData("a\0b", "a\0b")]
-        [InlineData("\ud83c\udf09", "\ud83c\udf09")]
+        [InlineData("\ud83c\udf09", "\ud83c\udf09")] // emoji, surrogate pair https://charbase.com/1f309-unicode-bridge-at-night
         [InlineData("\n\n", "\n\n")]
         [InlineData("\r\r", "\r\r")]
         [InlineData("\r\n\r\n", "\r\n\r\n")]
@@ -6830,28 +6930,65 @@ namespace System.Windows.Forms.Tests
         [InlineData("a\nb\rc\r\n\n\rd\r\r\n", "a\nb\rc\r\n\n\rd\r\r\n")]
         public void RichTextBox_Text_GetWithoutHandle_ReturnsExpected(string text, string expected)
         {
+            using (var control = new RichTextBox())
+            {
+                int invalidatedCallCount = 0;
+                control.Invalidated += (sender, e) => invalidatedCallCount++;
+                int styleChangedCallCount = 0;
+                control.StyleChanged += (sender, e) => styleChangedCallCount++;
+                int createdCallCount = 0;
+                control.HandleCreated += (sender, e) => createdCallCount++;
+
+                Assert.Empty(control.Text);
+                Assert.False(control.IsHandleCreated);
+                Assert.Equal(0, invalidatedCallCount);
+                Assert.Equal(0, styleChangedCallCount);
+                Assert.Equal(0, createdCallCount);
+
+                control.Text = text;
+
+                Assert.Equal(expected, control.Text);
+                Assert.Equal(0, invalidatedCallCount);
+                Assert.Equal(0, styleChangedCallCount);
+                Assert.Equal(0, createdCallCount);
+                Assert.False(control.IsHandleCreated);
+            }
+
+            // verify against RichEdit20W
+            using (var riched20 = new RichEditWithVersion("riched20.dll", "RichEdit20W"))
+            {
+                Assert.Empty(riched20.Text);
+                Assert.False(riched20.IsHandleCreated);
+
+                riched20.Text = text;
+
+                Assert.Equal(expected, riched20.Text);
+                Assert.False(riched20.IsHandleCreated);
+            }
+        }
+
+        [WinFormsTheory]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("abc", "abc")]
+        [InlineData("a\0b", "a")]
+        [InlineData("\ud83c\udf09", "\ud83c\udf09")] // emoji, surrogate pair https://charbase.com/1f309-unicode-bridge-at-night
+        [InlineData("\n\n", "\r\n\r\n")]
+        [InlineData("\r\r", "\r\n\r\n")]
+        [InlineData("\r\n\r\n", "\r\n\r\n")]
+        [InlineData("a\r\nb\r\nc\r\nd\r\n", "a\r\nb\r\nc\r\nd\r\n")]
+        [InlineData("a1\nb\rc\n\r\n\rd\r\r\n", "a1\r\nb\r\nc\r\n\r\n\r\nd")]
+        public void RichTextBox_Text_GetTextEx_USECRLF_ReturnsExpected(string text, string expected)
+        {
             using var control = new RichTextBox();
-            int invalidatedCallCount = 0;
-            control.Invalidated += (sender, e) => invalidatedCallCount++;
-            int styleChangedCallCount = 0;
-            control.StyleChanged += (sender, e) => styleChangedCallCount++;
-            int createdCallCount = 0;
-            control.HandleCreated += (sender, e) => createdCallCount++;
+            control.CreateControl();
 
             Assert.Empty(control.Text);
-            Assert.False(control.IsHandleCreated);
-            Assert.Equal(0, invalidatedCallCount);
-            Assert.Equal(0, styleChangedCallCount);
-            Assert.Equal(0, createdCallCount);
 
             control.Text = text;
 
-            Assert.Equal(expected, control.Text);
-            Assert.Equal(0, invalidatedCallCount);
-            Assert.Equal(0, styleChangedCallCount);
-            Assert.Equal(0, createdCallCount);
-
-            Assert.False(control.IsHandleCreated);
+            string textOldWay = control.TestAccessor().Dynamic.GetTextEx(GT.USECRLF);
+            Assert.Equal(expected, textOldWay);
         }
 
         [WinFormsFact]


### PR DESCRIPTION


Fixes #3778

<!-- Please read CONTRIBUTING.md before submitting a pull request -->



## Proposed changes

The default behaviour of EM_GETTEXTEX is to normalise line endings to '\r' (see: GT_DEFAULT, https://docs.microsoft.com/en-au/windows/win32/api/richedit/ns-richedit-gettextex#members),
whereas previously we would normalise to '\n'.
Setting GT.USECRLF flag we can only ask for '\r\n' line endings, but unable to ask for '\n'.

Unless GT.USECRLF was set, convert '\r' with '\n' to retain the original behaviour.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The original behaviour from .NET Framework/.NET Core is retained

## Regression? 

- Yes, introduced in https://github.com/dotnet/winforms/pull/3726

## Risk

- Minimum

<!-- end TELL-MODE -->




## Test methodology <!-- How did you ensure quality? -->

- Locally reverted https://github.com/dotnet/winforms/pull/3726
- Added unit tests to capture the original behaviour
- Restored https://github.com/dotnet/winforms/pull/3726
- Added the new fix to adhere to the original behaviour and see the tests pass

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3821)