### PR TITLE
Fix rendering of NumericUpDown control (#3939)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownButtons.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownButtons.cs
@@ -329,19 +329,11 @@ namespace System.Windows.Forms
 
                     Rectangle clientRect = ClientRectangle;
                     Point pt1 = new Point(clientRect.Left, clientRect.Bottom - 1);
-                    Point pt2 = new Point(clientRect.Right - 1, clientRect.Bottom - 1);
+                    Point pt2 = new Point(clientRect.Right, clientRect.Bottom - 1);
 
-                    if (!color.HasTransparency())
-                    {
-                        using var hdc = new DeviceContextHdcScope(e);
-                        using var hpen = new Gdi32.CreatePenScope(color);
-                        hdc.DrawLine(hpen, pt1, pt2);
-                    }
-                    else
-                    {
-                        using var pen = color.GetCachedPenScope();
-                        e.Graphics.DrawLine(pen, pt1, pt2);
-                    }
+                    using var hdc = new DeviceContextHdcScope(e);
+                    using var hpen = new Gdi32.CreatePenScope(color);
+                    hdc.DrawLine(hpen, pt1, pt2);
                 }
 
                 // Raise the paint event, just in case this inner class goes public some day

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
@@ -531,40 +531,25 @@ namespace System.Windows.Forms
                     clipRight.Intersect(clipBounds);
                     clipBottom.Intersect(clipBounds);
 
+                    using var hdc = new DeviceContextHdcScope(e);
+                    vsr.DrawBackground(hdc, bounds, clipLeft, HandleInternal);
+                    vsr.DrawBackground(hdc, bounds, clipTop, HandleInternal);
+                    vsr.DrawBackground(hdc, bounds, clipRight, HandleInternal);
+                    vsr.DrawBackground(hdc, bounds, clipBottom, HandleInternal);
+
+                    // Draw a rectangle around edit control with the background color.
                     Rectangle backRect = editBounds;
                     backRect.X--;
                     backRect.Y--;
-                    backRect.Width++;
-                    backRect.Height++;
-
-                    bool transparent = backColor.HasTransparency();
-
-                    using (var hdc = new DeviceContextHdcScope(e))
-                    {
-                        vsr.DrawBackground(hdc, bounds, clipLeft, HandleInternal);
-                        vsr.DrawBackground(hdc, bounds, clipTop, HandleInternal);
-                        vsr.DrawBackground(hdc, bounds, clipRight, HandleInternal);
-                        vsr.DrawBackground(hdc, bounds, clipBottom, HandleInternal);
-
-                        if (!transparent)
-                        {
-                            // Draw rectangle around edit control with background color
-                            using var hpen = new Gdi32.CreatePenScope(backColor);
-                            hdc.DrawRectangle(backRect, hpen);
-                        }
-                    }
-
-                    if (transparent)
-                    {
-                        // Need to use GDI+
-                        using var pen = backColor.GetCachedPenScope();
-                        e.GraphicsInternal.DrawRectangle(pen, backRect);
-                    }
+                    backRect.Width += 2;
+                    backRect.Height += 2;
+                    using var hpen = new Gdi32.CreatePenScope(backColor);
+                    hdc.DrawRectangle(backRect, hpen);
                 }
             }
             else
             {
-                // Draw rectangle around edit control with background color
+                // Draw a rectangle around edit control with the background color.
                 Rectangle backRect = editBounds;
                 backRect.Inflate(1, 1);
                 if (!Enabled)
@@ -577,17 +562,11 @@ namespace System.Windows.Forms
 
                 int width = Enabled ? 2 : 1;
 
-                if (!backColor.HasTransparency())
-                {
-                    using var hdc = new DeviceContextHdcScope(e);
-                    using var hpen = new Gdi32.CreatePenScope(backColor, width);
-                    hdc.DrawRectangle(backRect, hpen);
-                }
-                else
-                {
-                    using var pen = backColor.GetCachedPenScope(width);
-                    e.GraphicsInternal.DrawRectangle(pen, backRect);
-                }
+                backRect.Width++;
+                backRect.Height++;
+                using var hdc = new DeviceContextHdcScope(e);
+                using var hpen = new Gdi32.CreatePenScope(backColor, width);
+                hdc.DrawRectangle(backRect, hpen);
             }
 
             if (!Enabled && BorderStyle != BorderStyle.None && !_upDownEdit.ShouldSerializeBackColor())

--- a/src/System.Windows.Forms/tests/UnitTests/NumericUpDownTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/NumericUpDownTests.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
+using System.Windows.Forms.Metafiles;
 using Xunit;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -15,6 +18,67 @@ namespace System.Windows.Forms.Tests
 
             Assert.NotNull(nud);
             Assert.Equal("0", nud.Text);
+        }
+
+        [WinFormsFact]
+        public void NumericUpDown_BasicRendering()
+        {
+            using var form = new Form();
+            using var upDown = new NumericUpDown();
+
+            form.Controls.Add(upDown);
+
+            using var emf = new EmfScope();
+            DeviceContextState state = new DeviceContextState(emf);
+
+            Assert.Equal(new Rectangle(0, 0, 120, 23), upDown.Bounds);
+
+            // The rendering here is the "fill" for the background around the child edit control, which
+            // doesn't match up to the main control's bounds.
+            upDown.PrintToMetafile(emf);
+            emf.Validate(
+                state,
+                Validate.Rectangle(
+                    new Rectangle(1, 1, 98, 17),
+                    State.Pen(2, upDown.BackColor, Gdi32.PS.SOLID)));
+
+            // Printing the main control doesn't get the redraw for the child controls on the first render,
+            // directly hitting the up/down button subcontrol.
+
+            using var emfButtons = new EmfScope();
+            state = new DeviceContextState(emfButtons);
+            upDown.Controls[0].PrintToMetafile(emfButtons);
+
+            // This is the "fill" line under the up/down arrows
+            emfButtons.Validate(
+                state,
+                Validate.SkipType(Gdi32.EMR.STRETCHDIBITS),
+                Validate.SkipType(Gdi32.EMR.STRETCHDIBITS),
+                Validate.LineTo(
+                    (0, 18), (16, 18),
+                    State.Pen(1, upDown.BackColor, Gdi32.PS.SOLID)));
+
+            // Now check the disabled state
+
+            upDown.Enabled = false;
+
+            using var emfDisabled = new EmfScope();
+            state = new DeviceContextState(emfDisabled);
+            upDown.PrintToMetafile(emfDisabled);
+
+            emfDisabled.Validate(
+                state,
+                Validate.Rectangle(
+                    new Rectangle(0, 0, 99, 18),
+                    State.Pen(1, upDown.BackColor, Gdi32.PS.SOLID)),
+                Validate.Rectangle(
+                    new Rectangle(1, 1, 97, 16),
+                    State.Pen(1, SystemColors.Control, Gdi32.PS.SOLID)),
+                Validate.SkipType(Gdi32.EMR.STRETCHDIBITS),
+                Validate.SkipType(Gdi32.EMR.STRETCHDIBITS),
+                Validate.LineTo(
+                    (0, 18), (16, 18),
+                    State.Pen(1, upDown.BackColor, Gdi32.PS.SOLID)));
         }
     }
 }


### PR DESCRIPTION
#### Port of #3939 to RC2

GDI and GDI+ don't end their lines and rectangles on the same pixel. Lines end on the prior pixel and rectangles draw the right and bottom one pixel over. This wasn't caught at first as the color behind the control just happened to match the default on first render.

- Fix the GDI coordinates to match the GDI+ rendering
- Remove the GDI+ fork as it is impossible to set a transparent background color for NumericUpDown
- Add initial rendering tests

Validated with A/B testing between 3.1 and 5.0 with a loud background color. Validated with and without visual styles, enabled and disabled, and with different border styles.

Fixes #3931


## Proposed changes

- Correct GDI rendering for NumericUpDown
- Remove unhittable GDI+ branches

## Customer Impact

- Without this you get whatever random garbage is behind the form around the edges of the control

## Regression? 

- Yes

## Risk

- Low

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/8184940/93525609-2d588380-f8eb-11ea-9bbd-991c70a5e4d8.png)

### After

![image](https://user-images.githubusercontent.com/8184940/93525658-3d706300-f8eb-11ea-9aff-b2096901ac1b.png)

## Test methodology

- Manual validation of various rendering knobs between 3.1 and 5.0
- Added rendering tests where possible
- Ran a number of low-level line drawing tests to compare GDI/GDI+

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3942)