### PR TITLE
Output the full EMF log whenever EMF validation fail.

### DIFF
--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/EmfValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/EmfValidator.cs
@@ -42,16 +42,16 @@ namespace System.Windows.Forms.Metafiles
                                     : null;
                             }
                         }
-                        catch (XunitException e)
+                        catch (XunitException ex)
                         {
                             throw new WrappedXunitException(
-                                $"\nValidator index {currentIndex}: {currentValidator!.GetType().Name} failed",
-                                e);
+                                $"\nValidator index {currentIndex}: {currentValidator!.GetType().Name} failed\n\n{emf.RecordsToStringWithState(state)}",
+                                ex);
                         }
                     }
                     else
                     {
-                        Assert.False(IsRenderingRecord(record.Type), $"Got unexpected {record.Type}");
+                        Assert.False(IsRenderingRecord(record.Type), $"Got unexpected {record.Type}\n\n{emf.RecordsToStringWithState(state)}");
                     }
 
                     return true;
@@ -62,61 +62,62 @@ namespace System.Windows.Forms.Metafiles
             {
                 Assert.False(
                     currentValidator.FailIfIncomplete,
-                    $"{currentValidator.GetType().Name} did not receive expected records");
+                    $"{currentValidator.GetType().Name} did not receive expected records\n\n{emf.RecordsToStringWithState(state)}");
             }
         }
 
-        private static bool IsRenderingRecord(Gdi32.EMR recordType) => recordType switch
-        {
-            Gdi32.EMR.POLYBEZIER               => true,
-            Gdi32.EMR.POLYGON                  => true,
-            Gdi32.EMR.POLYLINE                 => true,
-            Gdi32.EMR.POLYBEZIERTO             => true,
-            Gdi32.EMR.POLYLINETO               => true,
-            Gdi32.EMR.POLYPOLYLINE             => true,
-            Gdi32.EMR.POLYPOLYGON              => true,
-            Gdi32.EMR.SETPIXELV                => true,
-            Gdi32.EMR.ANGLEARC                 => true,
-            Gdi32.EMR.ELLIPSE                  => true,
-            Gdi32.EMR.RECTANGLE                => true,
-            Gdi32.EMR.ROUNDRECT                => true,
-            Gdi32.EMR.ARC                      => true,
-            Gdi32.EMR.CHORD                    => true,
-            Gdi32.EMR.PIE                      => true,
-            Gdi32.EMR.EXTFLOODFILL             => true,
-            Gdi32.EMR.LINETO                   => true,
-            Gdi32.EMR.ARCTO                    => true,
-            Gdi32.EMR.POLYDRAW                 => true,
-            Gdi32.EMR.CLOSEFIGURE              => true,
-            Gdi32.EMR.FILLPATH                 => true,
-            Gdi32.EMR.STROKEANDFILLPATH        => true,
-            Gdi32.EMR.STROKEPATH               => true,
-            Gdi32.EMR.FILLRGN                  => true,
-            Gdi32.EMR.FRAMERGN                 => true,
-            Gdi32.EMR.INVERTRGN                => true,
-            Gdi32.EMR.PAINTRGN                 => true,
-            Gdi32.EMR.BITBLT                   => true,
-            Gdi32.EMR.STRETCHBLT               => true,
-            Gdi32.EMR.MASKBLT                  => true,
-            Gdi32.EMR.PLGBLT                   => true,
-            Gdi32.EMR.SETDIBITSTODEVICE        => true,
-            Gdi32.EMR.STRETCHDIBITS            => true,
-            Gdi32.EMR.EXTTEXTOUTA              => true,
-            Gdi32.EMR.EXTTEXTOUTW              => true,
-            Gdi32.EMR.POLYBEZIER16             => true,
-            Gdi32.EMR.POLYGON16                => true,
-            Gdi32.EMR.POLYLINE16               => true,
-            Gdi32.EMR.POLYBEZIERTO16           => true,
-            Gdi32.EMR.POLYLINETO16             => true,
-            Gdi32.EMR.POLYPOLYLINE16           => true,
-            Gdi32.EMR.POLYPOLYGON16            => true,
-            Gdi32.EMR.POLYDRAW16               => true,
-            Gdi32.EMR.POLYTEXTOUTA             => true,
-            Gdi32.EMR.POLYTEXTOUTW             => true,
-            Gdi32.EMR.ALPHABLEND               => true,
-            Gdi32.EMR.TRANSPARENTBLT           => true,
-            Gdi32.EMR.GRADIENTFILL             => true,
-            _ => false
-        };
+        private static bool IsRenderingRecord(Gdi32.EMR recordType)
+            => recordType switch
+            {
+                Gdi32.EMR.POLYBEZIER               => true,
+                Gdi32.EMR.POLYGON                  => true,
+                Gdi32.EMR.POLYLINE                 => true,
+                Gdi32.EMR.POLYBEZIERTO             => true,
+                Gdi32.EMR.POLYLINETO               => true,
+                Gdi32.EMR.POLYPOLYLINE             => true,
+                Gdi32.EMR.POLYPOLYGON              => true,
+                Gdi32.EMR.SETPIXELV                => true,
+                Gdi32.EMR.ANGLEARC                 => true,
+                Gdi32.EMR.ELLIPSE                  => true,
+                Gdi32.EMR.RECTANGLE                => true,
+                Gdi32.EMR.ROUNDRECT                => true,
+                Gdi32.EMR.ARC                      => true,
+                Gdi32.EMR.CHORD                    => true,
+                Gdi32.EMR.PIE                      => true,
+                Gdi32.EMR.EXTFLOODFILL             => true,
+                Gdi32.EMR.LINETO                   => true,
+                Gdi32.EMR.ARCTO                    => true,
+                Gdi32.EMR.POLYDRAW                 => true,
+                Gdi32.EMR.CLOSEFIGURE              => true,
+                Gdi32.EMR.FILLPATH                 => true,
+                Gdi32.EMR.STROKEANDFILLPATH        => true,
+                Gdi32.EMR.STROKEPATH               => true,
+                Gdi32.EMR.FILLRGN                  => true,
+                Gdi32.EMR.FRAMERGN                 => true,
+                Gdi32.EMR.INVERTRGN                => true,
+                Gdi32.EMR.PAINTRGN                 => true,
+                Gdi32.EMR.BITBLT                   => true,
+                Gdi32.EMR.STRETCHBLT               => true,
+                Gdi32.EMR.MASKBLT                  => true,
+                Gdi32.EMR.PLGBLT                   => true,
+                Gdi32.EMR.SETDIBITSTODEVICE        => true,
+                Gdi32.EMR.STRETCHDIBITS            => true,
+                Gdi32.EMR.EXTTEXTOUTA              => true,
+                Gdi32.EMR.EXTTEXTOUTW              => true,
+                Gdi32.EMR.POLYBEZIER16             => true,
+                Gdi32.EMR.POLYGON16                => true,
+                Gdi32.EMR.POLYLINE16               => true,
+                Gdi32.EMR.POLYBEZIERTO16           => true,
+                Gdi32.EMR.POLYLINETO16             => true,
+                Gdi32.EMR.POLYPOLYLINE16           => true,
+                Gdi32.EMR.POLYPOLYGON16            => true,
+                Gdi32.EMR.POLYDRAW16               => true,
+                Gdi32.EMR.POLYTEXTOUTA             => true,
+                Gdi32.EMR.POLYTEXTOUTW             => true,
+                Gdi32.EMR.ALPHABLEND               => true,
+                Gdi32.EMR.TRANSPARENTBLT           => true,
+                Gdi32.EMR.GRADIENTFILL             => true,
+                _ => false
+            };
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/EmfValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/EmfValidator.cs
@@ -45,13 +45,13 @@ namespace System.Windows.Forms.Metafiles
                         catch (XunitException ex)
                         {
                             throw new WrappedXunitException(
-                                $"\nValidator index {currentIndex}: {currentValidator!.GetType().Name} failed\n\n{emf.RecordsToStringWithState(state)}",
+                                $"\nValidator index {currentIndex}: {currentValidator!.GetType().Name} failed\n\n{emf.RecordsToString()}",
                                 ex);
                         }
                     }
                     else
                     {
-                        Assert.False(IsRenderingRecord(record.Type), $"Got unexpected {record.Type}\n\n{emf.RecordsToStringWithState(state)}");
+                        Assert.False(IsRenderingRecord(record.Type), $"Got unexpected {record.Type}\n\n{emf.RecordsToString()}");
                     }
 
                     return true;
@@ -62,7 +62,7 @@ namespace System.Windows.Forms.Metafiles
             {
                 Assert.False(
                     currentValidator.FailIfIncomplete,
-                    $"{currentValidator.GetType().Name} did not receive expected records\n\n{emf.RecordsToStringWithState(state)}");
+                    $"{currentValidator.GetType().Name} did not receive expected records\n\n{emf.RecordsToString()}");
             }
         }
 


### PR DESCRIPTION


## Proposed changes

- Enhance EMF validators and output the full instruction log whenever EMF validators fail.
This should help in investigations failures like this:
```
    System.Windows.Forms.Tests.DataGridViewTests.DataGridView_DefaultCellStyles_Rendering [FAIL]
      System.Windows.Forms.Metafiles.EmfValidator+WrappedXunitException : 
Validator index 3: SkipToValidator failed
      ---- Assert.Equal() Failure
                 (pos 0)
      Expected: DefaultCellStyle
      Actual:   [Font: Name=Tahoma, Size=8.25, Units=3, G���
                 (pos 0)
      Stack Trace:
        F:\workspace\_work\1\s\src\System.Windows.Forms.Primitives\tests\TestUtilities\Metafiles\Validators\EmfValidator.cs(47,0): at System.Windows.Forms.Metafiles.EmfValidator.<>c__DisplayClass0_0.<Validate>b__0(EmfRecord& record, DeviceContextState state)
        F:\workspace\_work\1\s\src\System.Windows.Forms.Primitives\tests\TestUtilities\Metafiles\EmfScope.cs(97,0): at System.Windows.Forms.Metafiles.EmfScope.<>c__DisplayClass11_0.<EnumerateWithState>g__stateTracker|0(EmfRecord& record)
        F:\workspace\_work\1\s\src\System.Windows.Forms.Primitives\tests\TestUtilities\Metafiles\EmfScope.cs(225,0): at System.Windows.Forms.Metafiles.EmfScope.CallBack(HDC hdc, HGDIOBJ* lpht, ENHMETARECORD* lpmr, Int32 nHandles, IntPtr data)
           at Interop.Gdi32.EnumEnhMetaFile(HDC hdc, HENHMETAFILE hmf, Enhmfenumproc proc, IntPtr param, RECT* lpRect)
        F:\workspace\_work\1\s\src\System.Windows.Forms.Primitives\tests\TestUtilities\Metafiles\EmfScope.cs(72,0): at System.Windows.Forms.Metafiles.EmfScope.Enumerate(ProcessRecordDelegate enumerator)
        F:\workspace\_work\1\s\src\System.Windows.Forms.Primitives\tests\TestUtilities\Metafiles\EmfScope.cs(93,0): at System.Windows.Forms.Metafiles.EmfScope.EnumerateWithState(ProcessRecordWithStateDelegate enumerator, DeviceContextState state)
        F:\workspace\_work\1\s\src\System.Windows.Forms.Primitives\tests\TestUtilities\Metafiles\Validators\EmfValidator.cs(28,0): at System.Windows.Forms.Metafiles.EmfValidator.Validate(EmfScope emf, DeviceContextState state, IEmfValidator[] validationSteps)
        F:\workspace\_work\1\s\src\System.Windows.Forms\tests\UnitTests\System\Windows\Forms\DataGridViewTests.Rendering.cs(174,0): at System.Windows.Forms.Tests.DataGridViewTests.DataGridView_DefaultCellStyles_Rendering()
        ----- Inner Stack Trace -----
        F:\workspace\_work\1\s\src\System.Windows.Forms.Primitives\tests\TestUtilities\Metafiles\Validators\TextOutValidator.cs(43,0): at System.Windows.Forms.Metafiles.TextOutValidator.Validate(EmfRecord& record, DeviceContextState state, Boolean& complete)
        F:\workspace\_work\1\s\src\System.Windows.Forms.Primitives\tests\TestUtilities\Metafiles\Validators\SkipToValidator.cs(24,0): at System.Windows.Forms.Metafiles.SkipToValidator.Validate(EmfRecord& record, DeviceContextState state, Boolean& complete)
        F:\workspace\_work\1\s\src\System.Windows.Forms.Primitives\tests\TestUtilities\Metafiles\Validators\EmfValidator.cs(34,0): at System.Windows.Forms.Metafiles.EmfValidator.<>c__DisplayClass0_0.<Validate>b__0(EmfRecord& record, DeviceContextState state)
    System.Windows.Forms.Tests.DataGridViewHeaderCellTests.DataGridViewHeaderCell_OnMouseLeave_InvalidRowIndexVisualStyles_ThrowsArgumentOutOfRangeException [SKIP]
```
https://dev.azure.com/dnceng/public/_build/results?buildId=848637&view=results

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4088)