### PR TITLE
Setting a new TreeNode in a TreeNodeCollection will replace existing one

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeCollection.cs
@@ -83,6 +83,7 @@ namespace System.Windows.Forms
                     return;
                 }
 
+                tv.nodeTable.Remove(actual.handle);
                 value.parent = owner;
                 value.index = index;
                 owner.children[index] = value;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeCollection.cs
@@ -66,6 +66,11 @@ namespace System.Windows.Forms
                 TreeView tv = owner.treeView;
                 TreeNode actual = owner.children[index];
 
+                if (value is null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
                 if (value.treeView != null && value.treeView.Handle != tv.Handle)
                 {
                     throw new ArgumentException(string.Format(SR.TreeNodeBoundToAnotherTreeView), nameof(value));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeCollection.cs
@@ -63,13 +63,13 @@ namespace System.Windows.Forms
                     throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
                 }
 
-                TreeView tv = owner.treeView;
-                TreeNode actual = owner.children[index];
-
                 if (value is null)
                 {
                     throw new ArgumentNullException(nameof(value));
                 }
+
+                TreeView tv = owner.treeView;
+                TreeNode actual = owner.children[index];
 
                 if (value.treeView != null && value.treeView.Handle != tv.Handle)
                 {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
@@ -115,6 +115,18 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<ArgumentException>(() => collection[0] = nodeOfAnotherTreeView);
         }
 
+        [WinFormsFact]
+        public void TreeNodeCollection_Item_SetTreeNodeReplacesExistingOne()
+        {
+            using var treeView = new TreeView();
+            IntPtr forcedHandle = treeView.Handle;
+            TreeNodeCollection collection = treeView.Nodes;
+            collection.Add("Node 1");
+            collection[0] = new TreeNode("New node 1");
+            Assert.Equal(1, treeView.nodeTable.Count);
+            Assert.Equal(1, collection.Count);
+        }
+
         [WinFormsTheory]
         [InlineData("name2")]
         [InlineData("NAME2")]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
@@ -81,6 +81,16 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
+        public void TreeNodeCollection_Item_SetNullTreeNode_ThrowsArgumentNullException()
+        {
+            using var treeView = new TreeView();
+            TreeNodeCollection collection = treeView.Nodes;
+            TreeNode node = new TreeNode("Node 0");
+            collection.Add(node);
+            Assert.Throws<ArgumentNullException>(() => collection[0] = null);
+        }
+
+        [WinFormsFact]
         public void TreeNodeCollection_Item_SetTreeNodeAlreadyAdded_Noop()
         {
             using var treeView = new TreeView();


### PR DESCRIPTION
Fixes #3437

## Proposed changes

- Setter of method this[int index] of class TreeNodeCollection is replacing the existing TreeNode instead of adding it

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4329)