### PR TITLE
DomainUpDown/NumericUpdown should be KeyboardFocusable

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.DomainUpDownAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.DomainUpDownAccessibleObject.cs
@@ -38,8 +38,6 @@ namespace System.Windows.Forms
                         return State;
                     case UiaCore.UIA.LegacyIAccessibleRolePropertyId:
                         return Role;
-                    case UiaCore.UIA.IsKeyboardFocusablePropertyId:
-                        return true;
                     default:
                         return base.GetPropertyValue(propertyID);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.DomainUpDownAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.DomainUpDownAccessibleObject.cs
@@ -39,7 +39,7 @@ namespace System.Windows.Forms
                     case UiaCore.UIA.LegacyIAccessibleRolePropertyId:
                         return Role;
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:
-                        return false;
+                        return true;
                     default:
                         return base.GetPropertyValue(propertyID);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDown.NumericUpDownAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDown.NumericUpDownAccessibleObject.cs
@@ -57,8 +57,6 @@ namespace System.Windows.Forms
                         return State;
                     case UiaCore.UIA.LegacyIAccessibleRolePropertyId:
                         return Role;
-                    case UiaCore.UIA.IsKeyboardFocusablePropertyId:
-                        return true;
                     default:
                         return base.GetPropertyValue(propertyID);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDown.NumericUpDownAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDown.NumericUpDownAccessibleObject.cs
@@ -58,7 +58,7 @@ namespace System.Windows.Forms
                     case UiaCore.UIA.LegacyIAccessibleRolePropertyId:
                         return Role;
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:
-                        return false;
+                        return true;
                     default:
                         return base.GetPropertyValue(propertyID);
                 }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DomainUpDownAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DomainUpDownAccessibleObjectTests.cs
@@ -11,9 +11,31 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
         [WinFormsFact]
         public void DomainUpDownAccessibleObject_Ctor_Default()
         {
-            using DomainUpDown numericUpDown = new DomainUpDown();
-            AccessibleObject accessibleObject = numericUpDown.AccessibilityObject;
+            using DomainUpDown domainUpDown = new DomainUpDown();
+            AccessibleObject accessibleObject = domainUpDown.AccessibilityObject;
             Assert.NotNull(accessibleObject);
+        }
+
+        [WinFormsFact]
+        public void DomainUpDownAccessibleObject_GetPropertyValue_IsKeyboardFocusable_ReturnsTrue()
+        {
+            using DomainUpDown domainUpDown = new DomainUpDown();
+            AccessibleObject accessibleObject = domainUpDown.AccessibilityObject;
+
+            bool isKeyboardFocusable = (bool)accessibleObject.GetPropertyValue(Interop.UiaCore.UIA.IsKeyboardFocusablePropertyId);
+            Assert.True(isKeyboardFocusable);
+        }
+
+        [WinFormsFact]
+        public void DomainUpDownAccessibleObject_GetPropertyValue_IsKeyboardFocusable_WhenDisabled_ReturnsFalse()
+        {
+            using DomainUpDown domainUpDown = new DomainUpDown();
+            AccessibleObject accessibleObject = domainUpDown.AccessibilityObject;
+
+            domainUpDown.Enabled = false;
+
+            bool isKeyboardFocusable = (bool)accessibleObject.GetPropertyValue(Interop.UiaCore.UIA.IsKeyboardFocusablePropertyId);
+            Assert.False(isKeyboardFocusable);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/NumericUpDownAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/NumericUpDownAccessibleObjectTests.cs
@@ -15,5 +15,27 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             AccessibleObject accessibleObject = numericUpDown.AccessibilityObject;
             Assert.NotNull(accessibleObject);
         }
+
+        [WinFormsFact]
+        public void NumericUpDownAccessibleObject_GetPropertyValue_IsKeyboardFocusable_ReturnsTrue()
+        {
+            using NumericUpDown numericUpDown = new NumericUpDown();
+            AccessibleObject accessibleObject = numericUpDown.AccessibilityObject;
+
+            bool isKeyboardFocusable = (bool)accessibleObject.GetPropertyValue(Interop.UiaCore.UIA.IsKeyboardFocusablePropertyId);
+            Assert.True(isKeyboardFocusable);
+        }
+
+        [WinFormsFact]
+        public void NumericUpDownAccessibleObject_GetPropertyValue_IsKeyboardFocusable_WhenDisabled_ReturnsFalse()
+        {
+            using NumericUpDown numericUpDown = new NumericUpDown();
+            AccessibleObject accessibleObject = numericUpDown.AccessibilityObject;
+
+            numericUpDown.Enabled = false;
+
+            bool isKeyboardFocusable = (bool)accessibleObject.GetPropertyValue(Interop.UiaCore.UIA.IsKeyboardFocusablePropertyId);
+            Assert.False(isKeyboardFocusable);
+        }
     }
 }


### PR DESCRIPTION
Fixes #4123

I tracked the current behavior to this PR: https://github.com/dotnet/winforms/pull/2382

## Proposed changes

- DomainUpDown/NumericUpdown should return true when queried for IsKeyboardFocusablePropertyId and they are visible and enabled. This is the behavior of the base class, so we shouldn't override it here.

## Regression? 

- Yes.

## Risk

- Someone might be relying on the current behavior.

## Test methodology <!-- How did you ensure quality? -->

- Added new tests.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4127)