### PR TITLE
Fixed position of bounding rectangle for ComboBox items when drop down shows a scrollbar

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObject.cs
@@ -43,6 +43,13 @@ namespace System.Windows.Forms
                 {
                     ChildAccessibleObject listAccessibleObject = _owningComboBox.ChildListAccessibleObject;
                     int currentIndex = GetCurrentIndex();
+                    if (_owningComboBox.IsHandleCreated)
+                    {
+                        int firstVisibleIndex = (int)(long)User32.SendMessageW(_owningComboBox, (User32.WM)User32.CB.GETTOPINDEX);
+
+                        // Using the first visible index, we make an index shift, which helps to draw a rectangle with the correct position
+                        currentIndex -= firstVisibleIndex;
+                    }
 
                     Rectangle parentRect = listAccessibleObject.BoundingRectangle;
                     int left = parentRect.Left;

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ComboBoxes.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ComboBoxes.Designer.cs
@@ -73,11 +73,15 @@ namespace WinformsControlsTest
             "aa",
             "bb",
             "cc",
-            "d"});
+            "d",
+            "ee",
+            "ff",
+            "gg",});
             this.comboBox2.Location = new System.Drawing.Point(148, 22);
             this.comboBox2.Name = "comboBox2";
             this.comboBox2.Size = new System.Drawing.Size(121, 21);
             this.comboBox2.TabIndex = 4;
+            this.comboBox2.DropDownHeight = 80;
             //
             // comboBox3
             //
@@ -87,11 +91,16 @@ namespace WinformsControlsTest
             "standard",
             "aa",
             "bb",
-            "cc"});
+            "cc",
+            "d",
+            "ee",
+            "ff",
+            "gg",});
             this.comboBox3.Location = new System.Drawing.Point(21, 59);
             this.comboBox3.Name = "comboBox3";
             this.comboBox3.Size = new System.Drawing.Size(121, 21);
             this.comboBox3.TabIndex = 5;
+            this.comboBox3.DropDownHeight = 80;
             //
             // comboBox4
             //
@@ -207,7 +216,10 @@ namespace WinformsControlsTest
             "aa",
             "bb",
             "cc",
-            "d"});
+            "d",
+            "ee",
+            "ff",
+            "gg",});
             this.comboBox12.Location = new System.Drawing.Point(275, 22);
             this.comboBox12.Name = "comboBox12";
             this.comboBox12.Size = new System.Drawing.Size(121, 150);


### PR DESCRIPTION
Fixes #4323

## Proposed changes
- Added logic that makes an index shift, which helps to draw a bounding rectangle with the correct position 

## Customer Impact
Before:
![Issue-4354-beforefix](https://user-images.githubusercontent.com/23376742/101778060-66784c80-3b04-11eb-95ff-f6cc42ac3638.gif)

After:
![Issue-4354-afterfix](https://user-images.githubusercontent.com/23376742/101778079-6c6e2d80-3b04-11eb-82de-6f9175c4c32d.gif)

## Regression? 
- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Manually

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Inspector
- Accessibility Insights
 
## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core 5.0.100-rc.2.20479.15

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4354)