### PR TITLE
Allow loading custom comctl32.dll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -373,3 +373,4 @@ Temporary Items
 
 # Ignore "InteropTests/NativeTests/out"
 InteropTests/NativeTests/out
+/src/System.Windows.Forms/src/comctl32.dll

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.LoadLibrary.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.LoadLibrary.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 
 internal partial class Interop
@@ -13,6 +14,31 @@ internal partial class Interop
 
         [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
         private static extern IntPtr LoadLibraryExW(string lpModuleName, IntPtr hFile, uint dwFlags);
+
+        /// <summary>
+        /// Loads comctl32.dll from either the <paramref name="startupPath"/>, if it is supplied;
+        /// or from the default system path.
+        /// </summary>
+        /// <param name="startupPath">The application start up path, where a custom comctl32.dll could be found.</param>
+        /// <returns>A </returns>
+        public static IntPtr LoadComctl32(string startupPath)
+        {
+            if (!string.IsNullOrWhiteSpace(startupPath))
+            {
+                string customPath = Path.Combine(startupPath, Libraries.Comctl32);
+                if (File.Exists(customPath))
+                {
+                    IntPtr result = LoadLibraryExW(customPath, IntPtr.Zero, 0);
+                    if (result != IntPtr.Zero)
+                    {
+                        return result;
+                    }
+                }
+            }
+
+            // Load the system default
+            return LoadLibraryFromSystemPathIfAvailable(Libraries.Comctl32);
+        }
 
         public static IntPtr LoadLibraryFromSystemPathIfAvailable(string libraryName)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.LoadLibrary.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.LoadLibrary.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 
@@ -20,14 +21,19 @@ internal partial class Interop
         /// or from the default system path.
         /// </summary>
         /// <param name="startupPath">The application start up path, where a custom comctl32.dll could be found.</param>
-        /// <returns>A </returns>
+        /// <returns>A handle to the loaded comctl32.dll module, if successful; <see cref="IntPtr.Zero"/> otherwise.</returns>
         public static IntPtr LoadComctl32(string startupPath)
         {
+            // NOTE: we don't look for the loaded module!
+
             if (!string.IsNullOrWhiteSpace(startupPath))
             {
-                string customPath = Path.Combine(startupPath, Libraries.Comctl32);
-                if (File.Exists(customPath))
+                string customPath = Path.Join(startupPath, Libraries.Comctl32);
+                Debug.Assert(Path.IsPathFullyQualified(customPath));
+
+                if (Path.IsPathFullyQualified(customPath))
                 {
+                    // OS will validate the path for us
                     IntPtr result = LoadLibraryExW(customPath, IntPtr.Zero, 0);
                     if (result != IntPtr.Zero)
                     {
@@ -40,6 +46,12 @@ internal partial class Interop
             return LoadLibraryFromSystemPathIfAvailable(Libraries.Comctl32);
         }
 
+        /// <summary>
+        /// Loads the requested <paramref name="libraryName"/> from the default system path.
+        /// If the module is already loaded, return the handle to it.
+        /// </summary>
+        /// <param name="libraryName">The assembly name to load.</param>
+        /// <returns>A handle to the loaded module, if successful; <see cref="IntPtr.Zero"/> otherwise.</returns>
         public static IntPtr LoadLibraryFromSystemPathIfAvailable(string libraryName)
         {
             IntPtr kernel32 = GetModuleHandleW(Libraries.Kernel32);

--- a/src/System.Windows.Forms/src/System.Windows.Forms.csproj
+++ b/src/System.Windows.Forms/src/System.Windows.Forms.csproj
@@ -687,4 +687,10 @@
       <SubType>Component</SubType>
     </Compile>
   </ItemGroup>
+
+  <ItemGroup Condition="Exists('comctl32.dll')">
+    <None Update="comctl32.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -124,7 +124,7 @@ namespace System.Windows.Forms
             }
 
             // Load comctl since GetModuleHandle failed to find it
-            hModule = Kernel32.LoadLibraryFromSystemPathIfAvailable(Libraries.Comctl32);
+            hModule = Kernel32.LoadComctl32(StartupPath);
             if (hModule == IntPtr.Zero)
             {
                 return false;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
@@ -214,7 +214,7 @@ namespace System.Windows.Forms
 
                     if (s_oleAccAvailable == NativeMethods.InvalidIntPtr)
                     {
-                        s_oleAccAvailable = Kernel32.LoadLibraryFromSystemPathIfAvailable("oleacc.dll");
+                        s_oleAccAvailable = Kernel32.LoadLibraryFromSystemPathIfAvailable(Libraries.Oleacc);
                         freeLib = (s_oleAccAvailable != IntPtr.Zero);
                     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -1473,7 +1473,7 @@ namespace System.Windows.Forms
                 if (s_needToLoadComCtl)
                 {
                     if ((Kernel32.GetModuleHandleW(Libraries.Comctl32) != IntPtr.Zero)
-                        || (Kernel32.LoadLibraryFromSystemPathIfAvailable(Libraries.Comctl32) != IntPtr.Zero))
+                     || (Kernel32.LoadComctl32(Application.StartupPath) != IntPtr.Zero))
                     {
                         s_needToLoadComCtl = false;
                     }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Properties/launchSettings.json
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "WinformsControlsTest": {
+      "commandName": "Project",
+      "nativeDebugging": true
+    }
+  }
+}


### PR DESCRIPTION


<!-- Please read CONTRIBUTING.md before submitting a pull request -->




## Proposed changes

Provide functionality to load a custom comctl32.dll from the application startup folder, if comctl32.dll is present in that location.

This allows loading debug and custom builds of the library.


## Screenshots <!-- Remove this section if PR does not change UI -->

![image](https://user-images.githubusercontent.com/4403806/100421914-68daaf80-30dd-11eb-9dbd-1b16299f6aa2.png)


## Test methodology <!-- How did you ensure quality? -->

- Adding a debug version comctl32.dll to /src/System.Windows.Forms/src
- Build and run WinformsControlsTest project
- Observe the comctl32.dll is copied to the output folder
- Run "ListView" example and observe debug asserts being hit in the comctl32 source
- Check loaded modules in "Modules" window


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4289)