### PR TITLE
Narrator and Inspect become unresponsive inspecting `Combobox` control (servicing)

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.IRawElementProviderHwndOverride.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.IRawElementProviderHwndOverride.cs
@@ -13,6 +13,7 @@ internal static partial class Interop
         ///  Implemented by providers which want to provide information about or want to
         ///  reposition contained HWND-based elements.
         /// </summary>
+        [ComImport]
         [Guid("1d5df27c-8947-4425-b8d9-79787bb460b8")]
         [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
         public interface IRawElementProviderHwndOverride

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -5025,22 +5025,6 @@ namespace System.Windows.Forms
                 }
             }
 
-            internal override UiaCore.IRawElementProviderSimple GetOverrideProviderForHwnd(IntPtr hwnd)
-            {
-                if (hwnd == _owningComboBox._childEdit.Handle)
-                {
-                    return _owningComboBox.ChildEditAccessibleObject;
-                }
-                else if (
-                    hwnd == _owningComboBox._childListBox.Handle ||
-                    hwnd == _owningComboBox._dropDownHandle)
-                {
-                    return _owningComboBox.ChildListAccessibleObject;
-                }
-
-                return null;
-            }
-
             /// <summary>
             ///  Gets the accessible child corresponding to the specified index.
             /// </summary>


### PR DESCRIPTION

(cherry picked from commit 2195c2c5687f695b1cdbf51db57af11eabe292d0)


Fixes #3452


## Proposed changes
Issue is reproduced due to incorrect implementation of the `ComboBoxAccessibleObject.IRawElementProviderHwndOverride` method. The presence of [`ComImport` attribute](https://github.com/dotnet/winforms/commit/423b2bc5726b4109741f189e34e5f37f90140d01) leads to the use of `ComboBoxAccessibleObject.IRawElementProviderHwndOverride`, which causes the issue. As fix for it, [we removed `ComImport`](https://github.com/dotnet/winforms/pull/3524) and stopped to using it.


However the issue is not with `ComImport` but the override of `ComboBoxAccessibleObject.IRawElementProviderHwndOverride` method.


## Customer Impact
- Customers will be able to use accessibility tools for forms that contain `ComboBox` controls.

## Regression? 
- Yes

## Risk
- Minimal 

## Test methodology <!-- How did you ensure quality? -->
- CTI 
- Manually

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Inspect
- Narrator

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .Net SDK 5.0.100-rc.2.20479.15

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4220)