### PR TITLE
Attempt to reduce concurrency while accessing `ImageList`

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageList.ImageCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageList.ImageCollectionTests.cs
@@ -14,6 +14,7 @@ namespace System.Windows.Forms.Tests
 {
     using Size = System.Drawing.Size;
 
+    [Collection("Sequential")] // ImageList doesn't appear to behave well under stress in multi-threaded env
     public class ImageCollectionTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,9 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.IO;
-using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
-using Moq;
 using WinForms.Common.Tests;
 using Xunit;
 
@@ -17,6 +15,7 @@ namespace System.Windows.Forms.Tests
     using Point = System.Drawing.Point;
     using Size = System.Drawing.Size;
 
+    [Collection("Sequential")] // ImageList doesn't appear to behave well under stress in multi-threaded env
     public class ImageListTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]


### PR DESCRIPTION
`ImageList` appears to behave badly under stress and in heavy multy-threaded environments, e.g. https://github.com/dotnet/winforms/issues/3898#issuecomment-708958624.
A shot from a hip in attempt to reduce concurrency.

Relates to #3898


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4113)