### PR TITLE
Adding Toggle pattern support for ListView items with checkboxes

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -4773,6 +4773,16 @@ namespace System.Windows.Forms
         protected virtual void OnItemChecked(ItemCheckedEventArgs e)
         {
             onItemChecked?.Invoke(this, e);
+
+            if (!CheckBoxes)
+            {
+                return;
+            }
+
+            ListViewItem item = e.Item;
+            UiaCore.ToggleState oldValue = item.Checked ? UiaCore.ToggleState.Off : UiaCore.ToggleState.On;
+            UiaCore.ToggleState newValue = item.Checked ? UiaCore.ToggleState.On : UiaCore.ToggleState.Off;
+            item.AccessibilityObject.RaiseAutomationPropertyChangedEvent(UiaCore.UIA.ToggleToggleStatePropertyId, oldValue, newValue);
         }
 
         protected virtual void OnItemDrag(ItemDragEventArgs e)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObject.cs
@@ -188,6 +188,11 @@ namespace System.Windows.Forms
                 }
             }
 
+            internal override UiaCore.ToggleState ToggleState
+                => _owningItem.Checked
+                    ? UiaCore.ToggleState.On
+                    : UiaCore.ToggleState.Off;
+
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
@@ -218,7 +223,8 @@ namespace System.Windows.Forms
                 if (patternId == UiaCore.UIA.ScrollItemPatternId ||
                     patternId == UiaCore.UIA.LegacyIAccessiblePatternId ||
                     patternId == UiaCore.UIA.SelectionItemPatternId ||
-                    patternId == UiaCore.UIA.InvokePatternId)
+                    patternId == UiaCore.UIA.InvokePatternId ||
+                    (patternId == UiaCore.UIA.TogglePatternId && _owningListView.CheckBoxes))
                 {
                     return true;
                 }
@@ -274,6 +280,11 @@ namespace System.Windows.Forms
                     // Since Whidbey API's should not throw an exception in places where Everett API's did not, we catch
                     // the ArgumentException and fail silently.
                 }
+            }
+
+            internal override void Toggle()
+            {
+                _owningItem.Checked = !_owningItem.Checked;
             }
         }
     }


### PR DESCRIPTION
- Fixes #4029
- Relates to PR #3963 and PR #3224

## Proposed changes

- Implement Toggle pattern for ListViewItemAccessibleObject if CheckBoxes is true
- Add on/off Narrator announcement for ListView items if CheckBoxes is true

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Now a user can hear if a ListView item is checked(on) or unchecked(off) using Narrator

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/49272759/94745939-62051a00-0384-11eb-82fc-bb6ef46701df.png)


### After
![image](https://user-images.githubusercontent.com/49272759/94745982-777a4400-0384-11eb-8568-87a6359565a6.png)


![image](https://user-images.githubusercontent.com/49272759/94746355-33d40a00-0385-11eb-90a6-03d5aea2f2db.png)




## Test methodology <!-- How did you ensure quality? -->

- Unit tests
- Manual testing

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- using Inspect and Narrator
<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- .Net Version: 5.0.0-rc.2.20472.5
- Microsoft Windows [Version 10.0.19041.508]

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4039)