### PR TITLE
Fix MSAA API for winforms controls

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.SystemIAccessibleWrapper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.SystemIAccessibleWrapper.cs
@@ -30,6 +30,8 @@ namespace System.Windows.Forms
 
             public bool IsIAccessibleCreated { get; }
 
+            internal IAccessible? SystemIAccessibleInternal => _systemIAccessible;
+
             public void accSelect(int flagsSelect, object varChild)
                 => Execute(systemIAccessible => systemIAccessible.accSelect(flagsSelect, varChild));
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -990,7 +990,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            if (systemIAccessible is null || systemIAccessible.accChildCount == 0)
+            if (systemIAccessible.accChildCount == 0)
             {
                 return null;
             }
@@ -1290,7 +1290,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            if (systemIAccessible is null || systemIAccessible.accChildCount == 0)
+            if (systemIAccessible.accChildCount == 0)
             {
                 return null;
             }
@@ -1347,7 +1347,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            return systemIAccessible?.get_accState(childID);
+            return systemIAccessible.get_accState(childID);
         }
 
         /// <summary>
@@ -1402,7 +1402,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            systemIAccessible?.set_accName(childID, newName);
+            systemIAccessible.set_accName(childID, newName);
         }
 
         /// <summary>
@@ -1431,7 +1431,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            systemIAccessible?.set_accValue(childID, newValue);
+            systemIAccessible.set_accValue(childID, newValue);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -1587,7 +1587,7 @@ namespace System.Windows.Forms
         {
             if (obj != null && obj.systemWrapper)
             {
-                return obj.systemIAccessible;
+                return obj.systemIAccessible.SystemIAccessibleInternal;
             }
 
             return obj;
@@ -1622,7 +1622,7 @@ namespace System.Windows.Forms
         /// </summary>
         internal bool IsNonClientObject => AccessibleObjectId == User32.OBJID.WINDOW;
 
-        internal IAccessible? GetSystemIAccessibleInternal() => systemIAccessible;
+        internal IAccessible? GetSystemIAccessibleInternal() => systemIAccessible.SystemIAccessibleInternal;
 
         protected void UseStdAccessibleObjects(IntPtr handle)
         {
@@ -1725,7 +1725,7 @@ namespace System.Windows.Forms
             }
 
             // Check to see if this object already wraps iacc
-            if (systemIAccessible == iacc)
+            if (systemIAccessible.SystemIAccessibleInternal == iacc)
             {
                 return this;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildDropDownButtonUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildDropDownButtonUiaProvider.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Drawing;
+using Accessibility;
 using static Interop;
 
 namespace System.Windows.Forms
@@ -18,6 +19,7 @@ namespace System.Windows.Forms
         {
             private const int COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX = 2;
             private readonly ComboBox _owner;
+            private IAccessible _systemIAccessible;
 
             /// <summary>
             ///  Initializes new instance of ComboBoxChildDropDownButtonUiaProvider.
@@ -28,6 +30,7 @@ namespace System.Windows.Forms
             {
                 _owner = owner;
                 UseStdAccessibleObjects(comboBoxControlhandle);
+                _systemIAccessible = GetSystemIAccessibleInternal();
             }
 
             /// <summary>
@@ -41,8 +44,7 @@ namespace System.Windows.Forms
                 }
                 set
                 {
-                    var systemIAccessible = GetSystemIAccessibleInternal();
-                    systemIAccessible.set_accName(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX, value);
+                    _systemIAccessible?.set_accName(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX, value);
                 }
             }
 
@@ -57,8 +59,7 @@ namespace System.Windows.Forms
                     int top = 0;
                     int width = 0;
                     int height = 0;
-                    var systemIAccessible = GetSystemIAccessibleInternal();
-                    systemIAccessible.accLocation(out left, out top, out width, out height, COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
+                    _systemIAccessible?.accLocation(out left, out top, out width, out height, COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
                     return new Rectangle(left, top, width, height);
                 }
             }
@@ -70,8 +71,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    var systemIAccessible = GetSystemIAccessibleInternal();
-                    return systemIAccessible.accDefaultAction[COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX];
+                    return _systemIAccessible?.accDefaultAction[COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX];
                 }
             }
 
@@ -166,8 +166,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    var systemIAccessible = GetSystemIAccessibleInternal();
-                    return systemIAccessible.accHelp[COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX];
+                    return _systemIAccessible?.accHelp[COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX];
                 }
             }
 
@@ -178,8 +177,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    var systemIAccessible = GetSystemIAccessibleInternal();
-                    return systemIAccessible.get_accKeyboardShortcut(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
+                    return _systemIAccessible?.get_accKeyboardShortcut(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
                 }
             }
 
@@ -206,8 +204,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    var systemIAccessible = GetSystemIAccessibleInternal();
-                    var accRole = systemIAccessible.get_accRole(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
+                    var accRole = _systemIAccessible?.get_accRole(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
                     return accRole != null
                         ? (AccessibleRole)accRole
                         : AccessibleRole.None;
@@ -242,8 +239,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    var systemIAccessible = GetSystemIAccessibleInternal();
-                    var accState = systemIAccessible.get_accState(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
+                    var accState = _systemIAccessible?.get_accState(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
                     return accState != null
                         ? (AccessibleStates)accState
                         : AccessibleStates.None;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjectTests.cs
@@ -2469,6 +2469,46 @@ namespace System.Windows.Forms.Tests
             Assert.Empty(childAccesibleObject2.Value);
         }
 
+        [WinFormsFact]
+        public void AccessibleObject_AsIAccessible_Invoke_DoesntReturnWrapper()
+        {
+            using Panel panel = new Panel();
+            panel.CreateControl();
+            using Button button = new Button();
+            button.CreateControl();
+            panel.Controls.Add(button);
+
+            IAccessible iAccessible = panel.AccessibilityObject.Navigate(AccessibleNavigation.FirstChild);
+            var wrapper = ((AccessibleObject)iAccessible).TestAccessor().Dynamic.systemIAccessible;
+            var child = iAccessible.get_accChild(0);
+
+            Assert.NotSame(wrapper, child);
+            Assert.Same(((AccessibleObject)iAccessible).GetSystemIAccessibleInternal(), child);
+        }
+
+        [WinFormsFact]
+        public void AccessibleObject_GetSystemIAccessibleInternal_Invoke_DoesntReturnWrapper()
+        {
+            using Button button = new Button();
+            button.CreateControl();
+            var accessibleObject = button.AccessibilityObject;
+            var wrapper = accessibleObject.TestAccessor().Dynamic.systemIAccessible;
+            Assert.NotSame(wrapper, accessibleObject.GetSystemIAccessibleInternal());
+        }
+
+        [WinFormsFact]
+        public void AccessibleObject_WrapIAccessible_Invoke_DoesntReturnWrapper()
+        {
+            using Button button = new Button();
+            button.CreateControl();
+            var accessibleObject = button.AccessibilityObject;
+            var wrapper = accessibleObject.TestAccessor().Dynamic.systemIAccessible;
+            var wrapIAccessibleResult = accessibleObject.TestAccessor().Dynamic.WrapIAccessible(accessibleObject.GetSystemIAccessibleInternal());
+
+            Assert.Same(accessibleObject, wrapIAccessibleResult);
+            Assert.NotSame(wrapper, accessibleObject.GetSystemIAccessibleInternal());
+        }
+
         private class SubAccessibleObject : AccessibleObject
         {
             public new void UseStdAccessibleObjects(IntPtr handle) => base.UseStdAccessibleObjects(handle);


### PR DESCRIPTION
Fixes #4100 


## Proposed changes
- Fixed wrong conditions. 
- Fixed method where we return SystemIAccessibleWrapper  instead of IAccessible 

## Customer Impact 
Before the fixing, we could not get information about the controls using MSAA API:
![4100-issue](https://user-images.githubusercontent.com/23376742/96119566-d77cf880-0ef5-11eb-82f8-530bd476f0d3.png)
After fixing, MSAA API works correctly:
![4100-fixed](https://user-images.githubusercontent.com/23376742/96119612-ebc0f580-0ef5-11eb-95c1-79738cef1231.png)

## Regression? 

- Yes

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Manual testing 
- CTI team

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Inspector

## Test environment(s) <!-- Remove any that don't apply -->
-Microsoft Windows [Version 10.0.19041.388]
- .NET Core 5.0.100-rc.1.20420.14


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4114)