### PR TITLE
Fix "MaxDropDownItems" property for ComboBox in the DataGridView

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
@@ -535,6 +535,8 @@ namespace System.Windows.Forms
                 Properties.SetInteger(s_propComboBoxCellMaxDropDownItems, (int)value);
                 if (OwnsEditingComboBox(RowIndex))
                 {
+                    // The "MaxDropDownItems" property will not work when the "IntegralHeight" property is True (default value)
+                    EditingComboBox.IntegralHeight = false;
                     EditingComboBox.MaxDropDownItems = value;
                 }
             }
@@ -1385,6 +1387,15 @@ namespace System.Windows.Forms
                 h = comboBox.Handle; // make sure that assigning the DataSource property does not assert.
                 comboBox.DropDownStyle = ComboBoxStyle.DropDownList;
                 comboBox.FormattingEnabled = true;
+
+                // If the Properties contain the "s_propComboBoxCellMaxDropDownItems" key, then the user has manually
+                // updated the "MaxDropDownItems" property and we should set the "IntegralHeight" property to False.
+                // The "MaxDropDownItems" property will not work when the "IntegralHeight" property is True (default value)
+                if (Properties.ContainsInteger(s_propComboBoxCellMaxDropDownItems))
+                {
+                    comboBox.IntegralHeight = false;
+                }
+
                 comboBox.MaxDropDownItems = MaxDropDownItems;
                 comboBox.DropDownWidth = DropDownWidth;
                 comboBox.DataSource = null;


### PR DESCRIPTION
Fixes #4373


## Proposed changes
- The issue is reproduced because "MaxDropDownItems" property does not work when the "IntegralHeight" flag has "True" value. As a workaround, the user can update the "IntegralHeight" flag themselves for the usual ComboBox and ToolStripComboBox, but the user does not have access to this flag in the DataGridViewComboBoxColumn and DataGridViewComboBoxCell. As a result, this property becomes useless for the ComboBoxes in the DataGridView. As a fix, we suggest to set "IntegralHeight" flag to "False" when the user updates "MaxDropDownItems" property of the DataGridViewComboBoxColumn or DataGridViewComboBoxCell. 

## Customer Impact
The behavior of the DataGridViewComboboxColumn, which has a "4" value in the "MaxDropDownItems" property:
Before:
![issue-4373-beforefix](https://user-images.githubusercontent.com/23376742/102586088-8e763a00-411a-11eb-9e35-f275807f4ede.png)
After:
![issue-4373-afterfix](https://user-images.githubusercontent.com/23376742/102586114-97ffa200-411a-11eb-8c4a-265788f8484d.png)



## Regression? 

- No

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Manual

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core 5.0.100-rc.2.20479.15

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4377)