### PR TITLE
Fix flaky test

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/GroupBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/GroupBoxTests.cs
@@ -835,20 +835,19 @@ namespace System.Windows.Forms.Tests
         [InlineData(FlatStyle.Flat, FlatStyle.Flat, false, true, true, 0, 0)]
         [InlineData(FlatStyle.Flat, FlatStyle.Popup, true, true, true, 1, 0)]
         [InlineData(FlatStyle.Flat, FlatStyle.Standard, true, true, true, 1, 0)]
-        [InlineData(FlatStyle.Flat, FlatStyle.System, true, false, false, 1, 1)]
+        [InlineData(FlatStyle.Flat, FlatStyle.System, true, false, false, 0, 1)]
         [InlineData(FlatStyle.Popup, FlatStyle.Flat, true, true, true, 1, 0)]
         [InlineData(FlatStyle.Popup, FlatStyle.Popup, false, true, true, 0, 0)]
         [InlineData(FlatStyle.Popup, FlatStyle.Standard, true, true, true, 1, 0)]
-        // [InlineData(FlatStyle.Popup, FlatStyle.System, true, false, false, 0, 1)] // Fails from cli, passes in VS
+        [InlineData(FlatStyle.Popup, FlatStyle.System, true, false, false, 0, 1)]
         [InlineData(FlatStyle.Standard, FlatStyle.Flat, true, true, true, 1, 0)]
         [InlineData(FlatStyle.Standard, FlatStyle.Popup, true, true, true, 1, 0)]
         [InlineData(FlatStyle.Standard, FlatStyle.Standard, false, true, false, 0, 0)]
-        // [InlineData(FlatStyle.Standard, FlatStyle.System, true, false, false, 0, 1)] // Fails from cli, passes in VS
+        [InlineData(FlatStyle.Standard, FlatStyle.System, true, false, false, 0, 1)]
         [InlineData(FlatStyle.System, FlatStyle.Flat, true, true, true, 0, 1)]
         [InlineData(FlatStyle.System, FlatStyle.Popup, true, true, true, 0, 1)]
         [InlineData(FlatStyle.System, FlatStyle.Standard, true, true, true, 0, 1)]
         [InlineData(FlatStyle.System, FlatStyle.System, false, false, false, 0, 0)]
-        [ActiveIssue("https://github.com/dotnet/winforms/issues/4213")]
         public void GroupBox_FlatStyle_VisualStyles_on_SetWithCustomOldValue_GetReturnsExpected(FlatStyle oldValue, FlatStyle value, bool containerControl, bool ownerDraw, bool userMouse, int expectedInvalidatedCallCount, int expectedCreatedCallCount)
         {
             if (!Application.UseVisualStyles)
@@ -878,7 +877,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(ownerDraw, control.GetStyle(ControlStyles.ResizeRedraw));
             Assert.Equal(userMouse, control.GetStyle(ControlStyles.UserMouse));
             Assert.True(control.IsHandleCreated);
-            Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
+            Assert.True(invalidatedCallCount >= expectedInvalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(expectedCreatedCallCount, createdCallCount);
 
@@ -891,7 +890,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(ownerDraw, control.GetStyle(ControlStyles.ResizeRedraw));
             Assert.Equal(userMouse, control.GetStyle(ControlStyles.UserMouse));
             Assert.True(control.IsHandleCreated);
-            Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
+            Assert.True(invalidatedCallCount >= expectedInvalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(expectedCreatedCallCount, createdCallCount);
         }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4213 

## Proposed changes

Do not perform an exact check on the number of invalidations since the OS may perform additional invalidations. See issue for a detailed analysis of the scenario we are fixing.

## Customer Impact

none, test-only

## Regression? 

no

## Risk

none, test-only

### Before

Test failed depending on last input, which was indeterministic due to multithreaded tests simulating user input.

### After

Test should be stable independent of input generated by other threads

## Test methodology

Run the test in the VS debugger and make sure its independent of keyboard/mouse input performed in the debugger


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4342)