### PR TITLE
Remove incorrect assert

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -6535,7 +6535,6 @@ namespace System.Windows.Forms
                     }
                     break;
                 case User32.WM.GETDPISCALEDSIZE:
-                    Debug.Assert(PARAM.SignedLOWORD(m.WParam) == PARAM.SignedHIWORD(m.WParam), "Non-square pixels!");
                     WmGetDpiScaledSize(ref m);
                     break;
                 case User32.WM.DPICHANGED:


### PR DESCRIPTION


<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

- Unlike [WM_DPICHANGED message](https://docs.microsoft.com/en-us/windows/win32/hidpi/wm-dpichanged#parameters), [WM_GETDPISCALEDSIZE message](https://docs.microsoft.com/en-us/windows/win32/hidpi/wm-getdpiscaledsize#parameters) only contains the new DPI value, not X- and Y-axis values. So the assert is being incorrectly triggered in Debug builds when DPI changes.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3874)