### PR TITLE
Fix MSAA accessibility

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.SystemIAccessibleWrapper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.SystemIAccessibleWrapper.cs
@@ -28,6 +28,8 @@ namespace System.Windows.Forms
                 IsIAccessibleCreated = systemIAccessible != null;
             }
 
+            internal IAccessible? SystemIAccessibleInternal => _systemIAccessible;
+
             public bool IsIAccessibleCreated { get; }
 
             public void accSelect(int flagsSelect, object varChild)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -1587,7 +1587,7 @@ namespace System.Windows.Forms
         {
             if (obj != null && obj.systemWrapper)
             {
-                return obj.systemIAccessible;
+                return obj.systemIAccessible.SystemIAccessibleInternal;
             }
 
             return obj;
@@ -1622,7 +1622,7 @@ namespace System.Windows.Forms
         /// </summary>
         internal bool IsNonClientObject => AccessibleObjectId == User32.OBJID.WINDOW;
 
-        internal IAccessible? GetSystemIAccessibleInternal() => systemIAccessible;
+        internal IAccessible? GetSystemIAccessibleInternal() => systemIAccessible.SystemIAccessibleInternal;
 
         protected void UseStdAccessibleObjects(IntPtr handle)
         {
@@ -1725,7 +1725,7 @@ namespace System.Windows.Forms
             }
 
             // Check to see if this object already wraps iacc
-            if (systemIAccessible == iacc)
+            if (systemIAccessible.SystemIAccessibleInternal == iacc)
             {
                 return this;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildDropDownButtonUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildDropDownButtonUiaProvider.cs
@@ -42,7 +42,7 @@ namespace System.Windows.Forms
                 set
                 {
                     var systemIAccessible = GetSystemIAccessibleInternal();
-                    systemIAccessible.set_accName(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX, value);
+                    systemIAccessible?.set_accName(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX, value);
                 }
             }
 
@@ -58,7 +58,7 @@ namespace System.Windows.Forms
                     int width = 0;
                     int height = 0;
                     var systemIAccessible = GetSystemIAccessibleInternal();
-                    systemIAccessible.accLocation(out left, out top, out width, out height, COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
+                    systemIAccessible?.accLocation(out left, out top, out width, out height, COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
                     return new Rectangle(left, top, width, height);
                 }
             }
@@ -71,7 +71,7 @@ namespace System.Windows.Forms
                 get
                 {
                     var systemIAccessible = GetSystemIAccessibleInternal();
-                    return systemIAccessible.accDefaultAction[COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX];
+                    return systemIAccessible?.accDefaultAction[COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX];
                 }
             }
 
@@ -167,7 +167,7 @@ namespace System.Windows.Forms
                 get
                 {
                     var systemIAccessible = GetSystemIAccessibleInternal();
-                    return systemIAccessible.accHelp[COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX];
+                    return systemIAccessible?.accHelp[COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX];
                 }
             }
 
@@ -179,7 +179,7 @@ namespace System.Windows.Forms
                 get
                 {
                     var systemIAccessible = GetSystemIAccessibleInternal();
-                    return systemIAccessible.get_accKeyboardShortcut(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
+                    return systemIAccessible?.get_accKeyboardShortcut(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
                 }
             }
 
@@ -207,7 +207,7 @@ namespace System.Windows.Forms
                 get
                 {
                     var systemIAccessible = GetSystemIAccessibleInternal();
-                    var accRole = systemIAccessible.get_accRole(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
+                    var accRole = systemIAccessible?.get_accRole(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
                     return accRole != null
                         ? (AccessibleRole)accRole
                         : AccessibleRole.None;
@@ -243,7 +243,7 @@ namespace System.Windows.Forms
                 get
                 {
                     var systemIAccessible = GetSystemIAccessibleInternal();
-                    var accState = systemIAccessible.get_accState(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
+                    var accState = systemIAccessible?.get_accState(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
                     return accState != null
                         ? (AccessibleStates)accState
                         : AccessibleStates.None;


### PR DESCRIPTION
`IAccessible` wrapper class was being used in some places instead of the actual `IAccessible` object.

Based on #4114. Narrows diff and adds an additional regression test (`TestAccessibleObjectFromPoint`).

Fixes #4100.

## Proposed changes

- Use actual `IAccessible` object instead of wrapper class

## Customer Impact

- MSAA does not work, preventing any accessibility tools or UI automation based on MSAA (`IAccessible`) from working
- No known workaround

## Regression? 

- Yes

## Risk

- Possible we're missing other issues
- Moderately low outside of `IAccessible` usage, which is effectively unusable without this change.

## Test methodology <!-- How did you ensure quality? -->

- Automated tests
- Manual testing (see #4114)
- Walk through code paths to look for appropriate null checks


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4117)