### PR TITLE
Respect padding options when rendering text

### DIFF
--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/TextOutValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/TextOutValidator.cs
@@ -18,10 +18,12 @@ namespace System.Windows.Forms.Metafiles
         private readonly Gdi32.MM _mapMode;
         private readonly Gdi32.BKMODE _backgroundMode;
         private readonly string? _fontFace;
+        private readonly Rectangle _bounds;
 
         public TextOutValidator(
             string text,
             Color textColor,
+            Rectangle? bounds,
             Gdi32.MM mapMode = default,
             Gdi32.BKMODE backgroundMode = default,
             string? fontFace = null,
@@ -32,6 +34,7 @@ namespace System.Windows.Forms.Metafiles
             _mapMode = mapMode;
             _backgroundMode = backgroundMode;
             _fontFace = fontFace;
+            _bounds = bounds.HasValue ? bounds.Value : default;
 
             if (validate != default)
             {
@@ -40,6 +43,11 @@ namespace System.Windows.Forms.Metafiles
             else
             {
                 _validate = Flags.Text;
+
+                if (bounds.HasValue)
+                {
+                    _validate |= Flags.Bounds;
+                }
 
                 if (!textColor.IsEmpty)
                 {
@@ -77,6 +85,11 @@ namespace System.Windows.Forms.Metafiles
                 Assert.Equal(_text, textOut->emrtext.GetString().ToString());
             }
 
+            if (_validate.HasFlag(Flags.Bounds))
+            {
+                Assert.Equal(_bounds, (Rectangle)textOut->rclBounds);
+            }
+
             if (_validate.HasFlag(Flags.MapMode))
             {
                 Assert.Equal(_mapMode, state.MapMode);
@@ -106,6 +119,7 @@ namespace System.Windows.Forms.Metafiles
             MapMode         = 0b00000000_00000000_00000000_00000100,
             BackgroundMode  = 0b00000000_00000000_00000000_00001000,
             FontFace        = 0b00000000_00000000_00000000_00010000,
+            Bounds          = 0b00000000_00000000_00000000_00100000,
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/Validate.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/Validate.cs
@@ -20,6 +20,23 @@ namespace System.Windows.Forms.Metafiles
             TextOutValidator.Flags validate = default) => new TextOutValidator(
                 text,
                 textColor: Color.Empty,
+                bounds: null,
+                mapMode,
+                backgroundMode,
+                fontFace,
+                validate);
+
+        internal static IEmfValidator TextOut(
+            string text,
+            Color textColor,
+            Rectangle bounds,
+            Gdi32.MM mapMode = Gdi32.MM.TEXT,
+            Gdi32.BKMODE backgroundMode = Gdi32.BKMODE.TRANSPARENT,
+            string? fontFace = null,
+            TextOutValidator.Flags validate = default) => new TextOutValidator(
+                text,
+                textColor,
+                bounds,
                 mapMode,
                 backgroundMode,
                 fontFace,
@@ -34,6 +51,7 @@ namespace System.Windows.Forms.Metafiles
             TextOutValidator.Flags validate = default) => new TextOutValidator(
                 text,
                 textColor,
+                bounds: null,
                 mapMode,
                 backgroundMode,
                 fontFace,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.cs
@@ -518,11 +518,11 @@ namespace System.Windows.Forms
                 }
 
                 using var hfont = GdiCache.GetHFONT(Font);
-                textSize = hdc.MeasureText(Text, hfont, new Size(textRectangle.Width, int.MaxValue), flags);
+                textSize = hdc.HDC.MeasureText(Text, hfont, new Size(textRectangle.Width, int.MaxValue), (TextFormatFlags)flags);
 
                 if (Enabled)
                 {
-                    hdc.DrawText(Text, hfont, textRectangle, ForeColor, flags);
+                    hdc.HDC.DrawText(Text, hfont, textRectangle, ForeColor, (TextFormatFlags)flags);
                 }
                 else
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
@@ -2389,7 +2389,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 textRectangle,
                 textColor,
                 backColor,
-                format);
+                (TextFormatFlags)format);
 
             ValueToolTipLocation = doToolTip ? new Point(rect.X + 2, rect.Y - 1) : InvalidPoint;
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TextRendererTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TextRendererTests.cs
@@ -751,5 +751,83 @@ namespace System.Windows.Forms.Tests
             public IntPtr GetHdc() => IntPtr.Zero;
             public void ReleaseHdc() { }
         }
+
+        [WinFormsTheory]
+        [MemberData(nameof(TextRenderer_DrawText_Padding_TestData))]
+        public unsafe void TextRenderer_DrawText_Padding_Point(TextFormatFlags flags, Rectangle expectedBounds)
+        {
+            using var emf = new EmfScope();
+            DeviceContextState state = new DeviceContextState(emf);
+            TextRenderer.DrawText(
+                new HdcDeviceContextAdapter(emf),
+                "Sparkling Cider",
+                SystemFonts.DefaultFont,
+                (Point) default,
+                Color.Red,
+                flags);
+
+            emf.Validate(
+                state,
+                Validate.TextOut(
+                    "Sparkling Cider",
+                    Color.Red,
+                    expectedBounds,
+                    fontFace: SystemFonts.DefaultFont.Name));
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(TextRenderer_DrawText_Padding_TestData))]
+        public unsafe void TextRenderer_DrawText_Padding_Rectangle(TextFormatFlags flags, Rectangle expectedBounds)
+        {
+            using var emf = new EmfScope();
+            DeviceContextState state = new DeviceContextState(emf);
+            TextRenderer.DrawText(
+                new HdcDeviceContextAdapter(emf),
+                "Sparkling Cider",
+                SystemFonts.DefaultFont,
+                new Rectangle(0, 0, int.MaxValue, int.MaxValue),
+                Color.Red,
+                flags);
+
+            emf.Validate(
+                state,
+                Validate.TextOut(
+                    "Sparkling Cider",
+                    Color.Red,
+                    expectedBounds,
+                    fontFace: SystemFonts.DefaultFont.Name));
+        }
+
+        public static TheoryData<TextFormatFlags, Rectangle> TextRenderer_DrawText_Padding_TestData
+            => new TheoryData<TextFormatFlags, Rectangle>
+            {
+                { TextFormatFlags.GlyphOverhangPadding, new Rectangle(3, 0, 70, 12) },
+                { TextFormatFlags.LeftAndRightPadding, new Rectangle(5, 0, 70, 12) },
+                { TextFormatFlags.NoPadding, new Rectangle(0, 0, 70, 12) }
+            };
+
+        [WinFormsTheory]
+        [MemberData(nameof(TextRenderer_MeasureText_Padding_TestData))]
+        public void TextRenderer_MeasureText_Padding(TextFormatFlags flags, Size expectedSize)
+        {
+            using var image = new Bitmap(200, 50);
+            using Graphics graphics = Graphics.FromImage(image);
+            Size size = TextRenderer.MeasureText(
+                graphics,
+                "Sparkling Cider",
+                SystemFonts.DefaultFont,
+                new Size(int.MaxValue, int.MaxValue),
+                flags);
+
+            Assert.Equal(expectedSize, size);
+        }
+
+        public static TheoryData<TextFormatFlags, Size> TextRenderer_MeasureText_Padding_TestData
+            => new TheoryData<TextFormatFlags, Size>
+            {
+                { TextFormatFlags.GlyphOverhangPadding, new Size(78, 13) },
+                { TextFormatFlags.LeftAndRightPadding, new Size(82, 13) },
+                { TextFormatFlags.NoPadding, new Size(71, 13) }
+            };
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/Text/FontMetrics.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/Text/FontMetrics.cs
@@ -85,7 +85,7 @@ namespace System.Windows.Forms.Tests.Text
 
             using var hfont = GdiCache.GetHFONT(font, Gdi32.QUALITY.CLEARTYPE);
             using var screen = GdiCache.GetScreenHdc();
-            Size measure = screen.HDC.MeasureText("Windows Foundation Classes", hfont, proposedSize, (User32.DT)dt);
+            Size measure = screen.HDC.MeasureText("Windows Foundation Classes", hfont, proposedSize, (TextFormatFlags)dt);
             Assert.Equal(expected, measure);
         }
 


### PR DESCRIPTION
Text padding got lost in the rendering refactor. Pushed the public type down to `TextExtensions` to avoid some of the obfuscation and added rendering and measurement tests for padding.

Fixes #3823

## Proposed changes

- Pass through padding options
- Add missing tests

## Customer Impact

- Without this you cannot change padding options

## Regression? 

- Yes

## Risk

- Low

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/8184940/92679361-11e2ec80-f2dd-11ea-8719-c6ff5cf15d26.png)

### After

![image](https://user-images.githubusercontent.com/8184940/92679391-28894380-f2dd-11ea-8855-e99dd6bb7fe1.png)

## Test methodology

- Manual testing in sample apps
- Add tests to validate rendering and measurement


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3872)