### PR TITLE
ensure that editor config follows runtime coding style (vars when type is obvious)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -94,7 +94,7 @@ csharp_indent_labels = one_less_than_current
 
 # only use var when it's obvious what the variable type is
 csharp_style_var_for_built_in_types = false:none
-csharp_style_var_when_type_is_apparent = false:none
+csharp_style_var_when_type_is_apparent = true:suggestion
 csharp_style_var_elsewhere = false:suggestion
 
 


### PR DESCRIPTION
From https://github.com/dotnet/runtime/blob/master/docs/coding-guidelines/coding-style.md:
`We only use var when it's obvious what the variable type is (e.g. var stream = new FileStream(...) not var stream = OpenStandardInput()).`



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4334)