### PR TITLE
Removing ignore for the "VScrollBarAccessibleObject_Ctor_Default" test

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/VScrollBar.VScrollBarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/VScrollBar.VScrollBarAccessibleObjectTests.cs
@@ -17,8 +17,7 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<ArgumentNullException>(() => new VScrollBar.VScrollBarAccessibleObject(null));
         }
 
-        [WinFormsTheory(Skip = "Crash with an unexpected result. See: https://github.com/dotnet/winforms/issues/3856")]
-        [ActiveIssue("https://github.com/dotnet/winforms/issues/3856")]
+        [WinFormsTheory]
         [InlineData(true, AccessibleRole.ScrollBar)]
         [InlineData(false, AccessibleRole.None)]
         public void VScrollBarAccessibleObject_Ctor_Default(bool createControl, AccessibleRole accessibleRole)


### PR DESCRIPTION
## Proposed changes
- Removed ignore for the "VScrollBarAccessibleObject_Ctor_Default" test

## Customer Impact
- No 

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->
- Unit tests 

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .Net SDK 5.0.100-rc.2.20479.15

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4300)