### PR TITLE
Correct imagelist binding for ListView groups (servicing)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
@@ -274,6 +274,7 @@ namespace System.Windows.Forms
         [Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(Drawing.Design.UITypeEditor))]
         [Localizable(true)]
         [RefreshProperties(RefreshProperties.Repaint)]
+        [RelatedImageList("ListView.GroupImageList")]
         [SRCategory(nameof(SR.CatBehavior))]
         [TypeConverter(typeof(NoneExcludedImageIndexConverter))]
         public int TitleImageIndex
@@ -314,6 +315,7 @@ namespace System.Windows.Forms
         [Editor("System.Windows.Forms.Design.ImageIndexEditor, " + AssemblyRef.SystemDesign, typeof(Drawing.Design.UITypeEditor))]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [RefreshProperties(RefreshProperties.Repaint)]
+        [RelatedImageList("ListView.GroupImageList")]
         [SRCategory(nameof(SR.CatBehavior))]
         [Localizable(true)]
         public string TitleImageKey


### PR DESCRIPTION
(cherry picked from commit db160691c31991b78a3b58860ba5fecd0de57bab)


Resolves #4310
Resolves dotnet/winforms-designer#2057

<!-- Please read CONTRIBUTING.md before submitting a pull request -->



## Proposed changes

ListViewGroups can't have title images set via either key or index, as propertygrid is unable to discover the bound imagelist.
Correct the missing binding by applying `RelatedImageListAttribute` to respective properties.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Currently it is impossible to set title images via UI tools (this includes Visual Studio designer). Thus affects the perception of working state of the Windows Forms designer.

## Regression? 

- No, support for `ListViewGroup` title images was introduced in .NET 5.0 in #3490.

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/4403806/100972543-1a218f80-358d-11eb-91a7-22ffe63fc489.png)


### After

![image](https://user-images.githubusercontent.com/4403806/100972337-bc8d4300-358c-11eb-8680-75b39d5146aa.png)



## Test methodology <!-- How did you ensure quality? -->

- By substituting binaries under C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App\6.0.0-alpha.1.20570.2 and running a sample project



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4322)