### PR TITLE
Adding border for focused ToolStripButton in PropertyGrid

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridToolStripButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridToolStripButton.cs
@@ -27,18 +27,56 @@ namespace System.Windows.Forms
                 // which calls the "VisualStyleRenderer.DrawBackground" method for drawing
                 // For high contrast mode we use the "ToolStripHighContrastRenderer.OnRenderButtonBackground" method
                 // which calls the "Graphics.DrawRectangle" method for drawing
-                if (!SystemInformation.HighContrast)
+                if (SystemInformation.HighContrast)
                 {
-                    bounds.Height -= 1;
+                    DrawHightContrastDashedBorer(e.Graphics);
                 }
-
-                // We support only one type of settings for all borders since it is consistent with the behavior of the same controls
-                ControlPaint.DrawBorder(e.Graphics, bounds,
-                    leftColor: Color.Black, leftWidth: 1, leftStyle: ButtonBorderStyle.Dashed, // left
-                    topColor: Color.Black, topWidth: 1, topStyle: ButtonBorderStyle.Dashed, // top
-                    rightColor: Color.Black, rightWidth: 1, rightStyle: ButtonBorderStyle.Dashed, // right
-                    bottomColor: Color.Black, bottomWidth: 1, bottomStyle: ButtonBorderStyle.Dashed); // bottom;
+                else
+                {
+                    DrawDashedBorer(e.Graphics);
+                }
             }
+        }
+
+        private void DrawDashedBorer(Graphics graphics)
+        {
+            var bounds = ClientBounds;
+
+            // It is necessary so that when HighContrast is off, the size of the dotted borders
+            // coincides with the size of the button background
+            // For normal mode we use the "ToolStripSystemRenderer.RenderItemInternal" method
+            // which calls the "VisualStyleRenderer.DrawBackground" method for drawing
+            // For high contrast mode we use the "ToolStripHighContrastRenderer.OnRenderButtonBackground" method
+            // which calls the "Graphics.DrawRectangle" method for drawing
+            bounds.Height -= 1;
+
+            // We support only one type of settings for all borders since it is consistent with the behavior of the same controls
+            ControlPaint.DrawBorder(graphics, bounds,
+                leftColor: Color.Black, leftWidth: 1, leftStyle: ButtonBorderStyle.Dashed, // left
+                topColor: Color.Black, topWidth: 1, topStyle: ButtonBorderStyle.Dashed, // top
+                rightColor: Color.Black, rightWidth: 1, rightStyle: ButtonBorderStyle.Dashed, // right
+                bottomColor: Color.Black, bottomWidth: 1, bottomStyle: ButtonBorderStyle.Dashed); // bottom;*/
+        }
+
+        private void DrawHightContrastDashedBorer(Graphics graphics)
+        {
+            var bounds = ClientBounds;
+            float[] dashValues = { 2, 2 };
+            int penWidth = 2;
+
+            var focusPen1 = new Pen(SystemColors.ControlText, penWidth)
+            {
+                DashPattern = dashValues
+            };
+
+            var focusPen2 = new Pen(SystemColors.Control, penWidth)
+            {
+                DashPattern = dashValues,
+                DashOffset = 2
+            };
+
+            graphics.DrawRectangle(focusPen1, bounds);
+            graphics.DrawRectangle(focusPen2, bounds);
         }
     }
 }


### PR DESCRIPTION
Fixes #4268

## Proposed changes
- Added a special method for high contrast mode that draws a black and white dashed border
- Added a special method for normal mode that draws a dashed border

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
**Before fix:**
![100072081-c5886100-2e76-11eb-92f5-390882b13f65](https://user-images.githubusercontent.com/23376742/100229792-d51aaf00-2f35-11eb-8625-d9fd9c79bbea.png)

**After fix:**
Normal mode:
![Issue-4282-NormalMode](https://user-images.githubusercontent.com/23376742/100229857-ecf23300-2f35-11eb-8b77-93d02c3ac487.gif)
High Contrast 1:
![Issue-4282-HC1](https://user-images.githubusercontent.com/23376742/100229952-0dba8880-2f36-11eb-9a85-3eb83b8087c7.gif)

High Contrast 2:
![Issue-4282-HC2](https://user-images.githubusercontent.com/23376742/100230189-70ac1f80-2f36-11eb-9463-28dfe1a1a5dc.gif)

High Contrast Black:
![Issue-4282-HCB](https://user-images.githubusercontent.com/23376742/100230209-786bc400-2f36-11eb-9b24-2770ccd1abb1.gif)

High Contrast White:
![Issue-4282-HCW](https://user-images.githubusercontent.com/23376742/100230230-7e61a500-2f36-11eb-88b7-81bbd8788eba.gif)

## Regression? 

- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Manually 

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core 5.0.100-rc.1.20420.14


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4282)