### PR TITLE
Adding Text pattern to DataGridViewTextBoxCell

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObject.cs
@@ -17,9 +17,14 @@ namespace System.Windows.Forms
             ///  The parent is changed when the editing control is attached to another editing cell.
             /// </summary>
             private AccessibleObject? _parentAccessibleObject;
+            private readonly TextBoxBase _owningDataGridViewTextBoxEditingControl;
+            private readonly TextBoxBaseUiaTextProvider _textProvider;
 
             public DataGridViewTextBoxEditingControlAccessibleObject(DataGridViewTextBoxEditingControl ownerControl) : base(ownerControl)
             {
+                _owningDataGridViewTextBoxEditingControl = ownerControl;
+                _textProvider = new TextBoxBaseUiaTextProvider(ownerControl);
+                UseTextProviders(_textProvider, _textProvider);
             }
 
             public override AccessibleObject? Parent => _parentAccessibleObject;
@@ -47,7 +52,9 @@ namespace System.Windows.Forms
                 {
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.EditControlTypeId,
                     UiaCore.UIA.NamePropertyId => Name,
-                    UiaCore.UIA.IsValuePatternAvailablePropertyId => true,
+                    UiaCore.UIA.IsTextPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.TextPatternId),
+                    UiaCore.UIA.IsTextPattern2AvailablePropertyId => IsPatternSupported(UiaCore.UIA.TextPattern2Id),
+                    UiaCore.UIA.IsValuePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ValuePatternId),
                     _ => base.GetPropertyValue(propertyID),
                 };
 
@@ -55,8 +62,12 @@ namespace System.Windows.Forms
                 => patternId switch
                 {
                     UiaCore.UIA.ValuePatternId => true,
+                    UiaCore.UIA.TextPatternId => true,
+                    UiaCore.UIA.TextPattern2Id => true,
                     _ => base.IsPatternSupported(patternId)
                 };
+
+            internal override bool IsReadOnly => _owningDataGridViewTextBoxEditingControl.ReadOnly;
 
             /// <summary>
             ///  Sets the parent accessible object for the node which can be added or removed to/from hierachy nodes.

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObjectTests.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using static System.Windows.Forms.DataGridViewTextBoxEditingControl;
+using static Interop;
+
+namespace System.Windows.Forms.Tests
+{
+    public class DataGridViewTextBoxEditingControl_DataGridViewTextBoxEditingControlAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsFact]
+        public void DataGridViewTextBoxEditingControlAccessibleObject_Ctor_Default()
+        {
+            using DataGridViewTextBoxEditingControl textCellControl = new DataGridViewTextBoxEditingControl();
+            DataGridViewTextBoxEditingControlAccessibleObject accessibleObject = new DataGridViewTextBoxEditingControlAccessibleObject(textCellControl);
+            Assert.Equal(textCellControl, accessibleObject.Owner);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTextBoxEditingControlAccessibleObject_Ctor_ThrowsException_IfOwnerIsNull()
+        {
+            using DataGridViewTextBoxEditingControl textCellControl = new DataGridViewTextBoxEditingControl();
+            Assert.Throws<ArgumentNullException>(() => new DataGridViewTextBoxEditingControlAccessibleObject(null));
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ToolStripTextBoxControlAccessibleObject_IsReadOnly_IsExpected(bool readOnly)
+        {
+            using DataGridViewTextBoxEditingControl textCellControl = new DataGridViewTextBoxEditingControl();
+            textCellControl.ReadOnly = readOnly;
+            AccessibleObject accessibleObject = textCellControl.AccessibilityObject;
+            Assert.Equal(readOnly, accessibleObject.IsReadOnly);
+        }
+
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.IsTextPatternAvailablePropertyId)]
+        [InlineData((int)UiaCore.UIA.IsTextPattern2AvailablePropertyId)]
+        [InlineData((int)UiaCore.UIA.IsValuePatternAvailablePropertyId)]
+        public void ToolStripTextBoxControlAccessibleObject_GetPropertyValue_PatternsSuported(int propertyID)
+        {
+            using DataGridViewTextBoxEditingControl textCellControl = new DataGridViewTextBoxEditingControl();
+            AccessibleObject accessibleObject = textCellControl.AccessibilityObject;
+            Assert.True((bool)accessibleObject.GetPropertyValue((UiaCore.UIA)propertyID));
+        }
+
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.ValuePatternId)]
+        [InlineData((int)UiaCore.UIA.TextPatternId)]
+        [InlineData((int)UiaCore.UIA.TextPattern2Id)]
+        public void ToolStripTextBoxControlAccessibleObject_IsPatternSupported_PatternsSuported(int patternId)
+        {
+            using DataGridViewTextBoxEditingControl textCellControl = new DataGridViewTextBoxEditingControl();
+            AccessibleObject accessibleObject = textCellControl.AccessibilityObject;
+            Assert.True(accessibleObject.IsPatternSupported((UiaCore.UIA)patternId));
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #2786
Original Bug: [1159872](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1159872)
Based on PR #2701

## Proposed changes

- Enable **Text pattern** support for `DataGridViewTextBoxEditingControlAccessibleObject`


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
- Visually impaired users will be able to read and interact with the text content of a DataGridViewTextBoxCell


## Regression? 

- No

## Risk

- Mininmal

<!-- end TELL-MODE -->

### Before
- Narrator does not announce the text navigation and selection of a DataGridViewTextBoxCell
<!-- TODO -->

### After
- Narrator announces the text content of a DataGridViewTextBoxCell (navigation, selection)
<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- CTI
- Unit tests


## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Using Narrator and Inspect
<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- .Net 5.0 Version: 5.0.0-rc.1.20431.5
- Microsoft Windows [Version 10.0.19041.450]


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3866)