### PR TITLE
Prepare CLI VB template for vs16.8 P4 VS templates.

### DIFF
--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/template.json
@@ -69,12 +69,12 @@
     },
     "hostIsCli": {
       "type": "computed",
-      "value": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")"
+      "value": "(HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\")"
     },
-      "skipAppModel": {
-        "type": "computed",
-        "value": "hostIsCli || !UseAppFramework"
-      }
+    "skipAppModel": {
+      "type": "computed",
+      "value": "(hostIsCli && !UseAppFramework)"
+    }
     },
     "primaryOutputs": [
       { "path": "Company.WinFormsApplication1.vbproj" },

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/ApplicationEvents.vb
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/ApplicationEvents.vb
@@ -11,6 +11,7 @@ Namespace My
     ' **NEW** ApplyHighDpiMode: Raised when the application queries the HighDpiMode to set it for the application.
 
     ' Example:
+
     ' Private Sub MyApplication_ApplyHighDpiMode(sender As Object, e As ApplyHighDpiModeEventArgs) Handles Me.ApplyHighDpiMode
     '     e.HighDpiMode = HighDpiMode.PerMonitorV2
     ' End Sub

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/Company.WinFormsApplication1.vbproj
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/Company.WinFormsApplication1.vbproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter-windows</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride-windows</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <RootNamespace>Company.WinFormsApplication1</RootNamespace>
     <StartupObject>Sub Main</StartupObject>
     <LangVersion Condition="'$(langVersion)' != ''">$(ProjectLanguageVersion)</LangVersion>

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/Program.vb
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/Program.vb
@@ -1,5 +1,6 @@
-Friend Module Program
+﻿Friend Module Program
 
+    ' Start and set HighDpiMode, Styles and TextRenderingDefault.
     <STAThread()>
     Friend Sub Main(args As String())
         Application.SetHighDpiMode(HighDpiMode.SystemAware)


### PR DESCRIPTION
This fixes #3893, and also is needed to make https://github.com/dotnet/templates/pull/375 work.

## Proposed changes

Enables the following experiences for Visual Basic WinForms templates:
* Creates a new VB WinForms App V3.1 from the CLI. (Default: `dotnet new winforms --language VB` )
* Creates a new VB WinForms App net5.0 ( `--Framework net5.0` )
* Creates a new VB WinForms App net5.0 WITH Application Framework support ( `--Framework net5.0 --use-app-framework=true` )
* New: Works together with the newly activated VS VB template (which have been disabled before).

## Customer Impact

Will enable the Customer to use the Visual Basic Application Framework for Windows Forms Apps for >=net 5.0.

## Regression? 

No.

## Risk

Low. Only affecting VB templates.

## Test methodology <!-- How did you ensure quality? -->

Manual testing of the new templates.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3894)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3967)