### PR TITLE
Consume intellisense from internal nuget package

### DIFF
--- a/docs/intellisense.md
+++ b/docs/intellisense.md
@@ -1,45 +1,13 @@
 # Intellisense XML Incorporation into Ref-Pack
 
+Intellisense XML's are produced in the `dotnet/dotnet-api-docs` repo. They now produce a nuget package on an internal feed (https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json) that we can consume normally.
 
-Intellisense XML's are produced in the `dotnet/dotnet-api-docs` repo. They are currently **not** published to a NuGet package or another easily consumable artifact. Thus, the process of ingestion of these XML files is a manual one at this time. 
+To update the version of docs included in the WinForms package, change the `MicrosoftPrivateIntellisenseVersion` in `Versions.props`. The version number is usually provided to us by the docs team.
 
-1. Go to OPS build site at https://ops.microsoft.com/#/sites/Docs/docsets/dotnet-api-docs?tabName=builds and obtain the latest build artifacts
-   - Filter by `Build Type = Intellisense`
-    - Download latest package (it's a `zip` file)
-2. Extract the zip contents and retain only the contents of `_intellisense\netcore-3.0` subfolder
-   - Copy these contents over to a new folder hierarchy that looks like this: 
-  
-    ```
-    DOTNET-API-DOCS_NETCOREAPP3.0-0.0.0.1-WIN32-X86
-    \---_intellisense
-        \---netcore-3.0
-    ```
+If you have a link to the api-docs build and you don't know the package version, here's how you find it:
 
-    - Create `version.txt` directly under the top-level folder, and save the commit-sha of the build obtained from the OPS site. 
-
- 3. Repeat the process (using the same files) and create `dotnet-api-docs_netcoreapp3.0-0.0.0.1-win64-x64\` folder. 
-
-*FUTURE NOTE: 
-	The version number `0.0.0.1` would change for each subsequent update to a new value, like `0.0.0.2`, etc.* 
-
-
-4. Compress each of the above folders like this: 
-
-  ```PowerShell
-  Compress-Archive -Path .\dotnet-api-docs_netcoreapp3.0-0.0.0.1-win32-x86\* -DestinationPath .\dotnet-api-docs_netcoreapp3.0-0.0.0.1-win32-x86.zip
-  Compress-Archive -path .\dotnet-api-docs_netcoreapp3.0-0.0.0.1-win64-x64\* -DestinationPath .\dotnet-api-docs_netcoreapp3.0-0.0.0.1-win64-x64.zip
-  ```
-
-   - It's very important to use Powershell, and no other tools, to create these zip files. 
-
-5. Upload the zip files using Azure Storage Explorer to `netcorenativeassets` blob store under this path: 
-  - `resource-packages -> external -> windows -> dotnet-api-docs_netcoreapp3.0` 
-6. Update the versions
-    - `global.json` for `native-tools.dotnet-api-docs_netcoreapp3.0`
-    - `ReferenceAssembly.targets` for `DotNetApiDocsNetCoreApp30` property
-    - Also update `global.json` in `dotnet-wpf-int` repository (if applicable).
-
-**Note:** 
- - We don't have access to this blob, so contact dnceng when you have something to upload and they can assist.
- - This blob is currently owned by [WPF](https://github.com/dotnet/wpf). Please coordinate with @dotnet/wpf-developers if there is ever a need to update this blob. 
- - This file is a copy of https://github.com/dotnet/wpf/blob/master/Documentation/intellisense.md
+1. Browse to the build (https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=167131&view=results, for example)
+1. Click on the `Phase 1` job to bring up all the steps and logs.
+1. Click on the `NuGet push` step
+1. Look for a line like this: `Pushing Microsoft.Private.Intellisense.5.0.0-preview-20201009.2.nupkg to ...`
+   * In this case, the version would be `5.0.0-preview-20201009.2`

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -79,6 +79,11 @@
   <PropertyGroup>
     <MicrosoftCodeAnalysisPublicApiAnalyzers>3.3.0-beta1.final</MicrosoftCodeAnalysisPublicApiAnalyzers>
   </PropertyGroup>
+  <!-- Intellisense docs -->
+  <PropertyGroup>
+    <MicrosoftPrivateIntellisense>Microsoft.Private.Intellisense</MicrosoftPrivateIntellisense>
+    <MicrosoftPrivateIntellisenseVersion>5.0.0-preview-20201009.2</MicrosoftPrivateIntellisenseVersion>
+  </PropertyGroup>
   <!-- Additional unchanging dependencies -->
   <PropertyGroup>
     <MoqPackageVersion>4.10.0</MoqPackageVersion>

--- a/eng/packageContent.targets
+++ b/eng/packageContent.targets
@@ -1,5 +1,13 @@
 ﻿<Project>
 
+  <!-- 
+    Download the intellisense package specified in Versions.props.
+    Note that `[xxx]` specifies an EXACT version, and is required when using PackageDownload.
+  -->
+  <ItemGroup>
+    <PackageDownload Include="$(MicrosoftPrivateIntellisense)" Version="[$(MicrosoftPrivateIntellisenseVersion)]" />
+  </ItemGroup>
+
   <Target Name="GetPackageContent"
           DependsOnTargets="SatelliteDllsProjectOutputGroup"
           Returns="@(PackageFile)">
@@ -16,15 +24,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <!-- Also in global.json -->
-      <DotNetApiDocsNet50>0.0.0.3</DotNetApiDocsNet50>
-
-      <!-- 
-        The xml file should ALWAYS come from the dotnet-api-docs artifact.
-        This blob lives in Azure storage at https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/dotnet-api-docs_net5.0/
-        Instructions for updating these artifacts are at https://github.com/dotnet/winforms/blob/master/docs/intellisense.md
-      -->
-      <IntellisenseXmlDir>$(CommonLibrary_NativeInstallDir)\bin\dotnet-api-docs_net5.0\$(DotNetApiDocsNet50)\_intellisense\net-5.0\</IntellisenseXmlDir>
+      <IntellisenseXmlDir>$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', '$(MicrosoftPrivateIntellisense)', '$(MicrosoftPrivateIntellisenseVersion)', 'IntellisenseFiles', 'net', '1033'))</IntellisenseXmlDir>
       <IntellisenseXmlFileSource>$(IntellisenseXmlDir)$(AssemblyName).xml</IntellisenseXmlFileSource>
 
       <!-- Set the xml destination (for a later step that copies files from the dotnet-api-docs to local build artifacts) -->

--- a/global.json
+++ b/global.json
@@ -21,7 +21,6 @@
     "Microsoft.NET.Sdk.IL": "6.0.0-alpha.1.20518.3"
   },
   "native-tools": {
-    "cmake": "3.17.3",
-    "dotnet-api-docs_net5.0": "0.0.0.3"
+    "cmake": "3.17.3"
   }
 }


### PR DESCRIPTION
This PR removes the download from Azure blob storage in favor of consuming the official package released by the docs team. It will enables us to easily rev versions for future releases without having to do any other manual steps.

This is based off of work in the runtime repo at https://github.com/dotnet/runtime/blob/688206b76481d00a61110d9f28218cb2bc58957c/eng/restore/docs.targets

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4138)