### PR TITLE
Allow setting `TreeNode` image index to magic number `-2`

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageIndexConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageIndexConverter.cs
@@ -50,7 +50,7 @@ namespace System.Windows.Forms
         {
             if (value is string stringValue && string.Compare(stringValue, SR.toStringNone, true, culture) == 0)
             {
-                return -1;
+                return ImageList.Indexer.DefaultIndex;
             }
 
             return base.ConvertFrom(context, culture, value);
@@ -70,7 +70,7 @@ namespace System.Windows.Forms
                 throw new ArgumentNullException(nameof(destinationType));
             }
 
-            if (destinationType == typeof(string) && value is int && ((int)value) == -1)
+            if (destinationType == typeof(string) && value is int index && index == ImageList.Indexer.DefaultIndex)
             {
                 return SR.toStringNone;
             }
@@ -116,7 +116,6 @@ namespace System.Windows.Forms
                     {
                         // We didn't find the image list in this component.  See if the
                         // component has a "parent" property.  If so, walk the tree...
-                        //
                         PropertyDescriptor parentProp = props[ParentImageListProperty];
                         if (parentProp != null)
                         {
@@ -125,7 +124,6 @@ namespace System.Windows.Forms
                         else
                         {
                             // Stick a fork in us, we're done.
-                            //
                             instance = null;
                         }
                     }
@@ -138,13 +136,12 @@ namespace System.Windows.Forms
                     if (imageList != null)
                     {
                         // Create array to contain standard values
-                        //
                         object[] values;
                         int nImages = imageList.Images.Count;
                         if (IncludeNoneAsStandardValue)
                         {
                             values = new object[nImages + 1];
-                            values[nImages] = -1;
+                            values[nImages] = ImageList.Indexer.DefaultIndex;
                         }
                         else
                         {
@@ -152,7 +149,6 @@ namespace System.Windows.Forms
                         }
 
                         // Fill in the array
-                        //
                         for (int i = 0; i < nImages; i++)
                         {
                             values[i] = i;
@@ -165,7 +161,7 @@ namespace System.Windows.Forms
 
             if (IncludeNoneAsStandardValue)
             {
-                return new StandardValuesCollection(new object[] { -1 });
+                return new StandardValuesCollection(new object[] { ImageList.Indexer.DefaultIndex });
             }
             else
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.Indexer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.Indexer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -13,8 +13,13 @@ namespace System.Windows.Forms
         /// </summary>
         internal class Indexer
         {
+            // Used by TreeViewImageIndexConverter to show "(none)"
+            internal const int NoneIndex = -2;
+
+            // Used by generally across the board to indicate unset image
             internal const string DefaultKey = "";
             internal const int DefaultIndex = -1;
+
             private string _key = DefaultKey;
             private int _index = DefaultIndex;
             private bool _useIntegerIndex = true;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItemStateImageIndexConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItemStateImageIndexConverter.cs
@@ -73,13 +73,12 @@ namespace System.Windows.Forms
                 if (imageList != null)
                 {
                     // Create array to contain standard values
-                    //
                     object[] values;
                     int nImages = imageList.Images.Count;
                     if (IncludeNoneAsStandardValue)
                     {
                         values = new object[nImages + 1];
-                        values[nImages] = -1;
+                        values[nImages] = ImageList.Indexer.DefaultIndex;
                     }
                     else
                     {
@@ -87,7 +86,6 @@ namespace System.Windows.Forms
                     }
 
                     // Fill in the array
-                    //
                     for (int i = 0; i < nImages; i++)
                     {
                         values[i] = i;
@@ -96,9 +94,10 @@ namespace System.Windows.Forms
                     return new StandardValuesCollection(values);
                 }
             }
+
             if (IncludeNoneAsStandardValue)
             {
-                return new StandardValuesCollection(new object[] { -1 });
+                return new StandardValuesCollection(new object[] { ImageList.Indexer.DefaultIndex });
             }
             else
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
@@ -570,7 +570,10 @@ namespace System.Windows.Forms
             get
             {
                 TreeView tv = TreeView;
-                if (ImageIndexer.Index != ImageList.Indexer.DefaultIndex && tv != null && tv.ImageList != null && ImageIndexer.Index >= tv.ImageList.Images.Count)
+                if (ImageIndexer.Index != ImageList.Indexer.NoneIndex
+                    && ImageIndexer.Index != ImageList.Indexer.DefaultIndex
+                    && tv?.ImageList != null
+                    && ImageIndexer.Index >= tv.ImageList.Images.Count)
                 {
                     return tv.ImageList.Images.Count - 1;
                 }
@@ -579,12 +582,14 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value < ImageList.Indexer.DefaultIndex)
+                if (value < ImageList.Indexer.NoneIndex)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(ImageIndex), value, ImageList.Indexer.DefaultIndex));
                 }
 
-                if (ImageIndexer.Index == value && value != ImageList.Indexer.DefaultIndex)
+                if (ImageIndexer.Index == value
+                    && value != ImageList.Indexer.NoneIndex
+                    && value != ImageList.Indexer.DefaultIndex)
                 {
                     return;
                 }
@@ -974,7 +979,10 @@ namespace System.Windows.Forms
             get
             {
                 TreeView tv = TreeView;
-                if (SelectedImageIndexer.Index != ImageList.Indexer.DefaultIndex && tv != null && tv.ImageList != null && SelectedImageIndexer.Index >= tv.ImageList.Images.Count)
+                if (SelectedImageIndexer.Index != ImageList.Indexer.NoneIndex
+                    && SelectedImageIndexer.Index != ImageList.Indexer.DefaultIndex
+                    && tv?.ImageList != null
+                    && SelectedImageIndexer.Index >= tv.ImageList.Images.Count)
                 {
                     return tv.ImageList.Images.Count - 1;
                 }
@@ -983,12 +991,14 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value < ImageList.Indexer.DefaultIndex)
+                if (value < ImageList.Indexer.NoneIndex)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(SelectedImageIndex), value, ImageList.Indexer.DefaultIndex));
                 }
 
-                if (SelectedImageIndexer.Index == value && value != ImageList.Indexer.DefaultIndex)
+                if (SelectedImageIndexer.Index == value
+                    && value != ImageList.Indexer.NoneIndex
+                    && value != ImageList.Indexer.DefaultIndex)
                 {
                     return;
                 }
@@ -2211,25 +2221,31 @@ namespace System.Windows.Forms
 
             if ((mask & TVIF.IMAGE) != 0)
             {
-                item.iImage = (ImageIndexer.ActualIndex == ImageList.Indexer.DefaultIndex) ? tv.ImageIndexer.ActualIndex : ImageIndexer.ActualIndex;
+                item.iImage = IsSpecialImageIndex(ImageIndexer.ActualIndex)
+                                ? tv.ImageIndexer.ActualIndex
+                                : ImageIndexer.ActualIndex;
             }
 
             if ((mask & TVIF.SELECTEDIMAGE) != 0)
             {
-                item.iSelectedImage = (SelectedImageIndexer.ActualIndex == ImageList.Indexer.DefaultIndex) ? tv.SelectedImageIndexer.ActualIndex : SelectedImageIndexer.ActualIndex;
+                item.iSelectedImage = IsSpecialImageIndex(SelectedImageIndexer.ActualIndex)
+                                ? tv.SelectedImageIndexer.ActualIndex
+                                : SelectedImageIndexer.ActualIndex;
             }
 
             if ((mask & TVIF.STATE) != 0)
             {
                 item.stateMask = TVIS.STATEIMAGEMASK;
+
+                // ActualIndex == -1 means "don't use custom image list"
+                // so just leave item.state set to zero, that tells the unmanaged control
+                // to use no state image for this node.
                 if (StateImageIndexer.ActualIndex != ImageList.Indexer.DefaultIndex)
                 {
                     item.state = (TVIS)((StateImageIndexer.ActualIndex + 1) << SHIFTVAL);
                 }
-                // ActualIndex == -1 means "don't use custom image list"
-                // so just leave item.state set to zero, that tells the unmanaged control
-                // to use no state image for this node.
             }
+
             if ((mask & TVIF.PARAM) != 0)
             {
                 item.lParam = handle;
@@ -2244,6 +2260,11 @@ namespace System.Windows.Forms
                     tv.ForceScrollbarUpdate(false);
                 }
             }
+
+            return;
+
+            static bool IsSpecialImageIndex(int actualIndex)
+                => actualIndex == ImageList.Indexer.NoneIndex || actualIndex == ImageList.Indexer.DefaultIndex;
         }
 
         internal unsafe void UpdateImage()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewImageIndexConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewImageIndexConverter.cs
@@ -32,13 +32,14 @@ namespace System.Windows.Forms
             {
                 if (string.Compare(strValue, SR.toStringDefault, true, culture) == 0)
                 {
-                    return -1;
+                    return ImageList.Indexer.DefaultIndex;
                 }
                 else if (string.Compare(strValue, SR.toStringNone, true, culture) == 0)
                 {
                     return -2;
                 }
             }
+
             return base.ConvertFrom(context, culture, value);
         }
 
@@ -56,14 +57,13 @@ namespace System.Windows.Forms
                 throw new ArgumentNullException(nameof(destinationType));
             }
 
-            if (destinationType == typeof(string) && value is int)
+            if (destinationType == typeof(string) && value is int index)
             {
-                int intValue = (int)value;
-                if (intValue == -1)
+                if (index == ImageList.Indexer.DefaultIndex)
                 {
                     return SR.toStringDefault;
                 }
-                else if (intValue == -2)
+                else if (index == -2)
                 {
                     return SR.toStringNone;
                 }
@@ -103,7 +103,6 @@ namespace System.Windows.Forms
                     {
                         // We didn't find the image list in this component.  See if the
                         // component has a "parent" property.  If so, walk the tree...
-                        //
                         PropertyDescriptor parentProp = props[ParentImageListProperty];
                         if (parentProp != null)
                         {
@@ -112,7 +111,6 @@ namespace System.Windows.Forms
                         else
                         {
                             // Stick a fork in us, we're done.
-                            //
                             instance = null;
                         }
                     }
@@ -129,11 +127,10 @@ namespace System.Windows.Forms
                         object[] values;
                         int nImages = imageList.Images.Count + 2;
                         values = new object[nImages];
-                        values[nImages - 2] = -1;
+                        values[nImages - 2] = ImageList.Indexer.DefaultIndex;
                         values[nImages - 1] = -2;
 
                         // Fill in the array
-                        //
                         for (int i = 0; i < nImages - 2; i++)
                         {
                             values[i] = i;
@@ -143,7 +140,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            return new StandardValuesCollection(new object[] { -1, -2 });
+            return new StandardValuesCollection(new object[] { ImageList.Indexer.DefaultIndex, -2 });
         }
     }
-} // Namespace system.windows.forms
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewImageIndexConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewImageIndexConverter.cs
@@ -36,7 +36,7 @@ namespace System.Windows.Forms
                 }
                 else if (string.Compare(strValue, SR.toStringNone, true, culture) == 0)
                 {
-                    return -2;
+                    return ImageList.Indexer.NoneIndex;
                 }
             }
 
@@ -63,7 +63,7 @@ namespace System.Windows.Forms
                 {
                     return SR.toStringDefault;
                 }
-                else if (index == -2)
+                else if (index == ImageList.Indexer.NoneIndex)
                 {
                     return SR.toStringNone;
                 }
@@ -140,7 +140,11 @@ namespace System.Windows.Forms
                 }
             }
 
-            return new StandardValuesCollection(new object[] { ImageList.Indexer.DefaultIndex, -2 });
+            return new StandardValuesCollection(new object[]
+                                                {
+                                                    ImageList.Indexer.DefaultIndex,
+                                                    ImageList.Indexer.NoneIndex
+                                                });
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItemStateImageIndexConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItemStateImageIndexConverterTests.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using static System.ComponentModel.TypeConverter;
+
+namespace System.Windows.Forms.Tests
+{
+    // NB: doesn't require thread affinity
+    public class ListViewItemStateImageIndexConverterTests
+    {
+        [Fact]
+        public void ListViewItemStateImageIndexConverter_IncludeNoneAsStandardValue_ReturnsFalse()
+        {
+            Assert.False(new ListViewItemStateImageIndexConverter().TestAccessor().Dynamic.IncludeNoneAsStandardValue);
+        }
+
+        [Fact]
+        public void ListViewItemStateImageIndexConverter_GetStandardValues_Null_Context_ReturnsExpected()
+        {
+            var converter = new ListViewItemStateImageIndexConverter();
+
+            StandardValuesCollection result = converter.GetStandardValues(context: null);
+
+            Assert.Equal(0, result.Count);
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NoneExcludedImageIndexConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NoneExcludedImageIndexConverterTests.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    // NB: doesn't require thread affinity
+    public class NoneExcludedImageIndexConverterTests
+    {
+        [Fact]
+        public void NoneExcludedImageIndexConverter_IncludeNoneAsStandardValue_ReturnsFalse()
+        {
+            Assert.False(new NoneExcludedImageIndexConverter().TestAccessor().Dynamic.IncludeNoneAsStandardValue);
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeTests.cs
@@ -250,7 +250,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(-2)]
+        [InlineData(-3)]
         public void TreeNode_Ctor_InvalidImageIndex_ThrowsArgumentOutOfRangeException(int imageIndex)
         {
             Assert.Throws<ArgumentOutOfRangeException>("value", () => new TreeNode("text", imageIndex, 0));
@@ -258,7 +258,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(-2)]
+        [InlineData(-3)]
         public void TreeNode_Ctor_InvalidSelectedImageIndex_ThrowsArgumentOutOfRangeException(int selectedImageIndex)
         {
             Assert.Throws<ArgumentOutOfRangeException>("value", () => new TreeNode("text", 0, selectedImageIndex));
@@ -962,13 +962,19 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(handle, node.Handle);
             Assert.False(control.IsHandleCreated);
         }
+        public static IEnumerable<object[]> TreeNode_ImageIndex_TestData()
+        {
+            // { image index, expected index without image, expected index with image }
+            yield return new object[] { -2, -2, -2 };
+            yield return new object[] { -1, -1, -1 };
+            yield return new object[] { 0, -1, 0 };
+            yield return new object[] { 1, -1, 0 };
+            yield return new object[] { 2, -1, 0 };
+        }
 
         [WinFormsTheory]
-        [InlineData(-1, -1)]
-        [InlineData(0, 0)]
-        [InlineData(1, 0)]
-        [InlineData(2, 0)]
-        public void TreeNode_ImageIndex_SetWithoutTreeView_GetReturnsExpected(int value, int expectedWithImage)
+        [MemberData(nameof(TreeNode_ImageIndex_TestData))]
+        public void TreeNode_ImageIndex_SetWithoutTreeView_GetReturnsExpected(int value, int expectedWithoutImage, int expectedWithImage)
         {
             var node = new TreeNode
             {
@@ -992,7 +998,7 @@ namespace System.Windows.Forms.Tests
             // Add image list.
             using var imageList = new ImageList();
             control.ImageList = imageList;
-            Assert.Equal(-1, node.ImageIndex);
+            Assert.Equal(expectedWithoutImage, node.ImageIndex);
             Assert.Empty(node.ImageKey);
             Assert.False(control.IsHandleCreated);
 
@@ -1005,11 +1011,8 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(-1, -1)]
-        [InlineData(0, 0)]
-        [InlineData(1, 0)]
-        [InlineData(2, 0)]
-        public void TreeNode_ImageIndex_SetWithImageKey_GetReturnsExpected(int value, int expectedWithImage)
+        [MemberData(nameof(TreeNode_ImageIndex_TestData))]
+        public void TreeNode_ImageIndex_SetWithImageKey_GetReturnsExpected(int value, int expectedWithoutImage, int expectedWithImage)
         {
             var node = new TreeNode
             {
@@ -1034,7 +1037,7 @@ namespace System.Windows.Forms.Tests
             // Add image list.
             using var imageList = new ImageList();
             control.ImageList = imageList;
-            Assert.Equal(-1, node.ImageIndex);
+            Assert.Equal(expectedWithoutImage, node.ImageIndex);
             Assert.Equal(ImageList.Indexer.DefaultKey, node.ImageKey);
             Assert.False(control.IsHandleCreated);
 
@@ -1047,11 +1050,8 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(-1, -1)]
-        [InlineData(0, 0)]
-        [InlineData(1, 0)]
-        [InlineData(2, 0)]
-        public void TreeNode_ImageIndex_SetWithTreeView_GetReturnsExpected(int value, int expectedWithImage)
+        [MemberData(nameof(TreeNode_ImageIndex_TestData))]
+        public void TreeNode_ImageIndex_SetWithTreeView_GetReturnsExpected(int value, int expectedWithoutImage, int expectedWithImage)
         {
             using var control = new TreeView();
             var node = new TreeNode();
@@ -1071,7 +1071,7 @@ namespace System.Windows.Forms.Tests
             // Add image list.
             using var imageList = new ImageList();
             control.ImageList = imageList;
-            Assert.Equal(-1, node.ImageIndex);
+            Assert.Equal(expectedWithoutImage, node.ImageIndex);
             Assert.Empty(node.ImageKey);
             Assert.False(control.IsHandleCreated);
 
@@ -1084,10 +1084,8 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(-1, -1)]
-        [InlineData(0, 0)]
-        [InlineData(1, 0)]
-        public void TreeNode_ImageIndex_SetWithTreeViewWithEmptyList_GetReturnsExpected(int value, int expectedWithImage)
+        [MemberData(nameof(TreeNode_ImageIndex_TestData))]
+        public void TreeNode_ImageIndex_SetWithTreeViewWithEmptyList_GetReturnsExpected(int value, int expectedWithoutImage, int expectedWithImage)
         {
             using var imageList = new ImageList();
             using var control = new TreeView
@@ -1098,13 +1096,13 @@ namespace System.Windows.Forms.Tests
             control.Nodes.Add(node);
 
             node.ImageIndex = value;
-            Assert.Equal(-1, node.ImageIndex);
+            Assert.Equal(expectedWithoutImage, node.ImageIndex);
             Assert.Empty(node.ImageKey);
             Assert.False(control.IsHandleCreated);
 
             // Set same.
             node.ImageIndex = value;
-            Assert.Equal(-1, node.ImageIndex);
+            Assert.Equal(expectedWithoutImage, node.ImageIndex);
             Assert.Empty(node.ImageKey);
             Assert.False(control.IsHandleCreated);
 
@@ -1117,6 +1115,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
+        [InlineData(-2, -2)]
         [InlineData(-1, -1)]
         [InlineData(0, 0)]
         [InlineData(1, 1)]
@@ -1148,11 +1147,8 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(-1, -1)]
-        [InlineData(0, 0)]
-        [InlineData(1, 0)]
-        [InlineData(2, 0)]
-        public void TreeNode_ImageIndex_SetWithTreeViewWithHandle_GetReturnsExpected(int value, int expectedWithImage)
+        [MemberData(nameof(TreeNode_ImageIndex_TestData))]
+        public void TreeNode_ImageIndex_SetWithTreeViewWithHandle_GetReturnsExpected(int value, int expectedWithoutImage, int expectedWithImage)
         {
             using var control = new TreeView();
             var node = new TreeNode();
@@ -1185,7 +1181,7 @@ namespace System.Windows.Forms.Tests
             // Add image list.
             using var imageList = new ImageList();
             control.ImageList = imageList;
-            Assert.Equal(-1, node.ImageIndex);
+            Assert.Equal(expectedWithoutImage, node.ImageIndex);
             Assert.Empty(node.ImageKey);
             Assert.True(control.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
@@ -1204,6 +1200,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
+        [InlineData(-2, 0)]
         [InlineData(-1, 0)]
         [InlineData(0, 0)]
         [InlineData(1, 1)]
@@ -1225,6 +1222,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
+        [InlineData(-2, 0)]
         [InlineData(-1, 0)]
         [InlineData(0, 0)]
         [InlineData(1, 1)]
@@ -1251,6 +1249,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
+        [InlineData(-2, 0)]
         [InlineData(-1, 0)]
         [InlineData(0, 0)]
         [InlineData(1, 1)]
@@ -1281,6 +1280,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
+        [InlineData(-2)]
         [InlineData(-1)]
         [InlineData(0)]
         [InlineData(1)]
@@ -1303,7 +1303,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(-2)]
+        [InlineData(-3)]
         public void TreeNode_ImageIndex_SetInvalid_ThrowsArgumentOutOfRangeException(int value)
         {
             var node = new TreeNode();
@@ -2993,11 +2993,8 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(-1, -1)]
-        [InlineData(0, 0)]
-        [InlineData(1, 0)]
-        [InlineData(2, 0)]
-        public void TreeNode_SelectedImageIndex_SetWithSelectedImageKey_GetReturnsExpected(int value, int expectedWithImage)
+        [MemberData(nameof(TreeNode_ImageIndex_TestData))]
+        public void TreeNode_SelectedImageIndex_SetWithSelectedImageKey_GetReturnsExpected(int value, int expectedWithoutImage, int expectedWithImage)
         {
             var node = new TreeNode
             {
@@ -3022,7 +3019,7 @@ namespace System.Windows.Forms.Tests
             // Add image list.
             using var imageList = new ImageList();
             control.ImageList = imageList;
-            Assert.Equal(-1, node.SelectedImageIndex);
+            Assert.Equal(expectedWithoutImage, node.SelectedImageIndex);
             Assert.Equal(ImageList.Indexer.DefaultKey, node.SelectedImageKey);
             Assert.False(control.IsHandleCreated);
 
@@ -3035,11 +3032,8 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(-1, -1)]
-        [InlineData(0, 0)]
-        [InlineData(1, 0)]
-        [InlineData(2, 0)]
-        public void TreeNode_SelectedImageIndex_SetWithTreeView_GetReturnsExpected(int value, int expectedWithImage)
+        [MemberData(nameof(TreeNode_ImageIndex_TestData))]
+        public void TreeNode_SelectedImageIndex_SetWithTreeView_GetReturnsExpected(int value, int expectedWithoutImage, int expectedWithImage)
         {
             using var control = new TreeView();
             var node = new TreeNode();
@@ -3059,7 +3053,7 @@ namespace System.Windows.Forms.Tests
             // Add image list.
             using var imageList = new ImageList();
             control.ImageList = imageList;
-            Assert.Equal(-1, node.SelectedImageIndex);
+            Assert.Equal(expectedWithoutImage, node.SelectedImageIndex);
             Assert.Empty(node.SelectedImageKey);
             Assert.False(control.IsHandleCreated);
 
@@ -3072,10 +3066,8 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(-1, -1)]
-        [InlineData(0, 0)]
-        [InlineData(1, 0)]
-        public void TreeNode_SelectedImageIndex_SetWithTreeViewWithEmptyList_GetReturnsExpected(int value, int expectedWithImage)
+        [MemberData(nameof(TreeNode_ImageIndex_TestData))]
+        public void TreeNode_SelectedImageIndex_SetWithTreeViewWithEmptyList_GetReturnsExpected(int value, int expectedWithoutImage, int expectedWithImage)
         {
             using var imageList = new ImageList();
             using var control = new TreeView
@@ -3086,13 +3078,13 @@ namespace System.Windows.Forms.Tests
             control.Nodes.Add(node);
 
             node.SelectedImageIndex = value;
-            Assert.Equal(-1, node.SelectedImageIndex);
+            Assert.Equal(expectedWithoutImage, node.SelectedImageIndex);
             Assert.Empty(node.SelectedImageKey);
             Assert.False(control.IsHandleCreated);
 
             // Set same.
             node.SelectedImageIndex = value;
-            Assert.Equal(-1, node.SelectedImageIndex);
+            Assert.Equal(expectedWithoutImage, node.SelectedImageIndex);
             Assert.Empty(node.SelectedImageKey);
             Assert.False(control.IsHandleCreated);
 
@@ -3105,6 +3097,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
+        [InlineData(-2, -2)]
         [InlineData(-1, -1)]
         [InlineData(0, 0)]
         [InlineData(1, 1)]
@@ -3136,11 +3129,8 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(-1, -1)]
-        [InlineData(0, 0)]
-        [InlineData(1, 0)]
-        [InlineData(2, 0)]
-        public void TreeNode_SelectedImageIndex_SetWithTreeViewWithHandle_GetReturnsExpected(int value, int expectedWithImage)
+        [MemberData(nameof(TreeNode_ImageIndex_TestData))]
+        public void TreeNode_SelectedImageIndex_SetWithTreeViewWithHandle_GetReturnsExpected(int value, int expectedWithoutImage, int expectedWithImage)
         {
             using var control = new TreeView();
             var node = new TreeNode();
@@ -3173,7 +3163,7 @@ namespace System.Windows.Forms.Tests
             // Add image list.
             using var imageList = new ImageList();
             control.ImageList = imageList;
-            Assert.Equal(-1, node.SelectedImageIndex);
+            Assert.Equal(expectedWithoutImage, node.SelectedImageIndex);
             Assert.Empty(node.SelectedImageKey);
             Assert.True(control.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
@@ -3192,6 +3182,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
+        [InlineData(-2, 0)]
         [InlineData(-1, 0)]
         [InlineData(0, 0)]
         [InlineData(1, 0)]
@@ -3213,6 +3204,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
+        [InlineData(-2, 0)]
         [InlineData(-1, 0)]
         [InlineData(0, 0)]
         [InlineData(1, 1)]
@@ -3241,6 +3233,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
+        [InlineData(-2, 0)]
         [InlineData(-1, 0)]
         [InlineData(0, 0)]
         [InlineData(1, 1)]
@@ -3271,6 +3264,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
+        [InlineData(-2)]
         [InlineData(-1)]
         [InlineData(0)]
         [InlineData(1)]
@@ -3293,7 +3287,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(-2)]
+        [InlineData(-3)]
         public void TreeNode_SelectedImageIndex_SetInvalid_ThrowsArgumentOutOfRangeException(int value)
         {
             var node = new TreeNode();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewImageIndexConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewImageIndexConverterTests.cs
@@ -1,0 +1,76 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+using static System.ComponentModel.TypeConverter;
+
+namespace System.Windows.Forms.Tests
+{
+    // NB: doesn't require thread affinity
+    public class TreeViewImageIndexConverterTests
+    {
+        [Fact]
+        public void TreeViewImageIndexConverter_IncludeNoneAsStandardValue_ReturnsFalse()
+        {
+            Assert.False(new TreeViewImageIndexConverter().TestAccessor().Dynamic.IncludeNoneAsStandardValue);
+        }
+
+        [Fact]
+        public void TreeViewImageIndexConverter_ConvertTo_destinationType_null_ThrowsArgumentNullException()
+        {
+            var converter = new TreeViewImageIndexConverter();
+
+            Assert.Throws<ArgumentNullException>("destinationType", () => converter.ConvertTo(context: null, culture: null, new object(), destinationType: null));
+        }
+
+        public static IEnumerable<object[]> TreeViewImageIndexConverter_ConvertFrom_special_string_to_int_ReturnsExpected_TestData()
+        {
+            yield return new object[] { SR.toStringDefault, - 1, };
+            yield return new object[] { SR.toStringDefault, ImageList.Indexer.DefaultIndex };
+            yield return new object[] { SR.toStringNone, -2 };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(TreeViewImageIndexConverter_ConvertFrom_special_string_to_int_ReturnsExpected_TestData))]
+        public void TreeViewImageIndexConverter_ConvertFrom_special_string_to_int_ReturnsExpected(object value, object expected)
+        {
+            var converter = new TreeViewImageIndexConverter();
+
+            object result = converter.ConvertFrom(context: null, culture: null, value);
+
+            Assert.Equal(expected, result);
+        }
+
+        public static IEnumerable<object[]> TreeViewImageIndexConverter_ConvertTo_special_int_to_string_ReturnsExpected_TestData()
+        {
+            yield return new object[] { -1, SR.toStringDefault };
+            yield return new object[] { ImageList.Indexer.DefaultIndex, SR.toStringDefault };
+            yield return new object[] { -2, SR.toStringNone };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(TreeViewImageIndexConverter_ConvertTo_special_int_to_string_ReturnsExpected_TestData))]
+        public void TreeViewImageIndexConverter_ConvertTo_special_int_to_string_ReturnsExpected(object value, object expected)
+        {
+            var converter = new TreeViewImageIndexConverter();
+
+            object result = converter.ConvertTo(context: null, culture: null, value, destinationType: typeof(string));
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void TreeViewImageIndexConverter_GetStandardValues_Null_Context_ReturnsExpected()
+        {
+            var converter = new TreeViewImageIndexConverter();
+
+            StandardValuesCollection result = converter.GetStandardValues(context: null);
+
+            Assert.Equal(2, result.Count);
+            Assert.Equal(ImageList.Indexer.DefaultIndex, result[0]);
+            Assert.Equal(-2, result[1]);
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewImageIndexConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewImageIndexConverterTests.cs
@@ -30,6 +30,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { SR.toStringDefault, - 1, };
             yield return new object[] { SR.toStringDefault, ImageList.Indexer.DefaultIndex };
             yield return new object[] { SR.toStringNone, -2 };
+            yield return new object[] { SR.toStringNone, ImageList.Indexer.NoneIndex };
         }
 
         [WinFormsTheory]
@@ -48,6 +49,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { -1, SR.toStringDefault };
             yield return new object[] { ImageList.Indexer.DefaultIndex, SR.toStringDefault };
             yield return new object[] { -2, SR.toStringNone };
+            yield return new object[] { ImageList.Indexer.NoneIndex, SR.toStringNone };
         }
 
         [WinFormsTheory]
@@ -70,7 +72,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.Equal(2, result.Count);
             Assert.Equal(ImageList.Indexer.DefaultIndex, result[0]);
-            Assert.Equal(-2, result[1]);
+            Assert.Equal(ImageList.Indexer.NoneIndex, result[1]);
         }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Resolves #4131


## Proposed changes

- `TreeViewImageIndexConverter` besides having a special meaning for -1 (which identifies the "default image index"), has a special meaning for -2 (which identifies "no image selected"). The latter is used whenever a `TreeNode` images is edited in a property grid.
During a code refactor in #3126 the meaning for -2 was lost, which broke the property grid experience.
- Refactor `TreeViewImageIndexConverter` and replace -1 with a const, add rudimentary tests.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- `TreeNode` can now have image indicies reset to "(none)".

## Regression? 

- Yes, regressed in #3126

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/4403806/97386477-02207580-1928-11eb-9d5d-8549f8e165a3.png)


### After

![image](https://user-images.githubusercontent.com/4403806/97386427-ddc49900-1927-11eb-80d7-ac6683554639.png)



## Test methodology <!-- How did you ensure quality? -->

- manual
- unit tests
- CTI


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4164)