### PR TITLE
Fixing the incorrect ScreenReader blue rectangle for a new character when typing (Text pattern area)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -578,6 +578,11 @@ namespace System.Windows.Forms
             set { richTextBoxFlags[protectedErrorSection] = value ? 1 : 0; }
         }
 
+        private protected override void RaiseAccessibilityTextChangedEvent()
+        {
+            // Do not do anything because Win32 provides unmanaged Text pattern for RichTextBox
+        }
+
         /// <summary>
         ///  Returns the name of the action that will be performed if the user
         ///  Redo's their last Undone operation. If no operation can be redone,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1608,7 +1608,15 @@ namespace System.Windows.Forms
             // the text changes.
             CommonProperties.xClearPreferredSizeCache(this);
             base.OnTextChanged(e);
+
+            if (UiaCore.UiaClientsAreListening().IsTrue())
+            {
+                RaiseAccessibilityTextChangedEvent();
+            }
         }
+
+        private protected virtual void RaiseAccessibilityTextChangedEvent()
+            => AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.Text_TextChangedEventId);
 
         /// <summary>
         ///  Returns the character nearest to the given point.


### PR DESCRIPTION
Fixes #3897

## Proposed changes

- Raise `Text_TextChangedEvent` to Narrator shows the correct blue rectangle when typing new characters in Edit controls (should work as in Win32 RichTextBox)
- Do not raise the event for RichTextBox because Win32 provides unmanaged Text pattern for it

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A user orientates on the blue rectangle when entering text, and the current behavior can be confusing. This fix implements expected behavior for all text controls as in RichTextBox

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
- Narrator doesn't show the blue rectangle correctly
![TT bug](https://user-images.githubusercontent.com/49272759/93825078-3770de00-fc6d-11ea-88c4-25affbe93919.gif)


<!-- TODO -->

### After
- The correct blue rectangle
![T](https://user-images.githubusercontent.com/49272759/93825085-3a6bce80-fc6d-11ea-9c8a-77f637d14d7e.gif)


<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- CTI
- Manual testing

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Using Narrator
<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- .Net 5.0 Version: 5.0.0-rc.1.20431.5
- Microsoft Windows [Version 10.0.19041.450]


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3969)