### PR TITLE
fix: PlaceholderText  BackColor

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
@@ -936,7 +936,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            TextRenderer.DrawText(graphics, PlaceholderText, Font, rectangle, SystemColors.GrayText, BackColor, flags);
+            TextRenderer.DrawText(graphics, PlaceholderText, Font, rectangle, SystemColors.GrayText, Enabled ? BackColor : Color.Empty, flags);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.Rendering.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.Rendering.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using System.Windows.Forms.Metafiles;
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.Tests
+{
+    public partial class TextBoxTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsFact]
+        public void TextBox_PlaceholderText_RendersBackgroundCorrectly()
+        {
+            using Form form = new Form();
+
+            // This adds a placeholder text with only whitespace so we can test the background of the placeholder text
+            using TextBox textBox = new TextBox
+            {
+                BackColor = Color.Blue,
+                Size = new Size(80, 23),
+                PlaceholderText = "                        ",
+                Enabled = false
+            };
+            form.Controls.Add(textBox);
+
+            // Force the handle creation
+            _ = form.Handle;
+            _ = textBox.Handle;
+            form.PerformLayout();
+
+            using var emf = new EmfScope();
+            DeviceContextState state = new DeviceContextState(emf);
+
+            Rectangle bounds = textBox.Bounds;
+            PaintEventArgs e = new PaintEventArgs(emf, bounds);
+            textBox.TestAccessor().Dynamic.OnPaintBackground(e);
+
+            Rectangle bitBltBounds = new Rectangle(bounds.X, bounds.Y, bounds.Width - 5, bounds.Height - 5);
+
+            emf.Validate(state,
+                Validate.BitBltValidator(
+                    bitBltBounds,
+                    State.BrushColor(Color.Blue)));
+
+            var details = emf.RecordsToString();
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -15,7 +15,7 @@ namespace System.Windows.Forms.Tests
     using Point = System.Drawing.Point;
     using Size = System.Drawing.Size;
 
-    public class TextBoxTests : IClassFixture<ThreadExceptionFixture>
+    public partial class TextBoxTests : IClassFixture<ThreadExceptionFixture>
     {
         private static int s_preferredHeight = Control.DefaultFont.Height + SystemInformation.BorderSize.Height * 4 + 3;
 


### PR DESCRIPTION
Changed the backcolor to empty of the placeholder text when the textbox is disabled.

Added a check to see if the Enabled property is true, if so the BackColor of the textbox will be used, if not Color.Empty will be used to render the placeholder text's background transparently.

Fixes #3642

## Screenshots 

### Before

![before](https://user-images.githubusercontent.com/439370/94249038-98bfd800-ff1f-11ea-8b35-8c23783a3767.png)

### After

![after](https://user-images.githubusercontent.com/439370/94248991-89d92580-ff1f-11ea-87f7-4169de3ad7e7.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4008)