### PR TITLE
Remove reference to the legacy Microsoft.NETCore.App package and use a different non-shipping package instead.

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -53,14 +53,14 @@
   <ItemGroup>
     <!-- Set TargetingPackVersion -->
     <FrameworkReference Update="Microsoft.NETCore.App" 
-      Condition=" '$(MicrosoftNETCoreAppPackageVersion)'!='' And $(TargetFramework.StartsWith('netcoreapp5.')) ">
-    <TargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</TargetingPackVersion>
+      Condition=" '$(VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion)'!='' And $(TargetFramework.StartsWith('netcoreapp5.')) ">
+    <TargetingPackVersion>$(VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion)</TargetingPackVersion>
     </FrameworkReference>
   </ItemGroup>
 
   <PropertyGroup>
-    <!-- Set RuntimeFrameworkVersion to MicrosoftNETCoreAppPackageVersion from Core Setup to prevent large SDK cycle -->
-    <RuntimeFrameworkVersion Condition="'$(MicrosoftNETCoreAppPackageVersion)'!='' And $(TargetFramework.StartsWith('netcoreapp5.')) ">$(MicrosoftNETCoreAppPackageVersion)</RuntimeFrameworkVersion>
+    <!-- Set RuntimeFrameworkVersion to VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion from Core Setup to prevent large SDK cycle -->
+    <RuntimeFrameworkVersion Condition="'$(VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion)'!='' And $(TargetFramework.StartsWith('netcoreapp5.')) ">$(VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion)</RuntimeFrameworkVersion>
 
     <!-- If TargetFramework is not netcoreapp5.x, then reset RuntimeFrameworkVersion -->
     <RuntimeFrameworkVersion Condition="!$(TargetFramework.StartsWith('netcoreapp5.'))" />

--- a/docs/testing-in-vs.md
+++ b/docs/testing-in-vs.md
@@ -44,7 +44,7 @@ There are two ways to get around this problem:
     * If you’re interested in seeing what this version is, look at `<yourRepoRoot>\.dotnet\sdk\<yourSdkVersion>\dotnet.runtimeconfig.json`
 * The winforms (runtime) repo DOES specify an explicit NetCore.App version, and we use the one published by the core-setup repo.
     * If you look at [Directory.Build.Targets](https://github.com/dotnet/winforms/blob/ac0426561b158522eb8564de2bedd28f28148f8d/Directory.Build.targets#L35), you can see where this is set 
-* `$(MicrosoftNETCoreAppPackageVersion)` is set in [Versions.props](https://github.com/dotnet/winforms/blob/ac0426561b158522eb8564de2bedd28f28148f8d/eng/Versions.props#L19), and gets automatically updated when we ingest dependencies from core-setup. (These PR's are automatically merged in if the build passes)
+* `$(VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion)` is set in [Versions.props](https://github.com/dotnet/winforms/blob/ac0426561b158522eb8564de2bedd28f28148f8d/eng/Versions.props#L19), and gets automatically updated when we ingest dependencies from core-setup. (These PR's are automatically merged in if the build passes)
     * You can see where the dependency comes from by looking at [Version.Details.xml](https://github.com/dotnet/winforms/blob/ac0426561b158522eb8564de2bedd28f28148f8d/eng/Version.Details.xml#L13)
     * The reason we use the version from core-setup instead of the version built-in to the SDK is we don’t want to wait for the runtime to come all the way through the SDK repo to consume it
 * Running tests from the command line (.\build -test) works because the build scripts automatically download both the sdk AND the NetCore.App that you need AND add the .dotnet folder to your PATH when running.

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -7,7 +7,7 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
 -->
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NETCore.App" Version="6.0.0-alpha.1.20557.2">
+    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.6.0" Version="6.0.0-alpha.1.20557.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>6cfef20c1524b8d4c1495a652dfe9e898c5a486b</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <!-- Below have corresponding entries in Versions.Details.XML because they are updated via Maestro -->
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>6.0.0-alpha.1.20557.2</MicrosoftNETCoreAppPackageVersion>
+    <VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>6.0.0-alpha.1.20557.2</VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>
     <SystemDiagnosticsEventLogPackageVersion>6.0.0-alpha.1.20557.2</SystemDiagnosticsEventLogPackageVersion>
     <SystemDirectoryServicesPackageVersion>6.0.0-alpha.1.20557.2</SystemDirectoryServicesPackageVersion>
     <SystemReflectionMetadataLoadContextPackageVersion>6.0.0-alpha.1.20557.2</SystemReflectionMetadataLoadContextPackageVersion>

--- a/global.json
+++ b/global.json
@@ -3,10 +3,10 @@
     "dotnet": "5.0.100-rc.2.20479.15",
     "runtimes": {
       "dotnet/x64": [
-        "$(MicrosoftNETCoreAppPackageVersion)"
+        "$(VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion)"
       ],
       "dotnet/x86": [
-        "$(MicrosoftNETCoreAppPackageVersion)"
+        "$(VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion)"
       ]
     }
   },


### PR DESCRIPTION
The Microsoft.NETCore.App package is being removed in https://github.com/dotnet/runtime/pull/38457/. The usage in WinForms can be replaced with the .NET Core Shared Framework VS insertion package, which has a nonshipping version number that matches a runtime.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4217)