### PR TITLE
Disable `RichTextBox_Text_GetWithHandle_ReturnsExpected`

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
@@ -6855,7 +6855,8 @@ namespace System.Windows.Forms.Tests
 
         //[WinFormsTheory]
         //[MemberData(nameof(RichTextBox_Text_GetWithHandle_TestData))]
-        [WinFormsFact]
+        [WinFormsFact(Skip = "Causes buffer overruns, see: https://github.com/dotnet/winforms/issues/3867")]
+        [ActiveIssue("https://github.com/dotnet/winforms/issues/3867")]
         public void RichTextBox_Text_GetWithHandle_ReturnsExpected()
         {
             using (var control = new RichTextBox())


### PR DESCRIPTION


<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

Under stress there's likely a race condition loading/unloading RichEdit20W control that leads to test runner crashes.
Disabling the test to unblock 5.0 release. The test will be reworked and fixed in 6.0 branch.

Relates to https://github.com/dotnet/winforms/issues/3867


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

None, test infra changes


/cc: @Pilchie 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3871)