### PR TITLE
Fix ControlPaint.DrawBorder dashed/dotted drawing

### DIFF
--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EmfRecord.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EmfRecord.cs
@@ -69,14 +69,18 @@ namespace System.Windows.Forms.Metafiles
             => Type == Gdi32.EMR.SETICMMODE ? (EMRENUMRECORD<Gdi32.ICM>*)_lpmr : null;
         public EMRPOLY16* Polygon16Record
             => Type == Gdi32.EMR.POLYGON16 ? (EMRPOLY16*)_lpmr : null;
-        public EMRPOLY16* PolyLine16Record
+        public EMRPOLY16* Polyline16Record
             => Type == Gdi32.EMR.POLYLINE16 ? (EMRPOLY16*)_lpmr : null;
         public EMRPOLY16* PolyBezier16Record
             => Type == Gdi32.EMR.POLYBEZIER16 ? (EMRPOLY16*)_lpmr : null;
-        public EMRPOLY16* PolyLineTo16Record
+        public EMRPOLY16* PolylineTo16Record
             => Type == Gdi32.EMR.POLYLINETO16 ? (EMRPOLY16*)_lpmr : null;
         public EMRPOLY16* PolyBezierTo16Record
             => Type == Gdi32.EMR.POLYBEZIERTO16 ? (EMRPOLY16*)_lpmr : null;
+        public EMRPOLYPOLY16* PolyPolyline16Record
+            => Type == Gdi32.EMR.POLYPOLYLINE16 ? (EMRPOLYPOLY16*)_lpmr : null;
+        public EMRPOLYPOLY16* PolyPolygon16Record
+            => Type == Gdi32.EMR.POLYPOLYGON16 ? (EMRPOLYPOLY16*)_lpmr : null;
         public EMRSETWORLDTRANSFORM* SetWorldTransformRecord
             => Type == Gdi32.EMR.SETWORLDTRANSFORM ? (EMRSETWORLDTRANSFORM*)_lpmr : null;
         public EMRMODIFYWORLDTRANSFORM* ModifyWorldTransformRecord
@@ -131,11 +135,13 @@ namespace System.Windows.Forms.Metafiles
             Gdi32.EMR.DELETEOBJECT => DeleteObjectRecord->ToString(),
             Gdi32.EMR.BITBLT => BitBltRecord->ToString(),
             Gdi32.EMR.SETICMMODE => SetIcmModeRecord->ToString(),
-            Gdi32.EMR.POLYLINE16 => PolyLine16Record->ToString(),
+            Gdi32.EMR.POLYLINE16 => Polyline16Record->ToString(),
             Gdi32.EMR.POLYBEZIER16 => PolyBezier16Record->ToString(),
             Gdi32.EMR.POLYGON16 => Polygon16Record->ToString(),
             Gdi32.EMR.POLYBEZIERTO16 => PolyBezierTo16Record->ToString(),
-            Gdi32.EMR.POLYLINETO16 => PolyLineTo16Record->ToString(),
+            Gdi32.EMR.POLYLINETO16 => PolylineTo16Record->ToString(),
+            Gdi32.EMR.POLYPOLYGON16 => PolyPolygon16Record->ToString(),
+            Gdi32.EMR.POLYPOLYLINE16 => PolyPolyline16Record->ToString(),
             Gdi32.EMR.SETWORLDTRANSFORM => SetWorldTransformRecord->ToString(),
             Gdi32.EMR.MODIFYWORLDTRANSFORM => ModifyWorldTransformRecord->ToString(),
             Gdi32.EMR.SETTEXTCOLOR => SetTextColorRecord->ToString(),
@@ -158,8 +164,10 @@ namespace System.Windows.Forms.Metafiles
 
         public string ToString(DeviceContextState state) => Type switch
         {
-            Gdi32.EMR.POLYLINE16 => PolyLine16Record->ToString(state),
+            Gdi32.EMR.POLYLINE16 => Polyline16Record->ToString(state),
             Gdi32.EMR.POLYGON16 => Polygon16Record->ToString(state),
+            Gdi32.EMR.POLYPOLYGON16 => PolyPolygon16Record->ToString(state),
+            Gdi32.EMR.POLYPOLYLINE16 => PolyPolyline16Record->ToString(state),
             _ => ToString()
         };
     }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EmfScope.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EmfScope.cs
@@ -7,6 +7,7 @@
 using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.InteropServices;
+using System.Text;
 using static Interop;
 
 namespace System.Windows.Forms.Metafiles
@@ -167,29 +168,29 @@ namespace System.Windows.Forms.Metafiles
             }
         }
 
-        public List<string> RecordsToString()
+        public string RecordsToString()
         {
-            var strings = new List<string>();
+            StringBuilder sb = new StringBuilder(1024);
             Enumerate((ref EmfRecord record) =>
             {
-                strings.Add(record.ToString());
+                sb.AppendLine(record.ToString());
                 return true;
             });
 
-            return strings;
+            return sb.ToString();
         }
 
-        public List<string> RecordsToStringWithState(DeviceContextState state)
+        public string RecordsToStringWithState(DeviceContextState state)
         {
-            var strings = new List<string>();
+            StringBuilder sb = new StringBuilder(1024);
             EnumerateWithState((ref EmfRecord record, DeviceContextState state) =>
             {
-                strings.Add(record.ToString(state));
+                sb.AppendLine(record.ToString(state));
                 return true;
             },
             state);
 
-            return strings;
+            return sb.ToString();
         }
 
         private static unsafe BOOL CallBack(

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/PolyPoly16Validator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/PolyPoly16Validator.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Drawing;
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.Metafiles
+{
+    internal abstract class PolyPoly16Validator : StateValidator
+    {
+        private readonly Rectangle? _bounds;
+        private readonly int? _polyCount;
+
+        /// <param name="bounds">Optional bounds to validate.</param>
+        /// <param name="polyCount">Number of expected polys.</param>
+        /// <param name="stateValidators">Optional device context state validation to perform.</param>
+        public PolyPoly16Validator(
+            RECT? bounds,
+            int? polyCount,
+            params IStateValidator[] stateValidators) : base(stateValidators)
+        {
+            // Full point validation still needs implemented
+            _polyCount = polyCount;
+            _bounds = bounds;
+        }
+
+        protected unsafe void Validate(EMRPOLYPOLY16* poly)
+        {
+            if (_bounds.HasValue)
+            {
+                Assert.Equal(_bounds.Value, (Rectangle)poly->rclBounds);
+            }
+
+            if (_polyCount.HasValue)
+            {
+                Assert.Equal(_polyCount.Value, (int)poly->nPolys);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/PolyPolygon16Validator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/PolyPolygon16Validator.cs
@@ -4,34 +4,33 @@
 
 #nullable enable
 
-using System.Drawing;
 using static Interop;
 
 namespace System.Windows.Forms.Metafiles
 {
-    internal class Polyline16Validator : Poly16Validator
+    internal class PolyPolygon16Validator : PolyPoly16Validator
     {
         /// <inheritdoc/>
-        public Polyline16Validator(
+        public PolyPolygon16Validator(
             RECT? bounds,
-            Point[]? points,
+            int? polyCount,
             params IStateValidator[] stateValidators) : base(
                 bounds,
-                points,
+                polyCount,
                 stateValidators)
         {
         }
 
-        public override bool ShouldValidate(Gdi32.EMR recordType) => recordType == Gdi32.EMR.POLYLINE16;
+        public override bool ShouldValidate(Gdi32.EMR recordType) => recordType == Gdi32.EMR.POLYPOLYGON16;
 
         public override unsafe void Validate(ref EmfRecord record, DeviceContextState state, out bool complete)
         {
             base.Validate(ref record, state, out _);
 
-            // We're only checking one Polyline16 record, so this call completes our work.
+            // We're only checking one PolyPolygon16 record, so this call completes our work.
             complete = true;
 
-            Validate(record.Polyline16Record);
+            Validate(record.PolyPolygon16Record);
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/PolyPolyline16Validator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/PolyPolyline16Validator.cs
@@ -4,34 +4,33 @@
 
 #nullable enable
 
-using System.Drawing;
 using static Interop;
 
 namespace System.Windows.Forms.Metafiles
 {
-    internal class Polyline16Validator : Poly16Validator
+    internal class PolyPolyline16Validator : PolyPoly16Validator
     {
         /// <inheritdoc/>
-        public Polyline16Validator(
+        public PolyPolyline16Validator(
             RECT? bounds,
-            Point[]? points,
+            int? polyCount,
             params IStateValidator[] stateValidators) : base(
                 bounds,
-                points,
+                polyCount,
                 stateValidators)
         {
         }
 
-        public override bool ShouldValidate(Gdi32.EMR recordType) => recordType == Gdi32.EMR.POLYLINE16;
+        public override bool ShouldValidate(Gdi32.EMR recordType) => recordType == Gdi32.EMR.POLYPOLYLINE16;
 
         public override unsafe void Validate(ref EmfRecord record, DeviceContextState state, out bool complete)
         {
             base.Validate(ref record, state, out _);
 
-            // We're only checking one Polyline16 record, so this call completes our work.
+            // We're only checking one PolyPolyline16 record, so this call completes our work.
             complete = true;
 
-            Validate(record.Polyline16Record);
+            Validate(record.PolyPolyline16Record);
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/Validate.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/Validate.cs
@@ -33,6 +33,28 @@ namespace System.Windows.Forms.Metafiles
                 points,
                 stateValidators);
 
+        /// <param name="bounds">Optional bounds to validate.</param>
+        /// <param name="polyCount">Optional count of polygons to validate.</param>
+        /// <param name="stateValidators">Optional device context state validation to perform.</param>
+        internal static IEmfValidator PolyPolygon16(
+            Rectangle? bounds = default,
+            int? polyCount = default,
+            params IStateValidator[] stateValidators) => new PolyPolygon16Validator(
+                bounds,
+                polyCount,
+                stateValidators);
+
+        /// <param name="bounds">Optional bounds to validate.</param>
+        /// <param name="polyCount">Optional count of polygons to validate.</param>
+        /// <param name="stateValidators">Optional device context state validation to perform.</param>
+        internal static IEmfValidator PolyPolyline16(
+            Rectangle? bounds = default,
+            int? polyCount = default,
+            params IStateValidator[] stateValidators) => new PolyPolyline16Validator(
+                bounds,
+                polyCount,
+                stateValidators);
+
         /// <param name="text">Optional text to validate.</param>
         /// <param name="bounds">Optional bounds to validate.</param>
         /// <param name="fontFace">Optional font face name to validate.</param>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
@@ -1154,7 +1154,7 @@ namespace System.Windows.Forms
 
             if (color.HasTransparency() || style != ButtonBorderStyle.Solid)
             {
-                // Gdi+ right and bottom DrawRectangle border are 1 greater than Gdi
+                // GDI+ right and bottom DrawRectangle border are 1 greater than GDI
                 bounds = new Rectangle(bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);
 
                 Graphics graphics = context.TryGetGraphics(create: true);
@@ -1164,13 +1164,14 @@ namespace System.Windows.Forms
                     {
                         using var pen = color.GetCachedPenScope();
                         graphics.DrawRectangle(pen, bounds);
-                        return;
                     }
                     else
                     {
                         using var pen = color.CreateStaticPen(BorderStyleToDashStyle(style));
                         graphics.DrawRectangle(pen, bounds);
                     }
+
+                    return;
                 }
             }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlPaintTests.Rendering.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlPaintTests.Rendering.cs
@@ -374,6 +374,5 @@ namespace System.Windows.Forms.Tests
                     State.Pen(16, Color.Pink, penStyle),
                     State.Brush(Color.Pink, Gdi32.BS.SOLID)));
         }
-
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlPaintTests.Rendering.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlPaintTests.Rendering.cs
@@ -1,0 +1,379 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using System.Numerics;
+using System.Windows.Forms.Metafiles;
+using Xunit;
+using static System.Windows.Forms.Metafiles.DataHelpers;
+using static Interop;
+
+namespace System.Windows.Forms.Tests
+{
+    public partial class ControlPaintTests
+    {
+        [WinFormsFact]
+        public void ControlPaint_DrawBorder_Solid_Rendering()
+        {
+            using var emf = new EmfScope();
+            DeviceContextState state = new DeviceContextState(emf);
+
+            using Graphics graphics = Graphics.FromHdc((IntPtr)emf.HDC);
+
+            Rectangle bounds = new Rectangle(10, 10, 10, 10);
+            ControlPaint.DrawBorder(graphics, bounds, Color.Blue, ButtonBorderStyle.Solid);
+
+            emf.Validate(
+                state,
+                Validate.Rectangle(
+                    // We match the legacy GDI+ rendering, where the right and bottom are drawn inside the bounds
+                    new Rectangle(10, 10, 9, 9),
+                    State.Pen(1, Color.Blue, Gdi32.PS.SOLID)));
+        }
+
+        [WinFormsFact]
+        public void ControlPaint_DrawBorder_Inset_Rendering()
+        {
+            using var emf = new EmfScope();
+            DeviceContextState state = new DeviceContextState(emf);
+
+            using Graphics graphics = Graphics.FromHdc((IntPtr)emf.HDC);
+
+            Rectangle bounds = new Rectangle(10, 10, 10, 10);
+            ControlPaint.DrawBorder(graphics, bounds, Color.Gray, ButtonBorderStyle.Inset);
+
+            // For whatever reason GDI+ renders as polylines scaled 16x with a 1/16th world transform applied.
+            // For test readability we'll transform the points from our coordinates to the logical coordinates.
+            Matrix3x2 oneSixteenth = Matrix3x2.CreateScale(0.0625f);
+            Matrix3x2 times16 = Matrix3x2.CreateScale(16.0f);
+
+            // This is the default pen style GDI+ renders polylines with
+            Gdi32.PS penStyle = Gdi32.PS.SOLID | Gdi32.PS.JOIN_ROUND | Gdi32.PS.COSMETIC | Gdi32.PS.ENDCAP_FLAT
+                | Gdi32.PS.JOIN_MITER | Gdi32.PS.GEOMETRIC;
+
+            emf.Validate(
+                state,
+                // Top
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 10, 10, 19, 10),
+                    State.Pen(16, ControlPaint.DarkDark(Color.Gray), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Left
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 10, 10, 10, 19),
+                    State.Pen(16, ControlPaint.DarkDark(Color.Gray), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Bottom
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 10, 19, 19, 19),
+                    State.Pen(16, ControlPaint.LightLight(Color.Gray), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Right
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 19, 10, 19, 19),
+                    State.Pen(16, ControlPaint.LightLight(Color.Gray), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Top inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 11, 11, 18, 11),
+                    State.Pen(16, ControlPaint.Light(Color.Gray), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Left inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 11, 11, 11, 18),
+                    State.Pen(16, ControlPaint.Light(Color.Gray), penStyle),
+                    State.Transform(oneSixteenth))
+                );
+        }
+
+        [WinFormsFact]
+        public void ControlPaint_DrawBorder_Inset_ControlColor_Rendering()
+        {
+            using var emf = new EmfScope();
+            DeviceContextState state = new DeviceContextState(emf);
+
+            using Graphics graphics = Graphics.FromHdc((IntPtr)emf.HDC);
+
+            Rectangle bounds = new Rectangle(10, 10, 10, 10);
+            ControlPaint.DrawBorder(graphics, bounds, SystemColors.Control, ButtonBorderStyle.Inset);
+
+            // For whatever reason GDI+ renders as polylines scaled 16x with a 1/16th world transform applied.
+            // For test readability we'll transform the points from our coordinates to the logical coordinates.
+            Matrix3x2 oneSixteenth = Matrix3x2.CreateScale(0.0625f);
+            Matrix3x2 times16 = Matrix3x2.CreateScale(16.0f);
+
+            // This is the default pen style GDI+ renders polylines with
+            Gdi32.PS penStyle = Gdi32.PS.SOLID | Gdi32.PS.JOIN_ROUND | Gdi32.PS.COSMETIC | Gdi32.PS.ENDCAP_FLAT
+                | Gdi32.PS.JOIN_MITER | Gdi32.PS.GEOMETRIC;
+
+            emf.Validate(
+                state,
+                // Top
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 10, 10, 19, 10),
+                    State.Pen(16, ControlPaint.DarkDark(SystemColors.Control), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Left
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 10, 10, 10, 19),
+                    State.Pen(16, ControlPaint.DarkDark(SystemColors.Control), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Bottom
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 10, 19, 19, 19),
+                    State.Pen(16, ControlPaint.LightLight(SystemColors.Control), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Right
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 19, 10, 19, 19),
+                    State.Pen(16, ControlPaint.LightLight(SystemColors.Control), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Top inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 11, 11, 18, 11),
+                    State.Pen(16, ControlPaint.Light(SystemColors.Control), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Left inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 11, 11, 11, 18),
+                    State.Pen(16, ControlPaint.Light(SystemColors.Control), penStyle),
+                    State.Transform(oneSixteenth)),
+
+                // The bottom/right insets are only drawn if the original color was SystemColors.Control.
+
+                // Bottom inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 11, 18, 18, 18),
+                    State.Pen(16, SystemColors.ControlLight, penStyle),
+                    State.Transform(oneSixteenth)),
+                // Right inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 18, 11, 18, 18),
+                    State.Pen(16, SystemColors.ControlLight, penStyle),
+                    State.Transform(oneSixteenth))
+                );
+        }
+
+        [WinFormsFact]
+        public void ControlPaint_DrawBorder_OutSet_Rendering()
+        {
+            using var emf = new EmfScope();
+            DeviceContextState state = new DeviceContextState(emf);
+
+            using Graphics graphics = Graphics.FromHdc((IntPtr)emf.HDC);
+
+            Rectangle bounds = new Rectangle(10, 10, 10, 10);
+            ControlPaint.DrawBorder(graphics, bounds, Color.PeachPuff, ButtonBorderStyle.Outset);
+
+            string dump = emf.RecordsToStringWithState(state);
+
+            // For whatever reason GDI+ renders as polylines scaled 16x with a 1/16th world transform applied.
+            // For test readability we'll transform the points from our coordinates to the logical coordinates.
+            Matrix3x2 oneSixteenth = Matrix3x2.CreateScale(0.0625f);
+            Matrix3x2 times16 = Matrix3x2.CreateScale(16.0f);
+
+            // This is the default pen style GDI+ renders polylines with
+            Gdi32.PS penStyle = Gdi32.PS.SOLID | Gdi32.PS.JOIN_ROUND | Gdi32.PS.COSMETIC | Gdi32.PS.ENDCAP_FLAT
+                | Gdi32.PS.JOIN_MITER | Gdi32.PS.GEOMETRIC;
+
+            emf.Validate(
+                state,
+                // Top
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 10, 10, 19, 10),
+                    State.Pen(16, ControlPaint.LightLight(Color.PeachPuff), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Left
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 10, 10, 10, 19),
+                    State.Pen(16, ControlPaint.LightLight(Color.PeachPuff), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Bottom
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 10, 19, 19, 19),
+                    State.Pen(16, ControlPaint.DarkDark(Color.PeachPuff), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Right
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 19, 10, 19, 19),
+                    State.Pen(16, ControlPaint.DarkDark(Color.PeachPuff), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Top inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 11, 11, 18, 11),
+                    State.Pen(16, Color.PeachPuff, penStyle),
+                    State.Transform(oneSixteenth)),
+                // Left inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 11, 11, 11, 18),
+                    State.Pen(16, Color.PeachPuff, penStyle),
+                    State.Transform(oneSixteenth)),
+                // Bottom inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 11, 18, 18, 18),
+                    State.Pen(16, ControlPaint.Dark(Color.PeachPuff), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Right inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 18, 11, 18, 18),
+                    State.Pen(16, ControlPaint.Dark(Color.PeachPuff), penStyle),
+                    State.Transform(oneSixteenth))
+                );
+        }
+
+        [WinFormsFact]
+        public void ControlPaint_DrawBorder_OutSet_ControlColor_Rendering()
+        {
+            using var emf = new EmfScope();
+            DeviceContextState state = new DeviceContextState(emf);
+
+            using Graphics graphics = Graphics.FromHdc((IntPtr)emf.HDC);
+
+            Rectangle bounds = new Rectangle(10, 10, 10, 10);
+            ControlPaint.DrawBorder(graphics, bounds, SystemColors.Control, ButtonBorderStyle.Outset);
+
+            string dump = emf.RecordsToStringWithState(state);
+
+            // For whatever reason GDI+ renders as polylines scaled 16x with a 1/16th world transform applied.
+            // For test readability we'll transform the points from our coordinates to the logical coordinates.
+            Matrix3x2 oneSixteenth = Matrix3x2.CreateScale(0.0625f);
+            Matrix3x2 times16 = Matrix3x2.CreateScale(16.0f);
+
+            // This is the default pen style GDI+ renders polylines with
+            Gdi32.PS penStyle = Gdi32.PS.SOLID | Gdi32.PS.JOIN_ROUND | Gdi32.PS.COSMETIC | Gdi32.PS.ENDCAP_FLAT
+                | Gdi32.PS.JOIN_MITER | Gdi32.PS.GEOMETRIC;
+
+            emf.Validate(
+                state,
+                // Top
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 10, 10, 19, 10),
+                    State.Pen(16, SystemColors.ControlLightLight, penStyle),
+                    State.Transform(oneSixteenth)),
+                // Left
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 10, 10, 10, 19),
+                    State.Pen(16, SystemColors.ControlLightLight, penStyle),
+                    State.Transform(oneSixteenth)),
+                // Bottom
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 10, 19, 19, 19),
+                    State.Pen(16, SystemColors.ControlDarkDark, penStyle),
+                    State.Transform(oneSixteenth)),
+                // Right
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 19, 10, 19, 19),
+                    State.Pen(16, SystemColors.ControlDarkDark, penStyle),
+                    State.Transform(oneSixteenth)),
+                // Top inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 11, 11, 18, 11),
+                    State.Pen(16, SystemColors.Control, penStyle),
+                    State.Transform(oneSixteenth)),
+                // Left inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 11, 11, 11, 18),
+                    State.Pen(16, SystemColors.Control, penStyle),
+                    State.Transform(oneSixteenth)),
+                // Bottom inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 11, 18, 18, 18),
+                    State.Pen(16, SystemColors.ControlDark, penStyle),
+                    State.Transform(oneSixteenth)),
+                // Right inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 18, 11, 18, 18),
+                    State.Pen(16, SystemColors.ControlDark, penStyle),
+                    State.Transform(oneSixteenth))
+                );
+        }
+
+        [WinFormsFact]
+        public void ControlPaint_DrawBorder_Dotted_Rendering()
+        {
+            using var emf = new EmfScope();
+            DeviceContextState state = new DeviceContextState(emf);
+
+            using Graphics graphics = Graphics.FromHdc((IntPtr)emf.HDC);
+
+            Rectangle bounds = new Rectangle(10, 10, 10, 10);
+            ControlPaint.DrawBorder(graphics, bounds, Color.Green, ButtonBorderStyle.Dotted);
+
+            // For whatever reason GDI+ renders as polygons scaled 16x with a 1/16th world transform applied.
+            Matrix3x2 oneSixteenth = Matrix3x2.CreateScale(0.0625f);
+
+            // This is the default pen style GDI+ renders dotted lines with
+            Gdi32.PS penStyle = Gdi32.PS.SOLID | Gdi32.PS.JOIN_ROUND | Gdi32.PS.COSMETIC | Gdi32.PS.ENDCAP_FLAT
+                | Gdi32.PS.JOIN_BEVEL | Gdi32.PS.GEOMETRIC;
+
+            emf.Validate(
+            state,
+                Validate.PolyPolygon16(
+                    new Rectangle(8, 8, 13, 13),
+                    polyCount: 18,
+                    State.Transform(oneSixteenth),
+                    State.Pen(16, Color.Green, penStyle),
+                    State.Brush(Color.Green, Gdi32.BS.SOLID)));
+        }
+
+        [WinFormsFact]
+        public void ControlPaint_DrawBorder_Dashed_Rendering()
+        {
+            using var emf = new EmfScope();
+            DeviceContextState state = new DeviceContextState(emf);
+
+            using Graphics graphics = Graphics.FromHdc((IntPtr)emf.HDC);
+
+            Rectangle bounds = new Rectangle(10, 10, 10, 10);
+            ControlPaint.DrawBorder(graphics, bounds, Color.Pink, ButtonBorderStyle.Dashed);
+
+            // For whatever reason GDI+ renders as polygons scaled 16x with a 1/16th world transform applied.
+            Matrix3x2 oneSixteenth = Matrix3x2.CreateScale(0.0625f);
+
+            // This is the default pen style GDI+ renders dotted lines with
+            Gdi32.PS penStyle = Gdi32.PS.SOLID | Gdi32.PS.JOIN_ROUND | Gdi32.PS.COSMETIC | Gdi32.PS.ENDCAP_FLAT
+                | Gdi32.PS.JOIN_BEVEL | Gdi32.PS.GEOMETRIC;
+
+            emf.Validate(
+            state,
+                Validate.PolyPolygon16(
+                    new Rectangle(8, 8, 13, 13),
+                    polyCount: 9,
+                    State.Transform(oneSixteenth),
+                    State.Pen(16, Color.Pink, penStyle),
+                    State.Brush(Color.Pink, Gdi32.BS.SOLID)));
+        }
+
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlPaintTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlPaintTests.cs
@@ -11,7 +11,7 @@ using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
-    public class ControlPaintTests : IClassFixture<ThreadExceptionFixture>
+    public partial class ControlPaintTests : IClassFixture<ThreadExceptionFixture>
     {
         public static IEnumerable<object[]> ControlCreateHBitmap16Bit_TestData()
         {


### PR DESCRIPTION
Fixes #3944

- Move return statement so it doesn't double draw
- Add regression tests

## Proposed changes

- Move return statement

## Customer Impact

- Dotted/dashed line rendering looks terrible, with no workaround

## Regression? 

- Yes

## Risk

- Very low

## Screenshots

Bad on left, good on right.

![image](https://user-images.githubusercontent.com/8184940/93552521-79281e80-f925-11ea-8d80-dee9e2a72920.png)

## Test methodology <!-- How did you ensure quality? -->

- Add detailed rendering tests
- Manually validate output between 3.1 and 5.0


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3950)