### PR TITLE
Use 'is not null' in System.Windows.Forms Resources, ButtonInternal a…

### DIFF
--- a/src/System.Windows.Forms/src/System/Resources/AssemblyNamesTypeResolutionService.cs
+++ b/src/System.Windows.Forms/src/System/Resources/AssemblyNamesTypeResolutionService.cs
@@ -49,18 +49,18 @@ namespace System.Resources
             if (result is null)
             {
                 result = Assembly.Load(name.FullName);
-                if (result != null)
+                if (result is not null)
                 {
                     _cachedAssemblies[name] = result;
                 }
-                else if (_names != null)
+                else if (_names is not null)
                 {
                     foreach (AssemblyName asmName in _names.Where(an => an.Equals(name)))
                     {
                         try
                         {
                             result = Assembly.LoadFrom(GetPathOfAssembly(asmName));
-                            if (result != null)
+                            if (result is not null)
                             {
                                 _cachedAssemblies[asmName] = result;
                             }
@@ -116,7 +116,7 @@ namespace System.Resources
                 result = Type.GetType(name, false, ignoreCase);
             }
 
-            if (result is null && _names != null)
+            if (result is null && _names is not null)
             {
                 // If the type is assembly qualified name, we sort the assembly names
                 // to put assemblies with same name in the front so that they can
@@ -134,7 +134,7 @@ namespace System.Resources
                     {
                     }
 
-                    if (assemblyName != null)
+                    if (assemblyName is not null)
                     {
                         List<AssemblyName> assemblyList = new List<AssemblyName>(_names.Length);
                         foreach (AssemblyName asmName in _names)
@@ -156,7 +156,7 @@ namespace System.Resources
                 foreach (AssemblyName asmName in _names)
                 {
                     Assembly asm = GetAssembly(asmName, false);
-                    if (asm != null)
+                    if (asm is not null)
                     {
                         result = asm.GetType(name, false, ignoreCase);
                         if (result is null)
@@ -170,7 +170,7 @@ namespace System.Resources
                         }
                     }
 
-                    if (result != null)
+                    if (result is not null)
                     {
                         break;
                     }
@@ -182,7 +182,7 @@ namespace System.Resources
                 throw new ArgumentException(string.Format(SR.InvalidResXNoType, name));
             }
 
-            if (result != null)
+            if (result is not null)
             {
                 // Only cache types from the shared framework  because they don't need to update.
                 // For simplicity, don't cache custom types
@@ -200,7 +200,7 @@ namespace System.Resources
         /// </summary>
         private bool IsDotNetAssembly(string assemblyPath)
         {
-            return assemblyPath != null && (assemblyPath.StartsWith(s_dotNetPath, StringComparison.OrdinalIgnoreCase) || assemblyPath.StartsWith(s_dotNetPathX86, StringComparison.OrdinalIgnoreCase));
+            return assemblyPath is not null && (assemblyPath.StartsWith(s_dotNetPath, StringComparison.OrdinalIgnoreCase) || assemblyPath.StartsWith(s_dotNetPathX86, StringComparison.OrdinalIgnoreCase));
         }
 
         public void ReferenceAssembly(AssemblyName name)

--- a/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
@@ -91,12 +91,12 @@ namespace System.Resources
 
             Type valueType = (value is null) ? typeof(object) : value.GetType();
 
-            if (value != null && !valueType.IsSerializable)
+            if (value is not null && !valueType.IsSerializable)
             {
                 throw new InvalidOperationException(string.Format(SR.NotSerializableType, name, valueType.FullName));
             }
 
-            if (value != null)
+            if (value is not null)
             {
                 _typeName = MultitargetUtil.GetAssemblyQualifiedName(valueType, _typeNameConverter);
             }
@@ -139,13 +139,13 @@ namespace System.Resources
                 nodeType = s_internalTypeResolver.GetType(_nodeInfo.TypeName, false, true);
             }
 
-            if (nodeType != null && nodeType.Equals(typeof(ResXFileRef)))
+            if (nodeType is not null && nodeType.Equals(typeof(ResXFileRef)))
             {
                 // we have a fileref, split the value data and populate the fields
                 string[] fileRefDetails = ResXFileRef.Converter.ParseResxFileRefString(_nodeInfo.ValueData);
-                if (fileRefDetails != null && fileRefDetails.Length > 1)
+                if (fileRefDetails is not null && fileRefDetails.Length > 1)
                 {
-                    if (!Path.IsPathRooted(fileRefDetails[0]) && basePath != null)
+                    if (!Path.IsPathRooted(fileRefDetails[0]) && basePath is not null)
                     {
                         _fileRefFullPath = Path.Combine(basePath, fileRefDetails[0]);
                     }
@@ -168,7 +168,7 @@ namespace System.Resources
             get
             {
                 string result = _comment;
-                if (result is null && _nodeInfo != null)
+                if (result is null && _nodeInfo is not null)
                 {
                     result = _nodeInfo.Comment;
                 }
@@ -185,7 +185,7 @@ namespace System.Resources
             get
             {
                 string result = _name;
-                if (result is null && _nodeInfo != null)
+                if (result is null && _nodeInfo is not null)
                 {
                     result = _nodeInfo.Name;
                 }
@@ -294,7 +294,7 @@ namespace System.Resources
             else
             {
                 Type valueType = (value is null) ? typeof(object) : value.GetType();
-                if (value != null && !valueType.IsSerializable)
+                if (value is not null && !valueType.IsSerializable)
                 {
                     throw new InvalidOperationException(string.Format(SR.NotSerializableType, _name, valueType.FullName));
                 }
@@ -388,7 +388,7 @@ namespace System.Resources
                     }
 
                     IFormatter formatter = _binaryFormatter;
-                    if (serializedData != null && serializedData.Length > 0)
+                    if (serializedData is not null && serializedData.Length > 0)
                     {
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
                         result = formatter.Deserialize(new MemoryStream(serializedData));
@@ -404,7 +404,7 @@ namespace System.Resources
                     if (!string.IsNullOrEmpty(typeName))
                     {
                         Type type = ResolveType(typeName, typeResolver);
-                        if (type != null)
+                        if (type is not null)
                         {
                             TypeConverter tc = TypeDescriptor.GetConverter(type);
                             if (tc.CanConvertFrom(typeof(byte[])))
@@ -412,7 +412,7 @@ namespace System.Resources
                                 string text = dataNodeInfo.ValueData;
                                 byte[] serializedData = FromBase64WrappedString(text);
 
-                                if (serializedData != null)
+                                if (serializedData is not null)
                                 {
                                     result = tc.ConvertFrom(serializedData);
                                 }
@@ -432,7 +432,7 @@ namespace System.Resources
             else if (!string.IsNullOrEmpty(typeName))
             {
                 Type type = ResolveType(typeName, typeResolver);
-                if (type != null)
+                if (type is not null)
                 {
                     if (type == typeof(ResXNullRef))
                     {
@@ -490,7 +490,7 @@ namespace System.Resources
         internal DataNodeInfo GetDataNodeInfo()
         {
             bool shouldSerialize = true;
-            if (_nodeInfo != null)
+            if (_nodeInfo is not null)
             {
                 shouldSerialize = false;
             }
@@ -503,11 +503,11 @@ namespace System.Resources
 
             // We always serialize if this node represents a FileRef. This is because FileRef is a public property,
             // so someone could have modified it.
-            if (shouldSerialize || FileRefFullPath != null)
+            if (shouldSerialize || FileRefFullPath is not null)
             {
                 // if we dont have a datanodeinfo it could be either
                 // a direct object OR a fileref
-                if (FileRefFullPath != null)
+                if (FileRefFullPath is not null)
                 {
                     _nodeInfo.ValueData = FileRef.ToString();
                     _nodeInfo.MimeType = null;
@@ -548,12 +548,12 @@ namespace System.Resources
             string result = FileRefType;
             Type objectType = null;
             // do we have a fileref?
-            if (result != null)
+            if (result is not null)
             {
                 // try to resolve this type
                 objectType = ResolveType(FileRefType, typeResolver);
             }
-            else if (_nodeInfo != null)
+            else if (_nodeInfo is not null)
             {
                 // we dont have a fileref, try to resolve the type of the datanode
                 result = _nodeInfo.TypeName;
@@ -583,7 +583,7 @@ namespace System.Resources
                             result = MultitargetUtil.GetAssemblyQualifiedName(typeof(object), _typeNameConverter);
                         }
 
-                        if (insideObject != null)
+                        if (insideObject is not null)
                         {
                             result = MultitargetUtil.GetAssemblyQualifiedName(insideObject.GetType(), _typeNameConverter);
                         }
@@ -599,7 +599,7 @@ namespace System.Resources
                     objectType = ResolveType(_nodeInfo.TypeName, typeResolver);
                 }
             }
-            if (objectType != null)
+            if (objectType is not null)
             {
                 if (objectType == typeof(ResXNullRef))
                 {
@@ -626,20 +626,20 @@ namespace System.Resources
         /// </summary>
         public object GetValue(ITypeResolutionService typeResolver)
         {
-            if (_value != null)
+            if (_value is not null)
             {
                 return _value;
             }
 
             object result = null;
-            if (FileRefFullPath != null)
+            if (FileRefFullPath is not null)
             {
                 Type objectType = ResolveType(FileRefType, typeResolver);
-                if (objectType != null)
+                if (objectType is not null)
                 {
                     // we have the FQN for this type
                     _fileRef =
-                        FileRefTextEncoding != null
+                        FileRefTextEncoding is not null
                             ? new ResXFileRef(FileRefFullPath, FileRefType, Encoding.GetEncoding(FileRefTextEncoding))
                             : new ResXFileRef(FileRefFullPath, FileRefType);
                     TypeConverter tc = TypeDescriptor.GetConverter(typeof(ResXFileRef));
@@ -652,7 +652,7 @@ namespace System.Resources
                     throw (newTle);
                 }
             }
-            else if (_nodeInfo.ValueData != null)
+            else if (_nodeInfo.ValueData is not null)
             {
                 // it's embedded, we deserialize it
                 result = GenerateObjectFromDataNodeInfo(_nodeInfo, typeResolver);
@@ -702,7 +702,7 @@ namespace System.Resources
         private Type ResolveType(string typeName, ITypeResolutionService typeResolver)
         {
             Type resolvedType = null;
-            if (typeResolver != null)
+            if (typeResolver is not null)
             {
                 // If we cannot find the strong-named type, then try to see
                 // if the TypeResolver can bind to partial names. For this,
@@ -715,7 +715,7 @@ namespace System.Resources
                     string[] typeParts = typeName.Split(',');
 
                     // Break up the type name from the rest of the assembly strong name.
-                    if (typeParts != null && typeParts.Length >= 2)
+                    if (typeParts is not null && typeParts.Length >= 2)
                     {
                         string partialName = typeParts[0].Trim();
                         string assemblyName = typeParts[1].Trim();

--- a/src/System.Windows.Forms/src/System/Resources/ResXFileRef.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXFileRef.cs
@@ -122,7 +122,7 @@ namespace System.Resources
             }
 
             result += TypeName;
-            if (TextFileEncoding != null)
+            if (TextFileEncoding is not null)
             {
                 result += (";" + TextFileEncoding.WebName);
             }

--- a/src/System.Windows.Forms/src/System/Resources/ResXResourceReader.ReaderAliasResolver.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXResourceReader.ReaderAliasResolver.cs
@@ -23,7 +23,7 @@ namespace System.Resources
             public AssemblyName ResolveAlias(string alias)
             {
                 AssemblyName result = null;
-                if (_cachedAliases != null)
+                if (_cachedAliases is not null)
                 {
                     result = (AssemblyName)_cachedAliases[alias];
                 }
@@ -33,7 +33,7 @@ namespace System.Resources
 
             public void PushAlias(string alias, AssemblyName name)
             {
-                if (_cachedAliases != null && !string.IsNullOrEmpty(alias))
+                if (_cachedAliases is not null && !string.IsNullOrEmpty(alias))
                 {
                     _cachedAliases[alias] = name;
                 }

--- a/src/System.Windows.Forms/src/System/Resources/ResXResourceReader.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXResourceReader.cs
@@ -196,13 +196,13 @@ namespace System.Resources
         {
             if (disposing)
             {
-                if (_fileName != null && _stream != null)
+                if (_fileName is not null && _stream is not null)
                 {
                     _stream.Close();
                     _stream = null;
                 }
 
-                if (_reader != null)
+                if (_reader is not null)
                 {
                     _reader.Close();
                     _reader = null;
@@ -244,15 +244,15 @@ namespace System.Resources
                 try
                 {
                     // Read data in any which way
-                    if (_fileContents != null)
+                    if (_fileContents is not null)
                     {
                         contentReader = new XmlTextReader(new StringReader(_fileContents));
                     }
-                    else if (_reader != null)
+                    else if (_reader is not null)
                     {
                         contentReader = new XmlTextReader(_reader);
                     }
-                    else if (_fileName != null || _stream != null)
+                    else if (_fileName is not null || _stream is not null)
                     {
                         if (_stream is null)
                         {
@@ -268,7 +268,7 @@ namespace System.Resources
                 }
                 finally
                 {
-                    if (_fileName != null && _stream != null)
+                    if (_fileName is not null && _stream is not null)
                     {
                         _stream.Close();
                         _stream = null;
@@ -432,17 +432,17 @@ namespace System.Resources
 
                 string readerTypeName = _resHeaderReaderType;
                 string writerTypeName = _resHeaderWriterType;
-                if (readerTypeName != null && readerTypeName.IndexOf(',') != -1)
+                if (readerTypeName is not null && readerTypeName.IndexOf(',') != -1)
                 {
                     readerTypeName = readerTypeName.Split(',')[0].Trim();
                 }
-                if (writerTypeName != null && writerTypeName.IndexOf(',') != -1)
+                if (writerTypeName is not null && writerTypeName.IndexOf(',') != -1)
                 {
                     writerTypeName = writerTypeName.Split(',')[0].Trim();
                 }
 
-                if (readerTypeName != null &&
-                    writerTypeName != null &&
+                if (readerTypeName is not null &&
+                    writerTypeName is not null &&
                     readerTypeName.Equals(readerType.FullName) &&
                     writerTypeName.Equals(writerType.FullName))
                 {
@@ -461,7 +461,7 @@ namespace System.Resources
         private void ParseResHeaderNode(XmlReader reader)
         {
             string name = reader[ResXResourceWriter.NameStr];
-            if (name != null)
+            if (name is not null)
             {
                 reader.ReadStartElement();
 
@@ -600,7 +600,7 @@ namespace System.Resources
                 assemblyName = _aliasResolver.ResolveAlias(alias);
             }
 
-            if (assemblyName != null)
+            if (assemblyName is not null)
             {
                 nodeInfo.TypeName = GetTypeFromTypeName(typeName) + ", " + assemblyName.FullName;
             }

--- a/src/System.Windows.Forms/src/System/Resources/ResXResourceWriter.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXResourceWriter.cs
@@ -155,20 +155,20 @@ namespace System.Resources
             {
                 bool writeHeaderRequired = false;
 
-                if (_textWriter != null)
+                if (_textWriter is not null)
                 {
                     _textWriter.WriteLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
                     writeHeaderRequired = true;
 
                     _xmlTextWriter = new XmlTextWriter(_textWriter);
                 }
-                else if (_stream != null)
+                else if (_stream is not null)
                 {
                     _xmlTextWriter = new XmlTextWriter(_stream, System.Text.Encoding.UTF8);
                 }
                 else
                 {
-                    Debug.Assert(_fileName != null, "Nothing to output to");
+                    Debug.Assert(_fileName is not null, "Nothing to output to");
                     _xmlTextWriter = new XmlTextWriter(_fileName, System.Text.Encoding.UTF8);
                 }
 
@@ -420,7 +420,7 @@ namespace System.Resources
                         {
                             type = null;
                         }
-                        else if (typeObject != null)
+                        else if (typeObject is not null)
                         {
                             assemblyName = GetFullName(MultitargetUtil.GetAssemblyQualifiedName(typeObject, _typeNameConverter));
                             alias = GetAliasFromName(new AssemblyName(assemblyName));
@@ -450,18 +450,18 @@ namespace System.Resources
                 }
                 else
                 {
-                    if (type != null)
+                    if (type is not null)
                     {
                         Writer.WriteAttributeString(TypeStr, type);
                     }
                 }
 
-                if (mimeType != null)
+                if (mimeType is not null)
                 {
                     Writer.WriteAttributeString(MimeTypeStr, mimeType);
                 }
 
-                if ((type is null && mimeType is null) || (type != null && type.StartsWith("System.Char", StringComparison.Ordinal)))
+                if ((type is null && mimeType is null) || (type is not null && type.StartsWith("System.Char", StringComparison.Ordinal)))
                 {
                     Writer.WriteAttributeString("xml", "space", null, "preserve");
                 }
@@ -546,19 +546,19 @@ namespace System.Resources
                     Generate();
                 }
 
-                if (_xmlTextWriter != null)
+                if (_xmlTextWriter is not null)
                 {
                     _xmlTextWriter.Close();
                     _xmlTextWriter = null;
                 }
 
-                if (_stream != null)
+                if (_stream is not null)
                 {
                     _stream.Close();
                     _stream = null;
                 }
 
-                if (_textWriter != null)
+                if (_textWriter is not null)
                 {
                     _textWriter.Close();
                     _textWriter = null;

--- a/src/System.Windows.Forms/src/System/Resources/ResXSerializationBinder.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXSerializationBinder.cs
@@ -44,7 +44,7 @@ namespace System.Resources
 
                 // Break up the assembly name from the rest of the assembly strong name.
                 // we try 1) FQN 2) FQN without a version 3) just the short name
-                if (typeParts != null && typeParts.Length > 2)
+                if (typeParts is not null && typeParts.Length > 2)
                 {
                     string partialName = typeParts[0].Trim();
 
@@ -86,7 +86,7 @@ namespace System.Resources
             //
             // another example are singleton objects like DBNull.Value which are serialized by System.UnitySerializationHolder
             typeName = null;
-            if (_typeNameConverter != null)
+            if (_typeNameConverter is not null)
             {
                 string assemblyQualifiedTypeName = MultitargetUtil.GetAssemblyQualifiedName(serializedType, _typeNameConverter);
                 if (!string.IsNullOrEmpty(assemblyQualifiedTypeName))

--- a/src/System.Windows.Forms/src/System/Resources/ResxFileRef.Converter.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResxFileRef.Converter.cs
@@ -52,7 +52,7 @@ namespace System.Resources
             internal static string[] ParseResxFileRefString(string stringValue)
             {
                 string[] result = null;
-                if (stringValue != null)
+                if (stringValue is not null)
                 {
                     stringValue = stringValue.Trim();
                     string fileName;
@@ -139,7 +139,7 @@ namespace System.Resources
 
                     using (FileStream fileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read))
                     {
-                        Debug.Assert(fileStream != null, "Couldn't open " + fileName);
+                        Debug.Assert(fileStream is not null, "Couldn't open " + fileName);
                         temp = new byte[fileStream.Length];
                         fileStream.Read(temp, 0, (int)fileStream.Length);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonBaseAdapter.LayoutData.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonBaseAdapter.LayoutData.cs
@@ -24,7 +24,7 @@ namespace System.Windows.Forms.ButtonInternal
 
             internal LayoutData(LayoutOptions options)
             {
-                Debug.Assert(options != null, "must have options");
+                Debug.Assert(options is not null, "must have options");
                 Options = options;
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonBaseAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonBaseAdapter.cs
@@ -424,7 +424,7 @@ namespace System.Windows.Forms.ButtonInternal
             if (color.HasTransparency())
             {
                 Graphics graphics = deviceContext.TryGetGraphics(create: true);
-                if (graphics != null)
+                if (graphics is not null)
                 {
                     using var pen = color.GetCachedPenScope();
                     graphics.DrawRectangle(pen, r.X, r.Y, r.Width - 1, r.Height - 1);
@@ -537,7 +537,7 @@ namespace System.Windows.Forms.ButtonInternal
         /// </summary>
         internal void PaintImage(PaintEventArgs e, LayoutData layout)
         {
-            if (Control.Image != null)
+            if (Control.Image is not null)
             {
                 // Setup new clip region & draw
                 DrawImageCore(e.GraphicsInternal, Control.Image, layout.ImageBounds, layout.ImageStart, layout);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonStandardAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonStandardAdapter.cs
@@ -104,7 +104,7 @@ namespace System.Windows.Forms.ButtonInternal
             }
 
             // This code is mostly taken from the non-themed rendering code path.
-            if (Control.BackgroundImage != null && !DisplayInformation.HighContrast)
+            if (Control.BackgroundImage is not null && !DisplayInformation.HighContrast)
             {
                 ControlPaint.DrawBackgroundImage(
                     e.GraphicsInternal,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/CheckBoxBaseAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/CheckBoxBaseAdapter.cs
@@ -308,7 +308,7 @@ namespace System.Windows.Forms.ButtonInternal
 
         private static Bitmap GetCheckBoxImage(Color checkColor, Rectangle fullSize, ref Color cacheCheckColor, ref Bitmap cacheCheckImage)
         {
-            if (cacheCheckImage != null &&
+            if (cacheCheckImage is not null &&
                 cacheCheckColor.Equals(checkColor) &&
                 cacheCheckImage.Width == fullSize.Width &&
                 cacheCheckImage.Height == fullSize.Height)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/CheckBoxPopupAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/CheckBoxPopupAdapter.cs
@@ -83,7 +83,7 @@ namespace System.Windows.Forms.ButtonInternal
                 AdjustFocusRectangle(layout);
                 PaintField(e, layout, colors, colors.WindowText, drawFocus: true);
 
-                if (originalClip != null)
+                if (originalClip is not null)
                 {
                     e.GraphicsInternal.Clip = originalClip;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/CheckableControlBaseAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/CheckableControlBaseAdapter.cs
@@ -89,7 +89,7 @@ namespace System.Windows.Forms.ButtonInternal
         internal static double GetDpiScaleRatio(Control control)
         {
             if (DpiHelper.IsPerMonitorV2Awareness
-                && control != null && control.IsHandleCreated)
+                && control is not null && control.IsHandleCreated)
             {
                 return control._deviceDpi / DpiHelper.LogicalDpi;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/BaseCAMarshaler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/BaseCAMarshaler.cs
@@ -40,7 +40,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         {
             try
             {
-                if (_itemArray is null && _caArrayAddress != null)
+                if (_itemArray is null && _caArrayAddress is not null)
                 {
                     object[] items = Items;
                 }
@@ -78,7 +78,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                     Debug.WriteLineIf(s_caMarshalSwitch.TraceVerbose, "Marshaling failed: " + ex.GetType().Name + ", " + ex.Message);
                 }
 #if DEBUG
-                if (_itemArray != null)
+                if (_itemArray is not null)
                 {
                     Debug.WriteLineIf(s_caMarshalSwitch.TraceVerbose, "Marshaled: " + _itemArray.Length.ToString(CultureInfo.InvariantCulture) + " items, array type=" + _itemArray.GetType().Name);
                 }
@@ -104,7 +104,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 try
                 {
                     object curItem = GetItemFromAddress(nativeItems[i]);
-                    if (curItem != null && ItemType.IsInstanceOfType(curItem))
+                    if (curItem is not null && ItemType.IsInstanceOfType(curItem))
                     {
                         items[i] = curItem;
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ComponentEditor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ComponentEditor.cs
@@ -42,7 +42,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 }
                 finally
                 {
-                    if (uuids.pElems != null)
+                    if (uuids.pElems is not null)
                     {
                         Marshal.FreeCoTaskMem((IntPtr)uuids.pElems);
                     }
@@ -119,7 +119,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                     finally
                     {
                         Marshal.Release(pUnk);
-                        if (uuids.pElems != null)
+                        if (uuids.pElems is not null)
                         {
                             Marshal.FreeCoTaskMem((IntPtr)uuids.pElems);
                         }
@@ -129,7 +129,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 {
                     string errString = SR.ErrorPropertyPageFailed;
 
-                    IUIService uiSvc = (context != null) ? ((IUIService)context.GetService(typeof(IUIService))) : null;
+                    IUIService uiSvc = (context is not null) ? ((IUIService)context.GetService(typeof(IUIService))) : null;
 
                     if (uiSvc is null)
                     {
@@ -137,7 +137,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                                 MessageBoxButtons.OK, MessageBoxIcon.Error,
                                 MessageBoxDefaultButton.Button1, 0);
                     }
-                    else if (ex != null)
+                    else if (ex is not null)
                     {
                         uiSvc.ShowError(ex, errString);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2Enum.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2Enum.cs
@@ -134,7 +134,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             {
                 this.names[i] = names[i];
                 this.values[i] = values[i];
-                if (values[i] != null)
+                if (values[i] is not null)
                 {
                     stringValues[i] = values[i].ToString();
                 }
@@ -146,7 +146,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// </summary>
         public virtual string ToString(object v)
         {
-            if (v != null)
+            if (v is not null)
             {
                 // in case this is a real enum...try to convert it.
                 //

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2EnumConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2EnumConverter.cs
@@ -69,7 +69,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
             if (destinationType == typeof(string))
             {
-                if (value != null)
+                if (value is not null)
                 {
                     string str = com2Enum.ToString(value);
                     return (str ?? "");
@@ -94,7 +94,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             if (values is null)
             {
                 object[] objValues = com2Enum.Values;
-                if (objValues != null)
+                if (objValues is not null)
                 {
                     values = new StandardValuesCollection(objValues);
                 }
@@ -130,7 +130,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         public override bool IsValid(ITypeDescriptorContext context, object value)
         {
             string strValue = com2Enum.ToString(value);
-            return strValue != null && strValue.Length > 0;
+            return strValue is not null && strValue.Length > 0;
         }
 
         public void RefreshValues()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ExtendedTypeConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ExtendedTypeConverter.cs
@@ -40,7 +40,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         {
             TypeConverter converter = innerConverter;
 
-            while (converter != null)
+            while (converter is not null)
             {
                 if (t.IsInstanceOfType(converter))
                 {
@@ -65,7 +65,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// </summary>
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
-            if (innerConverter != null)
+            if (innerConverter is not null)
             {
                 return innerConverter.CanConvertFrom(context, sourceType);
             }
@@ -78,7 +78,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// </summary>
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
-            if (innerConverter != null)
+            if (innerConverter is not null)
             {
                 return innerConverter.CanConvertTo(context, destinationType);
             }
@@ -90,7 +90,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// </summary>
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
-            if (innerConverter != null)
+            if (innerConverter is not null)
             {
                 return innerConverter.ConvertFrom(context, culture, value);
             }
@@ -106,7 +106,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// </summary>
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {
-            if (innerConverter != null)
+            if (innerConverter is not null)
             {
                 return innerConverter.ConvertTo(context, culture, value, destinationType);
             }
@@ -120,7 +120,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// </summary>
         public override object CreateInstance(ITypeDescriptorContext context, IDictionary propertyValues)
         {
-            if (innerConverter != null)
+            if (innerConverter is not null)
             {
                 return innerConverter.CreateInstance(context, propertyValues);
             }
@@ -133,7 +133,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// </summary>
         public override bool GetCreateInstanceSupported(ITypeDescriptorContext context)
         {
-            if (innerConverter != null)
+            if (innerConverter is not null)
             {
                 return innerConverter.GetCreateInstanceSupported(context);
             }
@@ -147,7 +147,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// </summary>
         public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object value, Attribute[] attributes)
         {
-            if (innerConverter != null)
+            if (innerConverter is not null)
             {
                 return innerConverter.GetProperties(context, value, attributes);
             }
@@ -160,7 +160,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// </summary>
         public override bool GetPropertiesSupported(ITypeDescriptorContext context)
         {
-            if (innerConverter != null)
+            if (innerConverter is not null)
             {
                 return innerConverter.GetPropertiesSupported(context);
             }
@@ -175,7 +175,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// </summary>
         public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
         {
-            if (innerConverter != null)
+            if (innerConverter is not null)
             {
                 return innerConverter.GetStandardValues(context);
             }
@@ -192,7 +192,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// </summary>
         public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
         {
-            if (innerConverter != null)
+            if (innerConverter is not null)
             {
                 return innerConverter.GetStandardValuesExclusive(context);
             }
@@ -205,7 +205,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// </summary>
         public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
         {
-            if (innerConverter != null)
+            if (innerConverter is not null)
             {
                 return innerConverter.GetStandardValuesSupported(context);
             }
@@ -217,7 +217,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// </summary>
         public override bool IsValid(ITypeDescriptorContext context, object value)
         {
-            if (innerConverter != null)
+            if (innerConverter is not null)
             {
                 return innerConverter.IsValid(context, value);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ExtendedUITypeEditor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ExtendedUITypeEditor.cs
@@ -35,7 +35,7 @@ namespace System.Drawing.Design
 
         public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
         {
-            if (innerEditor != null)
+            if (innerEditor is not null)
             {
                 return innerEditor.EditValue(context, provider, value);
             }
@@ -51,7 +51,7 @@ namespace System.Drawing.Design
         /// </summary>
         public override bool GetPaintValueSupported(ITypeDescriptorContext context)
         {
-            if (innerEditor != null)
+            if (innerEditor is not null)
             {
                 return innerEditor.GetPaintValueSupported(context);
             }
@@ -64,7 +64,7 @@ namespace System.Drawing.Design
         /// </summary>
         public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context)
         {
-            if (innerEditor != null)
+            if (innerEditor is not null)
             {
                 return innerEditor.GetEditStyle(context);
             }
@@ -78,7 +78,7 @@ namespace System.Drawing.Design
         /// </summary>
         public override void PaintValue(PaintValueEventArgs e)
         {
-            if (innerEditor != null)
+            if (innerEditor is not null)
             {
                 innerEditor.PaintValue(e);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2FontConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2FontConverter.cs
@@ -40,7 +40,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             IntPtr fontHandle = nativeFont.hFont;
 
             // see if we have this guy cached
-            if (fontHandle == _lastHandle && _lastFont != null)
+            if (fontHandle == _lastHandle && _lastFont is not null)
             {
                 return _lastFont;
             }
@@ -79,7 +79,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
             cancelSet = true;
 
-            if (_lastFont != null && _lastFont.Equals(managedValue))
+            if (_lastFont is not null && _lastFont.Equals(managedValue))
             {
                 // don't do anything here.
                 return null;
@@ -89,7 +89,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             IFont nativeFont = (IFont)pd.GetNativeValue(pd.TargetObject);
 
             // now, push all the values into the native side
-            if (nativeFont != null)
+            if (nativeFont is not null)
             {
                 bool changed = ControlPaint.FontToIFont(_lastFont, nativeFont);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ICategorizePropertiesHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ICategorizePropertiesHandler.cs
@@ -76,7 +76,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         {
             string cat = GetCategoryFromObject(sender.TargetObject, sender.DISPID);
 
-            if (cat != null && cat.Length > 0)
+            if (cat is not null && cat.Length > 0)
             {
                 attrEvent.Add(new CategoryAttribute(cat));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IManagedPerPropertyBrowsingHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IManagedPerPropertyBrowsingHandler.cs
@@ -40,7 +40,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             if (target is VSSDK.IVSMDPerPropertyBrowsing)
             {
                 Attribute[] attrs = GetComponentAttributes((VSSDK.IVSMDPerPropertyBrowsing)target, sender.DISPID);
-                if (attrs != null)
+                if (attrs is not null)
                 {
                     for (int i = 0; i < attrs.Length; i++)
                     {
@@ -83,7 +83,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 Type t = Type.GetType(attrName);
                 Assembly a = null;
 
-                if (t != null)
+                if (t is not null)
                 {
                     a = t.Assembly;
                 }
@@ -137,12 +137,12 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                         continue;
                     }
 
-                    if (t != null)
+                    if (t is not null)
                     {
                         FieldInfo fi = t.GetField(fieldName);
 
                         // only if it's static
-                        if (fi != null && fi.IsStatic)
+                        if (fi is not null && fi.IsStatic)
                         {
                             object fieldValue = fi.GetValue(null);
                             if (fieldValue is Attribute)
@@ -170,7 +170,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 // okay, if we got here, we need to build the attribute...
                 // get the initalizer value if we've got a one item ctor
 
-                if (!Convert.IsDBNull(varParams[i]) && varParams[i] != null)
+                if (!Convert.IsDBNull(varParams[i]) && varParams[i] is not null)
                 {
                     ConstructorInfo[] ctors = t.GetConstructors();
                     for (int c = 0; c < ctors.Length; c++)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IPerPropertyBrowsingHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IPerPropertyBrowsingHandler.cs
@@ -61,7 +61,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 return null;
             }
 
-            success = strVal != null;
+            success = strVal is not null;
             return strVal;
         }
 
@@ -208,7 +208,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 if (destType == typeof(string) && !itemsEnum.arraysFetched)
                 {
                     object curValue = itemsEnum.target.GetValue(itemsEnum.target.TargetObject);
-                    if (curValue == value || (curValue != null && curValue.Equals(value)))
+                    if (curValue == value || (curValue is not null && curValue.Equals(value)))
                     {
                         bool success = false;
                         string val = GetDisplayString((Oleaut32.IPerPropertyBrowsing)itemsEnum.target.TargetObject, itemsEnum.target.DISPID, ref success);
@@ -289,7 +289,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                     Oleaut32.IPerPropertyBrowsing ppb = (Oleaut32.IPerPropertyBrowsing)target.TargetObject;
                     int itemCount = 0;
 
-                    Debug.Assert(cookieItems != null && nameItems != null, "An item array is null");
+                    Debug.Assert(cookieItems is not null && nameItems is not null, "An item array is null");
 
                     if (nameItems.Length > 0)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IVsPerPropertyBrowsingHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IVsPerPropertyBrowsingHandler.cs
@@ -80,7 +80,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             // should we localize this?
             string[] pHelpString = new string[1];
             HRESULT hr = vsObj.GetLocalizedPropertyInfo(sender.DISPID, Kernel32.GetThreadLocale(), null, pHelpString);
-            if (hr == HRESULT.S_OK && pHelpString[0] != null)
+            if (hr == HRESULT.S_OK && pHelpString[0] is not null)
             {
                 attrEvent.Add(new DescriptionAttribute(pHelpString[0]));
             }
@@ -150,7 +150,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 // get the localized name, if applicable
                 string[] pNameString = new string[1];
                 HRESULT hr = vsObj.GetLocalizedPropertyInfo(sender.DISPID, Kernel32.GetThreadLocale(), pNameString, null);
-                if (hr == HRESULT.S_OK && pNameString[0] != null)
+                if (hr == HRESULT.S_OK && pNameString[0] is not null)
                 {
                     nameItem.Name = pNameString[0];
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PictureConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PictureConverter.cs
@@ -56,7 +56,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             IPicture nativePicture = (IPicture)nativeValue;
             IntPtr handle = (IntPtr)nativePicture.Handle;
 
-            if (_lastManaged != null && handle == _lastNativeHandle)
+            if (_lastManaged is not null && handle == _lastNativeHandle)
             {
                 return _lastManaged;
             }
@@ -100,14 +100,14 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             if (_lastManaged?.Equals(managedValue) == true)
             {
                 object target = _pictureRef?.Target;
-                if (target != null)
+                if (target is not null)
                 {
                     return target;
                 }
             }
 
             // We have to build an IPicture
-            if (managedValue != null)
+            if (managedValue is not null)
             {
                 BOOL own = BOOL.FALSE;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2Properties.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2Properties.cs
@@ -322,7 +322,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             }
 #endif
 
-            if (props != null)
+            if (props is not null)
             {
                 Disposed?.Invoke(this, EventArgs.Empty);
 
@@ -390,7 +390,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 return true;
             }
 
-            bool valid = weakObjRef != null && weakObjRef.IsAlive;
+            bool valid = weakObjRef is not null && weakObjRef.IsAlive;
 
             // check the version information for each ITypeInfo the object exposes.
             if (valid && checkVersions)
@@ -445,7 +445,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         internal void SetProps(Com2PropertyDescriptor[] props)
         {
             this.props = props;
-            if (props != null)
+            if (props is not null)
             {
                 for (int i = 0; i < props.Length; i++)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyBuilderUITypeEditor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyBuilderUITypeEditor.cs
@@ -39,10 +39,10 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             IntPtr parentHandle = (IntPtr)User32.GetFocus();
 
             IUIService uiSvc = (IUIService)provider.GetService(typeof(IUIService));
-            if (uiSvc != null)
+            if (uiSvc is not null)
             {
                 IWin32Window parent = uiSvc.GetDialogOwnerWindow();
-                if (parent != null)
+                if (parent is not null)
                 {
                     parentHandle = parent.Handle;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
@@ -156,7 +156,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
             this.dispid = dispid;
 
-            if (typeData != null)
+            if (typeData is not null)
             {
                 this.typeData = typeData;
                 if (typeData is Com2Enum)
@@ -172,7 +172,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             // check if this thing is hidden from metadata
             canShow = true;
 
-            if (attrs != null)
+            if (attrs is not null)
             {
                 for (int i = 0; i < attrs.Length; i++)
                 {
@@ -214,7 +214,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                         baseAttrs = new Attribute[attrList.Count];
                     }
 
-                    if (baseAttrs != null)
+                    if (baseAttrs is not null)
                     {
                         attrList.CopyTo(baseAttrs, 0);
                     }
@@ -262,7 +262,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 {
                     // check to see if the get still fails
                     object target = TargetObject;
-                    if (target != null)
+                    if (target is not null)
                     {
                         HRESULT hr = new ComNativeDescriptor().GetPropertyValue(target, dispid, new object[1]);
 
@@ -312,7 +312,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
                 // If we reconfigured attributes, then poke the new set back in.
                 //
-                if (newAttributes != null)
+                if (newAttributes is not null)
                 {
                     Attribute[] temp = new Attribute[newAttributes.Count];
                     newAttributes.CopyTo(temp, 0);
@@ -387,7 +387,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         {
             get
             {
-                return (valueConverter != null);
+                return (valueConverter is not null);
             }
         }
 
@@ -505,7 +505,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             get
             {
                 // replace the type with the mapped converter type
-                if (valueConverter != null)
+                if (valueConverter is not null)
                 {
                     return valueConverter.ManagedType;
                 }
@@ -543,7 +543,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         {
             get
             {
-                if (com2props != null)
+                if (com2props is not null)
                 {
                     return com2props.TargetObject;
                 }
@@ -667,7 +667,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
             ConstructorInfo ctor = t.GetConstructor(new Type[] { typeof(Com2PropertyDescriptor) });
             Com2DataTypeToManagedDataTypeConverter converter;
-            if (ctor != null)
+            if (ctor is not null)
             {
                 converter = (Com2DataTypeToManagedDataTypeConverter)ctor.Invoke(new object[] { this });
             }
@@ -697,18 +697,18 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             TypeConverter localConverter = null;
 
             TypeConverterAttribute attr = (TypeConverterAttribute)Attributes[typeof(TypeConverterAttribute)];
-            if (attr != null)
+            if (attr is not null)
             {
                 string converterTypeName = attr.ConverterTypeName;
-                if (converterTypeName != null && converterTypeName.Length > 0)
+                if (converterTypeName is not null && converterTypeName.Length > 0)
                 {
                     Type converterType = Type.GetType(converterTypeName);
-                    if (converterType != null && typeof(TypeConverter).IsAssignableFrom(converterType))
+                    if (converterType is not null && typeof(TypeConverter).IsAssignableFrom(converterType))
                     {
                         try
                         {
                             localConverter = (TypeConverter)Activator.CreateInstance(converterType);
-                            if (localConverter != null)
+                            if (localConverter is not null)
                             {
                                 refreshState |= Com2PropertyDescriptorRefresh.TypeConverterAttr;
                             }
@@ -753,22 +753,22 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
             object localEditor = null;
             EditorAttribute attr = (EditorAttribute)Attributes[typeof(EditorAttribute)];
-            if (attr != null)
+            if (attr is not null)
             {
                 string editorTypeName = attr.EditorBaseTypeName;
 
-                if (editorTypeName != null && editorTypeName.Length > 0)
+                if (editorTypeName is not null && editorTypeName.Length > 0)
                 {
                     Type attrEditorBaseType = Type.GetType(editorTypeName);
-                    if (attrEditorBaseType != null && attrEditorBaseType == editorBaseType)
+                    if (attrEditorBaseType is not null && attrEditorBaseType == editorBaseType)
                     {
                         Type type = Type.GetType(attr.EditorTypeName);
-                        if (type != null)
+                        if (type is not null)
                         {
                             try
                             {
                                 localEditor = Activator.CreateInstance(type);
-                                if (localEditor != null)
+                                if (localEditor is not null)
                                 {
                                     refreshState |= Com2PropertyDescriptorRefresh.TypeEditorAttr;
                                 }
@@ -911,11 +911,11 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         {
             lastValue = GetNativeValue(component);
             // do we need to convert the type?
-            if (ConvertingNativeType && lastValue != null)
+            if (ConvertingNativeType && lastValue is not null)
             {
                 lastValue = valueConverter.ConvertNativeToManaged(lastValue, this);
             }
-            else if (lastValue != null && propertyType != null && propertyType.IsEnum && lastValue.GetType().IsPrimitive)
+            else if (lastValue is not null && propertyType is not null && propertyType.IsEnum && lastValue.GetType().IsPrimitive)
             {
                 // we've got to convert the value here -- we built the enum but the native object returns
                 // us values as integers
@@ -962,7 +962,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             {
                 Type editorType = PropertyType;
                 object value = GetValue(TargetObject);
-                if (value != null)
+                if (value is not null)
                 {
                     editorType = value.GetType();
                 }
@@ -1014,7 +1014,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// </summary>
         public bool IsCurrentValue(object value)
         {
-            return (value == lastValue || (lastValue != null && lastValue.Equals(value)));
+            return (value == lastValue || (lastValue is not null && lastValue.Equals(value)));
         }
 
         /// <summary>
@@ -1227,7 +1227,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             }
 
             // do we need to convert the type?
-            if (valueConverter != null)
+            if (valueConverter is not null)
             {
                 bool cancel = false;
                 value = valueConverter.ConvertManagedToNative(value, this, ref cancel);
@@ -1293,7 +1293,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                             Oleaut32.GetErrorInfo(0, ref pErrorInfo);
 
                             string info = null;
-                            if (pErrorInfo != null && pErrorInfo.GetDescription(ref info).Succeeded())
+                            if (pErrorInfo is not null && pErrorInfo.GetDescription(ref info).Succeeded())
                             {
                                 errorInfo = info;
                             }
@@ -1405,7 +1405,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             {
                 PropertyDescriptorCollection props = TypeDescriptor.GetProperties(value, attributes);
 
-                if (props != null && props.Count > 0)
+                if (props is not null && props.Count > 0)
                 {
                     // Return sorted read-only collection (can't sort original because its read-only)
                     props = props.Sort();
@@ -1429,7 +1429,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                     {
                         // special case the font converter here.
                         //
-                        if ((pd.valueConverter != null && pd.valueConverter.AllowExpand) || Com2IVsPerPropertyBrowsingHandler.AllowChildProperties(pd))
+                        if ((pd.valueConverter is not null && pd.valueConverter.AllowExpand) || Com2IVsPerPropertyBrowsingHandler.AllowChildProperties(pd))
                         {
                             subprops = AllowSubprops;
                         }
@@ -1484,7 +1484,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         {
             get
             {
-                if (nameItem != null)
+                if (nameItem is not null)
                 {
                     return nameItem.ToString();
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyPageUITypeConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyPageUITypeConverter.cs
@@ -58,10 +58,10 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             }
             catch (Exception ex1)
             {
-                if (provider != null)
+                if (provider is not null)
                 {
                     IUIService uiSvc = (IUIService)provider.GetService(typeof(IUIService));
-                    if (uiSvc != null)
+                    if (uiSvc is not null)
                     {
                         uiSvc.ShowError(ex1, SR.ErrorTypeConverterFailed);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2TypeInfoProcessor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2TypeInfoProcessor.cs
@@ -107,7 +107,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                             continue;
                         }
 
-                        Debug.Assert(result != null, "IProvideMultipleClassInfo::GetInfoOfIndex returned S_OK for ITypeInfo index " + i + ", this is a issue in the object that's being browsed, NOT the property browser.");
+                        Debug.Assert(result is not null, "IProvideMultipleClassInfo::GetInfoOfIndex returned S_OK for ITypeInfo index " + i + ", this is a issue in the object that's being browsed, NOT the property browser.");
                         typeInfos[i] = result;
                     }
 
@@ -116,7 +116,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             }
 
             ITypeInfo temp = FindTypeInfo(obj, wantCoClass);
-            if (temp != null)
+            if (temp is not null)
             {
                 return new ITypeInfo[] { temp };
             }
@@ -161,7 +161,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             }
 
             // now get the dispid of the one that worked...
-            if (names != null)
+            if (names is not null)
             {
                 DispatchID pDispid = DispatchID.UNKNOWN;
                 Guid g = Guid.Empty;
@@ -216,7 +216,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 uint[] versions = new uint[2];
                 Guid typeGuid = GetGuidForTypeInfo(ti, versions);
                 PropertyDescriptor[] props = null;
-                bool dontProcess = typeGuid != Guid.Empty && processedLibraries != null && processedLibraries.Contains(typeGuid);
+                bool dontProcess = typeGuid != Guid.Empty && processedLibraries is not null && processedLibraries.Contains(typeGuid);
 
                 if (dontProcess)
                 {
@@ -257,7 +257,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                     }
                 }
 
-                if (props != null)
+                if (props is not null)
                 {
                     propList.AddRange(props);
                 }
@@ -283,7 +283,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
             try
             {
-                if (versions != null)
+                if (versions is not null)
                 {
                     versions[0] = pTypeAttr->wMajorVerNum;
                     versions[1] = pTypeAttr->wMinorVerNum;
@@ -328,7 +328,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
                 case VARENUM.PTR:
                     // we'll need to recurse into a user defined reference typeinfo
-                    Debug.Assert(typeDesc.union.lptdesc != null, "typeDesc doesn't contain an refTypeDesc!");
+                    Debug.Assert(typeDesc.union.lptdesc is not null, "typeDesc doesn't contain an refTypeDesc!");
                     if (typeDesc.union.lptdesc->vt == VARENUM.VARIANT)
                     {
                         return VTToType(typeDesc.union.lptdesc->vt);
@@ -350,7 +350,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 // here is where we look at the next level type info.
                 // if we get an enum, process it, otherwise we will recurse
                 // or get a dispatch.
-                if (refTypeInfo != null)
+                if (refTypeInfo is not null)
                 {
                     TYPEATTR* pTypeAttr = null;
                     hr = refTypeInfo.GetTypeAttr(&pTypeAttr);
@@ -562,7 +562,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                     flags |= VARFLAGS.FNONBROWSABLE;
                 }
 
-                if (pTypeData[0] != null)
+                if (pTypeData[0] is not null)
                 {
                     pi.TypeData = pTypeData[0];
                 }
@@ -661,7 +661,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                         }
                         else
                         {
-                            Debug.Assert(pFuncDesc->lprgelemdescParam != null, "ELEMDESC param is null!");
+                            Debug.Assert(pFuncDesc->lprgelemdescParam is not null, "ELEMDESC param is null!");
                             if (pFuncDesc->lprgelemdescParam is null || pFuncDesc->cParams != 1)
                             {
                                 continue;
@@ -675,7 +675,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                         pi = ProcessDataCore(typeInfo, propInfoList, pFuncDesc->memid, nameDispID, in typeDesc, (VARFLAGS)pFuncDesc->wFuncFlags);
 
                         // if we got a setmethod, it's not readonly
-                        if (pi != null && !isPropGet)
+                        if (pi is not null && !isPropGet)
                         {
                             pi.ReadOnly = PropInfo.ReadOnlyFalse;
                         }
@@ -786,7 +786,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                             }
                             else
                             {
-                                Debug.Assert(name != null, "No name for VARDESC member, but GetDocumentation returned S_OK!");
+                                Debug.Assert(name is not null, "No name for VARDESC member, but GetDocumentation returned S_OK!");
                                 nameString = name;
                             }
                             Debug.WriteLineIf(DbgTypeInfoProcessorSwitch.TraceVerbose, "ProcessTypeInfoEnum: adding name value=" + nameString);
@@ -821,7 +821,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
                             Type enumType = typeof(int);
 
-                            if (vars.Count > 0 && vars[0] != null)
+                            if (vars.Count > 0 && vars[0] is not null)
                             {
                                 enumType = vars[0].GetType();
                             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.cs
@@ -85,7 +85,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             if (component is VSSDK.IVsPerPropertyBrowsing)
             {
                 HRESULT hr = ((VSSDK.IVsPerPropertyBrowsing)component).GetClassName(ref name);
-                if (hr.Succeeded() && name != null)
+                if (hr.Succeeded() && name is not null)
                 {
                     return name;
                 }
@@ -127,7 +127,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 bool success = false;
                 object value = GetPropertyValue(component, dispid, ref success);
 
-                if (success && value != null)
+                if (success && value is not null)
                 {
                     return value.ToString();
                 }
@@ -259,7 +259,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                     {
                         entry = de.Value as Com2Properties;
 
-                        if (entry != null && entry.TooOld)
+                        if (entry is not null && entry.TooOld)
                         {
                             if (disposeList is null)
                             {
@@ -272,7 +272,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                     // now run through the ones that are dead and dispose them.
                     // there's going to be a very small number of these.
                     //
-                    if (disposeList != null)
+                    if (disposeList is not null)
                     {
                         object oldKey;
                         for (int i = disposeList.Count - 1; i >= 0; i--)
@@ -280,7 +280,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                             oldKey = disposeList[i];
                             entry = nativeProps[oldKey] as Com2Properties;
 
-                            if (entry != null)
+                            if (entry is not null)
                             {
                                 entry.Disposed -= new EventHandler(OnPropsInfoDisposed);
                                 entry.Dispose();
@@ -310,7 +310,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             if (propsInfo is null || !propsInfo.CheckValid())
             {
                 propsInfo = Com2TypeInfoProcessor.GetProperties(component);
-                if (propsInfo != null)
+                if (propsInfo is not null)
                 {
                     propsInfo.Disposed += new EventHandler(OnPropsInfoDisposed);
                     nativeProps.SetWeak(component, propsInfo);
@@ -362,7 +362,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             CheckClear(component);
 
             Com2Properties propsInfo = GetPropsInfo(component);
-            if (propsInfo != null)
+            if (propsInfo is not null)
             {
                 return propsInfo.DefaultProperty;
             }
@@ -455,16 +455,16 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         internal static void ResolveVariantTypeConverterAndTypeEditor(object propertyValue, ref TypeConverter currentConverter, Type editorType, ref object currentEditor)
         {
             object curValue = propertyValue;
-            if (curValue != null && curValue != null && !Convert.IsDBNull(curValue))
+            if (curValue is not null && curValue is not null && !Convert.IsDBNull(curValue))
             {
                 Type t = curValue.GetType();
                 TypeConverter subConverter = TypeDescriptor.GetConverter(t);
-                if (subConverter != null && subConverter.GetType() != typeof(TypeConverter))
+                if (subConverter is not null && subConverter.GetType() != typeof(TypeConverter))
                 {
                     currentConverter = subConverter;
                 }
                 object subEditor = TypeDescriptor.GetEditor(t, editorType);
-                if (subEditor != null)
+                if (subEditor is not null)
                 {
                     currentEditor = subEditor;
                 }


### PR DESCRIPTION
…nd ComponentModel

Contributes to https://github.com/dotnet/winforms/issues/3459

## Proposed changes

- Use 'is not null' in System.Windows.Forms Resources, ButtonInternal and ComponentModel.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4288)