### PR TITLE
Fixing "ListViewItem.ListViewItemAccessibleObject.ScrollIntoView" method

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObject.cs
@@ -234,51 +234,7 @@ namespace System.Windows.Forms
 
             internal override void ScrollIntoView()
             {
-                if (!_owningListView.IsHandleCreated)
-                {
-                    return;
-                }
-
-                int currentIndex = CurrentIndex;
-
-                if (_owningListView.SelectedItems is null) // no items selected
-                {
-                    User32.SendMessageW(_owningListView, (User32.WM)User32.LB.SETCARETINDEX, (IntPtr)currentIndex);
-                    return;
-                }
-
-                int firstVisibleIndex = (int)(long)User32.SendMessageW(_owningListView, (User32.WM)User32.LB.GETTOPINDEX);
-                if (currentIndex < firstVisibleIndex)
-                {
-                    User32.SendMessageW(_owningListView, (User32.WM)User32.LB.SETTOPINDEX, (IntPtr)currentIndex);
-                    return;
-                }
-
-                int itemsHeightSum = 0;
-                int listBoxHeight = _owningListView.ClientRectangle.Height;
-                int itemsCount = _owningListView.Items.Count;
-
-                for (int i = firstVisibleIndex; i < itemsCount; i++)
-                {
-                    int itemHeight = PARAM.ToInt(User32.SendMessageW(_owningListView, (User32.WM)User32.LB.GETITEMHEIGHT, (IntPtr)i));
-
-                    itemsHeightSum += itemHeight;
-
-                    if (itemsHeightSum <= listBoxHeight)
-                    {
-                        continue;
-                    }
-
-                    int lastVisibleIndex = i - 1; // less 1 because last "i" index is invisible
-                    int visibleItemsCount = lastVisibleIndex - firstVisibleIndex + 1; // add 1 because array indexes begin with 0
-
-                    if (currentIndex > lastVisibleIndex)
-                    {
-                        User32.SendMessageW(_owningListView, (User32.WM)User32.LB.SETTOPINDEX, (IntPtr)(currentIndex - visibleItemsCount + 1));
-                    }
-
-                    break;
-                }
+                _owningItem.EnsureVisible();
             }
 
             internal unsafe override void SelectItem()


### PR DESCRIPTION
Fixes #3957

## Proposed changes
- Updating logic for scrolling to item. Added calling of EnsureVisible method that scrolled to required item

## Customer Impact
Before fixing, "ListViewItem.ListViewItemAccessibleObject.ScrollIntoView" method was available for user, but this method did not work. If user or some program (Inspector, Accessibility Insights) tries to execute this then ListView will not scroll and the user will not see the required item in visible area. As result this method is useless.
![3964-before](https://user-images.githubusercontent.com/23376742/93862416-b2b4ad00-fcca-11ea-82ca-53f52edd500a.gif)

After fixing, this method starts to work correctly and user or program have ability to see required element after calling of "ScrollIntoView" method.
![3964-fixed](https://user-images.githubusercontent.com/23376742/93862427-b8aa8e00-fcca-11ea-88cf-a6a95f1b8cc5.gif)

## Regression? 

- No

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->

- Manually 

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- NET Core 5.0.100-rc.1.20420.14


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3964)