### PR TITLE
Fixing issue with showing of the bounding rectangle for invisible items in ComboBox

### DIFF
--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Extensions/AssertExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Extensions/AssertExtensions.cs
@@ -4,7 +4,9 @@
 
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
+using System.Windows.Forms;
 using Xunit;
+using static Interop;
 
 namespace System
 {
@@ -21,6 +23,16 @@ namespace System
             }
 
             return exception;
+        }
+
+        internal static void True(AccessibleObject accessibleObject, UiaCore.UIA propertyId)
+        {
+            Assert.True((bool)accessibleObject.GetPropertyValue(propertyId));
+        }
+
+        internal static void False(AccessibleObject accessibleObject, UiaCore.UIA propertyId)
+        {
+            Assert.False((bool)accessibleObject.GetPropertyValue(propertyId));
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/System.Windows.Forms.Primitives.TestUtilities.csproj
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/System.Windows.Forms.Primitives.TestUtilities.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\System.Windows.Forms\src\System.Windows.Forms.csproj" />
     <ProjectReference Include="..\..\src\System.Windows.Forms.Primitives.csproj" />
   </ItemGroup>
 

--- a/src/System.Windows.Forms/src/Properties/AssemblyInfo.cs
+++ b/src/System.Windows.Forms/src/Properties/AssemblyInfo.cs
@@ -11,6 +11,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("MauiMonthCalendarTests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("MauiTabControlTests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("MauiListViewTests, PublicKey=00000000000000000400000000000000")]
+[assembly: InternalsVisibleTo("System.Windows.Forms.Primitives.TestUtilities, PublicKey=00000000000000000400000000000000")]
 
 // This is needed in order to Moq internal interfaces for testing
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObject.cs
@@ -44,7 +44,8 @@ namespace System.Windows.Forms
                 {
                     int currentIndex = GetCurrentIndex();
                     IntPtr listHandle = _owningComboBox.GetListHandle();
-                    RECT itemRect = new RECT();
+                    RECT itemRect = new();
+
                     int result = unchecked((int)(long)User32.SendMessageW(
                         listHandle, (User32.WM)User32.LB.GETITEMRECT, (IntPtr)currentIndex, ref itemRect));
 
@@ -55,7 +56,6 @@ namespace System.Windows.Forms
 
                     // Translate the item rect to screen coordinates
                     User32.MapWindowPoints(listHandle, IntPtr.Zero, ref itemRect, 2);
-
                     return itemRect;
                 }
             }
@@ -230,9 +230,19 @@ namespace System.Windows.Forms
                 get
                 {
                     var accState = _systemIAccessible?.get_accState(GetChildId());
-                    return accState is not null
-                        ? (AccessibleStates)accState
-                        : AccessibleStates.None;
+                    if (accState is null)
+                    {
+                        return AccessibleStates.None;
+                    }
+
+                    AccessibleStates accessibleStates = (AccessibleStates)accState;
+
+                    if (!_owningComboBox.DroppedDown || !_owningComboBox.ChildListAccessibleObject.Bounds.IntersectsWith(Bounds))
+                    {
+                        accessibleStates |= AccessibleStates.Offscreen;
+                    }
+
+                    return accessibleStates;
                 }
             }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObjectTests.cs
@@ -14,6 +14,9 @@ namespace System.Windows.Forms.Tests
 {
     public class ComboBox_ComboBoxItemAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
     {
+        private const AccessibleStates InvisibleItemState = AccessibleStates.Invisible | AccessibleStates.Offscreen | AccessibleStates.Focusable | AccessibleStates.Selectable;
+        private const AccessibleStates VisibleItemState = AccessibleStates.Selected | AccessibleStates.Focusable | AccessibleStates.Selectable;
+
         [WinFormsFact]
         public void ComboBoxItemAccessibleObject_Get_Not_ThrowsException()
         {
@@ -77,67 +80,115 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [WinFormsFact]
-        public void ComboBoxItemAccessibleObject_SeveralSameItems_FragmentNavigate_NextSibling_ReturnExpected()
+        [WinFormsTheory]
+        [InlineData(ComboBoxStyle.DropDown)]
+        [InlineData(ComboBoxStyle.DropDownList)]
+        [InlineData(ComboBoxStyle.Simple)]
+        public void ComboBoxItemAccessibleObject_SeveralSameItems_FragmentNavigate_NextSibling_ReturnExpected(ComboBoxStyle comboBoxStyle)
         {
-            using (new NoAssertContext())
+            using ComboBox comboBox = new ComboBox
             {
-                using ComboBox comboBox = new ComboBox();
-                comboBox.CreateControl();
+                DropDownStyle = comboBoxStyle
+            };
 
-                comboBox.Items.AddRange(new[] { "aaa", "aaa", "aaa" });
-                ComboBox.ComboBoxItemAccessibleObject comboBoxItem1 = (ComboBox.ComboBoxItemAccessibleObject)comboBox
-                    .ChildListAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild);
-                Assert.Equal("aaa", comboBoxItem1.Name);
+            comboBox.Items.AddRange(new[] { "aaa", "aaa", "aaa" });
+            comboBox.CreateControl();
 
-                // FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling) should return accessible object for second "aaa" item
-                ComboBox.ComboBoxItemAccessibleObject comboBoxItem2 = (ComboBox.ComboBoxItemAccessibleObject)comboBoxItem1
-                    .FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling);
-                Assert.NotEqual(comboBoxItem1, comboBoxItem2);
-                Assert.Equal("aaa", comboBoxItem2.Name);
+            ComboBoxItemAccessibleObjectCollection itemAccessibleObjects = ((ComboBox.ComboBoxAccessibleObject)comboBox.AccessibilityObject).ItemAccessibleObjects;
 
-                // FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling) should return accessible object for third "aaa" item
-                ComboBox.ComboBoxItemAccessibleObject comboBoxItem3 = (ComboBox.ComboBoxItemAccessibleObject)comboBoxItem2
-                    .FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling);
-                Assert.NotEqual(comboBoxItem3, comboBoxItem2);
-                Assert.NotEqual(comboBoxItem3, comboBoxItem1);
-                Assert.Equal("aaa", comboBoxItem3.Name);
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem1 = (ComboBox.ComboBoxItemAccessibleObject)comboBox
+                .ChildListAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild);
+            Assert.Equal("aaa", comboBoxItem1.Name);
+            Assert.Equal(comboBoxItem1, itemAccessibleObjects.GetComboBoxItemAccessibleObject(comboBox.Items.InnerList[0]));
 
-                Assert.True(comboBox.IsHandleCreated);
-            }
+            // FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling) should return accessible object for second "aaa" item
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem2 = (ComboBox.ComboBoxItemAccessibleObject)comboBoxItem1
+                .FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling);
+            Assert.NotEqual(comboBoxItem1, comboBoxItem2);
+            Assert.Equal("aaa", comboBoxItem2.Name);
+            Assert.Equal(comboBoxItem2, itemAccessibleObjects.GetComboBoxItemAccessibleObject(comboBox.Items.InnerList[1]));
+
+            // FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling) should return accessible object for third "aaa" item
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem3 = (ComboBox.ComboBoxItemAccessibleObject)comboBoxItem2
+                .FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling);
+            Assert.NotEqual(comboBoxItem3, comboBoxItem2);
+            Assert.NotEqual(comboBoxItem3, comboBoxItem1);
+            Assert.Equal("aaa", comboBoxItem3.Name);
+            Assert.Equal(comboBoxItem3, itemAccessibleObjects.GetComboBoxItemAccessibleObject(comboBox.Items.InnerList[2]));
+
+            Assert.True(comboBox.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void ComboBoxItemAccessibleObject_SeveralSameItems_FragmentNavigate_PreviousSibling_ReturnExpected()
+        [WinFormsTheory]
+        [InlineData(ComboBoxStyle.DropDown)]
+        [InlineData(ComboBoxStyle.DropDownList)]
+        [InlineData(ComboBoxStyle.Simple)]
+        public void ComboBoxItemAccessibleObject_SeveralSameItems_FragmentNavigate_PreviousSibling_ReturnExpected(ComboBoxStyle comboBoxStyle)
         {
-            using (new NoAssertContext())
+            using ComboBox comboBox = new ComboBox
             {
-                using ComboBox comboBox = new ComboBox();
-                comboBox.CreateControl();
+                DropDownStyle = comboBoxStyle
+            };
 
-                comboBox.Items.AddRange(new[] { "aaa", "aaa", "aaa" });
-                ComboBox.ComboBoxItemAccessibleObject comboBoxItem3 = (ComboBox.ComboBoxItemAccessibleObject)comboBox
-                    .ChildListAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild);
+            comboBox.Items.AddRange(new[] { "aaa", "aaa", "aaa" });
+            comboBox.CreateControl();
 
-                // FragmentNavigate(Interop.UiaCore.NavigateDirection.PreviousSibling) should return accessible object for second "aaa" item
-                ComboBox.ComboBoxItemAccessibleObject comboBoxItem2 = (ComboBox.ComboBoxItemAccessibleObject)comboBoxItem3
-                    .FragmentNavigate(Interop.UiaCore.NavigateDirection.PreviousSibling);
-                Assert.NotEqual(comboBoxItem2, comboBoxItem3);
-                Assert.Equal("aaa", comboBoxItem2.Name);
+            ComboBoxItemAccessibleObjectCollection itemAccessibleObjects = ((ComboBox.ComboBoxAccessibleObject)comboBox.AccessibilityObject).ItemAccessibleObjects;
 
-                // FragmentNavigate(Interop.UiaCore.NavigateDirection.PreviousSibling) should return accessible object for first "aaa" item
-                ComboBox.ComboBoxItemAccessibleObject comboBoxItem1 = (ComboBox.ComboBoxItemAccessibleObject)comboBoxItem2
-                    .FragmentNavigate(Interop.UiaCore.NavigateDirection.PreviousSibling);
-                Assert.NotEqual(comboBoxItem1, comboBoxItem2);
-                Assert.NotEqual(comboBoxItem1, comboBoxItem3);
-                Assert.Equal("aaa", comboBoxItem1.Name);
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem3 = (ComboBox.ComboBoxItemAccessibleObject)comboBox
+                .ChildListAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild);
 
-                // FragmentNavigate(Interop.UiaCore.NavigateDirection.PreviousSibling) should return null for first "aaa" item
-                ComboBox.ComboBoxItemAccessibleObject comboBoxItemPrevious = (ComboBox.ComboBoxItemAccessibleObject)comboBoxItem1
-                    .FragmentNavigate(Interop.UiaCore.NavigateDirection.PreviousSibling);
-                Assert.Null(comboBoxItemPrevious);
-                Assert.True(comboBox.IsHandleCreated);
-            }
+            Assert.Equal("aaa", comboBoxItem3.Name);
+            Assert.Equal(comboBoxItem3, itemAccessibleObjects.GetComboBoxItemAccessibleObject(comboBox.Items.InnerList[2]));
+
+            // FragmentNavigate(Interop.UiaCore.NavigateDirection.PreviousSibling) should return accessible object for second "aaa" item
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem2 = (ComboBox.ComboBoxItemAccessibleObject)comboBoxItem3
+                .FragmentNavigate(Interop.UiaCore.NavigateDirection.PreviousSibling);
+
+            Assert.NotEqual(comboBoxItem2, comboBoxItem3);
+            Assert.Equal("aaa", comboBoxItem2.Name);
+            Assert.Equal(comboBoxItem2, itemAccessibleObjects.GetComboBoxItemAccessibleObject(comboBox.Items.InnerList[1]));
+
+            // FragmentNavigate(Interop.UiaCore.NavigateDirection.PreviousSibling) should return accessible object for first "aaa" item
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem1 = (ComboBox.ComboBoxItemAccessibleObject)comboBoxItem2
+                .FragmentNavigate(Interop.UiaCore.NavigateDirection.PreviousSibling);
+            Assert.NotEqual(comboBoxItem1, comboBoxItem2);
+            Assert.NotEqual(comboBoxItem1, comboBoxItem3);
+            Assert.Equal("aaa", comboBoxItem1.Name);
+            Assert.Equal(comboBoxItem1, itemAccessibleObjects.GetComboBoxItemAccessibleObject(comboBox.Items.InnerList[0]));
+
+            // FragmentNavigate(Interop.UiaCore.NavigateDirection.PreviousSibling) should return null for first "aaa" item
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItemPrevious = (ComboBox.ComboBoxItemAccessibleObject)comboBoxItem1
+                .FragmentNavigate(Interop.UiaCore.NavigateDirection.PreviousSibling);
+            Assert.Null(comboBoxItemPrevious);
+            Assert.True(comboBox.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(ComboBoxStyle.DropDown)]
+        [InlineData(ComboBoxStyle.DropDownList)]
+        [InlineData(ComboBoxStyle.Simple)]
+        public void ComboBoxItemAccessibleObject_FragmentNavigate_Parent_ReturnListAccessibleObject(ComboBoxStyle comboBoxStyle)
+        {
+            using ComboBox comboBox = GetComboBox(comboBoxStyle);
+            AccessibleObject childListAccessibleObject = comboBox.ChildListAccessibleObject;
+            AccessibleObject comboBoxItem = (AccessibleObject)childListAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild);
+
+            Assert.Equal(childListAccessibleObject, comboBoxItem.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+        }
+
+        [WinFormsTheory]
+        [InlineData(ComboBoxStyle.DropDown)]
+        [InlineData(ComboBoxStyle.DropDownList)]
+        [InlineData(ComboBoxStyle.Simple)]
+        public void ComboBoxItemAccessibleObject_FragmentNavigate_Child_ReturnNull(ComboBoxStyle comboBoxStyle)
+        {
+            using ComboBox comboBox = GetComboBox(comboBoxStyle);
+            AccessibleObject childListAccessibleObject = comboBox.ChildListAccessibleObject;
+            AccessibleObject comboBoxItem = (AccessibleObject)childListAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild);
+
+            Assert.Null(comboBoxItem.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(comboBoxItem.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
         }
 
         [WinFormsFact]
@@ -451,6 +502,191 @@ namespace System.Windows.Forms.Tests
                 e.DrawFocusRectangle();
                 base.OnDrawItem(e);
             }
+        }
+
+        [WinFormsTheory]
+        [InlineData(ComboBoxStyle.DropDownList)]
+        [InlineData(ComboBoxStyle.DropDown)]
+        public void ComboBoxItemAccessibleObject_MaxDropDownItems_State_ReturnExpected(ComboBoxStyle comboBoxStyle)
+        {
+            using ComboBox comboBox = GetComboBoxWithMaxItems(comboBoxStyle);
+
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem1 = (ComboBox.ComboBoxItemAccessibleObject)comboBox
+                    .ChildListAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild);
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem2 = (ComboBox.ComboBoxItemAccessibleObject)comboBoxItem1
+                    .FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling);
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem3 = (ComboBox.ComboBoxItemAccessibleObject)comboBoxItem2
+                    .FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling);
+
+            Assert.Equal(comboBoxItem1.State, InvisibleItemState); // comboBoxItem1 above the visible area
+            Assert.Equal(comboBoxItem2.State, VisibleItemState); // comboBoxItem2 in the visible area
+            Assert.Equal(comboBoxItem3.State, InvisibleItemState); // comboBoxItem3 below the visible area
+        }
+
+        [WinFormsTheory]
+        [InlineData(ComboBoxStyle.DropDownList)]
+        [InlineData(ComboBoxStyle.DropDown)]
+        public void ComboBoxItemAccessibleObject_DropDownHeight_State_ReturnExpected(ComboBoxStyle comboBoxStyle)
+        {
+            using ComboBox comboBox = GetComboBoxWithMaxHeight(comboBoxStyle);
+
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem1 = (ComboBox.ComboBoxItemAccessibleObject)comboBox
+                    .ChildListAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild);
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem2 = (ComboBox.ComboBoxItemAccessibleObject)comboBoxItem1
+                    .FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling);
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem3 = (ComboBox.ComboBoxItemAccessibleObject)comboBoxItem2
+                    .FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling);
+
+            Assert.Equal(comboBoxItem1.State, InvisibleItemState); // comboBoxItem1 above the visible area
+            Assert.Equal(comboBoxItem2.State, VisibleItemState); // comboBoxItem2 in the visible area
+            Assert.Equal(comboBoxItem3.State, InvisibleItemState); // comboBoxItem3 below the visible area
+        }
+
+        [WinFormsTheory]
+        [InlineData(ComboBoxStyle.DropDownList)]
+        [InlineData(ComboBoxStyle.DropDown)]
+        public void ComboBoxItemAccessibleObject_DropDownCollapsed_State_ReturnExpected(ComboBoxStyle comboBoxStyle)
+        {
+            using ComboBox comboBox = GetComboBox(comboBoxStyle);
+
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem1 = (ComboBox.ComboBoxItemAccessibleObject)comboBox
+                    .ChildListAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild);
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem2 = (ComboBox.ComboBoxItemAccessibleObject)comboBoxItem1
+                    .FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling);
+
+            Assert.Equal(comboBoxItem1.State, InvisibleItemState);
+            Assert.Equal(comboBoxItem2.State, InvisibleItemState);
+        }
+
+        [WinFormsFact]
+        public void ComboBoxItemAccessibleObject_State_ReturnExpected()
+        {
+            using ComboBox comboBox = GetComboBoxWithMaxSize(ComboBoxStyle.Simple);
+
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem1 = (ComboBox.ComboBoxItemAccessibleObject)comboBox
+                    .ChildListAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild);
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem2 = (ComboBox.ComboBoxItemAccessibleObject)comboBoxItem1
+                    .FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling);
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem3 = (ComboBox.ComboBoxItemAccessibleObject)comboBoxItem2
+                    .FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling);
+
+            AccessibleStates itemState = AccessibleStates.Invisible | AccessibleStates.Selected | AccessibleStates.Focusable | AccessibleStates.Selectable;
+
+            Assert.Equal(comboBoxItem1.State, InvisibleItemState); // comboBoxItem1 above the visible area
+            Assert.Equal(comboBoxItem2.State, itemState); // comboBoxItem2 in the visible area
+            Assert.Equal(comboBoxItem3.State, InvisibleItemState); // comboBoxItem3 below the visible area
+        }
+
+        [WinFormsTheory]
+        [InlineData(ComboBoxStyle.DropDownList)]
+        [InlineData(ComboBoxStyle.DropDown)]
+        public void ComboBoxItemAccessibleObject_MaxDropDownItems_GetOffScreenProperty_ReturnExpected(ComboBoxStyle comboBoxStyle)
+        {
+            using ComboBox comboBox = GetComboBoxWithMaxItems(comboBoxStyle);
+
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem1 = (ComboBox.ComboBoxItemAccessibleObject)comboBox
+                    .ChildListAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild);
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem2 = (ComboBox.ComboBoxItemAccessibleObject)comboBoxItem1
+                    .FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling);
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem3 = (ComboBox.ComboBoxItemAccessibleObject)comboBoxItem2
+                    .FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling);
+
+            AssertExtensions.True(comboBoxItem1, UiaCore.UIA.IsOffscreenPropertyId); // comboBoxItem1 above the visible area
+            AssertExtensions.False(comboBoxItem2, UiaCore.UIA.IsOffscreenPropertyId); // comboBoxItem2 in the visible area
+            AssertExtensions.True(comboBoxItem3, UiaCore.UIA.IsOffscreenPropertyId); // comboBoxItem3 below the visible area
+        }
+
+        [WinFormsTheory]
+        [InlineData(ComboBoxStyle.DropDownList)]
+        [InlineData(ComboBoxStyle.DropDown)]
+        public void ComboBoxItemAccessibleObject_DropDownHeight_GetOffScreenProperty_ReturnExpected(ComboBoxStyle comboBoxStyle)
+        {
+            using ComboBox comboBox = GetComboBoxWithMaxHeight(comboBoxStyle);
+
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem1 = (ComboBox.ComboBoxItemAccessibleObject)comboBox
+                    .ChildListAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild);
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem2 = (ComboBox.ComboBoxItemAccessibleObject)comboBoxItem1
+                    .FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling);
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem3 = (ComboBox.ComboBoxItemAccessibleObject)comboBoxItem2
+                    .FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling);
+
+            AssertExtensions.True(comboBoxItem1, UiaCore.UIA.IsOffscreenPropertyId); // comboBoxItem1 above the visible area
+            AssertExtensions.False(comboBoxItem2, UiaCore.UIA.IsOffscreenPropertyId); // comboBoxItem2 in the visible area
+            AssertExtensions.True(comboBoxItem3, UiaCore.UIA.IsOffscreenPropertyId); // comboBoxItem3 below the visible area
+        }
+
+        [WinFormsTheory]
+        [InlineData(ComboBoxStyle.DropDownList)]
+        [InlineData(ComboBoxStyle.DropDown)]
+        public void ComboBoxItemAccessibleObject_DropDownCollapsed_GetOffScreenProperty_ReturnExpected(ComboBoxStyle comboBoxStyle)
+        {
+            using ComboBox comboBox = GetComboBox(comboBoxStyle);
+
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem1 = (ComboBox.ComboBoxItemAccessibleObject)comboBox
+                    .ChildListAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild);
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem2 = (ComboBox.ComboBoxItemAccessibleObject)comboBoxItem1
+                    .FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling);
+
+            AssertExtensions.True(comboBoxItem1, UiaCore.UIA.IsOffscreenPropertyId);
+            AssertExtensions.True(comboBoxItem2, UiaCore.UIA.IsOffscreenPropertyId);
+        }
+
+        [WinFormsFact]
+        public void ComboBoxItemAccessibleObject_GetOffScreenProperty_ReturnExpected()
+        {
+            using ComboBox comboBox = GetComboBoxWithMaxSize(ComboBoxStyle.Simple);
+
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem1 = (ComboBox.ComboBoxItemAccessibleObject)comboBox
+                    .ChildListAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild);
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem2 = (ComboBox.ComboBoxItemAccessibleObject)comboBoxItem1
+                    .FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling);
+            ComboBox.ComboBoxItemAccessibleObject comboBoxItem3 = (ComboBox.ComboBoxItemAccessibleObject)comboBoxItem2
+                    .FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling);
+
+            AssertExtensions.True(comboBoxItem1, UiaCore.UIA.IsOffscreenPropertyId); // comboBoxItem1 above the visible area
+            AssertExtensions.False(comboBoxItem2, UiaCore.UIA.IsOffscreenPropertyId); // comboBoxItem2 in the visible area
+            AssertExtensions.True(comboBoxItem3, UiaCore.UIA.IsOffscreenPropertyId); // comboBoxItem3 below the visible area
+        }
+
+        private ComboBox GetComboBox(ComboBoxStyle comboBoxStyle)
+        {
+            ComboBox comboBox = new ComboBox
+            {
+                DropDownStyle = comboBoxStyle
+            };
+
+            comboBox.Items.Add(1);
+            comboBox.Items.Add(2);
+            comboBox.Items.Add(3);
+            comboBox.CreateControl();
+            return comboBox;
+        }
+
+        private ComboBox GetComboBoxWithMaxItems(ComboBoxStyle comboBoxStyle)
+        {
+            ComboBox comboBox = GetComboBox(comboBoxStyle);
+            comboBox.IntegralHeight = false;
+            comboBox.MaxDropDownItems = 1;
+            comboBox.SelectedIndex = 1;
+            comboBox.DroppedDown = true;
+            return comboBox;
+        }
+
+        private ComboBox GetComboBoxWithMaxHeight(ComboBoxStyle comboBoxStyle)
+        {
+            ComboBox comboBox = GetComboBox(comboBoxStyle);
+            comboBox.DropDownHeight = 10;
+            comboBox.SelectedIndex = 1;
+            comboBox.DroppedDown = true;
+            return comboBox;
+        }
+
+        private ComboBox GetComboBoxWithMaxSize(ComboBoxStyle comboBoxStyle)
+        {
+            ComboBox comboBox = GetComboBox(comboBoxStyle);
+            comboBox.Size = new Size(100, 50);
+            comboBox.SelectedIndex = 1;
+            return comboBox;
         }
     }
 }


### PR DESCRIPTION
Fixes #4372

## Proposed changes
- Added logic that checks that the drop down list is expanded and the item is in the visible area
- Added logic for supporting of the "OffScreen" state

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
CASE 1:
Before:
![Issue-4372-case1](https://user-images.githubusercontent.com/23376742/102372341-29163200-3fd0-11eb-801c-0c3256a82d96.gif)
After:
![Issue-4372-case1-fixed](https://user-images.githubusercontent.com/23376742/102372357-2d424f80-3fd0-11eb-8b51-103750c91252.gif)

CASE 2:
Before:
![Issue-4372-case2](https://user-images.githubusercontent.com/23376742/102372466-43e8a680-3fd0-11eb-8ca4-08272014624b.gif)
After:
![Issue-4372-case2-fixed](https://user-images.githubusercontent.com/23376742/102372504-4ea33b80-3fd0-11eb-8309-923fd4b9cbbb.gif)

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->
-  Manually
- Unit tests

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.19041.388]
- .NET Core 5.0.100-rc.2.20479.15


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4380)