### PR TITLE
Clean up Control/ComponentDesigner tests

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -436,12 +436,16 @@ namespace System.Windows.Forms.Design
                 }
 
                 _downPos = Point.Empty;
-                Control.ControlAdded -= new ControlEventHandler(OnControlAdded);
-                Control.ControlRemoved -= new ControlEventHandler(OnControlRemoved);
-                Control.ParentChanged -= new EventHandler(OnParentChanged);
-                Control.SizeChanged -= new EventHandler(OnSizeChanged);
-                Control.LocationChanged -= new EventHandler(OnLocationChanged);
-                Control.EnabledChanged -= new EventHandler(OnEnabledChanged);
+
+                if (Control != null)
+                {
+                    Control.ControlAdded -= new ControlEventHandler(OnControlAdded);
+                    Control.ControlRemoved -= new ControlEventHandler(OnControlRemoved);
+                    Control.ParentChanged -= new EventHandler(OnParentChanged);
+                    Control.SizeChanged -= new EventHandler(OnSizeChanged);
+                    Control.LocationChanged -= new EventHandler(OnLocationChanged);
+                    Control.EnabledChanged -= new EventHandler(OnEnabledChanged);
+                }
             }
 
             base.Dispose(disposing);
@@ -2009,17 +2013,20 @@ namespace System.Windows.Forms.Design
                     break;
                 case User32.WM.PAINT:
                     {
-                        // First, save off the update region and call our base class.
+#if FEATURE_OLEDRAGDROPHANDLER
                         if (OleDragDropHandler.FreezePainting)
                         {
                             User32.ValidateRect(m.HWnd, null);
                             break;
                         }
+#endif
 
                         if (Control is null)
                         {
                             break;
                         }
+
+                        // First, save off the update region and call our base class.
 
                         RECT clip = new RECT();
                         using var hrgn = new Gdi32.RegionScope(0, 0, 0, 0);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 using System.Drawing.Design;
 using System.Windows.Forms.Design.Behavior;
 
@@ -11,12 +10,13 @@ namespace System.Windows.Forms.Design
 {
     internal class OleDragDropHandler
     {
-        // This is a bit that we stuff into the DoDragDrop
-        // to indicate that the thing that is being dragged should only
-        // be allowed to be moved in the current DropTarget (e.g. parent designer).
-        // We use this for interited components that can be modified (e.g. location/size) changed
-        // but not removed from their parent.
-        //
+        // NOTE: This is only a stub of the .NET Framework OleDragDropHandler. Disabled code that interacted with
+        // this class is behind #if FEATURE_OLEDRAGDROPHANDLER
+
+        // This is a bit that we stuff into the DoDragDrop to indicate that the thing that is being dragged should
+        // only be allowed to be moved in the current DropTarget (e.g. parent designer). We use this for interited
+        // components that can be modified (e.g. location/size) changed but not removed from their parent.
+
         protected const int AllowLocalMoveOnly = 0x04000000;
         public const string CF_CODE = "CF_XMLCODE";
         public const string CF_COMPONENTTYPES = "CF_COMPONENTTYPES";

--- a/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs
@@ -13,42 +13,42 @@ namespace System.Windows.Forms.Design.Tests
         [Fact]
         public void AccessibleObjectField()
         {
-            TestControlDesigner controlDesigner = new TestControlDesigner();
+            using TestControlDesigner controlDesigner = new TestControlDesigner();
             Assert.Null(controlDesigner.GetAccessibleObjectField());
         }
 
         [Fact]
         public void BehaviorServiceProperty()
         {
-            TestControlDesigner controlDesigner = new TestControlDesigner();
+            using TestControlDesigner controlDesigner = new TestControlDesigner();
             Assert.Null(controlDesigner.GetBehaviorServiceProperty());
         }
 
         [Fact]
         public void AccessibilityObjectField()
         {
-            TestControlDesigner controlDesigner = new TestControlDesigner();
+            using TestControlDesigner controlDesigner = new TestControlDesigner();
             Assert.NotNull(controlDesigner.AccessibilityObject);
         }
 
         [Fact]
         public void EnableDragRectProperty()
         {
-            TestControlDesigner controlDesigner = new TestControlDesigner();
+            using TestControlDesigner controlDesigner = new TestControlDesigner();
             Assert.False(controlDesigner.GetEnableDragRectProperty());
         }
 
         [Fact]
         public void ParticipatesWithSnapLinesProperty()
         {
-            TestControlDesigner controlDesigner = new TestControlDesigner();
+            using TestControlDesigner controlDesigner = new TestControlDesigner();
             Assert.True(controlDesigner.ParticipatesWithSnapLines);
         }
 
         [Fact]
         public void AutoResizeHandlesProperty()
         {
-            TestControlDesigner controlDesigner = new TestControlDesigner();
+            using TestControlDesigner controlDesigner = new TestControlDesigner();
             Assert.True(controlDesigner.AutoResizeHandles = true);
             Assert.True(controlDesigner.AutoResizeHandles);
         }
@@ -56,47 +56,40 @@ namespace System.Windows.Forms.Design.Tests
         [Fact]
         public void SelectionRulesProperty()
         {
-            TestControlDesigner controlDesigner = new TestControlDesigner();
+            using TestControlDesigner controlDesigner = new TestControlDesigner();
             Assert.Equal(SelectionRules.Visible, controlDesigner.SelectionRules);
         }
 
         [Fact]
         public void InheritanceAttributeProperty()
         {
-            TestControlDesigner controlDesigner = new TestControlDesigner();
-            Assert.NotNull(controlDesigner);
-            controlDesigner.Initialize(new Button());
+            using TestControlDesigner controlDesigner = new TestControlDesigner();
+            using Button button = new Button();
+            controlDesigner.Initialize(button);
             Assert.NotNull(controlDesigner.GetInheritanceAttributeProperty());
         }
 
         [Fact]
         public void NumberOfInternalControlDesignersTest()
         {
-            TestControlDesigner controlDesigner = new TestControlDesigner();
+            using TestControlDesigner controlDesigner = new TestControlDesigner();
             Assert.Equal(0, controlDesigner.NumberOfInternalControlDesigners());
         }
 
         [Fact]
         public void BaseWndProcTest()
         {
-            TestControlDesigner controlDesigner = new TestControlDesigner();
+            using TestControlDesigner controlDesigner = new TestControlDesigner();
             Message m = default;
-            try
-            {
-                controlDesigner.BaseWndProcMethod(ref m);
-            }
-            catch (Exception ex)
-            {
-                Assert.True(false, "Expected no exception, but got: " + ex.Message);
-            }
+            controlDesigner.BaseWndProcMethod(ref m);
         }
 
         [Fact]
         public void CanBeParentedToTest()
         {
-            TestControlDesigner controlDesigner = new TestControlDesigner();
-            Assert.NotNull(controlDesigner);
-            controlDesigner.Initialize(new Button());
+            using TestControlDesigner controlDesigner = new TestControlDesigner();
+            using Button button = new Button();
+            controlDesigner.Initialize(button);
             Assert.True(controlDesigner.CanBeParentedTo(new ParentControlDesigner()));
         }
 
@@ -106,132 +99,78 @@ namespace System.Windows.Forms.Design.Tests
         [MemberData(nameof(BoolData))]
         public void EnableDragDropTest(bool val)
         {
-            TestControlDesigner controlDesigner = new TestControlDesigner();
-            try
-            {
-                controlDesigner.EnableDragDropMethod(val);
-            }
-            catch (Exception ex)
-            {
-                Assert.True(false, "Expected no exception, but got: " + ex.Message);
-            }
+            using TestControlDesigner controlDesigner = new TestControlDesigner();
+            controlDesigner.EnableDragDropMethod(val);
         }
 
         [Fact]
         public void GetHitTest()
         {
-            TestControlDesigner controlDesigner = new TestControlDesigner();
+            using TestControlDesigner controlDesigner = new TestControlDesigner();
             Assert.False(controlDesigner.GetHitTestMethod(new Drawing.Point()));
         }
 
         [Fact]
         public void HookChildControlsTest()
         {
-            TestControlDesigner controlDesigner = new TestControlDesigner();
-            Assert.NotNull(controlDesigner);
-            controlDesigner.Initialize(new Button());
-            try
-            {
-                controlDesigner.HookChildControlsMethod(new Control());
-            }
-            catch (Exception ex)
-            {
-                Assert.True(false, "Expected no exception, but got: " + ex.Message);
-            }
+            using TestControlDesigner controlDesigner = new TestControlDesigner();
+            using Button button = new Button();
+            controlDesigner.Initialize(button);
+            controlDesigner.HookChildControlsMethod(new Control());
         }
 
         [Fact]
         public void InitializeTest()
         {
-            TestControlDesigner controlDesigner = new TestControlDesigner();
-            try
-            {
-                controlDesigner.Initialize(new Button());
-            }
-            catch (Exception ex)
-            {
-                Assert.True(false, "Expected no exception, but got: " + ex.Message);
-            }
+            using TestControlDesigner controlDesigner = new TestControlDesigner();
+            using Button button = new Button();
+            controlDesigner.Initialize(button);
         }
 
         [Fact]
         public void InitializeNewComponentTest()
         {
-            TestControlDesigner controlDesigner = new TestControlDesigner();
-            Assert.NotNull(controlDesigner);
-            controlDesigner.Initialize(new Button());
-            try
-            {
-                controlDesigner.InitializeNewComponent(null);
-            }
-            catch (Exception ex)
-            {
-                Assert.True(false, "Expected no exception, but got: " + ex.Message);
-            }
+            using TestControlDesigner controlDesigner = new TestControlDesigner();
+            using Button button = new Button();
+            controlDesigner.Initialize(button);
         }
 
         [Fact]
         public void OnSetComponentDefaultsTest()
         {
-            TestControlDesigner controlDesigner = new TestControlDesigner();
-#pragma warning disable 618
-            Assert.NotNull(controlDesigner);
-            controlDesigner.Initialize(new Button());
-            try
-            {
-                controlDesigner.OnSetComponentDefaults();
-            }
-            catch (Exception ex)
-            {
-                Assert.True(false, "Expected no exception, but got: " + ex.Message);
-            }
-#pragma warning restore 618
+            using TestControlDesigner controlDesigner = new TestControlDesigner();
+            using Button button = new Button();
+            controlDesigner.Initialize(button);
+#pragma warning disable CS0618 // Type or member is obsolete
+            controlDesigner.OnSetComponentDefaults();
+#pragma warning restore CS0618
         }
 
         [Fact]
         public void OnContextMenuTest()
         {
-            TestControlDesigner controlDesigner = new TestControlDesigner();
-            try
-            {
-                controlDesigner.OnContextMenuMethod(0, 0);
-            }
-            catch (Exception ex)
-            {
-                Assert.True(false, "Expected no exception, but got: " + ex.Message);
-            }
+            using TestControlDesigner controlDesigner = new TestControlDesigner();
+            controlDesigner.OnContextMenuMethod(0, 0);
         }
 
         [Fact]
         public void OnCreateHandleTest()
         {
-            TestControlDesigner controlDesigner = new TestControlDesigner();
-            Assert.NotNull(controlDesigner);
-            controlDesigner.Initialize(new Button());
-            try
-            {
-                controlDesigner.OnCreateHandleMethod();
-            }
-            catch (Exception ex)
-            {
-                Assert.True(false, "Expected no exception, but got: " + ex.Message);
-            }
+            using TestControlDesigner controlDesigner = new TestControlDesigner();
+            using Button button = new Button();
+            controlDesigner.Initialize(button);
+            controlDesigner.OnCreateHandleMethod();
         }
 
-        [WinFormsFact(Skip = "OleDragDropHandler.FrezePainting is not implemented. See https://github.com/dotnet/winforms/issues/2400")]
+        [WinFormsFact]
         public void ControlDesigner_WndProc_InvokePaint_Success()
         {
-            var designer = new SubControlDesigner();
-            var m = new Message
+            using var designer = new ControlDesigner();
+            Message m = new Message
             {
                 Msg = (int)User32.WM.PAINT
             };
-            designer.WndProc(ref m);
-        }
-
-        private class SubControlDesigner : ControlDesigner
-        {
-            public new void WndProc(ref Message m) => base.WndProc(ref m);
+            designer.TestAccessor().Dynamic.WndProc(ref m);
         }
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ComponentDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ComponentDesignerTests.cs
@@ -5,8 +5,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Configuration;
-using System.Diagnostics;
-using System.Windows.Forms;
 using Moq;
 using Moq.Protected;
 using WinForms.Common.Tests;
@@ -19,7 +17,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_Ctor_Default()
         {
-            var designer = new SubComponentDesigner();
+            using var designer = new SubComponentDesigner();
             Assert.Empty(designer.ActionLists);
             Assert.Same(designer.ActionLists, designer.ActionLists);
             Assert.Empty(designer.AssociatedComponents);
@@ -37,36 +35,17 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_Children_GetDefault_ReturnsExpected()
         {
-            var designer = new ComponentDesigner();
+            using var designer = new ComponentDesigner();
             ITreeDesigner treeDesigner = designer;
             Assert.Empty(treeDesigner.Children);
         }
 
-        [Fact]
-        public void ComponentDesigner_Children_GetWithValidHostValidResult_ReturnsExpected()
+        private static Mock<ISite> CreateMockSiteWithDesignerHost(object designerHost)
         {
-            var mockComponent1 = new Mock<IComponent>(MockBehavior.Strict);
-            var mockComponent2 = new Mock<IComponent>(MockBehavior.Strict);
-            var mockDesigner1 = new Mock<IDesigner>(MockBehavior.Strict);
-            var mockDesigner2 = new Mock<IDesigner>(MockBehavior.Strict);
-            var designer = new CustomAssociatedComponentsComponentDesigner(new object[] { mockComponent1.Object, mockComponent2.Object });
-            ITreeDesigner treeDesigner = designer;
-            var mockDesignerHost = new Mock<IDesignerHost>(MockBehavior.Strict);
-            mockDesignerHost
-                .Setup(h => h.RootComponent)
-                .Returns<IComponent>(null);
-            mockDesignerHost
-                .Setup(h => h.GetDesigner(mockComponent1.Object))
-                .Returns(mockDesigner1.Object)
-                .Verifiable();
-            mockDesignerHost
-                .Setup(h => h.GetDesigner(mockComponent2.Object))
-                .Returns(mockDesigner2.Object)
-                .Verifiable();
             var mockSite = new Mock<ISite>(MockBehavior.Strict);
             mockSite
                 .Setup(s => s.GetService(typeof(IDesignerHost)))
-                .Returns(mockDesignerHost.Object);
+                .Returns(designerHost);
             mockSite
                 .Setup(s => s.GetService(typeof(IComponentChangeService)))
                 .Returns(null);
@@ -82,10 +61,41 @@ namespace System.ComponentModel.Design.Tests
             mockSite
                 .Setup(s => s.GetService(typeof(ITypeDescriptorFilterService)))
                 .Returns(null);
-            var component = new Component
+            mockSite
+                .SetupGet(s => s.Container)
+                .Returns((IContainer)null);
+
+            return mockSite;
+        }
+
+        [Fact]
+        public void ComponentDesigner_Children_GetWithValidHostValidResult_ReturnsExpected()
+        {
+            var mockComponent1 = new Mock<IComponent>(MockBehavior.Strict);
+            var mockComponent2 = new Mock<IComponent>(MockBehavior.Strict);
+            var mockDesigner1 = new Mock<IDesigner>(MockBehavior.Strict);
+            var mockDesigner2 = new Mock<IDesigner>(MockBehavior.Strict);
+            using var designer = new CustomAssociatedComponentsComponentDesigner(
+                new object[] { mockComponent1.Object, mockComponent2.Object });
+            ITreeDesigner treeDesigner = designer;
+            var mockDesignerHost = new Mock<IDesignerHost>(MockBehavior.Strict);
+            mockDesignerHost
+                .Setup(h => h.RootComponent)
+                .Returns<IComponent>(null);
+            mockDesignerHost
+                .Setup(h => h.GetDesigner(mockComponent1.Object))
+                .Returns(mockDesigner1.Object)
+                .Verifiable();
+            mockDesignerHost
+                .Setup(h => h.GetDesigner(mockComponent2.Object))
+                .Returns(mockDesigner2.Object)
+                .Verifiable();
+
+            using var component = new Component
             {
-                Site = mockSite.Object
+                Site = CreateMockSiteWithDesignerHost(mockDesignerHost.Object).Object
             };
+
             designer.Initialize(component);
             Assert.Equal(new object[] { mockDesigner1.Object, mockDesigner2.Object }, treeDesigner.Children);
             mockDesignerHost.Verify(h => h.GetDesigner(mockComponent1.Object), Times.Once());
@@ -103,7 +113,8 @@ namespace System.ComponentModel.Design.Tests
             var mockComponent1 = new Mock<IComponent>(MockBehavior.Strict);
             var mockComponent2 = new Mock<IComponent>(MockBehavior.Strict);
             var mockDesigner = new Mock<IDesigner>(MockBehavior.Strict);
-            var designer = new CustomAssociatedComponentsComponentDesigner(new object[] { new object(), null, mockComponent1.Object, mockComponent2.Object });
+            using var designer = new CustomAssociatedComponentsComponentDesigner(
+                new object[] { new object(), null, mockComponent1.Object, mockComponent2.Object });
             ITreeDesigner treeDesigner = designer;
             var mockDesignerHost = new Mock<IDesignerHost>(MockBehavior.Strict);
             mockDesignerHost
@@ -117,29 +128,12 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(h => h.GetDesigner(mockComponent2.Object))
                 .Returns<IDesigner>(null)
                 .Verifiable();
-            var mockSite = new Mock<ISite>(MockBehavior.Strict);
-            mockSite
-                .Setup(s => s.GetService(typeof(IDesignerHost)))
-                .Returns(mockDesignerHost.Object);
-            mockSite
-                .Setup(s => s.GetService(typeof(IComponentChangeService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IInheritanceService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IDictionaryService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IExtenderListService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(ITypeDescriptorFilterService)))
-                .Returns(null);
-            var component = new Component
+
+            using var component = new Component
             {
-                Site = mockSite.Object
+                Site = CreateMockSiteWithDesignerHost(mockDesignerHost.Object).Object
             };
+
             designer.Initialize(component);
             Assert.Equal(new object[] { mockDesigner.Object }, treeDesigner.Children);
             mockDesignerHost.Verify(h => h.GetDesigner(mockComponent1.Object), Times.Once());
@@ -164,31 +158,14 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(Children_GetInvalidService_TestData))]
         public void ComponentDesigner_Children_GetWithInvalidDesignerHost_ReturnsEmpty(ICollection associatedComponents, object host)
         {
-            var designer = new CustomAssociatedComponentsComponentDesigner(associatedComponents);
+            using var designer = new CustomAssociatedComponentsComponentDesigner(associatedComponents);
             ITreeDesigner treeDesigner = designer;
-            var mockSite = new Mock<ISite>(MockBehavior.Strict);
-            mockSite
-                .Setup(s => s.GetService(typeof(IDesignerHost)))
-                .Returns(host);
-            mockSite
-                .Setup(s => s.GetService(typeof(IComponentChangeService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IInheritanceService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IDictionaryService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IExtenderListService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(ITypeDescriptorFilterService)))
-                .Returns(null);
-            var component = new Component
+
+            using var component = new Component
             {
-                Site = mockSite.Object
+                Site = CreateMockSiteWithDesignerHost(host).Object
             };
+
             designer.Initialize(component);
             Assert.Empty(treeDesigner.Children);
         }
@@ -199,17 +176,8 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { new InheritanceAttribute(), 1, 1 };
         }
 
-        [Theory]
-        [MemberData(nameof(InheritanceAttribute_GetValidService_TestData))]
-        public void ComponentDesigner_InheritanceAttribute_GetWithValidService_ReturnsDefault(InheritanceAttribute attributeResult, int expectedCallCount1, int expectedCallCount2)
+        private static Mock<ISite> CreateMockSiteWithInheritanceService(object inheritanceService)
         {
-            var designer = new SubComponentDesigner();
-            var component = new Component();
-            var mockInheritanceService = new Mock<IInheritanceService>(MockBehavior.Strict);
-            mockInheritanceService
-                .Setup(s => s.GetInheritanceAttribute(component))
-                .Returns(attributeResult)
-                .Verifiable();
             var mockSite = new Mock<ISite>(MockBehavior.Strict);
             mockSite
                 .Setup(s => s.GetService(typeof(IDesignerHost)))
@@ -219,8 +187,7 @@ namespace System.ComponentModel.Design.Tests
                 .Returns(null);
             mockSite
                 .Setup(s => s.GetService(typeof(IInheritanceService)))
-                .Returns(mockInheritanceService.Object)
-                .Verifiable();
+                .Returns(inheritanceService);
             mockSite
                 .Setup(s => s.GetService(typeof(IDictionaryService)))
                 .Returns(null);
@@ -230,6 +197,25 @@ namespace System.ComponentModel.Design.Tests
             mockSite
                 .Setup(s => s.GetService(typeof(ITypeDescriptorFilterService)))
                 .Returns(null);
+            mockSite
+                .SetupGet(s => s.Container)
+                .Returns((IContainer)null);
+
+            return mockSite;
+        }
+
+        [Theory]
+        [MemberData(nameof(InheritanceAttribute_GetValidService_TestData))]
+        public void ComponentDesigner_InheritanceAttribute_GetWithValidService_ReturnsDefault(InheritanceAttribute attributeResult, int expectedCallCount1, int expectedCallCount2)
+        {
+            using var designer = new SubComponentDesigner();
+            using var component = new Component();
+            var mockInheritanceService = new Mock<IInheritanceService>(MockBehavior.Strict);
+            mockInheritanceService
+                .Setup(s => s.GetInheritanceAttribute(component))
+                .Returns(attributeResult)
+                .Verifiable();
+            var mockSite = CreateMockSiteWithInheritanceService(mockInheritanceService.Object);
             component.Site = mockSite.Object;
             designer.Initialize(component);
             mockSite.Verify(s => s.GetService(typeof(IInheritanceService)), Times.Exactly(expectedCallCount1));
@@ -250,31 +236,14 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(InheritanceAttribute_GetInvalidService_TestData))]
         public void ComponentDesigner_InheritanceAttribute_GetWithInvalidService_ReturnsDefault(object inheritanceService)
         {
-            var designer = new SubComponentDesigner();
-            var mockSite = new Mock<ISite>(MockBehavior.Strict);
-            mockSite
-                .Setup(s => s.GetService(typeof(IDesignerHost)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IComponentChangeService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IInheritanceService)))
-                .Returns(inheritanceService)
-                .Verifiable();
-            mockSite
-                .Setup(s => s.GetService(typeof(IDictionaryService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IExtenderListService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(ITypeDescriptorFilterService)))
-                .Returns(null);
-            var component = new Component
+            using var designer = new SubComponentDesigner();
+            var mockSite = CreateMockSiteWithInheritanceService(inheritanceService);
+
+            using var component = new Component
             {
                 Site = mockSite.Object
             };
+
             designer.Initialize(component);
             mockSite.Verify(s => s.GetService(typeof(IInheritanceService)), Times.Once());
 
@@ -297,7 +266,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(Inherited_Get_TestData))]
         public void ComponentDesigner_Inherited_Get_ReturnsExpected(InheritanceAttribute inheritanceAttribute, bool expected)
         {
-            var designer = new CustomInheritanceAttributeComponentDesigner(inheritanceAttribute);
+            using var designer = new CustomInheritanceAttributeComponentDesigner(inheritanceAttribute);
             Assert.Equal(expected, designer.Inherited);
         }
 
@@ -311,35 +280,18 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(ParentComponent_ValidService_TestData))]
         public void ComponentDesigner_ParentComponent_GetWithValidService_ReturnsExpected(Component rootComponent)
         {
-            var designer = new SubComponentDesigner();
+            using var designer = new SubComponentDesigner();
             var mockDesignerHost = new Mock<IDesignerHost>(MockBehavior.Strict);
             mockDesignerHost
                 .Setup(h => h.RootComponent)
                 .Returns(rootComponent);
-            var mockSite = new Mock<ISite>(MockBehavior.Strict);
-            mockSite
-                .Setup(s => s.GetService(typeof(IDesignerHost)))
-                .Returns(mockDesignerHost.Object);
-            mockSite
-                .Setup(s => s.GetService(typeof(IComponentChangeService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IInheritanceService)))
-                .Returns(null)
-                .Verifiable();
-            mockSite
-                .Setup(s => s.GetService(typeof(IDictionaryService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IExtenderListService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(ITypeDescriptorFilterService)))
-                .Returns(null);
-            var component = new Component
+            var mockSite = CreateMockSiteWithDesignerHost(mockDesignerHost.Object);
+
+            using var component = new Component
             {
                 Site = mockSite.Object
             };
+
             designer.Initialize(component);
             mockSite.Verify(s => s.GetService(typeof(IDesignerHost)), Times.Once());
             mockDesignerHost.Verify(h => h.RootComponent, Times.Once());
@@ -357,32 +309,13 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_ParentComponent_GetWithValidServiceRootComponentEqual_ReturnsNull()
         {
-            var designer = new SubComponentDesigner();
-            var component = new Component();
+            using var designer = new SubComponentDesigner();
+            using var component = new Component();
             var mockDesignerHost = new Mock<IDesignerHost>(MockBehavior.Strict);
             mockDesignerHost
                 .Setup(h => h.RootComponent)
                 .Returns(component);
-            var mockSite = new Mock<ISite>(MockBehavior.Strict);
-            mockSite
-                .Setup(s => s.GetService(typeof(IDesignerHost)))
-                .Returns(mockDesignerHost.Object);
-            mockSite
-                .Setup(s => s.GetService(typeof(IComponentChangeService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IInheritanceService)))
-                .Returns(null)
-                .Verifiable();
-            mockSite
-                .Setup(s => s.GetService(typeof(IDictionaryService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IExtenderListService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(ITypeDescriptorFilterService)))
-                .Returns(null);
+            var mockSite = CreateMockSiteWithDesignerHost(mockDesignerHost.Object);
             component.Site = mockSite.Object;
             designer.Initialize(component);
             mockSite.Verify(s => s.GetService(typeof(IDesignerHost)), Times.Once());
@@ -408,31 +341,14 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(ParentComponent_InvalidService_TestData))]
         public void ComponentDesigner_ParentComponent_GetWithInvalidService_ReturnsNull(object host)
         {
-            var designer = new SubComponentDesigner();
-            var mockSite = new Mock<ISite>(MockBehavior.Strict);
-            mockSite
-                .Setup(s => s.GetService(typeof(IDesignerHost)))
-                .Returns(host);
-            mockSite
-                .Setup(s => s.GetService(typeof(IComponentChangeService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IInheritanceService)))
-                .Returns(null)
-                .Verifiable();
-            mockSite
-                .Setup(s => s.GetService(typeof(IDictionaryService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IExtenderListService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(ITypeDescriptorFilterService)))
-                .Returns(null);
-            var component = new Component
+            using var designer = new SubComponentDesigner();
+            var mockSite = CreateMockSiteWithDesignerHost(host);
+
+            using var component = new Component
             {
                 Site = mockSite.Object
             };
+
             designer.Initialize(component);
             mockSite.Verify(s => s.GetService(typeof(IDesignerHost)), Times.Once());
 
@@ -448,7 +364,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(ParentComponent_ValidService_TestData))]
         public void ComponentDesigner_ITreeDesignerParent_GetWithValidService_ReturnsExpected(Component rootComponent)
         {
-            var designer = new SubComponentDesigner();
+            using var designer = new SubComponentDesigner();
             ITreeDesigner treeDesigner = designer;
             var mockDesignerHost = new Mock<IDesignerHost>(MockBehavior.Strict);
             mockDesignerHost
@@ -458,30 +374,13 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(h => h.GetDesigner(rootComponent))
                 .Returns(designer)
                 .Verifiable();
-            var mockSite = new Mock<ISite>(MockBehavior.Strict);
-            mockSite
-                .Setup(s => s.GetService(typeof(IDesignerHost)))
-                .Returns(mockDesignerHost.Object);
-            mockSite
-                .Setup(s => s.GetService(typeof(IComponentChangeService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IInheritanceService)))
-                .Returns(null)
-                .Verifiable();
-            mockSite
-                .Setup(s => s.GetService(typeof(IDictionaryService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IExtenderListService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(ITypeDescriptorFilterService)))
-                .Returns(null);
-            var component = new Component
+            var mockSite = CreateMockSiteWithDesignerHost(mockDesignerHost.Object);
+
+            using var component = new Component
             {
                 Site = mockSite.Object
             };
+
             designer.Initialize(component);
             mockSite.Verify(s => s.GetService(typeof(IDesignerHost)), Times.Once());
             mockDesignerHost.Verify(h => h.RootComponent, Times.Once());
@@ -502,33 +401,14 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_ITreeDesignerParent_GetWithValidServiceRootComponentEqual_ReturnsNull()
         {
-            var designer = new ComponentDesigner();
+            using var designer = new ComponentDesigner();
             ITreeDesigner treeDesigner = designer;
-            var component = new Component();
+            using var component = new Component();
             var mockDesignerHost = new Mock<IDesignerHost>(MockBehavior.Strict);
             mockDesignerHost
                 .Setup(h => h.RootComponent)
                 .Returns(component);
-            var mockSite = new Mock<ISite>(MockBehavior.Strict);
-            mockSite
-                .Setup(s => s.GetService(typeof(IDesignerHost)))
-                .Returns(mockDesignerHost.Object);
-            mockSite
-                .Setup(s => s.GetService(typeof(IComponentChangeService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IInheritanceService)))
-                .Returns(null)
-                .Verifiable();
-            mockSite
-                .Setup(s => s.GetService(typeof(IDictionaryService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IExtenderListService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(ITypeDescriptorFilterService)))
-                .Returns(null);
+            var mockSite = CreateMockSiteWithDesignerHost(mockDesignerHost.Object);
             component.Site = mockSite.Object;
             designer.Initialize(component);
             mockSite.Verify(s => s.GetService(typeof(IDesignerHost)), Times.Once());
@@ -548,32 +428,15 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(ParentComponent_InvalidService_TestData))]
         public void ComponentDesigner_ITreeDesignerParent_GetWithInvalidServiceFirstCall_ReturnsNull(object host)
         {
-            var designer = new SubComponentDesigner();
+            using var designer = new SubComponentDesigner();
             ITreeDesigner treeDesigner = designer;
-            var mockSite = new Mock<ISite>(MockBehavior.Strict);
-            mockSite
-                .Setup(s => s.GetService(typeof(IDesignerHost)))
-                .Returns(host);
-            mockSite
-                .Setup(s => s.GetService(typeof(IComponentChangeService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IInheritanceService)))
-                .Returns(null)
-                .Verifiable();
-            mockSite
-                .Setup(s => s.GetService(typeof(IDictionaryService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IExtenderListService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(ITypeDescriptorFilterService)))
-                .Returns(null);
-            var component = new Component
+            var mockSite = CreateMockSiteWithDesignerHost(host);
+
+            using var component = new Component
             {
                 Site = mockSite.Object
             };
+
             designer.Initialize(component);
             mockSite.Verify(s => s.GetService(typeof(IDesignerHost)), Times.Once());
 
@@ -589,7 +452,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(ParentComponent_InvalidService_TestData))]
         public void ComponentDesigner_ITreeDesignerParent_GetWithInvalidServiceSecondCall_ReturnsNull(object host)
         {
-            var designer = new SubComponentDesigner();
+            using var designer = new SubComponentDesigner();
             ITreeDesigner treeDesigner = designer;
             var mockDesignerHost = new Mock<IDesignerHost>(MockBehavior.Strict);
             mockDesignerHost
@@ -627,10 +490,15 @@ namespace System.ComponentModel.Design.Tests
             mockSite
                 .Setup(s => s.GetService(typeof(ITypeDescriptorFilterService)))
                 .Returns(null);
-            var component = new Component
+            mockSite
+                .SetupGet(s => s.Container)
+                .Returns((IContainer)null);
+
+            using var component = new Component
             {
                 Site = mockSite.Object
             };
+
             designer.Initialize(component);
             mockSite.Verify(s => s.GetService(typeof(IDesignerHost)), Times.Once());
 
@@ -645,7 +513,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_Dispose_InvokeWithComponent_Success()
         {
-            var designer = new ComponentDesigner();
+            using var designer = new ComponentDesigner();
             var mockComponent = new Mock<IComponent>(MockBehavior.Strict);
             mockComponent
                 .Setup(c => c.Site)
@@ -673,11 +541,8 @@ namespace System.ComponentModel.Design.Tests
             yield return new object[] { new Mock<IComponentChangeService>(MockBehavior.Strict).Object };
         }
 
-        [Theory]
-        [MemberData(nameof(Dispose_InvokeWithComponentChangeService_TestData))]
-        public void ComponentDesigner_Dispose_InvokeWithComponentChangeService_Success(object componentChangeService)
+        private static Mock<ISite> CreateMockSiteWithComponentChangeService(object componentChangeService)
         {
-            var designer = new ComponentDesigner();
             var mockSite = new Mock<ISite>(MockBehavior.Strict);
             mockSite
                 .Setup(s => s.GetService(typeof(IDesignerHost)))
@@ -697,9 +562,21 @@ namespace System.ComponentModel.Design.Tests
             mockSite
                 .Setup(s => s.GetService(typeof(ITypeDescriptorFilterService)))
                 .Returns(null);
-            var component = new Component
+            mockSite
+                .SetupGet(s => s.Container)
+                .Returns((IContainer)null);
+
+            return mockSite;
+        }
+
+        [Theory]
+        [MemberData(nameof(Dispose_InvokeWithComponentChangeService_TestData))]
+        public void ComponentDesigner_Dispose_InvokeWithComponentChangeService_Success(object componentChangeService)
+        {
+            using var designer = new ComponentDesigner();
+            using var component = new Component
             {
-                Site = mockSite.Object
+                Site = CreateMockSiteWithComponentChangeService(componentChangeService).Object
             };
             designer.Initialize(component);
             Assert.Same(component, designer.Component);
@@ -715,7 +592,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_Dispose_InvokeWithoutComponent_Success()
         {
-            var designer = new ComponentDesigner();
+            using var designer = new ComponentDesigner();
             designer.Dispose();
             Assert.Null(designer.Component);
 
@@ -728,7 +605,7 @@ namespace System.ComponentModel.Design.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void ComponentDesigner_Dispose_InvokeBoolWithComponent_Success(bool disposing)
         {
-            var designer = new SubComponentDesigner();
+            using var designer = new SubComponentDesigner();
             var mockComponent = new Mock<IComponent>(MockBehavior.Strict);
             mockComponent
                 .Setup(c => c.Site)
@@ -763,29 +640,10 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(Dispose_InvokeBoolWithComponentChangeService_TestData))]
         public void ComponentDesigner_Dispose_InvokeBoolWithComponentChangeService_Success(object componentChangeService, bool disposing)
         {
-            var designer = new SubComponentDesigner();
-            var mockSite = new Mock<ISite>(MockBehavior.Strict);
-            mockSite
-                .Setup(s => s.GetService(typeof(IDesignerHost)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IComponentChangeService)))
-                .Returns(componentChangeService);
-            mockSite
-                .Setup(s => s.GetService(typeof(IInheritanceService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IDictionaryService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IExtenderListService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(ITypeDescriptorFilterService)))
-                .Returns(null);
-            var component = new Component
+            using var designer = new SubComponentDesigner();
+            using var component = new Component
             {
-                Site = mockSite.Object
+                Site = CreateMockSiteWithComponentChangeService(componentChangeService).Object
             };
             designer.Initialize(component);
             Assert.Same(component, designer.Component);
@@ -802,7 +660,7 @@ namespace System.ComponentModel.Design.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void ComponentDesigner_Dispose_InvokeBoolWithoutComponent_Success(bool disposing)
         {
-            var designer = new SubComponentDesigner();
+            using var designer = new SubComponentDesigner();
             designer.Dispose(disposing);
             Assert.Null(designer.Component);
 
@@ -814,7 +672,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_DoDefaultAction_InvokeDefault_Nop()
         {
-            var designer = new ComponentDesigner();
+            using var designer = new ComponentDesigner();
             designer.DoDefaultAction();
 
             // Call again.
@@ -848,16 +706,16 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(DoDefaultAction_ValidProperty_TestData))]
         public void ComponentDesigner_DoDefaultAction_InvokeWithComponentWithHostValidProperty_Success(string property, ICollection compatibleMethods, int expectedSetCallCount, string uniqueMethodName)
         {
-            var designer = new ComponentDesigner();
-            var component1 = new DefaultEventComponent
+            using var designer = new ComponentDesigner();
+            using var component1 = new DefaultEventComponent
             {
                 StringProperty = "StringValue"
             };
-            var component2 = new DefaultEventComponent
+            using var component2 = new DefaultEventComponent
             {
                 StringProperty = string.Empty
             };
-            var component3 = new DefaultEventComponent
+            using var component3 = new DefaultEventComponent
             {
                 StringProperty = null
             };
@@ -913,7 +771,10 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(s => s.GetService(typeof(ISelectionService)))
                 .Returns(mockSelectionService.Object)
                 .Verifiable();
-            var rootComponent = new Component
+            mockSite
+                .SetupGet(s => s.Container)
+                .Returns((IContainer)null);
+            using var rootComponent = new Component
             {
                 Site = mockSite.Object
             };
@@ -966,8 +827,8 @@ namespace System.ComponentModel.Design.Tests
         [InlineData("name", "name", 1)]
         public void ComponentDesigner_DoDefaultAction_InvokeWithRootComponent_CallsShowCode(string value, string uniqueName, int expectedCallCount)
         {
-            var designer = new ComponentDesigner();
-            var component = new DefaultEventComponent
+            using var designer = new ComponentDesigner();
+            using var component = new DefaultEventComponent
             {
                 StringProperty = value
             };
@@ -1028,6 +889,9 @@ namespace System.ComponentModel.Design.Tests
             mockSite
                 .Setup(s => s.Name)
                 .Returns("Name");
+            mockSite
+                .SetupGet(s => s.Container)
+                .Returns((IContainer)null);
             component.Site = mockSite.Object;
             designer.Initialize(component);
             component.StringPropertySetCount = 0;
@@ -1061,16 +925,16 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(DoDefaultAction_ValidProperty_TestData))]
         public void ComponentDesigner_DoDefaultAction_InvokeWithComponentWithHostValidPropertyWithTransaction_Success(string property, ICollection compatibleMethods, int expectedSetCallCount, string uniqueMethodName)
         {
-            var designer = new ComponentDesigner();
-            var component1 = new DefaultEventComponent
+            using var designer = new ComponentDesigner();
+            using var component1 = new DefaultEventComponent
             {
                 StringProperty = "StringValue"
             };
-            var component2 = new DefaultEventComponent
+            using var component2 = new DefaultEventComponent
             {
                 StringProperty = string.Empty
             };
-            var component3 = new DefaultEventComponent
+            using var component3 = new DefaultEventComponent
             {
                 StringProperty = null
             };
@@ -1131,10 +995,15 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(s => s.GetService(typeof(ISelectionService)))
                 .Returns(mockSelectionService.Object)
                 .Verifiable();
-            var rootComponent = new Component
+            mockSite
+                .SetupGet(s => s.Container)
+                .Returns((IContainer)null);
+
+            using var rootComponent = new Component
             {
                 Site = mockSite.Object
             };
+
             designer.Initialize(rootComponent);
             component1.StringPropertySetCount = 0;
             component2.StringPropertySetCount = 0;
@@ -1185,8 +1054,8 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_DoDefaultAction_InvokeWithCanceledThrowingCreateTransaction_Success()
         {
-            var designer = new ComponentDesigner();
-            var component = new DefaultEventComponent
+            using var designer = new ComponentDesigner();
+            using var component = new DefaultEventComponent
             {
                 StringProperty = "StringValue"
             };
@@ -1234,10 +1103,15 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(s => s.GetService(typeof(ISelectionService)))
                 .Returns(mockSelectionService.Object)
                 .Verifiable();
-            var rootComponent = new Component
+            mockSite
+                .SetupGet(s => s.Container)
+                .Returns((IContainer)null);
+
+            using var rootComponent = new Component
             {
                 Site = mockSite.Object
             };
+
             designer.Initialize(rootComponent);
             component.StringPropertySetCount = 0;
 
@@ -1273,8 +1147,8 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(DoDefaultAction_NotCanceledException_TestData))]
         public void ComponentDesigner_DoDefaultAction_InvokeWithNotCanceledThrowingCreateTransaction_Rethrows(Exception exception)
         {
-            var designer = new ComponentDesigner();
-            var component = new DefaultEventComponent
+            using var designer = new ComponentDesigner();
+            using var component = new DefaultEventComponent
             {
                 StringProperty = "StringValue"
             };
@@ -1322,10 +1196,15 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(s => s.GetService(typeof(ISelectionService)))
                 .Returns(mockSelectionService.Object)
                 .Verifiable();
-            var rootComponent = new Component
+            mockSite
+                .SetupGet(s => s.Container)
+                .Returns((IContainer)null);
+
+            using var rootComponent = new Component
             {
                 Site = mockSite.Object
             };
+
             designer.Initialize(rootComponent);
             component.StringPropertySetCount = 0;
 
@@ -1354,8 +1233,8 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_DoDefaultAction_InvokeWithInvalidOperationExceptionThrowingCreateTransaction_Catches()
         {
-            var designer = new ComponentDesigner();
-            var component = new DefaultEventComponent
+            using var designer = new ComponentDesigner();
+            using var component = new DefaultEventComponent
             {
                 StringProperty = "StringValue"
             };
@@ -1408,7 +1287,11 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(s => s.GetService(typeof(ISelectionService)))
                 .Returns(mockSelectionService.Object)
                 .Verifiable();
-            var rootComponent = new Component
+            mockSite
+                .SetupGet(s => s.Container)
+                .Returns((IContainer)null);
+
+            using var rootComponent = new Component
             {
                 Site = mockSite.Object
             };
@@ -1440,8 +1323,8 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_DoDefaultAction_InvokeThrowsInvalidOperationException_CallsCancel()
         {
-            var designer = new ComponentDesigner();
-            var component = new DefaultEventComponent
+            using var designer = new ComponentDesigner();
+            using var component = new DefaultEventComponent
             {
                 StringProperty = "StringValue"
             };
@@ -1498,10 +1381,15 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(s => s.GetService(typeof(ISelectionService)))
                 .Returns(mockSelectionService.Object)
                 .Verifiable();
-            var rootComponent = new Component
+            mockSite
+                .SetupGet(s => s.Container)
+                .Returns((IContainer)null);
+
+            using var rootComponent = new Component
             {
                 Site = mockSite.Object
             };
+
             designer.Initialize(rootComponent);
             component.StringPropertySetCount = 0;
 
@@ -1542,8 +1430,8 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(DoDefaultAction_NonInvalidOperationException_TestData))]
         public void ComponentDesigner_DoDefaultAction_InvokeThrowsNonInvalidOperationException_CallsCommit(Exception exception)
         {
-            var designer = new ComponentDesigner();
-            var component = new DefaultEventComponent
+            using var designer = new ComponentDesigner();
+            using var component = new DefaultEventComponent
             {
                 StringProperty = "StringValue"
             };
@@ -1600,10 +1488,15 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(s => s.GetService(typeof(ISelectionService)))
                 .Returns(mockSelectionService.Object)
                 .Verifiable();
-            var rootComponent = new Component
+            mockSite
+                .SetupGet(s => s.Container)
+                .Returns((IContainer)null);
+
+            using var rootComponent = new Component
             {
                 Site = mockSite.Object
             };
+
             designer.Initialize(rootComponent);
             component.StringPropertySetCount = 0;
 
@@ -1644,8 +1537,8 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(DoDefaultAction_InvalidProperty_TestData))]
         public void ComponentDesigner_DoDefaultAction_InvokeWithComponentWithHostInvalidProperty_Success(PropertyDescriptor property)
         {
-            var designer = new ComponentDesigner();
-            var component = new DefaultEventComponent
+            using var designer = new ComponentDesigner();
+            using var component = new DefaultEventComponent
             {
                 StringProperty = "StringValue"
             };
@@ -1693,7 +1586,11 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(s => s.GetService(typeof(ISelectionService)))
                 .Returns(mockSelectionService.Object)
                 .Verifiable();
-            var rootComponent = new Component
+            mockSite
+                .SetupGet(s => s.Container)
+                .Returns((IContainer)null);
+
+            using var rootComponent = new Component
             {
                 Site = mockSite.Object
             };
@@ -1731,7 +1628,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(DoDefaultAction_InvalidSelectedComponents_TestData))]
         public void ComponentDesigner_DoDefaultAction_InvokeWithComponentWithHostInvalidSelectedComponents_Success(ICollection selectedComponents)
         {
-            var designer = new ComponentDesigner();
+            using var designer = new ComponentDesigner();
             var mockEventBindingService = new Mock<IEventBindingService>(MockBehavior.Strict);
             var mockSelectionService = new Mock<ISelectionService>(MockBehavior.Strict);
             mockSelectionService
@@ -1768,7 +1665,11 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(s => s.GetService(typeof(ISelectionService)))
                 .Returns(mockSelectionService.Object)
                 .Verifiable();
-            var rootComponent = new Component
+            mockSite
+                .SetupGet(s => s.Container)
+                .Returns((IContainer)null);
+
+            using var rootComponent = new Component
             {
                 Site = mockSite.Object
             };
@@ -1798,7 +1699,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(DoDefaultAction_InvalidEventBindingService_TestData))]
         public void ComponentDesigner_DoDefaultAction_InvokeInvalidEventBindingService_Nop(object eventBindingService)
         {
-            var designer = new ComponentDesigner();
+            using var designer = new ComponentDesigner();
             var mockSite = new Mock<ISite>(MockBehavior.Strict);
             mockSite
                 .Setup(s => s.GetService(typeof(IDesignerHost)))
@@ -1822,10 +1723,15 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(s => s.GetService(typeof(IEventBindingService)))
                 .Returns(eventBindingService)
                 .Verifiable();
-            var component = new Component
+            mockSite
+                .SetupGet(s => s.Container)
+                .Returns((IContainer)null);
+
+            using var component = new Component
             {
                 Site = mockSite.Object
             };
+
             designer.Initialize(component);
 
             designer.DoDefaultAction();
@@ -1848,7 +1754,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(DoDefaultAction_InvalidSelectionService_TestData))]
         public void ComponentDesigner_DoDefaultAction_InvokeInvalidSelectionService_Nop(object selectionService)
         {
-            var designer = new ComponentDesigner();
+            using var designer = new ComponentDesigner();
             var mockEventBindingService = new Mock<IEventBindingService>(MockBehavior.Strict);
             var mockSite = new Mock<ISite>(MockBehavior.Strict);
             mockSite
@@ -1877,7 +1783,10 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(s => s.GetService(typeof(ISelectionService)))
                 .Returns(selectionService)
                 .Verifiable();
-            var component = new Component
+            mockSite
+                .SetupGet(s => s.Container)
+                .Returns((IContainer)null);
+            using var component = new Component
             {
                 Site = mockSite.Object
             };
@@ -1905,11 +1814,11 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(DoDefaultAction_InvalidDesignerHost_TestData))]
         public void ComponentDesigner_DoDefaultAction_InvokeInvalidDesignerHost_Success(object designerHost)
         {
-            var component = new DefaultEventComponent
+            using var component = new DefaultEventComponent
             {
                 StringProperty = "StringValue"
             };
-            var designer = new ComponentDesigner();
+            using var designer = new ComponentDesigner();
             var mockEventBindingService = new Mock<IEventBindingService>(MockBehavior.Strict);
             var mockSelectionService = new Mock<ISelectionService>(MockBehavior.Strict);
             mockSelectionService
@@ -1950,7 +1859,10 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(s => s.GetService(typeof(ISelectionService)))
                 .Returns(mockSelectionService.Object)
                 .Verifiable();
-            var rootComponent = new Component
+            mockSite
+                .SetupGet(s => s.Container)
+                .Returns((IContainer)null);
+            using var rootComponent = new Component
             {
                 Site = mockSite.Object
             };
@@ -1985,7 +1897,7 @@ namespace System.ComponentModel.Design.Tests
         public void ComponentDesigner_GetService_InvokeWithComponentWithSite_ReturnsNull(Type serviceType)
         {
             var service = new object();
-            var designer = new SubComponentDesigner();
+            using var designer = new SubComponentDesigner();
             var mockSite = new Mock<ISite>(MockBehavior.Strict);
             mockSite
                 .Setup(s => s.GetService(serviceType))
@@ -2000,7 +1912,10 @@ namespace System.ComponentModel.Design.Tests
             mockSite
                 .Setup(s => s.GetService(typeof(IInheritanceService)))
                 .Returns(null);
-            var component = new Component
+            mockSite
+                .SetupGet(s => s.Container)
+                .Returns((IContainer)null);
+            using var component = new Component
             {
                 Site = mockSite.Object
             };
@@ -2014,7 +1929,7 @@ namespace System.ComponentModel.Design.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetTypeWithNullTheoryData))]
         public void ComponentDesigner_GetService_InvokeWithComponentWithoutSite_ReturnsNull(Type serviceType)
         {
-            var designer = new SubComponentDesigner();
+            using var designer = new SubComponentDesigner();
             designer.Initialize(new Component());
             Assert.Null(designer.GetService(serviceType));
         }
@@ -2023,15 +1938,15 @@ namespace System.ComponentModel.Design.Tests
         [CommonMemberData(nameof(CommonTestHelper.GetTypeWithNullTheoryData))]
         public void ComponentDesigner_GetService_InvokeWithoutComponent_ReturnsNull(Type serviceType)
         {
-            var designer = new SubComponentDesigner();
+            using var designer = new SubComponentDesigner();
             Assert.Null(designer.GetService(serviceType));
         }
 
         [Fact]
         public void ComponentDesigner_Initialize_Invoke_Success()
         {
-            var designer = new ComponentDesigner();
-            var component = new Component();
+            using var designer = new ComponentDesigner();
+            using var component = new Component();
             designer.Initialize(component);
             Assert.Same(component, designer.Component);
             Assert.Empty(designer.AssociatedComponents);
@@ -2045,8 +1960,8 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_Initialize_RootComponent_Success()
         {
-            var component = new Component();
-            var designer = new ComponentDesigner();
+            using var component = new Component();
+            using var designer = new ComponentDesigner();
             var mockDesignerHost = new Mock<IDesignerHost>(MockBehavior.Strict);
             mockDesignerHost
                 .Setup(h => h.RootComponent)
@@ -2076,6 +1991,9 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(s => s.GetService(typeof(ITypeDescriptorFilterService)))
                 .Returns(null)
                 .Verifiable();
+            mockSite
+                .SetupGet(s => s.Container)
+                .Returns((IContainer)null);
             component.Site = mockSite.Object;
 
             designer.Initialize(component);
@@ -2109,7 +2027,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(Initialize_NonRootComponent_TestData))]
         public void ComponentDesigner_Initialize_NonRootComponent_Success(object host, object componentChangeService)
         {
-            var designer = new ComponentDesigner();
+            using var designer = new ComponentDesigner();
             var mockSite = new Mock<ISite>(MockBehavior.Strict);
             mockSite
                 .Setup(s => s.GetService(typeof(IDesignerHost)))
@@ -2133,7 +2051,10 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(s => s.GetService(typeof(DesignerCommandSet)))
                 .Returns(null)
                 .Verifiable();
-            var component = new Component
+            mockSite
+                .SetupGet(s => s.Container)
+                .Returns((IContainer)null);
+            using var component = new Component
             {
                 Site = mockSite.Object
             };
@@ -2147,8 +2068,8 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_Initialize_NullInheritanceAttribute_Success()
         {
-            var designer = new CustomInheritanceAttributeComponentDesigner(null);
-            var component = new Component();
+            using var designer = new CustomInheritanceAttributeComponentDesigner(null);
+            using var component = new Component();
             designer.Initialize(component);
             Assert.Same(component, designer.Component);
             Assert.Empty(designer.AssociatedComponents);
@@ -2157,7 +2078,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_Initialize_InvokeIServiceContainerSiteWithNullDesignerCommandSet_CallsAddService()
         {
-            var designer = new ComponentDesigner();
+            using var designer = new ComponentDesigner();
             var mockSite = new Mock<ISite>(MockBehavior.Strict);
             mockSite
                 .Setup(s => s.GetService(typeof(IDesignerHost)))
@@ -2181,13 +2102,16 @@ namespace System.ComponentModel.Design.Tests
                 .Setup(s => s.GetService(typeof(DesignerCommandSet)))
                 .Returns(null)
                 .Verifiable();
+            mockSite
+                .SetupGet(s => s.Container)
+                .Returns((IContainer)null);
             DesignerCommandSet set = null;
             mockSite
                 .As<IServiceContainer>()
                 .Setup(c => c.AddService(typeof(DesignerCommandSet), It.IsAny<DesignerCommandSet>()))
                 .Callback<Type, object>((t, s) => set = Assert.IsAssignableFrom<DesignerCommandSet>(s))
                 .Verifiable();
-            var component = new Component
+            using var component = new Component
             {
                 Site = mockSite.Object
             };
@@ -2214,7 +2138,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(Initialize_NonNullDesignerCommandSet_TestData))]
         public void ComponentDesigner_Initialize_InvokeIServiceContainerSiteWithNonNullDesignerCommandSet_DoesNotCallAddService(object designerCommandSet)
         {
-            var designer = new ComponentDesigner();
+            using var designer = new ComponentDesigner();
             var mockSite = new Mock<ISite>(MockBehavior.Strict);
             mockSite
                 .Setup(s => s.GetService(typeof(IDesignerHost)))
@@ -2242,7 +2166,10 @@ namespace System.ComponentModel.Design.Tests
                 .As<IServiceContainer>()
                 .Setup(c => c.AddService(typeof(DesignerCommandSet), It.IsAny<DesignerCommandSet>()))
                 .Verifiable();
-            var component = new Component
+            mockSite
+                .SetupGet(s => s.Container)
+                .Returns((IContainer)null);
+            using var component = new Component
             {
                 Site = mockSite.Object
             };
@@ -2257,8 +2184,8 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_ParentComponent_GetWithHost_ReturnsExpected()
         {
-            var designer = new SubComponentDesigner();
-            var component = new Component();
+            using var designer = new SubComponentDesigner();
+            using var component = new Component();
             designer.Initialize(component);
         }
 
@@ -2272,7 +2199,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(IDictionary_TestData))]
         public void ComponentDesigner_InitializeExistingComponent_Invoke_ThrowsNotImplementedException(IDictionary defaultValues)
         {
-            var designer = new ComponentDesigner();
+            using var designer = new ComponentDesigner();
             Assert.Throws<NotImplementedException>(() => designer.InitializeExistingComponent(defaultValues));
         }
 
@@ -2280,7 +2207,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(IDictionary_TestData))]
         public void ComponentDesigner_InitializeNewComponent_Invoke_Nop(IDictionary defaultValues)
         {
-            var designer = new ComponentDesigner();
+            using var designer = new ComponentDesigner();
             designer.InitializeNewComponent(defaultValues);
         }
 
@@ -2288,7 +2215,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_InitializeNonDefault_Invoke_Nop()
         {
-            var designer = new ComponentDesigner();
+            using var designer = new ComponentDesigner();
             designer.InitializeNonDefault();
         }
 #pragma warning restore 0618
@@ -2296,14 +2223,14 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_InvokeGetInheritanceAttribute_InvokeNonNullToInvoke_ReturnsExpected()
         {
-            var designer = new SubComponentDesigner();
+            using var designer = new SubComponentDesigner();
             Assert.Same(designer.InheritanceAttribute, designer.InvokeGetInheritanceAttribute(designer));
         }
 
         [Fact]
         public void ComponentDesigner_InvokeGetInheritanceAttribute_InvokeNullToInvoke_ReturnsNull()
         {
-            var designer = new SubComponentDesigner();
+            using var designer = new SubComponentDesigner();
             Assert.Null(designer.InvokeGetInheritanceAttribute(null));
         }
 
@@ -2318,13 +2245,13 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_PreFilterProperties_WithComponentWithKey_Success()
         {
-            var designer = new SubComponentDesigner();
+            using var designer = new SubComponentDesigner();
             PropertyDescriptor descriptor = TypeDescriptor.GetProperties(typeof(CustomComponent))[0];
             var properties = new Dictionary<string, PropertyDescriptor>
             {
                 { "SettingsKey", descriptor }
             };
-            var component = new IPersistComponentSettingsComponent();
+            using var component = new IPersistComponentSettingsComponent();
             designer.Initialize(component);
             designer.PreFilterProperties(properties);
             PropertyDescriptor result = (PropertyDescriptor)properties["SettingsKey"];
@@ -2338,13 +2265,13 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_PreFilterProperties_WithIPersistComponentSettingsComponentWithKey_Success()
         {
-            var designer = new SubComponentDesigner();
+            using var designer = new SubComponentDesigner();
             PropertyDescriptor descriptor = TypeDescriptor.GetProperties(typeof(CustomComponent))[0];
             var properties = new Dictionary<string, PropertyDescriptor>
             {
                 { "SettingsKey", descriptor }
             };
-            var component = new IPersistComponentSettingsComponent();
+            using var component = new IPersistComponentSettingsComponent();
             designer.Initialize(component);
             designer.PreFilterProperties(properties);
             PropertyDescriptor result = (PropertyDescriptor)properties["SettingsKey"];
@@ -2359,10 +2286,10 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(PreFilterProperties_ComponentWithoutKey_TestData))]
         public void ComponentDesigner_PreFilterProperties_WithIPersistComponentSettingsComponentWithoutKey_Success(IDictionary properties)
         {
-            var designer = new SubComponentDesigner();
+            using var designer = new SubComponentDesigner();
             PropertyDescriptor descriptor = TypeDescriptor.GetProperties(typeof(CustomComponent))[0];
             object oldValue = properties?["SettingsKey"];
-            var component = new IPersistComponentSettingsComponent();
+            using var component = new IPersistComponentSettingsComponent();
             designer.Initialize(component);
             designer.PreFilterProperties(properties);
             Assert.Same(oldValue, properties?["SettingsKey"]);
@@ -2371,13 +2298,13 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_PreFilterProperties_WithNonIPersistComponentSettingsComponent_Nop()
         {
-            var designer = new SubComponentDesigner();
+            using var designer = new SubComponentDesigner();
             PropertyDescriptor descriptor = TypeDescriptor.GetProperties(typeof(CustomComponent))[0];
             var properties = new Dictionary<string, PropertyDescriptor>
             {
                 { "SettingsKey", descriptor }
             };
-            var component = new Component();
+            using var component = new Component();
             designer.Initialize(component);
             designer.PreFilterProperties(properties);
             Assert.Same(descriptor, properties["SettingsKey"]);
@@ -2387,7 +2314,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(IDictionary_TestData))]
         public void ComponentDesigner_PreFilterProperties_WithoutComponent_Nop(IDictionary properties)
         {
-            var designer = new SubComponentDesigner();
+            using var designer = new SubComponentDesigner();
             designer.PreFilterProperties(properties);
         }
 
@@ -2409,7 +2336,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(PostFilterAttributes_NoInheritanceAttribute_TestData))]
         public void ComponentDesigner_PostFilterAttributes_NoInheritanceAttribute_AddsToAttributes(InheritanceAttribute attribute, IDictionary attributes, object expected)
         {
-            var designer = new CustomInheritanceAttributeComponentDesigner(attribute);
+            using var designer = new CustomInheritanceAttributeComponentDesigner(attribute);
             designer.PostFilterAttributes(attributes);
             Assert.Same(expected, attributes?[typeof(InheritanceAttribute)]);
         }
@@ -2428,7 +2355,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(PostFilterAttributes_TestData))]
         public void ComponentDesigner_PostFilterAttributes_HasInheritanceAttributeKey_Sets(IDictionary attributes, object expected)
         {
-            var designer = new SubComponentDesigner();
+            using var designer = new SubComponentDesigner();
             designer.PostFilterAttributes(attributes);
             Assert.Same(expected, designer.InheritanceAttribute);
         }
@@ -2448,7 +2375,7 @@ namespace System.ComponentModel.Design.Tests
         {
             EventDescriptor descriptor = TypeDescriptor.GetEvents(typeof(CustomComponent))[0];
             var events = new Dictionary<object, object> { { "key1", descriptor }, { "Key2", null } };
-            var designer = new CustomInheritanceAttributeComponentDesigner(inheritanceAttribute);
+            using var designer = new CustomInheritanceAttributeComponentDesigner(inheritanceAttribute);
             designer.PostFilterEvents(events);
             if (valid)
             {
@@ -2482,7 +2409,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(PostFilterEvents_NoEvents_TestData))]
         public void ComponentDesigner_PostFilterEvents_InvokeWithoutEvents_Success(InheritanceAttribute inheritanceAttribute, IDictionary events, IDictionary expected)
         {
-            var designer = new CustomInheritanceAttributeComponentDesigner(inheritanceAttribute);
+            using var designer = new CustomInheritanceAttributeComponentDesigner(inheritanceAttribute);
             designer.PostFilterEvents(events);
             Assert.Equal(expected, events);
         }
@@ -2490,7 +2417,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_PostFilterEvents_InvokeWithInvalidEvents_ThrowsArrayTypeMismatchException()
         {
-            var designer = new CustomInheritanceAttributeComponentDesigner(InheritanceAttribute.InheritedReadOnly);
+            using var designer = new CustomInheritanceAttributeComponentDesigner(InheritanceAttribute.InheritedReadOnly);
             Assert.Throws<ArrayTypeMismatchException>(() => designer.PostFilterEvents(new Dictionary<object, object> { { "key", new object() } } ));
         }
 
@@ -2504,32 +2431,13 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(RaiseComponentChanged_TestData))]
         public void ComponentDesigner_RaiseComponentChanged_InvokeWithValidService_CallsOnOnComponentChanged(MemberDescriptor member, object oldValue, object newValue)
         {
-            var designer = new SubComponentDesigner();
-            var component = new Component();
+            using var designer = new SubComponentDesigner();
+            using var component = new Component();
             var mockComponentChangeService = new Mock<IComponentChangeService>(MockBehavior.Strict);
             mockComponentChangeService
                 .Setup(s => s.OnComponentChanged(component, member, oldValue, newValue))
                 .Verifiable();
-            var mockSite = new Mock<ISite>(MockBehavior.Strict);
-            mockSite
-                .Setup(s => s.GetService(typeof(IDesignerHost)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IComponentChangeService)))
-                .Returns(mockComponentChangeService.Object)
-                .Verifiable();
-            mockSite
-                .Setup(s => s.GetService(typeof(IInheritanceService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IDictionaryService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IExtenderListService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(ITypeDescriptorFilterService)))
-                .Returns(null);
+            var mockSite = CreateMockSiteWithComponentChangeService(mockComponentChangeService.Object);
             component.Site = mockSite.Object;
 
             designer.Initialize(component);
@@ -2552,28 +2460,9 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(RaiseComponentChanged_InvalidService_TestData))]
         public void ComponentDesigner_RaiseComponentChanged_InvokeWithInvalidService_CallsOnOnComponentChanged(object componentChangeService, MemberDescriptor member, object oldValue, object newValue)
         {
-            var designer = new SubComponentDesigner();
-            var component = new Component();
-            var mockSite = new Mock<ISite>(MockBehavior.Strict);
-            mockSite
-                .Setup(s => s.GetService(typeof(IDesignerHost)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IComponentChangeService)))
-                .Returns(componentChangeService)
-                .Verifiable();
-            mockSite
-                .Setup(s => s.GetService(typeof(IInheritanceService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IDictionaryService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IExtenderListService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(ITypeDescriptorFilterService)))
-                .Returns(null);
+            using var designer = new SubComponentDesigner();
+            using var component = new Component();
+            var mockSite = CreateMockSiteWithComponentChangeService(componentChangeService);
             component.Site = mockSite.Object;
 
             designer.Initialize(component);
@@ -2586,7 +2475,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(RaiseComponentChanged_TestData))]
         public void ComponentDesigner_RaiseComponentChanged_InvokeWithoutComponent_Nop(MemberDescriptor member, object oldValue, object newValue)
         {
-            var designer = new SubComponentDesigner();
+            using var designer = new SubComponentDesigner();
             designer.RaiseComponentChanged(member, oldValue, newValue);
         }
 
@@ -2600,32 +2489,13 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(RaiseComponentChanging_TestData))]
         public void ComponentDesigner_RaiseComponentChanging_InvokeWithValidService_CallsOnOnComponentChanged(MemberDescriptor member)
         {
-            var designer = new SubComponentDesigner();
-            var component = new Component();
+            using var designer = new SubComponentDesigner();
+            using var component = new Component();
             var mockComponentChangeService = new Mock<IComponentChangeService>(MockBehavior.Strict);
             mockComponentChangeService
                 .Setup(s => s.OnComponentChanging(component, member))
                 .Verifiable();
-            var mockSite = new Mock<ISite>(MockBehavior.Strict);
-            mockSite
-                .Setup(s => s.GetService(typeof(IDesignerHost)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IComponentChangeService)))
-                .Returns(mockComponentChangeService.Object)
-                .Verifiable();
-            mockSite
-                .Setup(s => s.GetService(typeof(IInheritanceService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IDictionaryService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IExtenderListService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(ITypeDescriptorFilterService)))
-                .Returns(null);
+            var mockSite = CreateMockSiteWithComponentChangeService(mockComponentChangeService.Object);
             component.Site = mockSite.Object;
 
             designer.Initialize(component);
@@ -2648,28 +2518,9 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(RaiseComponentChanging_InvalidService_TestData))]
         public void ComponentDesigner_RaiseComponentChanging_InvokeWithInvalidService_CallsOnOnComponentChanged(object componentChangeService, MemberDescriptor member)
         {
-            var designer = new SubComponentDesigner();
-            var component = new Component();
-            var mockSite = new Mock<ISite>(MockBehavior.Strict);
-            mockSite
-                .Setup(s => s.GetService(typeof(IDesignerHost)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IComponentChangeService)))
-                .Returns(componentChangeService)
-                .Verifiable();
-            mockSite
-                .Setup(s => s.GetService(typeof(IInheritanceService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IDictionaryService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(IExtenderListService)))
-                .Returns(null);
-            mockSite
-                .Setup(s => s.GetService(typeof(ITypeDescriptorFilterService)))
-                .Returns(null);
+            using var designer = new SubComponentDesigner();
+            using var component = new Component();
+            var mockSite = CreateMockSiteWithComponentChangeService(componentChangeService);
             component.Site = mockSite.Object;
 
             designer.Initialize(component);
@@ -2682,7 +2533,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(RaiseComponentChanging_TestData))]
         public void ComponentDesigner_RaiseComponentChanging_InvokeWithoutComponent_Nop(MemberDescriptor member)
         {
-            var designer = new SubComponentDesigner();
+            using var designer = new SubComponentDesigner();
             designer.RaiseComponentChanging(member);
         }
 
@@ -2699,7 +2550,7 @@ namespace System.ComponentModel.Design.Tests
         [InlineData("OldValue", "NewValue", "OldValue")]
         public void ComponentDesigner_OnSetComponentDefaults_InvokeWithComponentWithDefaultProperty_Nop(string oldValue, string siteName, string expectedValue)
         {
-            var designer = new ComponentDesigner();
+            using var designer = new ComponentDesigner();
             var mockSite = new Mock<ISite>(MockBehavior.Strict);
             mockSite
                 .Setup(s => s.GetService(typeof(IDesignerHost)))
@@ -2722,7 +2573,10 @@ namespace System.ComponentModel.Design.Tests
             mockSite
                 .Setup(s => s.Name)
                 .Returns(siteName);
-            var component = new StringDefaultPropertyComponent
+            mockSite
+                .SetupGet(s => s.Container)
+                .Returns((IContainer)null);
+            using var component = new StringDefaultPropertyComponent
             {
                 Site = mockSite.Object,
                 Value = oldValue
@@ -2765,7 +2619,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(OnSetComponentDefaults_InvalidComponent_TestData))]
         public void ComponentDesigner_OnSetComponentDefaults_InvokeWithInvalidComponent_Nop(Component component)
         {
-            var designer = new ComponentDesigner();
+            using var designer = new ComponentDesigner();
             designer.Initialize(component);
             designer.OnSetComponentDefaults();
         }
@@ -2773,8 +2627,8 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_OnSetComponentDefaults_InvokeWithComponentWithoutSite_Nop()
         {
-            var designer = new ComponentDesigner();
-            var component = new Component();
+            using var designer = new ComponentDesigner();
+            using var component = new Component();
             designer.Initialize(component);
             designer.OnSetComponentDefaults();
         }
@@ -2782,7 +2636,7 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_OnSetComponentDefaults_InvokeWithoutComponent_Nop()
         {
-            var designer = new ComponentDesigner();
+            using var designer = new ComponentDesigner();
             designer.OnSetComponentDefaults();
         }
 #pragma warning restore 0618
@@ -2820,14 +2674,14 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_IDesignerFilterPreFilterProperties_WithComponentWithKey_Success()
         {
-            var designer = new SubComponentDesigner();
+            using var designer = new SubComponentDesigner();
             IDesignerFilter filter = designer;
             PropertyDescriptor descriptor = TypeDescriptor.GetProperties(typeof(CustomComponent))[0];
             var properties = new Dictionary<string, PropertyDescriptor>
             {
                 { "SettingsKey", descriptor }
             };
-            var component = new IPersistComponentSettingsComponent();
+            using var component = new IPersistComponentSettingsComponent();
             designer.Initialize(component);
             filter.PreFilterProperties(properties);
             PropertyDescriptor result = (PropertyDescriptor)properties["SettingsKey"];
@@ -2841,14 +2695,14 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_IDesignerFilterPreFilterProperties_WithIPersistComponentSettingsComponentWithKey_Success()
         {
-            var designer = new SubComponentDesigner();
+            using var designer = new SubComponentDesigner();
             IDesignerFilter filter = designer;
             PropertyDescriptor descriptor = TypeDescriptor.GetProperties(typeof(CustomComponent))[0];
             var properties = new Dictionary<string, PropertyDescriptor>
             {
                 { "SettingsKey", descriptor }
             };
-            var component = new IPersistComponentSettingsComponent();
+            using var component = new IPersistComponentSettingsComponent();
             designer.Initialize(component);
             filter.PreFilterProperties(properties);
             PropertyDescriptor result = (PropertyDescriptor)properties["SettingsKey"];
@@ -2863,11 +2717,11 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(PreFilterProperties_ComponentWithoutKey_TestData))]
         public void ComponentDesigner_IDesignerFilterPreFilterProperties_WithIPersistComponentSettingsComponentWithoutKey_Success(IDictionary properties)
         {
-            var designer = new SubComponentDesigner();
+            using var designer = new SubComponentDesigner();
             IDesignerFilter filter = designer;
             PropertyDescriptor descriptor = TypeDescriptor.GetProperties(typeof(CustomComponent))[0];
             object oldValue = properties?["SettingsKey"];
-            var component = new IPersistComponentSettingsComponent();
+            using var component = new IPersistComponentSettingsComponent();
             designer.Initialize(component);
             filter.PreFilterProperties(properties);
             Assert.Same(oldValue, properties?["SettingsKey"]);
@@ -2876,14 +2730,14 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ComponentDesigner_IDesignerFilterPreFilterProperties_WithNonIPersistComponentSettingsComponent_Nop()
         {
-            var designer = new ComponentDesigner();
+            using var designer = new ComponentDesigner();
             IDesignerFilter filter = designer;
             PropertyDescriptor descriptor = TypeDescriptor.GetProperties(typeof(CustomComponent))[0];
             var properties = new Dictionary<string, PropertyDescriptor>
             {
                 { "SettingsKey", descriptor }
             };
-            var component = new Component();
+            using var component = new Component();
             designer.Initialize(component);
             filter.PreFilterProperties(properties);
             Assert.Same(descriptor, properties["SettingsKey"]);
@@ -2893,7 +2747,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(IDictionary_TestData))]
         public void ComponentDesigner_IDesignerFilterPreFilterProperties_WithoutComponent_Nop(IDictionary properties)
         {
-            var designer = new ComponentDesigner();
+            using var designer = new ComponentDesigner();
             IDesignerFilter filter = designer;
             filter.PreFilterProperties(properties);
         }
@@ -2917,7 +2771,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(PostFilterAttributes_NoInheritanceAttribute_TestData))]
         public void ComponentDesigner_IDesignerFilterPostFilterAttributes_NoInheritanceAttribute_AddsToAttributes(InheritanceAttribute attribute, IDictionary attributes, object expected)
         {
-            var designer = new CustomInheritanceAttributeComponentDesigner(attribute);
+            using var designer = new CustomInheritanceAttributeComponentDesigner(attribute);
             IDesignerFilter filter = designer;
             filter.PostFilterAttributes(attributes);
             Assert.Same(expected, attributes?[typeof(InheritanceAttribute)]);
@@ -2927,7 +2781,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(PostFilterAttributes_TestData))]
         public void ComponentDesigner_IDesignerFilterPostFilterAttributes_HasInheritanceAttributeKey_Sets(IDictionary attributes, object expected)
         {
-            var designer = new SubComponentDesigner();
+            using var designer = new SubComponentDesigner();
             IDesignerFilter filter = designer;
             filter.PostFilterAttributes(attributes);
             Assert.Same(expected, designer.InheritanceAttribute);
@@ -2958,7 +2812,7 @@ namespace System.ComponentModel.Design.Tests
         {
             EventDescriptor descriptor = TypeDescriptor.GetEvents(typeof(CustomComponent))[0];
             var events = new Dictionary<object, object> { { "key1", descriptor }, { "Key2", null } };
-            var designer = new CustomInheritanceAttributeComponentDesigner(inheritanceAttribute);
+            using var designer = new CustomInheritanceAttributeComponentDesigner(inheritanceAttribute);
             IDesignerFilter filter = designer;
             filter.PostFilterEvents(events);
             if (valid)
@@ -2979,7 +2833,7 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(PostFilterEvents_NoEvents_TestData))]
         public void ComponentDesigner_IDesignerFilterPostFilterEvents_InvokeWithoutEvents_Success(InheritanceAttribute inheritanceAttribute, IDictionary events, IDictionary expected)
         {
-            var designer = new CustomInheritanceAttributeComponentDesigner(inheritanceAttribute);
+            using var designer = new CustomInheritanceAttributeComponentDesigner(inheritanceAttribute);
             IDesignerFilter filter = designer;
             filter.PostFilterEvents(events);
             Assert.Equal(expected, events);


### PR DESCRIPTION
- Add usings for disposable objects
- Make necessary changes to mocks now that we're disposing
- Update ControlDesigner to not throw when getting WM_PAINT


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4011)