### PR TITLE
`RepeatValidator` must flag success once the counter has reached zero.

### DIFF
--- a/Winforms.sln
+++ b/Winforms.sln
@@ -143,6 +143,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Windows.Forms.Source
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Windows.Forms.SourceGenerators.Tests", "src\System.Windows.Forms.SourceGenerators\tests\UnitTests\System.Windows.Forms.SourceGenerators.Tests.csproj", "{1976540D-65A6-45D7-95D2-13106DE6D5BB}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Windows.Forms.Primitives.TestUtilities.Tests", "src\System.Windows.Forms.Primitives\tests\TestUtilities.Tests\System.Windows.Forms.Primitives.TestUtilities.Tests.csproj", "{6EE57002-9965-46E7-A48B-B449969738BB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -309,6 +311,10 @@ Global
 		{1976540D-65A6-45D7-95D2-13106DE6D5BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1976540D-65A6-45D7-95D2-13106DE6D5BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1976540D-65A6-45D7-95D2-13106DE6D5BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6EE57002-9965-46E7-A48B-B449969738BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6EE57002-9965-46E7-A48B-B449969738BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6EE57002-9965-46E7-A48B-B449969738BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6EE57002-9965-46E7-A48B-B449969738BB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -357,6 +363,7 @@ Global
 		{2F0973AD-498D-45B6-82ED-CD672F7A03AB} = {8F20A905-BD37-4D80-B8DF-FA45276FC23F}
 		{3BB220A9-7BC9-4D45-9DC7-B5A1D659B478} = {77FEDB47-F7F6-490D-AF7C-ABB4A9E0B9D7}
 		{1976540D-65A6-45D7-95D2-13106DE6D5BB} = {583F1292-AE8D-4511-B8D8-A81FE4642DDC}
+		{6EE57002-9965-46E7-A48B-B449969738BB} = {583F1292-AE8D-4511-B8D8-A81FE4642DDC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7B1B0433-F612-4E5A-BE7E-FCF5B9F6E136}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities.Tests/Metafiles/Validators/RepeatValidatorTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities.Tests/Metafiles/Validators/RepeatValidatorTests.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Moq;
+using Xunit;
+
+namespace System.Windows.Forms.Metafiles.Tests
+{
+    public class RepeatValidatorTests
+    {
+        [Fact]
+        public unsafe void RepeatValidator_Validate_complete_should_be_expected()
+        {
+            Mock<IEmfValidator> emfValidator = new();
+            RepeatValidator repeatValidator = new(emfValidator.Object, 2);
+
+            EmfRecord emfRecord = new();
+
+            repeatValidator.Validate(ref emfRecord, state: null!, out bool complete);
+            Assert.False(complete);
+
+            // call again - we'll be at zero now
+            repeatValidator.Validate(ref emfRecord, state: null!, out complete);
+            Assert.True(complete);
+
+            // call again - this will put us at negative count
+            repeatValidator.Validate(ref emfRecord, state: null!, out complete);
+            Assert.True(complete);
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities.Tests/Metafiles/Validators/RepeatValidatorTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities.Tests/Metafiles/Validators/RepeatValidatorTests.cs
@@ -23,10 +23,19 @@ namespace System.Windows.Forms.Metafiles.Tests
             // call again - we'll be at zero now
             repeatValidator.Validate(ref emfRecord, state: null!, out complete);
             Assert.True(complete);
+        }
 
-            // call again - this will put us at negative count
-            repeatValidator.Validate(ref emfRecord, state: null!, out complete);
-            Assert.True(complete);
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public unsafe void RepeatValidator_Validate_should_throw_IOE_if_count_not_positive(int count)
+        {
+            Mock<IEmfValidator> emfValidator = new();
+            RepeatValidator repeatValidator = new(emfValidator.Object, count);
+
+            EmfRecord emfRecord = new();
+
+            Assert.Throws<InvalidOperationException>(() => repeatValidator.Validate(ref emfRecord, state: null!, out bool complete));
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities.Tests/System.Windows.Forms.Primitives.TestUtilities.Tests.csproj
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities.Tests/System.Windows.Forms.Primitives.TestUtilities.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>System.Windows.Forms.Primitives.TestUtilities.Tests</AssemblyName>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>$(NoWarn);618</NoWarn>
+    <Nullable>enable</Nullable>
+    <RootNamespace>System.Windows.Forms.Primitives.TestUtilities.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
+    <PackageReference Include="xunit.stafact" Version="$(XUnitStaFactPackageVersion)" />
+    <PackageReference Include="coverlet.msbuild" Version="$(CoverletMSBuildPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TestUtilities\System.Windows.Forms.Primitives.TestUtilities.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/RepeatValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/RepeatValidator.cs
@@ -23,9 +23,11 @@ namespace System.Windows.Forms.Metafiles
 
         public void Validate(ref EmfRecord record, DeviceContextState state, out bool complete)
         {
+            // TODO: should we throw if we're at a negative count?
+
             _validator.Validate(ref record, state, out _);
             _count--;
-            complete = _count > 0;
+            complete = _count <= 0;
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/RepeatValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/RepeatValidator.cs
@@ -23,11 +23,12 @@ namespace System.Windows.Forms.Metafiles
 
         public void Validate(ref EmfRecord record, DeviceContextState state, out bool complete)
         {
-            // TODO: should we throw if we're at a negative count?
+            if (_count <= 0)
+                throw new InvalidOperationException();
 
             _validator.Validate(ref record, state, out _);
             _count--;
-            complete = _count <= 0;
+            complete = _count == 0;
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Properties/InternalsVisibleTo.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Properties/InternalsVisibleTo.cs
@@ -8,6 +8,10 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("System.Windows.Forms.Primitives.Tests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("System.Windows.Forms.Tests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("System.Windows.Forms.TestUtilities, PublicKey=00000000000000000400000000000000")]
+[assembly: InternalsVisibleTo("System.Windows.Forms.Primitives.TestUtilities.Tests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("System.Windows.Forms.Design.Tests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("WinformsControlsTest, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("MauiListViewTests, PublicKey=00000000000000000400000000000000")]
+
+// This is needed in order to Moq internal interfaces for testing
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonRenderingTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonRenderingTests.cs
@@ -43,7 +43,7 @@ namespace System.Windows.Forms.Tests
 
             emf.Validate(
                 state,
-                Validate.Repeat(Validate.SkipType(Gdi32.EMR.BITBLT), 2),
+                Validate.Repeat(Validate.SkipType(Gdi32.EMR.BITBLT), 1),
                 Validate.LineTo(
                     (bounds.Right - 1, 0), (0, 0),
                     State.PenColor(SystemColors.ControlLightLight)),


### PR DESCRIPTION
Button rendering with visual styles off is a set of the following operations:
```
    [ENHMETAHEADER] Bounds: {0, -1, 74, 22 (LTRB)} Device Size: {Width=3840, Height=2160} Header Size: 108
    [EMRCREATEBRUSHINDIRECT] Index: 1 Style: SOLID Color: [R=240, G=240, B=240] (COLOR_MENU, COLOR_BTNFACE, COLOR_MENUBAR)
    [EMRSELECTOBJECT] Index: 1
    [EMRBITBLT] Bounds: {2, 2, 72, 20 (LTRB)} Destination: {2, 2, 73, 21 (LTRB)} Rop: PATCOPY Source DC Color: [R=0, G=0, B=0] (COLOR_BACKGROUND, COLOR_MENUTEXT, COLOR_WINDOWTEXT, COLOR_CAPTIONTEXT, COLOR_BTNTEXT, COLOR_INACTIVECAPTIONTEXT, COLOR_INFOTEXT)
    [EMRSELECTOBJECT] StockObject: WHITE_BRUSH
    [EMRDELETEOBJECT] Index: 1
    [EMRSETROP2] Mode: R2_COPYPEN
    [EMRSETBKMODE] Mode: BKMODE_TRANSPARENT
    [EMRCREATEPEN] Index: 1 Style: ENDCAP_ROUND Width: {X=1,Y=0} Color: [R=255, G=255, B=255] (COLOR_WINDOW, COLOR_HIGHLIGHTTEXT, COLOR_BTNHIGHLIGHT)
    [EMRSELECTOBJECT] Index: 1
    [EMRMOVETOEX] Point: {X=74,Y=0}
    [EMRLINETO] Point: {X=0,Y=0}
    [EMRMOVETOEX] Point: {X=0,Y=0}
    [EMRSELECTOBJECT] StockObject: BLACK_PEN
    [EMRSETBKMODE] Mode: BKMODE_OPAQUE
    [EMRSETROP2] Mode: R2_COPYPEN
    [EMRSETBKMODE] Mode: BKMODE_TRANSPARENT
    [EMRSELECTOBJECT] Index: 1
    [EMRMOVETOEX] Point: {X=0,Y=0}
    [EMRLINETO] Point: {X=0,Y=22}
    [EMRMOVETOEX] Point: {X=0,Y=0}
    [EMRSELECTOBJECT] StockObject: BLACK_PEN
    [EMRSETBKMODE] Mode: BKMODE_OPAQUE
    [EMRSETROP2] Mode: R2_COPYPEN
    [EMRSETBKMODE] Mode: BKMODE_TRANSPARENT
    [EMRCREATEPEN] Index: 2 Style: ENDCAP_ROUND Width: {X=1,Y=0} Color: [R=105, G=105, B=105] (COLOR_3DDKSHADOW)
    [EMRSELECTOBJECT] Index: 2
    [EMRMOVETOEX] Point: {X=0,Y=22}
    [EMRLINETO] Point: {X=74,Y=22}
    [EMRMOVETOEX] Point: {X=0,Y=0}
    [EMRSELECTOBJECT] StockObject: BLACK_PEN
    [EMRSETBKMODE] Mode: BKMODE_OPAQUE
    [EMRSETROP2] Mode: R2_COPYPEN
    [EMRSETBKMODE] Mode: BKMODE_TRANSPARENT
    [EMRSELECTOBJECT] Index: 2
    [EMRMOVETOEX] Point: {X=74,Y=22}
    [EMRLINETO] Point: {X=74,Y=-1}
    [EMRMOVETOEX] Point: {X=0,Y=0}
    [EMRSELECTOBJECT] StockObject: BLACK_PEN
    [EMRSETBKMODE] Mode: BKMODE_OPAQUE
    [EMRSETROP2] Mode: R2_COPYPEN
    [EMRSETBKMODE] Mode: BKMODE_TRANSPARENT
    [EMRCREATEPEN] Index: 3 Style: ENDCAP_ROUND Width: {X=1,Y=0} Color: [R=240, G=240, B=240] (COLOR_MENU, COLOR_BTNFACE, COLOR_MENUBAR)
    [EMRSELECTOBJECT] Index: 3
    [EMRMOVETOEX] Point: {X=73,Y=1}
    [EMRLINETO] Point: {X=1,Y=1}
    [EMRMOVETOEX] Point: {X=0,Y=0}
    [EMRSELECTOBJECT] StockObject: BLACK_PEN
    [EMRSETBKMODE] Mode: BKMODE_OPAQUE
    [EMRSETROP2] Mode: R2_COPYPEN
    [EMRSETBKMODE] Mode: BKMODE_TRANSPARENT
    [EMRSELECTOBJECT] Index: 3
    [EMRMOVETOEX] Point: {X=1,Y=1}
    [EMRLINETO] Point: {X=1,Y=21}
    [EMRMOVETOEX] Point: {X=0,Y=0}
    [EMRSELECTOBJECT] StockObject: BLACK_PEN
    [EMRSETBKMODE] Mode: BKMODE_OPAQUE
    [EMRSETROP2] Mode: R2_COPYPEN
    [EMRSETBKMODE] Mode: BKMODE_TRANSPARENT
    [EMRCREATEPEN] Index: 4 Style: ENDCAP_ROUND Width: {X=1,Y=0} Color: [R=160, G=160, B=160] (COLOR_BTNSHADOW)
    [EMRMOVETOEX] Point: {X=1,Y=21}
    [EMRSELECTOBJECT] Index: 4
    [EMRLINETO] Point: {X=73,Y=21}
    [EMRMOVETOEX] Point: {X=0,Y=0}
    [EMRSELECTOBJECT] StockObject: BLACK_PEN
    [EMRSETBKMODE] Mode: BKMODE_OPAQUE
    [EMRSETROP2] Mode: R2_COPYPEN
    [EMRSETBKMODE] Mode: BKMODE_TRANSPARENT
    [EMRSELECTOBJECT] Index: 4
    [EMRMOVETOEX] Point: {X=73,Y=21}
    [EMRLINETO] Point: {X=73,Y=0}
    [EMRMOVETOEX] Point: {X=0,Y=0}
    [EMRSELECTOBJECT] StockObject: BLACK_PEN
    [EMRSETBKMODE] Mode: BKMODE_OPAQUE
    [EMRDELETEOBJECT] Index: 4
    [EMRDELETEOBJECT] Index: 3
    [EMRDELETEOBJECT] Index: 2
    [EMRDELETEOBJECT] Index: 1
    [EMREOF]
```

There's only a single `EMRBITBLT` however the test has expected to 2 due to incorrect `complete` flag in the validator.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4210)