### PR TITLE
Skip VScrollBarAccessibleObject_Ctor_Default to avoid intermittent CI build fails

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/VScrollBar.VScrollBarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/VScrollBar.VScrollBarAccessibleObjectTests.cs
@@ -16,6 +16,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory(Skip = "Crash with an unexpected result. See: https://github.com/dotnet/winforms/issues/3856")]
+        [ActiveIssue("https://github.com/dotnet/winforms/issues/3856")]
         [InlineData(true, AccessibleRole.ScrollBar)]
         [InlineData(false, AccessibleRole.None)]
         public void VScrollBarAccessibleObject_Ctor_Default(bool createControl, AccessibleRole accessibleRole)

--- a/src/System.Windows.Forms/tests/UnitTests/VScrollBar.VScrollBarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/VScrollBar.VScrollBarAccessibleObjectTests.cs
@@ -15,7 +15,7 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<ArgumentNullException>(() => new VScrollBar.VScrollBarAccessibleObject(null));
         }
 
-        [WinFormsTheory]
+        [WinFormsTheory(Skip = "Crash with an unexpected result. See: https://github.com/dotnet/winforms/issues/3856")]
         [InlineData(true, AccessibleRole.ScrollBar)]
         [InlineData(false, AccessibleRole.None)]
         public void VScrollBarAccessibleObject_Ctor_Default(bool createControl, AccessibleRole accessibleRole)


### PR DESCRIPTION
Fixes #3856

## Proposed changes

- Skip the test until .Net 6.0


## Customer Impact

- No

## Regression? 

- No

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->

- Unit testing


## Test environment(s) <!-- Remove any that don't apply -->

- .Net Version: 5.0.100-rc.2.20473.8
- Microsoft Windows [Version 10.0.19041.508]

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4022)