### PR TITLE
Fix flaky Cursor accessor test

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CursorConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CursorConverterTests.cs
@@ -189,6 +189,15 @@ namespace System.Windows.Forms.Tests
         public void CursorConverter_GetStandardValues_Invoke_ReturnsExpected()
         {
             var converter = new CursorConverter();
+
+            // The static accessors only provide a weak guarantee about their return values, when multiple threads
+            // are involved it is possible that return values differ between calls. We need a dry run and memory barrier
+            // to ensure the fields backing the property are all initialized and visible to the current thread,
+            // failing to do so means that the very first call to a static cursor accessor may return a different
+            // cursor instance than subsequent calls.
+            converter.GetStandardValues();
+            Threading.Thread.MemoryBarrier();
+
             ICollection<Cursor> values = converter.GetStandardValues().Cast<Cursor>().ToArray();
             Assert.Equal(28, values.Count);
             Assert.Contains(Cursors.AppStarting, values);


### PR DESCRIPTION
Ensure static Cursor accessors are initialized before testing return value consistency in multithreaded environments

Fixes #4309

## Proposed changes

as mentioned in the issue returning different instances during multithreaded access is acceptable and the test needs to take that into consideration

## Customer Impact

none, product behavior remains as-is, only the test is changed

## Regression? 

no

## Risk

no new risks, test made incorrect assumptions

### Before

If two threads are accessing the static cursor properties at the same time both may have observed the backing field as null and created their own cursor instance. Only one of them "wins" the write to the backing field, the other will return a different instance than on subsequent calls to the property. The test was making the assumption that the value returned from static properties never changes which is not true in this scenario.

### After

The test should be robust against running on multiple threads

## Test methodology

- code review
- running tests multiple times locally


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4312)