### PR TITLE
Use 'is not null' in System.Windows.Forms.Primitives

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TTOOLINFOW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TTOOLINFOW.cs
@@ -63,7 +63,7 @@ internal static partial class Interop
                 fixed (char* c = Text)
                 fixed (void* i = &Info)
                 {
-                    if (Text != null)
+                    if (Text is not null)
                     {
                         Info.lpszText = c;
                     }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.GPStream.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.GPStream.cs
@@ -82,10 +82,10 @@ internal static partial class Interop
 
                 ArrayPool<byte>.Shared.Return(buffer);
 
-                if (pcbRead != null)
+                if (pcbRead is not null)
                     *pcbRead = totalRead;
 
-                if (pcbWritten != null)
+                if (pcbWritten is not null)
                     *pcbWritten = totalWritten;
             }
 
@@ -96,7 +96,7 @@ internal static partial class Interop
                 Span<byte> buffer = new Span<byte>(pv, checked((int)cb));
                 int read = _dataStream.Read(buffer);
 
-                if (pcbRead != null)
+                if (pcbRead is not null)
                     *pcbRead = (uint)read;
             }
 
@@ -198,7 +198,7 @@ internal static partial class Interop
                 var buffer = new ReadOnlySpan<byte>(pv, checked((int)cb));
                 _dataStream.Write(buffer);
 
-                if (pcbWritten != null)
+                if (pcbWritten is not null)
                     *pcbWritten = cb;
             }
 

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/DeviceContextHdcScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/DeviceContextHdcScope.cs
@@ -108,13 +108,13 @@ namespace System.Windows.Forms
                 // Graphics object available.
                 needToApplyProperties = false;
             }
-            else if (provider != null && provider.IsGraphicsStateClean)
+            else if (provider is not null && provider.IsGraphicsStateClean)
             {
                 // We have IGraphicsHdcProvider and it is telling us we have no properties to apply (case 1 above)
                 needToApplyProperties = false;
             }
 
-            if (provider != null)
+            if (provider is not null)
             {
                 // We have a provider, grab the underlying HDC if possible unless we know we've created and
                 // modified a Graphics object around it.
@@ -153,9 +153,9 @@ namespace System.Windows.Forms
 
             // elements (XFORM) = [eM11, eM12, eM21, eM22, eDx, eDy], eDx/eDy specify the translation offset.
             float[]? elements = applyTransform ? worldTransform?.Elements : null;
-            int dx = elements != null ? (int)elements[4] : 0;
-            int dy = elements != null ? (int)elements[5] : 0;
-            applyTransform = applyTransform && elements != null && (dx != 0 || dy != 0);
+            int dx = elements is not null ? (int)elements[4] : 0;
+            int dy = elements is not null ? (int)elements[5] : 0;
+            applyTransform = applyTransform && elements is not null && (dx != 0 || dy != 0);
 
             using var graphicsRegion = applyClipping ? new Gdi32.RegionScope(clipRegion!, graphics) : default;
             applyClipping = applyClipping && !graphicsRegion!.Region.IsNull;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlacesCollection.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlacesCollection.cs
@@ -20,7 +20,7 @@ namespace System.Windows.Forms
                 try
                 {
                     IShellItem? shellItem = customPlace.GetNativePath();
-                    if (shellItem != null)
+                    if (shellItem is not null)
                     {
                         dialog.AddPlace(shellItem, 0);
                     }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/GdiPlus/GdiPlusCache.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/GdiPlus/GdiPlusCache.cs
@@ -33,7 +33,7 @@ namespace System.Windows.Forms
                     ? SystemPens.FromSystemColor(color)
                     : PenFromKnownColor(color.ToKnownColor());
 
-                if (pen != null)
+                if (pen is not null)
                 {
                     return new PenCache.Scope(pen);
                 }
@@ -50,7 +50,7 @@ namespace System.Windows.Forms
                     ? (SolidBrush?)SystemBrushes.FromSystemColor(color)
                     : (SolidBrush?)BrushFromKnownColor(color.ToKnownColor());
 
-                if (solidBrush != null)
+                if (solidBrush is not null)
                 {
                     return new SolidBrushCache.Scope(solidBrush);
                 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/DpiHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/DpiHelper.cs
@@ -284,7 +284,7 @@ namespace System.Windows.Forms
                 return;
             }
             Bitmap deviceBitmap = CreateScaledBitmap(logicalBitmap, deviceDpi);
-            if (deviceBitmap != null)
+            if (deviceBitmap is not null)
             {
                 logicalBitmap.Dispose();
                 logicalBitmap = deviceBitmap;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -183,7 +183,7 @@ namespace System.Windows.Forms
         /// </summary>
         internal static string GetLocalPath(string fileName)
         {
-            System.Diagnostics.Debug.Assert(fileName != null && fileName.Length > 0, "Cannot get local path, fileName is not valid");
+            System.Diagnostics.Debug.Assert(fileName is not null && fileName.Length > 0, "Cannot get local path, fileName is not valid");
 
             Uri uri = new Uri(fileName);
             return uri.LocalPath + uri.Fragment;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/WeakRefCollection.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/WeakRefCollection.cs
@@ -175,7 +175,7 @@ namespace System.Windows.Forms
 
             internal WeakRefObject(object obj)
             {
-                Debug.Assert(obj != null, "Unexpected null object!");
+                Debug.Assert(obj is not null, "Unexpected null object!");
                 weakHolder = new WeakReference(obj);
                 _hash = obj.GetHashCode();
             }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/ObjectCache.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/ObjectCache.cs
@@ -33,7 +33,7 @@ namespace System.Windows.Forms
             for (int i = 0; i < _itemsCache.Length; i++)
             {
                 item = Interlocked.Exchange(ref _itemsCache[i], null);
-                if (item != null && Accept(item))
+                if (item is not null && Accept(item))
                 {
                     return item;
                 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/RefCountedCache.Scope.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/RefCountedCache.Scope.cs
@@ -39,7 +39,7 @@ namespace System.Windows.Forms
 
             public Scope(CacheEntry entry)
             {
-                Debug.Assert(entry != null);
+                Debug.Assert(entry is not null);
                 _object = default!;
                 Entry = entry;
                 Entry.AddRef();

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/SinglyLinkedList.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/SinglyLinkedList.cs
@@ -48,7 +48,7 @@ namespace System.Windows.Forms
             else
             {
                 // Add at the end
-                Debug.Assert(First != null && Last != null);
+                Debug.Assert(First is not null && Last is not null);
                 Last!.Next = node;
                 Last = node;
             }
@@ -119,7 +119,7 @@ namespace System.Windows.Forms
                     // At the start
                     _current = _list.First;
                 }
-                else if (_current.Next != null)
+                else if (_current.Next is not null)
                 {
                     // Not to the end yet
                     _previous = _current;
@@ -163,7 +163,7 @@ namespace System.Windows.Forms
                 else if (_current == _list.Last)
                 {
                     // End of list, set last to previous
-                    Debug.Assert(_previous != null);
+                    Debug.Assert(_previous is not null);
                     _list.Last = _previous;
                     _previous!.Next = null;
                     _current = _previous;
@@ -171,7 +171,7 @@ namespace System.Windows.Forms
                 else
                 {
                     // In the middle
-                    Debug.Assert(_previous != null);
+                    Debug.Assert(_previous is not null);
                     Node? next = _current.Next;
                     _current = _previous;
                     _previous!.Next = next;
@@ -203,7 +203,7 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                Debug.Assert(_previous != null);
+                Debug.Assert(_previous is not null);
 
                 if (_current.Next is null)
                 {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Contributes to https://github.com/dotnet/winforms/issues/3459

## Proposed changes

- Use 'is not null' in System.Windows.Forms.Primitives.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4233)