### PR TITLE
fix: Prevent GC'on of native callback

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -5552,6 +5552,7 @@ namespace System.Windows.Forms
                 NativeMethods.ListViewCompareCallback callback = new NativeMethods.ListViewCompareCallback(CompareFunc);
                 IntPtr callbackPointer = Marshal.GetFunctionPointerForDelegate(callback);
                 User32.SendMessageW(this, (User32.WM)LVM.SORTITEMS, IntPtr.Zero, callbackPointer);
+                GC.KeepAlive(callback);
             }
         }
 


### PR DESCRIPTION

Fixes #4264

(cherry picked from commit 9b140c0952647840d8f1b6984a812c548b002738)

<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

The native callback can be garbage collected even in a simple app, which leads to an app crash with ExecutionEngineException.
The issue can be observed even in an app as simple as:
```cs
namespace repro_listview
{
    static class Program
    {
        [STAThread]
        static void Main()
        {
            Application.SetHighDpiMode(HighDpiMode.SystemAware);
            Application.EnableVisualStyles();
            Application.SetCompatibleTextRenderingDefault(false);

            var f = new Form();
            var listView = new ListView();

            f.Controls.Add(listView);

            listView.Items.Add("A");
            listView.Items.Add("Z");
            listView.Items.Add("X");
            listView.ListViewItemSorter = new TestComparer();

            Application.Run(f);
        }

        class TestComparer : Comparer<ListViewItem>
        {
            public override int Compare(ListViewItem x, ListViewItem y)
            {
                GC.Collect();
                Thread.Sleep(10);
                return 0;
            }
        }
    }
}
```

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Interacting with a `ListView` with sort enabled won't be crashing an app due to a GC'ed native callback.

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->



## Test methodology <!-- How did you ensure quality? -->

- manual, by replacing binaries in C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App\6.0.0-alpha.1.20570.2
- no automation test could be devised as the problem couldn't be reproduced from the Windows Forms codebase, either 5.0 or 6.0 branches




<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4280)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4281)