### PR TITLE
Cut down warnings in VS

### DIFF
--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
@@ -10,7 +10,6 @@ Imports System.IO.Pipes
 Imports System.Reflection
 Imports System.Runtime.InteropServices
 Imports System.Security
-Imports System.Security.Permissions
 Imports System.Threading
 Imports Microsoft.VisualBasic.CompilerServices
 Imports Microsoft.VisualBasic.CompilerServices.Utils
@@ -307,12 +306,8 @@ Namespace Microsoft.VisualBasic.ApplicationServices
             '(network gets created during event hookup) and we need the context in place for it to latch on to.  The WindowsFormsSynchronizationContext
             'won't otherwise get created until OnCreateMainForm() when the startup form is created and by then it is too late.
             'When the startup form gets created, WinForms is going to push our context into the previous context and then restore it when Application.Run() exits.
-#Disable Warning BC40000 ' Type or member is obsolete
-            Call New UIPermission(UIPermissionWindow.AllWindows).Assert()
             _appSyncronizationContext = AsyncOperationManager.SynchronizationContext
             AsyncOperationManager.SynchronizationContext = New Windows.Forms.WindowsFormsSynchronizationContext()
-            PermissionSet.RevertAssert() 'CLR also reverts if we throw or when we return from this function
-#Enable Warning BC40000 ' Type or member is obsolete
         End Sub
 
         ''' <summary>
@@ -513,9 +508,6 @@ Namespace Microsoft.VisualBasic.ApplicationServices
         Protected Overridable Sub OnStartupNextInstance(eventArgs As StartupNextInstanceEventArgs)
             RaiseEvent StartupNextInstance(Me, eventArgs)
             'Activate the original instance
-#Disable Warning BC40000 ' Type or member is obsolete
-            Call New UIPermission(UIPermissionWindow.SafeSubWindows Or UIPermissionWindow.SafeTopLevelWindows).Assert()
-#Enable Warning BC40000 ' Type or member is obsolete
             If eventArgs.BringToForeground = True AndAlso MainForm IsNot Nothing Then
                 If MainForm.WindowState = Windows.Forms.FormWindowState.Minimized Then
                     MainForm.WindowState = Windows.Forms.FormWindowState.Normal
@@ -641,11 +633,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
                 '       swapping the order of the two If blocks). This is to fix the issue where the main form
                 '       doesn't come to the front after the Splash screen disappears
                 If MainForm IsNot Nothing Then
-#Disable Warning BC40000 ' Type or member is obsolete
-                    Call New UIPermission(UIPermissionWindow.AllWindows).Assert()
                     MainForm.Activate()
-                    PermissionSet.RevertAssert() 'CLR also reverts if we throw or when we return from this function
-#Enable Warning BC40000 ' Type or member is obsolete
                 End If
                 If _splashScreen IsNot Nothing AndAlso Not _splashScreen.IsDisposed Then
                     Dim TheBigGoodbye As New DisposeDelegate(AddressOf _splashScreen.Dispose)
@@ -781,11 +769,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
                 If _app.ShutdownStyle = ShutdownMode.AfterMainFormCloses Then
                     MyBase.OnMainFormClosed(sender, e)
                 Else 'identify a new main form so we can keep running
-#Disable Warning BC40000 ' Type or member is obsolete
-                    Call New UIPermission(UIPermissionWindow.AllWindows).Assert()
                     Dim forms As Windows.Forms.FormCollection = Windows.Forms.Application.OpenForms
-                    PermissionSet.RevertAssert() 'CLR also reverts if we throw or when we return from this function.
-#Enable Warning BC40000 ' Type or member is obsolete
 
                     If forms.Count > 0 Then
                         'Note: Initially I used Process::MainWindowHandle to obtain an open form.  But that is bad for two reasons:

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Devices/Audio.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Devices/Audio.vb
@@ -105,7 +105,7 @@ Namespace Microsoft.VisualBasic
             ''' </summary>
             Public Sub [Stop]()
                 Dim sound As New Media.SoundPlayer()
-                InternalStop(sound)
+                sound.Stop()
             End Sub
 #Enable Warning CA1822 ' Mark members as static
 
@@ -121,7 +121,7 @@ Namespace Microsoft.VisualBasic
 
                 ' Stopping the sound ensures it's safe to dispose it. This could happen when we change the value of m_Sound below
                 If _sound IsNot Nothing Then
-                    InternalStop(_sound)
+                    _sound.Stop()
                 End If
 
                 _sound = sound
@@ -137,24 +137,6 @@ Namespace Microsoft.VisualBasic
                         Debug.Fail("Unknown AudioPlayMode")
                 End Select
 
-            End Sub
-
-            ''' <summary>
-            ''' SoundPlayer.Stop requires unmanaged code permissions. This method allows us to wrap calls to SoundPlayer.Stop
-            ''' with the appropriate Demand/Assert
-            ''' </summary>
-            ''' <param name="sound"></param>
-            Private Shared Sub InternalStop(sound As Media.SoundPlayer)
-
-                ' Stop requires unmanaged code permission. Stop demands SafeSubWindows permissions, so we don't need to do it here                     
-#Disable Warning BC40000 ' Type or member is obsolete
-                Call New Security.Permissions.SecurityPermission(System.Security.Permissions.SecurityPermissionFlag.UnmanagedCode).Assert()
-                Try
-                    sound.Stop()
-                Finally
-                    System.Security.CodeAccessPermission.RevertAssert()
-#Enable Warning BC40000 ' Type or member is obsolete
-                End Try
             End Sub
 
             ''' <summary>

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Devices/Network.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Devices/Network.vb
@@ -7,7 +7,6 @@ Option Strict On
 Imports System.ComponentModel
 Imports System.Net
 Imports System.Security
-Imports System.Security.Permissions
 Imports System.Threading
 Imports Microsoft.VisualBasic.CompilerServices
 Imports Microsoft.VisualBasic.CompilerServices.ExceptionUtils
@@ -391,12 +390,6 @@ Namespace Microsoft.VisualBasic.Devices
 
                 Dim dialog As ProgressDialog = Nothing
                 If showUI AndAlso System.Environment.UserInteractive Then
-                    ' Do UI demand here rather than waiting for form.show so that exception is thrown as early as possible
-#Disable Warning BC40000 ' Type or member is obsolete
-                    Dim UIPermission As New UIPermission(UIPermissionWindow.SafeSubWindows)
-#Enable Warning BC40000 ' Type or member is obsolete
-                    UIPermission.Demand()
-
                     dialog = New ProgressDialog With {
                         .Text = GetResourceString(SR.ProgressDialogDownloadingTitle, address.AbsolutePath),
                         .LabelText = GetResourceString(SR.ProgressDialogDownloadingLabel, address.AbsolutePath, fullFilename)

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Interaction.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Interaction.vb
@@ -45,22 +45,16 @@ Namespace Microsoft.VisualBasic
                 'free the string fields since the API manages it instead.  But its OK here because we are just passing along the memory
                 'that GetStartupInfo() allocated along to CreateProcess() which just reads the string fields.
 
-#Disable Warning BC40000 ' Type or member is obsolete
-                RuntimeHelpers.PrepareConstrainedRegions()
-#Enable Warning BC40000 ' Type or member is obsolete
-                Try
-                Finally
-                    ok = NativeMethods.CreateProcess(Nothing, PathName, Nothing, Nothing, False, NativeTypes.NORMAL_PRIORITY_CLASS, Nothing, Nothing, StartupInfo, ProcessInfo)
-                    If ok = 0 Then
-                        ErrorCode = Marshal.GetLastWin32Error()
-                    End If
-                    If ProcessInfo.hProcess <> IntPtr.Zero AndAlso ProcessInfo.hProcess <> NativeTypes.INVALID_HANDLE Then
-                        safeProcessHandle.InitialSetHandle(ProcessInfo.hProcess)
-                    End If
-                    If ProcessInfo.hThread <> IntPtr.Zero AndAlso ProcessInfo.hThread <> NativeTypes.INVALID_HANDLE Then
-                        safeThreadHandle.InitialSetHandle(ProcessInfo.hThread)
-                    End If
-                End Try
+                ok = NativeMethods.CreateProcess(Nothing, PathName, Nothing, Nothing, False, NativeTypes.NORMAL_PRIORITY_CLASS, Nothing, Nothing, StartupInfo, ProcessInfo)
+                If ok = 0 Then
+                    ErrorCode = Marshal.GetLastWin32Error()
+                End If
+                If ProcessInfo.hProcess <> IntPtr.Zero AndAlso ProcessInfo.hProcess <> NativeTypes.INVALID_HANDLE Then
+                    safeProcessHandle.InitialSetHandle(ProcessInfo.hProcess)
+                End If
+                If ProcessInfo.hThread <> IntPtr.Zero AndAlso ProcessInfo.hThread <> NativeTypes.INVALID_HANDLE Then
+                    safeThreadHandle.InitialSetHandle(ProcessInfo.hThread)
+                End If
 
                 Try
                     If (ok <> 0) Then

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Logging/FileLogTraceListener.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Logging/FileLogTraceListener.vb
@@ -8,7 +8,6 @@ Option Strict On
 Imports System.ComponentModel
 Imports System.Globalization
 Imports System.IO
-Imports System.Security.Permissions
 Imports System.Text
 Imports System.Windows.Forms
 Imports Microsoft.VisualBasic.CompilerServices
@@ -233,10 +232,6 @@ Namespace Microsoft.VisualBasic.Logging
 
                 ' We shouldn't use fields for demands so we use a local variable
                 Dim returnPath As String = _fullFileName
-#Disable Warning BC40000 ' Type or member is obsolete
-                Dim filePermission As New FileIOPermission(FileIOPermissionAccess.PathDiscovery, returnPath)
-#Enable Warning BC40000 ' Type or member is obsolete
-                filePermission.Demand()
 
                 Return returnPath
             End Get
@@ -373,10 +368,6 @@ Namespace Microsoft.VisualBasic.Logging
                 End If
 
                 Dim fileName As String = Path.GetFullPath(_customLocation)
-#Disable Warning BC40000 ' Type or member is obsolete
-                Dim filePermission As New FileIOPermission(FileIOPermissionAccess.PathDiscovery, fileName)
-#Enable Warning BC40000 ' Type or member is obsolete
-                filePermission.Demand()
                 Return fileName
             End Get
             Set(value As String)
@@ -725,12 +716,6 @@ Namespace Microsoft.VisualBasic.Logging
                             refStream = Nothing
                         Else
                             If Append Then
-                                ' We are handing off an already existing stream, so we need to make sure the caller has permissions to write to this stream
-#Disable Warning BC40000 ' Type or member is obsolete
-                                Dim filePermission As New FileIOPermission(FileIOPermissionAccess.Write, fileName)
-#Enable Warning BC40000 ' Type or member is obsolete
-                                filePermission.Demand()
-
                                 refStream.AddReference()
                                 _fullFileName = fileName
                                 Return refStream
@@ -879,11 +864,6 @@ Namespace Microsoft.VisualBasic.Logging
             Dim TotalUserSpace As Long
             Dim TotalFreeSpace As Long
 
-#Disable Warning BC40000 ' Type or member is obsolete
-            Dim discoveryPermission As New FileIOPermission(FileIOPermissionAccess.PathDiscovery, PathName)
-#Enable Warning BC40000 ' Type or member is obsolete
-            discoveryPermission.Demand()
-
             If UnsafeNativeMethods.GetDiskFreeSpaceEx(PathName, FreeUserSpace, TotalUserSpace, TotalFreeSpace) Then
                 If FreeUserSpace > -1 Then
                     Return FreeUserSpace
@@ -947,10 +927,6 @@ Namespace Microsoft.VisualBasic.Logging
         Private Sub DemandWritePermission()
             Debug.Assert(Not String.IsNullOrWhiteSpace(Path.GetDirectoryName(LogFileName)), "The log directory shouldn't be empty.")
             Dim fileName As String = Path.GetDirectoryName(LogFileName)
-#Disable Warning BC40000 ' Type or member is obsolete
-            Dim filePermission As New FileIOPermission(FileIOPermissionAccess.Write, fileName)
-#Enable Warning BC40000 ' Type or member is obsolete
-            filePermission.Demand()
         End Sub
 
         ''' <summary>

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/MyServices/ClipboardProxy.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/MyServices/ClipboardProxy.vb
@@ -9,19 +9,16 @@ Imports System.Collections.Specialized
 Imports System.ComponentModel
 Imports System.Drawing
 Imports System.IO
-Imports System.Security.Permissions
 Imports System.Windows.Forms
 
 Namespace Microsoft.VisualBasic.MyServices
 
-#Disable Warning BC40000 ' Type or member is obsolete
     ''' <summary>
     ''' A class that wraps System.Windows.Forms.Clipboard so that
     ''' a clipboard can be instanced.
     ''' </summary>
-    <EditorBrowsable(EditorBrowsableState.Never), HostProtection(Resources:=HostProtectionResource.ExternalProcessMgmt)>
+    <EditorBrowsable(EditorBrowsableState.Never)>
     Public Class ClipboardProxy
-#Enable Warning BC40000 ' Type or member is obsolete
 
         ''' <summary>
         ''' Only Allows instantiation of the class

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ExceptionCollectionTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ExceptionCollectionTests.cs
@@ -45,9 +45,9 @@ namespace System.ComponentModel.Design.Tests
             {
                 var formatter = new BinaryFormatter();
                 var collection = new ExceptionCollection(new ArrayList());
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618, SYSLIB0011 // Type or member is obsolete
                 Assert.Throws<SerializationException>(() => formatter.Serialize(stream, collection));
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618, SYSLIB0011 // Type or member is obsolete
             }
         }
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationServiceTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationServiceTests.cs
@@ -804,9 +804,9 @@ namespace System.ComponentModel.Design.Serialization.Tests
             using (var stream = new MemoryStream())
             {
                 var formatter = new BinaryFormatter();
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618, SYSLIB0011 // Type or member is obsolete
                 Assert.Throws<SerializationException>(() => formatter.Serialize(stream, store));
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618, SYSLIB0011 // Type or member is obsolete
             }
         }
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/CodeDomSerializerExceptionTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/CodeDomSerializerExceptionTests.cs
@@ -95,9 +95,9 @@ namespace System.Windows.Forms.Design.Serialization.Tests
             {
                 var formatter = new BinaryFormatter();
                 var exception = new CodeDomSerializerException("message", new CodeLinePragma("fileName.cs", 11));
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618, SYSLIB0011 // Type or member is obsolete
                 Assert.Throws<SerializationException>(() => formatter.Serialize(stream, exception));
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618, SYSLIB0011 // Type or member is obsolete
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
@@ -351,9 +351,9 @@ namespace System.Resources
 
                     using (MemoryStream ms = new MemoryStream())
                     {
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618, SYSLIB0011 // Type or member is obsolete
                         _binaryFormatter.Serialize(ms, value);
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618, SYSLIB0011 // Type or member is obsolete
                         nodeInfo.ValueData = ToBase64WrappedString(ms.ToArray());
                     }
 
@@ -390,9 +390,9 @@ namespace System.Resources
                     IFormatter formatter = _binaryFormatter;
                     if (serializedData != null && serializedData.Length > 0)
                     {
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618, SYSLIB0011 // Type or member is obsolete
                         result = formatter.Deserialize(new MemoryStream(serializedData));
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618, SYSLIB0011 // Type or member is obsolete
                         if (result is ResXNullRef)
                         {
                             result = null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.PropertyBagStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.PropertyBagStream.cs
@@ -23,9 +23,9 @@ namespace System.Windows.Forms
                 BinaryFormatter formatter = new BinaryFormatter();
                 try
                 {
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618, SYSLIB0011 // Type or member is obsolete
                     bag = (Hashtable)formatter.Deserialize(stream);
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618, SYSLIB0011 // Type or member is obsolete
                 }
                 catch
                 {
@@ -70,9 +70,9 @@ namespace System.Windows.Forms
             internal void Write(Stream stream)
             {
                 BinaryFormatter formatter = new BinaryFormatter();
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618, SYSLIB0011 // Type or member is obsolete
                 formatter.Serialize(stream, bag);
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618, SYSLIB0011 // Type or member is obsolete
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -1121,9 +1121,9 @@ namespace System.Windows.Forms
                                     byte[] bytes = Convert.FromBase64String(obj.ToString());
                                     MemoryStream stream = new MemoryStream(bytes);
                                     BinaryFormatter formatter = new BinaryFormatter();
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618, SYSLIB0011 // Type or member is obsolete
                                     props[i].SetValue(_control, formatter.Deserialize(stream));
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618, SYSLIB0011 // Type or member is obsolete
                                 }
                                 else
                                 {
@@ -1801,9 +1801,9 @@ namespace System.Windows.Forms
                             // Resource property.  Save this to the bag as a 64bit encoded string.
                             MemoryStream stream = new MemoryStream();
                             BinaryFormatter formatter = new BinaryFormatter();
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618, SYSLIB0011 // Type or member is obsolete
                             formatter.Serialize(stream, props[i].GetValue(_control));
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618, SYSLIB0011 // Type or member is obsolete
                             byte[] bytes = new byte[(int)stream.Length];
                             stream.Position = 0;
                             stream.Read(bytes, 0, bytes.Length);
@@ -2477,9 +2477,9 @@ namespace System.Windows.Forms
                     BinaryFormatter formatter = new BinaryFormatter();
                     try
                     {
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618, SYSLIB0011 // Type or member is obsolete
                         _bag = (Hashtable)formatter.Deserialize(stream);
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618, SYSLIB0011 // Type or member is obsolete
                     }
                     catch (Exception e)
                     {
@@ -2514,9 +2514,9 @@ namespace System.Windows.Forms
                 {
                     Stream stream = new DataStreamFromComStream(istream);
                     BinaryFormatter formatter = new BinaryFormatter();
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618, SYSLIB0011 // Type or member is obsolete
                     formatter.Serialize(stream, _bag);
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618, SYSLIB0011 // Type or member is obsolete
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
@@ -379,9 +379,9 @@ namespace System.Windows.Forms
                     formatter.Binder = new BitmapBinder();
                 }
                 formatter.AssemblyFormat = FormatterAssemblyStyle.Simple;
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618, SYSLIB0011 // Type or member is obsolete
                 return formatter.Deserialize(stream);
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618, SYSLIB0011 // Type or member is obsolete
             }
 
             /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
@@ -804,9 +804,9 @@ namespace System.Windows.Forms
                 formatter.Binder = new BitmapBinder();
             }
 
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618, SYSLIB0011 // Type or member is obsolete
             formatter.Serialize(stream, data);
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618, SYSLIB0011 // Type or member is obsolete
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MergePropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MergePropertyDescriptor.cs
@@ -219,11 +219,11 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 BinaryFormatter f = new BinaryFormatter();
                 MemoryStream ms = new MemoryStream();
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618, SYSLIB0011 // Type or member is obsolete
                 f.Serialize(ms, value);
                 ms.Position = 0;
                 clonedValue = f.Deserialize(ms);
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618, SYSLIB0011 // Type or member is obsolete
             }
 
             if (clonedValue != null)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
@@ -448,11 +448,11 @@ namespace System.Windows.Forms.Tests
         {
             using var stream = new MemoryStream();
             var formatter = new BinaryFormatter();
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618, SYSLIB0011 // Type or member is obsolete
             formatter.Serialize(stream, source);
             stream.Position = 0;
             return (T)formatter.Deserialize(stream);
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618, SYSLIB0011 // Type or member is obsolete
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/TableLayoutSettingsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/TableLayoutSettingsTests.cs
@@ -1784,12 +1784,12 @@ namespace System.Windows.Forms.Layout.Tests
             using (var stream = new MemoryStream())
             {
                 var formatter = new BinaryFormatter();
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618, SYSLIB0011 // Type or member is obsolete
                 formatter.Serialize(stream, settings);
                 stream.Seek(0, SeekOrigin.Begin);
 
                 TableLayoutSettings result = Assert.IsType<TableLayoutSettings>(formatter.Deserialize(stream));
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618, SYSLIB0011 // Type or member is obsolete
                 Assert.Equal(columnStyle.SizeType, ((ColumnStyle)Assert.Single(result.ColumnStyles)).SizeType);
                 Assert.Equal(columnStyle.Width, ((ColumnStyle)Assert.Single(result.ColumnStyles)).Width);
                 Assert.Equal(rowStyle.SizeType, ((RowStyle)Assert.Single(result.RowStyles)).SizeType);
@@ -1813,12 +1813,12 @@ namespace System.Windows.Forms.Layout.Tests
             using (var stream = new MemoryStream())
             {
                 var formatter = new BinaryFormatter();
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618, SYSLIB0011 // Type or member is obsolete
                 formatter.Serialize(stream, settings);
                 stream.Seek(0, SeekOrigin.Begin);
 
                 Assert.Throws<SerializationException>(() => formatter.Deserialize(stream));
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618, SYSLIB0011 // Type or member is obsolete
             }
         }
 
@@ -1833,13 +1833,13 @@ namespace System.Windows.Forms.Layout.Tests
             using (var stream = new MemoryStream())
             {
                 var formatter = new BinaryFormatter();
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618, SYSLIB0011 // Type or member is obsolete
                 formatter.Serialize(stream, settings);
 
                 stream.Seek(0, SeekOrigin.Begin);
 
                 TableLayoutSettings result = Assert.IsType<TableLayoutSettings>(formatter.Deserialize(stream));
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618, SYSLIB0011 // Type or member is obsolete
                 Assert.NotNull(result.LayoutEngine);
                 Assert.Same(result.LayoutEngine, result.LayoutEngine);
                 Assert.Throws<NullReferenceException>(() => result.ColumnCount);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupTests.cs
@@ -1319,12 +1319,12 @@ namespace System.Windows.Forms.Tests
             using (var stream = new MemoryStream())
             {
                 var formatter = new BinaryFormatter();
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618, SYSLIB0011 // Type or member is obsolete
                 formatter.Serialize(stream, group);
                 stream.Seek(0, SeekOrigin.Begin);
 
                 ListViewGroup result = Assert.IsType<ListViewGroup>(formatter.Deserialize(stream));
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618, SYSLIB0011 // Type or member is obsolete
                 Assert.Equal(group.Header, result.Header);
                 Assert.Equal(group.HeaderAlignment, result.HeaderAlignment);
                 Assert.Equal(group.Items.Cast<ListViewItem>().Select(i => i.Text), result.Items.Cast<ListViewItem>().Select(i => i.Text));

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewSubItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewSubItemTests.cs
@@ -584,12 +584,12 @@ namespace System.Windows.Forms.Tests
             using (var stream = new MemoryStream())
             {
                 var formatter = new BinaryFormatter();
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618, SYSLIB0011 // Type or member is obsolete
                 formatter.Serialize(stream, subItem);
                 stream.Seek(0, SeekOrigin.Begin);
 
                 ListViewItem.ListViewSubItem result = Assert.IsType<ListViewItem.ListViewSubItem>(formatter.Deserialize(stream));
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618, SYSLIB0011 // Type or member is obsolete
                 Assert.Equal(subItem.BackColor, result.BackColor);
                 Assert.Equal(subItem.Font, result.Font);
                 Assert.Equal(subItem.ForeColor, result.ForeColor);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/OwnerDrawPropertyBagTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/OwnerDrawPropertyBagTests.cs
@@ -117,12 +117,12 @@ namespace System.Windows.Forms.Tests
             using (var stream = new MemoryStream())
             {
                 var formatter = new BinaryFormatter();
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618, SYSLIB0011 // Type or member is obsolete
                 formatter.Serialize(stream, original);
 
                 stream.Position = 0;
                 OwnerDrawPropertyBag bag = Assert.IsType<OwnerDrawPropertyBag>(formatter.Deserialize(stream));
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618, SYSLIB0011 // Type or member is obsolete
                 Assert.Equal(Color.Blue, bag.BackColor);
                 Assert.Equal(SystemFonts.MenuFont.Name, bag.Font.Name);
                 Assert.Equal(Color.Red, bag.ForeColor);


### PR DESCRIPTION
Remove security no-ops in VB code
Add SYSLIB0011 to quiet our other analyzers for binary formatter


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/3972)