### PR TITLE
Enable nullability in ConvertEventArgs and ListControlConvertEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -9501,10 +9501,10 @@ System.Windows.Forms.CheckBox.CheckBoxAccessibleObject.CheckBoxAccessibleObject(
 ~System.Windows.Forms.ControlBindingsCollection.this[string propertyName].get -> System.Windows.Forms.Binding
 ~System.Windows.Forms.ControlEventArgs.Control.get -> System.Windows.Forms.Control
 ~System.Windows.Forms.ControlEventArgs.ControlEventArgs(System.Windows.Forms.Control control) -> void
-~System.Windows.Forms.ConvertEventArgs.ConvertEventArgs(object value, System.Type desiredType) -> void
-~System.Windows.Forms.ConvertEventArgs.DesiredType.get -> System.Type
-~System.Windows.Forms.ConvertEventArgs.Value.get -> object
-~System.Windows.Forms.ConvertEventArgs.Value.set -> void
+System.Windows.Forms.ConvertEventArgs.ConvertEventArgs(object? value, System.Type? desiredType) -> void
+System.Windows.Forms.ConvertEventArgs.DesiredType.get -> System.Type?
+System.Windows.Forms.ConvertEventArgs.Value.get -> object?
+System.Windows.Forms.ConvertEventArgs.Value.set -> void
 ~System.Windows.Forms.CreateParams.Caption.get -> string
 ~System.Windows.Forms.CreateParams.Caption.set -> void
 ~System.Windows.Forms.CreateParams.ClassName.get -> string
@@ -10201,8 +10201,8 @@ System.Windows.Forms.ListBox.ObjectCollection.Remove(object! value) -> void
 ~System.Windows.Forms.ListControl.SelectedValue.set -> void
 ~System.Windows.Forms.ListControl.ValueMember.get -> string
 ~System.Windows.Forms.ListControl.ValueMember.set -> void
-~System.Windows.Forms.ListControlConvertEventArgs.ListControlConvertEventArgs(object value, System.Type desiredType, object listItem) -> void
-~System.Windows.Forms.ListControlConvertEventArgs.ListItem.get -> object
+System.Windows.Forms.ListControlConvertEventArgs.ListControlConvertEventArgs(object? value, System.Type? desiredType, object? listItem) -> void
+System.Windows.Forms.ListControlConvertEventArgs.ListItem.get -> object?
 ~System.Windows.Forms.ListView.CheckedIndexCollection.CheckedIndexCollection(System.Windows.Forms.ListView owner) -> void
 ~System.Windows.Forms.ListView.CheckedIndexCollection.GetEnumerator() -> System.Collections.IEnumerator
 ~System.Windows.Forms.ListView.CheckedIndices.get -> System.Windows.Forms.ListView.CheckedIndexCollection

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ConvertEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ConvertEventArgs.cs
@@ -2,20 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class ConvertEventArgs : EventArgs
     {
-        public ConvertEventArgs(object value, Type desiredType)
+        public ConvertEventArgs(object? value, Type? desiredType)
         {
             Value = value;
             DesiredType = desiredType;
         }
 
-        public object Value { get; set; }
+        public object? Value { get; set; }
 
-        public Type DesiredType { get; }
+        public Type? DesiredType { get; }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListControlConvertEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListControlConvertEventArgs.cs
@@ -2,17 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class ListControlConvertEventArgs : ConvertEventArgs
     {
-        public ListControlConvertEventArgs(object value, Type desiredType, object listItem) : base(value, desiredType)
+        public ListControlConvertEventArgs(object? value, Type? desiredType, object? listItem)
+            : base(value, desiredType)
         {
             ListItem = listItem;
         }
 
-        public object ListItem { get; }
+        public object? ListItem { get; }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ConvertEventArgs and ListControlConvertEventArgs.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4384)