### PR TITLE
Fixing issue that Narrator cannot focus on ListView second time

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+~override System.Windows.Forms.ListView.OnGotFocus(System.EventArgs e) -> void
 ~override System.Windows.Forms.RichTextBox.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
 ~override System.Windows.Forms.TextBox.OnKeyUp(System.Windows.Forms.KeyEventArgs e) -> void
 ~override System.Windows.Forms.TextBox.OnMouseDown(System.Windows.Forms.MouseEventArgs e) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -4752,6 +4752,15 @@ namespace System.Windows.Forms
             base.OnHandleDestroyed(e);
         }
 
+        protected override void OnGotFocus(EventArgs e)
+        {
+            base.OnGotFocus(e);
+            if (IsHandleCreated && AccessibilityObject.GetFocus() is AccessibleObject focusedAccessibleObject)
+            {
+                focusedAccessibleObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+            }
+        }
+
         /// <summary>
         ///  Fires the itemActivate event.
         /// </summary>


### PR DESCRIPTION
Fixes #4030


## Proposed changes

- added calling of "RaiseAutomationEvent" method to "OnGotFocus" method for ListViewItem that had focus. This call returns the Narrator focus (blue rectangle) back to the element;
- added unit tests

## Customer Impact
Narrator focus doesn't switches between ListView when user presses Tab button:
![4030-broken](https://user-images.githubusercontent.com/23376742/94689418-84247b00-0337-11eb-9744-c4583f9a2264.gif)
After fixing, Narrator focus works correctly:
![4030-fixed](https://user-images.githubusercontent.com/23376742/94689509-a0281c80-0337-11eb-95aa-6ab9685ca603.gif)


## Regression? 

- Yes

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->

- Manually
-  Unit tests

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core 5.0.100-rc.1.20420.14

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4037)