### PR TITLE
Fix resize grip in DropDown editor

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
@@ -1903,8 +1903,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Draws a size grip at the given location. The color of the size grip is based
-        ///  on the given background color.
+        ///  Draws a size grip at the given location. The color of the size grip is based on the given background color.
         /// </summary>
         public static void DrawSizeGrip(Graphics graphics, Color backColor, Rectangle bounds)
             => DrawSizeGrip(graphics, backColor, bounds.X, bounds.Y, bounds.Width, bounds.Height);
@@ -1917,7 +1916,19 @@ namespace System.Windows.Forms
             if (graphics is null)
                 throw new ArgumentNullException(nameof(graphics));
 
-            DrawSizeGrip((IDeviceContext)graphics, backColor, x, y, width, height);
+            using var bright = GdiPlusCache.GetCachedPenScope(LightLight(backColor));
+            using var dark = GdiPlusCache.GetCachedPenScope(Dark(backColor));
+
+            int minDim = Math.Min(width, height);
+            int right = x + width - 1;
+            int bottom = y + height - 2;
+
+            for (int i = 0; i < minDim - 4; i += 4)
+            {
+                graphics.DrawLine(dark, right - (i + 1) - 2, bottom, right, bottom - (i + 1) - 2);
+                graphics.DrawLine(dark, right - (i + 2) - 2, bottom, right, bottom - (i + 2) - 2);
+                graphics.DrawLine(bright, right - (i + 3) - 2, bottom, right, bottom - (i + 3) - 2);
+            }
         }
 
         internal static void DrawSizeGrip(

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.DropDownHolder.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.DropDownHolder.cs
@@ -32,9 +32,9 @@ namespace System.Windows.Forms.PropertyGridInternal
             private Rectangle dragBaseRect = Rectangle.Empty; // the original bounds of our control.
             private int currentMoveType = MoveTypeNone; // what type of move are we processing? left, bottom, or both?
 
+            private readonly static int ResizeGripSize = SystemInformation.HorizontalScrollBarHeight; // the size of the 4-way resize grip at outermost corner of the resize bar
             private readonly static int ResizeBarSize = ResizeGripSize + 1; // the thickness of the resize bar
             private readonly static int ResizeBorderSize = ResizeBarSize / 2; // the thickness of the 2-way resize area along the outer edge of the resize bar
-            private readonly static int ResizeGripSize = SystemInformation.HorizontalScrollBarHeight; // the size of the 4-way resize grip at outermost corner of the resize bar
             private readonly static Size MinDropDownSize =
                 new Size(SystemInformation.VerticalScrollBarWidth * 4, SystemInformation.HorizontalScrollBarHeight * 4); // the minimum size for the control.
             private Bitmap sizeGripGlyph; // our cached size grip glyph.  Control paint only does right bottom glyphs, so we cache a mirrored one.  See GetSizeGripGlyph
@@ -223,8 +223,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return sizeGripGlyph;
                 }
 
-                // create our drawing surface based on the current graphics context.
-                //
+                // Create our drawing surface based on the current graphics context.
                 sizeGripGlyph = new Bitmap(ResizeGripSize, ResizeGripSize, g);
 
                 using (Graphics glyphGraphics = Graphics.FromImage(sizeGripGlyph))
@@ -246,6 +245,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     ControlPaint.DrawSizeGrip(glyphGraphics, BackColor, 0, 0, ResizeGripSize, ResizeGripSize);
                     glyphGraphics.ResetTransform();
                 }
+
                 sizeGripGlyph.MakeTransparent(BackColor);
                 return sizeGripGlyph;
             }


### PR DESCRIPTION
Order statics so sizing is correctly calculated. Change ControlPaint.DrawSizeGrip to use GDI+ to get fully applied transforms.

Fixes #4238

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4340)