### PR TITLE
Fix issue with announcing ExpandedCollapsedState for ComboBox in Property grid #1987

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6734,4 +6734,7 @@ Stack trace where the illegal operation occurred was:
   <data name="UpDownEditLocalizedControlTypeName" xml:space="preserve">
     <value>Edit</value>
   </data>
+  <data name="PropertyGridViewGridEntryExpandedStateDescription" xml:space="preserve">
+    <value>Expanded</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -8326,6 +8326,11 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">Nastavuje barvu popředí oblasti mřížky.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewGridEntryExpandedStateDescription">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyManagerPropDoesNotExist">
         <source>Property {0} does not exist in {1}.</source>
         <target state="translated">Vlastnost {0} v {1} neexistuje.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -8326,6 +8326,11 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">Legt die Vordergrundfarbe des Rasterbereichs fest.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewGridEntryExpandedStateDescription">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyManagerPropDoesNotExist">
         <source>Property {0} does not exist in {1}.</source>
         <target state="translated">Die Eigenschaft {0} ist nicht in {1} vorhanden.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -8326,6 +8326,11 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">Establece el color de primer plano del área de cuadrícula.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewGridEntryExpandedStateDescription">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyManagerPropDoesNotExist">
         <source>Property {0} does not exist in {1}.</source>
         <target state="translated">La propiedad {0} no existe en {1}.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -8326,6 +8326,11 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">Définit la couleur de premier plan de la grille.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewGridEntryExpandedStateDescription">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyManagerPropDoesNotExist">
         <source>Property {0} does not exist in {1}.</source>
         <target state="translated">La propriété {0} n'existe pas dans {1}.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -8326,6 +8326,11 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">Imposta il colore di primo piano per l'area della griglia.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewGridEntryExpandedStateDescription">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyManagerPropDoesNotExist">
         <source>Property {0} does not exist in {1}.</source>
         <target state="translated">La proprietà {0} non esiste in {1}.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -8326,6 +8326,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">グリッド領域の前景色です。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewGridEntryExpandedStateDescription">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyManagerPropDoesNotExist">
         <source>Property {0} does not exist in {1}.</source>
         <target state="translated">プロパティ {0} は {1} に存在しません。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -8326,6 +8326,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">표 영역의 전경색을 설정합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewGridEntryExpandedStateDescription">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyManagerPropDoesNotExist">
         <source>Property {0} does not exist in {1}.</source>
         <target state="translated">{1}에 {0} 속성이 없습니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -8326,6 +8326,11 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">Ustawia kolor pierwszego planu obszaru siatki.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewGridEntryExpandedStateDescription">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyManagerPropDoesNotExist">
         <source>Property {0} does not exist in {1}.</source>
         <target state="translated">Właściwość {0} nie istnieje w {1}.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -8326,6 +8326,11 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">Define a cor de primeiro plano da área da grade.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewGridEntryExpandedStateDescription">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyManagerPropDoesNotExist">
         <source>Property {0} does not exist in {1}.</source>
         <target state="translated">A propriedade {0} não existe em {1}.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -8327,6 +8327,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">Задает цвет переднего плана для области сетки.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewGridEntryExpandedStateDescription">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyManagerPropDoesNotExist">
         <source>Property {0} does not exist in {1}.</source>
         <target state="translated">Свойство {0} в {1} не существует.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -8326,6 +8326,11 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">Kılavuz alanının ön plan rengini ayarlar.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewGridEntryExpandedStateDescription">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyManagerPropDoesNotExist">
         <source>Property {0} does not exist in {1}.</source>
         <target state="translated">{0} özelliği {1} içinde yok.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -8326,6 +8326,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">设置网格区域的前景色。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewGridEntryExpandedStateDescription">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyManagerPropDoesNotExist">
         <source>Property {0} does not exist in {1}.</source>
         <target state="translated">{1} 中不存在属性 {0}。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -8326,6 +8326,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">設定方格區域的前景色彩。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropertyGridViewGridEntryExpandedStateDescription">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyManagerPropDoesNotExist">
         <source>Property {0} does not exist in {1}.</source>
         <target state="translated">屬性 {0} 不存在於 {1} 中。</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -1774,11 +1774,10 @@ namespace System.Windows.Forms.PropertyGridInternal
             var gridEntry = GetGridEntryFromRow(selectedRow);
             if (gridEntry != null)
             {
-                gridEntry.AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
-                gridEntry.AccessibilityObject.RaiseAutomationPropertyChangedEvent(
-                    UiaCore.UIA.ExpandCollapseExpandCollapseStatePropertyId,
-                    UiaCore.ExpandCollapseState.Collapsed,
-                    UiaCore.ExpandCollapseState.Expanded);
+                gridEntry.AccessibilityObject.InternalRaiseAutomationNotification(
+                    Automation.AutomationNotificationKind.Other,
+                    Automation.AutomationNotificationProcessing.CurrentThenMostRecent,
+                    SR.PropertyGridViewGridEntryExpandedStateDescription);
             }
 
             try


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1987

## Proposed changes

- removed RaiseAutomationEvent and RaiseAutomationPropertyChangedEvent and replaced them on a RaiseAutomationNotification

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
Due to two competing requests to the Narrator in half of the cases the narrator announces the selected option, and in the other half the ExpandedCollapsedState of the control:
![1987-issue](https://user-images.githubusercontent.com/23376742/95203022-d1e32c80-07ea-11eb-8424-67fd208aaea9.gif)
After fixing, the focus always remains on the selected item and Narrator announces selected option and ExpandedCollapsedState of control:
![1987-fixed](https://user-images.githubusercontent.com/23376742/95203058-e58e9300-07ea-11eb-952a-d3515fef4e12.gif)




## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.19041.388]
- .Net SDK 5.0.100-rc.1.20420.14

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4059)