### PR TITLE
Fixing issue with null BoundingRectangle property of ToolStripStatusLabel

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.ToolStripHostedControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.ToolStripHostedControlAccessibleObject.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
 using static Interop;
 
 namespace System.Windows.Forms
@@ -67,6 +68,8 @@ namespace System.Windows.Forms
                 {
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
                         return (State & AccessibleStates.Focused) == AccessibleStates.Focused;
+                    case UiaCore.UIA.IsOffscreenPropertyId:
+                        return _toolStripControlHost?.Placement != ToolStripItemPlacement.Main || Bounds.Height <= 0 || Bounds.Width <= 0;
                 }
 
                 return base.GetPropertyValue(propertyID);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.ToolStripHostedControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.ToolStripHostedControlAccessibleObject.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Drawing;
 using static Interop;
 
 namespace System.Windows.Forms
@@ -69,7 +68,7 @@ namespace System.Windows.Forms
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
                         return (State & AccessibleStates.Focused) == AccessibleStates.Focused;
                     case UiaCore.UIA.IsOffscreenPropertyId:
-                        return _toolStripControlHost?.Placement != ToolStripItemPlacement.Main || Bounds.Height <= 0 || Bounds.Width <= 0;
+                        return GetIsOffscreenPropertyValue(_toolStripControlHost?.Placement, Bounds);
                 }
 
                 return base.GetPropertyValue(propertyID);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemAccessibleObject.cs
@@ -128,7 +128,7 @@ namespace System.Windows.Forms
                     case UiaCore.UIA.IsEnabledPropertyId:
                         return _ownerItem.Enabled;
                     case UiaCore.UIA.IsOffscreenPropertyId:
-                        return _ownerItem.Placement != ToolStripItemPlacement.Main || Bounds.Height <= 0 || Bounds.Width <= 0;
+                        return GetIsOffscreenPropertyValue(_ownerItem.Placement, Bounds);
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:
                         return _ownerItem.CanSelect;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemAccessibleObject.cs
@@ -128,7 +128,7 @@ namespace System.Windows.Forms
                     case UiaCore.UIA.IsEnabledPropertyId:
                         return _ownerItem.Enabled;
                     case UiaCore.UIA.IsOffscreenPropertyId:
-                        return _ownerItem.Placement != ToolStripItemPlacement.Main;
+                        return _ownerItem.Placement != ToolStripItemPlacement.Main || Bounds.Height <= 0 || Bounds.Width <= 0;
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:
                         return _ownerItem.CanSelect;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
@@ -328,6 +328,7 @@ namespace System.Windows.Forms
                 get
                 {
                     Rectangle bounds = Owner.Bounds;
+
                     if (Owner.ParentInternal != null && Owner.ParentInternal.Visible)
                     {
                         return new Rectangle(Owner.ParentInternal.PointToScreen(bounds.Location), bounds.Size);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -3384,6 +3384,11 @@ namespace System.Windows.Forms
             return toPoint;
         }
 
+        internal static bool GetIsOffscreenPropertyValue(ToolStripItemPlacement? toolStripItemPlacement, Rectangle bounds)
+        {
+            return toolStripItemPlacement != ToolStripItemPlacement.Main || bounds.Height <= 0 || bounds.Width <= 0;
+        }
+
         internal ToolStrip RootToolStrip
         {
             get

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripProgressBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripProgressBar.cs
@@ -444,6 +444,11 @@ namespace System.Windows.Forms
 
             internal override object GetPropertyValue(UiaCore.UIA propertyID)
             {
+                if (propertyID == UiaCore.UIA.IsOffscreenPropertyId && Owner is ToolStripProgressBarControl toolStripProgressBarControl)
+                {
+                    return toolStripProgressBarControl.Owner.Placement != ToolStripItemPlacement.Main || Bounds.Height <= 0 || Bounds.Width <= 0;
+                }
+
                 return base.GetPropertyValue(propertyID);
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripProgressBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripProgressBar.cs
@@ -408,20 +408,18 @@ namespace System.Windows.Forms
 
         internal class ToolStripProgressBarControlAccessibleObject : ProgressBar.ProgressBarAccessibleObject
         {
+            private readonly ToolStripProgressBarControl _ownerToolStripProgressBarControl;
+
             public ToolStripProgressBarControlAccessibleObject(ToolStripProgressBarControl toolStripProgressBarControl) : base(toolStripProgressBarControl)
             {
+                _ownerToolStripProgressBarControl = toolStripProgressBarControl;
             }
 
             internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot
             {
                 get
                 {
-                    if (Owner is ToolStripProgressBarControl toolStripProgressBarControl)
-                    {
-                        return toolStripProgressBarControl.Owner.Owner.AccessibilityObject;
-                    }
-
-                    return base.FragmentRoot;
+                    return _ownerToolStripProgressBarControl.Owner.Owner.AccessibilityObject;
                 }
             }
 
@@ -432,11 +430,7 @@ namespace System.Windows.Forms
                     case UiaCore.NavigateDirection.Parent:
                     case UiaCore.NavigateDirection.PreviousSibling:
                     case UiaCore.NavigateDirection.NextSibling:
-                        if (Owner is ToolStripProgressBarControl toolStripProgressBarControl)
-                        {
-                            return toolStripProgressBarControl.Owner.AccessibilityObject.FragmentNavigate(direction);
-                        }
-                        break;
+                        return _ownerToolStripProgressBarControl.Owner.AccessibilityObject.FragmentNavigate(direction);
                 }
 
                 return base.FragmentNavigate(direction);
@@ -445,16 +439,9 @@ namespace System.Windows.Forms
             internal override object GetPropertyValue(UiaCore.UIA propertyID) =>
                 propertyID switch
                 {
-                    UiaCore.UIA.IsOffscreenPropertyId => GetIsOffscreenPropertyValue(),
+                    UiaCore.UIA.IsOffscreenPropertyId => GetIsOffscreenPropertyValue(_ownerToolStripProgressBarControl.Owner.Placement, Bounds),
                     _ => base.GetPropertyValue(propertyID)
                 };
-
-            private object GetIsOffscreenPropertyValue()
-            {
-                return Owner is ToolStripProgressBarControl toolStripProgressBarControl
-                    ? toolStripProgressBarControl.Owner.Placement != ToolStripItemPlacement.Main || Bounds.Height <= 0 || Bounds.Width <= 0
-                    : base.GetPropertyValue(UiaCore.UIA.IsOffscreenPropertyId);
-            }
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripProgressBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripProgressBar.cs
@@ -442,14 +442,18 @@ namespace System.Windows.Forms
                 return base.FragmentNavigate(direction);
             }
 
-            internal override object GetPropertyValue(UiaCore.UIA propertyID)
-            {
-                if (propertyID == UiaCore.UIA.IsOffscreenPropertyId && Owner is ToolStripProgressBarControl toolStripProgressBarControl)
+            internal override object GetPropertyValue(UiaCore.UIA propertyID) =>
+                propertyID switch
                 {
-                    return toolStripProgressBarControl.Owner.Placement != ToolStripItemPlacement.Main || Bounds.Height <= 0 || Bounds.Width <= 0;
-                }
+                    UiaCore.UIA.IsOffscreenPropertyId => GetIsOffscreenPropertyValue(),
+                    _ => base.GetPropertyValue(propertyID)
+                };
 
-                return base.GetPropertyValue(propertyID);
+            private object GetIsOffscreenPropertyValue()
+            {
+                return Owner is ToolStripProgressBarControl toolStripProgressBarControl
+                    ? toolStripProgressBarControl.Owner.Placement != ToolStripItemPlacement.Main || Bounds.Height <= 0 || Bounds.Width <= 0
+                    : base.GetPropertyValue(UiaCore.UIA.IsOffscreenPropertyId);
             }
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ToolStripControlHost.ToolStripHostedControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ToolStripControlHost.ToolStripHostedControlAccessibleObjectTests.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using Xunit;
+using static Interop.UiaCore;
+
+namespace System.Windows.Forms.Tests
+{
+    public class ToolStripHostedControlAccessibleObject : IClassFixture<ThreadExceptionFixture>
+    {
+        public static IEnumerable<object[]> ToolStripItemAccessibleObject_TestData()
+        {
+            return ReflectionHelper.GetPublicNotAbstractClasses<ToolStripControlHost>().Select(type => new object[] { type });
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ToolStripItemAccessibleObject_TestData))]
+        public void ToolStripHostedControlAccessibleObject_GetPropertyValue_IsOffscreenPropertyId_ReturnExpected(Type type)
+        {
+            using var toolStrip = new ToolStrip();
+            toolStrip.CreateControl();
+            using ToolStripControlHost item = ReflectionHelper.InvokePublicConstructor<ToolStripControlHost>(type);
+            item.Size = new Size(0, 0);
+            toolStrip.Items.Add(item);
+
+            AccessibleObject toolStripItemAccessibleObject = item.AccessibilityObject;
+            AccessibleObject toolStripItemControlAccessibleObject = item.Control.AccessibilityObject;
+
+            Assert.True((bool)toolStripItemAccessibleObject.GetPropertyValue(UIA.IsOffscreenPropertyId)
+                || (toolStripItemAccessibleObject.Bounds.Width > 0 && toolStripItemAccessibleObject.Bounds.Height > 0));
+
+            Assert.True((bool)toolStripItemControlAccessibleObject.GetPropertyValue(UIA.IsOffscreenPropertyId)
+                || (toolStripItemControlAccessibleObject.Bounds.Width > 0 && toolStripItemControlAccessibleObject.Bounds.Height > 0));
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ToolStripControlHost.ToolStripHostedControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ToolStripControlHost.ToolStripHostedControlAccessibleObjectTests.cs
@@ -27,14 +27,11 @@ namespace System.Windows.Forms.Tests
             item.Size = new Size(0, 0);
             toolStrip.Items.Add(item);
 
-            AccessibleObject toolStripItemAccessibleObject = item.AccessibilityObject;
-            AccessibleObject toolStripItemControlAccessibleObject = item.Control.AccessibilityObject;
-
-            Assert.True((bool)toolStripItemAccessibleObject.GetPropertyValue(UIA.IsOffscreenPropertyId)
-                || (toolStripItemAccessibleObject.Bounds.Width > 0 && toolStripItemAccessibleObject.Bounds.Height > 0));
-
-            Assert.True((bool)toolStripItemControlAccessibleObject.GetPropertyValue(UIA.IsOffscreenPropertyId)
-                || (toolStripItemControlAccessibleObject.Bounds.Width > 0 && toolStripItemControlAccessibleObject.Bounds.Height > 0));
+            Assert.True(GetIsOffscreenPropertyValue(item.AccessibilityObject));
+            Assert.True(GetIsOffscreenPropertyValue(item.Control.AccessibilityObject));
         }
+
+        private bool GetIsOffscreenPropertyValue(AccessibleObject accessibleObject) =>
+            (bool)accessibleObject.GetPropertyValue(UIA.IsOffscreenPropertyId) || (accessibleObject.Bounds.Width > 0 && accessibleObject.Bounds.Height > 0);
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ToolStripItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ToolStripItemAccessibleObjectTests.cs
@@ -107,6 +107,22 @@ namespace System.Windows.Forms.Tests
             Assert.Equal("Test Name", accessibleName);
         }
 
+        [WinFormsTheory]
+        [MemberData(nameof(ToolStripItemAccessibleObject_TestData))]
+        public void ToolStripHostedControlAccessibleObject_GetPropertyValue_IsOffscreenPropertyId_ReturnExpected(Type type)
+        {
+            using var toolStrip = new ToolStrip();
+            toolStrip.CreateControl();
+            using ToolStripItem item = ReflectionHelper.InvokePublicConstructor<ToolStripItem>(type);
+            item.Size = new Size(0, 0);
+            toolStrip.Items.Add(item);
+
+            AccessibleObject toolStripItemAccessibleObject = item.AccessibilityObject;
+
+            Assert.True((bool)toolStripItemAccessibleObject.GetPropertyValue(UIA.IsOffscreenPropertyId) ||
+                (toolStripItemAccessibleObject.Bounds.Width > 0 && toolStripItemAccessibleObject.Bounds.Height > 0));
+        }
+
         private class SubToolStripItem : ToolStripItem
         {
             public SubToolStripItem() : base()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3884


## Proposed changes
- updated implementation for IsOffscreen property. Now, in addition to the Placement of the ListViewItem, it also respects its size. In this way Inspector or Accessibility Insights see that element is not displayed and don't try to get its BoundingRectangle
- added unit tests;

## Customer Impact
Accessibility Insight show exception for Form containing a ToolStripStatusLabel with a zero size:
![92879854-fd6b3500-f43f-11ea-8954-b87da53296d2](https://user-images.githubusercontent.com/23376742/94912027-b5c05200-04af-11eb-938b-9492fee6058d.png)
After fixing, Accessibility Insight doesn't show errors:
![3884-fixed](https://user-images.githubusercontent.com/23376742/94912134-de484c00-04af-11eb-8103-b2a3cf101d2f.jpg)


## Regression? 

- No

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->

- Unit tests
- Manually

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Inspector
- Accessibility Insight 

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core 5.0.100-rc.1.20420.14

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4049)