### PR TITLE
Fix broken link in README.md for Windows Forms Projects Templates

### DIFF
--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/readme.md
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/readme.md
@@ -22,7 +22,7 @@ In the command prompt of your choice run the following command:
     ```
     > dotnet new -u
     ```
-    ![templates-check-installed](../../Documentation/images/templates-check-installed.png)
+    ![templates-check-installed](../../docs/images/templates-check-installed.png)
 
 3. Create an app from your template:
     ```

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/readme.md
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/readme.md
@@ -22,7 +22,7 @@ In the command prompt of your choice run the following command:
     ```
     > dotnet new -u
     ```
-    ![templates-check-installed](../../docs/images/templates-check-installed.png)
+    ![image](../../docs/images/templates-check-installed.png)
 
 3. Create an app from your template:
     ```


### PR DESCRIPTION
This PR fixes broken link in README.md for "Windows Forms Projects Templates" . 

Currently, the README.md has broken link in the link to template check installation:

![image](https://user-images.githubusercontent.com/8773147/94945709-49703d80-0505-11eb-8827-878f82bb2a12.png)


## Proposed changes
- only update the link 
- 
- 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- no impact
- 

## Regression? 

- No

## Risk

- No risk, as this PR is not changing codes at all

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- 
- 
- 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- <!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4051)