### PR TITLE
Fix `ListView` no longer displays images (servicing)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.ImageCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.ImageCollection.cs
@@ -29,6 +29,9 @@ namespace System.Windows.Forms
             ///  issues by holding on to extra references.
             private int _lastAccessedIndex = -1;
 
+            // Indicates whether images are added in a batch.
+            private bool _isBatchAdd;
+
             /// <summary>
             ///  Returns the keys in the image list - images without keys return String.Empty.
             /// </summary>
@@ -183,6 +186,8 @@ namespace System.Windows.Forms
                             bitmap.Dispose();
                         }
                     }
+
+                    _owner.OnRecreateHandle(EventArgs.Empty);
                 }
             }
 
@@ -196,7 +201,7 @@ namespace System.Windows.Forms
                         throw new ArgumentException(SR.ImageListBadImage, nameof(value));
                     }
 
-                    this[index] = (Image)value;
+                    this[index] = image;
                 }
             }
 
@@ -373,9 +378,10 @@ namespace System.Windows.Forms
                     _imageInfoCollection.Add(imageInfo);
                 }
 
-                if (!_owner._inAddRange)
+                if (!_isBatchAdd)
                 {
                     _owner.OnChangeHandle(EventArgs.Empty);
+                    _owner.OnRecreateHandle(EventArgs.Empty);
                 }
 
                 return index;
@@ -388,14 +394,15 @@ namespace System.Windows.Forms
                     throw new ArgumentNullException(nameof(images));
                 }
 
-                _owner._inAddRange = true;
+                _isBatchAdd = true;
                 foreach (Image image in images)
                 {
                     Add(image);
                 }
 
-                _owner._inAddRange = false;
+                _isBatchAdd = false;
                 _owner.OnChangeHandle(EventArgs.Empty);
+                _owner.OnRecreateHandle(EventArgs.Empty);
             }
 
             /// <summary>
@@ -446,6 +453,7 @@ namespace System.Windows.Forms
                 }
 
                 _owner.OnChangeHandle(EventArgs.Empty);
+                _owner.OnRecreateHandle(EventArgs.Empty);
             }
 
             [EditorBrowsable(EditorBrowsableState.Never)]
@@ -555,7 +563,9 @@ namespace System.Windows.Forms
                 if (value is Image image)
                 {
                     Remove(image);
+
                     _owner.OnChangeHandle(EventArgs.Empty);
+                    _owner.OnRecreateHandle(EventArgs.Empty);
                 }
             }
 
@@ -576,7 +586,9 @@ namespace System.Windows.Forms
                 if ((_imageInfoCollection != null) && (index >= 0 && index < _imageInfoCollection.Count))
                 {
                     _imageInfoCollection.RemoveAt(index);
+
                     _owner.OnChangeHandle(EventArgs.Empty);
+                    _owner.OnRecreateHandle(EventArgs.Empty);
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
@@ -53,8 +53,6 @@ namespace System.Windows.Forms
         private EventHandler _recreateHandler;
         private EventHandler _changeHandler;
 
-        private bool _inAddRange;
-
         /// <summary>
         ///  Creates a new ImageList Control with a default image size of 16x16
         ///  pixels

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.Designer.cs
@@ -39,6 +39,11 @@ namespace WinformsControlsTest
             this.columnHeader1 = (System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader());
             this.columnHeader2 = (System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader());
             this.imageList2 = new System.Windows.Forms.ImageList(this.components);
+            this.btnClearListView1 = new System.Windows.Forms.Button();
+            this.btnLoadImagesListView1 = new System.Windows.Forms.Button();
+            this.LargeImageList = new System.Windows.Forms.ImageList(this.components);
+            this.btnReplaceImageListView1 = new System.Windows.Forms.Button();
+            this.openFileDialog1 = new System.Windows.Forms.OpenFileDialog();
             this.SuspendLayout();
             // 
             // imageList1
@@ -71,8 +76,11 @@ namespace WinformsControlsTest
             (System.Windows.Forms.ListViewItem)(resources.GetObject("listView1.Items2"))});
             this.listView1.LargeImageList = this.imageList2;
             resources.ApplyResources(this.listView1, "listView1");
+            this.listView1.Location = new System.Drawing.Point(12, 33);
             this.listView1.Name = "listView1";
+            this.listView1.Size = new System.Drawing.Size(439, 159);
             this.listView1.SmallImageList = this.imageList1;
+            this.listView1.TabIndex = 0;
             this.listView1.UseCompatibleStateImageBehavior = false;
             // 
             // imageList2
@@ -82,10 +90,55 @@ namespace WinformsControlsTest
             this.imageList2.Images.SetKeyName(0, "LargeA.bmp");
             this.imageList2.Images.SetKeyName(1, "LargeABlue.bmp");
             // 
-            // Form1
+            // btnClearListView1
+            // 
+            this.btnClearListView1.Location = new System.Drawing.Point(13, 4);
+            this.btnClearListView1.Name = "btnClearListView1";
+            this.btnClearListView1.Size = new System.Drawing.Size(75, 23);
+            this.btnClearListView1.TabIndex = 1;
+            this.btnClearListView1.Text = "Clear";
+            this.btnClearListView1.UseVisualStyleBackColor = true;
+            this.btnClearListView1.Click += new System.EventHandler(this.btnClearListView1_Click);
+            // 
+            // btnLoadImagesListView1
+            // 
+            this.btnLoadImagesListView1.Location = new System.Drawing.Point(95, 4);
+            this.btnLoadImagesListView1.Name = "btnLoadImagesListView1";
+            this.btnLoadImagesListView1.Size = new System.Drawing.Size(75, 23);
+            this.btnLoadImagesListView1.TabIndex = 2;
+            this.btnLoadImagesListView1.Text = "Load images";
+            this.btnLoadImagesListView1.UseVisualStyleBackColor = true;
+            this.btnLoadImagesListView1.Click += new System.EventHandler(this.btnLoadImagesListView1_Click);
+            // 
+            // LargeImageList
+            // 
+            this.LargeImageList.ColorDepth = System.Windows.Forms.ColorDepth.Depth24Bit;
+            this.LargeImageList.ImageSize = new System.Drawing.Size(256, 256);
+            this.LargeImageList.TransparentColor = System.Drawing.Color.Transparent;
+            // 
+            // openFileDialog1
+            // 
+            this.openFileDialog1.FileName = "openFileDialog1";
+            this.openFileDialog1.Multiselect = true;
+            this.openFileDialog1.SupportMultiDottedExtensions = true;
+            // 
+            // btnReplaceImageListView1
+            // 
+            this.btnReplaceImageListView1.Location = new System.Drawing.Point(176, 4);
+            this.btnReplaceImageListView1.Name = "btnReplaceImageListView1";
+            this.btnReplaceImageListView1.Size = new System.Drawing.Size(87, 23);
+            this.btnReplaceImageListView1.TabIndex = 3;
+            this.btnReplaceImageListView1.Text = "Replace image";
+            this.btnReplaceImageListView1.UseVisualStyleBackColor = true;
+            this.btnReplaceImageListView1.Click += new System.EventHandler(this.btnReplaceImageListView1_Click);
+            // 
+            // ListViewTest
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.btnReplaceImageListView1);
+            this.Controls.Add(this.btnLoadImagesListView1);
+            this.Controls.Add(this.btnClearListView1);
             this.Controls.Add(this.listView1);
             this.Name = "ListViewTest";
             this.Name = "ListView Test";
@@ -95,10 +148,15 @@ namespace WinformsControlsTest
 
         #endregion
 
-        private System.Windows.Forms.ImageList imageList1;
         private System.Windows.Forms.ListView listView1;
+        private System.Windows.Forms.ImageList imageList1;
         private System.Windows.Forms.ImageList imageList2;
+        private System.Windows.Forms.ImageList LargeImageList;
         private System.Windows.Forms.ColumnHeader columnHeader1;
         private System.Windows.Forms.ColumnHeader columnHeader2;
+        private System.Windows.Forms.Button btnClearListView1;
+        private System.Windows.Forms.Button btnLoadImagesListView1;
+        private System.Windows.Forms.Button btnReplaceImageListView1;
+        private System.Windows.Forms.OpenFileDialog openFileDialog1;
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics;
 using System.Drawing;
+using System.IO;
 using System.Windows.Forms;
 
 namespace WinformsControlsTest
@@ -221,6 +222,61 @@ namespace WinformsControlsTest
 
             var random = new Random();
             listView2.Columns[random.Next(0, listView2.Columns.Count)].ImageIndex = random.Next(0, 2);
+        }
+
+        private void btnClearListView1_Click(object sender, EventArgs e)
+        {
+            listView1.Clear();
+            LargeImageList.Images.Clear();
+
+            listView1.LargeImageList = LargeImageList;
+            listView1.View = View.LargeIcon;
+        }
+
+        private void btnLoadImagesListView1_Click(object sender, EventArgs e)
+        {
+            if (openFileDialog1.ShowDialog() != DialogResult.OK)
+            {
+                return;
+            }
+
+            foreach (string file in openFileDialog1.FileNames)
+            {
+                Bitmap bitmap = (Bitmap)Bitmap.FromFile(file);
+                LargeImageList.Images.Add(file, bitmap);
+
+                ListViewItem item = new ListViewItem
+                {
+                    Text = Path.GetFileName(file),
+                    Name = file,
+                    ImageKey = file,
+                    Checked = true
+                };
+                listView1.Items.Add(item);
+            }
+        }
+
+        private void btnReplaceImageListView1_Click(object sender, EventArgs e)
+        {
+            if (listView1.SelectedIndices.Count != 1)
+            {
+                return;
+            }
+
+            openFileDialog1.Multiselect = false;
+            DialogResult result = openFileDialog1.ShowDialog();
+            openFileDialog1.Multiselect = true;
+
+            if (result != DialogResult.OK)
+            {
+                return;
+            }
+
+            string file = openFileDialog1.FileName;
+            Bitmap bitmap = (Bitmap)Bitmap.FromFile(file);
+            LargeImageList.Images[listView1.SelectedIndices[0]] = bitmap;
+
+            listView1.Refresh();
         }
     }
 }


### PR DESCRIPTION
(cherry picked from commit d0608e72a356ad991f9c9d12518e29b43a1fb4f0)

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4169


## Proposed changes

Changes in `ImageList` ownership model in #3601 means that very are now two  instances of imagelists - one instance is tracked by Windows Forms (i.e. managed) side, and another one tracked by the underlying Win32 (unmanaged) side. This was done due to an observed ownership disconnect between the managed and unmanaged code, that led to situations where the unmanaged code would effectively destroy and instance of an imagelist, which the managed code was oblivious to.

However with the above change changes to images in an imagelist on the managed side, i.e. a user adding or replacing an image in the imagelist, would not be reflected in the imagelist on the unmanaged side, and thus would not be reflected in the UI (which is drawn by the Win32).

The fix reuses the established infrastructure that notifies the managed imagelist implementation of changes to the images collection, and once a notification of a chance is received, the unmanaged imagelist is re-created, thus ensuring the UI has all the correct images to display.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A control that references an `ImageList` that gets its images dynamically modified will render the images correctly.

## Regression? 

- Yes 

## Risk

- Minor

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4222)