### PR TITLE
Extend EMF validation (#3890)

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Interop.POINTS.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Interop.POINTS.cs
@@ -12,5 +12,7 @@ internal static partial class Interop
         public short y;
 
         public override string ToString() => $"{{X={x} Y={y}}}";
+
+        public static implicit operator Point(POINTS point) => new Point(point.x, point.y);
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Extensions/AssertExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Extensions/AssertExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
 using Xunit;
 
 namespace System

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Extensions/GdiExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Extensions/GdiExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
+using System.Numerics;
 using static Interop;
 
 namespace System
@@ -10,5 +12,60 @@ namespace System
     {
         public static string ToSystemColorString(this COLORREF colorRef)
             => SystemCOLORs.ToSystemColorString(colorRef);
+
+        public static Point TransformPoint(in this Matrix3x2 transform, Point point)
+        {
+            if (transform.IsIdentity)
+            {
+                return point;
+            }
+
+            float y = point.Y;
+            float x = point.X;
+
+            float xadd = y * transform.M21 + transform.M31;
+            float yadd = x * transform.M12 + transform.M32;
+            x *= transform.M11;
+            x += xadd;
+            y *= transform.M22;
+            y += yadd;
+
+            return new Point((int)x, (int)y);
+        }
+
+        public static Color ToSystemColor(User32.COLOR color) => color switch
+        {
+            User32.COLOR.SCROLLBAR => SystemColors.ScrollBar,
+            User32.COLOR.DESKTOP => SystemColors.Desktop,                   // Also BACKGROUND
+            User32.COLOR.ACTIVECAPTION => SystemColors.ActiveCaption,
+            User32.COLOR.INACTIVECAPTION => SystemColors.InactiveCaption,
+            User32.COLOR.MENU => SystemColors.Menu,
+            User32.COLOR.WINDOW => SystemColors.Window,
+            User32.COLOR.WINDOWFRAME => SystemColors.WindowFrame,
+            User32.COLOR.MENUTEXT => SystemColors.MenuText,
+            User32.COLOR.WINDOWTEXT => SystemColors.WindowText,
+            User32.COLOR.CAPTIONTEXT => SystemColors.ActiveCaptionText,
+            User32.COLOR.ACTIVEBORDER => SystemColors.ActiveBorder,
+            User32.COLOR.INACTIVEBORDER => SystemColors.InactiveBorder,
+            User32.COLOR.APPWORKSPACE => SystemColors.AppWorkspace,
+            User32.COLOR.HIGHLIGHT => SystemColors.Highlight,
+            User32.COLOR.HIGHLIGHTTEXT => SystemColors.HighlightText,
+            User32.COLOR.BTNFACE => SystemColors.ButtonFace,
+            User32.COLOR.BTNSHADOW => SystemColors.ButtonShadow,
+            User32.COLOR.GRAYTEXT => SystemColors.GrayText,
+            User32.COLOR.BTNTEXT => SystemColors.ControlText,
+            User32.COLOR.INACTIVECAPTIONTEXT => SystemColors.InactiveCaptionText,
+            User32.COLOR.BTNHIGHLIGHT => SystemColors.ButtonHighlight,
+            User32.COLOR.DKSHADOW3D => SystemColors.ControlDarkDark,
+            User32.COLOR.LIGHT3D => SystemColors.ControlLight,
+            User32.COLOR.INFOTEXT => SystemColors.InfoText,
+            User32.COLOR.INFOBK => SystemColors.Info,
+            User32.COLOR.HOTLIGHT => SystemColors.HotTrack,
+            User32.COLOR.GRADIENTACTIVECAPTION => SystemColors.GradientActiveCaption,
+            User32.COLOR.GRADIENTINACTIVECAPTION => SystemColors.GradientInactiveCaption,
+            User32.COLOR.MENUHILIGHT => SystemColors.MenuHighlight,
+            User32.COLOR.MENUBAR => SystemColors.MenuBar,
+            _ => throw new ArgumentOutOfRangeException(nameof(color))
+        };
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Extensions/SpanExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Extensions/SpanExtensions.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System
+{
+    public static class SpanExtensions
+    {
+        public static T2[] Transform<T1, T2>(this ReadOnlySpan<T1> span, Func<T1, T2> transform)
+        {
+            T2[] output = new T2[span.Length];
+            for (int i = 0; i < span.Length; i++)
+            {
+                output[i] = transform(span[i]);
+            }
+            return output;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/DataHelpers.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/DataHelpers.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace System.Windows.Forms.Metafiles
+{
+    public static class DataHelpers
+    {
+        public static unsafe Point[] PointArray(params int[] values)
+        {
+            if (values is null)
+                throw new ArgumentNullException(nameof(values));
+
+            if (values.Length % 2 != 0)
+                throw new ArgumentOutOfRangeException(nameof(values));
+
+            Point[] points = new Point[values.Length / 2];
+            fixed (int* i = values)
+            fixed (Point* p = points)
+            {
+                Unsafe.CopyBlock(p, i, (uint)(sizeof(int) * values.Length));
+            }
+
+            return points;
+        }
+
+        public static unsafe Point[] PointArray(Matrix3x2 transform, params int[] values)
+        {
+            Point[] points = PointArray(values);
+            for (int i = 0; i < points.Length; i++)
+            {
+                points[i] = transform.TransformPoint(points[i]);
+            }
+
+            return points;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EmfRecord.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EmfRecord.cs
@@ -57,6 +57,8 @@ namespace System.Windows.Forms.Metafiles
             => Type == Gdi32.EMR.SETBKMODE ? (EMRENUMRECORD<Gdi32.BKMODE>*)_lpmr : null;
         public EMRCREATEPEN* CreatePenRecord
             => Type == Gdi32.EMR.CREATEPEN ? (EMRCREATEPEN*)_lpmr : null;
+        public EMREXTCREATEPEN* ExtCreatePenRecord
+            => Type == Gdi32.EMR.EXTCREATEPEN ? (EMREXTCREATEPEN*)_lpmr : null;
         public EMRINDEXRECORD* SelectObjectRecord
             => Type == Gdi32.EMR.SELECTOBJECT ? (EMRINDEXRECORD*)_lpmr : null;
         public EMRINDEXRECORD* DeleteObjectRecord
@@ -75,6 +77,8 @@ namespace System.Windows.Forms.Metafiles
             => Type == Gdi32.EMR.POLYLINETO16 ? (EMRPOLY16*)_lpmr : null;
         public EMRPOLY16* PolyBezierTo16Record
             => Type == Gdi32.EMR.POLYBEZIERTO16 ? (EMRPOLY16*)_lpmr : null;
+        public EMRSETWORLDTRANSFORM* SetWorldTransformRecord
+            => Type == Gdi32.EMR.SETWORLDTRANSFORM ? (EMRSETWORLDTRANSFORM*)_lpmr : null;
         public EMRMODIFYWORLDTRANSFORM* ModifyWorldTransformRecord
             => Type == Gdi32.EMR.MODIFYWORLDTRANSFORM ? (EMRMODIFYWORLDTRANSFORM*)_lpmr : null;
         public EMRSETCOLOR* SetBkColorRecord
@@ -105,6 +109,8 @@ namespace System.Windows.Forms.Metafiles
             => Type == Gdi32.EMR.ELLIPSE ? (EMRRECTRECORD*)_lpmr : null;
         public EMRRECTRECORD* RectangleRecord
             => Type == Gdi32.EMR.RECTANGLE ? (EMRRECTRECORD*)_lpmr : null;
+        public EMRRESTOREDC* RestoreDCRecord
+            => Type == Gdi32.EMR.RESTOREDC ? (EMRRESTOREDC*)_lpmr : null;
 
         public override string ToString() => Type switch
         {
@@ -120,11 +126,17 @@ namespace System.Windows.Forms.Metafiles
             Gdi32.EMR.SETBKMODE => SetBkModeRecord->ToString(),
             Gdi32.EMR.SETROP2 => SetROP2Record->ToString(),
             Gdi32.EMR.CREATEPEN => CreatePenRecord->ToString(),
+            Gdi32.EMR.EXTCREATEPEN => ExtCreatePenRecord->ToString(),
             Gdi32.EMR.SELECTOBJECT => SelectObjectRecord->ToString(),
             Gdi32.EMR.DELETEOBJECT => DeleteObjectRecord->ToString(),
             Gdi32.EMR.BITBLT => BitBltRecord->ToString(),
             Gdi32.EMR.SETICMMODE => SetIcmModeRecord->ToString(),
+            Gdi32.EMR.POLYLINE16 => PolyLine16Record->ToString(),
+            Gdi32.EMR.POLYBEZIER16 => PolyBezier16Record->ToString(),
             Gdi32.EMR.POLYGON16 => Polygon16Record->ToString(),
+            Gdi32.EMR.POLYBEZIERTO16 => PolyBezierTo16Record->ToString(),
+            Gdi32.EMR.POLYLINETO16 => PolyLineTo16Record->ToString(),
+            Gdi32.EMR.SETWORLDTRANSFORM => SetWorldTransformRecord->ToString(),
             Gdi32.EMR.MODIFYWORLDTRANSFORM => ModifyWorldTransformRecord->ToString(),
             Gdi32.EMR.SETTEXTCOLOR => SetTextColorRecord->ToString(),
             Gdi32.EMR.SETBKCOLOR => SetBkColorRecord->ToString(),
@@ -140,7 +152,15 @@ namespace System.Windows.Forms.Metafiles
             Gdi32.EMR.INTERSECTCLIPRECT => IntersetClipRectRecord->ToString(),
             Gdi32.EMR.ELLIPSE => EllipseRecord->ToString(),
             Gdi32.EMR.RECTANGLE => RectangleRecord->ToString(),
+            Gdi32.EMR.RESTOREDC => RestoreDCRecord->ToString(),
             _ => $"[EMR{Type}]"
+        };
+
+        public string ToString(DeviceContextState state) => Type switch
+        {
+            Gdi32.EMR.POLYLINE16 => PolyLine16Record->ToString(state),
+            Gdi32.EMR.POLYGON16 => Polygon16Record->ToString(state),
+            _ => ToString()
         };
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EmfScope.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EmfScope.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System.Collections.Generic;
+using System.Numerics;
 using System.Runtime.InteropServices;
 using static Interop;
 
@@ -136,6 +137,30 @@ namespace System.Windows.Forms.Metafiles
                     case Gdi32.EMR.DELETEOBJECT:
                         state.GdiObjects[(int)record.DeleteObjectRecord->index] = default;
                         break;
+                    case Gdi32.EMR.SETWORLDTRANSFORM:
+                        state.Transform = record.SetWorldTransformRecord->xform;
+                        break;
+                    case Gdi32.EMR.MODIFYWORLDTRANSFORM:
+                        var transform = record.ModifyWorldTransformRecord;
+                        switch (transform->iMode)
+                        {
+                            case Gdi32.MWT.IDENTITY:
+                                state.Transform = Matrix3x2.Identity;
+                                break;
+                            case Gdi32.MWT.LEFTMULTIPLY:
+                                state.Transform = transform->xform * state.Transform;
+                                break;
+                            case Gdi32.MWT.RIGHTMULTIPLY:
+                                state.Transform = state.Transform * transform->xform;
+                                break;
+                        }
+                        break;
+                    case Gdi32.EMR.SAVEDC:
+                        state.SaveDC();
+                        break;
+                    case Gdi32.EMR.RESTOREDC:
+                        state.RestoreDC(record.RestoreDCRecord->iRelative);
+                        break;
                 }
 
                 return result;
@@ -150,6 +175,19 @@ namespace System.Windows.Forms.Metafiles
                 strings.Add(record.ToString());
                 return true;
             });
+
+            return strings;
+        }
+
+        public List<string> RecordsToStringWithState(DeviceContextState state)
+        {
+            var strings = new List<string>();
+            EnumerateWithState((ref EmfRecord record, DeviceContextState state) =>
+            {
+                strings.Add(record.ToString(state));
+                return true;
+            },
+            state);
 
             return strings;
         }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMREXTCREATEPEN.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMREXTCREATEPEN.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Runtime.InteropServices;
+using static Interop;
+
+namespace System.Windows.Forms.Metafiles
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct EMREXTCREATEPEN
+    {
+        public EMR emr;
+        public uint ihPen;              // Pen handle index
+        public uint offBmi;             // Offset to the BITMAPINFO structure if any
+        public uint cbBmi;              // Size of the BITMAPINFO structure if any
+                                        // The bitmap info is followed by the bitmap
+                                        // bits to form a packed DIB.
+        public uint offBits;            // Offset to the brush bitmap bits if any
+        public uint cbBits;             // Size of the brush bitmap bits if any
+        public EXTLOGPEN32 elp;         // The extended pen with the style array.
+
+        public override string ToString()
+            => $@"[{nameof(EMREXTCREATEPEN)}] Index: {ihPen} Style: {elp.elpPenStyle} Width: {
+                elp.elpWidth} BrushStyle: {elp.elpBrushStyle} Color: {
+                elp.elpColor.ToSystemColorString()}";
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct EXTLOGPEN32
+    {
+        public Gdi32.PS elpPenStyle;
+        public uint elpWidth;
+        public Gdi32.BS elpBrushStyle;
+        public COLORREF elpColor;
+        public uint elpHatch;
+        public uint elpNumEntries;
+        public uint elpStyleEntry;
+
+        public static implicit operator EXTLOGPEN32(Gdi32.LOGPEN logPen) => new EXTLOGPEN32
+        {
+            elpPenStyle = logPen.lopnStyle,
+            elpWidth = (uint)logPen.lopnWidth.X,
+            elpColor = logPen.lopnColor
+        };
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMREXTTEXTOUTW.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMREXTTEXTOUTW.cs
@@ -20,7 +20,7 @@ namespace System.Windows.Forms.Metafiles
         public EMRTEXT emrtext;          // This is followed by the string and spacing
 
         public override string ToString()
-            => $@"[{nameof(EMREXTTEXTOUTW)}] Bounds: {rclBounds} Text: '{emrtext.GetString().ToString()}'";
+            => $@"[{nameof(EMREXTTEXTOUTW)}] Bounds: {rclBounds} Text: '{emrtext.GetText().ToString()}'";
 
         internal enum GM : uint
         {

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMRPOLY16.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMRPOLY16.cs
@@ -5,7 +5,9 @@
 #nullable enable
 
 using System.Runtime.InteropServices;
+using System.Linq;
 using static Interop;
+using System.Drawing;
 
 namespace System.Windows.Forms.Metafiles
 {
@@ -27,11 +29,16 @@ namespace System.Windows.Forms.Metafiles
         public EMR emr;
         public RECT rclBounds;          // Inclusive-inclusive bounds in device units
         public uint cpts;
-        public POINTS apts;
+        private POINTS _apts;
 
-        public override string ToString()
+        public ReadOnlySpan<POINTS> points => TrailingArray<POINTS>.GetBuffer(ref _apts, cpts);
+
+        public override string ToString() => $"[EMR{emr.iType}] Bounds: {rclBounds} Points: {string.Join(' ', points.ToArray())}";
+
+        public string ToString(DeviceContextState state)
         {
-            return $"[EMR{emr.iType}] Bounds: {rclBounds} Points: {cpts}";
+            Point[] transformedPoints = points.Transform(point => state.TransformPoint(point));
+            return $"[EMR{emr.iType}] Bounds: {rclBounds} Points: {string.Join(' ', transformedPoints)}";
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMRRESTOREDC.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMRRESTOREDC.cs
@@ -5,18 +5,15 @@
 #nullable enable
 
 using System.Runtime.InteropServices;
-using System.Numerics;
-using static Interop;
 
 namespace System.Windows.Forms.Metafiles
 {
     [StructLayout(LayoutKind.Sequential)]
-    internal struct EMRMODIFYWORLDTRANSFORM
+    internal struct EMRRESTOREDC
     {
         public EMR emr;
-        public Matrix3x2 xform;
-        public Gdi32.MWT iMode;
+        public int iRelative;
 
-        public override string ToString() => $"[{nameof(EMRMODIFYWORLDTRANSFORM)}] Mode: {iMode} Transform: {xform}";
+        public override string ToString() => $"[{nameof(EMRRESTOREDC)}] Index: {iRelative}";
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMRSETWORLDTRANSFORM.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMRSETWORLDTRANSFORM.cs
@@ -6,17 +6,15 @@
 
 using System.Runtime.InteropServices;
 using System.Numerics;
-using static Interop;
 
 namespace System.Windows.Forms.Metafiles
 {
     [StructLayout(LayoutKind.Sequential)]
-    internal struct EMRMODIFYWORLDTRANSFORM
+    internal struct EMRSETWORLDTRANSFORM
     {
         public EMR emr;
         public Matrix3x2 xform;
-        public Gdi32.MWT iMode;
 
-        public override string ToString() => $"[{nameof(EMRMODIFYWORLDTRANSFORM)}] Mode: {iMode} Transform: {xform}";
+        public override string ToString() => $"[{nameof(EMRSETWORLDTRANSFORM)}] Transform: {xform}";
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMRTEXT.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMRTEXT.cs
@@ -20,7 +20,7 @@ namespace System.Windows.Forms.Metafiles
         public RECT rcl;
         public uint offDx;              // Offset to the inter-character spacing array.
 
-        public unsafe ReadOnlySpan<char> GetString()
+        public unsafe ReadOnlySpan<char> GetText()
         {
             int offset = (int)offString - sizeof(EMREXTTEXTOUTW) + sizeof(EMRTEXT);
             fixed (Point* p = &ptlReference)

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/BrushColorValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/BrushColorValidator.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Drawing;
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.Metafiles
+{
+    internal class BrushColorValidator : IStateValidator
+    {
+        private readonly Color _brushColor;
+        public BrushColorValidator(Color brushColor) => _brushColor = brushColor;
+        public void Validate(DeviceContextState state) => Assert.Equal((COLORREF)_brushColor, state.SelectedBrush.lbColor);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/BrushStyleValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/BrushStyleValidator.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.Metafiles
+{
+    internal class BrushStyleValidator : IStateValidator
+    {
+        private readonly Gdi32.BS _brushStyle;
+        public BrushStyleValidator(Gdi32.BS brushStyle) => _brushStyle = brushStyle;
+        public void Validate(DeviceContextState state) => Assert.Equal(_brushStyle, state.SelectedBrush.lbStyle);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/BrushValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/BrushValidator.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Drawing;
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.Metafiles
+{
+    internal class BrushValidator : IStateValidator
+    {
+        private readonly Color _brushColor;
+        private readonly Gdi32.BS _brushStyle;
+
+        public BrushValidator(Color brushColor, Gdi32.BS brushStyle)
+        {
+            _brushColor = brushColor;
+            _brushStyle = brushStyle;
+        }
+
+        public void Validate(DeviceContextState state)
+        {
+            Assert.Equal((COLORREF)_brushColor, state.SelectedBrush.lbColor);
+            Assert.Equal(_brushStyle, state.SelectedBrush.lbStyle);
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/EmfValidator.WrappedXunitException.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/EmfValidator.WrappedXunitException.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using Xunit.Sdk;
+
+namespace System.Windows.Forms.Metafiles
+{
+    internal static partial class EmfValidator
+    {
+        private class WrappedXunitException : XunitException
+        {
+            public WrappedXunitException(string userMessage, XunitException innerException)
+                : base (userMessage, innerException)
+            {
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/EmfValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/EmfValidator.cs
@@ -5,11 +5,12 @@
 #nullable enable
 
 using Xunit;
+using Xunit.Sdk;
 using static Interop;
 
 namespace System.Windows.Forms.Metafiles
 {
-    internal static class EmfValidator
+    internal static partial class EmfValidator
     {
         internal static void Validate(
             this EmfScope emf,
@@ -28,14 +29,24 @@ namespace System.Windows.Forms.Metafiles
                 {
                     if (currentValidator?.ShouldValidate(record.Type) ?? false)
                     {
-                        currentValidator.Validate(ref record, state, out bool complete);
-                        if (complete)
+                        try
                         {
-                            // Current validator doesn't want to look at any more records.
-                            currentIndex++;
-                            currentValidator = currentIndex < validationSteps.Length
-                                ? validationSteps[currentIndex]
-                                : null;
+                            currentValidator.Validate(ref record, state, out bool complete);
+
+                            if (complete)
+                            {
+                                // Current validator doesn't want to look at any more records.
+                                currentIndex++;
+                                currentValidator = currentIndex < validationSteps.Length
+                                    ? validationSteps[currentIndex]
+                                    : null;
+                            }
+                        }
+                        catch (XunitException e)
+                        {
+                            throw new WrappedXunitException(
+                                $"\nValidator index {currentIndex}: {currentValidator!.GetType().Name} failed",
+                                e);
                         }
                     }
                     else
@@ -49,8 +60,8 @@ namespace System.Windows.Forms.Metafiles
 
             if (currentValidator != null)
             {
-                Assert.True(
-                    currentValidator.ValidationSatisfied,
+                Assert.False(
+                    currentValidator.FailIfIncomplete,
                     $"{currentValidator.GetType().Name} did not receive expected records");
             }
         }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/IEmfValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/IEmfValidator.cs
@@ -26,8 +26,8 @@ namespace System
         void Validate(ref EmfRecord record, DeviceContextState state, out bool complete);
 
         /// <summary>
-        ///  Return true if this validator doesn't require any additional records.
+        ///  Return true if this validator is still in scope when all records have been processed.
         /// </summary>
-        bool ValidationSatisfied => false;
+        bool FailIfIncomplete => true;
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/IStateValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/IStateValidator.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+namespace System.Windows.Forms.Metafiles
+{
+    internal interface IStateValidator
+    {
+        void Validate(DeviceContextState state);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/LineToValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/LineToValidator.cs
@@ -10,120 +10,43 @@ using static Interop;
 
 namespace System.Windows.Forms.Metafiles
 {
-    internal sealed class LineToValidator : IEmfValidator
+    internal sealed class LineToValidator : StateValidator
     {
-        private readonly Flags _validate;
-        private readonly Point _from;
-        private readonly Point _to;
-        private readonly int _penWidth;
-        private readonly Color _penColor;
-        private readonly Gdi32.PS _penStyle;
-        private readonly Gdi32.R2 _rop2;
-        private readonly Gdi32.BKMODE _backgroundMode;
+        private readonly Point? _from;
+        private readonly Point? _to;
 
+        /// <param name="from">Optional source point to validate.</param>
+        /// <param name="to">Optional destination point to validate.</param>
+        /// <param name="stateValidators">Optional device context state validation to perform.</param>
         public LineToValidator(
-            Point from,
-            Point to,
-            Color penColor,
-            int penWidth = 1,
-            Gdi32.PS penStyle = default,
-            Gdi32.R2 rop2 = Gdi32.R2.COPYPEN,
-            Gdi32.BKMODE backgroundMode = Gdi32.BKMODE.TRANSPARENT,
-            Flags validate = default)
+            Point? from,
+            Point? to,
+            params IStateValidator[] stateValidators) : base(stateValidators)
         {
             _from = from;
             _to = to;
-            _penWidth = penWidth;
-            _penColor = penColor;
-            _penStyle = penStyle;
-            _rop2 = rop2;
-            _backgroundMode = backgroundMode;
-
-            if (validate != default)
-            {
-                _validate = validate;
-                return;
-            }
-
-            // Default values for all of these are valid expectations so we always turn them on.
-            _validate = Flags.From | Flags.To | Flags.PenStyle;
-
-            if (penWidth != 0)
-            {
-                _validate |= Flags.PenWidth;
-            }
-
-            if (!penColor.IsEmpty)
-            {
-                _validate |= Flags.PenColor;
-            }
-
-            if (backgroundMode != default)
-            {
-                _validate |= Flags.BackgroundMode;
-            }
-
-            if (_rop2 != default)
-            {
-                _validate |= Flags.RopMode;
-            }
         }
 
-        public bool ShouldValidate(Gdi32.EMR recordType) => recordType == Gdi32.EMR.LINETO;
+        public override bool ShouldValidate(Gdi32.EMR recordType) => recordType == Gdi32.EMR.LINETO;
 
-        public unsafe void Validate(ref EmfRecord record, DeviceContextState state, out bool complete)
+        public override unsafe void Validate(ref EmfRecord record, DeviceContextState state, out bool complete)
         {
-            // We're only checking one TextOut record, so this call completes our work.
+            base.Validate(ref record, state, out _);
+
+            // We're only checking one LineTo record, so this call completes our work.
             complete = true;
 
             EMRPOINTRECORD* lineTo = record.LineToRecord;
 
-            if (_validate.HasFlag(Flags.From))
+            if (_from.HasValue)
             {
-                Assert.Equal(_from, state.BrushOrigin);
+                Assert.Equal(_from.Value, state.BrushOrigin);
             }
 
-            if (_validate.HasFlag(Flags.To))
+            if (_to.HasValue)
             {
-                Assert.Equal(_to, lineTo->point);
+                Assert.Equal(_to.Value, lineTo->point);
             }
-
-            if (_validate.HasFlag(Flags.PenColor))
-            {
-                Assert.Equal((COLORREF)_penColor, state.SelectedPen.lopnColor);
-            }
-
-            if (_validate.HasFlag(Flags.PenWidth))
-            {
-                Assert.Equal(_penWidth, state.SelectedPen.lopnWidth.X);
-            }
-
-            if (_validate.HasFlag(Flags.PenStyle))
-            {
-                Assert.Equal(_penStyle, state.SelectedPen.lopnStyle);
-            }
-
-            if (_validate.HasFlag(Flags.BackgroundMode))
-            {
-                Assert.Equal(_backgroundMode, state.BackgroundMode);
-            }
-
-            if (_validate.HasFlag(Flags.RopMode))
-            {
-                Assert.Equal(_rop2, state.Rop2Mode);
-            }
-        }
-
-        [Flags]
-        public enum Flags : uint
-        {
-            From            = 0b00000000_00000000_00000000_00000001,
-            To              = 0b00000000_00000000_00000000_00000010,
-            PenColor        = 0b00000000_00000000_00000000_00000100,
-            PenWidth        = 0b00000000_00000000_00000000_00001000,
-            PenStyle        = 0b00000000_00000000_00000000_00010000,
-            RopMode         = 0b00000000_00000000_00000000_00100000,
-            BackgroundMode  = 0b00000000_00000000_00000000_01000000,
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/PenColorValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/PenColorValidator.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Drawing;
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.Metafiles
+{
+    internal class PenColorValidator : IStateValidator
+    {
+        private readonly Color _penColor;
+        public PenColorValidator(Color penColor) => _penColor = penColor;
+        public void Validate(DeviceContextState state) => Assert.Equal((COLORREF)_penColor, state.SelectedPen.elpColor);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/PenStyleValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/PenStyleValidator.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.Metafiles
+{
+    internal class PenStyleValidator : IStateValidator
+    {
+        private readonly Gdi32.PS _penStyle;
+        public PenStyleValidator(Gdi32.PS penStyle) => _penStyle = penStyle;
+        public void Validate(DeviceContextState state) => Assert.Equal(_penStyle, state.SelectedPen.elpPenStyle);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/PenValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/PenValidator.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Drawing;
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.Metafiles
+{
+    internal class PenValidator : IStateValidator
+    {
+        private readonly int _penWidth;
+        private readonly Gdi32.PS _penStyle;
+        private readonly Color _penColor;
+
+        public PenValidator(int penWidth, Color penColor, Gdi32.PS penStyle)
+        {
+            _penWidth = penWidth;
+            _penColor = penColor;
+            _penStyle = penStyle;
+        }
+
+        public void Validate(DeviceContextState state)
+        {
+            Assert.Equal(_penWidth, (int)state.SelectedPen.elpWidth);
+            Assert.Equal((COLORREF)_penColor, state.SelectedPen.elpColor);
+            Assert.Equal(_penStyle, state.SelectedPen.elpPenStyle);
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/PenWidthValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/PenWidthValidator.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using Xunit;
+
+namespace System.Windows.Forms.Metafiles
+{
+    internal class PenWidthValidator : IStateValidator
+    {
+        private readonly int _penWidth;
+        public PenWidthValidator(int penWidth) => _penWidth = penWidth;
+        public void Validate(DeviceContextState state) => Assert.Equal(_penWidth, (int)state.SelectedPen.elpWidth);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/Polygon16Validator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/Polygon16Validator.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Drawing;
+using static Interop;
+
+namespace System.Windows.Forms.Metafiles
+{
+    internal class Polygon16Validator : Poly16Validator
+    {
+        /// <inheritdoc/>
+        public Polygon16Validator(
+            RECT? bounds,
+            Point[]? points,
+            params IStateValidator[] stateValidators) : base(
+                bounds,
+                points,
+                stateValidators)
+        {
+        }
+
+        public override bool ShouldValidate(Gdi32.EMR recordType) => recordType == Gdi32.EMR.POLYGON16;
+
+        public override unsafe void Validate(ref EmfRecord record, DeviceContextState state, out bool complete)
+        {
+            base.Validate(ref record, state, out _);
+
+            // We're only checking one Polygon16 record, so this call completes our work.
+            complete = true;
+
+            Validate(record.Polygon16Record);
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/Polyline16Validator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/Polyline16Validator.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Drawing;
+using static Interop;
+
+namespace System.Windows.Forms.Metafiles
+{
+    internal class Polyline16Validator : Poly16Validator
+    {
+        /// <inheritdoc/>
+        public Polyline16Validator(
+            RECT? bounds,
+            Point[]? points,
+            params IStateValidator[] stateValidators) : base(
+                bounds,
+                points,
+                stateValidators)
+        {
+        }
+
+        public override bool ShouldValidate(Gdi32.EMR recordType) => recordType == Gdi32.EMR.POLYLINE16;
+
+        public override unsafe void Validate(ref EmfRecord record, DeviceContextState state, out bool complete)
+        {
+            base.Validate(ref record, state, out _);
+
+            // We're only checking one Polyline16 record, so this call completes our work.
+            complete = true;
+
+            Validate(record.PolyLine16Record);
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/Rop2Validator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/Rop2Validator.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.Metafiles
+{
+    internal class Rop2Validator : IStateValidator
+    {
+        private readonly Gdi32.R2 _rop2Mode;
+        public Rop2Validator(Gdi32.R2 rop2Mode) => _rop2Mode = rop2Mode;
+        public void Validate(DeviceContextState state) => Assert.Equal(_rop2Mode, state.Rop2Mode);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/SkipAllValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/SkipAllValidator.cs
@@ -19,5 +19,8 @@ namespace System.Windows.Forms.Metafiles
             // Always want to remain in scope.
             complete = false;
         }
+
+        // We don't require any more records to "pass"
+        public bool FailIfIncomplete => false;
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/State.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/State.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Drawing;
+using System.Numerics;
+using static Interop;
+
+namespace System.Windows.Forms.Metafiles
+{
+    internal static class State
+    {
+        internal static IStateValidator TextColor(Color textColor) => new TextColorValidator(textColor);
+        internal static IStateValidator Pen(int penWidth, Color penColor, Gdi32.PS penStyle)
+            => new PenValidator(penWidth, penColor, penStyle);
+        internal static IStateValidator PenColor(Color penColor) => new PenColorValidator(penColor);
+        internal static IStateValidator PenStyle(Gdi32.PS penStyle) => new PenStyleValidator(penStyle);
+        internal static IStateValidator PenWidth(int penWidth) => new PenWidthValidator(penWidth);
+        internal static IStateValidator Brush(Color brushColor, Gdi32.BS brushStyle)
+            => new BrushValidator(brushColor, brushStyle);
+        internal static IStateValidator BrushColor(Color brushColor) => new BrushColorValidator(brushColor);
+        internal static IStateValidator BrushStyle(Gdi32.BS brushStyle) => new BrushStyleValidator(brushStyle);
+        internal static IStateValidator Rop2(Gdi32.R2 rop2Mode) => new Rop2Validator(rop2Mode);
+        internal static IStateValidator Transform(Matrix3x2 transform) => new TransformValidator(transform);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/StateValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/StateValidator.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using static Interop;
+
+namespace System.Windows.Forms.Metafiles
+{
+    /// <summary>
+    ///  Base <see cref="IEmfValidator"/> that handles optional validation of device context state.
+    /// </summary>
+    internal abstract class StateValidator : IEmfValidator
+    {
+        private readonly IStateValidator[] _stateValidators;
+        public StateValidator(IStateValidator[] stateValidators) => _stateValidators = stateValidators;
+        public abstract bool ShouldValidate(Gdi32.EMR recordType);
+
+        public virtual void Validate(ref EmfRecord record, DeviceContextState state, out bool complete)
+        {
+            complete = false;
+
+            if (_stateValidators is null)
+            {
+                return;
+            }
+
+            foreach (IStateValidator validator in _stateValidators)
+            {
+                validator.Validate(state);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/TextColorValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/TextColorValidator.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Drawing;
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.Metafiles
+{
+    internal class TextColorValidator : IStateValidator
+    {
+        private readonly Color _textColor;
+        public TextColorValidator(Color textColor) => _textColor = textColor;
+        public void Validate(DeviceContextState state) => Assert.Equal((COLORREF)_textColor, state.TextColor);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/TextOutValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/TextOutValidator.cs
@@ -10,116 +10,52 @@ using static Interop;
 
 namespace System.Windows.Forms.Metafiles
 {
-    internal sealed class TextOutValidator : IEmfValidator
+    internal sealed class TextOutValidator : StateValidator
     {
-        private readonly Flags _validate;
-        private readonly string _text;
-        private readonly Color _textColor;
-        private readonly Gdi32.MM _mapMode;
-        private readonly Gdi32.BKMODE _backgroundMode;
+        private readonly string? _text;
         private readonly string? _fontFace;
-        private readonly Rectangle _bounds;
+        private readonly Rectangle? _bounds;
 
+        /// <param name="text">Optional text to validate.</param>
+        /// <param name="bounds">Optional bounds to validate.</param>
+        /// <param name="fontFace">Optional font face name to validate.</param>
+        /// <param name="stateValidators">Optional device context state validation to perform.</param>
         public TextOutValidator(
-            string text,
-            Color textColor,
-            Rectangle? bounds,
-            Gdi32.MM mapMode = default,
-            Gdi32.BKMODE backgroundMode = default,
-            string? fontFace = null,
-            Flags validate = default)
+            string? text,
+            Rectangle? bounds = default,
+            string? fontFace = default,
+            params IStateValidator[] stateValidators) : base(stateValidators)
         {
             _text = text;
-            _textColor = textColor;
-            _mapMode = mapMode;
-            _backgroundMode = backgroundMode;
             _fontFace = fontFace;
-            _bounds = bounds.HasValue ? bounds.Value : default;
-
-            if (validate != default)
-            {
-                _validate = validate;
-            }
-            else
-            {
-                _validate = Flags.Text;
-
-                if (bounds.HasValue)
-                {
-                    _validate |= Flags.Bounds;
-                }
-
-                if (!textColor.IsEmpty)
-                {
-                    _validate |= Flags.TextColor;
-                }
-
-                if (mapMode != default)
-                {
-                    _validate |= Flags.MapMode;
-                }
-
-                if (backgroundMode != default)
-                {
-                    _validate |= Flags.BackgroundMode;
-                }
-
-                if (!string.IsNullOrEmpty(fontFace))
-                {
-                    _validate |= Flags.FontFace;
-                }
-            }
+            _bounds = bounds;
         }
 
-        public bool ShouldValidate(Gdi32.EMR recordType) => recordType == Gdi32.EMR.EXTTEXTOUTW;
+        public override bool ShouldValidate(Gdi32.EMR recordType) => recordType == Gdi32.EMR.EXTTEXTOUTW;
 
-        public unsafe void Validate(ref EmfRecord record, DeviceContextState state, out bool complete)
+        public override unsafe void Validate(ref EmfRecord record, DeviceContextState state, out bool complete)
         {
+            base.Validate(ref record, state, out _);
+
             // We're only checking one TextOut record, so this call completes our work.
             complete = true;
 
             EMREXTTEXTOUTW* textOut = record.ExtTextOutWRecord;
 
-            if (_validate.HasFlag(Flags.Text))
+            if (_text != null)
             {
-                Assert.Equal(_text, textOut->emrtext.GetString().ToString());
+                Assert.Equal(_text, textOut->emrtext.GetText().ToString());
             }
 
-            if (_validate.HasFlag(Flags.Bounds))
+            if (_bounds.HasValue)
             {
-                Assert.Equal(_bounds, (Rectangle)textOut->rclBounds);
+                Assert.Equal(_bounds.Value, (Rectangle)textOut->rclBounds);
             }
 
-            if (_validate.HasFlag(Flags.MapMode))
-            {
-                Assert.Equal(_mapMode, state.MapMode);
-            }
-
-            if (_validate.HasFlag(Flags.BackgroundMode))
-            {
-                Assert.Equal(_backgroundMode, state.BackgroundMode);
-            }
-
-            if (_validate.HasFlag(Flags.TextColor))
-            {
-                Assert.Equal((COLORREF)_textColor, state.TextColor);
-            }
-
-            if (_validate.HasFlag(Flags.FontFace))
+            if (_fontFace != null)
             {
                 Assert.Equal(_fontFace, state.SelectedFont.FaceName.ToString());
             }
-        }
-
-        [Flags]
-        public enum Flags : uint
-        {
-            Text            = 0b00000000_00000000_00000000_00000001,
-            TextColor       = 0b00000000_00000000_00000000_00000010,
-            MapMode         = 0b00000000_00000000_00000000_00000100,
-            BackgroundMode  = 0b00000000_00000000_00000000_00001000,
-            FontFace        = 0b00000000_00000000_00000000_00010000,
-            Bounds          = 0b00000000_00000000_00000000_00100000,
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/TransformValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/TransformValidator.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Numerics;
+using Xunit;
+
+namespace System.Windows.Forms.Metafiles
+{
+    internal class TransformValidator : IStateValidator
+    {
+        private readonly Matrix3x2 _transform;
+        public TransformValidator(Matrix3x2 transform) => _transform = transform;
+        public void Validate(DeviceContextState state) => Assert.Equal(_transform, state.Transform);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/Validate.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/Validate.cs
@@ -5,95 +5,66 @@
 #nullable enable
 
 using System.Drawing;
-using System.Net;
 using static Interop;
 
 namespace System.Windows.Forms.Metafiles
 {
     internal static class Validate
     {
-        internal static IEmfValidator TextOut(
-            string text,
-            Gdi32.MM mapMode = Gdi32.MM.TEXT,
-            Gdi32.BKMODE backgroundMode = Gdi32.BKMODE.TRANSPARENT,
-            string? fontFace = null,
-            TextOutValidator.Flags validate = default) => new TextOutValidator(
-                text,
-                textColor: Color.Empty,
-                bounds: null,
-                mapMode,
-                backgroundMode,
-                fontFace,
-                validate);
-
-        internal static IEmfValidator TextOut(
-            string text,
-            Color textColor,
-            Rectangle bounds,
-            Gdi32.MM mapMode = Gdi32.MM.TEXT,
-            Gdi32.BKMODE backgroundMode = Gdi32.BKMODE.TRANSPARENT,
-            string? fontFace = null,
-            TextOutValidator.Flags validate = default) => new TextOutValidator(
-                text,
-                textColor,
+        /// <param name="bounds">Optional bounds to validate.</param>
+        /// <param name="points">Optional points to validate.</param>
+        /// <param name="stateValidators">Optional device context state validation to perform.</param>
+        internal static IEmfValidator Polygon16(
+            Rectangle? bounds = default,
+            Point[]? points = default,
+            params IStateValidator[] stateValidators) => new Polygon16Validator(
                 bounds,
-                mapMode,
-                backgroundMode,
-                fontFace,
-                validate);
+                points,
+                stateValidators);
 
+        /// <param name="bounds">Optional bounds to validate.</param>
+        /// <param name="points">Optional points to validate.</param>
+        /// <param name="stateValidators">Optional device context state validation to perform.</param>
+        internal static IEmfValidator Polyline16(
+            Rectangle? bounds = default,
+            Point[]? points = default,
+            params IStateValidator[] stateValidators) => new Polyline16Validator(
+                bounds,
+                points,
+                stateValidators);
+
+        /// <param name="text">Optional text to validate.</param>
+        /// <param name="bounds">Optional bounds to validate.</param>
+        /// <param name="fontFace">Optional font face name to validate.</param>
+        /// <param name="stateValidators">Optional device context state validation to perform.</param>
         internal static IEmfValidator TextOut(
-            string text,
-            Color textColor,
-            Gdi32.MM mapMode = Gdi32.MM.TEXT,
-            Gdi32.BKMODE backgroundMode = Gdi32.BKMODE.TRANSPARENT,
-            string? fontFace = null,
-            TextOutValidator.Flags validate = default) => new TextOutValidator(
+            string? text = default,
+            Rectangle? bounds = default,
+            string? fontFace = default,
+            params IStateValidator[] stateValidators) => new TextOutValidator(
                 text,
-                textColor,
-                bounds: null,
-                mapMode,
-                backgroundMode,
+                bounds,
                 fontFace,
-                validate);
+                stateValidators);
 
+        /// <param name="from">Optional source point to validate.</param>
+        /// <param name="to">Optional destination point to validate.</param>
+        /// <param name="stateValidators">Optional device context state validation to perform.</param>
         internal static IEmfValidator LineTo(
-            EasyPoint from,
-            EasyPoint to,
-            Color penColor,
-            int penWidth = 1,
-            Gdi32.PS penStyle = default,
-            Gdi32.R2 rop2Mode = Gdi32.R2.COPYPEN,
-            Gdi32.BKMODE backgroundMode = Gdi32.BKMODE.TRANSPARENT,
-            LineToValidator.Flags validate = default) => new LineToValidator(
+            EasyPoint? from,
+            EasyPoint? to,
+            params IStateValidator[] stateValidators) => new LineToValidator(
                 from,
                 to,
-                penColor,
-                penWidth,
-                penStyle,
-                rop2Mode,
-                backgroundMode,
-                validate);
+                stateValidators);
 
+        /// <param name="bounds">Optional bounds to validate.</param>
+        /// <param name="stateValidators">Optional device context state validation to perform.</param>
         internal static IEmfValidator Rectangle(
-            RECT bounds,
-            Color penColor,
-            Color brushColor,
-            int penWidth = 1,
-            Gdi32.PS penStyle = default,
-            Gdi32.R2 rop2 = Gdi32.R2.COPYPEN,
-            Gdi32.BKMODE backgroundMode = Gdi32.BKMODE.TRANSPARENT,
-            Gdi32.BS brushStyle = default,
-            RectangleValidator.Flags validate = default) => new RectangleValidator(
+            RECT? bounds,
+            params IStateValidator[] stateValidators) => new RectangleValidator(
                 bounds,
-                penColor,
-                brushColor,
-                penWidth,
-                penStyle,
-                rop2,
-                backgroundMode,
-                brushStyle,
-                validate);
+                stateValidators);
 
         /// <summary>
         ///  Simple wrapper to allow doing an arbitrary action for a given <paramref name="recordType"/>.

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonRenderingTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonRenderingTests.cs
@@ -44,14 +44,30 @@ namespace System.Windows.Forms.Tests
             emf.Validate(
                 state,
                 Validate.Repeat(Validate.SkipType(Gdi32.EMR.BITBLT), 2),
-                Validate.LineTo((bounds.Right - 1, 0), (0, 0), SystemColors.ControlLightLight),
-                Validate.LineTo((0, 0), (0, bounds.Bottom - 1), SystemColors.ControlLightLight),
-                Validate.LineTo((0, bounds.Bottom - 1), (bounds.Right - 1, bounds.Bottom - 1), SystemColors.ControlDarkDark),
-                Validate.LineTo((bounds.Right - 1, bounds.Bottom - 1), (bounds.Right - 1, -1), SystemColors.ControlDarkDark),
-                Validate.LineTo((bounds.Right - 2, 1), (1, 1), SystemColors.Control),
-                Validate.LineTo((1, 1), (1, bounds.Bottom - 2), SystemColors.Control),
-                Validate.LineTo((1, bounds.Bottom - 2), (bounds.Right - 2, bounds.Bottom - 2), SystemColors.ControlDark),
-                Validate.LineTo((bounds.Right - 2, bounds.Bottom - 2), (bounds.Right - 2, 0), SystemColors.ControlDark));
+                Validate.LineTo(
+                    (bounds.Right - 1, 0), (0, 0),
+                    State.PenColor(SystemColors.ControlLightLight)),
+                Validate.LineTo(
+                    (0, 0), (0, bounds.Bottom - 1),
+                    State.PenColor(SystemColors.ControlLightLight)),
+                Validate.LineTo(
+                    (0, bounds.Bottom - 1), (bounds.Right - 1, bounds.Bottom - 1),
+                    State.PenColor(SystemColors.ControlDarkDark)),
+                Validate.LineTo(
+                    (bounds.Right - 1, bounds.Bottom - 1), (bounds.Right - 1, -1),
+                    State.PenColor(SystemColors.ControlDarkDark)),
+                Validate.LineTo(
+                    (bounds.Right - 2, 1), (1, 1),
+                    State.PenColor(SystemColors.Control)),
+                Validate.LineTo(
+                    (1, 1), (1, bounds.Bottom - 2),
+                    State.PenColor(SystemColors.Control)),
+                Validate.LineTo(
+                    (1, bounds.Bottom - 2), (bounds.Right - 2, bounds.Bottom - 2),
+                    State.PenColor(SystemColors.ControlDark)),
+                Validate.LineTo(
+                    (bounds.Right - 2, bounds.Bottom - 2), (bounds.Right - 2, 0),
+                    State.PenColor(SystemColors.ControlDark)));
         }
 
         [WinFormsFact]
@@ -69,14 +85,30 @@ namespace System.Windows.Forms.Tests
                 state,
                 Validate.SkipType(Gdi32.EMR.BITBLT),
                 Validate.TextOut("Hello"),
-                Validate.LineTo((bounds.Right - 1, 0), (0, 0), SystemColors.ControlLightLight),
-                Validate.LineTo((0, 0), (0, bounds.Bottom - 1), SystemColors.ControlLightLight),
-                Validate.LineTo((0, bounds.Bottom - 1), (bounds.Right - 1, bounds.Bottom - 1), SystemColors.ControlDarkDark),
-                Validate.LineTo((bounds.Right - 1, bounds.Bottom - 1), (bounds.Right - 1, -1), SystemColors.ControlDarkDark),
-                Validate.LineTo((bounds.Right - 2, 1), (1, 1), SystemColors.Control),
-                Validate.LineTo((1, 1), (1, bounds.Bottom - 2), SystemColors.Control),
-                Validate.LineTo((1, bounds.Bottom - 2), (bounds.Right - 2, bounds.Bottom - 2), SystemColors.ControlDark),
-                Validate.LineTo((bounds.Right - 2, bounds.Bottom - 2), (bounds.Right - 2, 0), SystemColors.ControlDark));
+                Validate.LineTo(
+                    (bounds.Right - 1, 0), (0, 0),
+                    State.PenColor(SystemColors.ControlLightLight)),
+                Validate.LineTo(
+                    (0, 0), (0, bounds.Bottom - 1),
+                    State.PenColor(SystemColors.ControlLightLight)),
+                Validate.LineTo(
+                    (0, bounds.Bottom - 1), (bounds.Right - 1, bounds.Bottom - 1),
+                    State.PenColor(SystemColors.ControlDarkDark)),
+                Validate.LineTo(
+                    (bounds.Right - 1, bounds.Bottom - 1), (bounds.Right - 1, -1),
+                    State.PenColor(SystemColors.ControlDarkDark)),
+                Validate.LineTo(
+                    (bounds.Right - 2, 1), (1, 1),
+                    State.PenColor(SystemColors.Control)),
+                Validate.LineTo(
+                    (1, 1), (1, bounds.Bottom - 2),
+                    State.PenColor(SystemColors.Control)),
+                Validate.LineTo(
+                    (1, bounds.Bottom - 2), (bounds.Right - 2, bounds.Bottom - 2),
+                    State.PenColor(SystemColors.ControlDark)),
+                Validate.LineTo(
+                    (bounds.Right - 2, bounds.Bottom - 2), (bounds.Right - 2, 0),
+                    State.PenColor(SystemColors.ControlDark)));
         }
 
         [WinFormsFact]
@@ -114,11 +146,10 @@ namespace System.Windows.Forms.Tests
                 Validate.TextOut("Flat Style"),
                 Validate.Rectangle(
                     new Rectangle(0, 0, button.Width - 1, button.Height - 1),
-                    penColor: Color.Black,
-                    penStyle: Gdi32.PS.ENDCAP_ROUND,
-                    brushColor: Color.Empty,        // Color doesn't really matter as we're using a null brush
-                    brushStyle: Gdi32.BS.NULL,      // Regressed in https://github.com/dotnet/winforms/pull/3667
-                    rop2: Gdi32.R2.COPYPEN));
+                    State.PenColor(Color.Black),
+                    State.PenStyle(Gdi32.PS.ENDCAP_ROUND),
+                    State.BrushStyle(Gdi32.BS.NULL),       // Regressed in https://github.com/dotnet/winforms/pull/3667
+                    State.Rop2( Gdi32.R2.COPYPEN)));
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
@@ -7,6 +7,10 @@ using System.ComponentModel;
 using Xunit;
 using WinForms.Common.Tests;
 using System.Drawing;
+using System.Windows.Forms.Metafiles;
+using System.Numerics;
+using static System.Windows.Forms.Metafiles.DataHelpers;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -2729,6 +2733,92 @@ namespace System.Windows.Forms.Tests
 
             Assert.Equal(1, changedCount);
             Assert.Equal(Color.Red, dataGrid.GridColor);
+        }
+
+        [WinFormsFact]
+        public void DataGridView_GridColor_Rendering()
+        {
+            using Form form = new Form();
+
+            // Only want to render one cell to validate
+            using var dataGrid = new DataGridView
+            {
+                GridColor = Color.Blue,
+                ColumnCount = 1,
+                RowCount = 1,
+                ColumnHeadersVisible = false,
+                RowHeadersVisible = false
+            };
+
+            form.Controls.Add(dataGrid);
+
+            using var emf = new EmfScope();
+            DeviceContextState state = new DeviceContextState(emf);
+
+            dataGrid.PrintToMetafile(emf);
+
+            Assert.Equal(new Rectangle(0, 0, 240, 150), dataGrid.Bounds);
+            Assert.Equal(new Size(100, 25), dataGrid[0, 0].Size);
+
+            Rectangle bounds = dataGrid.Bounds;
+
+            // For whatever reason GDI+ renders as polylines scaled 16x with a 1/16th world transform applied.
+            // For test readability we'll transform the points from our coordinates to the logical coordinates.
+            Matrix3x2 oneSixteenth = Matrix3x2.CreateScale(0.0625f);
+            Matrix3x2 times16 = Matrix3x2.CreateScale(16.0f);
+
+            // This is the default pen style GDI+ renders with
+            Gdi32.PS penStyle = Gdi32.PS.SOLID | Gdi32.PS.JOIN_ROUND | Gdi32.PS.COSMETIC | Gdi32.PS.ENDCAP_FLAT
+                | Gdi32.PS.JOIN_MITER | Gdi32.PS.GEOMETRIC;
+
+            // Don't really care about the bounds, just the actual shapes/lines
+            emf.Validate(
+                state,
+                // The datagrid background
+                Validate.Polygon16(
+                    bounds: null,
+                    PointArray(times16, 1, 1, 1, 149, 239, 149, 239, 1, 1, 1),
+                    State.Pen(1, Color.Empty, Gdi32.PS.NULL),
+                    State.Brush(SystemColors.ButtonShadow, Gdi32.BS.SOLID),
+                    State.Transform(oneSixteenth)),
+                // Left cell border
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 1, 1, 1, 26),
+                    State.Pen(16, Color.Blue, penStyle),
+                    State.Transform(oneSixteenth)),
+                // Right cell border
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 101, 1, 101, 26),
+                    State.Pen(16, Color.Blue, penStyle),
+                    State.Transform(oneSixteenth)),
+                // Top cell border
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 1, 1, 101, 1),
+                    State.Pen(16, Color.Blue, penStyle),
+                    State.Transform(oneSixteenth)),
+                // Bottom cell border
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 1, 26, 101, 26),
+                    State.Pen(16, Color.Blue, penStyle),
+                    State.Transform(oneSixteenth)),
+                // Cell background
+                Validate.Polygon16(
+                    bounds: null,
+                    PointArray(times16, 2, 2, 2, 26, 101, 26, 101, 2, 2, 2),
+                    State.Pen(1, Color.Empty, Gdi32.PS.NULL),
+                    State.Brush(SystemColors.ButtonHighlight, Gdi32.BS.SOLID),
+                    State.Transform(oneSixteenth)),
+                // Datagrid border
+                Validate.Polygon16(
+                    bounds: null,
+                    PointArray(times16, 0, 0, 239, 0, 239, 149, 0, 149),
+                    State.Pen(16, SystemColors.Desktop, penStyle),
+                    State.Brush(Color.Empty, Gdi32.BS.NULL),
+                    State.Transform(oneSixteenth)));
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TextRendererTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TextRendererTests.cs
@@ -668,8 +668,9 @@ namespace System.Windows.Forms.Tests
                 state,
                 Validate.TextOut(
                     "Acrylic",
-                    Color.Blue,
-                    fontFace: SystemFonts.DefaultFont.Name));
+                    bounds: null,                                   // Don't care about the bounds for this test
+                    fontFace: SystemFonts.DefaultFont.Name,
+                    State.TextColor(Color.Blue)));
         }
 
         public static TheoryData<Func<IDeviceContext, Action>> TextRenderer_DrawText_DefaultBackground_RendersTransparent_TestData
@@ -770,9 +771,9 @@ namespace System.Windows.Forms.Tests
                 state,
                 Validate.TextOut(
                     "Sparkling Cider",
-                    Color.Red,
                     expectedBounds,
-                    fontFace: SystemFonts.DefaultFont.Name));
+                    SystemFonts.DefaultFont.Name,
+                    State.TextColor(Color.Red)));
         }
 
         [WinFormsTheory]
@@ -793,9 +794,9 @@ namespace System.Windows.Forms.Tests
                 state,
                 Validate.TextOut(
                     "Sparkling Cider",
-                    Color.Red,
                     expectedBounds,
-                    fontFace: SystemFonts.DefaultFont.Name));
+                    SystemFonts.DefaultFont.Name,
+                    State.TextColor(Color.Red)));
         }
 
         public static TheoryData<TextFormatFlags, Rectangle> TextRenderer_DrawText_Padding_TestData


### PR DESCRIPTION
Port (cherry-pick) test change #3890 to RC2. Has one trivial change to product code in `Interop.POINTS.cs`- the rest is test code.

This is needed to pull in tests for rendering fixes and includes tests for a change that has already come into RC2.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3941)