### PR TITLE
Fixing issue with getting of textbox from DataGridViewTextBoxCell by Accessibility Insights (port to 5.0)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -2589,6 +2589,12 @@ namespace System.Windows.Forms
 
             Debug.Assert(dgv.EditingControl.ParentInternal == dgv.EditingPanel);
             Debug.Assert(dgv.EditingPanel.ParentInternal == dgv);
+
+            if (AccessibleRestructuringNeeded)
+            {
+                dgv.EditingControlAccessibleObject.SetParent(AccessibilityObject);
+                AccessibilityObject.SetDetachableChild(dgv.EditingControlAccessibleObject);
+            }
         }
 
         protected virtual bool KeyDownUnsharesRow(KeyEventArgs e, int rowIndex)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellTests.cs
@@ -4826,6 +4826,34 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<ArgumentOutOfRangeException>("rowIndex", () => cell.GetInheritedStyle(new DataGridViewCellStyle(), rowIndex, true));
         }
 
+        [WinFormsFact]
+        public void DataGridViewCell_InitializeEditingControl_Set_Parent()
+        {
+            using DataGridView dataGridView = new DataGridView();
+            dataGridView.CreateControl();
+            using DataGridViewTextBoxColumn column1 = new DataGridViewTextBoxColumn();
+            dataGridView.Columns.Add(column1);
+            dataGridView.Rows.Add();
+            var cell = dataGridView.Rows[0].Cells[0];
+            cell.Selected = true;
+
+            // Attach EditingControl.AccessibilityObject to cell
+            dataGridView.BeginEdit(false);
+            Assert.NotNull(dataGridView.EditingControl.AccessibilityObject.Parent);
+            Assert.Same(cell.AccessibilityObject, dataGridView.EditingControl.AccessibilityObject.Parent);
+
+            // Detach EditingControl.AccessibilityObject
+            dataGridView.EndEdit();
+            Assert.Null(dataGridView.EditingControlAccessibleObject);
+
+            // Reattach EditingControl.AccessibilityObject to cell
+            dataGridView.BeginEdit(false);
+            Assert.NotNull(dataGridView.EditingControl.AccessibilityObject.Parent);
+            Assert.Same(cell.AccessibilityObject, dataGridView.EditingControl.AccessibilityObject.Parent);
+
+            dataGridView.EndEdit();
+        }
+
         [StaFact]
         public void DataGridViewCell_GetNeighboringToolsRectangles_ReturnsCorrectRectangles()
         {


### PR DESCRIPTION
Fixes #3925
Based on changes from #4124

## Proposed changes
- Added logic for restoring of parent during reattaching of EditingControlAccessibleObject. 
- Added unit tests

## Customer Impact
Fixed issue with hanging of Accessibility Insights during getting of data about textbox from DataGridViewTextBoxCell

## Regression? 

- Yes

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Manually 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Narrator
- Inspector
- Accessibility Insights

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core 5.0.100-rc.2.20479.15

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4351)