### PR TITLE
Fix DrawSizeGrip

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
@@ -1931,9 +1931,9 @@ namespace System.Windows.Forms
 
             for (int i = 0; i < size - 4; i += 4)
             {
-                hdc.DrawLine(hpenDark, right - (i + 1) - 2, bottom, right, bottom - (i + 1) - 2);
-                hdc.DrawLine(hpenDark, right - (i + 2) - 2, bottom, right, bottom - (i + 2) - 2);
-                hdc.DrawLine(hpenBright, right - (i + 3) - 2, bottom, right, bottom - (i + 3) - 2);
+                hdc.DrawLine(hpenDark, right - (i + 1) - 2, bottom, right + 1, bottom - (i + 1) - 3);
+                hdc.DrawLine(hpenDark, right - (i + 2) - 2, bottom, right + 1, bottom - (i + 2) - 3);
+                hdc.DrawLine(hpenBright, right - (i + 3) - 2, bottom, right + 1, bottom - (i + 3) - 3);
             }
         }
 


### PR DESCRIPTION
End point needed adjusted for GDI to match GDI+

Fixes #3953

## Proposed changes

- Adjust the end points so the grip draws without a gap

## Customer Impact

- Control.DrawSizeGrip draws with a new gap
- Forms without visual styles enabled draw the size grip with a gap

## Regression? 

- Yes

## Risk

- Very low

## Screenshots

Good is on left, bad is on right: (while the right may look more appealing out of context making it "centered" would require all users to upgrade their code to get their existing behavior)

![image](https://user-images.githubusercontent.com/8184940/93653904-be088f80-f9cf-11ea-8165-845cde68d874.png)

## Test methodology

- Manually verified pixel-by-pixel
