### PR TITLE
Fixing ErrorProvider error text announcing by a screen reader

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
@@ -785,6 +785,14 @@ namespace System.Windows.Forms
         public void SetError(Control control, string value)
         {
             EnsureControlItem(control).Error = value;
+
+            if (UiaCore.UiaClientsAreListening().IsTrue())
+            {
+                control.AccessibilityObject.RaiseAutomationNotification(
+                    Automation.AutomationNotificationKind.ActionAborted,
+                    Automation.AutomationNotificationProcessing.All,
+                    value);
+            }
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/MainFormControlsTabOrder.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/MainFormControlsTabOrder.cs
@@ -30,5 +30,6 @@ namespace System.Windows.Forms.IntegrationTests.Common
         FormBorderStylesButton,
         ToggleIconButton,
         FileDialogButton,
+        ErrorProviderButton
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ErrorProviderTest.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ErrorProviderTest.Designer.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace WinformsControlsTest
+{
+    partial class ErrorProviderTest
+    {
+        /// <summary>
+        ///  Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        ///  Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        ///  Required method for Designer support - do not modify
+        ///  the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.textBox1 = new System.Windows.Forms.TextBox();
+            this.errorProvider1 = new System.Windows.Forms.ErrorProvider(this.components);
+            this.submitButton = new System.Windows.Forms.Button();
+            this.label1 = new System.Windows.Forms.Label();
+            ((System.ComponentModel.ISupportInitialize)(this.errorProvider1)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // textBox1
+            // 
+            this.textBox1.Location = new System.Drawing.Point(35, 60);
+            this.textBox1.Name = "textBox1";
+            this.textBox1.Size = new System.Drawing.Size(120, 23);
+            this.textBox1.TabIndex = 0;
+            // 
+            // errorProvider1
+            // 
+            this.errorProvider1.ContainerControl = this;
+            // 
+            // submitButton
+            // 
+            this.submitButton.Location = new System.Drawing.Point(35, 109);
+            this.submitButton.Name = "submitButton";
+            this.submitButton.Size = new System.Drawing.Size(120, 27);
+            this.submitButton.TabIndex = 1;
+            this.submitButton.Text = "Submit";
+            this.submitButton.UseVisualStyleBackColor = true;
+            this.submitButton.Click += new System.EventHandler(this.submitButton_Click);
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(19, 26);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(155, 15);
+            this.label1.TabIndex = 2;
+            this.label1.Text = "Type from 5 to 10 characters";
+            // 
+            // Form1
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(194, 165);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.submitButton);
+            this.Controls.Add(this.textBox1);
+            this.Name = "Form1";
+            this.Text = "Form1";
+            ((System.ComponentModel.ISupportInitialize)(this.errorProvider1)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TextBox textBox1;
+        private System.Windows.Forms.ErrorProvider errorProvider1;
+        private System.Windows.Forms.Button submitButton;
+        private System.Windows.Forms.Label label1;
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ErrorProviderTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ErrorProviderTest.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Windows.Forms;
+
+namespace WinformsControlsTest
+{
+    public partial class ErrorProviderTest : Form
+    {
+        public ErrorProviderTest()
+        {
+            InitializeComponent();
+        }
+
+        private void submitButton_Click(object sender, EventArgs e)
+        {
+            if (textBox1.TextLength < 5 || textBox1.TextLength > 10)
+            {
+                errorProvider1.SetError(textBox1, "The length of the testbox is invalid!");
+            }
+            else
+            {
+                errorProvider1.Clear();
+                MessageBox.Show("All right!", "OK", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ErrorProviderTest.resx
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ErrorProviderTest.resx
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
@@ -145,6 +145,10 @@ namespace WinformsControlsTest
             {
                 MainFormControlsTabOrder.FileDialogButton,
                 new InitInfo("FileDialog", (obj, e) => new FileDialog().Show())
+            },
+            {
+                MainFormControlsTabOrder.ErrorProviderButton,
+                new InitInfo("ErrorProvider", (obj, e) => new ErrorProviderTest().Show())
             }
         };
 


### PR DESCRIPTION
Fixes #2390
Original bug: [987891](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/987891)
Based on PR #2391


## Proposed changes

- Raise an automation notification when setting an error for a control
- Don't add a tooltip announcing as in PR #2391 because it leads to Issue #2538
- Add a UI test app to check an `ErrorProvider`

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A screen reader can announce an `ErrorProvider` error text

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
- Narrator doesn't announce an error text:
![image](https://user-images.githubusercontent.com/49272759/100414854-ce9e4b80-308b-11eb-97ec-316e4b8aa91e.png)


### After
- Narrator announces an error text when a red icon of an `ErrorProvider` appears:
![Expected](https://user-images.githubusercontent.com/49272759/100414911-f392be80-308b-11eb-9c4a-28b37e00c6dc.gif)

### Test app
- Added `ErrorProviderTest` app to `WinformsControlsTest` project
![image](https://user-images.githubusercontent.com/49272759/100415640-b5969a00-308d-11eb-99c7-9cc8444b3c5d.png)





## Test methodology <!-- How did you ensure quality? -->

- UI testing
- CTI

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Using Narrator and NVDA
 

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.19042.630]
- .NET Version:   6.0.100-alpha.1.20554.10


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4286)