### PR TITLE
Update some links to docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,4 +9,4 @@ See [Contributing Guide][contributing] for information about:
 
 [comment]: <> (Links)
 
-[contributing]: ../Documentation/contributing.md
+[contributing]: ../docs/contributing.md

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-<!-- Read https://github.com/dotnet/winforms/blob/master/Documentation/issue-guide.md -->
+<!-- Read https://github.com/dotnet/winforms/blob/master/docs/issue-guide.md -->
 
 * .NET Core Version: 
 <!-- e.g. 3.0 Preview1, or daily build number, use `dotnet --info` -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-<!-- Read https://github.com/dotnet/winforms/blob/master/Documentation/issue-guide.md -->
+<!-- Read https://github.com/dotnet/winforms/blob/master/docs/issue-guide.md -->
 
 **Is your feature request related to a problem? Please describe.**
 <!--
@@ -23,7 +23,7 @@ assignees: ''
     - Details showing the usage/consumption of the proposed new API, and alternatives (e.g. not having this API).
     - Any other context or screenshots about the feature request here.
 
-    :exclamation: Read https://github.com/dotnet/winforms/blob/master/Documentation/issue-guide.md for more details
+    :exclamation: Read https://github.com/dotnet/winforms/blob/master/docs/issue-guide.md for more details
 
   -->
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Windows Forms (WinForms) is a UI framework for building Windows desktop applicat
 Windows Forms also provides one of the most productive ways to create desktop applications based on the visual designer provided in Visual Studio. It enables drag-and-drop of visual controls and other similar functionality that make it easy to build desktop applications.
 
 ## Windows Forms Designer
-For more information about the designer, please see the [Windows Forms Designer Documentation](Documentation/winforms-designer.md).
+For more information about the designer, please see the [Windows Forms Designer Documentation](docs/winforms-designer.md).
 
 To learn about project priorities as well as status and ship dates see the [Windows Forms Roadmap](roadmap.md).
 
@@ -44,7 +44,7 @@ To learn about project priorities as well as status and ship dates see the [Wind
 Some of the best ways to contribute are to try things out, file bugs, join in design conversations, and fix issues.
 
 * The [contributing guidelines][contributing] and the more general [.NET Core contributing guide](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/contributing.md) define contributing rules.
-* The [Developer Guide](Documentation/developer-guide.md) defines the setup and workflow for working on this repository.
+* The [Developer Guide](docs/developer-guide.md) defines the setup and workflow for working on this repository.
 * If you have a question or have found a bug, [file an issue](https://github.com/dotnet/winforms/issues/new?template=bug_report.md).
 * Use [daily builds][getting-started] if you want to contribute and stay up to date with the team.
 
@@ -75,9 +75,9 @@ This project uses the [.NET Foundation Code of Conduct](https://dotnetfoundation
 .NET Core WinForms is a [.NET Foundation](https://www.dotnetfoundation.org/projects) project.<br />
 See the [.NET home repository](https://github.com/Microsoft/dotnet) to find other .NET-related projects.
 
-[getting-started]: Documentation/getting-started.md
-[contributing]: Documentation/contributing.md
-[porting-guidelines]: Documentation/porting-guidelines.md
+[getting-started]: docs/getting-started.md
+[contributing]: docs/contributing.md
+[porting-guidelines]: docs/porting-guidelines.md
 
 [master-public-build]: https://dev.azure.com/dnceng/public/_apis/build/status/267?branchName=master
 [release3-public-build]: https://dev.azure.com/dnceng/public/_apis/build/status/267?branchName=release%2f3.0

--- a/Winforms.sln
+++ b/Winforms.sln
@@ -80,20 +80,20 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{462AD69A
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "documentation", "documentation", "{C029199F-7D5C-417C-AA52-913A214E3285}"
 	ProjectSection(SolutionItems) = preProject
-		Documentation\building.md = Documentation\building.md
+		docs\building.md = docs\building.md
 		CODE_OF_CONDUCT.md = CODE_OF_CONDUCT.md
-		Documentation\contributing.md = Documentation\contributing.md
-		Documentation\debugging.md = Documentation\debugging.md
-		Documentation\developer-guide.md = Documentation\developer-guide.md
-		Documentation\getting-started.md = Documentation\getting-started.md
-		Documentation\intellisense.md = Documentation\intellisense.md
-		Documentation\issue-guide.md = Documentation\issue-guide.md
-		Documentation\porting-guidelines.md = Documentation\porting-guidelines.md
+		docs\contributing.md = docs\contributing.md
+		docs\debugging.md = docs\debugging.md
+		docs\developer-guide.md = docs\developer-guide.md
+		docs\getting-started.md = docs\getting-started.md
+		docs\intellisense.md = docs\intellisense.md
+		docs\issue-guide.md = docs\issue-guide.md
+		docs\porting-guidelines.md = docs\porting-guidelines.md
 		README.md = README.md
 		roadmap.md = roadmap.md
-		Documentation\testing.md = Documentation\testing.md
+		docs\testing.md = docs\testing.md
 		THIRD-PARTY-NOTICES.TXT = THIRD-PARTY-NOTICES.TXT
-		Documentation\winforms-designer.md = Documentation\winforms-designer.md
+		docs\winforms-designer.md = docs\winforms-designer.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "accessibility", "accessibility", "{D390F7D2-1E11-4DEE-B7F1-4FD0681A81F0}"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -74,7 +74,7 @@ To test from Visual Studio, start Visual Studio via `.\start-vs.cmd`, and test h
 
 * When testing from Visual Studio, test errors show up as normal in the Test Explorer.
 * To troubleshoot, debug the selected test and set breakpoints as you normally would.
-* For common issues when running tests through Visual Studio, see [Testing in Visual Studio](https://github.com/dotnet/winforms/blob/master/Documentation/testing-in-vs.md)
+* For common issues when running tests through Visual Studio, see [Testing in Visual Studio](https://github.com/dotnet/winforms/blob/master/docs/testing-in-vs.md)
 
 ## Adding new unit tests
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialog.cs
@@ -56,7 +56,7 @@ namespace System.Windows.Forms
         /// </para>
         /// <para>
         ///   See documentation/repro in
-        ///   /Documentation/src/System/Windows/Forms/TaskDialog/Issue_ButtonClickHandlerCalledTwice.md
+        ///   /docs/src/System/Windows/Forms/TaskDialog/Issue_ButtonClickHandlerCalledTwice.md
         /// </para>
         /// <para>
         ///   Note: We use a WM_APP message with a high value (WM_USER is not
@@ -996,7 +996,7 @@ namespace System.Windows.Forms
                             // the native TaskDialog.
                             //
                             // See documentation/repro in
-                            // /Documentation/src/System/Windows/Forms/TaskDialog/Issue_AccessViolation_NavigationInButtonClicked.md
+                            // /docs/src/System/Windows/Forms/TaskDialog/Issue_AccessViolation_NavigationInButtonClicked.md
                             //
                             // To fix the memory access problems, we simply always return
                             // S_FALSE when the callback received a TDN_NAVIGATED
@@ -1134,7 +1134,7 @@ namespace System.Windows.Forms
             // until we receive the TDN_NAVIGATED notification).
             // See:
             // https://github.com/dotnet/winforms/issues/146#issuecomment-466784079
-            // and /Documentation/src/System/Windows/Forms/TaskDialog/Issue_AccessViolation_NavigationInRadioButtonClicked.md
+            // and /docs/src/System/Windows/Forms/TaskDialog/Issue_AccessViolation_NavigationInRadioButtonClicked.md
             if (RadioButtonClickedStackCount > 0)
             {
                 throw new InvalidOperationException(string.Format(

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogRadioButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogRadioButton.cs
@@ -199,10 +199,10 @@ namespace System.Windows.Forms
                 // endless loop of TDN_RADIO_BUTTON_CLICKED notifications even
                 // when we don't send any further messages to the dialog.
                 // See documentation/repro in
-                // /Documentation/src/System/Windows/Forms/TaskDialog/Issue_RadioButton_InfiniteLoop.md
+                // /docs/src/System/Windows/Forms/TaskDialog/Issue_RadioButton_InfiniteLoop.md
                 //
                 // See also:
-                // /Documentation/src/System/Windows/Forms/TaskDialog/Issue_RadioButton_WeirdBehavior.md
+                // /docs/src/System/Windows/Forms/TaskDialog/Issue_RadioButton_WeirdBehavior.md
                 if (BoundPage.BoundDialog!.RadioButtonClickedStackCount > 0)
                 {
                     throw new InvalidOperationException(string.Format(


### PR DESCRIPTION
This PR updates some links pointing to nowhere. The folder for most of the documentation files has been renamed from `Documentation` to `docs` and there are some links that were not updated. This PR fixes some of them.

## Customer Impact
- When opening a feature request, this link is in the issue template: `Read https://github.com/dotnet/winforms/blob/master/Documentation/issue-guide.md`, which points to 404.
	- When fixing this, the user will more likely find and read the issue guide.

## Regression? 
- No

## Risk
- Some external documentation generators or script might map `Documentation` to a valid path. This would break in that case.

## Test methodology
- Ctrl+F `Documentation` and check if its affected


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3852)