### PR TITLE
Port one-off line drawing fixes to RC2

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
@@ -745,7 +745,8 @@ namespace System.Windows.Forms
                             using var hpen = new Gdi32.CreatePenScope(topColor);
                             for (int i = 0; i < topWidth; i++)
                             {
-                                hdc.DrawLine(hpen, topLineLefts[i], bounds.Y + i, topLineRights[i], bounds.Y + i);
+                                // Need to add one to the destination point for GDI to render the same as GDI+
+                                hdc.DrawLine(hpen, topLineLefts[i], bounds.Y + i, topLineRights[i] + 1, bounds.Y + i);
                             }
                         }
                         else
@@ -778,7 +779,9 @@ namespace System.Windows.Forms
                             using var hpen = new Gdi32.CreatePenScope(topStyle == ButtonBorderStyle.Inset
                                 ? hlsColor.Darker(1.0f - i * inc)
                                 : hlsColor.Lighter(1.0f - i * inc));
-                            hdc.DrawLine(hpen, topLineLefts[i], bounds.Y + i, topLineRights[i], bounds.Y + i);
+
+                            // Need to add one to the destination point for GDI to render the same as GDI+
+                            hdc.DrawLine(hpen, topLineLefts[i], bounds.Y + i, topLineRights[i] + 1, bounds.Y + i);
                         }
                         break;
                     }
@@ -799,7 +802,8 @@ namespace System.Windows.Forms
                             using var hpen = new Gdi32.CreatePenScope(leftColor);
                             for (int i = 0; i < leftWidth; i++)
                             {
-                                hdc.DrawLine(hpen, bounds.X + i, leftLineTops[i], bounds.X + i, leftLineBottoms[i]);
+                                // Need to add one to the destination point for GDI to render the same as GDI+
+                                hdc.DrawLine(hpen, bounds.X + i, leftLineTops[i], bounds.X + i, leftLineBottoms[i] + 1);
                             }
                         }
                         else
@@ -831,7 +835,9 @@ namespace System.Windows.Forms
                             using var hpen = new Gdi32.CreatePenScope(leftStyle == ButtonBorderStyle.Inset
                                 ? hlsColor.Darker(1.0f - i * inc)
                                 : hlsColor.Lighter(1.0f - i * inc));
-                            hdc.DrawLine(hpen, bounds.X + i, leftLineTops[i], bounds.X + i, leftLineBottoms[i]);
+
+                            // Need to add one to the destination point for GDI to render the same as GDI+
+                            hdc.DrawLine(hpen, bounds.X + i, leftLineTops[i], bounds.X + i, leftLineBottoms[i] + 1);
                         }
                         break;
                     }
@@ -852,11 +858,12 @@ namespace System.Windows.Forms
                             using var hpen = new Gdi32.CreatePenScope(bottomColor);
                             for (int i = 0; i < bottomWidth; i++)
                             {
+                                // Need to add one to the destination point for GDI to render the same as GDI+
                                 hdc.DrawLine(
                                     hpen,
                                     bottomLineLefts[i],
                                     bounds.Y + bounds.Height - 1 - i,
-                                    bottomLineRights[i],
+                                    bottomLineRights[i] + 1,
                                     bounds.Y + bounds.Height - 1 - i);
                             }
                         }
@@ -894,11 +901,13 @@ namespace System.Windows.Forms
                             using var hpen = new Gdi32.CreatePenScope(bottomStyle != ButtonBorderStyle.Inset
                                 ? hlsColor.Darker(1.0f - i * inc)
                                 : hlsColor.Lighter(1.0f - i * inc));
+
+                            // Need to add one to the destination point for GDI to render the same as GDI+
                             hdc.DrawLine(
                                 hpen,
                                 bottomLineLefts[i],
                                 bounds.Y + bounds.Height - 1 - i,
-                                bottomLineRights[i],
+                                bottomLineRights[i] + 1,
                                 bounds.Y + bounds.Height - 1 - i);
                         }
                         break;
@@ -920,12 +929,13 @@ namespace System.Windows.Forms
                             using var hpen = new Gdi32.CreatePenScope(rightColor);
                             for (int i = 0; i < rightWidth; i++)
                             {
+                                // Need to add one to the destination point for GDI to render the same as GDI+
                                 hdc.DrawLine(
                                     hpen,
                                     bounds.X + bounds.Width - 1 - i,
                                     rightLineTops[i],
                                     bounds.X + bounds.Width - 1 - i,
-                                    rightLineBottoms[i]);
+                                    rightLineBottoms[i] + 1);
                             }
                         }
                         else
@@ -963,11 +973,12 @@ namespace System.Windows.Forms
                                 ? hlsColor.Darker(1.0f - i * inc)
                                 : hlsColor.Lighter(1.0f - i * inc));
 
+                            // Need to add one to the destination point for GDI to render the same as GDI+
                             hdc.DrawLine(hpen,
                                 bounds.X + bounds.Width - 1 - i,
                                 rightLineTops[i],
                                 bounds.X + bounds.Width - 1 - i,
-                                rightLineBottoms[i]);
+                                rightLineBottoms[i] + 1);
                         }
                         break;
                     }
@@ -1154,7 +1165,7 @@ namespace System.Windows.Forms
 
             if (color.HasTransparency() || style != ButtonBorderStyle.Solid)
             {
-                // Gdi+ right and bottom DrawRectangle border are 1 greater than Gdi
+                // GDI+ right and bottom DrawRectangle border are 1 greater than GDI
                 bounds = new Rectangle(bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);
 
                 Graphics graphics = context.TryGetGraphics(create: true);
@@ -1164,13 +1175,14 @@ namespace System.Windows.Forms
                     {
                         using var pen = color.GetCachedPenScope();
                         graphics.DrawRectangle(pen, bounds);
-                        return;
                     }
                     else
                     {
                         using var pen = color.CreateStaticPen(BorderStyleToDashStyle(style));
                         graphics.DrawRectangle(pen, bounds);
                     }
+
+                    return;
                 }
             }
 
@@ -1931,9 +1943,9 @@ namespace System.Windows.Forms
 
             for (int i = 0; i < size - 4; i += 4)
             {
-                hdc.DrawLine(hpenDark, right - (i + 1) - 2, bottom, right, bottom - (i + 1) - 2);
-                hdc.DrawLine(hpenDark, right - (i + 2) - 2, bottom, right, bottom - (i + 2) - 2);
-                hdc.DrawLine(hpenBright, right - (i + 3) - 2, bottom, right, bottom - (i + 3) - 2);
+                hdc.DrawLine(hpenDark, right - (i + 1) - 2, bottom, right + 1, bottom - (i + 1) - 3);
+                hdc.DrawLine(hpenDark, right - (i + 2) - 2, bottom, right + 1, bottom - (i + 2) - 3);
+                hdc.DrawLine(hpenBright, right - (i + 3) - 2, bottom, right + 1, bottom - (i + 3) - 3);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownButtons.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownButtons.cs
@@ -329,19 +329,11 @@ namespace System.Windows.Forms
 
                     Rectangle clientRect = ClientRectangle;
                     Point pt1 = new Point(clientRect.Left, clientRect.Bottom - 1);
-                    Point pt2 = new Point(clientRect.Right - 1, clientRect.Bottom - 1);
+                    Point pt2 = new Point(clientRect.Right, clientRect.Bottom - 1);
 
-                    if (!color.HasTransparency())
-                    {
-                        using var hdc = new DeviceContextHdcScope(e);
-                        using var hpen = new Gdi32.CreatePenScope(color);
-                        hdc.DrawLine(hpen, pt1, pt2);
-                    }
-                    else
-                    {
-                        using var pen = color.GetCachedPenScope();
-                        e.Graphics.DrawLine(pen, pt1, pt2);
-                    }
+                    using var hdc = new DeviceContextHdcScope(e);
+                    using var hpen = new Gdi32.CreatePenScope(color);
+                    hdc.DrawLine(hpen, pt1, pt2);
                 }
 
                 // Raise the paint event, just in case this inner class goes public some day

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
@@ -531,40 +531,25 @@ namespace System.Windows.Forms
                     clipRight.Intersect(clipBounds);
                     clipBottom.Intersect(clipBounds);
 
+                    using var hdc = new DeviceContextHdcScope(e);
+                    vsr.DrawBackground(hdc, bounds, clipLeft, HandleInternal);
+                    vsr.DrawBackground(hdc, bounds, clipTop, HandleInternal);
+                    vsr.DrawBackground(hdc, bounds, clipRight, HandleInternal);
+                    vsr.DrawBackground(hdc, bounds, clipBottom, HandleInternal);
+
+                    // Draw a rectangle around edit control with the background color.
                     Rectangle backRect = editBounds;
                     backRect.X--;
                     backRect.Y--;
-                    backRect.Width++;
-                    backRect.Height++;
-
-                    bool transparent = backColor.HasTransparency();
-
-                    using (var hdc = new DeviceContextHdcScope(e))
-                    {
-                        vsr.DrawBackground(hdc, bounds, clipLeft, HandleInternal);
-                        vsr.DrawBackground(hdc, bounds, clipTop, HandleInternal);
-                        vsr.DrawBackground(hdc, bounds, clipRight, HandleInternal);
-                        vsr.DrawBackground(hdc, bounds, clipBottom, HandleInternal);
-
-                        if (!transparent)
-                        {
-                            // Draw rectangle around edit control with background color
-                            using var hpen = new Gdi32.CreatePenScope(backColor);
-                            hdc.DrawRectangle(backRect, hpen);
-                        }
-                    }
-
-                    if (transparent)
-                    {
-                        // Need to use GDI+
-                        using var pen = backColor.GetCachedPenScope();
-                        e.GraphicsInternal.DrawRectangle(pen, backRect);
-                    }
+                    backRect.Width += 2;
+                    backRect.Height += 2;
+                    using var hpen = new Gdi32.CreatePenScope(backColor);
+                    hdc.DrawRectangle(backRect, hpen);
                 }
             }
             else
             {
-                // Draw rectangle around edit control with background color
+                // Draw a rectangle around edit control with the background color.
                 Rectangle backRect = editBounds;
                 backRect.Inflate(1, 1);
                 if (!Enabled)
@@ -577,17 +562,11 @@ namespace System.Windows.Forms
 
                 int width = Enabled ? 2 : 1;
 
-                if (!backColor.HasTransparency())
-                {
-                    using var hdc = new DeviceContextHdcScope(e);
-                    using var hpen = new Gdi32.CreatePenScope(backColor, width);
-                    hdc.DrawRectangle(backRect, hpen);
-                }
-                else
-                {
-                    using var pen = backColor.GetCachedPenScope(width);
-                    e.GraphicsInternal.DrawRectangle(pen, backRect);
-                }
+                backRect.Width++;
+                backRect.Height++;
+                using var hdc = new DeviceContextHdcScope(e);
+                using var hpen = new Gdi32.CreatePenScope(backColor, width);
+                hdc.DrawRectangle(backRect, hpen);
             }
 
             if (!Enabled && BorderStyle != BorderStyle.None && !_upDownEdit.ShouldSerializeBackColor())


### PR DESCRIPTION
Proposing porting the changes that fix the class of off by one bugs for the end point of lines that were switched from GDI+ to GDI (for performance and memory usage). Note that the majority of the code in these commits are test code.

Fixes #3953
Fixes #3945 
Fixes #3931
Fixes #3944

## Proposed changes

- Adjust end points one over to render correctly
- Remove unreachable code
- Move misplaced return statement

## Customer Impact

- Control vendors controls render incorrectly as they build on our helper code
- Customer UI has gaps in numerous controls and strange artifacts in the NumericUpDown and DomainUpDown controls.

## Regression? 

- Yes

## Risk

- Very low

## Screenshots

UpDownControl example, before and after:

![image](https://user-images.githubusercontent.com/8184940/93525609-2d588380-f8eb-11ea-9bbd-991c70a5e4d8.png)
![image](https://user-images.githubusercontent.com/8184940/93525658-3d706300-f8eb-11ea-9aff-b2096901ac1b.png)

Good grab handle is on left, bad is on right: (while the right may look more appealing out of context making it "centered" would require all users to upgrade their code to get their existing behavior)

![image](https://user-images.githubusercontent.com/8184940/93653904-be088f80-f9cf-11ea-8165-845cde68d874.png)

Good DrawBorder is on the left, bad on the right. The dotted/dashed are ok as that always draws with GDI+.

![image](https://user-images.githubusercontent.com/8184940/93557172-294e5500-f92f-11ea-9e19-eb8956268504.png)

Bad DrawBorder on left, good on right.

![image](https://user-images.githubusercontent.com/8184940/93552521-79281e80-f925-11ea-8d80-dee9e2a72920.png)

## Test methodology

- Manual pixel validation between 3.1 and 5.0
- Wrote automated rendering regression tests
- Look at internal callers of helper methods to ensure they are using the APIs the way they used to



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3961)