### PR TITLE
Fix Application.EnableVisualStyles in single file publishing mode  (servicing)

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.ACTCTXW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.ACTCTXW.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -9,6 +9,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
         public unsafe struct ACTCTXW
         {
             public uint cbSize;
@@ -19,6 +20,7 @@ internal partial class Interop
             public char* lpAssemblyDirectory;
             public IntPtr lpResourceName;
             public char* lpApplicationName;
+            public IntPtr hModule;
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.ACTCTX_FLAG.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.ACTCTX_FLAG.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,14 +11,14 @@ internal partial class Interop
         [Flags]
         public enum ACTCTX_FLAG : uint
         {
-            PROCESSOR_ARCHITECTURE_VALID = 0x00000001,
-            LANGID_VALID = 0x00000002,
-            ASSEMBLY_DIRECTORY_VALID = 0x00000004,
-            RESOURCE_NAME_VALID = 0x00000008,
-            SET_PROCESS_DEFAULT = 0x00000010,
-            APPLICATION_NAME_VALID = 0x00000020,
-            SOURCE_IS_ASSEMBLYREF = 0x00000040,
-            HMODULE_VALID = 0x00000080,
+            PROCESSOR_ARCHITECTURE_VALID    = 0x00000001,
+            LANGID_VALID                    = 0x00000002,
+            ASSEMBLY_DIRECTORY_VALID        = 0x00000004,
+            RESOURCE_NAME_VALID             = 0x00000008,
+            SET_PROCESS_DEFAULT             = 0x00000010,
+            APPLICATION_NAME_VALID          = 0x00000020,
+            SOURCE_IS_ASSEMBLYREF           = 0x00000040,
+            HMODULE_VALID                   = 0x00000080,
         }
     }
 }

--- a/src/System.Windows.Forms/src/System.Windows.Forms.csproj
+++ b/src/System.Windows.Forms/src/System.Windows.Forms.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>System.Windows.Forms</AssemblyName>
@@ -12,6 +12,10 @@
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <UsePublicApiAnalyzers>true</UsePublicApiAnalyzers>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="Resources\System\Windows\Forms\XPThemes.manifest" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\Accessibility\src\Accessibility.ilproj" />
@@ -627,6 +631,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Resources\System\Windows\Forms\ToolStrip\BlankToolstrip.ico">
       <LogicalName>System.Windows.Forms.blank</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\System\Windows\Forms\XPThemes.manifest">
+      <LogicalName>System.Windows.Forms.XPThemes.manifest</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -820,15 +820,27 @@ namespace System.Windows.Forms
         public static void EnableVisualStyles()
         {
             // Pull manifest from our resources
-            string assemblyLoc = typeof(Application).Assembly.Location;
-            if (assemblyLoc != null)
-            {
-                // CSC embeds DLL manifests as resource ID 2
-                UseVisualStyles = ThemingScope.CreateActivationContext(assemblyLoc, nativeResourceManifestID: 2);
-                Debug.Assert(UseVisualStyles, "Enable Visual Styles failed");
+            Module module = typeof(Application).Module;
+            IntPtr moduleHandle = Kernel32.GetModuleHandleW(module.Name);
 
-                s_comCtlSupportsVisualStylesInitialized = false;
+            if (moduleHandle != IntPtr.Zero)
+            {
+                // We have a native module, point to our native embedded manifest resource.
+                // CSC embeds DLL manifests as native resource ID 2
+                UseVisualStyles = ThemingScope.CreateActivationContext(moduleHandle, nativeResourceManifestID: 2);
             }
+            else
+            {
+                // We couldn't grab the module handle, likely we're running from a single file package.
+                // Extract the manifest from managed resources.
+                using Stream stream = module.Assembly.GetManifestResourceStream(
+                    "System.Windows.Forms.XPThemes.manifest");
+                UseVisualStyles = ThemingScope.CreateActivationContext(stream);
+            }
+
+            Debug.Assert(UseVisualStyles, "Enable Visual Styles failed");
+
+            s_comCtlSupportsVisualStylesInitialized = false;
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Threading;
 using System.Windows.Forms.VisualStyles;
 using Microsoft.DotNet.RemoteExecutor;
@@ -138,6 +139,15 @@ namespace System.Windows.Forms.Tests
                     Application.VisualStyleState = state;
                 }
             }, valueParam.ToString());
+        }
+
+        [Fact]
+        public void Application_EnableVisualStyles_ManifestResourceExists()
+        {
+            // Check to make sure the manifest we use for single file publishing is present
+            using Stream stream = typeof(Application).Module.Assembly.GetManifestResourceStream(
+                "System.Windows.Forms.XPThemes.manifest");
+            Assert.NotNull(stream);
         }
 
         private class CustomLCIDCultureInfo : CultureInfo


### PR DESCRIPTION
Fixes #4145 
(cherry picked from commit 082cbf243b3c258e666f388825be9cfe2749ec48)

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- `Application.EnableVisualStyles` gives Windows a manifest that enables the v6 common controls. We normally pull this manifest from a native resource in System.Windows.Forms.dll. In single file mode there is no "dll" to load from so this feature was not working as intended.
In the case where we can't get a Win32 HMODULE we now fall back to pulling the manifest from a managed resource and dumping it to the temp folder.
- Make `ACTCTXW` blittable.

## Regression? 

- No, but makes the feature 'Self-contained + Produce Single File' virtually unsuitable for Windows Forms apps.

## Risk

- Minimal

<!-- end TELL-MODE -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4177)