### PR TITLE
Fixing exception when switching between DataGridViewCell with active Narrator

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -2359,7 +2359,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                return EditingControl.AccessibilityObject;
+                return EditingControl?.AccessibilityObject;
             }
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridView.DataGridViewEditingPanelAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridView.DataGridViewEditingPanelAccessibleObjectTests.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.Tests.AccessibleObjects
+{
+    public class DataGridView_DataGridViewEditingPanelAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsFact]
+        public void DataGridViewEditingPanelAccessibleObject_FirstAndLastChildren_AreNull()
+        {
+            using DataGridView dataGridView = new DataGridView();
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            AccessibleObject accessibleObject = dataGridView.EditingPanelAccessibleObject;
+
+            // Exception does not appear when trying to get first Child
+            UiaCore.IRawElementProviderFragment firstChild = accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild);
+            Assert.Null(firstChild);
+
+            // Exception does not appear when trying to get last Child
+            UiaCore.IRawElementProviderFragment lastChild = accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild);
+            Assert.Null(lastChild);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewEditingPanelAccessibleObject_EditedState_FirstAndLastChildren_AreNotNull()
+        {
+            using DataGridView dataGridView = new DataGridView();
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            DataGridViewCell cell = dataGridView.Rows[0].Cells[0];
+            dataGridView.CurrentCell = cell;
+            dataGridView.BeginEdit(false);
+
+            AccessibleObject accessibleObject = dataGridView.EditingPanelAccessibleObject;
+
+            UiaCore.IRawElementProviderFragment firstChild = accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild);
+            Assert.NotNull(firstChild);
+
+            UiaCore.IRawElementProviderFragment lastChild = accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild);
+            Assert.NotNull(lastChild);
+        }
+    }
+}


### PR DESCRIPTION
## Minimal repro:

1. Create application with DataGridView.
2. Add any default data to DataGridView.
3. Run application
4. Start to edit existing cell.
5. Select cell from new row and start to edit
6. Select existing row and start to edit.
![3850](https://user-images.githubusercontent.com/23376742/92460216-60569500-f1d0-11ea-96bd-9644c46cac8c.gif)


## Proposed changes

- Add check that EditingControl is not null 

## Customer Impact
- Customers using accessibility tools won't get NRE when modifying a datagrid

## Regression? 

- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
-  Manual testing
## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.18363.900]
- .NET Core SDK 5.0.100-rc.1.20420.14

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3850)