### PR TITLE
Correct and simplify `ImageCollection_Item_Get32bppColorDepth_Success`

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.ImageCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.ImageCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -150,7 +150,6 @@ namespace System.Windows.Forms
                     {
                         // Since there's no ImageList_ReplaceMasked, we need to generate
                         // a transparent bitmap
-                        Bitmap source = bitmap;
                         bitmap = (Bitmap)bitmap.Clone();
                         bitmap.MakeTransparent(_owner.TransparentColor);
                         ownsImage = true;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageList.ImageCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageList.ImageCollectionTests.cs
@@ -143,119 +143,69 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void ImageCollection_Item_Get32bppColorDepth_Success()
         {
+            using var image1bppIndexedEmpty = new Bitmap(16, 16, PixelFormat.Format1bppIndexed);
+            using var image1bppIndexedCustom = new Bitmap(16, 16, PixelFormat.Format1bppIndexed);
+            using var image24bppRgbEmpty = new Bitmap(16, 16, PixelFormat.Format24bppRgb);
+            using var image24bppRgbCustom = new Bitmap(16, 16, PixelFormat.Format24bppRgb);
+            image24bppRgbCustom.SetPixel(0, 0, Color.Red);
+            image24bppRgbCustom.SetPixel(1, 0, Color.FromArgb(200, 50, 75, 100));
+            using var image32bppRgbEmpty = new Bitmap(16, 16, PixelFormat.Format32bppRgb);
+            using var image32bppRgbCustom = new Bitmap(16, 16, PixelFormat.Format32bppRgb);
+            image32bppRgbCustom.SetPixel(0, 0, Color.Red);
+            image32bppRgbCustom.SetPixel(1, 0, Color.FromArgb(200, 50, 75, 100));
+            using var image32bppArgbEmpty = new Bitmap(16, 16, PixelFormat.Format32bppArgb);
+            using var image32bppArgbCustom = new Bitmap(16, 16, PixelFormat.Format32bppArgb);
+            image32bppArgbCustom.SetPixel(0, 0, Color.Red);
+            image32bppArgbCustom.SetPixel(1, 0, Color.FromArgb(200, 50, 75, 100));
+            using var image32bppPargbEmpty = new Bitmap(16, 16, PixelFormat.Format32bppPArgb);
+            using var image32bppPargbCustom = new Bitmap(16, 16, PixelFormat.Format32bppPArgb);
+            image32bppPargbCustom.SetPixel(0, 0, Color.Red);
+            image32bppPargbCustom.SetPixel(1, 0, Color.FromArgb(200, 50, 75, 100));
+
+            // Add all bitmaps to an array for ease of tracking
+            Bitmap[] bitmaps = new[]
+            {
+                image1bppIndexedEmpty,
+                image1bppIndexedCustom,
+                image24bppRgbEmpty,
+                image24bppRgbCustom,
+                image32bppRgbEmpty,
+                image32bppRgbCustom,
+                image32bppArgbEmpty,
+                image32bppArgbCustom,
+                image32bppPargbEmpty,
+                image32bppPargbCustom,
+            };
+
             using var list = new ImageList
             {
                 ColorDepth = ColorDepth.Depth32Bit
             };
             ImageList.ImageCollection collection = list.Images;
 
-            using var image1bppIndexedEmpty = new Bitmap(16, 16, PixelFormat.Format1bppIndexed);
             collection.Add(image1bppIndexedEmpty);
-
-            using var image1bppIndexedCustom = new Bitmap(16, 16, PixelFormat.Format1bppIndexed);
             collection.Add(image1bppIndexedCustom);
-
-            using var image24bppRgbEmpty = new Bitmap(16, 16, PixelFormat.Format24bppRgb);
             collection.Add(image24bppRgbEmpty);
-
-            using var image24bppRgbCustom = new Bitmap(16, 16, PixelFormat.Format24bppRgb);
-            image24bppRgbCustom.SetPixel(0, 0, Color.Red);
-            image24bppRgbCustom.SetPixel(1, 0, Color.FromArgb(200, 50, 75, 100));
             collection.Add(image24bppRgbCustom);
-
-            using var image32bppRgbEmpty = new Bitmap(16, 16, PixelFormat.Format32bppRgb);
             collection.Add(image32bppRgbEmpty);
-
-            using var image32bppRgbCustom = new Bitmap(16, 16, PixelFormat.Format32bppRgb);
-            image32bppRgbCustom.SetPixel(0, 0, Color.Red);
-            image32bppRgbCustom.SetPixel(1, 0, Color.FromArgb(200, 50, 75, 100));
             collection.Add(image32bppRgbCustom);
-
-            using var image32bppArgbEmpty = new Bitmap(16, 16, PixelFormat.Format32bppArgb);
             collection.Add(image32bppArgbEmpty);
-
-            using var image32bppArgbCustom = new Bitmap(16, 16, PixelFormat.Format32bppArgb);
-            image32bppArgbCustom.SetPixel(0, 0, Color.Red);
-            image32bppArgbCustom.SetPixel(1, 0, Color.FromArgb(200, 50, 75, 100));
             collection.Add(image32bppArgbCustom);
-
-            using var image32bppPargbEmpty = new Bitmap(16, 16, PixelFormat.Format32bppPArgb);
             collection.Add(image32bppPargbEmpty);
-
-            using var image32bppPargbCustom = new Bitmap(16, 16, PixelFormat.Format32bppPArgb);
-            image32bppPargbCustom.SetPixel(0, 0, Color.Red);
-            image32bppPargbCustom.SetPixel(1, 0, Color.FromArgb(200, 50, 75, 100));
             collection.Add(image32bppPargbCustom);
 
-            using Bitmap resultImage1bppEmpty = Assert.IsType<Bitmap>(collection[0]);
-            Assert.NotSame(image1bppIndexedEmpty, resultImage1bppEmpty);
-            Assert.Equal(new Size(16, 16), resultImage1bppEmpty.Size);
-            Assert.Equal(PixelFormat.Format32bppArgb, resultImage1bppEmpty.PixelFormat);
-            Assert.Equal(Color.FromArgb(0xFF, 0x00, 0x00, 0x00), resultImage1bppEmpty.GetPixel(0, 0));
-            Assert.Equal(Color.FromArgb(0xFF, 0x00, 0x00, 0x00), resultImage1bppEmpty.GetPixel(1, 0));
+            for (int i = 0; i < collection.Count; i++)
+            {
+                // By getting a bitmap from the ImageListcollection ImageList will clone the original bitmap.
+                // Assert that the new bitmap contains all the same properties.
 
-            using Bitmap resultImage1bppRgbCustom = Assert.IsType<Bitmap>(collection[1]);
-            Assert.NotSame(image1bppIndexedCustom, resultImage1bppRgbCustom);
-            Assert.Equal(new Size(16, 16), resultImage1bppRgbCustom.Size);
-            Assert.Equal(PixelFormat.Format32bppArgb, resultImage1bppRgbCustom.PixelFormat);
-            Assert.Equal(Color.FromArgb(0xFF, 0x00, 0x00, 0x00), resultImage1bppRgbCustom.GetPixel(0, 0));
-            Assert.Equal(Color.FromArgb(0xFF, 0x00, 0x00, 0x00), resultImage1bppRgbCustom.GetPixel(1, 0));
+                Bitmap resultImage = Assert.IsType<Bitmap>(collection[i]);
 
-            using Bitmap resultImage24bppEmpty = Assert.IsType<Bitmap>(collection[4]);
-            Assert.NotSame(image24bppRgbEmpty, resultImage24bppEmpty);
-            Assert.Equal(new Size(16, 16), resultImage24bppEmpty.Size);
-            Assert.Equal(PixelFormat.Format32bppArgb, resultImage24bppEmpty.PixelFormat);
-            Assert.Equal(Color.FromArgb(0xFF, 0x00, 0x00, 0x00), resultImage24bppEmpty.GetPixel(0, 0));
-            Assert.Equal(Color.FromArgb(0xFF, 0x00, 0x00, 0x00), resultImage24bppEmpty.GetPixel(1, 0));
-
-            using Bitmap resultImage24bppRgbCustom = Assert.IsType<Bitmap>(collection[5]);
-            Assert.NotSame(image24bppRgbCustom, resultImage24bppRgbCustom);
-            Assert.Equal(new Size(16, 16), resultImage24bppRgbCustom.Size);
-            Assert.Equal(PixelFormat.Format32bppArgb, resultImage24bppRgbCustom.PixelFormat);
-            Assert.Equal(Color.FromArgb(0xFF, 0xFF, 0x00, 0x00), resultImage24bppRgbCustom.GetPixel(0, 0));
-            Assert.Equal(Color.FromArgb(0xFF, 50, 75, 100), resultImage24bppRgbCustom.GetPixel(1, 0));
-
-            using Bitmap resultImage32bppEmpty = Assert.IsType<Bitmap>(collection[4]);
-            Assert.NotSame(image32bppRgbEmpty, resultImage32bppEmpty);
-            Assert.Equal(new Size(16, 16), resultImage32bppEmpty.Size);
-            Assert.Equal(PixelFormat.Format32bppArgb, resultImage32bppEmpty.PixelFormat);
-            Assert.Equal(Color.FromArgb(0xFF, 0x00, 0x00, 0x00), resultImage32bppEmpty.GetPixel(0, 0));
-            Assert.Equal(Color.FromArgb(0xFF, 0x00, 0x00, 0x00), resultImage32bppEmpty.GetPixel(1, 0));
-
-            using Bitmap resultImage32bppRgbCustom = Assert.IsType<Bitmap>(collection[5]);
-            Assert.NotSame(image32bppRgbCustom, resultImage32bppRgbCustom);
-            Assert.Equal(new Size(16, 16), resultImage32bppRgbCustom.Size);
-            Assert.Equal(PixelFormat.Format32bppArgb, resultImage32bppRgbCustom.PixelFormat);
-            Assert.Equal(Color.FromArgb(0xFF, 0xFF, 0x00, 0x00), resultImage32bppRgbCustom.GetPixel(0, 0));
-            Assert.Equal(Color.FromArgb(0xFF, 50, 75, 100), resultImage32bppRgbCustom.GetPixel(1, 0));
-
-            using Bitmap resultImage32bppArgbEmpty = Assert.IsType<Bitmap>(collection[6]);
-            Assert.NotSame(image32bppArgbEmpty, resultImage32bppArgbEmpty);
-            Assert.Equal(new Size(16, 16), resultImage32bppArgbEmpty.Size);
-            Assert.Equal(PixelFormat.Format32bppArgb, resultImage32bppArgbEmpty.PixelFormat);
-            Assert.Equal(Color.FromArgb(0x00, 0x00, 0x00, 0x00), resultImage32bppArgbEmpty.GetPixel(0, 0));
-            Assert.Equal(Color.FromArgb(0x00, 0x00, 0x00, 0x00), resultImage32bppArgbEmpty.GetPixel(1, 0));
-
-            using Bitmap resultImage32bppArgbCustom = Assert.IsType<Bitmap>(collection[7]);
-            Assert.NotSame(image32bppArgbCustom, resultImage32bppArgbCustom);
-            Assert.Equal(new Size(16, 16), resultImage32bppArgbCustom.Size);
-            Assert.Equal(PixelFormat.Format32bppArgb, resultImage32bppArgbCustom.PixelFormat);
-            Assert.Equal(Color.FromArgb(0xFF, 0xFF, 0x00, 0x00), resultImage32bppArgbCustom.GetPixel(0, 0));
-            Assert.Equal(Color.FromArgb(0xC8, 0x55, 0x68, 0x7B), resultImage32bppArgbCustom.GetPixel(1, 0));
-
-            using Bitmap resultImage32bppPargbEmpty = Assert.IsType<Bitmap>(collection[8]);
-            Assert.NotSame(image32bppPargbEmpty, resultImage32bppPargbEmpty);
-            Assert.Equal(new Size(16, 16), resultImage32bppPargbEmpty.Size);
-            Assert.Equal(PixelFormat.Format32bppArgb, resultImage32bppPargbEmpty.PixelFormat);
-            Assert.Equal(Color.FromArgb(0x00, 0x00, 0x00, 0x00), resultImage32bppPargbEmpty.GetPixel(0, 0));
-            Assert.Equal(Color.FromArgb(0x00, 0x00, 0x00, 0x00), resultImage32bppPargbEmpty.GetPixel(1, 0));
-
-            using Bitmap resultImage32bppPargbCustom = Assert.IsType<Bitmap>(collection[9]);
-            Assert.NotSame(image32bppPargbCustom, resultImage32bppPargbCustom);
-            Assert.Equal(new Size(16, 16), resultImage32bppPargbCustom.Size);
-            Assert.Equal(PixelFormat.Format32bppArgb, resultImage32bppPargbCustom.PixelFormat);
-            Assert.Equal(Color.FromArgb(0xFF, 0xFF, 0x00, 0x00), resultImage32bppPargbCustom.GetPixel(0, 0));
-            Assert.Equal(Color.FromArgb(0xC8, 0x55, 0x68, 0x7B), resultImage32bppPargbCustom.GetPixel(1, 0));
+                Assert.Equal(bitmaps[i].Size, resultImage.Size);
+                Assert.Equal(bitmaps[i].PixelFormat, resultImage.PixelFormat);
+                Assert.Equal(bitmaps[i].GetPixel(0, 0), resultImage.GetPixel(0, 0));
+                Assert.Equal(bitmaps[i].GetPixel(1, 0), resultImage.GetPixel(1, 0));
+            }
         }
 
         [WinFormsTheory]


### PR DESCRIPTION
The original implementation incorrectly referenced elements in the collection.
It also double disposed elements in the collection that under stress could lead to instabilities.
And it was too verbose that made it harder to maintain the test.

Closes #3898


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4092)