### PR TITLE
Enable nullability in CompatibleIComparer and WeakHashtable

### DIFF
--- a/src/System.Windows.Forms/src/misc/CompatibleIComparer.cs
+++ b/src/System.Windows.Forms/src/misc/CompatibleIComparer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Collections.Specialized
 {
     using System.Collections;
@@ -17,7 +15,7 @@ namespace System.Collections.Specialized
         }
 
         //For backcompat
-        public static int GetHashCode(string obj)
+        public static int GetHashCode(string? obj)
         {
             unsafe
             {
@@ -37,14 +35,14 @@ namespace System.Collections.Specialized
             }
         }
 
-        bool IEqualityComparer.Equals(object a, object b)
+        bool IEqualityComparer.Equals(object? a, object? b)
         {
             return Object.Equals(a, b);
         }
 
         public virtual int GetHashCode(object o)
         {
-            if (!(o is string obj))
+            if (o is not string obj)
             {
                 return o.GetHashCode();
             }

--- a/src/System.Windows.Forms/src/misc/WeakHashtable.cs
+++ b/src/System.Windows.Forms/src/misc/WeakHashtable.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.ComponentModel
 {
     using System;
@@ -45,7 +43,7 @@ namespace System.ComponentModel
         ///  Override of Item that wraps a weak reference around the
         ///  key and performs a scavenge.
         /// </summary>
-        public void SetWeak(object key, object value)
+        public void SetWeak(object key, object? value)
         {
             ScavengeKeys();
             this[new EqualityWeakReference(key)] = value;
@@ -94,7 +92,7 @@ namespace System.ComponentModel
                 // Perform a scavenge through our keys, looking
                 // for dead references.
                 //
-                ArrayList cleanupList = null;
+                ArrayList? cleanupList = null;
                 foreach (object o in Keys)
                 {
                     if (o is WeakReference wr && !wr.IsAlive)
@@ -123,7 +121,7 @@ namespace System.ComponentModel
 
         private class WeakKeyComparer : IEqualityComparer
         {
-            bool IEqualityComparer.Equals(object x, object y)
+            bool IEqualityComparer.Equals(object? x, object? y)
             {
                 if (x is null)
                 {
@@ -177,7 +175,7 @@ namespace System.ComponentModel
                 _hashCode = o.GetHashCode();
             }
 
-            public override bool Equals(object o)
+            public override bool Equals(object? o)
             {
                 if (o is null)
                 {


### PR DESCRIPTION
## Proposed changes

- Enable nullability in CompatibleIComparer and WeakHashtable.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4382)