### PR TITLE
Fix PaintEventArgs Graphics property (#3913)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Internal/DrawingEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Internal/DrawingEventArgs.cs
@@ -18,7 +18,7 @@ namespace System.Windows.Forms
     ///  That would make things a little more robust, but would require API review as the class itself would have to
     ///  be public. The internal functionality can obviously still be internal.
     /// </remarks>
-    internal partial struct DrawingEventArgs
+    internal partial class DrawingEventArgs
     {
         private Graphics? _graphics;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PaintEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PaintEventArgs.cs
@@ -92,7 +92,7 @@ namespace System.Windows.Forms
             GC.SuppressFinalize(this);
         }
 
-        protected virtual void Dispose(bool disposing) => _event.Dispose(disposing);
+        protected virtual void Dispose(bool disposing) => _event?.Dispose(disposing);
 
         /// <summary>
         ///  If ControlStyles.AllPaintingInWmPaint, we call this method after OnPaintBackground so it appears to

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PaintEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PaintEventArgsTests.cs
@@ -25,7 +25,7 @@ namespace System.Windows.Forms.Tests
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
 
-            var e = new PaintEventArgs(graphics, clipRect);
+            using var e = new PaintEventArgs(graphics, clipRect);
             Assert.Equal(graphics, e.Graphics);
             Assert.Equal(clipRect, e.ClipRectangle);
         }
@@ -56,6 +56,17 @@ namespace System.Windows.Forms.Tests
             var e = new SubPaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
             e.DisposeEntry(disposing);
             e.DisposeEntry(disposing);
+        }
+
+        [Fact]
+        public void GraphicsIdentity()
+        {
+            // https://github.com/dotnet/winforms/issues/3910
+            using var hdc = GdiCache.GetScreenHdc();
+            using PaintEventArgs args = new PaintEventArgs(hdc, default);
+            Graphics g1 = args.Graphics;
+            Graphics g2 = args.Graphics;
+            Assert.Same(g1, g2);
         }
 
         private class SubPaintEventArgs : PaintEventArgs


### PR DESCRIPTION
#### Port #3913 to RC2 branch

Move the shared logic to a class from a struct to avoid working on a copy of the nested data.

Fixes #3910


## Proposed changes

- Change shared logic container from struct to class

## Customer Impact

- Without this, the Graphics object is always recreated when the args are created from an HDC
- Modifcations to the Graphics object are never retained

## Regression? 

- Yes

## Risk

- Low, changing to a class avoids copies

## Test methodology <!-- How did you ensure quality? -->

- Add specific test to make sure we're retaining the right instance on an args created from an HDC

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3913)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3916)