### PR TITLE
Add focus rectangle focus to ToolStripButtons on PropertyGrid

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -2037,7 +2037,7 @@ namespace System.Windows.Forms
 
         private ToolStripButton CreatePushButton(string toolTipText, int imageIndex, EventHandler eventHandler, bool useCheckButtonRole = false)
         {
-            ToolStripButton button = new ToolStripButton
+            PropertyGridToolStripButton button = new PropertyGridToolStripButton
             {
                 Text = toolTipText,
                 AutoToolTip = true,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridToolStripButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridToolStripButton.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System.Drawing;
+
+namespace System.Windows.Forms
+{
+    internal class PropertyGridToolStripButton : ToolStripButton
+    {
+        /// <summary>
+        ///  Inheriting classes should override this method to handle this event.
+        /// </summary>
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            base.OnPaint(e);
+
+            if (Selected)
+            {
+                var bounds = ClientBounds;
+
+                // It is necessary so that when HighContrast is off, the size of the dotted borders
+                // coincides with the size of the button background
+                // For normal mode we use the "ToolStripSystemRenderer.RenderItemInternal" method
+                // which calls the "VisualStyleRenderer.DrawBackground" method for drawing
+                // For high contrast mode we use the "ToolStripHighContrastRenderer.OnRenderButtonBackground" method
+                // which calls the "Graphics.DrawRectangle" method for drawing
+                if (!SystemInformation.HighContrast)
+                {
+                    bounds.Height -= 1;
+                }
+
+                // We support only one type of settings for all borders since it is consistent with the behavior of the same controls
+                ControlPaint.DrawBorder(e.Graphics, bounds,
+                    leftColor: Color.Black, leftWidth: 1, leftStyle: ButtonBorderStyle.Dashed, // left
+                    topColor: Color.Black, topWidth: 1, topStyle: ButtonBorderStyle.Dashed, // top
+                    rightColor: Color.Black, rightWidth: 1, rightStyle: ButtonBorderStyle.Dashed, // right
+                    bottomColor: Color.Black, bottomWidth: 1, bottomStyle: ButtonBorderStyle.Dashed); // bottom;
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3659 


## Proposed changes
- added a new "DrawButtonBorder" method to the ToolStripRender for drawing a dotted border around the ToolStripButtons in the PropertyGrid
- added unit tests

## Customer Impact
Focus is not clearly visible on "Categorized", "Alphabetical" and " Property Pages" when user uses Keyboard for navigating.
![3659-issue](https://user-images.githubusercontent.com/23376742/95320055-935c7900-08a1-11eb-9bbe-8e1e4a181221.gif)
As a fix, we show a dotted border around the ToolStripButtons in the PropertyGrid
![Issue-4063](https://user-images.githubusercontent.com/23376742/99252985-f4705880-2820-11eb-9dd1-54f4d2bec74d.gif)
![Issue-4063-highcontrast](https://user-images.githubusercontent.com/23376742/99252995-f803df80-2820-11eb-848e-7fcbd0431f0b.gif)

## Regression? 

- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->

- Manual testing

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.19041.388]
- .Net SDK 5.0.100-rc.1.20420.14

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4063)