### PR TITLE
Fix VS experience

### DIFF
--- a/eng/packageContent.targets
+++ b/eng/packageContent.targets
@@ -1,38 +1,38 @@
 ﻿<Project>
 
-  <PropertyGroup>
-    <RefPackagePath Condition="'$(RefPackagePath)' == ''">ref/$(TargetFramework)</RefPackagePath>
-    <IncludePdbInPackage Condition="'$(IncludePdbInPackage)' == '' AND '$(IsFacadeAssembly)' != 'true' AND '$(DebugType)' != 'embedded'">true</IncludePdbInPackage>
-    <IncludeResourcesInPackage>true</IncludeResourcesInPackage>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(PackagePath)' == ''">
-    <PackagePath>lib/$(TargetFramework)</PackagePath>
-    <PackagePath Condition="'$(IsFacadeAssembly)' == 'true'">lib/$(TargetFramework);$(RefPackagePath)</PackagePath>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <!-- Also in global.json -->
-    <DotNetApiDocsNet50>0.0.0.1</DotNetApiDocsNet50>
-
-    <!-- 
-      The xml file should ALWAYS come from the dotnet-api-docs artifact.
-      This blob lives in Azure storage at https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/dotnet-api-docs_net5.0/
-      Instructions for updating these artifacts are at https://github.com/dotnet/winforms/blob/master/docs/intellisense.md
-    -->
-    <IntellisenseXmlDir>$(CommonLibrary_NativeInstallDir)\bin\dotnet-api-docs_net5.0\$(DotNetApiDocsNet50)\_intellisense\net-5.0\</IntellisenseXmlDir>
-    <IntellisenseXmlFileSource>$(IntellisenseXmlDir)$(AssemblyName).xml</IntellisenseXmlFileSource>
-
-    <!-- Set the xml destination (for a later step that copies files from the dotnet-api-docs to local build artifacts) -->
-    <IntellisenseXmlDest Condition="'$(ProduceReferenceAssembly)' == 'true' And '$(PackageAsRefAndLib)' != 'true'" >$([System.IO.Path]::ChangeExtension('$(TargetRefPath)', '.xml'))</IntellisenseXmlDest>
-    <IntellisenseXmlDest Condition="'$(PackageAsRefAndLib)' == 'true'" >$([System.IO.Path]::ChangeExtension('$(TargetPath)', '.xml'))</IntellisenseXmlDest>
-    <IntellisenseXmlDestDir Condition="'$(IntellisenseXmlDest)' != ''">$([System.IO.Path]::GetDirectoryName('$(IntellisenseXml)'))</IntellisenseXmlDestDir>
-
-  </PropertyGroup>
-
   <Target Name="GetPackageContent"
           DependsOnTargets="SatelliteDllsProjectOutputGroup"
           Returns="@(PackageFile)">
+
+    <PropertyGroup>
+      <RefPackagePath Condition="'$(RefPackagePath)' == ''">ref/$(TargetFramework)</RefPackagePath>
+      <IncludePdbInPackage Condition="'$(IncludePdbInPackage)' == '' AND '$(IsFacadeAssembly)' != 'true' AND '$(DebugType)' != 'embedded'">true</IncludePdbInPackage>
+      <IncludeResourcesInPackage>true</IncludeResourcesInPackage>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(PackagePath)' == ''">
+      <PackagePath>lib/$(TargetFramework)</PackagePath>
+      <PackagePath Condition="'$(IsFacadeAssembly)' == 'true'">lib/$(TargetFramework);$(RefPackagePath)</PackagePath>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <!-- Also in global.json -->
+      <DotNetApiDocsNet50>0.0.0.1</DotNetApiDocsNet50>
+
+      <!-- 
+        The xml file should ALWAYS come from the dotnet-api-docs artifact.
+        This blob lives in Azure storage at https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/dotnet-api-docs_net5.0/
+        Instructions for updating these artifacts are at https://github.com/dotnet/winforms/blob/master/docs/intellisense.md
+      -->
+      <IntellisenseXmlDir>$(CommonLibrary_NativeInstallDir)\bin\dotnet-api-docs_net5.0\$(DotNetApiDocsNet50)\_intellisense\net-5.0\</IntellisenseXmlDir>
+      <IntellisenseXmlFileSource>$(IntellisenseXmlDir)$(AssemblyName).xml</IntellisenseXmlFileSource>
+
+      <!-- Set the xml destination (for a later step that copies files from the dotnet-api-docs to local build artifacts) -->
+      <IntellisenseXmlDest Condition="'$(ProduceReferenceAssembly)' == 'true' And '$(PackageAsRefAndLib)' != 'true'" >$([System.IO.Path]::ChangeExtension('$(TargetRefPath)', '.xml'))</IntellisenseXmlDest>
+      <IntellisenseXmlDest Condition="'$(PackageAsRefAndLib)' == 'true'" >$([System.IO.Path]::ChangeExtension('$(TargetPath)', '.xml'))</IntellisenseXmlDest>
+      <IntellisenseXmlDestDir Condition="'$(IntellisenseXmlDest)' != ''">$([System.IO.Path]::GetDirectoryName('$(IntellisenseXml)'))</IntellisenseXmlDestDir>
+
+    </PropertyGroup>
 
     <!-- 
       If this file does NOT exist, and the assembly is NOT a facade assembly, this is an error. 

--- a/start-vs.cmd
+++ b/start-vs.cmd
@@ -13,6 +13,8 @@ set DOTNET_MULTILEVEL_LOOKUP=0
 :: Put our local dotnet.exe on PATH first so Visual Studio knows which one to use
 set PATH=%DOTNET_ROOT%;%PATH%
 
+call restore.cmd
+
 if not exist "%DOTNET_ROOT%\dotnet.exe" (
     echo [ERROR] .NET Core has not yet been installed. Run `%~dp0restore.cmd` to install tools
     exit /b 1


### PR DESCRIPTION
Relates to #3998

<!-- Please read CONTRIBUTING.md before submitting a pull request -->



## Proposed changes

- #3998 has regressed VS experience due to changed packageContent.targets, that no longer could resolve `$(IntellisenseXml)` variable. This prevented VS from resolving tooling and dependencies.
To fix this move all properties within `GetPackageContent` target.

- Also run `restore.cmd` before launching VS. This is required to ensure the intellisense bundle, as well as all required SDK and tooling are downloaded.
This streamlined the DevEx.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- None, infra changes

<!-- end TELL-MODE -->



## Test methodology <!-- How did you ensure quality? -->

- Cleaned repo `git clean -xfd`
- Launched VS via `start-vs.cmd` to record the issue
- Run `restore.cmd` to observe the intellisense bundle downloaded, restart VS and still observe failures to build
- Correct packageContent.targets, restart VS via the script and build the solution
- Also run `build -pack` from cli to ensure packing still works


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4007)