### PR TITLE
Fix MSAA accessibility (#4117)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.SystemIAccessibleWrapper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.SystemIAccessibleWrapper.cs
@@ -28,6 +28,8 @@ namespace System.Windows.Forms
                 IsIAccessibleCreated = systemIAccessible != null;
             }
 
+            internal IAccessible? SystemIAccessibleInternal => _systemIAccessible;
+
             public bool IsIAccessibleCreated { get; }
 
             public void accSelect(int flagsSelect, object varChild)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -1582,7 +1582,7 @@ namespace System.Windows.Forms
         {
             if (obj != null && obj.systemWrapper)
             {
-                return obj.systemIAccessible;
+                return obj.systemIAccessible.SystemIAccessibleInternal;
             }
 
             return obj;
@@ -1617,7 +1617,7 @@ namespace System.Windows.Forms
         /// </summary>
         internal bool IsNonClientObject => AccessibleObjectId == User32.OBJID.WINDOW;
 
-        internal IAccessible? GetSystemIAccessibleInternal() => systemIAccessible;
+        internal IAccessible? GetSystemIAccessibleInternal() => systemIAccessible.SystemIAccessibleInternal;
 
         protected void UseStdAccessibleObjects(IntPtr handle)
         {
@@ -1720,7 +1720,7 @@ namespace System.Windows.Forms
             }
 
             // Check to see if this object already wraps iacc
-            if (systemIAccessible == iacc)
+            if (systemIAccessible.SystemIAccessibleInternal == iacc)
             {
                 return this;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -5778,7 +5778,7 @@ namespace System.Windows.Forms
                 set
                 {
                     var systemIAccessible = GetSystemIAccessibleInternal();
-                    systemIAccessible.set_accName(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX, value);
+                    systemIAccessible?.set_accName(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX, value);
                 }
             }
 
@@ -5794,7 +5794,7 @@ namespace System.Windows.Forms
                     int width = 0;
                     int height = 0;
                     var systemIAccessible = GetSystemIAccessibleInternal();
-                    systemIAccessible.accLocation(out left, out top, out width, out height, COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
+                    systemIAccessible?.accLocation(out left, out top, out width, out height, COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
                     return new Rectangle(left, top, width, height);
                 }
             }
@@ -5807,7 +5807,7 @@ namespace System.Windows.Forms
                 get
                 {
                     var systemIAccessible = GetSystemIAccessibleInternal();
-                    return systemIAccessible.accDefaultAction[COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX];
+                    return systemIAccessible?.accDefaultAction[COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX];
                 }
             }
 
@@ -5903,7 +5903,7 @@ namespace System.Windows.Forms
                 get
                 {
                     var systemIAccessible = GetSystemIAccessibleInternal();
-                    return systemIAccessible.accHelp[COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX];
+                    return systemIAccessible?.accHelp[COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX];
                 }
             }
 
@@ -5915,7 +5915,7 @@ namespace System.Windows.Forms
                 get
                 {
                     var systemIAccessible = GetSystemIAccessibleInternal();
-                    return systemIAccessible.get_accKeyboardShortcut(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
+                    return systemIAccessible?.get_accKeyboardShortcut(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
                 }
             }
 
@@ -5943,7 +5943,7 @@ namespace System.Windows.Forms
                 get
                 {
                     var systemIAccessible = GetSystemIAccessibleInternal();
-                    var accRole = systemIAccessible.get_accRole(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
+                    var accRole = systemIAccessible?.get_accRole(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
                     return accRole != null
                         ? (AccessibleRole)accRole
                         : AccessibleRole.None;
@@ -5979,7 +5979,7 @@ namespace System.Windows.Forms
                 get
                 {
                     var systemIAccessible = GetSystemIAccessibleInternal();
-                    var accState = systemIAccessible.get_accState(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
+                    var accState = systemIAccessible?.get_accState(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
                     return accState != null
                         ? (AccessibleStates)accState
                         : AccessibleStates.None;


### PR DESCRIPTION
Port of #4117 - see for more details

* Fix MSAA accessibility

IAccessible wrapper class was being used in some places instead of the actual IAccessible object.

Based on #4114. Narrows diff and adds an additional regression test (`TestAccessibleObjectFromPoint`).

Fixes #4100.

* Add a second test and validate the varItem type.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4119)