### PR TITLE
Fix NotifyIcon.Text limits text to 63 characters, but should be 127

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -6138,7 +6138,7 @@ Stack trace where the illegal operation occurred was:
     <value>Control does not support transparent background colors.</value>
   </data>
   <data name="TrayIcon_TextTooLong" xml:space="preserve">
-    <value>Text length must be less than 64 characters long.</value>
+    <value>Text length must be less than 128 characters long.</value>
   </data>
   <data name="TreeNodeBackColorDescr" xml:space="preserve">
     <value>The background color of tree node.</value>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -10412,8 +10412,8 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <note />
       </trans-unit>
       <trans-unit id="TrayIcon_TextTooLong">
-        <source>Text length must be less than 64 characters long.</source>
-        <target state="translated">Délka textu musí být menší než 64 znaků.</target>
+        <source>Text length must be less than 128 characters long.</source>
+        <target state="translated">Délka textu musí být menší než 128 znaků.</target>
         <note />
       </trans-unit>
       <trans-unit id="TreeNodeBackColorDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -10412,8 +10412,8 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <note />
       </trans-unit>
       <trans-unit id="TrayIcon_TextTooLong">
-        <source>Text length must be less than 64 characters long.</source>
-        <target state="translated">Der Text muss kürzer als 64 Zeichen sein.</target>
+        <source>Text length must be less than 128 characters long.</source>
+        <target state="translated">Der Text muss kürzer als 128 Zeichen sein.</target>
         <note />
       </trans-unit>
       <trans-unit id="TreeNodeBackColorDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -10412,8 +10412,8 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <note />
       </trans-unit>
       <trans-unit id="TrayIcon_TextTooLong">
-        <source>Text length must be less than 64 characters long.</source>
-        <target state="translated">La longitud del texto debe ser inferior a 64 caracteres.</target>
+        <source>Text length must be less than 128 characters long.</source>
+        <target state="translated">La longitud del texto debe ser inferior a 128 caracteres.</target>
         <note />
       </trans-unit>
       <trans-unit id="TreeNodeBackColorDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -10412,8 +10412,8 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <note />
       </trans-unit>
       <trans-unit id="TrayIcon_TextTooLong">
-        <source>Text length must be less than 64 characters long.</source>
-        <target state="translated">La longueur du texte doit être inférieure à 64 caractères.</target>
+        <source>Text length must be less than 128 characters long.</source>
+        <target state="translated">La longueur du texte doit être inférieure à 128 caractères.</target>
         <note />
       </trans-unit>
       <trans-unit id="TreeNodeBackColorDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -10412,8 +10412,8 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <note />
       </trans-unit>
       <trans-unit id="TrayIcon_TextTooLong">
-        <source>Text length must be less than 64 characters long.</source>
-        <target state="translated">La lunghezza del testo deve essere inferiore ai 64 caratteri.</target>
+        <source>Text length must be less than 128 characters long.</source>
+        <target state="translated">La lunghezza del testo deve essere inferiore ai 128 caratteri.</target>
         <note />
       </trans-unit>
       <trans-unit id="TreeNodeBackColorDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -10412,8 +10412,8 @@ Stack trace where the illegal operation occurred was:
         <note />
       </trans-unit>
       <trans-unit id="TrayIcon_TextTooLong">
-        <source>Text length must be less than 64 characters long.</source>
-        <target state="translated">文字列の長さは 64 文字未満でなければなりません。</target>
+        <source>Text length must be less than 128 characters long.</source>
+        <target state="translated">文字列の長さは 128 文字未満でなければなりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="TreeNodeBackColorDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -10412,8 +10412,8 @@ Stack trace where the illegal operation occurred was:
         <note />
       </trans-unit>
       <trans-unit id="TrayIcon_TextTooLong">
-        <source>Text length must be less than 64 characters long.</source>
-        <target state="translated">텍스트 길이는 64자 미만이어야 합니다.</target>
+        <source>Text length must be less than 128 characters long.</source>
+        <target state="translated">텍스트 길이는 128 자 미만이어야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="TreeNodeBackColorDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -10413,7 +10413,7 @@ Stack trace where the illegal operation occurred was:
       </trans-unit>
       <trans-unit id="TrayIcon_TextTooLong">
         <source>Text length must be less than 128 characters long.</source>
-        <target state="translated">텍스트 길이는 128 자 미만이어야 합니다.</target>
+        <target state="translated">텍스트 길이는 128자 미만이어야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="TreeNodeBackColorDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -10412,8 +10412,8 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <note />
       </trans-unit>
       <trans-unit id="TrayIcon_TextTooLong">
-        <source>Text length must be less than 64 characters long.</source>
-        <target state="translated">Długość tekstu musi być mniejsza niż 64 znaki.</target>
+        <source>Text length must be less than 128 characters long.</source>
+        <target state="translated">Długość tekstu musi być mniejsza niż 128 znaki.</target>
         <note />
       </trans-unit>
       <trans-unit id="TreeNodeBackColorDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -10412,8 +10412,8 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <note />
       </trans-unit>
       <trans-unit id="TrayIcon_TextTooLong">
-        <source>Text length must be less than 64 characters long.</source>
-        <target state="translated">O texto deve ter menos de 64 caracteres.</target>
+        <source>Text length must be less than 128 characters long.</source>
+        <target state="translated">O texto deve ter menos de 128 caracteres.</target>
         <note />
       </trans-unit>
       <trans-unit id="TreeNodeBackColorDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -10413,8 +10413,8 @@ Stack trace where the illegal operation occurred was:
         <note />
       </trans-unit>
       <trans-unit id="TrayIcon_TextTooLong">
-        <source>Text length must be less than 64 characters long.</source>
-        <target state="translated">Длина текста должна быть меньше 64 символов.</target>
+        <source>Text length must be less than 128 characters long.</source>
+        <target state="translated">Длина текста должна быть меньше 128 символов.</target>
         <note />
       </trans-unit>
       <trans-unit id="TreeNodeBackColorDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -10412,8 +10412,8 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <note />
       </trans-unit>
       <trans-unit id="TrayIcon_TextTooLong">
-        <source>Text length must be less than 64 characters long.</source>
-        <target state="translated">Metin uzunluğu 64 karakterden az olmalı.</target>
+        <source>Text length must be less than 128 characters long.</source>
+        <target state="translated">Metin uzunluğu 128 karakterden az olmalı.</target>
         <note />
       </trans-unit>
       <trans-unit id="TreeNodeBackColorDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -10412,8 +10412,8 @@ Stack trace where the illegal operation occurred was:
         <note />
       </trans-unit>
       <trans-unit id="TrayIcon_TextTooLong">
-        <source>Text length must be less than 64 characters long.</source>
-        <target state="translated">文本长度必须少于 64 个字符。</target>
+        <source>Text length must be less than 128 characters long.</source>
+        <target state="translated">文本长度必须少于 128 个字符。</target>
         <note />
       </trans-unit>
       <trans-unit id="TreeNodeBackColorDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -10412,8 +10412,8 @@ Stack trace where the illegal operation occurred was:
         <note />
       </trans-unit>
       <trans-unit id="TrayIcon_TextTooLong">
-        <source>Text length must be less than 64 characters long.</source>
-        <target state="translated">文字長度必須少於 64 個字元。</target>
+        <source>Text length must be less than 128 characters long.</source>
+        <target state="translated">文字長度必須少於 128 個字元。</target>
         <note />
       </trans-unit>
       <trans-unit id="TreeNodeBackColorDescr">

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
@@ -13,6 +13,7 @@ using static Interop.Shell32;
 
 namespace System.Windows.Forms
 {
+
     /// <summary>
     ///  Specifies a component that creates
     ///  an icon in the Windows System Tray. This class cannot be inherited.
@@ -24,6 +25,7 @@ namespace System.Windows.Forms
     [SRDescription(nameof(SR.DescriptionNotifyIcon))]
     public sealed class NotifyIcon : Component
     {
+        internal const int MaxNotifyIconTextSize = 127;
         private static readonly object EVENT_MOUSEDOWN = new object();
         private static readonly object EVENT_MOUSEMOVE = new object();
         private static readonly object EVENT_MOUSEUP = new object();
@@ -251,7 +253,7 @@ namespace System.Windows.Forms
 
                 if (value != null && !value.Equals(text))
                 {
-                    if (value != null && value.Length > 127)
+                    if (value != null && value.Length > MaxNotifyIconTextSize)
                     {
                         throw new ArgumentOutOfRangeException(nameof(Text), value, SR.TrayIcon_TextTooLong);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
@@ -13,7 +13,6 @@ using static Interop.Shell32;
 
 namespace System.Windows.Forms
 {
-
     /// <summary>
     ///  Specifies a component that creates
     ///  an icon in the Windows System Tray. This class cannot be inherited.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
@@ -24,7 +24,7 @@ namespace System.Windows.Forms
     [SRDescription(nameof(SR.DescriptionNotifyIcon))]
     public sealed class NotifyIcon : Component
     {
-        internal const int MaxNotifyIconTextSize = 127;
+        internal const int MaxTextSize = 127;
         private static readonly object EVENT_MOUSEDOWN = new object();
         private static readonly object EVENT_MOUSEMOVE = new object();
         private static readonly object EVENT_MOUSEUP = new object();
@@ -252,7 +252,7 @@ namespace System.Windows.Forms
 
                 if (value != null && !value.Equals(text))
                 {
-                    if (value != null && value.Length > MaxNotifyIconTextSize)
+                    if (value != null && value.Length > MaxTextSize)
                     {
                         throw new ArgumentOutOfRangeException(nameof(Text), value, SR.TrayIcon_TextTooLong);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
@@ -251,7 +251,7 @@ namespace System.Windows.Forms
 
                 if (value != null && !value.Equals(text))
                 {
-                    if (value != null && value.Length > 63)
+                    if (value != null && value.Length > 127)
                     {
                         throw new ArgumentOutOfRangeException(nameof(Text), value, SR.TrayIcon_TextTooLong);
                     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NotifyIconTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NotifyIconTests.cs
@@ -13,6 +13,8 @@ namespace System.Windows.Forms.Tests
 {
     public class NotifyIconTests : IClassFixture<ThreadExceptionFixture>
     {
+        private const int MaxNotifyIconTextSize = 127;
+
         [WinFormsFact]
         public void NotifyIcon_Ctor_Default()
         {
@@ -338,7 +340,7 @@ namespace System.Windows.Forms.Tests
                     yield return new object[] { visible, icon, null, string.Empty };
                     yield return new object[] { visible, icon, string.Empty, string.Empty };
                     yield return new object[] { visible, icon, "text", "text" };
-                    yield return new object[] { visible, icon, new string('a', 127), new string('a', 127) };
+                    yield return new object[] { visible, icon, new string('a', MaxNotifyIconTextSize), new string('a', MaxNotifyIconTextSize) };
                 }
             }
         }
@@ -390,13 +392,13 @@ namespace System.Windows.Forms.Tests
                 }
 
                 yield return new object[] { visible, null, "text", "text", 0 };
-                yield return new object[] { visible, null, new string('a', 127), new string('a', 127), 0 };
+                yield return new object[] { visible, null, new string('a', MaxNotifyIconTextSize), new string('a', MaxNotifyIconTextSize), 0 };
             }
 
             yield return new object[] { false, new Icon("bitmaps/10x16_one_entry_32bit.ico"), "text", "text", 0 };
-            yield return new object[] { false, new Icon("bitmaps/10x16_one_entry_32bit.ico"), new string('a', 127), new string('a', 127), 0 };
+            yield return new object[] { false, new Icon("bitmaps/10x16_one_entry_32bit.ico"), new string('a', MaxNotifyIconTextSize), new string('a', MaxNotifyIconTextSize), 0 };
             yield return new object[] { true, new Icon("bitmaps/10x16_one_entry_32bit.ico"), "text", "text", 1 };
-            yield return new object[] { true, new Icon("bitmaps/10x16_one_entry_32bit.ico"), new string('a', 127), new string('a', 127), 1 };
+            yield return new object[] { true, new Icon("bitmaps/10x16_one_entry_32bit.ico"), new string('a', MaxNotifyIconTextSize), new string('a', MaxNotifyIconTextSize), 1 };
         }
 
         [WinFormsTheory]
@@ -430,7 +432,7 @@ namespace System.Windows.Forms.Tests
         public void NotifyIcon_Text_SetLongValue_ThrowsArgumentOutOfRangeException()
         {
             using var notifyIcon = new NotifyIcon();
-            Assert.Throws<ArgumentOutOfRangeException>("Text", () => notifyIcon.Text = new string('a', 128));
+            Assert.Throws<ArgumentOutOfRangeException>("Text", () => notifyIcon.Text = new string('a', MaxNotifyIconTextSize + 1));
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NotifyIconTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NotifyIconTests.cs
@@ -13,6 +13,7 @@ namespace System.Windows.Forms.Tests
 {
     public class NotifyIconTests : IClassFixture<ThreadExceptionFixture>
     {
+        internal const int MaxNotifyIconTextSize = 127;
 
         [WinFormsFact]
         public void NotifyIcon_Ctor_Default()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NotifyIconTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NotifyIconTests.cs
@@ -338,7 +338,7 @@ namespace System.Windows.Forms.Tests
                     yield return new object[] { visible, icon, null, string.Empty };
                     yield return new object[] { visible, icon, string.Empty, string.Empty };
                     yield return new object[] { visible, icon, "text", "text" };
-                    yield return new object[] { visible, icon, new string('a', 63), new string('a', 63) };
+                    yield return new object[] { visible, icon, new string('a', 127), new string('a', 127) };
                 }
             }
         }
@@ -390,13 +390,13 @@ namespace System.Windows.Forms.Tests
                 }
 
                 yield return new object[] { visible, null, "text", "text", 0 };
-                yield return new object[] { visible, null, new string('a', 63), new string('a', 63), 0 };
+                yield return new object[] { visible, null, new string('a', 127), new string('a', 127), 0 };
             }
 
             yield return new object[] { false, new Icon("bitmaps/10x16_one_entry_32bit.ico"), "text", "text", 0 };
-            yield return new object[] { false, new Icon("bitmaps/10x16_one_entry_32bit.ico"), new string('a', 63), new string('a', 63), 0 };
+            yield return new object[] { false, new Icon("bitmaps/10x16_one_entry_32bit.ico"), new string('a', 127), new string('a', 127), 0 };
             yield return new object[] { true, new Icon("bitmaps/10x16_one_entry_32bit.ico"), "text", "text", 1 };
-            yield return new object[] { true, new Icon("bitmaps/10x16_one_entry_32bit.ico"), new string('a', 63), new string('a', 63), 1 };
+            yield return new object[] { true, new Icon("bitmaps/10x16_one_entry_32bit.ico"), new string('a', 127), new string('a', 127), 1 };
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NotifyIconTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NotifyIconTests.cs
@@ -13,8 +13,6 @@ namespace System.Windows.Forms.Tests
 {
     public class NotifyIconTests : IClassFixture<ThreadExceptionFixture>
     {
-        internal const int MaxNotifyIconTextSize = 127;
-
         [WinFormsFact]
         public void NotifyIcon_Ctor_Default()
         {
@@ -340,7 +338,7 @@ namespace System.Windows.Forms.Tests
                     yield return new object[] { visible, icon, null, string.Empty };
                     yield return new object[] { visible, icon, string.Empty, string.Empty };
                     yield return new object[] { visible, icon, "text", "text" };
-                    yield return new object[] { visible, icon, new string('a', MaxNotifyIconTextSize), new string('a', MaxNotifyIconTextSize) };
+                    yield return new object[] { visible, icon, new string('a', NotifyIcon.MaxTextSize), new string('a', NotifyIcon.MaxTextSize) };
                 }
             }
         }
@@ -392,13 +390,13 @@ namespace System.Windows.Forms.Tests
                 }
 
                 yield return new object[] { visible, null, "text", "text", 0 };
-                yield return new object[] { visible, null, new string('a', MaxNotifyIconTextSize), new string('a', MaxNotifyIconTextSize), 0 };
+                yield return new object[] { visible, null, new string('a', NotifyIcon.MaxTextSize), new string('a', NotifyIcon.MaxTextSize), 0 };
             }
 
             yield return new object[] { false, new Icon("bitmaps/10x16_one_entry_32bit.ico"), "text", "text", 0 };
-            yield return new object[] { false, new Icon("bitmaps/10x16_one_entry_32bit.ico"), new string('a', MaxNotifyIconTextSize), new string('a', MaxNotifyIconTextSize), 0 };
+            yield return new object[] { false, new Icon("bitmaps/10x16_one_entry_32bit.ico"), new string('a', NotifyIcon.MaxTextSize), new string('a', NotifyIcon.MaxTextSize), 0 };
             yield return new object[] { true, new Icon("bitmaps/10x16_one_entry_32bit.ico"), "text", "text", 1 };
-            yield return new object[] { true, new Icon("bitmaps/10x16_one_entry_32bit.ico"), new string('a', MaxNotifyIconTextSize), new string('a', MaxNotifyIconTextSize), 1 };
+            yield return new object[] { true, new Icon("bitmaps/10x16_one_entry_32bit.ico"), new string('a', NotifyIcon.MaxTextSize), new string('a', NotifyIcon.MaxTextSize), 1 };
         }
 
         [WinFormsTheory]
@@ -432,7 +430,7 @@ namespace System.Windows.Forms.Tests
         public void NotifyIcon_Text_SetLongValue_ThrowsArgumentOutOfRangeException()
         {
             using var notifyIcon = new NotifyIcon();
-            Assert.Throws<ArgumentOutOfRangeException>("Text", () => notifyIcon.Text = new string('a', MaxNotifyIconTextSize + 1));
+            Assert.Throws<ArgumentOutOfRangeException>("Text", () => notifyIcon.Text = new string('a', NotifyIcon.MaxTextSize + 1));
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NotifyIconTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NotifyIconTests.cs
@@ -13,7 +13,6 @@ namespace System.Windows.Forms.Tests
 {
     public class NotifyIconTests : IClassFixture<ThreadExceptionFixture>
     {
-        private const int MaxNotifyIconTextSize = 127;
 
         [WinFormsFact]
         public void NotifyIcon_Ctor_Default()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NotifyIconTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NotifyIconTests.cs
@@ -430,7 +430,7 @@ namespace System.Windows.Forms.Tests
         public void NotifyIcon_Text_SetLongValue_ThrowsArgumentOutOfRangeException()
         {
             using var notifyIcon = new NotifyIcon();
-            Assert.Throws<ArgumentOutOfRangeException>("Text", () => notifyIcon.Text = new string('a', 64));
+            Assert.Throws<ArgumentOutOfRangeException>("Text", () => notifyIcon.Text = new string('a', 128));
         }
 
         [WinFormsTheory]


### PR DESCRIPTION
Fixes #4361


## Proposed changes

- Change character limit for text in NotifyIcon.Text from 63 to 127 characters.

## Customer Impact

- This matches the Windows Control that was changed in an OS released before .Net is supported.  

## Regression? 

- No

## Risk

- Very low, all tests updated and all supported OS's support 127.


## Test methodology <!-- How did you ensure quality? -->

- Update all tests to of this code to use 127 instead of 63


## Accessibility testing 
The underlying windows control supports 127 characters and the testing now uses 127 allowing the text to support longer descriptions.  

## Test environment(s) <!-- Remove any that don't apply -->

- 5.0.200-preview.20601.7 [C:\Program Files\dotnet\sdk]


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4363)