### PR TITLE
Fixing the argument type definition of Marshal.GetNativeVariantForObject method in EnumVariantObject

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.EnumVariantObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.EnumVariantObject.cs
@@ -179,7 +179,10 @@ namespace System.Windows.Forms
                 for (i = 0; i < celt && currentChild < childCount; ++i)
                 {
                     ++currentChild;
-                    Marshal.GetNativeVariantForObject(((object)currentChild), GetAddressOfVariantAtIndex(rgVar, i));
+                    // Using "currentChild" as uint type leads to incorrect object boxing and converting an object to a COM VARIANT.
+                    // Because of this, controls without UIA support build an incorrect Accessibility tree.
+                    // It needs to cast "currentChild" to int type before converting to get a correct object argument
+                    Marshal.GetNativeVariantForObject(((object)(int)currentChild), GetAddressOfVariantAtIndex(rgVar, i));
                     Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, "AccessibleObject.IEV.Next: adding own child " + currentChild + " of " + childCount);
                 }
 


### PR DESCRIPTION
Fixes #4120 (`LinkLabel` accessiblity tree)
Fixes #4121 (`CheckedListBox` accessiblity tree)
Fixes #4130 (MSAA `UpDown` controls)
Fixes #4172 (MSAA `CheckedListBox`)

Regression from 0c4d3cb9198d9246e85af732c8fa81c3f3e0d88c

## Proposed changes

- Cast `currentChild` from `uint` to `int` before using in Marshal.GetNativeVariantForObject

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A user can see a correct accessibility tree for controls that don't support the UIA provider using Inspect tool

## Regression? 

- Yes (from 0c4d3cb9198d9246e85af732c8fa81c3f3e0d88c)

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
- `CheckedListBox` doesn't have internal items AccessibleObjects in the accessibility tree
![image](https://user-images.githubusercontent.com/49272759/97482828-b7265280-1967-11eb-920e-e90a0d778ec1.png)

<!-- TODO -->

### After
- `CheckedListBox` has the correct accessibility tree with the internal items
![image](https://user-images.githubusercontent.com/49272759/97482428-35cec000-1967-11eb-9951-ad90abb0195d.png)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- CTI

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Using Inspect tool
<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- .Net Version: 6.0.0-alpha.1.20513.9
- Microsoft Windows [Version 10.0.19042.572]


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4168)