### PR TITLE
Read accessible name of a data bound ListBox from the DisplayMember of the data source

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.AccessibleObject.cs
@@ -13,8 +13,6 @@ namespace System.Windows.Forms
     {
         /// <summary>
         ///  ListBox control accessible object with UI Automation provider functionality.
-        ///  This inherits from the base ListBoxExAccessibleObject and ListBoxAccessibleObject
-        ///  to have all base functionality.
         /// </summary>
         internal class ListBoxAccessibleObject : ControlAccessibleObject
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ItemAccessibleObject.cs
@@ -12,9 +12,7 @@ namespace System.Windows.Forms
     public partial class ListBox
     {
         /// <summary>
-        ///  ListBox control accessible object with UI Automation provider functionality.
-        ///  This inherits from the base ListBoxExAccessibleObject and ListBoxAccessibleObject
-        ///  to have all base functionality.
+        ///  ListBox item control accessible object with UI Automation provider functionality.
         /// </summary>
         internal class ListBoxItemAccessibleObject : AccessibleObject
         {
@@ -71,7 +69,7 @@ namespace System.Windows.Forms
             }
 
             /// <summary>
-            ///  Gets the ListBox Item bounds.
+            ///  Gets the <see cref="ListBox"/> item bounds.
             /// </summary>
             public override Rectangle Bounds
             {
@@ -104,7 +102,7 @@ namespace System.Windows.Forms
             }
 
             /// <summary>
-            ///  Gets the ListBox item default action.
+            ///  Gets the <see cref="ListBox"/> item default action.
             /// </summary>
             public override string? DefaultAction
                 => _systemIAccessible?.accDefaultAction[GetChildId()];
@@ -116,13 +114,13 @@ namespace System.Windows.Forms
                 => _systemIAccessible?.accHelp[GetChildId()];
 
             /// <summary>
-            ///  Gets or sets the accessible name.
+            ///  Gets or sets the item accessible name.
             /// </summary>
             public override string? Name
             {
                 get
                 {
-                    return _itemEntry.item.ToString();
+                    return _owningListBox.GetItemText(_itemEntry.item);
                 }
                 set => base.Name = value;
             }
@@ -142,7 +140,7 @@ namespace System.Windows.Forms
             }
 
             /// <summary>
-            ///  Gets the accessible state.
+            ///  Gets the item accessible state.
             /// </summary>
             public override AccessibleStates State
             {
@@ -210,7 +208,8 @@ namespace System.Windows.Forms
 
             internal override int GetChildId()
             {
-                return CurrentIndex + 1; // Index is zero-based, Child ID is 1-based.
+                // Index is zero-based, Child ID is 1-based.
+                return CurrentIndex + 1;
             }
 
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
@@ -278,7 +277,6 @@ namespace System.Windows.Forms
                 }
 
                 int itemsHeightSum = 0;
-                int visibleItemsCount = 0;
                 int listBoxHeight = _owningListBox.ClientRectangle.Height;
                 int itemsCount = _owningListBox.Items.Count;
 
@@ -292,7 +290,7 @@ namespace System.Windows.Forms
                     }
 
                     int lastVisibleIndex = i - 1; // - 1 because last "i" index is invisible
-                    visibleItemsCount = lastVisibleIndex - firstVisibleIndex + 1; // + 1 because array indexes begin with 0
+                    int visibleItemsCount = lastVisibleIndex - firstVisibleIndex + 1; // + 1 because array indexes begin with 0
 
                     if (currentIndex > lastVisibleIndex)
                     {
@@ -336,12 +334,13 @@ namespace System.Windows.Forms
                 }
                 catch (ArgumentException)
                 {
-                    // In Everett, the ListBox accessible children did not have any selection capability.
-                    // In Whidbey, they delegate the selection capability to OLEACC.
-                    // However, OLEACC does not deal w/ several Selection flags: ExtendSelection, AddSelection, RemoveSelection.
+                    // In .NET Framework 1.1, the ListBox accessible children did not have any selection capability.
+                    // In .NET Framework 2.0, they delegate the selection capability to OLEACC.
+                    // However, OLEACC does not deal with several selection flags:
+                    // ExtendSelection, AddSelection, RemoveSelection.
                     // OLEACC instead throws an ArgumentException.
-                    // Since Whidbey API's should not throw an exception in places where Everett API's did not, we catch
-                    // the ArgumentException and fail silently.
+                    // Since .NET Framework 2.0 API's should not throw an exception in places where
+                    // .NET Framework 1.1 API's did not, we catch the ArgumentException and fail silently.
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -765,8 +765,8 @@ namespace System.Windows.Forms
                     {
                         if (itemsCollection != null)
                         {
-                            int cnt = itemsCollection.Count;
-                            for (int i = 0; i < cnt; i++)
+                            int count = itemsCollection.Count;
+                            for (int i = 0; i < count; i++)
                             {
                                 height += GetItemHeight(i);
                             }
@@ -775,9 +775,16 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    //When the list is empty, we don't want to multiply by 0 here.
-                    int cnt = (itemsCollection is null || itemsCollection.Count == 0) ? 1 : itemsCollection.Count;
-                    height = GetItemHeight(0) * cnt;
+                    height = GetItemHeight(0);
+
+                    if (itemsCollection != null)
+                    {
+                        int count = itemsCollection.Count;
+                        if (count != 0)
+                        {
+                            height *= count;
+                        }
+                    }
                 }
 
                 if (borderStyle != BorderStyle.None)
@@ -807,6 +814,7 @@ namespace System.Windows.Forms
             {
                 return DefaultSize;
             }
+
             return new Size(width, height) + Padding.Size;
         }
 
@@ -2056,7 +2064,7 @@ namespace System.Windows.Forms
 
             object[] newItems = null;
 
-            // if we have a dataSource and a DisplayMember, then use it
+            // If we have a DataSource and a DisplayMember, then use it
             // to populate the Items collection
             //
             if (DataManager != null && DataManager.Count != -1)
@@ -2086,7 +2094,7 @@ namespace System.Windows.Forms
             {
                 if (DataManager != null)
                 {
-                    // put the selectedIndex in sync w/ the position in the dataManager
+                    // Put the selectedIndex in sync with the position in the dataManager
                     SelectedIndex = DataManager.Position;
                 }
                 else

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBox.ListBoxItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBox.ListBoxItemAccessibleObjectTests.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Forms.IntegrationTests.Common;
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    public class ListBox_ListBoxItemAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsFact]
+        public void ListBoxItemAccessibleObject_DataBoundAccessibleName()
+        {
+            // Regression test for https://github.com/dotnet/winforms/issues/3706
+
+            using var form = new Form
+            {
+                BindingContext = new BindingContext()
+            };
+
+            using var control = new ListBox
+            {
+                Parent = form,
+                DisplayMember = TestDataSources.PersonDisplayMember,
+                DataSource = TestDataSources.GetPersons()
+            };
+
+            ListBox.ListBoxAccessibleObject accessibleObject =
+                Assert.IsType<ListBox.ListBoxAccessibleObject>(control.AccessibilityObject);
+
+            Collections.Generic.List<Person> persons = TestDataSources.GetPersons();
+            Assert.Equal(persons.Count, accessibleObject.GetChildCount());
+
+            for (int i = 0; i < persons.Count; i++)
+            {
+                Person person = persons[i];
+                AccessibleObject itemAccessibleObject = accessibleObject.GetChild(i);
+
+                Assert.IsType<ListBox.ListBoxItemAccessibleObject>(itemAccessibleObject);
+                Assert.Equal(person.Name, itemAccessibleObject.Name);
+            }
+
+            Assert.False(control.IsHandleCreated);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3706 

## Proposed changes
When reading AccessibleObject.Name from the ListBox item, use the helper API that is used to access test that the list box displays instead of the ToString method becasue that API takes into account data binding.
<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
1. Accessibility tools users will not know what UI element they are working with.
2. Automation tools that are looking up UI elements by the accessible name will not find list box items

## Regression? 

- Yes  - from Core 3.1 and .NET Framework

## Risk

- low

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://user-images.githubusercontent.com/15823268/92152358-636c1280-edd7-11ea-9087-f2050afcb180.png)

### After

<!-- TODO -->
![after](https://user-images.githubusercontent.com/15823268/92152374-67983000-edd7-11ea-9284-b5bfa107c5b3.PNG)

## Test methodology <!-- How did you ensure quality? -->

manual and unit test

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
done
<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- <!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3831)