### PR TITLE
Fix ControlPaint regressions

### DIFF
--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EmfRecord.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EmfRecord.cs
@@ -69,14 +69,18 @@ namespace System.Windows.Forms.Metafiles
             => Type == Gdi32.EMR.SETICMMODE ? (EMRENUMRECORD<Gdi32.ICM>*)_lpmr : null;
         public EMRPOLY16* Polygon16Record
             => Type == Gdi32.EMR.POLYGON16 ? (EMRPOLY16*)_lpmr : null;
-        public EMRPOLY16* PolyLine16Record
+        public EMRPOLY16* Polyline16Record
             => Type == Gdi32.EMR.POLYLINE16 ? (EMRPOLY16*)_lpmr : null;
         public EMRPOLY16* PolyBezier16Record
             => Type == Gdi32.EMR.POLYBEZIER16 ? (EMRPOLY16*)_lpmr : null;
-        public EMRPOLY16* PolyLineTo16Record
+        public EMRPOLY16* PolylineTo16Record
             => Type == Gdi32.EMR.POLYLINETO16 ? (EMRPOLY16*)_lpmr : null;
         public EMRPOLY16* PolyBezierTo16Record
             => Type == Gdi32.EMR.POLYBEZIERTO16 ? (EMRPOLY16*)_lpmr : null;
+        public EMRPOLYPOLY16* PolyPolyline16Record
+            => Type == Gdi32.EMR.POLYPOLYLINE16 ? (EMRPOLYPOLY16*)_lpmr : null;
+        public EMRPOLYPOLY16* PolyPolygon16Record
+            => Type == Gdi32.EMR.POLYPOLYGON16 ? (EMRPOLYPOLY16*)_lpmr : null;
         public EMRSETWORLDTRANSFORM* SetWorldTransformRecord
             => Type == Gdi32.EMR.SETWORLDTRANSFORM ? (EMRSETWORLDTRANSFORM*)_lpmr : null;
         public EMRMODIFYWORLDTRANSFORM* ModifyWorldTransformRecord
@@ -131,11 +135,13 @@ namespace System.Windows.Forms.Metafiles
             Gdi32.EMR.DELETEOBJECT => DeleteObjectRecord->ToString(),
             Gdi32.EMR.BITBLT => BitBltRecord->ToString(),
             Gdi32.EMR.SETICMMODE => SetIcmModeRecord->ToString(),
-            Gdi32.EMR.POLYLINE16 => PolyLine16Record->ToString(),
+            Gdi32.EMR.POLYLINE16 => Polyline16Record->ToString(),
             Gdi32.EMR.POLYBEZIER16 => PolyBezier16Record->ToString(),
             Gdi32.EMR.POLYGON16 => Polygon16Record->ToString(),
             Gdi32.EMR.POLYBEZIERTO16 => PolyBezierTo16Record->ToString(),
-            Gdi32.EMR.POLYLINETO16 => PolyLineTo16Record->ToString(),
+            Gdi32.EMR.POLYLINETO16 => PolylineTo16Record->ToString(),
+            Gdi32.EMR.POLYPOLYGON16 => PolyPolygon16Record->ToString(),
+            Gdi32.EMR.POLYPOLYLINE16 => PolyPolyline16Record->ToString(),
             Gdi32.EMR.SETWORLDTRANSFORM => SetWorldTransformRecord->ToString(),
             Gdi32.EMR.MODIFYWORLDTRANSFORM => ModifyWorldTransformRecord->ToString(),
             Gdi32.EMR.SETTEXTCOLOR => SetTextColorRecord->ToString(),
@@ -158,8 +164,10 @@ namespace System.Windows.Forms.Metafiles
 
         public string ToString(DeviceContextState state) => Type switch
         {
-            Gdi32.EMR.POLYLINE16 => PolyLine16Record->ToString(state),
+            Gdi32.EMR.POLYLINE16 => Polyline16Record->ToString(state),
             Gdi32.EMR.POLYGON16 => Polygon16Record->ToString(state),
+            Gdi32.EMR.POLYPOLYGON16 => PolyPolygon16Record->ToString(state),
+            Gdi32.EMR.POLYPOLYLINE16 => PolyPolyline16Record->ToString(state),
             _ => ToString()
         };
     }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EmfScope.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EmfScope.cs
@@ -7,6 +7,7 @@
 using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.InteropServices;
+using System.Text;
 using static Interop;
 
 namespace System.Windows.Forms.Metafiles
@@ -167,29 +168,29 @@ namespace System.Windows.Forms.Metafiles
             }
         }
 
-        public List<string> RecordsToString()
+        public string RecordsToString()
         {
-            var strings = new List<string>();
+            StringBuilder sb = new StringBuilder(1024);
             Enumerate((ref EmfRecord record) =>
             {
-                strings.Add(record.ToString());
+                sb.AppendLine(record.ToString());
                 return true;
             });
 
-            return strings;
+            return sb.ToString();
         }
 
-        public List<string> RecordsToStringWithState(DeviceContextState state)
+        public string RecordsToStringWithState(DeviceContextState state)
         {
-            var strings = new List<string>();
+            StringBuilder sb = new StringBuilder(1024);
             EnumerateWithState((ref EmfRecord record, DeviceContextState state) =>
             {
-                strings.Add(record.ToString(state));
+                sb.AppendLine(record.ToString(state));
                 return true;
             },
             state);
 
-            return strings;
+            return sb.ToString();
         }
 
         private static unsafe BOOL CallBack(

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/PolyPoly16Validator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/PolyPoly16Validator.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Drawing;
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.Metafiles
+{
+    internal abstract class PolyPoly16Validator : StateValidator
+    {
+        private readonly Rectangle? _bounds;
+        private readonly int? _polyCount;
+
+        /// <param name="bounds">Optional bounds to validate.</param>
+        /// <param name="polyCount">Number of expected polys.</param>
+        /// <param name="stateValidators">Optional device context state validation to perform.</param>
+        public PolyPoly16Validator(
+            RECT? bounds,
+            int? polyCount,
+            params IStateValidator[] stateValidators) : base(stateValidators)
+        {
+            // Full point validation still needs implemented
+            _polyCount = polyCount;
+            _bounds = bounds;
+        }
+
+        protected unsafe void Validate(EMRPOLYPOLY16* poly)
+        {
+            if (_bounds.HasValue)
+            {
+                Assert.Equal(_bounds.Value, (Rectangle)poly->rclBounds);
+            }
+
+            if (_polyCount.HasValue)
+            {
+                Assert.Equal(_polyCount.Value, (int)poly->nPolys);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/PolyPolygon16Validator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/PolyPolygon16Validator.cs
@@ -4,34 +4,33 @@
 
 #nullable enable
 
-using System.Drawing;
 using static Interop;
 
 namespace System.Windows.Forms.Metafiles
 {
-    internal class Polyline16Validator : Poly16Validator
+    internal class PolyPolygon16Validator : PolyPoly16Validator
     {
         /// <inheritdoc/>
-        public Polyline16Validator(
+        public PolyPolygon16Validator(
             RECT? bounds,
-            Point[]? points,
+            int? polyCount,
             params IStateValidator[] stateValidators) : base(
                 bounds,
-                points,
+                polyCount,
                 stateValidators)
         {
         }
 
-        public override bool ShouldValidate(Gdi32.EMR recordType) => recordType == Gdi32.EMR.POLYLINE16;
+        public override bool ShouldValidate(Gdi32.EMR recordType) => recordType == Gdi32.EMR.POLYPOLYGON16;
 
         public override unsafe void Validate(ref EmfRecord record, DeviceContextState state, out bool complete)
         {
             base.Validate(ref record, state, out _);
 
-            // We're only checking one Polyline16 record, so this call completes our work.
+            // We're only checking one PolyPolygon16 record, so this call completes our work.
             complete = true;
 
-            Validate(record.Polyline16Record);
+            Validate(record.PolyPolygon16Record);
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/PolyPolyline16Validator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/PolyPolyline16Validator.cs
@@ -4,34 +4,33 @@
 
 #nullable enable
 
-using System.Drawing;
 using static Interop;
 
 namespace System.Windows.Forms.Metafiles
 {
-    internal class Polyline16Validator : Poly16Validator
+    internal class PolyPolyline16Validator : PolyPoly16Validator
     {
         /// <inheritdoc/>
-        public Polyline16Validator(
+        public PolyPolyline16Validator(
             RECT? bounds,
-            Point[]? points,
+            int? polyCount,
             params IStateValidator[] stateValidators) : base(
                 bounds,
-                points,
+                polyCount,
                 stateValidators)
         {
         }
 
-        public override bool ShouldValidate(Gdi32.EMR recordType) => recordType == Gdi32.EMR.POLYLINE16;
+        public override bool ShouldValidate(Gdi32.EMR recordType) => recordType == Gdi32.EMR.POLYPOLYLINE16;
 
         public override unsafe void Validate(ref EmfRecord record, DeviceContextState state, out bool complete)
         {
             base.Validate(ref record, state, out _);
 
-            // We're only checking one Polyline16 record, so this call completes our work.
+            // We're only checking one PolyPolyline16 record, so this call completes our work.
             complete = true;
 
-            Validate(record.Polyline16Record);
+            Validate(record.PolyPolyline16Record);
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/Validate.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/Validate.cs
@@ -33,6 +33,28 @@ namespace System.Windows.Forms.Metafiles
                 points,
                 stateValidators);
 
+        /// <param name="bounds">Optional bounds to validate.</param>
+        /// <param name="polyCount">Optional count of polygons to validate.</param>
+        /// <param name="stateValidators">Optional device context state validation to perform.</param>
+        internal static IEmfValidator PolyPolygon16(
+            Rectangle? bounds = default,
+            int? polyCount = default,
+            params IStateValidator[] stateValidators) => new PolyPolygon16Validator(
+                bounds,
+                polyCount,
+                stateValidators);
+
+        /// <param name="bounds">Optional bounds to validate.</param>
+        /// <param name="polyCount">Optional count of polygons to validate.</param>
+        /// <param name="stateValidators">Optional device context state validation to perform.</param>
+        internal static IEmfValidator PolyPolyline16(
+            Rectangle? bounds = default,
+            int? polyCount = default,
+            params IStateValidator[] stateValidators) => new PolyPolyline16Validator(
+                bounds,
+                polyCount,
+                stateValidators);
+
         /// <param name="text">Optional text to validate.</param>
         /// <param name="bounds">Optional bounds to validate.</param>
         /// <param name="fontFace">Optional font face name to validate.</param>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
@@ -745,7 +745,8 @@ namespace System.Windows.Forms
                             using var hpen = new Gdi32.CreatePenScope(topColor);
                             for (int i = 0; i < topWidth; i++)
                             {
-                                hdc.DrawLine(hpen, topLineLefts[i], bounds.Y + i, topLineRights[i], bounds.Y + i);
+                                // Need to add one to the destination point for GDI to render the same as GDI+
+                                hdc.DrawLine(hpen, topLineLefts[i], bounds.Y + i, topLineRights[i] + 1, bounds.Y + i);
                             }
                         }
                         else
@@ -778,7 +779,9 @@ namespace System.Windows.Forms
                             using var hpen = new Gdi32.CreatePenScope(topStyle == ButtonBorderStyle.Inset
                                 ? hlsColor.Darker(1.0f - i * inc)
                                 : hlsColor.Lighter(1.0f - i * inc));
-                            hdc.DrawLine(hpen, topLineLefts[i], bounds.Y + i, topLineRights[i], bounds.Y + i);
+
+                            // Need to add one to the destination point for GDI to render the same as GDI+
+                            hdc.DrawLine(hpen, topLineLefts[i], bounds.Y + i, topLineRights[i] + 1, bounds.Y + i);
                         }
                         break;
                     }
@@ -799,7 +802,8 @@ namespace System.Windows.Forms
                             using var hpen = new Gdi32.CreatePenScope(leftColor);
                             for (int i = 0; i < leftWidth; i++)
                             {
-                                hdc.DrawLine(hpen, bounds.X + i, leftLineTops[i], bounds.X + i, leftLineBottoms[i]);
+                                // Need to add one to the destination point for GDI to render the same as GDI+
+                                hdc.DrawLine(hpen, bounds.X + i, leftLineTops[i], bounds.X + i, leftLineBottoms[i] + 1);
                             }
                         }
                         else
@@ -831,7 +835,9 @@ namespace System.Windows.Forms
                             using var hpen = new Gdi32.CreatePenScope(leftStyle == ButtonBorderStyle.Inset
                                 ? hlsColor.Darker(1.0f - i * inc)
                                 : hlsColor.Lighter(1.0f - i * inc));
-                            hdc.DrawLine(hpen, bounds.X + i, leftLineTops[i], bounds.X + i, leftLineBottoms[i]);
+
+                            // Need to add one to the destination point for GDI to render the same as GDI+
+                            hdc.DrawLine(hpen, bounds.X + i, leftLineTops[i], bounds.X + i, leftLineBottoms[i] + 1);
                         }
                         break;
                     }
@@ -852,11 +858,12 @@ namespace System.Windows.Forms
                             using var hpen = new Gdi32.CreatePenScope(bottomColor);
                             for (int i = 0; i < bottomWidth; i++)
                             {
+                                // Need to add one to the destination point for GDI to render the same as GDI+
                                 hdc.DrawLine(
                                     hpen,
                                     bottomLineLefts[i],
                                     bounds.Y + bounds.Height - 1 - i,
-                                    bottomLineRights[i],
+                                    bottomLineRights[i] + 1,
                                     bounds.Y + bounds.Height - 1 - i);
                             }
                         }
@@ -894,11 +901,13 @@ namespace System.Windows.Forms
                             using var hpen = new Gdi32.CreatePenScope(bottomStyle != ButtonBorderStyle.Inset
                                 ? hlsColor.Darker(1.0f - i * inc)
                                 : hlsColor.Lighter(1.0f - i * inc));
+
+                            // Need to add one to the destination point for GDI to render the same as GDI+
                             hdc.DrawLine(
                                 hpen,
                                 bottomLineLefts[i],
                                 bounds.Y + bounds.Height - 1 - i,
-                                bottomLineRights[i],
+                                bottomLineRights[i] + 1,
                                 bounds.Y + bounds.Height - 1 - i);
                         }
                         break;
@@ -920,12 +929,13 @@ namespace System.Windows.Forms
                             using var hpen = new Gdi32.CreatePenScope(rightColor);
                             for (int i = 0; i < rightWidth; i++)
                             {
+                                // Need to add one to the destination point for GDI to render the same as GDI+
                                 hdc.DrawLine(
                                     hpen,
                                     bounds.X + bounds.Width - 1 - i,
                                     rightLineTops[i],
                                     bounds.X + bounds.Width - 1 - i,
-                                    rightLineBottoms[i]);
+                                    rightLineBottoms[i] + 1);
                             }
                         }
                         else
@@ -963,11 +973,12 @@ namespace System.Windows.Forms
                                 ? hlsColor.Darker(1.0f - i * inc)
                                 : hlsColor.Lighter(1.0f - i * inc));
 
+                            // Need to add one to the destination point for GDI to render the same as GDI+
                             hdc.DrawLine(hpen,
                                 bounds.X + bounds.Width - 1 - i,
                                 rightLineTops[i],
                                 bounds.X + bounds.Width - 1 - i,
-                                rightLineBottoms[i]);
+                                rightLineBottoms[i] + 1);
                         }
                         break;
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
@@ -1943,9 +1943,9 @@ namespace System.Windows.Forms
 
             for (int i = 0; i < size - 4; i += 4)
             {
-                hdc.DrawLine(hpenDark, right - (i + 1) - 2, bottom, right, bottom - (i + 1) - 2);
-                hdc.DrawLine(hpenDark, right - (i + 2) - 2, bottom, right, bottom - (i + 2) - 2);
-                hdc.DrawLine(hpenBright, right - (i + 3) - 2, bottom, right, bottom - (i + 3) - 2);
+                hdc.DrawLine(hpenDark, right - (i + 1) - 2, bottom, right + 1, bottom - (i + 1) - 3);
+                hdc.DrawLine(hpenDark, right - (i + 2) - 2, bottom, right + 1, bottom - (i + 2) - 3);
+                hdc.DrawLine(hpenBright, right - (i + 3) - 2, bottom, right + 1, bottom - (i + 3) - 3);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
@@ -1154,7 +1154,7 @@ namespace System.Windows.Forms
 
             if (color.HasTransparency() || style != ButtonBorderStyle.Solid)
             {
-                // Gdi+ right and bottom DrawRectangle border are 1 greater than Gdi
+                // GDI+ right and bottom DrawRectangle border are 1 greater than GDI
                 bounds = new Rectangle(bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);
 
                 Graphics graphics = context.TryGetGraphics(create: true);
@@ -1164,13 +1164,14 @@ namespace System.Windows.Forms
                     {
                         using var pen = color.GetCachedPenScope();
                         graphics.DrawRectangle(pen, bounds);
-                        return;
                     }
                     else
                     {
                         using var pen = color.CreateStaticPen(BorderStyleToDashStyle(style));
                         graphics.DrawRectangle(pen, bounds);
                     }
+
+                    return;
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownButtons.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownButtons.cs
@@ -329,19 +329,11 @@ namespace System.Windows.Forms
 
                     Rectangle clientRect = ClientRectangle;
                     Point pt1 = new Point(clientRect.Left, clientRect.Bottom - 1);
-                    Point pt2 = new Point(clientRect.Right - 1, clientRect.Bottom - 1);
+                    Point pt2 = new Point(clientRect.Right, clientRect.Bottom - 1);
 
-                    if (!color.HasTransparency())
-                    {
-                        using var hdc = new DeviceContextHdcScope(e);
-                        using var hpen = new Gdi32.CreatePenScope(color);
-                        hdc.DrawLine(hpen, pt1, pt2);
-                    }
-                    else
-                    {
-                        using var pen = color.GetCachedPenScope();
-                        e.Graphics.DrawLine(pen, pt1, pt2);
-                    }
+                    using var hdc = new DeviceContextHdcScope(e);
+                    using var hpen = new Gdi32.CreatePenScope(color);
+                    hdc.DrawLine(hpen, pt1, pt2);
                 }
 
                 // Raise the paint event, just in case this inner class goes public some day

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
@@ -531,40 +531,25 @@ namespace System.Windows.Forms
                     clipRight.Intersect(clipBounds);
                     clipBottom.Intersect(clipBounds);
 
+                    using var hdc = new DeviceContextHdcScope(e);
+                    vsr.DrawBackground(hdc, bounds, clipLeft, HandleInternal);
+                    vsr.DrawBackground(hdc, bounds, clipTop, HandleInternal);
+                    vsr.DrawBackground(hdc, bounds, clipRight, HandleInternal);
+                    vsr.DrawBackground(hdc, bounds, clipBottom, HandleInternal);
+
+                    // Draw a rectangle around edit control with the background color.
                     Rectangle backRect = editBounds;
                     backRect.X--;
                     backRect.Y--;
-                    backRect.Width++;
-                    backRect.Height++;
-
-                    bool transparent = backColor.HasTransparency();
-
-                    using (var hdc = new DeviceContextHdcScope(e))
-                    {
-                        vsr.DrawBackground(hdc, bounds, clipLeft, HandleInternal);
-                        vsr.DrawBackground(hdc, bounds, clipTop, HandleInternal);
-                        vsr.DrawBackground(hdc, bounds, clipRight, HandleInternal);
-                        vsr.DrawBackground(hdc, bounds, clipBottom, HandleInternal);
-
-                        if (!transparent)
-                        {
-                            // Draw rectangle around edit control with background color
-                            using var hpen = new Gdi32.CreatePenScope(backColor);
-                            hdc.DrawRectangle(backRect, hpen);
-                        }
-                    }
-
-                    if (transparent)
-                    {
-                        // Need to use GDI+
-                        using var pen = backColor.GetCachedPenScope();
-                        e.GraphicsInternal.DrawRectangle(pen, backRect);
-                    }
+                    backRect.Width += 2;
+                    backRect.Height += 2;
+                    using var hpen = new Gdi32.CreatePenScope(backColor);
+                    hdc.DrawRectangle(backRect, hpen);
                 }
             }
             else
             {
-                // Draw rectangle around edit control with background color
+                // Draw a rectangle around edit control with the background color.
                 Rectangle backRect = editBounds;
                 backRect.Inflate(1, 1);
                 if (!Enabled)
@@ -577,17 +562,11 @@ namespace System.Windows.Forms
 
                 int width = Enabled ? 2 : 1;
 
-                if (!backColor.HasTransparency())
-                {
-                    using var hdc = new DeviceContextHdcScope(e);
-                    using var hpen = new Gdi32.CreatePenScope(backColor, width);
-                    hdc.DrawRectangle(backRect, hpen);
-                }
-                else
-                {
-                    using var pen = backColor.GetCachedPenScope(width);
-                    e.GraphicsInternal.DrawRectangle(pen, backRect);
-                }
+                backRect.Width++;
+                backRect.Height++;
+                using var hdc = new DeviceContextHdcScope(e);
+                using var hpen = new Gdi32.CreatePenScope(backColor, width);
+                hdc.DrawRectangle(backRect, hpen);
             }
 
             if (!Enabled && BorderStyle != BorderStyle.None && !_upDownEdit.ShouldSerializeBackColor())

--- a/src/System.Windows.Forms/tests/UnitTests/NumericUpDownTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/NumericUpDownTests.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
+using System.Windows.Forms.Metafiles;
 using Xunit;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -15,6 +18,67 @@ namespace System.Windows.Forms.Tests
 
             Assert.NotNull(nud);
             Assert.Equal("0", nud.Text);
+        }
+
+        [WinFormsFact]
+        public void NumericUpDown_BasicRendering()
+        {
+            using var form = new Form();
+            using var upDown = new NumericUpDown();
+
+            form.Controls.Add(upDown);
+
+            using var emf = new EmfScope();
+            DeviceContextState state = new DeviceContextState(emf);
+
+            Assert.Equal(new Rectangle(0, 0, 120, 23), upDown.Bounds);
+
+            // The rendering here is the "fill" for the background around the child edit control, which
+            // doesn't match up to the main control's bounds.
+            upDown.PrintToMetafile(emf);
+            emf.Validate(
+                state,
+                Validate.Rectangle(
+                    new Rectangle(1, 1, 98, 17),
+                    State.Pen(2, upDown.BackColor, Gdi32.PS.SOLID)));
+
+            // Printing the main control doesn't get the redraw for the child controls on the first render,
+            // directly hitting the up/down button subcontrol.
+
+            using var emfButtons = new EmfScope();
+            state = new DeviceContextState(emfButtons);
+            upDown.Controls[0].PrintToMetafile(emfButtons);
+
+            // This is the "fill" line under the up/down arrows
+            emfButtons.Validate(
+                state,
+                Validate.SkipType(Gdi32.EMR.STRETCHDIBITS),
+                Validate.SkipType(Gdi32.EMR.STRETCHDIBITS),
+                Validate.LineTo(
+                    (0, 18), (16, 18),
+                    State.Pen(1, upDown.BackColor, Gdi32.PS.SOLID)));
+
+            // Now check the disabled state
+
+            upDown.Enabled = false;
+
+            using var emfDisabled = new EmfScope();
+            state = new DeviceContextState(emfDisabled);
+            upDown.PrintToMetafile(emfDisabled);
+
+            emfDisabled.Validate(
+                state,
+                Validate.Rectangle(
+                    new Rectangle(0, 0, 99, 18),
+                    State.Pen(1, upDown.BackColor, Gdi32.PS.SOLID)),
+                Validate.Rectangle(
+                    new Rectangle(1, 1, 97, 16),
+                    State.Pen(1, SystemColors.Control, Gdi32.PS.SOLID)),
+                Validate.SkipType(Gdi32.EMR.STRETCHDIBITS),
+                Validate.SkipType(Gdi32.EMR.STRETCHDIBITS),
+                Validate.LineTo(
+                    (0, 18), (16, 18),
+                    State.Pen(1, upDown.BackColor, Gdi32.PS.SOLID)));
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlPaintTests.Rendering.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlPaintTests.Rendering.cs
@@ -1,0 +1,378 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using System.Numerics;
+using System.Windows.Forms.Metafiles;
+using Xunit;
+using static System.Windows.Forms.Metafiles.DataHelpers;
+using static Interop;
+
+namespace System.Windows.Forms.Tests
+{
+    public partial class ControlPaintTests
+    {
+        [WinFormsFact]
+        public void ControlPaint_DrawBorder_Solid_Rendering()
+        {
+            using var emf = new EmfScope();
+            DeviceContextState state = new DeviceContextState(emf);
+
+            using Graphics graphics = Graphics.FromHdc((IntPtr)emf.HDC);
+
+            Rectangle bounds = new Rectangle(10, 10, 10, 10);
+            ControlPaint.DrawBorder(graphics, bounds, Color.Blue, ButtonBorderStyle.Solid);
+
+            emf.Validate(
+                state,
+                Validate.Rectangle(
+                    // We match the legacy GDI+ rendering, where the right and bottom are drawn inside the bounds
+                    new Rectangle(10, 10, 9, 9),
+                    State.Pen(1, Color.Blue, Gdi32.PS.SOLID)));
+        }
+
+        [WinFormsFact]
+        public void ControlPaint_DrawBorder_Inset_Rendering()
+        {
+            using var emf = new EmfScope();
+            DeviceContextState state = new DeviceContextState(emf);
+
+            using Graphics graphics = Graphics.FromHdc((IntPtr)emf.HDC);
+
+            Rectangle bounds = new Rectangle(10, 10, 10, 10);
+            ControlPaint.DrawBorder(graphics, bounds, Color.Gray, ButtonBorderStyle.Inset);
+
+            // For whatever reason GDI+ renders as polylines scaled 16x with a 1/16th world transform applied.
+            // For test readability we'll transform the points from our coordinates to the logical coordinates.
+            Matrix3x2 oneSixteenth = Matrix3x2.CreateScale(0.0625f);
+            Matrix3x2 times16 = Matrix3x2.CreateScale(16.0f);
+
+            // This is the default pen style GDI+ renders polylines with
+            Gdi32.PS penStyle = Gdi32.PS.SOLID | Gdi32.PS.JOIN_ROUND | Gdi32.PS.COSMETIC | Gdi32.PS.ENDCAP_FLAT
+                | Gdi32.PS.JOIN_MITER | Gdi32.PS.GEOMETRIC;
+
+            emf.Validate(
+                state,
+                // Top
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 10, 10, 19, 10),
+                    State.Pen(16, ControlPaint.DarkDark(Color.Gray), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Left
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 10, 10, 10, 19),
+                    State.Pen(16, ControlPaint.DarkDark(Color.Gray), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Bottom
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 10, 19, 19, 19),
+                    State.Pen(16, ControlPaint.LightLight(Color.Gray), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Right
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 19, 10, 19, 19),
+                    State.Pen(16, ControlPaint.LightLight(Color.Gray), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Top inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 11, 11, 18, 11),
+                    State.Pen(16, ControlPaint.Light(Color.Gray), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Left inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 11, 11, 11, 18),
+                    State.Pen(16, ControlPaint.Light(Color.Gray), penStyle),
+                    State.Transform(oneSixteenth))
+                );
+        }
+
+        [WinFormsFact]
+        public void ControlPaint_DrawBorder_Inset_ControlColor_Rendering()
+        {
+            using var emf = new EmfScope();
+            DeviceContextState state = new DeviceContextState(emf);
+
+            using Graphics graphics = Graphics.FromHdc((IntPtr)emf.HDC);
+
+            Rectangle bounds = new Rectangle(10, 10, 10, 10);
+            ControlPaint.DrawBorder(graphics, bounds, SystemColors.Control, ButtonBorderStyle.Inset);
+
+            // For whatever reason GDI+ renders as polylines scaled 16x with a 1/16th world transform applied.
+            // For test readability we'll transform the points from our coordinates to the logical coordinates.
+            Matrix3x2 oneSixteenth = Matrix3x2.CreateScale(0.0625f);
+            Matrix3x2 times16 = Matrix3x2.CreateScale(16.0f);
+
+            // This is the default pen style GDI+ renders polylines with
+            Gdi32.PS penStyle = Gdi32.PS.SOLID | Gdi32.PS.JOIN_ROUND | Gdi32.PS.COSMETIC | Gdi32.PS.ENDCAP_FLAT
+                | Gdi32.PS.JOIN_MITER | Gdi32.PS.GEOMETRIC;
+
+            emf.Validate(
+                state,
+                // Top
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 10, 10, 19, 10),
+                    State.Pen(16, ControlPaint.DarkDark(SystemColors.Control), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Left
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 10, 10, 10, 19),
+                    State.Pen(16, ControlPaint.DarkDark(SystemColors.Control), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Bottom
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 10, 19, 19, 19),
+                    State.Pen(16, ControlPaint.LightLight(SystemColors.Control), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Right
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 19, 10, 19, 19),
+                    State.Pen(16, ControlPaint.LightLight(SystemColors.Control), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Top inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 11, 11, 18, 11),
+                    State.Pen(16, ControlPaint.Light(SystemColors.Control), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Left inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 11, 11, 11, 18),
+                    State.Pen(16, ControlPaint.Light(SystemColors.Control), penStyle),
+                    State.Transform(oneSixteenth)),
+
+                // The bottom/right insets are only drawn if the original color was SystemColors.Control.
+
+                // Bottom inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 11, 18, 18, 18),
+                    State.Pen(16, SystemColors.ControlLight, penStyle),
+                    State.Transform(oneSixteenth)),
+                // Right inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 18, 11, 18, 18),
+                    State.Pen(16, SystemColors.ControlLight, penStyle),
+                    State.Transform(oneSixteenth))
+                );
+        }
+
+        [WinFormsFact]
+        public void ControlPaint_DrawBorder_OutSet_Rendering()
+        {
+            using var emf = new EmfScope();
+            DeviceContextState state = new DeviceContextState(emf);
+
+            using Graphics graphics = Graphics.FromHdc((IntPtr)emf.HDC);
+
+            Rectangle bounds = new Rectangle(10, 10, 10, 10);
+            ControlPaint.DrawBorder(graphics, bounds, Color.PeachPuff, ButtonBorderStyle.Outset);
+
+            string dump = emf.RecordsToStringWithState(state);
+
+            // For whatever reason GDI+ renders as polylines scaled 16x with a 1/16th world transform applied.
+            // For test readability we'll transform the points from our coordinates to the logical coordinates.
+            Matrix3x2 oneSixteenth = Matrix3x2.CreateScale(0.0625f);
+            Matrix3x2 times16 = Matrix3x2.CreateScale(16.0f);
+
+            // This is the default pen style GDI+ renders polylines with
+            Gdi32.PS penStyle = Gdi32.PS.SOLID | Gdi32.PS.JOIN_ROUND | Gdi32.PS.COSMETIC | Gdi32.PS.ENDCAP_FLAT
+                | Gdi32.PS.JOIN_MITER | Gdi32.PS.GEOMETRIC;
+
+            emf.Validate(
+                state,
+                // Top
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 10, 10, 19, 10),
+                    State.Pen(16, ControlPaint.LightLight(Color.PeachPuff), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Left
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 10, 10, 10, 19),
+                    State.Pen(16, ControlPaint.LightLight(Color.PeachPuff), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Bottom
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 10, 19, 19, 19),
+                    State.Pen(16, ControlPaint.DarkDark(Color.PeachPuff), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Right
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 19, 10, 19, 19),
+                    State.Pen(16, ControlPaint.DarkDark(Color.PeachPuff), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Top inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 11, 11, 18, 11),
+                    State.Pen(16, Color.PeachPuff, penStyle),
+                    State.Transform(oneSixteenth)),
+                // Left inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 11, 11, 11, 18),
+                    State.Pen(16, Color.PeachPuff, penStyle),
+                    State.Transform(oneSixteenth)),
+                // Bottom inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 11, 18, 18, 18),
+                    State.Pen(16, ControlPaint.Dark(Color.PeachPuff), penStyle),
+                    State.Transform(oneSixteenth)),
+                // Right inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 18, 11, 18, 18),
+                    State.Pen(16, ControlPaint.Dark(Color.PeachPuff), penStyle),
+                    State.Transform(oneSixteenth))
+                );
+        }
+
+        [WinFormsFact]
+        public void ControlPaint_DrawBorder_OutSet_ControlColor_Rendering()
+        {
+            using var emf = new EmfScope();
+            DeviceContextState state = new DeviceContextState(emf);
+
+            using Graphics graphics = Graphics.FromHdc((IntPtr)emf.HDC);
+
+            Rectangle bounds = new Rectangle(10, 10, 10, 10);
+            ControlPaint.DrawBorder(graphics, bounds, SystemColors.Control, ButtonBorderStyle.Outset);
+
+            string dump = emf.RecordsToStringWithState(state);
+
+            // For whatever reason GDI+ renders as polylines scaled 16x with a 1/16th world transform applied.
+            // For test readability we'll transform the points from our coordinates to the logical coordinates.
+            Matrix3x2 oneSixteenth = Matrix3x2.CreateScale(0.0625f);
+            Matrix3x2 times16 = Matrix3x2.CreateScale(16.0f);
+
+            // This is the default pen style GDI+ renders polylines with
+            Gdi32.PS penStyle = Gdi32.PS.SOLID | Gdi32.PS.JOIN_ROUND | Gdi32.PS.COSMETIC | Gdi32.PS.ENDCAP_FLAT
+                | Gdi32.PS.JOIN_MITER | Gdi32.PS.GEOMETRIC;
+
+            emf.Validate(
+                state,
+                // Top
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 10, 10, 19, 10),
+                    State.Pen(16, SystemColors.ControlLightLight, penStyle),
+                    State.Transform(oneSixteenth)),
+                // Left
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 10, 10, 10, 19),
+                    State.Pen(16, SystemColors.ControlLightLight, penStyle),
+                    State.Transform(oneSixteenth)),
+                // Bottom
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 10, 19, 19, 19),
+                    State.Pen(16, SystemColors.ControlDarkDark, penStyle),
+                    State.Transform(oneSixteenth)),
+                // Right
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 19, 10, 19, 19),
+                    State.Pen(16, SystemColors.ControlDarkDark, penStyle),
+                    State.Transform(oneSixteenth)),
+                // Top inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 11, 11, 18, 11),
+                    State.Pen(16, SystemColors.Control, penStyle),
+                    State.Transform(oneSixteenth)),
+                // Left inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 11, 11, 11, 18),
+                    State.Pen(16, SystemColors.Control, penStyle),
+                    State.Transform(oneSixteenth)),
+                // Bottom inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 11, 18, 18, 18),
+                    State.Pen(16, SystemColors.ControlDark, penStyle),
+                    State.Transform(oneSixteenth)),
+                // Right inset
+                Validate.Polyline16(
+                    bounds: null,
+                    PointArray(times16, 18, 11, 18, 18),
+                    State.Pen(16, SystemColors.ControlDark, penStyle),
+                    State.Transform(oneSixteenth))
+                );
+        }
+
+        [WinFormsFact]
+        public void ControlPaint_DrawBorder_Dotted_Rendering()
+        {
+            using var emf = new EmfScope();
+            DeviceContextState state = new DeviceContextState(emf);
+
+            using Graphics graphics = Graphics.FromHdc((IntPtr)emf.HDC);
+
+            Rectangle bounds = new Rectangle(10, 10, 10, 10);
+            ControlPaint.DrawBorder(graphics, bounds, Color.Green, ButtonBorderStyle.Dotted);
+
+            // For whatever reason GDI+ renders as polygons scaled 16x with a 1/16th world transform applied.
+            Matrix3x2 oneSixteenth = Matrix3x2.CreateScale(0.0625f);
+
+            // This is the default pen style GDI+ renders dotted lines with
+            Gdi32.PS penStyle = Gdi32.PS.SOLID | Gdi32.PS.JOIN_ROUND | Gdi32.PS.COSMETIC | Gdi32.PS.ENDCAP_FLAT
+                | Gdi32.PS.JOIN_BEVEL | Gdi32.PS.GEOMETRIC;
+
+            emf.Validate(
+            state,
+                Validate.PolyPolygon16(
+                    new Rectangle(8, 8, 13, 13),
+                    polyCount: 18,
+                    State.Transform(oneSixteenth),
+                    State.Pen(16, Color.Green, penStyle),
+                    State.Brush(Color.Green, Gdi32.BS.SOLID)));
+        }
+
+        [WinFormsFact]
+        public void ControlPaint_DrawBorder_Dashed_Rendering()
+        {
+            using var emf = new EmfScope();
+            DeviceContextState state = new DeviceContextState(emf);
+
+            using Graphics graphics = Graphics.FromHdc((IntPtr)emf.HDC);
+
+            Rectangle bounds = new Rectangle(10, 10, 10, 10);
+            ControlPaint.DrawBorder(graphics, bounds, Color.Pink, ButtonBorderStyle.Dashed);
+
+            // For whatever reason GDI+ renders as polygons scaled 16x with a 1/16th world transform applied.
+            Matrix3x2 oneSixteenth = Matrix3x2.CreateScale(0.0625f);
+
+            // This is the default pen style GDI+ renders dotted lines with
+            Gdi32.PS penStyle = Gdi32.PS.SOLID | Gdi32.PS.JOIN_ROUND | Gdi32.PS.COSMETIC | Gdi32.PS.ENDCAP_FLAT
+                | Gdi32.PS.JOIN_BEVEL | Gdi32.PS.GEOMETRIC;
+
+            emf.Validate(
+            state,
+                Validate.PolyPolygon16(
+                    new Rectangle(8, 8, 13, 13),
+                    polyCount: 9,
+                    State.Transform(oneSixteenth),
+                    State.Pen(16, Color.Pink, penStyle),
+                    State.Brush(Color.Pink, Gdi32.BS.SOLID)));
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlPaintTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlPaintTests.cs
@@ -11,7 +11,7 @@ using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
-    public class ControlPaintTests : IClassFixture<ThreadExceptionFixture>
+    public partial class ControlPaintTests : IClassFixture<ThreadExceptionFixture>
     {
         public static IEnumerable<object[]> ControlCreateHBitmap16Bit_TestData()
         {


### PR DESCRIPTION
Proposing porting the changes that fix the class of off by one bugs for the end point of lines that were switched from GDI+ to GDI (for performance and memory usage). Note that the majority of the code in these commits are test code.

Fixes #3953
Fixes #3945 
Fixes #3931
Fixes #3944

## Proposed changes

- Adjust end points one over to render correctly
- Remove unreachable code
- Move misplaced return statement

## Customer Impact

- Control vendors controls render incorrectly as they build on our helper code
- Customer UI has gaps in numerous controls and strange artifacts in the NumericUpDown and DomainUpDown controls.

## Regression? 

- Yes

## Risk

- Very low

## Screenshots

UpDownControl example, before and after:

![image](https://user-images.githubusercontent.com/8184940/93525609-2d588380-f8eb-11ea-9bbd-991c70a5e4d8.png)
![image](https://user-images.githubusercontent.com/8184940/93525658-3d706300-f8eb-11ea-9aff-b2096901ac1b.png)

Good grab handle is on left, bad is on right: (while the right may look more appealing out of context making it "centered" would require all users to upgrade their code to get their existing behavior)

![image](https://user-images.githubusercontent.com/8184940/93653904-be088f80-f9cf-11ea-8165-845cde68d874.png)

Good DrawBorder is on the left, bad on the right. The dotted/dashed are ok as that always draws with GDI+.

![image](https://user-images.githubusercontent.com/8184940/93557172-294e5500-f92f-11ea-9e19-eb8956268504.png)

Bad DrawBorder on left, good on right.

![image](https://user-images.githubusercontent.com/8184940/93552521-79281e80-f925-11ea-8d80-dee9e2a72920.png)

## Test methodology

- Manual pixel validation between 3.1 and 5.0
- Wrote automated rendering regression tests
- Look at internal callers of helper methods to ensure they are using the APIs the way they used to



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3956)