### PR TITLE
Correct TextBox.PlaceholderText font transparency

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.BeginPaintScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.BeginPaintScope.cs
@@ -21,7 +21,7 @@ internal static partial class Interop
         internal readonly ref struct BeginPaintScope
 #endif
         {
-            public readonly PAINTSTRUCT _paintStruct;
+            private readonly PAINTSTRUCT _paintStruct;
 
             public Gdi32.HDC HDC { get; }
             public IntPtr HWND { get; }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/BackgroundModeValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/BackgroundModeValidator.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.Metafiles
+{
+    internal class BackgroundModeValidator : IStateValidator
+    {
+        private readonly Gdi32.BKMODE _backgroundMode;
+        public BackgroundModeValidator(Gdi32.BKMODE backgroundMode) => _backgroundMode = backgroundMode;
+        public void Validate(DeviceContextState state) => Assert.Equal(_backgroundMode, state.BackgroundMode);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/State.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/State.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -12,6 +12,7 @@ namespace System.Windows.Forms.Metafiles
 {
     internal static class State
     {
+        internal static IStateValidator BackgroundMode(Gdi32.BKMODE backgroundMode) => new BackgroundModeValidator(backgroundMode);
         internal static IStateValidator Brush(Color brushColor, Gdi32.BS brushStyle)
             => new BrushValidator(brushColor, brushStyle);
         internal static IStateValidator BrushColor(Color brushColor) => new BrushColorValidator(brushColor);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
@@ -891,7 +891,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Draws the <see cref="PlaceholderText"/> in the client area of the <see cref="TextBox"/> using the default font and color.
         /// </summary>
-        private void DrawPlaceholderText(Graphics graphics)
+        private void DrawPlaceholderText(Gdi32.HDC hdc)
         {
             TextFormatFlags flags = TextFormatFlags.NoPadding | TextFormatFlags.Top |
                                     TextFormatFlags.EndEllipsis;
@@ -936,7 +936,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            TextRenderer.DrawText(graphics, PlaceholderText, Font, rectangle, SystemColors.GrayText, Color.Empty, flags);
+            TextRenderer.DrawTextInternal(hdc, PlaceholderText, Font, rectangle, SystemColors.GrayText, TextRenderer.DefaultQuality, flags);
         }
 
         /// <summary>
@@ -944,7 +944,7 @@ namespace System.Windows.Forms
         ///  to add extra functionality, but should not forget to call
         ///  base.wndProc(m); to ensure the combo continues to function properly.
         /// </summary>
-        protected override void WndProc(ref Message m)
+        protected unsafe override void WndProc(ref Message m)
         {
             switch ((User32.WM)m.Msg)
             {
@@ -959,26 +959,55 @@ namespace System.Windows.Forms
                         base.WndProc(ref m);
                     }
                     break;
+
+                case User32.WM.PAINT:
+                    {
+                        // The native control tracks its own state, so it is get into a state Where either the native control invalidates
+                        // itself, and thus blastsover the placeholder text
+                        // - or -
+                        // The placeholder text is written multiple times without being cleared first.
+                        //
+                        // To avoid either of the above we need the following operations.
+                        //
+                        // NOTE: there is still an observable flicker with this implementations. We're getting a second WM_PAINT after we
+                        // do our begin/end paint. Something is apparently invalidating the control again. Explicitly calling ValidateRect
+                        // should, in theory, prevent this second call but it clearly isn't happening.
+
+                        // Invalidate the whole control to make sure the native control doesn't make any assumptions over what it has to paint
+                        if (ShouldRenderPlaceHolderText())
+                        {
+                            User32.InvalidateRect(Handle, null, bErase: BOOL.TRUE);
+                        }
+
+                        // Let the native implementation draw the background and animate the frame
+                        base.WndProc(ref m);
+
+                        if (ShouldRenderPlaceHolderText())
+                        {
+                            // Invalidate again because the native WM_PAINT already validated everything by calling BeginPaint itself.
+                            User32.InvalidateRect(Handle, null, bErase: BOOL.TRUE);
+
+                            // Use BeginPaint instead of GetDC to prevent flicker and support print-to-image scenarios.
+                            using var paintScope = new User32.BeginPaintScope(Handle);
+                            DrawPlaceholderText(paintScope);
+
+                            User32.ValidateRect(this, null);
+                        }
+                    }
+                    break;
+
                 case User32.WM.PRINT:
                     WmPrint(ref m);
                     break;
+
                 default:
                     base.WndProc(ref m);
                     break;
             }
-
-            if (ShouldRenderPlaceHolderText(m))
-            {
-                using (Graphics g = CreateGraphics())
-                {
-                    DrawPlaceholderText(g);
-                }
-            }
         }
 
-        private bool ShouldRenderPlaceHolderText(in Message m) =>
+        private bool ShouldRenderPlaceHolderText() =>
             !string.IsNullOrEmpty(PlaceholderText) &&
-            (m.Msg == (int)User32.WM.PAINT || m.Msg == (int)User32.WM.KILLFOCUS) &&
             !GetStyle(ControlStyles.UserPaint) &&
             !Focused &&
             TextLength == 0;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
@@ -936,7 +936,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            TextRenderer.DrawText(graphics, PlaceholderText, Font, rectangle, SystemColors.GrayText, BackColor, flags);
+            TextRenderer.DrawText(graphics, PlaceholderText, Font, rectangle, SystemColors.GrayText, Color.Empty, flags);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextRenderer.cs
@@ -4,7 +4,6 @@
 
 using System.Drawing;
 using System.Drawing.Text;
-using System.Windows.Forms.Internal;
 using static Interop;
 
 namespace System.Windows.Forms
@@ -14,7 +13,7 @@ namespace System.Windows.Forms
     /// </summary>
     public static class TextRenderer
     {
-        private static readonly Gdi32.QUALITY s_defaultQuality = GetDefaultFontQuality();
+        internal static Gdi32.QUALITY DefaultQuality { get; } = GetDefaultFontQuality();
 
         internal static Size MaxSize { get; } = new Size(int.MaxValue, int.MaxValue);
 
@@ -335,7 +334,7 @@ namespace System.Windows.Forms
             }
             else
             {
-                DrawTextInternal(hdc, text, font, bounds, foreColor, s_defaultQuality, backColor, flags);
+                DrawTextInternal(hdc, text, font, bounds, foreColor, DefaultQuality, backColor, flags);
             }
         }
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MultipleControls.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MultipleControls.Designer.cs
@@ -79,6 +79,7 @@ namespace WinformsControlsTest
             this.button1.TabIndex = 1;
             this.button1.Text = "button1";
             this.button1.UseVisualStyleBackColor = true;
+            this.button1.Click += Button1_Click;
             //
             // label1
             //
@@ -114,6 +115,7 @@ namespace WinformsControlsTest
             //
             this.textBox1.Location = new System.Drawing.Point(13, 229);
             this.textBox1.Name = "textBox1";
+            this.textBox1.PlaceholderText = "Type some text here...";
             this.textBox1.Size = new System.Drawing.Size(100, 20);
             this.textBox1.TabIndex = 5;
             this.textBox1.Text = "LLLLL";

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MultipleControls.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MultipleControls.cs
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Text;
-using System.Windows.Forms;
 using System.Threading;
+using System.Windows.Forms;
 
 namespace WinformsControlsTest
 {
@@ -37,6 +33,11 @@ namespace WinformsControlsTest
         private void backgroundWorker1_ProgressChanged(object sender, ProgressChangedEventArgs e)
         {
             progressBar1.Value = e.ProgressPercentage;
+        }
+
+        private void Button1_Click(object sender, System.EventArgs e)
+        {
+            textBox1.Enabled = !textBox1.Enabled;
         }
 
         private void MenuStripScaling_Load(object sender, EventArgs e)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TextRendererTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TextRendererTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -9,6 +9,7 @@ using System.Windows.Forms.Metafiles;
 using Moq;
 using WinForms.Common.Tests;
 using Xunit;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -585,7 +586,8 @@ namespace System.Windows.Forms.Tests
                     "Acrylic",
                     bounds: null,                                   // Don't care about the bounds for this test
                     State.FontFace(SystemFonts.DefaultFont.Name),
-                    State.TextColor(Color.Blue)));
+                    State.TextColor(Color.Blue),
+                    State.BackgroundMode(Gdi32.BKMODE.TRANSPARENT)));
         }
 
         public static TheoryData<Func<IDeviceContext, Action>> TextRenderer_DrawText_DefaultBackground_RendersTransparent_TestData

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.Rendering.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.Rendering.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using System.Windows.Forms.Metafiles;
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.Tests
+{
+    public partial class TextBoxTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsFact]
+        public void TextBox_Disabled_PlaceholderText_RendersBackgroundCorrectly()
+        {
+            // Regression test for https://github.com/dotnet/winforms/issues/3706
+
+            using Form form = new Form();
+            using TextBox textBox = new TextBox
+            {
+                Size = new Size(80, 23),
+                PlaceholderText = "abc",
+                Enabled = false
+            };
+            form.Controls.Add(textBox);
+
+            // Force the handle creation
+            Assert.NotEqual(IntPtr.Zero, form.Handle);
+            Assert.NotEqual(IntPtr.Zero, textBox.Handle);
+
+            using var emf = new EmfScope();
+            DeviceContextState state = new DeviceContextState(emf);
+
+            textBox.TestAccessor().Dynamic.DrawPlaceholderText(emf.HDC);
+
+            emf.Validate(
+                state,
+                Validate.TextOut(
+                    "abc",
+                    bounds: null,                                   // Don't care about the bounds for this test
+                    State.BackgroundMode(Gdi32.BKMODE.TRANSPARENT)));
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -15,7 +15,7 @@ namespace System.Windows.Forms.Tests
     using Point = System.Drawing.Point;
     using Size = System.Drawing.Size;
 
-    public class TextBoxTests : IClassFixture<ThreadExceptionFixture>
+    public partial class TextBoxTests : IClassFixture<ThreadExceptionFixture>
     {
         private static int s_preferredHeight = Control.DefaultFont.Height + SystemInformation.BorderSize.Height * 4 + 3;
 

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.cs
@@ -334,51 +334,29 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> TextBox_ShouldRenderPlaceHolderText_TestData()
         {
             // Test PlaceholderText
-            var tb = new SubTextBox() { PlaceholderText = "", IsUserPaint = false, IsFocused = false, TextCount = 0 };
-            var msg = new Message() { Msg = (int)User32.WM.PAINT };
-            yield return new object[] { tb, msg, false };
-
-            // Test PlaceholderText
-            tb = new SubTextBox() { PlaceholderText = null, IsUserPaint = false, IsFocused = false, TextCount = 0 };
-            msg = new Message() { Msg = (int)User32.WM.PAINT };
-            yield return new object[] { tb, msg, false };
-
-            // Test Message
-            msg.Msg = (int)User32.WM.USER;
-            tb = new SubTextBox() { PlaceholderText = "Text", IsUserPaint = false, IsFocused = false, TextCount = 0 };
-            yield return new object[] { tb, msg, false };
+            yield return new object[] { null, /* isUserPaint */ false, /* isIsFocused */ false, /* textCount */ 0, /* expected */ false };
+            yield return new object[] { "", /* isUserPaint */ false, /* isIsFocused */ false, /* textCount */ 0, /* expected */ false };
 
             // Test UserPaint
-            msg.Msg = (int)User32.WM.PAINT;
-            tb = new SubTextBox() { PlaceholderText = "Text", IsUserPaint = true, IsFocused = false, TextCount = 0 };
-            yield return new object[] { tb, msg, false };
+            yield return new object[] { "Text", /* isUserPaint */ true, /* isIsFocused */ false, /* textCount */ 0, /* expected */ false };
 
             // Test Focused
-            msg.Msg = (int)User32.WM.PAINT;
-            tb = new SubTextBox() { PlaceholderText = "Text", IsUserPaint = false, IsFocused = true, TextCount = 0 };
-            yield return new object[] { tb, msg, false };
+            yield return new object[] { "Text", /* isUserPaint */ false, /* isIsFocused */ true, /* textCount */ 0, /* expected */ false };
 
             // Test TextLength
-            msg.Msg = (int)User32.WM.PAINT;
-            tb = new SubTextBox() { PlaceholderText = "Text", IsUserPaint = false, IsFocused = false, TextCount = 1 };
-            yield return new object[] { tb, msg, false };
+            yield return new object[] { "Text", /* isUserPaint */ false, /* isIsFocused */ false, /* textCount */ 1, /* expected */ false };
 
-            // Test WM_PAINT
-            tb = new SubTextBox() { PlaceholderText = "Text", IsUserPaint = false, IsFocused = false, TextCount = 0 };
-            msg.Msg = (int)User32.WM.PAINT;
-            yield return new object[] { tb, msg, true };
-
-            // Test WM_KILLFOCUS
-            tb = new SubTextBox() { PlaceholderText = "Text", IsUserPaint = false, IsFocused = false, TextCount = 0 };
-            msg.Msg = (int)User32.WM.KILLFOCUS;
-            yield return new object[] { tb, msg, true };
+            // Happy path
+            yield return new object[] { "Text", /* isUserPaint */ false, /* isIsFocused */ false, /* textCount */ 0, /* expected */ true };
         }
 
         [WinFormsTheory]
         [MemberData(nameof(TextBox_ShouldRenderPlaceHolderText_TestData))]
-        public void TextBox_ShouldRenderPlaceHolderText(TextBox textBox, Message m, bool expected)
+        public void TextBox_ShouldRenderPlaceHolderText(string text, bool isUserPaint, bool isIsFocused, int textCount, bool expected)
         {
-            bool result = textBox.TestAccessor().Dynamic.ShouldRenderPlaceHolderText(m);
+            using var textBox = new SubTextBox() { PlaceholderText = text, IsUserPaint = isUserPaint, IsFocused = isIsFocused, TextCount = textCount };
+
+            bool result = textBox.TestAccessor().Dynamic.ShouldRenderPlaceHolderText();
             Assert.Equal(expected, result);
         }
 


### PR DESCRIPTION




## Proposed changes

Whenever the `PlaceHolderText` property was set on a disabled textbox the placeholder text would be drawn with an opaque background.
Correct the text background transparency.

Fixes #3642.
Closes https://github.com/dotnet/winforms/pull/4008 as obsolete

<!-- We are in TELL-MODE the following section must be completed -->


## Screenshots <!-- Remove this section if PR does not change UI -->

Copied from https://github.com/dotnet/winforms/pull/4008

### Before

![before](https://user-images.githubusercontent.com/439370/94249038-98bfd800-ff1f-11ea-8b35-8c23783a3767.png)

### After

![after](https://user-images.githubusercontent.com/439370/94248991-89d92580-ff1f-11ea-87f7-4169de3ad7e7.png)





## Test methodology <!-- How did you ensure quality? -->

- manual
- tests

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4057)