### PR TITLE
Fix ListView is in virtual mode

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Drawing;
 using static Interop;
 
@@ -30,7 +29,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (!_owningListView.IsHandleCreated || !_owningListView.ShowGroups)
+                    if (!_owningListView.IsHandleCreated || !_owningListView.ShowGroups || _owningListView.VirtualMode)
                     {
                         return false;
                     }
@@ -266,10 +265,10 @@ namespace System.Windows.Forms
                     return Array.Empty<UiaCore.IRawElementProviderSimple>();
                 }
 
-                UiaCore.IRawElementProviderSimple[] selectedItemProviders = new UiaCore.IRawElementProviderSimple[_owningListView.SelectedItems.Count];
+                UiaCore.IRawElementProviderSimple[] selectedItemProviders = new UiaCore.IRawElementProviderSimple[_owningListView.SelectedIndices.Count];
                 for (int i = 0; i < selectedItemProviders.Length; i++)
                 {
-                    selectedItemProviders[i] = _owningListView.SelectedItems[i].AccessibilityObject;
+                    selectedItemProviders[i] = _owningListView.Items[_owningListView.SelectedIndices[i]].AccessibilityObject;
                 }
 
                 return selectedItemProviders;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -7676,6 +7676,11 @@ namespace System.Windows.Forms
 
             public bool Contains(int selectedIndex)
             {
+                if (selectedIndex < 0 || selectedIndex >= owner.Items.Count)
+                {
+                    return false;
+                }
+
                 return owner.Items[selectedIndex].Selected;
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
@@ -19,7 +19,13 @@ namespace System.Windows.Forms
             public ListViewGroupAccessibleObject(ListViewGroup owningGroup, bool owningGroupIsDefault)
             {
                 _owningGroup = owningGroup ?? throw new ArgumentNullException(nameof(owningGroup));
-                _owningListView = owningGroup.ListView ?? throw new InvalidOperationException(nameof(owningGroup.ListView));
+
+                // Using item from group for getting of ListView is a workaround for https://github.com/dotnet/winforms/issues/4019
+                _owningListView = owningGroup.ListView
+                    ?? (owningGroup.Items.Count > 0 && _owningGroup.Items[0].ListView != null
+                        ? _owningGroup.Items[0].ListView
+                        : throw new InvalidOperationException(nameof(owningGroup.ListView)));
+
                 _owningGroupIsDefault = owningGroupIsDefault;
             }
 
@@ -30,7 +36,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (!_owningListView.IsHandleCreated)
+                    if (!_owningListView.IsHandleCreated || _owningListView.VirtualMode)
                     {
                         return Rectangle.Empty;
                     }
@@ -114,7 +120,7 @@ namespace System.Windows.Forms
 
             private bool GetNativeFocus()
             {
-                if (!_owningListView.IsHandleCreated)
+                if (!_owningListView.IsHandleCreated || _owningListView.VirtualMode)
                 {
                     return false;
                 }
@@ -144,6 +150,11 @@ namespace System.Windows.Forms
 
             internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
             {
+                if (!_owningListView.IsHandleCreated || _owningListView.VirtualMode)
+                {
+                    return null;
+                }
+
                 switch (direction)
                 {
                     case UiaCore.NavigateDirection.Parent:
@@ -160,6 +171,7 @@ namespace System.Windows.Forms
                         }
 
                         return null;
+
                     case UiaCore.NavigateDirection.LastChild:
                         childCount = GetChildCount();
                         if (childCount > 0)
@@ -168,6 +180,7 @@ namespace System.Windows.Forms
                         }
 
                         return null;
+
                     default:
                         return null;
                 }
@@ -175,6 +188,11 @@ namespace System.Windows.Forms
 
             public override AccessibleObject? GetChild(int index)
             {
+                if (!_owningListView.IsHandleCreated || _owningListView.VirtualMode)
+                {
+                    return null;
+                }
+
                 if (!_owningGroupIsDefault)
                 {
                     if (index < 0 || index >= _owningGroup.Items.Count)
@@ -198,6 +216,11 @@ namespace System.Windows.Forms
 
             private int GetChildIndex(AccessibleObject child)
             {
+                if (!_owningListView.IsHandleCreated || _owningListView.VirtualMode)
+                {
+                    return -1;
+                }
+
                 int childCount = GetChildCount();
                 for (int i = 0; i < childCount; i++)
                 {
@@ -213,6 +236,11 @@ namespace System.Windows.Forms
 
             internal AccessibleObject? GetNextChild(AccessibleObject currentChild)
             {
+                if (!_owningListView.IsHandleCreated || _owningListView.VirtualMode)
+                {
+                    return null;
+                }
+
                 int currentChildIndex = GetChildIndex(currentChild);
                 if (currentChildIndex == -1)
                 {
@@ -230,6 +258,11 @@ namespace System.Windows.Forms
 
             internal AccessibleObject? GetPreviousChild(AccessibleObject currentChild)
             {
+                if (!_owningListView.IsHandleCreated || _owningListView.VirtualMode)
+                {
+                    return null;
+                }
+
                 int currentChildIndex = GetChildIndex(currentChild);
                 if (currentChildIndex <= 0)
                 {
@@ -241,6 +274,11 @@ namespace System.Windows.Forms
 
             public override int GetChildCount()
             {
+                if (!_owningListView.IsHandleCreated || _owningListView.VirtualMode)
+                {
+                    return -1;
+                }
+
                 if (_owningGroupIsDefault)
                 {
                     int count = 0;
@@ -273,6 +311,11 @@ namespace System.Windows.Forms
 
             internal override unsafe void SetFocus()
             {
+                if (!_owningListView.IsHandleCreated || _owningListView.VirtualMode)
+                {
+                    return;
+                }
+
                 _owningListView.FocusedGroup = _owningGroup;
 
                 RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
@@ -63,9 +63,9 @@ namespace System.Windows.Forms
                 => SR.AccessibleActionDoubleClick;
 
             internal override UiaCore.ExpandCollapseState ExpandCollapseState
-                => _owningGroup.CollapsedState == ListViewGroupCollapsedState.Expanded
-                    ? UiaCore.ExpandCollapseState.Expanded
-                    : UiaCore.ExpandCollapseState.Collapsed;
+                => _owningGroup.CollapsedState == ListViewGroupCollapsedState.Collapsed
+                    ? UiaCore.ExpandCollapseState.Collapsed
+                    : UiaCore.ExpandCollapseState.Expanded;
 
             public override string Name
                 => _owningGroup.Header;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObject.cs
@@ -23,7 +23,7 @@ namespace System.Windows.Forms
             public ListViewItemAccessibleObject(ListViewItem owningItem, ListViewGroup? owningGroup)
             {
                 _owningItem = owningItem ?? throw new ArgumentNullException(nameof(owningItem));
-                _owningListView = owningItem.ListView ?? throw new InvalidOperationException(nameof(owningItem.ListView));
+                _owningListView = owningItem.ListView ?? owningGroup?.ListView ?? throw new InvalidOperationException(nameof(owningItem.ListView));
                 _owningGroup = owningGroup;
                 _systemIAccessible = _owningListView.AccessibilityObject.GetSystemIAccessibleInternal();
             }
@@ -78,7 +78,7 @@ namespace System.Windows.Forms
                 {
                     AccessibleStates state = AccessibleStates.Selectable | AccessibleStates.Focusable | AccessibleStates.MultiSelectable;
 
-                    if (_owningListView.SelectedItems.Contains(_owningItem))
+                    if (_owningListView.SelectedIndices.Contains(_owningItem.Index))
                     {
                         return state |= AccessibleStates.Selected | AccessibleStates.Focused;
                     }
@@ -232,10 +232,7 @@ namespace System.Windows.Forms
             internal override UiaCore.IRawElementProviderSimple ItemSelectionContainer
                 => _owningListView.AccessibilityObject;
 
-            internal override void ScrollIntoView()
-            {
-                _owningItem.EnsureVisible();
-            }
+            internal override void ScrollIntoView() => _owningItem.EnsureVisible();
 
             internal unsafe override void SelectItem()
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObject.cs
@@ -32,7 +32,9 @@ namespace System.Windows.Forms
                 => string.Format("{0}-{1}", typeof(ListViewItem).Name, CurrentIndex);
 
             public override Rectangle Bounds
-                => new Rectangle(
+                => _owningGroup?.CollapsedState == ListViewGroupCollapsedState.Collapsed
+                    ? Rectangle.Empty
+                    : new Rectangle(
                         _owningListView.AccessibilityObject.Bounds.X + _owningItem.Bounds.X,
                         _owningListView.AccessibilityObject.Bounds.Y + _owningItem.Bounds.Y,
                         _owningItem.Bounds.Width,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
@@ -228,7 +228,7 @@ namespace System.Windows.Forms
             Group = group;
         }
 
-        internal AccessibleObject AccessibilityObject
+        internal virtual AccessibleObject AccessibilityObject
         {
             get
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListVIew.ListViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListVIew.ListViewAccessibleObjectTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Reflection;
 using Xunit;
 using static System.Windows.Forms.ListViewGroup;
 using static System.Windows.Forms.ListViewItem;
@@ -9,7 +11,7 @@ using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
-    public class ListView_ListViewAccessibleObjectTests
+    public class ListView_ListViewAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]
         public void ListViewAccessibleObject_Ctor_Default()
@@ -251,6 +253,412 @@ namespace System.Windows.Forms.Tests
 
             Assert.True((bool)listAccessibleObject.GetPropertyValue(UiaCore.UIA.IsMultipleViewPatternAvailablePropertyId));
             Assert.False(list.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> ListViewAccessibleObject_OwnerHasDefaultGroup_TestData()
+        {
+            foreach (View view in Enum.GetValues(typeof(View)))
+            {
+                foreach (bool virtualMode in new[] { true, false })
+                {
+                    foreach (bool showGroups in new[] { true, false })
+                    {
+                        foreach (bool createHandle in new[] { true, false })
+                        {
+                            yield return new object[] { virtualMode, showGroups, createHandle };
+                        }
+                    }
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewAccessibleObject_OwnerHasDefaultGroup_TestData))]
+        public void ListViewAccessibleObject_OwnerHasDefaultGroup_ReturnsExpected_WithoutItems(bool virtualMode, bool showGroups, bool createHandle)
+        {
+            using ListView listView = new ListView
+            {
+                ShowGroups = showGroups,
+                VirtualMode = virtualMode
+            };
+
+            if (createHandle)
+            {
+                listView.CreateControl();
+            }
+
+            AccessibleObject accessibleObject = listView.AccessibilityObject;
+
+            bool actual = accessibleObject.TestAccessor().Dynamic.OwnerHasDefaultGroup;
+
+            // Since the listview either
+            //  1. isn't materialised, or
+            //  2. is in virtual mode, or
+            //  3. has no items
+            // ...it doesn't have the default group
+            Assert.False(actual);
+
+            Assert.Equal(createHandle, listView.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> ListViewAccessibleObject_OwnerHasDefaultGroup_DefaultMode_WithAllItemsInGroups_TestData()
+        {
+            foreach (View view in Enum.GetValues(typeof(View)))
+            {
+                foreach (bool showGroups in new[] { true, false })
+                {
+                    foreach (bool createHandle in new[] { true, false })
+                    {
+                        yield return new object[] { showGroups, createHandle };
+                    }
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewAccessibleObject_OwnerHasDefaultGroup_DefaultMode_WithAllItemsInGroups_TestData))]
+        public void ListViewAccessibleObject_OwnerHasDefaultGroup_DefaultMode_WithAllItemsInGroups_ReturnsExpected(bool showGroups, bool createHandle)
+        {
+            using ListView listView = new ListView
+            {
+                ShowGroups = showGroups,
+                VirtualMode = false // default mode
+            };
+
+            if (createHandle)
+            {
+                listView.CreateControl();
+            }
+
+            ListViewGroup group1 = new ListViewGroup("First");
+            ListViewItem item1 = new ListViewItem(group1);
+            ListViewGroup group2 = new ListViewGroup("Second");
+            ListViewItem item2 = new ListViewItem(group2);
+            listView.Groups.Add(group1);
+            listView.Groups.Add(group2);
+
+            AccessibleObject accessibleObject = listView.AccessibilityObject;
+            bool actual = accessibleObject.TestAccessor().Dynamic.OwnerHasDefaultGroup;
+
+            Assert.False(actual);
+
+            Assert.Equal(createHandle, listView.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> ListViewAccessibleObject_OwnerHasDefaultGroup_DefaultMode_WithItemsNotInGroup_TestData()
+        {
+            foreach (View view in Enum.GetValues(typeof(View)))
+            {
+                foreach (bool showGroups in new[] { true, false })
+                {
+                    foreach (bool createHandle in new[] { true, false })
+                    {
+                        bool expected = showGroups && createHandle;
+                        yield return new object[] { showGroups, createHandle, expected };
+                    }
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewAccessibleObject_OwnerHasDefaultGroup_DefaultMode_WithItemsNotInGroup_TestData))]
+        public void ListViewAccessibleObject_OwnerHasDefaultGroup_DefaultMode_ReturnsExpected_WithItemsNotInGroup(bool showGroups, bool createHandle, bool expected)
+        {
+            using ListView listView = new ListView
+            {
+                ShowGroups = showGroups,
+                VirtualMode = false // default mode
+            };
+
+            if (createHandle)
+            {
+                listView.CreateControl();
+            }
+
+            ListViewGroup group1 = new ListViewGroup("First");
+            listView.Groups.Add(group1);
+
+            ListViewItem item1 = new ListViewItem(group1);
+            listView.Items.Add(item1);
+            ListViewItem item2 = new ListViewItem();
+            listView.Items.Add(item2);
+
+            AccessibleObject accessibleObject = listView.AccessibilityObject;
+            bool actual = accessibleObject.TestAccessor().Dynamic.OwnerHasDefaultGroup;
+
+            Assert.Equal(expected, actual);
+
+            Assert.Equal(createHandle, listView.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> ListViewAccessibleObject_OwnerHasDefaultGroup_VirtualMode_TestData()
+        {
+            foreach (View view in Enum.GetValues(typeof(View)))
+            {
+                // View.Tile is not supported by ListView in Virtual mode
+                if (view == View.Tile)
+                {
+                    continue;
+                }
+
+                foreach (bool showGroups in new[] { true, false })
+                {
+                    foreach (bool createHandle in new[] { true, false })
+                    {
+                        yield return new object[] { showGroups, createHandle };
+                    }
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewAccessibleObject_OwnerHasDefaultGroup_VirtualMode_TestData))]
+        public void ListViewAccessibleObject_OwnerHasDefaultGroup_VirtualMode_ReturnsExpected_WithItems(bool showGroups, bool createHandle)
+        {
+            using ListView listView = new ListView
+            {
+                ShowGroups = showGroups,
+                VirtualMode = true,
+                VirtualListSize = 2 // we can't add items, just indicate how many we have
+            };
+
+            listView.RetrieveVirtualItem += (s, e) =>
+            {
+                e.Item = e.ItemIndex switch
+                {
+                    0 => new ListViewItem(),
+                    1 => new ListViewItem(),
+                    _ => new ListViewItem(),
+                };
+            };
+
+            if (createHandle)
+            {
+                listView.CreateControl();
+            }
+
+            AccessibleObject accessibleObject = listView.AccessibilityObject;
+
+            // Since the listview is in virtual mode - it doesn't have the default group
+            Assert.False(accessibleObject.TestAccessor().Dynamic.OwnerHasDefaultGroup);
+
+            Assert.Equal(createHandle, listView.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> ListViewAccessibleObject_GetSelectionInvoke_TestData()
+        {
+            foreach (View view in Enum.GetValues(typeof(View)))
+            {
+                foreach (bool showGroups in new[] { true, false })
+                {
+                    yield return new object[] { view, showGroups };
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewAccessibleObject_GetSelectionInvoke_TestData))]
+        public void ListViewAccessibleObject_GetSelectionInvoke_ReturnsExpected(View view, bool showGroups)
+        {
+            using var listView = new ListView
+            {
+                View = view,
+                ShowGroups = showGroups
+            };
+
+            listView.CreateControl();
+
+            ListViewGroup listGroup1 = new ListViewGroup("Group1");
+            ListViewGroup listGroup2 = new ListViewGroup("Group2");
+            ListViewGroup listGroup3 = new ListViewGroup("Group2");
+            ListViewItem listItem1 = new ListViewItem(listGroup1);
+            ListViewItem listItem2 = new ListViewItem();
+            ListViewItem listItem3 = new ListViewItem(listGroup2);
+            ListViewItem listItem4 = new ListViewItem(listGroup2);
+            listView.Groups.Add(listGroup1);
+            listView.Groups.Add(listGroup2);
+            listView.Items.Add(listItem1);
+            listView.Items.Add(listItem2);
+            listView.Items.Add(listItem3);
+            listView.Items.Add(listItem4);
+
+            listView.Items[0].Selected = true;
+            listView.Items[1].Selected = true;
+            listView.Items[3].Selected = true;
+
+            var listSelection = listView.AccessibilityObject.GetSelection();
+            Assert.Equal(listItem1.AccessibilityObject, (ListViewItemAccessibleObject)listSelection[0]);
+            Assert.Equal(listItem2.AccessibilityObject, (ListViewItemAccessibleObject)listSelection[1]);
+            Assert.Equal(listItem4.AccessibilityObject, (ListViewItemAccessibleObject)listSelection[2]);
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewAccessibleObject_GetSelectionInvoke_TestData))]
+        public void ListViewAccessibleObject_GetSelectionInvoke_WithoutSelectedItems_ReturnsExpected(View view, bool showGroups)
+        {
+            using var listView = new ListView
+            {
+                View = view,
+                ShowGroups = showGroups
+            };
+
+            listView.CreateControl();
+            ListViewItem listItem1 = new ListViewItem();
+            listView.Items.Add(listItem1);
+
+            var listSelection = listView.AccessibilityObject.GetSelection();
+            Assert.Equal(0, listSelection.Length);
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewAccessibleObject_GetSelectionInvoke_TestData))]
+        public void ListViewAccessibleObject_GetSelectionInvoke_ReturnsExpected_IfHandleNotCreated(View view, bool showGroups)
+        {
+            using var listView = new ListView
+            {
+                View = view,
+                ShowGroups = showGroups
+            };
+
+            ListViewItem listItem1 = new ListViewItem();
+            listView.Items.Add(listItem1);
+
+            var listSelection = listView.AccessibilityObject.GetSelection();
+            Assert.Equal(0, listSelection.Length);
+
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> ListViewAccessibleObject_GetSelectionInvoke_VirtualMode_TestData()
+        {
+            foreach (View view in Enum.GetValues(typeof(View)))
+            {
+                // View.Tile is not supported by ListView in Virtual mode
+                if (view == View.Tile)
+                {
+                    continue;
+                }
+
+                foreach (bool showGroups in new[] { true, false })
+                {
+                    yield return new object[] { view, showGroups };
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewAccessibleObject_GetSelectionInvoke_VirtualMode_TestData))]
+        public void ListViewAccessibleObject_GetSelectionInvoke_VirtualMode_ReturnsExpected(View view, bool showGroups)
+        {
+            using ListView listView = new ListView
+            {
+                View = view,
+                VirtualMode = true,
+                ShowGroups = showGroups,
+                VirtualListSize = 4
+            };
+
+            ListViewGroup listViewGroup1 = new ListViewGroup("Test1");
+            ListViewGroup listViewGroup2 = new ListViewGroup("Test2");
+            listView.Groups.Add(listViewGroup1);
+            listView.Groups.Add(listViewGroup2);
+
+            ListViewItem listItem1 = new ListViewItem(new string[] { "Item 1", "Item A" }, -1, listViewGroup1);
+            ListViewItem listItem2 = new ListViewItem("Group item 2", listViewGroup1);
+            ListViewItem listItem3 = new ListViewItem("Item 3");
+            ListViewItem listItem4 = new ListViewItem(new string[] { "Item 4", "Item B" }, -1);
+
+            listView.RetrieveVirtualItem += (s, e) =>
+            {
+                e.Item = e.ItemIndex switch
+                {
+                    0 => listItem1,
+                    1 => listItem2,
+                    2 => listItem3,
+                    3 => listItem4,
+                    _ => throw new NotImplementedException()
+                };
+            };
+
+            listView.CreateControl();
+            listItem1.SetItemIndex(listView, 0);
+            listItem2.SetItemIndex(listView, 1);
+            listItem3.SetItemIndex(listView, 2);
+            listItem4.SetItemIndex(listView, 3);
+
+            listView.Items[0].Selected = true;
+            listView.Items[1].Selected = true;
+            listView.Items[3].Selected = true;
+
+            var listSelection = listView.AccessibilityObject.GetSelection();
+            Assert.Equal(listItem1.AccessibilityObject, (ListViewItemAccessibleObject)listSelection[0]);
+            Assert.Equal(listItem2.AccessibilityObject, (ListViewItemAccessibleObject)listSelection[1]);
+            Assert.Equal(listItem4.AccessibilityObject, (ListViewItemAccessibleObject)listSelection[2]);
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewAccessibleObject_GetSelectionInvoke_VirtualMode_TestData))]
+        public void ListViewAccessibleObject_GetSelectionInvoke_WithoutSelectedItems_VirtualModeReturnsExpected(View view, bool showGroups)
+        {
+            using ListView listView = new ListView
+            {
+                View = view,
+                VirtualMode = true,
+                ShowGroups = showGroups,
+                VirtualListSize = 1
+            };
+
+            ListViewItem listItem1 = new ListViewItem();
+
+            listView.RetrieveVirtualItem += (s, e) =>
+            {
+                e.Item = e.ItemIndex switch
+                {
+                    0 => listItem1,
+                    _ => throw new NotImplementedException()
+                };
+            };
+
+            listView.CreateControl();
+            listItem1.SetItemIndex(listView, 0);
+
+            var listSelection = listView.AccessibilityObject.GetSelection();
+            Assert.Equal(0, listSelection.Length);
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewAccessibleObject_GetSelectionInvoke_VirtualMode_TestData))]
+        public void ListViewAccessibleObject_GetSelectionInvoke_VirtualMode_ReturnsExpected_IfHandleNotCreated(View view, bool showGroups)
+        {
+            using ListView listView = new ListView
+            {
+                View = view,
+                VirtualMode = true,
+                ShowGroups = showGroups,
+                VirtualListSize = 1
+            };
+
+            ListViewItem listItem1 = new ListViewItem();
+
+            listView.RetrieveVirtualItem += (s, e) =>
+            {
+                e.Item = e.ItemIndex switch
+                {
+                    0 => listItem1,
+                    _ => throw new NotImplementedException()
+                };
+            };
+
+            listItem1.SetItemIndex(listView, 0);
+
+            var listSelection = listView.AccessibilityObject.GetSelection();
+            Assert.Equal(0, listSelection.Length);
+
+            Assert.False(listView.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
@@ -595,5 +595,44 @@ namespace System.Windows.Forms.Tests
             Assert.NotNull(listViewGroup.AccessibilityObject);
             Assert.Equal(createHandle, listView.IsHandleCreated);
         }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewGroupAccessibleObject_TestData))]
+        public void ListViewGroupAccessibleObject_ExpandCollapseState_ReturnExpected(View view, bool showGroups, bool createHandle)
+        {
+            using ListView listView = new ListView
+            {
+                View = view,
+                ShowGroups = showGroups,
+            };
+
+            var lvgroup1 = new ListViewGroup
+            {
+                Header = "CollapsibleGroup1",
+                CollapsedState = ListViewGroupCollapsedState.Expanded
+            };
+
+            listView.Groups.Add(lvgroup1);
+            listView.Items.Add(new ListViewItem("Item1", lvgroup1));
+
+            var lvgroup2 = new ListViewGroup
+            {
+                Header = "CollapsibleGroup2",
+                CollapsedState = ListViewGroupCollapsedState.Collapsed
+            };
+
+            listView.Groups.Add(lvgroup2);
+            listView.Items.Add(new ListViewItem("Item2", lvgroup2));
+
+            if (createHandle)
+            {
+                Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            }
+
+            Assert.Equal(ExpandCollapseState.Expanded, lvgroup1.AccessibilityObject.ExpandCollapseState);
+            Assert.Equal(ExpandCollapseState.Collapsed, lvgroup2.AccessibilityObject.ExpandCollapseState);
+            Assert.Equal(ExpandCollapseState.Expanded, listView.DefaultGroup.AccessibilityObject.ExpandCollapseState);
+            Assert.Equal(createHandle, listView.IsHandleCreated);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Drawing;
 using System.Reflection;
 using Microsoft.DotNet.RemoteExecutor;
@@ -9,10 +10,11 @@ using Xunit;
 using static System.Windows.Forms.ListViewGroup;
 using static System.Windows.Forms.ListViewItem;
 using static Interop;
+using static Interop.UiaCore;
 
 namespace System.Windows.Forms.Tests
 {
-    public class ListViewGroup_ListViewGroupAccessibleObjectTests
+    public class ListViewGroup_ListViewGroupAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]
         public void ListViewGroupAccessibleObject_Ctor_ThrowsArgumentNullException()
@@ -147,24 +149,15 @@ namespace System.Windows.Forms.Tests
             Assert.Null(group1AccObj.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
 
             // Parent
-            Assert.Equal(defaultGroupAccObj.FragmentNavigate(UiaCore.NavigateDirection.Parent), list.AccessibilityObject);
-            Assert.Equal(group1AccObj.FragmentNavigate(UiaCore.NavigateDirection.Parent), list.AccessibilityObject);
+            Assert.Null(defaultGroupAccObj.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            Assert.Null(group1AccObj.FragmentNavigate(UiaCore.NavigateDirection.Parent));
 
             // Childs
-            AccessibleObject firstChild = group1AccObj.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
-            AccessibleObject lastChild = group1AccObj.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
-            Assert.IsType<ListViewItemAccessibleObject>(firstChild);
-            Assert.IsType<ListViewItemAccessibleObject>(lastChild);
-            Assert.NotEqual(firstChild, lastChild);
-            Assert.Equal(firstChild, listItem1.AccessibilityObject);
-            Assert.Equal(lastChild, listItem2.AccessibilityObject);
+            Assert.Null(group1AccObj.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(group1AccObj.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
 
-            firstChild = defaultGroupAccObj.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
-            lastChild = defaultGroupAccObj.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
-            Assert.IsType<ListViewItemAccessibleObject>(firstChild);
-            Assert.IsType<ListViewItemAccessibleObject>(lastChild);
-            Assert.Equal(firstChild, lastChild);
-            Assert.Equal(firstChild, listItem3.AccessibilityObject);
+            Assert.Null(defaultGroupAccObj.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(defaultGroupAccObj.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
         }
 
         [WinFormsFact]
@@ -208,6 +201,399 @@ namespace System.Windows.Forms.Tests
                 Rectangle expectedBounds = groupRect;
                 Assert.Equal(expectedBounds, actualBounds);
             });
+        }
+        public static IEnumerable<object[]> ListViewGroupAccessibleObject_TestData()
+        {
+            foreach (View view in Enum.GetValues(typeof(View)))
+            {
+                foreach (bool showGroups in new[] { true, false })
+                {
+                    foreach (bool createHandle in new[] { true, false })
+                    {
+                        yield return new object[] { view, showGroups, createHandle };
+                    }
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewGroupAccessibleObject_GetChild_Invoke_TestData))]
+        public void ListViewGroupAccessibleObject_GetChildCount_Invoke_ReturnExpected_IfHandleCreated(View view, bool showGroups)
+        {
+            using ListView listView = new ListView
+            {
+                View = view,
+                ShowGroups = showGroups
+            };
+
+            Assert.NotEqual(IntPtr.Zero, listView.Handle);
+
+            ListViewGroup listGroup1 = new ListViewGroup("Group1");
+            ListViewGroup listGroup2 = new ListViewGroup("Group2");
+            ListViewItem listItem1 = new ListViewItem(listGroup1);
+            ListViewItem listItem2 = new ListViewItem(listGroup1);
+            ListViewItem listItem3 = new ListViewItem();
+            ListViewItem listItem4 = new ListViewItem(listGroup2);
+            ListViewItem listItem5 = new ListViewItem(listGroup2);
+            ListViewItem listItem6 = new ListViewItem(listGroup2);
+            listView.Groups.Add(listGroup1);
+            listView.Groups.Add(listGroup2);
+            listView.Items.Add(listItem1);
+            listView.Items.Add(listItem2);
+            listView.Items.Add(listItem3);
+            listView.Items.Add(listItem4);
+            listView.Items.Add(listItem5);
+            listView.Items.Add(listItem6);
+            ListViewGroupAccessibleObject group1AccObj = (ListViewGroupAccessibleObject)listGroup1.AccessibilityObject;
+            ListViewGroupAccessibleObject group2AccObj = (ListViewGroupAccessibleObject)listGroup2.AccessibilityObject;
+            ListViewGroupAccessibleObject defaultGroupAccObj = (ListViewGroupAccessibleObject)listView.DefaultGroup.AccessibilityObject;
+            Assert.Equal(2, group1AccObj.GetChildCount());
+            Assert.Equal(3, group2AccObj.GetChildCount());
+            Assert.Equal(1, defaultGroupAccObj.GetChildCount());
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewGroupAccessibleObject_GetChild_Invoke_TestData))]
+        public void ListViewGroupAccessibleObject_GetChildCount_Invoke_ReturnExpected_IfHandleNotCreated(View view, bool showGroups)
+        {
+            using ListView listView = new ListView
+            {
+                View = view,
+                ShowGroups = showGroups
+            };
+
+            ListViewGroup listGroup1 = new ListViewGroup("Group1");
+            ListViewGroup listGroup2 = new ListViewGroup("Group2");
+            ListViewItem listItem1 = new ListViewItem(listGroup1);
+            ListViewItem listItem2 = new ListViewItem(listGroup1);
+            ListViewItem listItem3 = new ListViewItem();
+            ListViewItem listItem4 = new ListViewItem(listGroup2);
+            ListViewItem listItem5 = new ListViewItem(listGroup2);
+            ListViewItem listItem6 = new ListViewItem(listGroup2);
+            listView.Groups.Add(listGroup1);
+            listView.Groups.Add(listGroup2);
+            listView.Items.Add(listItem1);
+            listView.Items.Add(listItem2);
+            listView.Items.Add(listItem3);
+            listView.Items.Add(listItem4);
+            listView.Items.Add(listItem5);
+            listView.Items.Add(listItem6);
+            ListViewGroupAccessibleObject group1AccObj = (ListViewGroupAccessibleObject)listGroup1.AccessibilityObject;
+            ListViewGroupAccessibleObject group2AccObj = (ListViewGroupAccessibleObject)listGroup2.AccessibilityObject;
+            ListViewGroupAccessibleObject defaultGroupAccObj = (ListViewGroupAccessibleObject)listView.DefaultGroup.AccessibilityObject;
+            Assert.Equal(-1, group1AccObj.GetChildCount());
+            Assert.Equal(-1, group2AccObj.GetChildCount());
+            Assert.Equal(-1, defaultGroupAccObj.GetChildCount());
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> ListViewGroupAccessibleObject_VirtualMode_TestData()
+        {
+            foreach (View view in Enum.GetValues(typeof(View)))
+            {
+                // View.Tile is not supported by ListView in virtual mode
+                if (view == View.Tile)
+                {
+                    continue;
+                }
+
+                foreach (bool showGroups in new[] { true, false })
+                {
+                    foreach (bool createHandle in new[] { true, false })
+                    {
+                        yield return new object[] { view, showGroups, createHandle };
+                    }
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewGroupAccessibleObject_VirtualMode_TestData))]
+        public void ListViewGroupAccessibleObject_GetChildCount_Invoke_VirtualMode_ReturnExpected(View view, bool showGroups, bool createHandle)
+        {
+            using ListView listView = new ListView
+            {
+                View = view,
+                VirtualMode = true,
+                ShowGroups = showGroups,
+                VirtualListSize = 4
+            };
+
+            ListViewGroup listViewGroup1 = new ListViewGroup("Test1");
+            ListViewGroup listViewGroup2 = new ListViewGroup("Test2");
+            listView.Groups.Add(listViewGroup1);
+            listView.Groups.Add(listViewGroup2);
+
+            ListViewItem listItem1 = new ListViewItem(new string[] { "Item 1", "Item A" }, -1, listViewGroup1);
+            ListViewItem listItem2 = new ListViewItem("Group item 2", listViewGroup1);
+            ListViewItem listItem3 = new ListViewItem("Item 3");
+            ListViewItem listItem4 = new ListViewItem(new string[] { "Item 4", "Item B" }, -1);
+
+            listView.RetrieveVirtualItem += (s, e) =>
+            {
+                e.Item = e.ItemIndex switch
+                {
+                    0 => listItem1,
+                    1 => listItem2,
+                    2 => listItem3,
+                    3 => listItem4,
+                    _ => throw new NotImplementedException()
+                };
+            };
+
+            if (createHandle)
+            {
+                listView.CreateControl();
+            }
+
+            listItem1.SetItemIndex(listView, 0);
+            listItem2.SetItemIndex(listView, 1);
+            listItem3.SetItemIndex(listView, 2);
+            listItem4.SetItemIndex(listView, 3);
+
+            ListViewGroupAccessibleObject group1AccObj = (ListViewGroupAccessibleObject)listViewGroup1.AccessibilityObject;
+            ListViewGroupAccessibleObject group2AccObj = (ListViewGroupAccessibleObject)listViewGroup2.AccessibilityObject;
+            ListViewGroupAccessibleObject defaultGroupAccObj = (ListViewGroupAccessibleObject)listView.DefaultGroup.AccessibilityObject;
+            Assert.Equal(-1, group1AccObj.GetChildCount());
+            Assert.Equal(-1, group2AccObj.GetChildCount());
+            Assert.Equal(-1, defaultGroupAccObj.GetChildCount());
+            Assert.Equal(createHandle, listView.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> ListViewGroupAccessibleObject_GetChild_Invoke_TestData()
+        {
+            foreach (View view in Enum.GetValues(typeof(View)))
+            {
+                foreach (bool showGroups in new[] { true, false })
+                {
+                    yield return new object[] { view, showGroups };
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewGroupAccessibleObject_GetChild_Invoke_TestData))]
+        public void ListViewGroupAccessibleObject_GetChild_Invoke_ReturnsExpected_IfHandleCreated(View view, bool showGroups)
+        {
+            using ListView listView = new ListView
+            {
+                View = view,
+                ShowGroups = showGroups
+            };
+
+            Assert.NotEqual(IntPtr.Zero, listView.Handle);
+
+            ListViewGroup listGroup1 = new ListViewGroup("Group1");
+            ListViewGroup listGroup2 = new ListViewGroup("Group2");
+            ListViewGroup listGroup3 = new ListViewGroup("Group2");
+            ListViewItem listItem1 = new ListViewItem(listGroup1);
+            ListViewItem listItem2 = new ListViewItem();
+            ListViewItem listItem3 = new ListViewItem(listGroup2);
+            ListViewItem listItem4 = new ListViewItem(listGroup2);
+            listView.Groups.Add(listGroup1);
+            listView.Groups.Add(listGroup2);
+            listView.Groups.Add(listGroup3);
+            listView.Items.Add(listItem1);
+            listView.Items.Add(listItem2);
+            listView.Items.Add(listItem3);
+            listView.Items.Add(listItem4);
+            ListViewGroupAccessibleObject group1AccObj = (ListViewGroupAccessibleObject)listGroup1.AccessibilityObject;
+            ListViewGroupAccessibleObject group2AccObj = (ListViewGroupAccessibleObject)listGroup2.AccessibilityObject;
+            ListViewGroupAccessibleObject group3AccObj = (ListViewGroupAccessibleObject)listGroup3.AccessibilityObject;
+            ListViewGroupAccessibleObject defaultGroupAccObj = (ListViewGroupAccessibleObject)listView.DefaultGroup.AccessibilityObject;
+
+            Assert.Null(group1AccObj.GetChild(-1));
+            Assert.Null(group1AccObj.GetChild(1));
+            Assert.Equal(listItem1.AccessibilityObject, group1AccObj.GetChild(0));
+
+            Assert.Null(group2AccObj.GetChild(-1));
+            Assert.Null(group2AccObj.GetChild(2));
+            Assert.Equal(listItem3.AccessibilityObject, group2AccObj.GetChild(0));
+            Assert.Equal(listItem4.AccessibilityObject, group2AccObj.GetChild(1));
+
+            Assert.Null(group3AccObj.GetChild(-1));
+            Assert.Null(group3AccObj.GetChild(0));
+
+            Assert.Null(defaultGroupAccObj.GetChild(-1));
+            Assert.Null(defaultGroupAccObj.GetChild(1));
+            Assert.Equal(listItem2.AccessibilityObject, defaultGroupAccObj.GetChild(0));
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewGroupAccessibleObject_GetChild_Invoke_TestData))]
+        public void ListViewGroupAccessibleObject_GetChild_Invoke_ReturnsExpected_IfHandleIsNotCreated(View view, bool showGroups)
+        {
+            using ListView listView = new ListView
+            {
+                View = view,
+                ShowGroups = showGroups
+            };
+
+            ListViewGroup listGroup1 = new ListViewGroup("Group1");
+            ListViewGroup listGroup2 = new ListViewGroup("Group2");
+            ListViewGroup listGroup3 = new ListViewGroup("Group2");
+            ListViewItem listItem1 = new ListViewItem(listGroup1);
+            ListViewItem listItem2 = new ListViewItem();
+            ListViewItem listItem3 = new ListViewItem(listGroup2);
+            ListViewItem listItem4 = new ListViewItem(listGroup2);
+            listView.Groups.Add(listGroup1);
+            listView.Groups.Add(listGroup2);
+            listView.Groups.Add(listGroup3);
+            listView.Items.Add(listItem1);
+            listView.Items.Add(listItem2);
+            listView.Items.Add(listItem3);
+            listView.Items.Add(listItem4);
+            ListViewGroupAccessibleObject group1AccObj = (ListViewGroupAccessibleObject)listGroup1.AccessibilityObject;
+            ListViewGroupAccessibleObject group2AccObj = (ListViewGroupAccessibleObject)listGroup2.AccessibilityObject;
+            ListViewGroupAccessibleObject group3AccObj = (ListViewGroupAccessibleObject)listGroup3.AccessibilityObject;
+            ListViewGroupAccessibleObject defaultGroupAccObj = (ListViewGroupAccessibleObject)listView.DefaultGroup.AccessibilityObject;
+
+            Assert.Null(group1AccObj.GetChild(-1));
+            Assert.Null(group1AccObj.GetChild(0));
+            Assert.Null(group1AccObj.GetChild(1));
+
+            Assert.Null(group2AccObj.GetChild(-1));
+            Assert.Null(group2AccObj.GetChild(0));
+            Assert.Null(group2AccObj.GetChild(1));
+            Assert.Null(group2AccObj.GetChild(2));
+
+            Assert.Null(group3AccObj.GetChild(-1));
+            Assert.Null(group3AccObj.GetChild(0));
+
+            Assert.Null(defaultGroupAccObj.GetChild(-1));
+            Assert.Null(defaultGroupAccObj.GetChild(0));
+            Assert.Null(defaultGroupAccObj.GetChild(1));
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewGroupAccessibleObject_VirtualMode_TestData))]
+        public void ListViewGroupAccessibleObject_GetChild_Invoke_VirtualMode_ReturnExpected(View view, bool showGroups, bool createHandle)
+        {
+            using ListView listView = new ListView
+            {
+                View = view,
+                VirtualMode = true,
+                ShowGroups = showGroups,
+                VirtualListSize = 4
+            };
+
+            ListViewGroup listViewGroup1 = new ListViewGroup("Test1");
+            ListViewGroup listViewGroup2 = new ListViewGroup("Test2");
+            listView.Groups.Add(listViewGroup1);
+            listView.Groups.Add(listViewGroup2);
+
+            ListViewItem listItem1 = new ListViewItem(new string[] { "Item 1", "Item A" }, -1, listViewGroup1);
+            ListViewItem listItem2 = new ListViewItem("Group item 2", listViewGroup1);
+            ListViewItem listItem3 = new ListViewItem("Item 3");
+            ListViewItem listItem4 = new ListViewItem(new string[] { "Item 4", "Item B" }, -1);
+
+            listView.RetrieveVirtualItem += (s, e) =>
+            {
+                e.Item = e.ItemIndex switch
+                {
+                    0 => listItem1,
+                    1 => listItem2,
+                    2 => listItem3,
+                    3 => listItem4,
+                    _ => throw new NotImplementedException()
+                };
+            };
+
+            if (createHandle)
+            {
+                listView.CreateControl();
+            }
+
+            listItem1.SetItemIndex(listView, 0);
+            listItem2.SetItemIndex(listView, 1);
+            listItem3.SetItemIndex(listView, 2);
+            listItem4.SetItemIndex(listView, 3);
+
+            ListViewGroupAccessibleObject group1AccObj = (ListViewGroupAccessibleObject)listViewGroup1.AccessibilityObject;
+            ListViewGroupAccessibleObject group2AccObj = (ListViewGroupAccessibleObject)listViewGroup2.AccessibilityObject;
+            ListViewGroupAccessibleObject defaultGroupAccObj = (ListViewGroupAccessibleObject)listView.DefaultGroup.AccessibilityObject;
+
+            Assert.Null(group1AccObj.GetChild(-1));
+            Assert.Null(group1AccObj.GetChild(0));
+            Assert.Null(group1AccObj.GetChild(1));
+            Assert.Null(group1AccObj.GetChild(2));
+
+            Assert.Null(group2AccObj.GetChild(-1));
+            Assert.Null(group2AccObj.GetChild(0));
+
+            Assert.Null(defaultGroupAccObj.GetChild(-1));
+            Assert.Null(defaultGroupAccObj.GetChild(0));
+            Assert.Null(defaultGroupAccObj.GetChild(1));
+            Assert.Null(defaultGroupAccObj.GetChild(2));
+            Assert.Equal(createHandle, listView.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> ListViewGroup_GroupAddedWithItem_AccessibleObject_TestData()
+        {
+            foreach (bool virtualMode in new[] { true, false })
+            {
+                foreach (View view in Enum.GetValues(typeof(View)))
+                {
+                    // View.Tile is not supported by ListView in virtual mode
+                    if (virtualMode == true && View.Tile == view)
+                    {
+                        continue;
+                    }
+
+                    foreach (bool showGroups in new[] { true, false })
+                    {
+                        foreach (bool createHandle in new[] { true, false })
+                        {
+                            yield return new object[] { view, showGroups, createHandle, virtualMode };
+                        }
+                    }
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewGroup_GroupAddedWithItem_AccessibleObject_TestData))]
+        public void ListViewGroup_GroupAddedWithItem_AccessibleObject_DoesntThrowException(View view, bool showGroups, bool createHandle, bool virtualMode)
+        {
+            using var listView = new ListView
+            {
+                View = view,
+                ShowGroups = showGroups,
+                VirtualListSize = 1,
+                VirtualMode = virtualMode
+            };
+
+            var listViewGroup = new ListViewGroup("Test Group");
+            var listViewItem = new ListViewItem("Test item", listViewGroup);
+
+            if (virtualMode)
+            {
+                listView.RetrieveVirtualItem += (s, e) =>
+                {
+                    e.Item = e.ItemIndex switch
+                    {
+                        0 => listViewItem,
+                        _ => throw new NotImplementedException()
+                    };
+                };
+
+                listViewItem.SetItemIndex(listView, 0);
+            }
+            else
+            {
+                listView.Items.Add(listViewItem);
+            }
+
+            if (createHandle)
+            {
+                Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            }
+
+            Assert.Null(listViewGroup.ListView);
+            Assert.NotNull(listViewGroup.AccessibilityObject);
+            Assert.Equal(createHandle, listView.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupTests.cs
@@ -1402,5 +1402,53 @@ namespace System.Windows.Forms.Tests
             var context = new StreamingContext();
             Assert.Throws<ArgumentNullException>("info", () => iSerializable.GetObjectData(null, context));
         }
+
+        public static IEnumerable<object[]> ListViewGroup_AddGroup_Invoke_VirtualMode_TestData()
+        {
+            foreach (View view in Enum.GetValues(typeof(View)))
+            {
+                // View.Tile is not supported by ListView in virtual mode
+                if (view == View.Tile)
+                {
+                    continue;
+                }
+
+                foreach (bool showGroups in new[] { true, false })
+                {
+                    yield return new object[] { view, showGroups };
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewGroup_AddGroup_Invoke_VirtualMode_TestData))]
+        public void ListViewGroup_AddGroup_Invoke_VirtualMode_ThrowsException_IfHandleCreated(View view, bool showGroups)
+        {
+            using var listView = new ListView
+            {
+                View = view,
+                VirtualMode = true,
+                ShowGroups = showGroups
+            };
+
+            listView.CreateControl();
+
+            Assert.Throws<InvalidOperationException>(() => listView.Groups.Add(new ListViewGroup()));
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewGroup_AddGroup_Invoke_VirtualMode_TestData))]
+        public void ListViewGroup_AddGroup_Invoke_VirtualMode_DoesNotThrowException_IfHandleNotCreated(View view, bool showGroups)
+        {
+            using var listView = new ListView
+            {
+                View = view,
+                VirtualMode = true,
+                ShowGroups = showGroups
+            };
+
+            // ListView in Virtual Mode does not throw exception when trying to add new group
+            listView.Groups.Add(new ListViewGroup());
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Drawing;
 using System.Reflection;
 using Xunit;
 using static System.Windows.Forms.ListViewItem;
@@ -10,7 +12,7 @@ using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
-    public class ListViewItem_ListViewItemAccessibleObjectTests
+    public class ListViewItem_ListViewItemAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]
         public void ListViewItemAccessibleObject_Ctor_ThrowsArgumentNullException()
@@ -42,8 +44,51 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(AccessibleRole.ListItem, accessibleObject.Role);
         }
 
+        public static IEnumerable<object[]> ListViewItemAccessibleObject_InGroup_Ctor_TestData()
+        {
+            foreach (View view in Enum.GetValues(typeof(View)))
+            {
+                foreach (bool showGroups in new[] { true, false })
+                {
+                    foreach (bool createHandle in new[] { true, false })
+                    {
+                        yield return new object[] { view, showGroups, createHandle };
+                    }
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewItemAccessibleObject_InGroup_Ctor_TestData))]
+        public void ListViewItemAccessibleObject_InGroup_Ctor(View view, bool showGroups, bool createHandle)
+        {
+            using ListView listView = new ListView
+            {
+                View = view,
+                ShowGroups = showGroups
+            };
+
+            if (createHandle)
+            {
+                Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            }
+
+            ListViewGroup listviewGroup = new ListViewGroup();
+            ListViewItem listViewItem1 = new ListViewItem();
+            ListViewItem listViewItem2 = new ListViewItem(listviewGroup);
+            listviewGroup.Items.Add(listViewItem1);
+            listView.Groups.Add(listviewGroup);
+            listView.Items.Add(listViewItem2);
+
+            AccessibleObject accessibleObject1 = listViewItem1.AccessibilityObject;
+            AccessibleObject accessibleObject2 = listViewItem2.AccessibilityObject;
+            Assert.NotNull(accessibleObject1);
+            Assert.NotNull(accessibleObject2);
+            Assert.Equal(createHandle, listView.IsHandleCreated);
+        }
+
         [WinFormsFact]
-        public void ListViewItemAccessibleObject_GetPropertyValue_returns_correct_values()
+        public void ListViewItemAccessibleObject_GetPropertyValue_ReturnsExpected()
         {
             using var list = new ListView();
             ListViewItem listItem = new ListViewItem("ListItem");
@@ -66,8 +111,235 @@ namespace System.Windows.Forms.Tests
             Assert.False(list.IsHandleCreated);
         }
 
+        public static IEnumerable<object[]> ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_TestData()
+        {
+            foreach (View view in Enum.GetValues(typeof(View)))
+            {
+                foreach (bool showGroups in new[] { true, false })
+                {
+                    yield return new object[] { view, showGroups};
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_TestData))]
+        public void ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_ReturnsExpected_IfHandleCreated(View view, bool showGroups)
+        {
+            using ListView listView = new ListView
+            {
+                View = view,
+                ShowGroups = showGroups
+            };
+
+            Assert.NotEqual(IntPtr.Zero, listView.Handle);
+
+            ListViewGroup listViewGroup = new ListViewGroup("Test");
+            ListViewItem listItem1 = new ListViewItem(new string[] { "Item 1", "Item A" }, -1, listViewGroup);
+            ListViewItem listItem2 = new ListViewItem("Group item 2", listViewGroup);
+            ListViewItem listItem3 = new ListViewItem("Item 3");
+            ListViewItem listItem4 = new ListViewItem(new string[] { "Item 4", "Item B" }, -1);
+
+            listView.Groups.Add(listViewGroup);
+            listView.Items.AddRange(new ListViewItem[] { listItem1, listItem2, listItem3, listItem4 });
+
+            AccessibleObject accessibleObject1 = listItem1.AccessibilityObject;
+            AccessibleObject accessibleObject2 = listItem2.AccessibilityObject;
+            AccessibleObject accessibleObject3 = listItem3.AccessibilityObject;
+            AccessibleObject accessibleObject4 = listItem4.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling), accessibleObject2);
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.Parent), listViewGroup.AccessibilityObject);
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+
+            Assert.Equal(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling), accessibleObject1);
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.Parent), listViewGroup.AccessibilityObject);
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
+            AccessibleObject firstChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem3);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem3);
+            Assert.Equal(firstChildItem3, lastChildItem3);
+
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
+            AccessibleObject firstChildItem2 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem2 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem2);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem2);
+            Assert.NotEqual(firstChildItem2, lastChildItem2);
+
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_TestData))]
+        public void ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_ReturnsExpected_IfHandleNotCreated(View view, bool showGroups)
+        {
+            using ListView listView = new ListView
+            {
+                View = view,
+                ShowGroups = showGroups
+            };
+
+            ListViewGroup listViewGroup = new ListViewGroup("Test");
+            ListViewItem listItem1 = new ListViewItem(new string[] { "Item 1", "Item A" }, -1, listViewGroup);
+            ListViewItem listItem2 = new ListViewItem("Group item 2", listViewGroup);
+            ListViewItem listItem3 = new ListViewItem("Item 3");
+            ListViewItem listItem4 = new ListViewItem(new string[] { "Item 4", "Item B" }, -1);
+
+            listView.Groups.Add(listViewGroup);
+            listView.Items.AddRange(new ListViewItem[] { listItem1, listItem2, listItem3, listItem4 });
+
+            AccessibleObject accessibleObject1 = listItem1.AccessibilityObject;
+            AccessibleObject accessibleObject2 = listItem2.AccessibilityObject;
+            AccessibleObject accessibleObject3 = listItem3.AccessibilityObject;
+            AccessibleObject accessibleObject4 = listItem4.AccessibilityObject;
+
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.Parent), listViewGroup.AccessibilityObject);
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.Parent), listViewGroup.AccessibilityObject);
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
+            AccessibleObject firstChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem3);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem3);
+            Assert.Equal(firstChildItem3, lastChildItem3);
+
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
+            AccessibleObject firstChildItem2 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem2 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem2);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem2);
+            Assert.NotEqual(firstChildItem2, lastChildItem2);
+
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_VirtualMode_TestData()
+        {
+            foreach (View view in Enum.GetValues(typeof(View)))
+            {
+                // View.Tile is not supported by ListView in virtual mode
+                if (view == View.Tile)
+                {
+                    continue;
+                }
+
+                foreach (bool showGroups in new[] { true, false })
+                {
+                    foreach (bool createHandle in new[] { true, false })
+                    {
+                        yield return new object[] { view, showGroups, createHandle };
+                    }
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_VirtualMode_TestData))]
+        public void ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_VirtualMode_ReturnsExpected(View view, bool showGroups, bool createHandle)
+        {
+            using ListView listView = new ListView
+            {
+                View = view,
+                VirtualMode = true,
+                ShowGroups = showGroups,
+                VirtualListSize = 4
+            };
+
+            ListViewGroup listViewGroup = new ListViewGroup("Test");
+            listView.Groups.Add(listViewGroup);
+
+            ListViewItem listItem1 = new ListViewItem(new string[] { "Item 1", "Item A" }, -1, listViewGroup);
+            ListViewItem listItem2 = new ListViewItem("Group item 2", listViewGroup);
+            ListViewItem listItem3 = new ListViewItem("Item 3");
+            ListViewItem listItem4 = new ListViewItem(new string[] { "Item 4", "Item B" }, -1);
+
+            listView.RetrieveVirtualItem += (s, e) =>
+            {
+                e.Item = e.ItemIndex switch
+                {
+                    0 => listItem1,
+                    1 => listItem2,
+                    2 => listItem3,
+                    3 => listItem4,
+                    _ => throw new NotImplementedException()
+                };
+            };
+
+            if (createHandle)
+            {
+                listView.CreateControl();
+            }
+
+            listItem1.SetItemIndex(listView, 0);
+            listItem2.SetItemIndex(listView, 1);
+            listItem3.SetItemIndex(listView, 2);
+            listItem4.SetItemIndex(listView, 3);
+
+            AccessibleObject accessibleObject1 = listItem1.AccessibilityObject;
+            AccessibleObject accessibleObject2 = listItem2.AccessibilityObject;
+            AccessibleObject accessibleObject3 = listItem3.AccessibilityObject;
+            AccessibleObject accessibleObject4 = listItem4.AccessibilityObject;
+
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.Parent), listViewGroup.AccessibilityObject);
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.Parent), listViewGroup.AccessibilityObject);
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
+            AccessibleObject firstChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem3);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem3);
+            Assert.Equal(firstChildItem3, lastChildItem3);
+
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
+            AccessibleObject firstChildItem2 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem2 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem2);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem2);
+            Assert.NotEqual(firstChildItem2, lastChildItem2);
+
+            Assert.Equal(createHandle, listView.IsHandleCreated);
+        }
+
         [WinFormsFact]
-        public void ListViewItemAccessibleObject_ListWithTwoItems_FragmentNavigateWorkCorrectly_IfHandleIsCreated()
+        public void ListViewItemAccessibleObject_FragmentNavigate_ListWithItems_ReturnsExpected_IfHandleCreated()
         {
             using ListView listView = new ListView();
             listView.CreateControl();
@@ -118,22 +390,17 @@ namespace System.Windows.Forms.Tests
             Assert.IsType<ListViewSubItemAccessibleObject>(firstChild);
             Assert.IsType<ListViewSubItemAccessibleObject>(lastChild);
             Assert.NotEqual(firstChild, lastChild);
+
             Assert.True(listView.IsHandleCreated);
         }
 
         [WinFormsFact]
-        public void ListViewItemAccessibleObject_ListWithTwoItems_FragmentNavigateWorkCorrectly_IfHandleIsNotCreated()
+        public void ListViewItemAccessibleObject_FragmentNavigate_ListWithItems_ReturnsExpected_IfHandleNotCreated()
         {
             using ListView listView = new ListView();
-            ListViewItem listItem1 = new ListViewItem(new string[] {
-                "Test A",
-                "Alpha"}, -1);
-            ListViewItem listItem2 = new ListViewItem(new string[] {
-                "Test B",
-                "Beta"}, -1);
-            ListViewItem listItem3 = new ListViewItem(new string[] {
-                "Test C",
-                "Gamma"}, -1);
+            ListViewItem listItem1 = new ListViewItem(new string[] { "Test A", "Alpha" }, -1);
+            ListViewItem listItem2 = new ListViewItem(new string[] { "Test B", "Beta" }, -1);
+            ListViewItem listItem3 = new ListViewItem(new string[] { "Test C", "Gamma" }, -1);
             listView.Items.Add(listItem1);
             listView.Items.Add(listItem2);
             listView.Items.Add(listItem3);
@@ -162,6 +429,349 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
 
             Assert.False(listView.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> ListViewItemAccessibleObject_View_ShowGroups_VirtualMode_TestData()
+        {
+            foreach (View view in Enum.GetValues(typeof(View)))
+            {
+                // View.Tile is not supported by ListView in virtual mode
+                if (view == View.Tile)
+                {
+                    continue;
+                }
+
+                foreach (bool showGroups in new[] { true, false })
+                {
+                    yield return new object[] { view, showGroups };
+                    yield return new object[] { view, showGroups };
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewItemAccessibleObject_View_ShowGroups_VirtualMode_TestData))]
+        public void ListViewItemAccessibleObject_FragmentNavigate_ListWithItems_VirtualMode_VirtualListSize1_ReturnsExpected(View view, bool showGroups)
+        {
+            using ListView listView = new ListView
+            {
+                View = view,
+                VirtualMode = true,
+                ShowGroups = showGroups
+            };
+
+            listView.VirtualListSize = 1;
+
+            ListViewItem listItem1 = new ListViewItem(new string[] {
+                "Test A",
+                "Alpha"}, -1);
+            ListViewItem listItem2 = new ListViewItem(new string[] {
+                "Test B",
+                "Beta"}, -1);
+            ListViewItem listItem3 = new ListViewItem(new string[] {
+                "Test C",
+                "Gamma"}, -1);
+
+            listView.RetrieveVirtualItem += (s, e) =>
+            {
+                e.Item = e.ItemIndex switch
+                {
+                    0 => listItem1,
+                    1 => listItem2,
+                    2 => listItem3,
+                    _ => throw new NotImplementedException()
+                };
+            };
+
+            listItem1.SetItemIndex(listView, 0);
+            listItem2.SetItemIndex(listView, 1);
+            listItem3.SetItemIndex(listView, 2);
+
+            listView.CreateControl();
+
+            AccessibleObject accessibleObject1 = listItem1.AccessibilityObject;
+            AccessibleObject accessibleObject2 = listItem2.AccessibilityObject;
+            AccessibleObject accessibleObject3 = listItem3.AccessibilityObject;
+
+            // First list view item
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            // Second list view item
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            // Third list view item
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            // Parent
+            Assert.Equal(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
+            Assert.Equal(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
+            Assert.Equal(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
+
+            // Childs
+            AccessibleObject firstChild = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChild = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChild);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChild);
+            Assert.NotEqual(firstChild, lastChild);
+
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewItemAccessibleObject_View_ShowGroups_VirtualMode_TestData))]
+        public void ListViewItemAccessibleObject_FragmentNavigate_ListWithItems_VirtualMode_VirtualListSize3_ReturnsExpected(View view, bool showGroups)
+        {
+            using ListView listView = new ListView
+            {
+                View = view,
+                VirtualMode = true,
+                ShowGroups = showGroups
+            };
+
+            listView.VirtualListSize = 3;
+
+            ListViewItem listItem1 = new ListViewItem(new string[] {
+                "Test A",
+                "Alpha"}, -1);
+            ListViewItem listItem2 = new ListViewItem(new string[] {
+                "Test B",
+                "Beta"}, -1);
+            ListViewItem listItem3 = new ListViewItem(new string[] {
+                "Test C",
+                "Gamma"}, -1);
+
+            listView.RetrieveVirtualItem += (s, e) =>
+            {
+                e.Item = e.ItemIndex switch
+                {
+                    0 => listItem1,
+                    1 => listItem2,
+                    2 => listItem3,
+                    _ => throw new NotImplementedException()
+                };
+            };
+
+            listItem1.SetItemIndex(listView, 0);
+            listItem2.SetItemIndex(listView, 1);
+            listItem3.SetItemIndex(listView, 2);
+
+            listView.CreateControl();
+
+            AccessibleObject accessibleObject1 = listItem1.AccessibilityObject;
+            AccessibleObject accessibleObject2 = listItem2.AccessibilityObject;
+            AccessibleObject accessibleObject3 = listItem3.AccessibilityObject;
+
+            // First list view item
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            UiaCore.IRawElementProviderFragment listItem1NextSibling = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling);
+            Assert.IsType<ListViewItemAccessibleObject>(listItem1NextSibling);
+            Assert.Equal(accessibleObject2, listItem1NextSibling);
+
+            // Second list view item
+            UiaCore.IRawElementProviderFragment listItem2PreviousSibling = accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling);
+            UiaCore.IRawElementProviderFragment listItem2NextSibling = accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling);
+            Assert.IsType<ListViewItemAccessibleObject>(listItem2PreviousSibling);
+            Assert.IsType<ListViewItemAccessibleObject>(listItem2NextSibling);
+            Assert.Equal(accessibleObject1, listItem2PreviousSibling);
+            Assert.Equal(accessibleObject3, listItem2NextSibling);
+
+            // Third list view item
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            UiaCore.IRawElementProviderFragment listItem3PreviousSibling = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling);
+            Assert.IsType<ListViewItemAccessibleObject>(listItem3PreviousSibling);
+            Assert.Equal(accessibleObject2, listItem3PreviousSibling);
+
+            // Parent
+            Assert.Equal(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
+            Assert.Equal(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
+            Assert.Equal(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
+
+            // Childs
+            AccessibleObject firstChild = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChild = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChild);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChild);
+            Assert.NotEqual(firstChild, lastChild);
+
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewItemAccessibleObject_View_ShowGroups_VirtualMode_TestData))]
+        public void ListViewItemAccessibleObject_FragmentNavigate_ListWithItems_VirtualMode_VirtualListSize3_ReturnsExpected_IfHandleNotCreated(View view, bool showGroups)
+        {
+            using ListView listView = new ListView
+            {
+                View = view,
+                VirtualMode = true,
+                ShowGroups = showGroups
+            };
+
+            listView.VirtualListSize = 3;
+
+            ListViewItem listItem1 = new ListViewItem(new string[] {
+                "Test A",
+                "Alpha"}, -1);
+            ListViewItem listItem2 = new ListViewItem(new string[] {
+                "Test B",
+                "Beta"}, -1);
+            ListViewItem listItem3 = new ListViewItem(new string[] {
+                "Test C",
+                "Gamma"}, -1);
+
+            listView.RetrieveVirtualItem += (s, e) =>
+            {
+                e.Item = e.ItemIndex switch
+                {
+                    0 => listItem1,
+                    1 => listItem2,
+                    2 => listItem3,
+                    _ => throw new NotImplementedException()
+                };
+            };
+
+            listItem1.SetItemIndex(listView, 0);
+            listItem2.SetItemIndex(listView, 1);
+            listItem3.SetItemIndex(listView, 2);
+
+            AccessibleObject accessibleObject1 = listItem1.AccessibilityObject;
+            AccessibleObject accessibleObject2 = listItem2.AccessibilityObject;
+            AccessibleObject accessibleObject3 = listItem3.AccessibilityObject;
+
+            // First list view item
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            // Second list view item
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            // Third list view item
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            // Parent
+            Assert.Equal(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
+            Assert.Equal(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
+            Assert.Equal(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
+
+            // Childs
+            AccessibleObject firstChild = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChild = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChild);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChild);
+            Assert.NotEqual(firstChild, lastChild);
+
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> ListViewItemAccessibleObject_State_TestData()
+        {
+            AccessibleStates defaultStates = AccessibleStates.Selectable | AccessibleStates.Focusable | AccessibleStates.MultiSelectable;
+            AccessibleStates selectedStates = defaultStates | AccessibleStates.Selected | AccessibleStates.Focused;
+
+            foreach (View view in Enum.GetValues(typeof(View)))
+            {
+                foreach (bool selected in new[] { true, false })
+                {
+                    foreach (bool createHandle in new[] { true, false })
+                    {
+                        AccessibleStates expectedState = selected ? selectedStates : defaultStates;
+                        yield return new object[] { view, selected, expectedState, createHandle };
+                    }
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewItemAccessibleObject_State_TestData))]
+        public void ListViewItemAccessibleObject_State_ReturnExpected(View view, bool selected, AccessibleStates expectedAcessibleStates, bool createHandle)
+        {
+            using ListView listView = new ListView
+            {
+                View = view
+            };
+
+            if (createHandle)
+            {
+                Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            }
+
+            ListViewItem listItem1 = new ListViewItem(new string[] { "Test A", "Alpha" }, -1);
+            listView.Items.Add(listItem1);
+            listView.Items[0].Selected = selected;
+            ListViewItemAccessibleObject accessibleObject = (ListViewItemAccessibleObject)listView.Items[0].AccessibilityObject;
+
+            Assert.Equal(expectedAcessibleStates, accessibleObject.State);
+
+            Assert.Equal(createHandle, listView.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> ListViewItemAccessibleObject_State_VirtualMode_TestData()
+        {
+            AccessibleStates defaultStates = AccessibleStates.Selectable | AccessibleStates.Focusable | AccessibleStates.MultiSelectable;
+            AccessibleStates selectedStates = defaultStates | AccessibleStates.Selected | AccessibleStates.Focused;
+
+            foreach (View view in Enum.GetValues(typeof(View)))
+            {
+                // View.Tile is not supported by ListView in virtual mode
+                if (view == View.Tile)
+                {
+                    continue;
+                }
+
+                foreach (bool selected in new[] { true, false })
+                {
+                    foreach (bool createHandle in new[] { true, false })
+                    {
+                        AccessibleStates expectedState = selected ? selectedStates : defaultStates;
+                        yield return new object[] { view, selected, expectedState, createHandle };
+                    }
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewItemAccessibleObject_State_VirtualMode_TestData))]
+        public void ListViewItemAccessibleObject_State_Virtual_ModeReturnExpected(View view, bool selected, AccessibleStates expectedAcessibleStates, bool createHandle)
+        {
+            using ListView listView = new ListView
+            {
+                View = view,
+                VirtualMode = true,
+                VirtualListSize = 1
+            };
+
+            ListViewItem listItem1 = new ListViewItem(new string[] { "Test A", "Alpha" }, -1);
+
+            listView.RetrieveVirtualItem += (s, e) =>
+            {
+                e.Item = e.ItemIndex switch
+                {
+                    0 => listItem1,
+                    _ => throw new NotImplementedException()
+                };
+            };
+
+            listItem1.SetItemIndex(listView, 0);
+
+            if (createHandle)
+            {
+                Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            }
+
+            if (selected)
+            {
+                listView.Items[0].Selected = true;
+            }
+
+            ListViewItemAccessibleObject accessibleObject = (ListViewItemAccessibleObject)listView.Items[0].AccessibilityObject;
+
+            Assert.Equal(expectedAcessibleStates, accessibleObject.State);
+            Assert.Equal(createHandle, listView.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
@@ -9,7 +9,7 @@ using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
-    public class ListViewItem_ListViewSubItem_ListViewSubItemAccessibleObjectTests
+    public class ListViewItem_ListViewSubItem_ListViewSubItemAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]
         public void ListViewSubItemAccessibleObject_GetChild_ReturnCorrectValue()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -6,10 +6,10 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Microsoft.DotNet.RemoteExecutor;
 using WinForms.Common.Tests;
 using Xunit;
+using static System.Windows.Forms.ListViewItem;
 using static Interop;
 using static Interop.ComCtl32;
 
@@ -2968,9 +2968,73 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void ListView_ShowGroups_VirtualMode_Set_GetReturnsExpected(bool value)
+        {
+            using var listView = new ListView
+            {
+                ShowGroups = value,
+                VirtualMode = true,
+            };
+            Assert.Equal(value, listView.ShowGroups);
+            Assert.False(listView.IsHandleCreated);
+
+            // Set same.
+            listView.ShowGroups = value;
+            Assert.Equal(value, listView.ShowGroups);
+            Assert.False(listView.IsHandleCreated);
+
+            // Set different.
+            listView.ShowGroups = !value;
+            Assert.Equal(!value, listView.ShowGroups);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void ListView_ShowGroups_SetWithHandle_GetReturnsExpected(bool value)
         {
             using var listView = new ListView();
+            Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            int invalidatedCallCount = 0;
+            listView.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            listView.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            listView.HandleCreated += (sender, e) => createdCallCount++;
+
+            listView.ShowGroups = value;
+            Assert.Equal(value, listView.ShowGroups);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+
+            // Set same.
+            listView.ShowGroups = value;
+            Assert.Equal(value, listView.ShowGroups);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+
+            // Set different.
+            listView.ShowGroups = !value;
+            Assert.Equal(!value, listView.ShowGroups);
+            Assert.True(listView.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void ListView_ShowGroups_VirtualMode_SetWithHandle_GetReturnsExpected(bool value)
+        {
+            using var listView = new ListView
+            {
+                VirtualMode = true,
+            };
+
             Assert.NotEqual(IntPtr.Zero, listView.Handle);
             int invalidatedCallCount = 0;
             listView.Invalidated += (sender, e) => invalidatedCallCount++;
@@ -4162,6 +4226,390 @@ namespace System.Windows.Forms.Tests
             var nonEmptyImageList = new ImageList();
             nonEmptyImageList.Images.Add(new Bitmap(10, 10));
             return nonEmptyImageList;
+        }
+
+        public static IEnumerable<object[]> ListView_InvokeOnSelectedIndexChanged_TestData()
+        {
+            foreach (View view in Enum.GetValues(typeof(View)))
+            {
+                foreach (bool showGrops in new[] { true, false })
+                {
+                    foreach (bool focused in new[] { true, false })
+                    {
+                        foreach (bool selected in new[] { true, false })
+                        {
+                            // Updating Focused property of ListViewItem always calls RaiseAutomatiomEvent.
+                            // If ListViewItem is focused and selected then RaiseAutomatiomEvent is also called.
+                            int expectedCallCount = focused && selected ? 2 : 1;
+                            yield return new object[] { view, showGrops, focused, selected, expectedCallCount };
+                        }
+                    }
+                };
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListView_InvokeOnSelectedIndexChanged_TestData))]
+        public void ListView_OnSelectedIndexChanged_Invoke(View view, bool showGroups, bool focused, bool selected, int expectedCallCount)
+        {
+            using var listView = new SubListView
+            {
+                View = view,
+                VirtualMode = false,
+                ShowGroups = showGroups
+            };
+
+            listView.CreateControl();
+
+            SubListViewItem testItem = new SubListViewItem("Test 1");
+
+            listView.Items.Add(testItem);
+
+            SubListViewItemAccessibleObject customAccessibleObject = new SubListViewItemAccessibleObject(testItem);
+            testItem.CustomAccessibleObject = customAccessibleObject;
+
+            listView.Items[0].Focused = focused;
+            listView.Items[0].Selected = selected;
+
+            Assert.Equal(expectedCallCount, customAccessibleObject?.RaiseAutomationEventCalls);
+        }
+
+        public static IEnumerable<object[]> ListView_InvokeOnSelectedIndexChanged_VirtualMode_TestData()
+        {
+            foreach (View view in Enum.GetValues(typeof(View)))
+            {
+                // View.Tile is not supported by ListView in virtual mode
+                if (view == View.Tile)
+                {
+                    continue;
+                }
+
+                foreach (bool showGrops in new[] { true, false })
+                {
+                    foreach (bool focused in new[] { true, false })
+                    {
+                        foreach (bool selected in new[] { true, false })
+                        {
+                            // Updating Focused property of ListViewItem always calls RaiseAutomatiomEvent.
+                            // If ListViewItem is focused and selected then RaiseAutomatiomEvent is also called.
+                            int expectedCallCount = focused && selected ? 2 : 1;
+                            yield return new object[] { view, showGrops, focused, selected, expectedCallCount };
+                        }
+                    }
+                };
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListView_InvokeOnSelectedIndexChanged_VirtualMode_TestData))]
+        public void ListView_OnSelectedIndexChanged_VirtualMode_Invoke(View view, bool showGroups, bool focused, bool selected, int expectedCallCount)
+        {
+            SubListViewItem listItem1 = new SubListViewItem("Test 1");
+
+            using ListView listView = new ListView
+            {
+                View = view,
+                VirtualMode = true,
+                ShowGroups = showGroups,
+                VirtualListSize = 1
+            };
+
+            listView.RetrieveVirtualItem += (s, e) =>
+            {
+                e.Item = e.ItemIndex switch
+                {
+                    0 => listItem1,
+                    _ => throw new NotImplementedException()
+                };
+            };
+
+            listView.CreateControl();
+            listItem1.SetItemIndex(listView, 0);
+
+            SubListViewItemAccessibleObject customAccessibleObject = new SubListViewItemAccessibleObject(listItem1);
+            listItem1.CustomAccessibleObject = customAccessibleObject;
+
+            listView.Items[0].Focused = focused;
+            listView.Items[0].Selected = selected;
+
+            Assert.Equal(expectedCallCount, customAccessibleObject?.RaiseAutomationEventCalls);
+        }
+
+        public static IEnumerable<object[]> ListView_Checkboxes_VirtualMode_Disabling_TestData()
+        {
+            foreach (View view in Enum.GetValues(typeof(View)))
+            {
+                // View.Tile is not supported by ListView in virtual mode
+                if (view == View.Tile)
+                {
+                    continue;
+                }
+
+                foreach (bool showGroups in new[] { true, false })
+                {
+                    yield return new object[] { view, showGroups };
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListView_Checkboxes_VirtualMode_Disabling_TestData))]
+        public void ListView_Checkboxes_VirtualMode_Disabling_ThrowException(View view, bool showGroups)
+        {
+            using var listView = new SubListView
+            {
+                View = view,
+                VirtualMode = true,
+                ShowGroups = showGroups
+            };
+
+            listView.CheckBoxes = true;
+            Assert.Throws<InvalidOperationException>(() => listView.CheckBoxes = false);
+        }
+
+        private class SubListViewItem : ListViewItem
+        {
+            public AccessibleObject CustomAccessibleObject { get; set; }
+
+            public SubListViewItem(string text) : base(text)
+            {
+            }
+
+            internal override AccessibleObject AccessibilityObject => CustomAccessibleObject;
+        }
+
+        private class SubListViewItemAccessibleObject : ListViewItemAccessibleObject
+        {
+            public int RaiseAutomationEventCalls;
+
+            public SubListViewItemAccessibleObject(ListViewItem owningItem) : base(owningItem, null)
+            {
+            }
+
+            internal override bool RaiseAutomationEvent(UiaCore.UIA eventId)
+            {
+                RaiseAutomationEventCalls++;
+                return base.RaiseAutomationEvent(eventId);
+            }
+        }
+
+        [WinFormsFact]
+        public void ListView_WmReflectNotify_LVN_KEYDOWN_WithoutGroups_and_CheckBoxes_DoesntHaveSelectedItems()
+        {
+            using var control = new ListView();
+            control.Items.Add(new ListViewItem());
+            control.Items.Add(new ListViewItem());
+            control.CreateControl();
+            User32.SendMessageW(control, User32.WM.KEYDOWN);
+            Assert.Equal(0, control.SelectedItems.Count);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, true, true)]
+        [InlineData(true, false, true)]
+        [InlineData(false, true, true)]
+        [InlineData(false, false, true)]
+        [InlineData(true, true, false)]
+        [InlineData(true, false, false)]
+        [InlineData(false, true, false)]
+        [InlineData(false, false, false)]
+        public unsafe void ListView_WmReflectNotify_LVN_KEYDOWN_SpaceKey_HasCheckBoxes_WithoutGroups_CheckedExpected(bool focusItem, bool checkItem, bool selectItems)
+        {
+            using var control = new ListView();
+            control.CheckBoxes = true;
+            ListViewItem item1 = new ListViewItem();
+            item1.Text = "First";
+            ListViewItem item2 = new ListViewItem();
+            item2.Text = "Second";
+
+            control.Items.Add(item1);
+            control.Items.Add(item2);
+            control.CreateControl();
+            control.VirtualMode = false;
+
+            item1.Focused = focusItem;
+            item1.Checked = checkItem;
+            item1.Selected = selectItems;
+            item2.Selected = selectItems;
+
+            // https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-keydown?redirectedfrom=MSDN
+            // The MSDN page tells us what bits of lParam to use for each of the parameters.
+            // All we need to do is some bit shifting to assemble lParam
+            // lParam = repeatCount | (scanCode << 16)
+            // The source: https://stackoverflow.com/questions/21994276/setting-wm-keydown-lparam-parameters
+            uint keyCode = (uint)Keys.Space;
+            uint lParam = (0x00000001 | keyCode << 16);
+
+            User32.SendMessageW(control, User32.WM.KEYDOWN, (IntPtr)keyCode, (IntPtr)lParam);
+            Assert.Equal(selectItems ? 2 : 0, control.SelectedItems.Count);
+            Assert.Equal(!checkItem && selectItems && focusItem, item2.Checked);
+        }
+
+        [WinFormsTheory]
+        [InlineData(Keys.Down)]
+        [InlineData(Keys.Up)]
+        public unsafe void ListView_WmReflectNotify_LVN_KEYDOWN_WithGroups_WithoutSelection_DoesntFocusGroup(Keys key)
+        {
+            using var control = new ListView();
+            ListViewItem item1 = new ListViewItem();
+            item1.Text = "First";
+            ListViewItem item2 = new ListViewItem();
+            item2.Text = "Second";
+
+            ListViewGroup group = new ListViewGroup("Test group");
+            group.Items.Add(item1);
+            group.Items.Add(item2);
+
+            control.VirtualMode = false;
+            control.Groups.Add(group);
+            control.CreateControl();
+
+            // https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-keydown?redirectedfrom=MSDN
+            // The MSDN page tells us what bits of lParam to use for each of the parameters.
+            // All we need to do is some bit shifting to assemble lParam
+            // lParam = repeatCount | (scanCode << 16)
+            // The source: https://stackoverflow.com/questions/21994276/setting-wm-keydown-lparam-parameters
+            uint keyCode = (uint)key;
+            uint lParam = (0x00000001 | keyCode << 16);
+
+            // If control doesn't have selected items noone will be focused.
+            User32.SendMessageW(control, User32.WM.KEYDOWN, (IntPtr)keyCode, (IntPtr)lParam);
+            Assert.Empty(control.SelectedIndices);
+            Assert.Null(control.FocusedItem);
+            Assert.Null(control.FocusedGroup);
+        }
+
+        [WinFormsTheory(Skip = "Crash with unexpected invokerHandle ExitCode")]
+        [InlineData("Keys.Down", "2")]
+        [InlineData("Keys.Up", "1")]
+        public unsafe void ListView_WmReflectNotify_LVN_KEYDOWN_WithGroups_and_SelectedItems_FocusedGroupIsExpected(string keyString, string expectedGroupIndexString)
+        {
+            // Run this from another thread as we call Application.EnableVisualStyles.
+            using RemoteInvokeHandle invokerHandle = RemoteExecutor.Invoke((key_s, expectedGroupIndex_s) =>
+            {
+                Application.EnableVisualStyles();
+
+                using var control = new ListView();
+                ListViewGroup group1 = new ListViewGroup("Test group1");
+                ListViewGroup group2 = new ListViewGroup("Test group2");
+                ListViewGroup group3 = new ListViewGroup("Test group3");
+                ListViewItem item1 = new ListViewItem(group1);
+                item1.Text = "First";
+                ListViewItem item2 = new ListViewItem(group2);
+                item2.Text = "Second";
+                ListViewItem item3 = new ListViewItem(group3);
+                item3.Text = "Third";
+                control.Items.Add(item1);
+                control.Items.Add(item2);
+                control.Items.Add(item3);
+                control.Groups.Add(group1);
+                control.Groups.Add(group2);
+                control.Groups.Add(group3);
+                control.VirtualMode = false;
+                control.CreateControl();
+
+                item2.Selected = true;
+
+                // https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-keydown?redirectedfrom=MSDN
+                // The MSDN page tells us what bits of lParam to use for each of the parameters.
+                // All we need to do is some bit shifting to assemble lParam
+                // lParam = repeatCount | (scanCode << 16)
+                // The source: https://stackoverflow.com/questions/21994276/setting-wm-keydown-lparam-parameters
+                uint keyCode = (uint)(key_s == "Keys.Down" ? Keys.Down : Keys.Up);
+                uint lParam = (0x00000001 | keyCode << 16);
+
+                User32.SendMessageW(control, User32.WM.KEYDOWN, (IntPtr)keyCode, (IntPtr)lParam);
+                Assert.False(control.GroupsEnabled);
+                Assert.True(control.Items.Count > 0);
+                int expectedGroupIndex = int.Parse(expectedGroupIndex_s);
+                Assert.Equal(control.Groups[expectedGroupIndex], control.FocusedGroup);
+            }, keyString, expectedGroupIndexString);
+
+            // verify the remote process succeeded
+            Assert.Equal(0, invokerHandle.ExitCode);
+        }
+
+        [WinFormsTheory]
+        [InlineData(Keys.Down)]
+        [InlineData(Keys.Up)]
+        public unsafe void ListView_VirtualMode_WmReflectNotify_LVN_KEYDOWN_WithGroups_DoenstFocusGroups(Keys key)
+        {
+            using ListView control = new ListView
+            {
+                ShowGroups = true,
+                CheckBoxes = false,
+                VirtualMode = true,
+                VirtualListSize = 2 // we can't add items, just indicate how many we have
+            };
+
+            ListViewGroup group = new ListViewGroup("Test group");
+            control.Groups.Add(group);
+
+            control.RetrieveVirtualItem += (s, e) =>
+            {
+                e.Item = e.ItemIndex switch
+                {
+                    0 => new ListViewItem(group) { Selected = true },
+                    _ => new ListViewItem(group),
+                };
+            };
+
+            control.CreateControl();
+
+            // https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-keydown?redirectedfrom=MSDN
+            // The MSDN page tells us what bits of lParam to use for each of the parameters.
+            // All we need to do is some bit shifting to assemble lParam
+            // lParam = repeatCount | (scanCode << 16)
+            // The source: https://stackoverflow.com/questions/21994276/setting-wm-keydown-lparam-parameters
+            uint keyCode = (uint)key;
+            uint lParam = (0x00000001 | keyCode << 16);
+
+            // Actually ListView in VirtualMode can't have Groups
+            User32.SendMessageW(control, User32.WM.KEYDOWN, (IntPtr)keyCode, (IntPtr)lParam);
+            Assert.Null(control.FocusedGroup);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public unsafe void ListView_VirtualMode_WmReflectNotify_LVN_KEYDOWN_EnabledCheckBoxes_WithoutGroups_DoenstCheckItems(bool checkedItem)
+        {
+            using ListView control = new ListView
+            {
+                ShowGroups = true,
+                CheckBoxes = true,
+                VirtualMode = true,
+                VirtualListSize = 2 // we can't add items, just indicate how many we have
+            };
+
+            ListViewItem item1 = new ListViewItem();
+            ListViewItem item2 = new ListViewItem();
+
+            control.RetrieveVirtualItem += (s, e) =>
+            {
+                e.Item = e.ItemIndex switch
+                {
+                    0 => item1,
+                    _ => item2,
+                };
+            };
+
+            control.CreateControl();
+            item1.Checked = checkedItem;
+            item2.Checked = false;
+            control.FocusedItem = item1;
+
+            // https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-keydown?redirectedfrom=MSDN
+            // The MSDN page tells us what bits of lParam to use for each of the parameters.
+            // All we need to do is some bit shifting to assemble lParam
+            // lParam = repeatCount | (scanCode << 16)
+            // The source: https://stackoverflow.com/questions/21994276/setting-wm-keydown-lparam-parameters
+            uint keyCode = (uint)Keys.Space;
+            uint lParam = (0x00000001 | keyCode << 16);
+
+            // Actually ListView in VirtualMode doesn't check items here
+            User32.SendMessageW(control, User32.WM.KEYDOWN, (IntPtr)keyCode, (IntPtr)lParam);
+            Assert.False(item2.Checked);
         }
 
         private class SubListView : ListView


### PR DESCRIPTION
Fixes #3962

## Proposed changes
- implemented using SelectedIndices instead of SelectedItems when getting Accessible Objects, because SelectedIndices property is available in any mode (virtual and default);
- added a check for methods from ListViewGroup that the ListView is not in virtual mode, since ListViewGroups are not supported for virtual mode;
- replaced "groups.Count > 0" condition on "GroupsEnabled" in logic for navigation on ListView by keyboard. Together with the "groups.Count > 0" condition, it also checks that Groups is displayed and ListView is in default (not virtual) mode;
- updated logic for "ExpandCollapseState" property ;
- added the condition that if a ListViewItem is located in a ListViewGroup and this ListViewGroup is collapsed we return empty rectangle otherwise we call old logic for getting of rectangle
- added check that the index should be greater than -1 and less than the number of Items in the ListView. If check is failed then we will return false, otherwise we will get the ListViewItem using index and check "Selected" property;

## Customer Impact
**ListView in virtual mode**
During implementation of accessible objects for ListView we started to use "SelectedItems" properties for getting of required items. Unfortunately, "SelectedItems", "CheckedItems" and partially "Items" properties are not available when the ListView is in virtual mode. If trying to get any properties/methods from "SelecedItems", "CheckedItems" or get enumerator of "Items" then ListView throws IOE in virtual mode. As result we got an exceptions when tried to do any UI action when ListView is in virtual mode.
![93773875-403fc080-fc29-11ea-926b-9d671694d720](https://user-images.githubusercontent.com/23376742/94565227-99cf6d00-0271-11eb-83f1-f984e30f21c0.gif)
After fixing issue with ListView in a virtual mode, it is  again available for navigation and UI interaction:
![ListView in virtual mode](https://user-images.githubusercontent.com/23376742/94567353-0f3c3d00-0274-11eb-9413-d6126ab36e09.gif)
**ListViewGroup.ListViewGroupAccessibleObject.ExpandCollapseState**
The ExpandCollapseState is not valid for non-collapsible ListViewGroup. User sees that such group has "Collapsed" state although the group cannot be collapsed:
![Issue-3962-collapsed](https://user-images.githubusercontent.com/23376742/94568080-c042d780-0274-11eb-88d4-f00ab6c090c9.jpg)
After fixing, ExpandCollapseState is valid for non-collapsible ListViewGroup:
![Issue-3962-expanded](https://user-images.githubusercontent.com/23376742/94568198-e1a3c380-0274-11eb-831b-d86d07a98e88.jpg)

**ListViewItem.ListViewItemAccessibleObject.Bounds**
If a ListViewItem is in a collapsed ListViewGroup and user tries to selects it in Inspector then user will see exception:
![ListView-collapsedFails](https://user-images.githubusercontent.com/23376742/94568564-570f9400-0275-11eb-8e98-10b7a42eedb2.gif)
After fixing, user can see data about ListViewItem in a collapsed ListViewGroup without application exception:
![ListView-collapsedSuccesd](https://user-images.githubusercontent.com/23376742/94568814-a81f8800-0275-11eb-80fb-1d66fc4c1929.gif)

## Regression? 

- Yes

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->

- Manually 
- Unit tests
- CTI

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.19041.388]
- NET Core 5.0.100-rc.1.20420.14

## Accessibility Testing ##
- Narrator
- Inspector

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3963)