### PR TITLE
Change DataGridView.GridColor when set. (#3869)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -2775,6 +2775,7 @@ namespace System.Windows.Forms
 
                 if (!value.Equals(GridPenColor))
                 {
+                    GridPenColor = value;
                     OnGridColorChanged(EventArgs.Empty);
                 }
             }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using Xunit;
 using WinForms.Common.Tests;
+using System.Drawing;
 
 namespace System.Windows.Forms.Tests
 {
@@ -2711,6 +2712,23 @@ namespace System.Windows.Forms.Tests
             public new void OnRowHeadersWidthChanged(EventArgs e) => base.OnRowHeadersWidthChanged(e);
 
             public new void OnRowHeadersWidthSizeModeChanged(DataGridViewAutoSizeModeEventArgs e) => base.OnRowHeadersWidthSizeModeChanged(e);
+        }
+
+        [WinFormsFact]
+        public void DataGridView_GridColor()
+        {
+            using var dataGrid = new DataGridView();
+
+            int changedCount = 0;
+            dataGrid.GridColorChanged += (object sender, EventArgs e) =>
+            {
+                changedCount++;
+            };
+
+            dataGrid.GridColor = Color.Red;
+
+            Assert.Equal(1, changedCount);
+            Assert.Equal(Color.Red, dataGrid.GridColor);
         }
     }
 }


### PR DESCRIPTION
#### Port of #3869 to RC2

Actually change the GridColor when set. Add a test for GridColor.

Fixes #3829

## Proposed changes

- Fix missing property set 

## Customer Impact

- Can't set the grid color without this change 

## Regression? 

- Yes

## Risk

- Very low

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

See #3829, grid was black.

### After

![image](https://user-images.githubusercontent.com/8184940/92660008-691d9880-f2ae-11ea-9ac3-bb3cac3126b4.png)

## Test methodology <!-- How did you ensure quality? -->

- Add test for property
- Validate visually in WinForms app
- Examine GDI calls involved (Tests for the calls forthcoming, need to fill out the emf validation more. The records are a bit complicated as we're using GDI+ to draw the grid and it uses transforms and polylines to draw)


cc: @Pilchie for RC2

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3870)