### PR TITLE
Fixing the incorrect ControlType value of ListView subitem

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
@@ -109,7 +109,11 @@ namespace System.Windows.Forms
                 internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                     => propertyID switch
                     {
-                        UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.TextControlTypeId,
+                        // All subitems are "text" except the first.
+                        // It can be "edit" if ListView.LabelEdit is true.
+                        UiaCore.UIA.ControlTypePropertyId => _owningListView.LabelEdit && GetCurrentSubItemIndex() == 0
+                                                             ? UiaCore.UIA.EditControlTypeId
+                                                             : UiaCore.UIA.TextControlTypeId,
                         UiaCore.UIA.NamePropertyId => Name,
                         UiaCore.UIA.FrameworkIdPropertyId => NativeMethods.WinFormFrameworkId,
 #pragma warning disable CA1837 // Use 'Environment.ProcessId'

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
@@ -38,13 +38,17 @@ namespace System.Windows.Forms.Tests
             Assert.False(list.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void ListViewSubItemAccessibleObject_GetPropertyValue_returns_correct_values()
+        [WinFormsTheory]
+        [InlineData(true, 0, (int)UiaCore.UIA.EditControlTypeId)]
+        [InlineData(false, 0, (int)UiaCore.UIA.TextControlTypeId)]
+        [InlineData(true, 1, (int)UiaCore.UIA.TextControlTypeId)]
+        [InlineData(false, 1, (int)UiaCore.UIA.TextControlTypeId)]
+        public void ListViewSubItemAccessibleObject_GetPropertyValue_returns_correct_values(bool labelEdit, int childId, int expectedControlType)
         {
             using ListView list = new ListView();
             ListViewItem listViewItem1 = new ListViewItem(new string[] {
             "Test 1",
-            "Item 1",
+            "Test 2",
             "Something 1"}, -1);
 
             ColumnHeader columnHeader1 = new ColumnHeader();
@@ -58,20 +62,21 @@ namespace System.Windows.Forms.Tests
             list.HideSelection = false;
             list.Items.Add(listViewItem1);
             list.View = View.Details;
+            list.LabelEdit = labelEdit;
 
-            AccessibleObject accessibleObject = listViewItem1.AccessibilityObject.GetChild(0);
+            AccessibleObject accessibleObject = listViewItem1.AccessibilityObject.GetChild(childId);
 
             object accessibleName = accessibleObject.GetPropertyValue(UiaCore.UIA.NamePropertyId);
-            Assert.Equal("Test 1", accessibleName);
+            Assert.Equal($"Test {childId + 1}", accessibleName);
 
             object automationId = accessibleObject.GetPropertyValue(UiaCore.UIA.AutomationIdPropertyId);
-            Assert.Equal("ListViewSubItem-0", automationId);
+            Assert.Equal($"ListViewSubItem-{childId}", automationId);
 
             object frameworkId = accessibleObject.GetPropertyValue(UiaCore.UIA.FrameworkIdPropertyId);
             Assert.Equal("WinForm", frameworkId);
 
             object controlType = accessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
-            UiaCore.UIA expected = UiaCore.UIA.TextControlTypeId;
+            UiaCore.UIA expected = (UiaCore.UIA)expectedControlType;
             Assert.Equal(expected, controlType);
 
             Assert.True((bool)accessibleObject.GetPropertyValue(UiaCore.UIA.IsGridItemPatternAvailablePropertyId));


### PR DESCRIPTION
Fixes #4032 

## Proposed changes

- Change the first subitem `ControlType` depending `ListView.LabelEdit` value. 
The first subitem has "text" ControlType if `LabelEdit` is false
and it has "edit" `ControlType` if `LabelEdit` is true.
The rest subitems always are "text". 
The implementation is consistent with .Net Framework 4.7.2 behavior.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A user can see a correct `ControlType` value of the first subitem in a ListView if `ListView.LabelEdit` is true

## Regression? 

- Yes (since #3224)

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
- The first subitem always has "text" `ControlType` (`ListView.LabelEdit` is true or false)
![image](https://user-images.githubusercontent.com/49272759/95734793-96ce7680-0c8c-11eb-9be2-5d2e636da955.png)

<!-- TODO -->

### After
- The first subitem has the correct `ControlType` value:
 1.`ListView.LabelEdit` is true - "edit"
![image](https://user-images.githubusercontent.com/49272759/95739007-ced8b800-0c92-11eb-898c-21e913b78a61.png)
 
   2.`ListView.LabelEdit` is false - "text"
![image](https://user-images.githubusercontent.com/49272759/95735046-fd539480-0c8c-11eb-8a47-013c25d006ab.png)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- CTI
- Unit tests
- Manual testing

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Using Inspect

## Test environment(s) <!-- Remove any that don't apply -->

- .Net 6.0.100-alpha.1.20479.7
- Microsoft Windows [Version 10.0.19042.508]


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4090)