### PR TITLE
Revert "Explicit ImageList ownership management" (servicing)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.ImageCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.ImageCollection.cs
@@ -186,8 +186,6 @@ namespace System.Windows.Forms
                             bitmap.Dispose();
                         }
                     }
-
-                    _owner.OnRecreateHandle(EventArgs.Empty);
                 }
             }
 
@@ -381,7 +379,6 @@ namespace System.Windows.Forms
                 if (!_isBatchAdd)
                 {
                     _owner.OnChangeHandle(EventArgs.Empty);
-                    _owner.OnRecreateHandle(EventArgs.Empty);
                 }
 
                 return index;
@@ -402,7 +399,6 @@ namespace System.Windows.Forms
 
                 _isBatchAdd = false;
                 _owner.OnChangeHandle(EventArgs.Empty);
-                _owner.OnRecreateHandle(EventArgs.Empty);
             }
 
             /// <summary>
@@ -453,7 +449,6 @@ namespace System.Windows.Forms
                 }
 
                 _owner.OnChangeHandle(EventArgs.Empty);
-                _owner.OnRecreateHandle(EventArgs.Empty);
             }
 
             [EditorBrowsable(EditorBrowsableState.Never)]
@@ -565,7 +560,6 @@ namespace System.Windows.Forms
                     Remove(image);
 
                     _owner.OnChangeHandle(EventArgs.Empty);
-                    _owner.OnRecreateHandle(EventArgs.Empty);
                 }
             }
 
@@ -588,7 +582,6 @@ namespace System.Windows.Forms
                     _imageInfoCollection.RemoveAt(index);
 
                     _owner.OnChangeHandle(EventArgs.Empty);
-                    _owner.OnRecreateHandle(EventArgs.Empty);
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.NativeImageList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.NativeImageList.cs
@@ -71,8 +71,7 @@ namespace System.Windows.Forms
                         return;
                     }
 
-                    var result = ComCtl32.ImageList.Destroy(Handle);
-                    Debug.Assert(result.IsTrue());
+                    ComCtl32.ImageList.Destroy(Handle);
                     Handle = IntPtr.Zero;
                 }
             }
@@ -90,13 +89,6 @@ namespace System.Windows.Forms
                 return;
             }
 #endif
-
-            internal IntPtr TransferOwnership()
-            {
-                var handle = Handle;
-                Handle = IntPtr.Zero;
-                return handle;
-            }
 
             internal NativeImageList Duplicate()
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -138,17 +138,6 @@ namespace System.Windows.Forms
                 }
                 return _nativeImageList.Handle;
             }
-        }
-
-        internal IntPtr CreateUniqueHandle()
-        {
-            if (_nativeImageList is null)
-            {
-                CreateHandle();
-            }
-
-            using var iml = _nativeImageList.Duplicate();
-            return iml.TransferOwnership();
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -581,21 +581,11 @@ namespace System.Windows.Forms
                         {
                             if (CheckBoxes)
                             { // we want custom checkboxes
-                                var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, _imageListState.CreateUniqueHandle());
-                                if (previousHandle != IntPtr.Zero)
-                                {
-                                    var result = ComCtl32.ImageList.Destroy(previousHandle);
-                                    Debug.Assert(result.IsTrue());
-                                }
+                                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, _imageListState.Handle);
                             }
                             else
                             {
-                                var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, IntPtr.Zero);
-                                if (previousHandle != IntPtr.Zero)
-                                {
-                                    var result = ComCtl32.ImageList.Destroy(previousHandle);
-                                    Debug.Assert(result.IsTrue());
-                                }
+                                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, IntPtr.Zero);
                             }
                         }
 
@@ -676,9 +666,7 @@ namespace System.Windows.Forms
                     cp.Style |= (currentStyle & (int)(User32.WS.HSCROLL | User32.WS.VSCROLL));
                 }
 
-                // disabled until ownership management of list handles is fixed
-                // https://github.com/dotnet/winforms/issues/3531
-                //cp.Style |= (int)LVS.SHAREIMAGELISTS;
+                cp.Style |= (int)LVS.SHAREIMAGELISTS;
 
                 switch (alignStyle)
                 {
@@ -1000,13 +988,8 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.GROUPHEADER,
-                        value is null ? IntPtr.Zero : value.CreateUniqueHandle());
-                if (previousHandle != IntPtr.Zero)
-                {
-                    var result = ComCtl32.ImageList.Destroy(previousHandle);
-                    Debug.Assert(result.IsTrue());
-                }
+                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.GROUPHEADER,
+                        value is null ? IntPtr.Zero : value.Handle);
             }
         }
 
@@ -1274,13 +1257,7 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.NORMAL, value is null ? IntPtr.Zero : value.CreateUniqueHandle());
-                if (previousHandle != IntPtr.Zero)
-                {
-                    var result = ComCtl32.ImageList.Destroy(previousHandle);
-                    Debug.Assert(result.IsTrue());
-                }
-
+                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.NORMAL, value is null ? IntPtr.Zero : value.Handle);
                 if (AutoArrange && !listViewState1[LISTVIEWSTATE1_disposingImageLists])
                 {
                     UpdateListViewItemsLocations();
@@ -1519,12 +1496,7 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.SMALL, value is null ? IntPtr.Zero : value.CreateUniqueHandle());
-                if (previousHandle != IntPtr.Zero)
-                {
-                    var result = ComCtl32.ImageList.Destroy(previousHandle);
-                    Debug.Assert(result.IsTrue());
-                }
+                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.SMALL, value is null ? IntPtr.Zero : value.Handle);
 
                 if (View == View.SmallIcon)
                 {
@@ -1632,12 +1604,7 @@ namespace System.Windows.Forms
 
                     if (IsHandleCreated)
                     {
-                        var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, value is null ? IntPtr.Zero : value.CreateUniqueHandle());
-                        if (previousHandle != IntPtr.Zero)
-                        {
-                            var result = ComCtl32.ImageList.Destroy(previousHandle);
-                            Debug.Assert(result.IsTrue());
-                        }
+                        User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, value is null ? IntPtr.Zero : value.Handle);
                     }
                 }
                 else
@@ -1652,12 +1619,7 @@ namespace System.Windows.Forms
                         // (Yes, it does exactly that even though our wrapper sets LVS_SHAREIMAGELISTS on the native listView.)
                         // So we make the native listView forget about its StateImageList just before we recreate the handle.
                         // Likely related to https://devblogs.microsoft.com/oldnewthing/20171128-00/?p=97475
-                        var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, IntPtr.Zero);
-                        if (previousHandle != IntPtr.Zero)
-                        {
-                            var result = ComCtl32.ImageList.Destroy(previousHandle);
-                            Debug.Assert(result.IsTrue());
-                        }
+                        User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, IntPtr.Zero);
                     }
 
                     _imageListState = value;
@@ -1675,13 +1637,8 @@ namespace System.Windows.Forms
                     }
                     else
                     {
-                        var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE,
-                            (_imageListState is null || _imageListState.Images.Count == 0) ? IntPtr.Zero : _imageListState.CreateUniqueHandle());
-                        if (previousHandle != IntPtr.Zero)
-                        {
-                            var result = ComCtl32.ImageList.Destroy(previousHandle);
-                            Debug.Assert(result.IsTrue());
-                        }
+                        User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE,
+                            (_imageListState is null || _imageListState.Images.Count == 0) ? IntPtr.Zero : _imageListState.Handle);
                     }
 
                     // Comctl should handle auto-arrange for us, but doesn't
@@ -3754,13 +3711,8 @@ namespace System.Windows.Forms
                 return;
             }
 
-            IntPtr handle = (GroupImageList is null) ? IntPtr.Zero : GroupImageList.CreateUniqueHandle();
-            var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.GROUPHEADER, handle);
-            if (previousHandle != IntPtr.Zero)
-            {
-                var result = ComCtl32.ImageList.Destroy(previousHandle);
-                Debug.Assert(result.IsTrue());
-            }
+            IntPtr handle = (GroupImageList is null) ? IntPtr.Zero : GroupImageList.Handle;
+            User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.GROUPHEADER, handle);
         }
 
         public ListViewHitTestInfo HitTest(Point point)
@@ -4330,13 +4282,8 @@ namespace System.Windows.Forms
                 return;
             }
 
-            IntPtr handle = (LargeImageList is null) ? IntPtr.Zero : LargeImageList.CreateUniqueHandle();
-            var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.NORMAL, handle);
-            if (previousHandle != IntPtr.Zero)
-            {
-                var result = ComCtl32.ImageList.Destroy(previousHandle);
-                Debug.Assert(result.IsTrue());
-            }
+            IntPtr handle = (LargeImageList is null) ? IntPtr.Zero : LargeImageList.Handle;
+            User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.NORMAL, handle);
 
             ForceCheckBoxUpdate();
         }
@@ -4679,34 +4626,6 @@ namespace System.Windows.Forms
 
         protected override void OnHandleDestroyed(EventArgs e)
         {
-            var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.NORMAL);
-            if (previousHandle != IntPtr.Zero)
-            {
-                var result = ComCtl32.ImageList.Destroy(previousHandle);
-                Debug.Assert(result.IsTrue());
-            }
-
-            previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.SMALL);
-            if (previousHandle != IntPtr.Zero)
-            {
-                var result = ComCtl32.ImageList.Destroy(previousHandle);
-                Debug.Assert(result.IsTrue());
-            }
-
-            previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE);
-            if (previousHandle != IntPtr.Zero)
-            {
-                var result = ComCtl32.ImageList.Destroy(previousHandle);
-                Debug.Assert(result.IsTrue());
-            }
-
-            previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.GROUPHEADER);
-            if (previousHandle != IntPtr.Zero)
-            {
-                var result = ComCtl32.ImageList.Destroy(previousHandle);
-                Debug.Assert(result.IsTrue());
-            }
-
             // don't save the list view items state when in virtual mode : it is the responsability of the
             // user to cache the list view items in virtual mode
             if (!Disposing && !VirtualMode)
@@ -4963,42 +4882,22 @@ namespace System.Windows.Forms
 
             if (_imageListLarge != null)
             {
-                var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.NORMAL, _imageListLarge.CreateUniqueHandle());
-                if (previousHandle != IntPtr.Zero)
-                {
-                    var result = ComCtl32.ImageList.Destroy(previousHandle);
-                    Debug.Assert(result.IsTrue());
-                }
+                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.NORMAL, _imageListLarge.Handle);
             }
 
             if (_imageListSmall != null)
             {
-                var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.SMALL, _imageListSmall.CreateUniqueHandle());
-                if (previousHandle != IntPtr.Zero)
-                {
-                    var result = ComCtl32.ImageList.Destroy(previousHandle);
-                    Debug.Assert(result.IsTrue());
-                }
+                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.SMALL, _imageListSmall.Handle);
             }
 
             if (_imageListState != null)
             {
-                var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, _imageListState.CreateUniqueHandle());
-                if (previousHandle != IntPtr.Zero)
-                {
-                    var result = ComCtl32.ImageList.Destroy(previousHandle);
-                    Debug.Assert(result.IsTrue());
-                }
+                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, _imageListState.Handle);
             }
 
             if (_imageListGroup != null)
             {
-                var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.GROUPHEADER, _imageListGroup.CreateUniqueHandle());
-                if (previousHandle != IntPtr.Zero)
-                {
-                    var result = ComCtl32.ImageList.Destroy(previousHandle);
-                    Debug.Assert(result.IsTrue());
-                }
+                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.GROUPHEADER, _imageListGroup.Handle);
             }
         }
 
@@ -5525,13 +5424,8 @@ namespace System.Windows.Forms
                 return;
             }
 
-            IntPtr handle = (SmallImageList is null) ? IntPtr.Zero : SmallImageList.CreateUniqueHandle();
-            var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.SMALL, handle);
-            if (previousHandle != IntPtr.Zero)
-            {
-                var result = ComCtl32.ImageList.Destroy(previousHandle);
-                Debug.Assert(result.IsTrue());
-            }
+            IntPtr handle = (SmallImageList is null) ? IntPtr.Zero : SmallImageList.Handle;
+            User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.SMALL, handle);
 
             ForceCheckBoxUpdate();
         }
@@ -5563,13 +5457,8 @@ namespace System.Windows.Forms
                 return;
             }
 
-            IntPtr handle = (StateImageList is null) ? IntPtr.Zero : StateImageList.CreateUniqueHandle();
-            var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, handle);
-            if (previousHandle != IntPtr.Zero)
-            {
-                var result = ComCtl32.ImageList.Destroy(previousHandle);
-                Debug.Assert(result.IsTrue());
-            }
+            IntPtr handle = (StateImageList is null) ? IntPtr.Zero : StateImageList.Handle;
+            User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, handle);
         }
 
         /// <summary>
@@ -6334,12 +6223,7 @@ namespace System.Windows.Forms
             // (Yes, it does exactly that even though our wrapper sets LVS_SHAREIMAGELISTS on the native listView.)
             if (IsHandleCreated && StateImageList != null)
             {
-                var previousHandle = User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, IntPtr.Zero);
-                if (previousHandle != IntPtr.Zero)
-                {
-                    var result = ComCtl32.ImageList.Destroy(previousHandle);
-                    Debug.Assert(result.IsTrue());
-                }
+                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, IntPtr.Zero);
             }
 
             RecreateHandle();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -662,7 +662,7 @@ namespace System.Windows.Forms
                                     value is null ? IntPtr.Zero : value.Handle);
                         if (StateImageList != null && StateImageList.Images.Count > 0 && internalStateImageList != null)
                         {
-                            SetStateImageList(internalStateImageList.CreateUniqueHandle());
+                            SetStateImageList(internalStateImageList.Handle);
                         }
                     }
                     UpdateCheckedState(root, true);
@@ -1819,7 +1819,7 @@ namespace System.Windows.Forms
                 IntPtr handle = IntPtr.Zero;
                 if (internalStateImageList != null)
                 {
-                    handle = internalStateImageList.CreateUniqueHandle();
+                    handle = internalStateImageList.Handle;
                 }
                 SetStateImageList(handle);
             }
@@ -1859,7 +1859,7 @@ namespace System.Windows.Forms
                             internalStateImageList.ImageSize = (Size)ScaledStateImageSize;
                         }
 
-                        SetStateImageList(internalStateImageList.CreateUniqueHandle());
+                        SetStateImageList(internalStateImageList.Handle);
                     }
                 }
                 else //stateImageList is null || stateImageList.Images.Count = 0;
@@ -2050,7 +2050,7 @@ namespace System.Windows.Forms
                     images[i] = stateImageList.Images[i - 1];
                 }
                 newImageList.Images.AddRange(images);
-                User32.SendMessageW(this, (User32.WM)TVM.SETIMAGELIST, (IntPtr)TVSIL.STATE, newImageList.CreateUniqueHandle());
+                User32.SendMessageW(this, (User32.WM)TVM.SETIMAGELIST, (IntPtr)TVSIL.STATE, newImageList.Handle);
 
                 if (internalStateImageList != null)
                 {
@@ -2067,8 +2067,7 @@ namespace System.Windows.Forms
             IntPtr handleOld = User32.SendMessageW(this, (User32.WM)TVM.SETIMAGELIST, (IntPtr)TVSIL.STATE, handle);
             if ((handleOld != IntPtr.Zero) && (handleOld != handle))
             {
-                var result = ComCtl32.ImageList.Destroy(new HandleRef(this, handleOld));
-                Debug.Assert(result.IsTrue());
+                ComCtl32.ImageList.Destroy(new HandleRef(this, handleOld));
             }
         }
 
@@ -2079,8 +2078,7 @@ namespace System.Windows.Forms
             IntPtr handle = User32.SendMessageW(this, (User32.WM)TVM.GETIMAGELIST, (IntPtr)TVSIL.STATE);
             if (handle != IntPtr.Zero)
             {
-                var result = ComCtl32.ImageList.Destroy(new HandleRef(this, handle));
-                Debug.Assert(result.IsTrue());
+                ComCtl32.ImageList.Destroy(new HandleRef(this, handle));
                 if (reset)
                 {
                     User32.SendMessageW(this, (User32.WM)TVM.SETIMAGELIST, (IntPtr)TVSIL.STATE);
@@ -2621,7 +2619,7 @@ namespace System.Windows.Forms
                     // user's images.
                     if (internalStateImageList != null)
                     {
-                        SetStateImageList(internalStateImageList.CreateUniqueHandle());
+                        SetStateImageList(internalStateImageList.Handle);
                     }
                 }
             }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -170,9 +170,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(97, createParams.Height);
             Assert.Equal(IntPtr.Zero, createParams.Parent);
             Assert.Null(createParams.Param);
-            // LVS.SHAREIMAGELISTS is temporarily removed from style until ownership management is fixed
-            // https://github.com/dotnet/winforms/issues/3531
-            Assert.Equal(0x56010108, createParams.Style);
+            Assert.Equal(0x56010148, createParams.Style);
             Assert.Equal(121, createParams.Width);
             Assert.Equal(0, createParams.X);
             Assert.Equal(0, createParams.Y);


### PR DESCRIPTION
This reverts commit 03db3fbfcc6884356f70141f882433638b23bb49.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Resolves #4169
Resolves #4275


## Proposed changes


Revert "Explicit ImageList ownership management. (#3601)"
This reverts commit 03db3fbfcc6884356f70141f882433638b23bb49.

Revert "Fix `ListView` no longer displays images (#4184)"
This reverts commit d0608e72a356ad991f9c9d12518e29b43a1fb4f0.

We have observed an instability of tests under stress (and reasonably high degree of concurrency) presumably caused by ImageList lifetime handling (notably #3358).
The changes introduced in #3601 have helped with tests stability, however resulted in a number of regressions, such as #4169 and #4275.

Restore the original implementation given it worked reasonably well for the past so many years.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The `ImageList` behaviours should be the same as in .NET Framework and .NET Core.


## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4314)