### PR TITLE
Fix initial directory and custom places in file dialogs

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.SHILCreateFromPath.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Shell32/Interop.SHILCreateFromPath.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Shell32
     {
-        [DllImport(Libraries.Shell32, ExactSpelling = true)]
+        [DllImport(Libraries.Shell32, ExactSpelling = true, CharSet = CharSet.Unicode)]
         public static extern HRESULT SHILCreateFromPath(string pszPath, out IntPtr ppidl, ref uint rgflnOut);
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Shell32/ShellItemTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Shell32/ShellItemTests.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Runtime.InteropServices;
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.Tests.Interop.Shell32Tests
+{
+    public class ShellItemTests
+    {
+        [Fact]
+        public void SHILCreateFromPath_ValidPath()
+        {
+            string path = Path.GetTempPath();
+            uint rgflnOut = default;
+            HRESULT result = Shell32.SHILCreateFromPath(path, out IntPtr ppidl, ref rgflnOut);
+            try
+            {
+                Assert.Equal(HRESULT.S_OK, result);
+                Assert.NotEqual(IntPtr.Zero, ppidl);
+            }
+            finally
+            {
+                if (ppidl != IntPtr.Zero)
+                {
+                    Marshal.FreeCoTaskMem(ppidl);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION


`FileDialog.InitialDirectory` and `FileDialog.CustomPlaces` do not work as paths we're incorrectly marshalled as ANSI.

Wrote an interop regression test and manually validated the two scenarios.

Fixes #3513
(cherry picked from commit 197420f37596230252e283a2debc2f938bfb0e70)


## Proposed changes

- Add the appropriate charset marshalling directive

## Customer Impact

- `InitialDirectory` and `CustomPlaces` do not work for `FileDialog`
- No customer workaround

## Regression? 

- Yes

## Risk

- Very low

## Test methodology <!-- How did you ensure quality? -->

- Wrote regression interop test
- Manually tested the file dialog


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4111)