### PR TITLE
Fixing MonthCalendar a display dates range resets and flickers after calling UpdateBoldedDates 

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendarTests.cs
@@ -258,7 +258,7 @@ namespace System.Windows.Forms.Tests
             Assert.True(calendar.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
-            Assert.Equal(1, createdCallCount);
+            Assert.Equal(0, createdCallCount);
 
             // Set same.
             calendar.AnnuallyBoldedDates = value;
@@ -276,7 +276,7 @@ namespace System.Windows.Forms.Tests
             Assert.True(calendar.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
-            Assert.Equal(2, createdCallCount);
+            Assert.Equal(0, createdCallCount);
         }
 
         public static IEnumerable<object[]> BackColor_Set_TestData()
@@ -586,7 +586,7 @@ namespace System.Windows.Forms.Tests
             Assert.True(calendar.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
-            Assert.Equal(1, createdCallCount);
+            Assert.Equal(0, createdCallCount);
 
             // Set same.
             calendar.BoldedDates = value;
@@ -604,7 +604,7 @@ namespace System.Windows.Forms.Tests
             Assert.True(calendar.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
-            Assert.Equal(2, createdCallCount);
+            Assert.Equal(0, createdCallCount);
         }
 
         public static IEnumerable<object[]> CalendarDimensions_Set_TestData()
@@ -1611,7 +1611,7 @@ namespace System.Windows.Forms.Tests
             Assert.True(calendar.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
-            Assert.Equal(1, createdCallCount);
+            Assert.Equal(0, createdCallCount);
 
             // Set same.
             calendar.MonthlyBoldedDates = value;
@@ -1629,7 +1629,7 @@ namespace System.Windows.Forms.Tests
             Assert.True(calendar.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
-            Assert.Equal(2, createdCallCount);
+            Assert.Equal(0, createdCallCount);
         }
 
         [WinFormsTheory]


### PR DESCRIPTION
Fixes #4283



## Proposed changes

- Use [MCM_SETDAYSTATE](https://docs.microsoft.com/windows/win32/controls/mcm-setdaystate) message to a native control instead of recreating its `Handle` in the Month view
- Change unit tests, because we don't create a `Handle` anymore when setting `BoldedDates`, `AnnuallyBoldedDates`, and `MonthlyBoldedDates`

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A calendar doesn't reset a display dates range after calling [UpdateBoldedDates](https://docs.microsoft.com/dotnet/api/system.windows.forms.monthcalendar.updateboldeddates) method now.
- The flickers have not disappeared but there are fewer of them than before. 
> The flickers reproduce for a native [MonthCalendar](https://docs.microsoft.com/windows/win32/controls/month-calendar-control-reference) control too, it seems it is a native control issue.

## Regression? 

- No

## Risk

- Middle, we are changing a public API. It has to be tested carefully.

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
- MonthCalendar has flickers and changes a display dates range when calling UpdateBoldedDates 
![fail](https://user-images.githubusercontent.com/49272759/100968378-495edf00-3542-11eb-8f26-a87860b74f27.gif)


### After
- MonthCalendar doesn't change a display dates range and has fewer flickers when calling UpdateBoldedDates 
![wokrs](https://user-images.githubusercontent.com/49272759/100968377-482db200-3542-11eb-929c-d60f9b2a2953.gif)



## Test methodology <!-- How did you ensure quality? -->

- CTI
- UI testing

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.19042.630]
- .NET (6.0.100-alpha.1.20554.10)


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4317)