### PR TITLE
Fix ControlPaint.DrawBorder rendering

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
@@ -745,7 +745,8 @@ namespace System.Windows.Forms
                             using var hpen = new Gdi32.CreatePenScope(topColor);
                             for (int i = 0; i < topWidth; i++)
                             {
-                                hdc.DrawLine(hpen, topLineLefts[i], bounds.Y + i, topLineRights[i], bounds.Y + i);
+                                // Need to add one to the destination point for GDI to render the same as GDI+
+                                hdc.DrawLine(hpen, topLineLefts[i], bounds.Y + i, topLineRights[i] + 1, bounds.Y + i);
                             }
                         }
                         else
@@ -778,7 +779,9 @@ namespace System.Windows.Forms
                             using var hpen = new Gdi32.CreatePenScope(topStyle == ButtonBorderStyle.Inset
                                 ? hlsColor.Darker(1.0f - i * inc)
                                 : hlsColor.Lighter(1.0f - i * inc));
-                            hdc.DrawLine(hpen, topLineLefts[i], bounds.Y + i, topLineRights[i], bounds.Y + i);
+
+                            // Need to add one to the destination point for GDI to render the same as GDI+
+                            hdc.DrawLine(hpen, topLineLefts[i], bounds.Y + i, topLineRights[i] + 1, bounds.Y + i);
                         }
                         break;
                     }
@@ -799,7 +802,8 @@ namespace System.Windows.Forms
                             using var hpen = new Gdi32.CreatePenScope(leftColor);
                             for (int i = 0; i < leftWidth; i++)
                             {
-                                hdc.DrawLine(hpen, bounds.X + i, leftLineTops[i], bounds.X + i, leftLineBottoms[i]);
+                                // Need to add one to the destination point for GDI to render the same as GDI+
+                                hdc.DrawLine(hpen, bounds.X + i, leftLineTops[i], bounds.X + i, leftLineBottoms[i] + 1);
                             }
                         }
                         else
@@ -831,7 +835,9 @@ namespace System.Windows.Forms
                             using var hpen = new Gdi32.CreatePenScope(leftStyle == ButtonBorderStyle.Inset
                                 ? hlsColor.Darker(1.0f - i * inc)
                                 : hlsColor.Lighter(1.0f - i * inc));
-                            hdc.DrawLine(hpen, bounds.X + i, leftLineTops[i], bounds.X + i, leftLineBottoms[i]);
+
+                            // Need to add one to the destination point for GDI to render the same as GDI+
+                            hdc.DrawLine(hpen, bounds.X + i, leftLineTops[i], bounds.X + i, leftLineBottoms[i] + 1);
                         }
                         break;
                     }
@@ -852,11 +858,12 @@ namespace System.Windows.Forms
                             using var hpen = new Gdi32.CreatePenScope(bottomColor);
                             for (int i = 0; i < bottomWidth; i++)
                             {
+                                // Need to add one to the destination point for GDI to render the same as GDI+
                                 hdc.DrawLine(
                                     hpen,
                                     bottomLineLefts[i],
                                     bounds.Y + bounds.Height - 1 - i,
-                                    bottomLineRights[i],
+                                    bottomLineRights[i] + 1,
                                     bounds.Y + bounds.Height - 1 - i);
                             }
                         }
@@ -894,11 +901,13 @@ namespace System.Windows.Forms
                             using var hpen = new Gdi32.CreatePenScope(bottomStyle != ButtonBorderStyle.Inset
                                 ? hlsColor.Darker(1.0f - i * inc)
                                 : hlsColor.Lighter(1.0f - i * inc));
+
+                            // Need to add one to the destination point for GDI to render the same as GDI+
                             hdc.DrawLine(
                                 hpen,
                                 bottomLineLefts[i],
                                 bounds.Y + bounds.Height - 1 - i,
-                                bottomLineRights[i],
+                                bottomLineRights[i] + 1,
                                 bounds.Y + bounds.Height - 1 - i);
                         }
                         break;
@@ -920,12 +929,13 @@ namespace System.Windows.Forms
                             using var hpen = new Gdi32.CreatePenScope(rightColor);
                             for (int i = 0; i < rightWidth; i++)
                             {
+                                // Need to add one to the destination point for GDI to render the same as GDI+
                                 hdc.DrawLine(
                                     hpen,
                                     bounds.X + bounds.Width - 1 - i,
                                     rightLineTops[i],
                                     bounds.X + bounds.Width - 1 - i,
-                                    rightLineBottoms[i]);
+                                    rightLineBottoms[i] + 1);
                             }
                         }
                         else
@@ -963,11 +973,12 @@ namespace System.Windows.Forms
                                 ? hlsColor.Darker(1.0f - i * inc)
                                 : hlsColor.Lighter(1.0f - i * inc));
 
+                            // Need to add one to the destination point for GDI to render the same as GDI+
                             hdc.DrawLine(hpen,
                                 bounds.X + bounds.Width - 1 - i,
                                 rightLineTops[i],
                                 bounds.X + bounds.Width - 1 - i,
-                                rightLineBottoms[i]);
+                                rightLineBottoms[i] + 1);
                         }
                         break;
                     }


### PR DESCRIPTION
Fixes #3945

The DrawBorder overload that takes individual side parameters needed to adjust line ends when drawing in GDI.

Manually validated output at different widths and transparencies between 3.1 and 5.0. Will follow up with automated regression tests in a separate PR.

## Proposed changes

- Adjust line ends when drawing with GDI

## Customer Impact

- ControlPaint.DrawBorder leaves a gap in the border- there is no workaround
- Customer controls built on this API render incorrectly

## Regression? 

- Yes

## Risk

- Very low

## Screenshots

Good is on the left, bad on the right. The dotted/dashed are ok as that always draws with GDI+.

![image](https://user-images.githubusercontent.com/8184940/93557172-294e5500-f92f-11ea-9e19-eb8956268504.png)

## Test methodology

- Ran pixel level comparison between 3.1 and 5.0 with all options and with/without transparency

(Automated tests will be in a follup-up PR- these require several hundred lines of code.)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3952)