### PR TITLE
Add Rich Navigation to CI, a new Rich Nav pipeline

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,6 +9,8 @@
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet6-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6-transport/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <!-- Used for the Rich Navigation indexing task -->
+    <add key="richnav" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -22,10 +22,6 @@ stages:
         - checkout: self
           clean: true
 
-        # Build and rename binlog
-        # The /p:Coverage argument is passed here since some build properties change to accommodate running with
-        # coverage. This is part of the workarounds for https://github.com/tonerdo/coverlet/issues/362 and
-        # https://github.com/tonerdo/coverlet/issues/363.
         - script: eng\cibuild.cmd
             -restore
             -build

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -1,9 +1,5 @@
-parameters:
-  # parameters should default to values for running in the External / Public
-  # be read from a user-defined variable (Azure DevOps limitation)
-  agentPoolName: NetCorePublic-Pool
-  agentPool: 'BuildPool.Windows.10.Amd64.VS2019.Open'
-  repoName: dotnet/winforms
+trigger:
+- master
 
 stages:
 - stage: build
@@ -12,27 +8,15 @@ stages:
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
       enableMicrobuild: true
-      enablePublishBuildArtifacts: true
-      enablePublishTestResults: true
-      enablePublishBuildAssets: true
-      enablePublishUsingPipelines: true
       enableTelemetry: true
-      helixRepo: ${{ parameters.repoName }}
 
       jobs:
       - job: Windows
         enableRichCodeNavigation: true
         richCodeNavigationEnvironment: 'production'
-        _BuildConfig: Debug
         pool:
-          ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            name: NetCorePublic-Pool
-            queue: BuildPool.Windows.10.Amd64.VS2019.Open
-          ${{ if ne(variables['System.TeamProject'], 'public') }}:
-            name: NetCoreInternal-Pool
-            queue: BuildPool.Windows.10.Amd64.VS2019.Pre
-
-        variables:
+          name: NetCorePublic-Pool
+          queue: BuildPool.Windows.10.Amd64.VS2019.Open
 
         steps:
         - checkout: self
@@ -45,6 +29,6 @@ stages:
         - script: eng\cibuild.cmd
             -restore
             -build
-            -configuration $(_BuildConfig)
-            /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\BuildSrc.binlog
+            -configuration Debug
+            /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\Debug\BuildSrc.binlog
           displayName: Build

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -30,5 +30,4 @@ stages:
             -restore
             -build
             -configuration Debug
-            /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\Debug\BuildSrc.binlog
           displayName: Build

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -1,0 +1,49 @@
+parameters:
+  # parameters should default to values for running in the External / Public
+  # be read from a user-defined variable (Azure DevOps limitation)
+  agentPoolName: NetCorePublic-Pool
+  agentPool: 'BuildPool.Windows.10.Amd64.VS2019.Open'
+  repoName: dotnet/winforms
+
+stages:
+- stage: build
+  displayName: Build
+  jobs:
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      enableMicrobuild: true
+      enablePublishBuildArtifacts: true
+      enablePublishTestResults: true
+      enablePublishBuildAssets: true
+      enablePublishUsingPipelines: true
+      enableTelemetry: true
+      helixRepo: ${{ parameters.repoName }}
+
+      jobs:
+      - job: Windows
+        enableRichCodeNavigation: true
+        _BuildConfig: Debug
+        pool:
+          ${{ if eq(variables['System.TeamProject'], 'public') }}:
+            name: NetCorePublic-Pool
+            queue: BuildPool.Windows.10.Amd64.VS2019.Open
+          ${{ if ne(variables['System.TeamProject'], 'public') }}:
+            name: NetCoreInternal-Pool
+            queue: BuildPool.Windows.10.Amd64.VS2019.Pre
+
+        variables:
+
+        steps:
+        - checkout: self
+          clean: true
+
+        # Build and rename binlog
+        # The /p:Coverage argument is passed here since some build properties change to accommodate running with
+        # coverage. This is part of the workarounds for https://github.com/tonerdo/coverlet/issues/362 and
+        # https://github.com/tonerdo/coverlet/issues/363.
+        - script: eng\cibuild.cmd
+            -restore
+            -build
+            -configuration $(_BuildConfig)
+            /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\BuildSrc.binlog
+          displayName: Build

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -22,6 +22,7 @@ stages:
       jobs:
       - job: Windows
         enableRichCodeNavigation: true
+        richCodeNavigationEnvironment: 'production'
         _BuildConfig: Debug
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:

--- a/eng/ci.yml
+++ b/eng/ci.yml
@@ -70,14 +70,14 @@ stages:
             - _InternalRuntimeDownloadArgs: /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet
                 /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
 
-          # - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['_BuildConfig'], 'Debug')) }}:
-          #   enableRichCodeNavigation: true
+          - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['_BuildConfig'], 'Debug')) }}:
+            enableRichCodeNavigation: true
 
         strategy:
           matrix:
             ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
               Debug:
-                enableRichCodeNavigation: true
+                # enableRichCodeNavigation: true
                 _BuildConfig: Debug
                 # override some variables for debug
                 _PublishType: none

--- a/eng/ci.yml
+++ b/eng/ci.yml
@@ -21,6 +21,7 @@ stages:
 
       jobs:
       - job: Windows
+        enableRichCodeNavigation: true
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: NetCorePublic-Pool

--- a/eng/ci.yml
+++ b/eng/ci.yml
@@ -70,13 +70,14 @@ stages:
             - _InternalRuntimeDownloadArgs: /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet
                 /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
 
-          - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['_BuildConfig'], 'Debug')) }}:
-            enableRichCodeNavigation: true
+          # - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['_BuildConfig'], 'Debug')) }}:
+          #   enableRichCodeNavigation: true
 
         strategy:
           matrix:
             ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
               Debug:
+                enableRichCodeNavigation: true
                 _BuildConfig: Debug
                 # override some variables for debug
                 _PublishType: none

--- a/eng/ci.yml
+++ b/eng/ci.yml
@@ -25,6 +25,7 @@ stages:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: NetCorePublic-Pool
             queue: BuildPool.Windows.10.Amd64.VS2019.Open
+            enableRichCodeNavigation: true
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
             name: NetCoreInternal-Pool
             queue: BuildPool.Windows.10.Amd64.VS2019.Pre
@@ -70,14 +71,10 @@ stages:
             - _InternalRuntimeDownloadArgs: /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet
                 /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
 
-          - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['_BuildConfig'], 'Debug')) }}:
-            enableRichCodeNavigation: true
-
         strategy:
           matrix:
             ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
               Debug:
-                # enableRichCodeNavigation: true
                 _BuildConfig: Debug
                 # override some variables for debug
                 _PublishType: none

--- a/eng/ci.yml
+++ b/eng/ci.yml
@@ -18,9 +18,6 @@ stages:
       enablePublishUsingPipelines: true
       enableTelemetry: true
       helixRepo: ${{ parameters.repoName }}
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        enableRichCodeNavigation: true
-        richCodeNavigationEnvironment: 'production'
 
       jobs:
       - job: Windows

--- a/eng/ci.yml
+++ b/eng/ci.yml
@@ -20,6 +20,7 @@ stages:
       helixRepo: ${{ parameters.repoName }}
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         enableRichCodeNavigation: true
+        richCodeNavigationEnvironment: 'production'
 
       jobs:
       - job: Windows

--- a/eng/ci.yml
+++ b/eng/ci.yml
@@ -18,6 +18,8 @@ stages:
       enablePublishUsingPipelines: true
       enableTelemetry: true
       helixRepo: ${{ parameters.repoName }}
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        enableRichCodeNavigation: true
 
       jobs:
       - job: Windows
@@ -25,7 +27,6 @@ stages:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: NetCorePublic-Pool
             queue: BuildPool.Windows.10.Amd64.VS2019.Open
-            enableRichCodeNavigation: true
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
             name: NetCoreInternal-Pool
             queue: BuildPool.Windows.10.Amd64.VS2019.Pre

--- a/eng/ci.yml
+++ b/eng/ci.yml
@@ -21,7 +21,6 @@ stages:
 
       jobs:
       - job: Windows
-        enableRichCodeNavigation: true
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: NetCorePublic-Pool
@@ -70,6 +69,9 @@ stages:
           - ${{ if ne(variables['System.TeamProject'], 'public') }}:
             - _InternalRuntimeDownloadArgs: /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet
                 /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
+
+          - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['_BuildConfig'], 'Debug')) }}:
+            enableRichCodeNavigation: true
 
         strategy:
           matrix:


### PR DESCRIPTION
I've altered two files:
1. Add a Rich Navigation specific build (which will appear as a new build pipeline), indexing on every push to master. This will allow you to use Rich Navigation in Visual Studio to enable cross-repository searches, serverless navigation at https://online.visualstudio.com/github/dotnet/msbuild, and integrated GitHub C# navigation once that is released (or, comment below if you want to be added to the preview now 😊).
1. Added the Rich Navigation task to your normal unit test CI. This has all the same benefits of ^, but also indexes your pull requests for a richer code review experience. This does come at the cost of increasing the time of your CI.

Based on your team's preference, only one of these changes is necessary.

## Rich Code Navigation

[Docs Link](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/1047/Rich-Code-Navigation)
With Rich Code Navigation, you can use editor-level navigation capabilities (like peek definition, find all references, and even diagnostics) on a pull request, without requiring a local checkout. This is available across all files and dependencies of your repository.

Rich Code Navigation is available for Visual Studio (for repos hosted on GitHub or Azure Repos) and Visual Studio Code (for repos hosted on GitHub).

Rich Code Navigation supports these capabilities:

- Hover
- Peek definition and Go to definition
- Peek references and Find all references
- Go to type definition
- Go to implementation
- Diagnostics

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4086)