### PR TITLE
Adding virtual mode validation for a double click

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -5830,7 +5830,7 @@ namespace System.Windows.Forms
             // If we're checked, hittest to see if we're
             // on the item
 
-            if (!CheckBoxes)
+            if (!CheckBoxes || VirtualMode)
             {
                 return;
             }

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiListViewTests/MauiListViewTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiListViewTests/MauiListViewTests.cs
@@ -9,6 +9,7 @@ using ReflectTools;
 using System.Windows.Forms.IntegrationTests.Common;
 using System.Runtime.InteropServices;
 using static Interop;
+using static Interop.User32;
 
 namespace System.Windows.Forms.IntegrationTests.MauiTests
 {
@@ -32,7 +33,7 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
         [Scenario(true)]
         public ScenarioResult Click_On_Second_Column_Does_Not_Alter_Checkboxes(TParams p)
         {
-            InitializeItems(_listView, p);
+            InitializeItems(_listView, virtualModeEnabled: false, checkBoxesEnabled: true, p);
 
             foreach (ListViewItem item in _listView.Items)
             {
@@ -49,10 +50,10 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
             KeyboardHelper.SendKey(Keys.ShiftKey, true);
 
             var pt = MouseHelper.GetCenter(_listView.RectangleToScreen(_listView.Items[0].SubItems[1].Bounds));
-            MouseHelper.SendClick(pt.x, pt.y);
+            MouseHelper.SendClick(pt.X, pt.Y);
 
             pt = MouseHelper.GetCenter(_listView.RectangleToScreen(_listView.Items[2].SubItems[1].Bounds));
-            MouseHelper.SendClick(pt.x, pt.y);
+            MouseHelper.SendClick(pt.X, pt.Y);
 
             KeyboardHelper.SendKey(Keys.ShiftKey, false);
             Application.DoEvents();
@@ -72,12 +73,82 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
             return new ScenarioResult(true);
         }
 
-        private void InitializeItems(ListView listView, TParams p)
+        [Scenario(true)]
+        public ScenarioResult ListView_DoubleClick_Updates_Checkbox_State(TParams p)
         {
-            listView.Items.Clear();
-            listView.CheckBoxes = true;
-            listView.FullRowSelect = true;
-            listView.View = View.Details;
+            InitializeItems(_listView, virtualModeEnabled: false, checkBoxesEnabled: true, p);
+
+            bool checkBoxState = _listView.Items[0].Checked;
+            ExecuteDoubleClickOnItem(_listView.Items[0]);
+
+            if (_listView.Items[0].Checked == checkBoxState)
+            {
+                return new ScenarioResult(false, "Double click doesn't update Checkbox state");
+            }
+
+            return new ScenarioResult(true);
+        }
+
+        [Scenario(true)]
+        public ScenarioResult ListView_CheckBoxDisabled_DoubleClick_DoesNotUpdate_Checkbox_State(TParams p)
+        {
+            InitializeItems(_listView, virtualModeEnabled: false, checkBoxesEnabled: false, p);
+
+            bool checkBoxState = _listView.Items[0].Checked;
+            ExecuteDoubleClickOnItem(_listView.Items[0]);
+
+            if (_listView.Items[0].Checked != checkBoxState)
+            {
+                return new ScenarioResult(false, "Double click doesn't update Checkbox state");
+            }
+
+            return new ScenarioResult(true);
+        }
+
+        [Scenario(true)]
+        public ScenarioResult ListView_VirtualMode_DoubleClick_DoesNotUpdate_Checkbox_State(TParams p)
+        {
+            InitializeItems(_listView, virtualModeEnabled: true, checkBoxesEnabled: true, p);
+
+            bool checkBoxState = _listView.Items[0].Checked;
+            ExecuteDoubleClickOnItem(_listView.Items[0]);
+
+            if (_listView.Items[0].Checked != checkBoxState)
+            {
+                return new ScenarioResult(false, "Double click updates Checkbox state when ListView is in virtual mode");
+            }
+
+            return new ScenarioResult(true);
+        }
+
+        private void ExecuteDoubleClickOnItem(ListViewItem listViewItem)
+        {
+            Point previousPosition = new Point();
+            BOOL setOldCursorPos = GetPhysicalCursorPos(ref previousPosition);
+
+            try
+            {
+                Rectangle pt = _listView.RectangleToScreen(listViewItem.Bounds);
+
+                // We shouldn't move the cursor to the old position immediately after double-clicking,
+                // because the ListView uses the cursor position to get data about the item that was double-clicked.
+                MouseHelper.SendDoubleClick(pt.X, pt.Y);
+                Application.DoEvents();
+            }
+            finally
+            {
+                if (setOldCursorPos.IsTrue())
+                {
+                    // Move cursor to old position
+                    MouseHelper.ChangeMousePosition(previousPosition.X, previousPosition.Y);
+                    Application.DoEvents();
+                }
+            }
+        }
+
+        private void InitializeItems(ListView listView, bool virtualModeEnabled, bool checkBoxesEnabled, TParams p)
+        {
+            listView.Columns.Clear();
 
             var columnHeader1 = new ColumnHeader { Text = "ColumnHeader1", Width = 140 };
             var columnHeader2 = new ColumnHeader { Text = "ColumnHeader2", Width = 140 };
@@ -87,7 +158,29 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
             var listViewItem1 = new ListViewItem(new[] { "row1", "row1Col2", "row1Col3" }, -1) { StateImageIndex = 0 };
             var listViewItem2 = new ListViewItem(new[] { "row2", "row2Col2", "row2Col3" }, -1) { StateImageIndex = 0 };
             var listViewItem3 = new ListViewItem(new[] { "row3", "row3Col2", "row3Col3" }, -1) { StateImageIndex = 0 };
-            listView.Items.AddRange(new[] { listViewItem1, listViewItem2, listViewItem3 });
+
+            listView.RetrieveVirtualItem += (s, e) =>
+            {
+                e.Item = e.ItemIndex switch
+                {
+                    0 => listViewItem1,
+                    1 => listViewItem2,
+                    2 => listViewItem3,
+                    _ => listViewItem1,
+                };
+            };
+
+            listView.Items.Clear();
+            listView.CheckBoxes = checkBoxesEnabled;
+            listView.FullRowSelect = true;
+            listView.View = View.Details;
+            listView.VirtualMode = virtualModeEnabled;
+            listView.VirtualListSize = 3;
+
+            if (!virtualModeEnabled)
+            {
+                listView.Items.AddRange(new[] { listViewItem1, listViewItem2, listViewItem3 });
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiTestsHelper/MouseHelper.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiTestsHelper/MouseHelper.cs
@@ -12,6 +12,11 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
 {
     public static class MouseHelper
     {
+        public static void ChangeMousePosition(int x, int y)
+        {
+            SendMouseInput(x, y, MOUSEEVENTF.MOVE | MOUSEEVENTF.ABSOLUTE);
+        }
+
         public static void SendClick(int x, int y)
         {
             var previousPosition = new Point();
@@ -20,8 +25,8 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
             bool mouseSwapped = GetSystemMetrics(SystemMetric.SM_SWAPBUTTON) != 0;
 
             SendMouseInput(x, y, MOUSEEVENTF.MOVE | MOUSEEVENTF.ABSOLUTE);
-            SendMouseInput(0, 0, mouseSwapped ? MOUSEEVENTF.RIGHTDOWN : MOUSEEVENTF.LEFTDOWN);
-            SendMouseInput(0, 0, mouseSwapped ? MOUSEEVENTF.RIGHTUP : MOUSEEVENTF.LEFTUP);
+            SendMouseInput(x: 0, y: 0, mouseSwapped ? MOUSEEVENTF.RIGHTDOWN : MOUSEEVENTF.LEFTDOWN);
+            SendMouseInput(x: 0, y: 0, mouseSwapped ? MOUSEEVENTF.RIGHTUP : MOUSEEVENTF.LEFTUP);
 
             Thread.Sleep(50);
 
@@ -30,6 +35,19 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
             {
                 SendMouseInput(previousPosition.X, previousPosition.Y, MOUSEEVENTF.MOVE | MOUSEEVENTF.ABSOLUTE);
             }
+        }
+
+        public static void SendDoubleClick(int x, int y)
+        {
+            bool mouseSwapped = GetSystemMetrics(SystemMetric.SM_SWAPBUTTON) != 0;
+            SendMouseInput(x, y, MOUSEEVENTF.MOVE | MOUSEEVENTF.ABSOLUTE);
+            SendMouseInput(x: 0, y: 0, mouseSwapped ? MOUSEEVENTF.RIGHTDOWN : MOUSEEVENTF.LEFTDOWN);
+            SendMouseInput(x: 0, y: 0, mouseSwapped ? MOUSEEVENTF.RIGHTUP : MOUSEEVENTF.LEFTUP);
+
+            Thread.Sleep(100);
+
+            SendMouseInput(x: 0, y: 0, mouseSwapped ? MOUSEEVENTF.RIGHTDOWN : MOUSEEVENTF.LEFTDOWN);
+            SendMouseInput(x: 0, y: 0, mouseSwapped ? MOUSEEVENTF.RIGHTUP : MOUSEEVENTF.LEFTUP);
         }
 
         private unsafe static void SendMouseInput(int x, int y, MOUSEEVENTF flags)
@@ -81,11 +99,11 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
             SendInput(1, &mouseInput, Marshal.SizeOf(mouseInput));
         }
 
-        public static (int x, int y) GetCenter(System.Drawing.Rectangle rect)
+        public static Point GetCenter(System.Drawing.Rectangle rect)
         {
             int x = rect.Left + ((rect.Right - rect.Left) / 2);
             int y = rect.Top + ((rect.Bottom - rect.Top) / 2);
-            return (x, y);
+            return new Point(x, y);
         }
     }
 }


### PR DESCRIPTION
Fixes #4156


## Proposed changes
- Added virtual mode validation for a double click

## Customer Impact
The checkbox will not change its value on a double click when ListView is in virtual mode.
Before fix:
![Issue-4290-beforefix](https://user-images.githubusercontent.com/23376742/100435207-af64e580-30ae-11eb-8a9c-79e17759544f.gif)

After fix:
![Issue-4290-afterfix](https://user-images.githubusercontent.com/23376742/100435241-ba1f7a80-30ae-11eb-9c4f-f1c788f0a876.gif)


## Regression? 
- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Manually

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .Net SDK 5.0.100-rc.2.20479.15

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4290)