### PR TITLE
Use 'is not null' in some System.Windows.Forms files

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/CategoryGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/CategoryGridEntry.cs
@@ -27,7 +27,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 #if DEBUG
             for (int n = 0; n < childGridEntries.Length; n++)
             {
-                Debug.Assert(childGridEntries[n] != null, "Null item in category subproperty list");
+                Debug.Assert(childGridEntries[n] is not null, "Null item in category subproperty list");
             }
 #endif
             if (categoryStates is null)
@@ -75,13 +75,13 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             if (disposing)
             {
-                if (backBrush != null)
+                if (backBrush is not null)
                 {
                     backBrush.Dispose();
                     backBrush = null;
                 }
 
-                if (ChildCollection != null)
+                if (ChildCollection is not null)
                 {
                     ChildCollection = null;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DocComment.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DocComment.cs
@@ -282,7 +282,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (_parentPropertyGrid.AccessibilityObject is PropertyGridAccessibleObject propertyGridAccessibleObject)
             {
                 UiaCore.IRawElementProviderFragment navigationTarget = propertyGridAccessibleObject.ChildFragmentNavigate(this, direction);
-                if (navigationTarget != null)
+                if (navigationTarget is not null)
                 {
                     return navigationTarget;
                 }
@@ -309,7 +309,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             get
             {
                 string name = Owner?.AccessibleName;
-                if (name != null)
+                if (name is not null)
                 {
                     return name;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.cs
@@ -273,7 +273,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         internal override UiaCore.IRawElementProviderFragment FragmentNavigate(UiaCore.NavigateDirection direction)
         {
             if (direction == UiaCore.NavigateDirection.Parent &&
-                _owningPropertyGrid.SelectedGridEntry != null &&
+                _owningPropertyGrid.SelectedGridEntry is not null &&
                 _owningDropDownButton.Visible)
             {
                 return _owningPropertyGrid.SelectedGridEntry?.AccessibilityObject;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
@@ -134,9 +134,9 @@ namespace System.Windows.Forms.PropertyGridInternal
             parentPE = peParent;
             ownerGrid = owner;
 
-            Debug.Assert(ownerGrid != null, "GridEntry w/o PropertyGrid owner, text rendering will fail.");
+            Debug.Assert(ownerGrid is not null, "GridEntry w/o PropertyGrid owner, text rendering will fail.");
 
-            if (peParent != null)
+            if (peParent is not null)
             {
                 propertyDepth = peParent.PropertyDepth + 1;
                 PropertySort = peParent.PropertySort;
@@ -161,7 +161,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 if (DpiHelper.IsScalingRequirementMet)
                 {
-                    if (GridEntryHost != null)
+                    if (GridEntryHost is not null)
                     {
                         return GridEntryHost.LogicalToDeviceUnits(OUTLINE_ICON_PADDING);
                     }
@@ -238,7 +238,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     return (IComponent)owner;
                 }
-                if (parentPE != null)
+                if (parentPE is not null)
                 {
                     return parentPE.Component;
                 }
@@ -266,10 +266,10 @@ namespace System.Windows.Forms.PropertyGridInternal
             get
             {
                 IComponent component = Component;
-                if (component != null)
+                if (component is not null)
                 {
                     ISite site = component.Site;
-                    if (site != null)
+                    if (site is not null)
                     {
                         return site.Container;
                     }
@@ -293,7 +293,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 Debug.Assert(value is null || !Disposed, "Why are we putting new children in after we are disposed?");
                 if (childCollection != value)
                 {
-                    if (childCollection != null)
+                    if (childCollection is not null)
                     {
                         childCollection.Dispose();
                         childCollection = null;
@@ -307,7 +307,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (Children != null)
+                if (Children is not null)
                 {
                     return Children.Count;
                 }
@@ -331,7 +331,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (parentPE != null)
+                if (parentPE is not null)
                 {
                     return parentPE.CurrentTab;
                 }
@@ -339,7 +339,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             set
             {
-                if (parentPE != null)
+                if (parentPE is not null)
                 {
                     parentPE.CurrentTab = value;
                 }
@@ -363,7 +363,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (parentPE != null)
+                if (parentPE is not null)
                 {
                     return parentPE.DesignerHost;
                 }
@@ -371,7 +371,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             set
             {
-                if (parentPE != null)
+                if (parentPE is not null)
                 {
                     parentPE.DesignerHost = value;
                 }
@@ -400,7 +400,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 bool fExpandable = GetFlagSet(FL_EXPANDABLE);
 
-                if (fExpandable && childCollection != null && childCollection.Count > 0)
+                if (fExpandable && childCollection is not null && childCollection.Count > 0)
                 {
                     return true;
                 }
@@ -457,7 +457,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return;
                 }
 
-                if (childCollection != null && childCollection.Count > 0)
+                if (childCollection is not null && childCollection.Count > 0)
                 {
                     SetFlag(FL_EXPAND, value);
                 }
@@ -506,7 +506,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 object value = Instance;
                 bool forceReadOnly = ForceReadOnly;
 
-                if (value != null)
+                if (value is not null)
                 {
                     forceReadOnly |= TypeDescriptor.GetAttributes(value).Contains(InheritanceAttribute.InheritedReadOnly);
                 }
@@ -548,7 +548,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     flags |= GridEntry.FLAG_RENDER_PASSWORD;
                 }
 
-                if (uiEditor != null)
+                if (uiEditor is not null)
                 {
                     if (uiEditor.GetPaintValueSupported(this))
                     {
@@ -604,7 +604,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return;
                 }
 
-                if (cacheItems != null)
+                if (cacheItems is not null)
                 {
                     cacheItems.lastValueString = null;
                     cacheItems.useValueString = false;
@@ -644,12 +644,12 @@ namespace System.Windows.Forms.PropertyGridInternal
             get
             {
                 string str = null;
-                if (parentPE != null)
+                if (parentPE is not null)
                 {
                     str = parentPE.FullLabel;
                 }
 
-                if (str != null)
+                if (str is not null)
                 {
                     str += ".";
                 }
@@ -672,7 +672,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     throw new ObjectDisposedException(SR.GridItemDisposed);
                 }
 
-                if (IsExpandable && childCollection != null && childCollection.Count == 0)
+                if (IsExpandable && childCollection is not null && childCollection.Count == 0)
                 {
                     CreateChildren();
                 }
@@ -685,7 +685,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {        // ACCESSOR: virtual was missing from this get
-                if (parentPE != null)
+                if (parentPE is not null)
                 {
                     return parentPE.GridEntryHost;
                 }
@@ -726,7 +726,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 string keyWord = null;
 
-                if (parentPE != null)
+                if (parentPE is not null)
                 {
                     keyWord = parentPE.HelpKeyword;
                 }
@@ -755,7 +755,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if ((flags & FL_CHECKED) == 0)
                 {
                     UITypeEditor typeEd = UITypeEditor;
-                    if (typeEd != null)
+                    if (typeEd is not null)
                     {
                         if ((flags & GridEntry.FLAG_CUSTOM_PAINT) != 0 ||
                             (flags & GridEntry.FL_NO_CUSTOM_PAINT) != 0)
@@ -823,7 +823,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 object owner = GetValueOwner();
 
-                if (parentPE != null && owner is null)
+                if (parentPE is not null && owner is null)
                 {
                     return parentPE.Instance;
                 }
@@ -912,7 +912,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return outlineRect;
                 }
                 PropertyGridView gridHost = GridEntryHost;
-                Debug.Assert(gridHost != null, "No propEntryHost!");
+                Debug.Assert(gridHost is not null, "No propEntryHost!");
                 int outlineSize = gridHost.GetOutlineIconSize();
                 int borderWidth = outlineSize + OutlineIconPadding;
                 int left = (propertyDepth * borderWidth) + (OutlineIconPadding) / 2;
@@ -940,12 +940,12 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 Debug.Assert(value != this, "how can we be our own parent?");
                 parentPE = value;
-                if (value != null)
+                if (value is not null)
                 {
                     propertyDepth = value.PropertyDepth + 1;
 
                     // Microsoft, why do we do this?
-                    if (childCollection != null)
+                    if (childCollection is not null)
                     {
                         for (int i = 0; i < childCollection.Count; i++)
                         {
@@ -1041,7 +1041,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             get
             {
                 object obj = PropertyValue;
-                if (obj != null)
+                if (obj is not null)
                 {
                     return obj.GetType();
                 }
@@ -1060,7 +1060,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (cacheItems != null)
+                if (cacheItems is not null)
                 {
                     return cacheItems.lastValue;
                 }
@@ -1118,7 +1118,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (editor is null && PropertyType != null)
+                if (editor is null && PropertyType is not null)
                 {
                     editor = (UITypeEditor)TypeDescriptor.GetEditor(PropertyType, typeof(UITypeEditor));
                 }
@@ -1235,7 +1235,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         internal void ClearCachedValues(bool clearChildren)
         {
-            if (cacheItems != null)
+            if (cacheItems is not null)
             {
                 cacheItems.useValueString = false;
                 cacheItems.lastValue = null;
@@ -1310,7 +1310,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (!GetFlagSet(FL_EXPANDABLE))
             {
-                if (childCollection != null)
+                if (childCollection is not null)
                 {
                     childCollection.Clear();
                 }
@@ -1321,7 +1321,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return false;
             }
 
-            if (!diffOldChildren && childCollection != null && childCollection.Count > 0)
+            if (!diffOldChildren && childCollection is not null && childCollection.Count > 0)
             {
                 return true;
             }
@@ -1330,9 +1330,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                                                         PropertyValue,
                                                         PropertyType);
 
-            bool fExpandable = (childProps != null && childProps.Length > 0);
+            bool fExpandable = (childProps is not null && childProps.Length > 0);
 
-            if (diffOldChildren && childCollection != null && childCollection.Count > 0)
+            if (diffOldChildren && childCollection is not null && childCollection.Count > 0)
             {
                 bool same = true;
                 if (childProps.Length == childCollection.Count)
@@ -1360,7 +1360,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (!fExpandable)
             {
                 SetFlag(FL_EXPANDABLE_FAILED, true);
-                if (childCollection != null)
+                if (childCollection is not null)
                 {
                     childCollection.Clear();
                 }
@@ -1376,7 +1376,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             else
             {
-                if (childCollection != null)
+                if (childCollection is not null)
                 {
                     childCollection.Clear();
                     childCollection.AddRange(childProps);
@@ -1418,7 +1418,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         public virtual void DisposeChildren()
         {
-            if (childCollection != null)
+            if (childCollection is not null)
             {
                 childCollection.Dispose();
                 childCollection = null;
@@ -1435,7 +1435,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         internal virtual void EditPropertyValue(PropertyGridView iva)
         {
-            if (UITypeEditor != null)
+            if (UITypeEditor is not null)
             {
                 try
                 {
@@ -1477,7 +1477,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 catch (Exception e)
                 {
                     IUIService uiSvc = (IUIService)GetService(typeof(IUIService));
-                    if (uiSvc != null)
+                    if (uiSvc is not null)
                     {
                         uiSvc.ShowError(e);
                     }
@@ -1509,12 +1509,12 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             object owner = GetValueOwner();
             PropertyDescriptor property = TypeDescriptor.GetProperties(owner)[propertyName];
-            if (property != null && property.PropertyType == propertyType)
+            if (property is not null && property.PropertyType == propertyType)
             {
                 return property.GetValue(owner);
             }
 
-            if (parentPE != null)
+            if (parentPE is not null)
             {
                 return parentPE.FindPropertyValue(propertyName, propertyType);
             }
@@ -1538,7 +1538,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         public virtual IComponent[] GetComponents()
         {
             IComponent component = Component;
-            if (component != null)
+            if (component is not null)
             {
                 return new IComponent[] { component };
             }
@@ -1617,7 +1617,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         public virtual object[] GetValueOwners()
         {
             object owner = GetValueOwner();
-            if (owner != null)
+            if (owner is not null)
             {
                 return new object[] { owner };
             }
@@ -1694,7 +1694,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             BrowsableAttributes.CopyTo(attributes, 0);
 
             PropertyTab tab = CurrentTab;
-            Debug.Assert(tab != null, "No current tab!");
+            Debug.Assert(tab is not null, "No current tab!");
 
             try
             {
@@ -1703,7 +1703,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (!forceReadOnly)
                 {
                     ReadOnlyAttribute readOnlyAttr = (ReadOnlyAttribute)TypeDescriptor.GetAttributes(obj)[typeof(ReadOnlyAttribute)];
-                    forceReadOnly = (readOnlyAttr != null && !readOnlyAttr.IsDefaultAttribute());
+                    forceReadOnly = (readOnlyAttr is not null && !readOnlyAttr.IsDefaultAttribute());
                 }
 
                 // do we want to expose sub properties?
@@ -1714,7 +1714,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     //
                     PropertyDescriptorCollection props = null;
                     PropertyDescriptor defProp = null;
-                    if (tab != null)
+                    if (tab is not null)
                     {
                         props = tab.GetProperties(this, obj, attributes);
                         defProp = tab.GetDefaultProperty(obj);
@@ -1751,7 +1751,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     // if the target object is an array and nothing else has provided a set of
                     // properties to use, then expand the array.
                     //
-                    if ((props is null || props.Count == 0) && objType != null && objType.IsArray && obj != null)
+                    if ((props is null || props.Count == 0) && objType is not null && objType.IsArray && obj is not null)
                     {
                         Array objArray = (Array)obj;
 
@@ -1915,7 +1915,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         public virtual object[] GetPropertyValueList()
         {
             ICollection values = TypeConverter.GetStandardValues(this);
-            if (values != null)
+            if (values is not null)
             {
                 object[] valueArray = new object[values.Count];
                 values.CopyTo(valueArray, 0);
@@ -1958,7 +1958,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return (GridItem)this;
             }
 
-            if (parentPE != null)
+            if (parentPE is not null)
             {
                 return parentPE.GetService(serviceType);
             }
@@ -1995,7 +1995,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         public virtual void PaintLabel(Graphics g, Rectangle rect, Rectangle clipRect, bool selected, bool paintFullLabel)
         {
             PropertyGridView gridHost = GridEntryHost;
-            Debug.Assert(gridHost != null, "No propEntryHost");
+            Debug.Assert(gridHost is not null, "No propEntryHost");
             string strLabel = PropertyLabel;
 
             int borderWidth = gridHost.GetOutlineIconSize() + OUTLINE_ICON_PADDING;
@@ -2123,7 +2123,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     outlineRect = Rectangle.Empty;
                     lastPaintWithExplorerStyle = true;
                 }
-                PaintOutlineWithExplorerTreeStyle(g, r, (GridEntryHost != null) ? GridEntryHost.HandleInternal : IntPtr.Zero);
+                PaintOutlineWithExplorerTreeStyle(g, r, (GridEntryHost is not null) ? GridEntryHost.HandleInternal : IntPtr.Zero);
             }
             // draw tree-view glyphs as +/-
             else
@@ -2163,7 +2163,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (colorInversionNeededInHC)
                 {
                     Color textColor = InvertColor(ownerGrid.LineColor);
-                    if (g != null)
+                    if (g is not null)
                     {
                         using var brush = textColor.GetCachedSolidBrushScope();
                         g.FillRectangle(brush, outline);
@@ -2241,7 +2241,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         public virtual void PaintValue(object val, Graphics g, Rectangle rect, Rectangle clipRect, PaintValueFlags paintFlags)
         {
             PropertyGridView gridHost = GridEntryHost;
-            Debug.Assert(gridHost != null);
+            Debug.Assert(gridHost is not null);
 
             Color textColor = ShouldRenderReadOnly ? GridEntryHost.GrayTextColor : gridHost.GetTextColor();
 
@@ -2249,7 +2249,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (paintFlags.HasFlag(PaintValueFlags.FetchValue))
             {
-                if (cacheItems != null && cacheItems.useValueString)
+                if (cacheItems is not null && cacheItems.useValueString)
                 {
                     text = cacheItems.lastValueString;
                     val = cacheItems.lastValue;
@@ -2396,7 +2396,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         public virtual bool OnComponentChanging()
         {
-            if (ComponentChangeService != null)
+            if (ComponentChangeService is not null)
             {
                 try
                 {
@@ -2416,7 +2416,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         public virtual void OnComponentChanged()
         {
-            if (ComponentChangeService != null)
+            if (ComponentChangeService is not null)
             {
                 ComponentChangeService.OnComponentChanged(GetValueOwner(), PropertyDescriptor, null, null);
             }
@@ -2449,7 +2449,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             // where are we at?
             PropertyGridView gridHost = GridEntryHost;
-            Debug.Assert(gridHost != null, "No prop entry host!");
+            Debug.Assert(gridHost is not null, "No prop entry host!");
 
             // make sure it's the left button
             if ((button & MouseButtons.Left) != MouseButtons.Left)
@@ -2536,7 +2536,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         protected virtual void OnRecreateChildren(GridEntryRecreateChildrenEventArgs e)
         {
             Delegate handler = GetEventHandler(EVENT_RECREATE_CHILDREN);
-            if (handler != null)
+            if (handler is not null)
             {
                 ((GridEntryRecreateChildrenEventHandler)handler)(this, e);
             }
@@ -2615,7 +2615,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         internal virtual bool ShouldSerializePropertyValue()
         {
-            if (cacheItems != null)
+            if (cacheItems is not null)
             {
                 if (cacheItems.useShouldSerialize)
                 {
@@ -2662,7 +2662,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 for (int i = 0; i < props.Length; i++)
                 {
-                    if (props[i] != null)
+                    if (props[i] is not null)
                     {
                         newProps[newPos++] = props[i];
                     }
@@ -2737,16 +2737,16 @@ namespace System.Windows.Forms.PropertyGridInternal
         public virtual void Refresh()
         {
             Type type = PropertyType;
-            if (type != null && type.IsArray)
+            if (type is not null && type.IsArray)
             {
                 CreateChildren(true);
             }
 
-            if (childCollection != null)
+            if (childCollection is not null)
             {
                 // check to see if the value has changed.
                 //
-                if (InternalExpanded && cacheItems != null && cacheItems.lastValue != null && cacheItems.lastValue != PropertyValue)
+                if (InternalExpanded && cacheItems is not null && cacheItems.lastValue is not null && cacheItems.lastValue != PropertyValue)
                 {
                     ClearCachedValues();
                     RecreateChildren();
@@ -2759,7 +2759,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     while (childEnum.MoveNext())
                     {
                         object o = childEnum.Current;
-                        Debug.Assert(o != null, "Collection contains a null element.  But how? Garbage collector hole?  GDI+ corrupting memory?");
+                        Debug.Assert(o is not null, "Collection contains a null element.  But how? Garbage collector hole?  GDI+ corrupting memory?");
                         GridEntry e = (GridEntry)o;
                         e.Refresh();
                     }
@@ -2818,10 +2818,10 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         public virtual bool SetPropertyTextValue(string str)
         {
-            bool fChildrenPrior = (childCollection != null && childCollection.Count > 0);
+            bool fChildrenPrior = (childCollection is not null && childCollection.Count > 0);
             PropertyValue = ConvertTextToValue(str);
             CreateChildren();
-            bool fChildrenAfter = (childCollection != null && childCollection.Count > 0);
+            bool fChildrenAfter = (childCollection is not null && childCollection.Count > 0);
             return (fChildrenPrior != fChildrenAfter);
         }
 
@@ -2842,7 +2842,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return;
                 }
 
-                for (EventEntry e = eventList; e != null; e = e.next)
+                for (EventEntry e = eventList; e is not null; e = e.next)
                 {
                     if (e.key == key)
                     {
@@ -2857,7 +2857,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         protected virtual void RaiseEvent(object key, EventArgs e)
         {
             Delegate handler = GetEventHandler(key);
-            if (handler != null)
+            if (handler is not null)
             {
                 ((EventHandler)handler)(this, e);
             }
@@ -2868,7 +2868,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             // Locking 'this' here is ok since this is an internal class.
             lock (this)
             {
-                for (EventEntry e = eventList; e != null; e = e.next)
+                for (EventEntry e = eventList; e is not null; e = e.next)
                 {
                     if (e.key == key)
                     {
@@ -2889,7 +2889,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return;
                 }
 
-                for (EventEntry e = eventList, prev = null; e != null; prev = e, e = e.next)
+                for (EventEntry e = eventList, prev = null; e is not null; prev = e, e = e.next)
                 {
                     if (e.key == key)
                     {
@@ -2938,13 +2938,13 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             public GridEntryAccessibleObject(GridEntry owner) : base()
             {
-                Debug.Assert(owner != null, "GridEntryAccessibleObject must have a valid owner GridEntry");
+                Debug.Assert(owner is not null, "GridEntryAccessibleObject must have a valid owner GridEntry");
                 this.owner = owner;
             }
 
             public override Rectangle Bounds
             {
-                get => PropertyGridView != null && PropertyGridView.IsHandleCreated
+                get => PropertyGridView is not null && PropertyGridView.IsHandleCreated
                     ? PropertyGridView.AccessibilityGetGridEntryBounds(owner)
                     : Rectangle.Empty;
             }
@@ -2995,7 +2995,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     case UiaCore.NavigateDirection.Parent:
                         GridEntry parentGridEntry = owner.ParentGridEntry;
-                        if (parentGridEntry != null)
+                        if (parentGridEntry is not null)
                         {
                             if (parentGridEntry is SingleSelectRootGridEntry)
                             {
@@ -3123,7 +3123,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         return true;
 
                     case UiaCore.UIA.ExpandCollapsePatternId:
-                        if (owner != null && owner.Expandable)
+                        if (owner is not null && owner.Expandable)
                         {
                             return true;
                         }
@@ -3140,7 +3140,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         // Only top level rows are grid items.
                         // Sub-items (for instance height in size is not a grid item)
                         GridEntry parentGridEntry = owner.ParentGridEntry;
-                        if (parentGridEntry != null && parentGridEntry is SingleSelectRootGridEntry)
+                        if (parentGridEntry is not null && parentGridEntry is SingleSelectRootGridEntry)
                         {
                             return true;
                         }
@@ -3213,7 +3213,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 get
                 {
                     var propertyGridViewAccessibleObject = Parent as PropertyGridView.PropertyGridViewAccessibleObject;
-                    if (propertyGridViewAccessibleObject != null)
+                    if (propertyGridViewAccessibleObject is not null)
                     {
                         return propertyGridViewAccessibleObject.Owner as PropertyGridView;
                     }
@@ -3250,7 +3250,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     // Determine selected
                     //
-                    Debug.Assert(Parent != null, "GridEntry AO does not have a parent AO");
+                    Debug.Assert(Parent is not null, "GridEntry AO does not have a parent AO");
                     PropertyGridView.PropertyGridViewAccessibleObject parent = (PropertyGridView.PropertyGridViewAccessibleObject)Parent;
                     if (parent.GetSelected() == this)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntryCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntryCollection.cs
@@ -24,7 +24,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 throw new ArgumentNullException(nameof(value));
             }
 
-            Debug.Assert(_entries != null, "Entries is initialized in the base class constructor.");
+            Debug.Assert(_entries is not null, "Entries is initialized in the base class constructor.");
             var newArray = new GridEntry[_entries.Length + value.Length];
             _entries.CopyTo(newArray, 0);
             value.CopyTo(newArray, _entries.Length);
@@ -49,11 +49,11 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             if (disposing)
             {
-                if (_owner != null)
+                if (_owner is not null)
                 {
                     for (int i = 0; i < _entries.Length; i++)
                     {
-                        if (_entries[i] != null)
+                        if (_entries[i] is not null)
                         {
                             ((GridEntry)_entries[i]).Dispose();
                             _entries[i] = null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridErrorDlg.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridErrorDlg.cs
@@ -331,7 +331,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 // Location is relative to its parent,
                 // therefore, we need to take its parent into consideration
                 Control parent = detailsBtn.Parent;
-                while (parent != null && !(parent is Form))
+                while (parent is not null && !(parent is Form))
                 {
                     y += parent.Location.Y;
                     parent = parent.Parent;
@@ -380,7 +380,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         internal override bool IsIAccessibleExSupported()
         {
-            Debug.Assert(ownerItem != null, "AccessibleObject owner cannot be null");
+            Debug.Assert(ownerItem is not null, "AccessibleObject owner cannot be null");
             return true;
         }
 
@@ -418,7 +418,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         internal override void Expand()
         {
-            if (ownerItem != null && !ownerItem.Expanded)
+            if (ownerItem is not null && !ownerItem.Expanded)
             {
                 DoDefaultAction();
             }
@@ -426,7 +426,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         internal override void Collapse()
         {
-            if (ownerItem != null && ownerItem.Expanded)
+            if (ownerItem is not null && ownerItem.Expanded)
             {
                 DoDefaultAction();
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridToolTip.cs
@@ -48,7 +48,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     Reset();
                 }
 
-                if (value != null && value.Length > maximumToolTipLength)
+                if (value is not null && value.Length > maximumToolTipLength)
                 {
                     //Let the user know the text was truncated by throwing on an ellipsis
                     value = value.Substring(0, maximumToolTipLength) + "...";

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/HotCommands.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/HotCommands.cs
@@ -90,7 +90,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return (component != null);
+                return (component is not null);
             }
         }
 
@@ -100,7 +100,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 int lineHeight = (int)(1.5 * Font.Height);
                 int verbCount = 0;
-                if (verbs != null)
+                if (verbs is not null)
                 {
                     verbCount = verbs.Length;
                 }
@@ -171,7 +171,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         public virtual void SetVerbs(object component, DesignerVerb[] verbs)
         {
-            if (this.verbs != null)
+            if (this.verbs is not null)
             {
                 for (int i = 0; i < this.verbs.Length; i++)
                 {
@@ -277,7 +277,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (_parentPropertyGrid.AccessibilityObject is PropertyGridAccessibleObject propertyGridAccessibleObject)
             {
                 UiaCore.IRawElementProviderFragment navigationTarget = propertyGridAccessibleObject.ChildFragmentNavigate(this, direction);
-                if (navigationTarget != null)
+                if (navigationTarget is not null)
                 {
                     return navigationTarget;
                 }
@@ -304,7 +304,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             get
             {
                 string name = Owner?.AccessibleName;
-                if (name != null)
+                if (name is not null)
                 {
                     return name;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/ImmutablePropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/ImmutablePropertyDescriptorGridEntry.cs
@@ -46,7 +46,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 for (int i = 0; i < props.Count; i++)
                 {
-                    if (_propertyInfo.Name != null && _propertyInfo.Name.Equals(props[i].Name))
+                    if (_propertyInfo.Name is not null && _propertyInfo.Name.Equals(props[i].Name))
                     {
                         values[props[i].Name] = value;
                     }
@@ -74,7 +74,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
                 }
 
-                if (newObject != null)
+                if (newObject is not null)
                 {
                     parentEntry.PropertyValue = newObject;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MergePropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MergePropertyDescriptor.cs
@@ -200,7 +200,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     // Instance descriptors provide full fidelity unless
                     // they are marked as incomplete.
                     InstanceDescriptor desc = (InstanceDescriptor)converter.ConvertTo(null, CultureInfo.InvariantCulture, value, typeof(InstanceDescriptor));
-                    if (desc != null && desc.IsComplete)
+                    if (desc is not null && desc.IsComplete)
                     {
                         clonedValue = desc.Invoke();
                     }
@@ -226,7 +226,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
             }
 
-            if (clonedValue != null)
+            if (clonedValue is not null)
             {
                 return clonedValue;
             }
@@ -299,7 +299,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 object objCur = descriptors[i].GetValue(GetPropertyOwnerForComponent(components, i));
 
-                if (collection != null)
+                if (collection is not null)
                 {
                     if (!collection.MergeCollection((ICollection)objCur))
                     {
@@ -308,7 +308,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
                 }
                 else if ((obj is null && objCur is null) ||
-                         (obj != null && obj.Equals(objCur)))
+                         (obj is not null && obj.Equals(objCur)))
                 {
                     continue;
                 }
@@ -319,7 +319,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
             }
 
-            if (allEqual && collection != null && collection.Count == 0)
+            if (allEqual && collection is not null && collection.Count == 0)
             {
                 return null;
             }
@@ -358,7 +358,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             try
             {
-                if (collection != null)
+                if (collection is not null)
                 {
                     collection.Locked = true;
                 }
@@ -384,7 +384,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             finally
             {
-                if (collection != null)
+                if (collection is not null)
                 {
                     collection.Locked = false;
                 }
@@ -449,7 +449,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 get
                 {
-                    if (items != null)
+                    if (items is not null)
                     {
                         return items.Length;
                     }
@@ -503,7 +503,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             public IEnumerator GetEnumerator()
             {
-                if (items != null)
+                if (items is not null)
                 {
                     return items.GetEnumerator();
                 }
@@ -535,7 +535,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 for (int i = 0; i < newItems.Length; i++)
                 {
                     if (((newItems[i] is null) != (items[i] is null)) ||
-                        (items[i] != null && !items[i].Equals(newItems[i])))
+                        (items[i] is not null && !items[i].Equals(newItems[i])))
                     {
                         items = Array.Empty<object>();
                         return false;
@@ -592,10 +592,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
 
                 Attribute value;
-                if (foundAttributes != null)
+                if (foundAttributes is not null)
                 {
                     value = foundAttributes[attributeType] as Attribute;
-                    if (value != null)
+                    if (value is not null)
                     {
                         return value;
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiPropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiPropertyDescriptorGridEntry.cs
@@ -37,7 +37,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         break;
                     }
 
-                    if (comp.Site != null)
+                    if (comp.Site is not null)
                     {
                         if (c is null)
                         {
@@ -126,7 +126,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose && mergedProps is null, "PropertyGridView: MergedProps returned null!");
 
-                if (mergedProps != null)
+                if (mergedProps is not null)
                 {
                     ChildCollection.AddRange(mergedProps);
                 }
@@ -189,7 +189,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             IDesignerHost host = DesignerHost;
             DesignerTransaction trans = null;
 
-            if (host != null)
+            if (host is not null)
             {
                 trans = host.CreateTransaction();
             }
@@ -199,7 +199,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             finally
             {
-                if (trans != null)
+                if (trans is not null)
                 {
                     trans.Commit();
                 }
@@ -210,7 +210,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         protected override void NotifyParentChange(GridEntry ge)
         {
             // now see if we need to notify the parent(s) up the chain
-            while (ge != null &&
+            while (ge is not null &&
                    ge is PropertyDescriptorGridEntry &&
                    ((PropertyDescriptorGridEntry)ge)._propertyInfo.Attributes.Contains(NotifyParentPropertyAttribute.Yes))
             {
@@ -228,13 +228,13 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
 
                 // fire the change on that owner
-                if (ge != null)
+                if (ge is not null)
                 {
                     owner = ge.GetValueOwner();
 
                     IComponentChangeService changeService = ComponentChangeService;
 
-                    if (changeService != null)
+                    if (changeService is not null)
                     {
                         if (owner is Array ownerArray)
                         {
@@ -248,7 +248,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                                     pd = ((MergePropertyDescriptor)pd)[i];
                                 }
 
-                                if (pd != null)
+                                if (pd is not null)
                                 {
                                     changeService.OnComponentChanging(ownerArray.GetValue(i), pd);
                                     changeService.OnComponentChanged(ownerArray.GetValue(i), pd, null, null);
@@ -278,12 +278,12 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     object[] objects = (object[])obj;
 
-                    if (objects != null && objects.Length > 0)
+                    if (objects is not null && objects.Length > 0)
                     {
                         IDesignerHost host = DesignerHost;
                         DesignerTransaction trans = null;
 
-                        if (host != null)
+                        if (host is not null)
                         {
                             trans = host.CreateTransaction(string.Format(SR.PropertyGridResetValue, PropertyName));
                         }
@@ -294,7 +294,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                             {
                                 if (!OnComponentChanging())
                                 {
-                                    if (trans != null)
+                                    if (trans is not null)
                                     {
                                         trans.Cancel();
                                         trans = null;
@@ -313,7 +313,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         }
                         finally
                         {
-                            if (trans != null)
+                            if (trans is not null)
                             {
                                 trans.Commit();
                             }
@@ -334,10 +334,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                             _eventBindings = (IEventBindingService)GetService(typeof(IEventBindingService));
                         }
 
-                        if (_eventBindings != null)
+                        if (_eventBindings is not null)
                         {
                             EventDescriptor descriptor = _eventBindings.GetEvent(mpd[0]);
-                            if (descriptor != null)
+                            if (descriptor is not null)
                             {
                                 return ViewEvent(obj, null, descriptor, true);
                             }
@@ -379,7 +379,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         public override bool OnComponentChanging()
         {
-            if (ComponentChangeService != null)
+            if (ComponentChangeService is not null)
             {
                 int cLength = objs.Length;
                 for (int i = 0; i < cLength; i++)
@@ -403,7 +403,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         public override void OnComponentChanged()
         {
-            if (ComponentChangeService != null)
+            if (ComponentChangeService is not null)
             {
                 int cLength = objs.Length;
                 for (int i = 0; i < cLength; i++)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiSelectRootGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiSelectRootGridEntry.cs
@@ -32,7 +32,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     foreach (object obj in (Array)objValue)
                     {
                         ReadOnlyAttribute readOnlyAttr = (ReadOnlyAttribute)TypeDescriptor.GetAttributes(obj)[typeof(ReadOnlyAttribute)];
-                        if ((readOnlyAttr != null && !readOnlyAttr.IsDefaultAttribute()) || TypeDescriptor.GetAttributes(obj).Contains(InheritanceAttribute.InheritedReadOnly))
+                        if ((readOnlyAttr is not null && !readOnlyAttr.IsDefaultAttribute()) || TypeDescriptor.GetAttributes(obj).Contains(InheritanceAttribute.InheritedReadOnly))
                         {
                             anyRO = true;
                             break;
@@ -65,7 +65,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose && mergedProps is null, "PropertyGridView: MergedProps returned null!");
 
-                if (mergedProps != null)
+                if (mergedProps is not null)
                 {
                     ChildCollection.AddRange(mergedProps);
                 }
@@ -278,7 +278,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     for (int i = 0; i < entries.Length; i++)
                     {
-                        if (entries[i] != null)
+                        if (entries[i] is not null)
                         {
                             newEntries[newPos++] = entries[i];
                         }
@@ -335,7 +335,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         offset = len / 2;
                     }
 
-                    if (mergedEntryList != null)
+                    if (mergedEntryList is not null)
                     {
                         mergeArray[0] = basePd;
                         Array.Copy(mergedEntryList, 0, mergeArray, 1, mergedEntryList.Length);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertiesTab.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertiesTab.cs
@@ -34,7 +34,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (def is null)
             {
                 PropertyDescriptorCollection props = GetProperties(obj);
-                if (props != null)
+                if (props is not null)
                 {
                     for (int i = 0; i < props.Count; i++)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
@@ -98,7 +98,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     HelpKeywordAttribute helpAttribute = (HelpKeywordAttribute)_propertyInfo.Attributes[typeof(HelpKeywordAttribute)];
 
-                    if (helpAttribute != null && !helpAttribute.IsDefaultAttribute())
+                    if (helpAttribute is not null && !helpAttribute.IsDefaultAttribute())
                     {
                         return helpAttribute.HelpKeyword;
                     }
@@ -108,7 +108,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                         GridEntry ge = this;
 
-                        while (ge.ParentGridEntry != null)
+                        while (ge.ParentGridEntry is not null)
                         {
                             ge = ge.ParentGridEntry;
 
@@ -142,7 +142,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                             if (!componentType.IsPublic || !componentType.IsAssignableFrom(ownerType))
                             {
                                 PropertyDescriptor componentProperty = TypeDescriptor.GetProperties(ownerType)[PropertyName];
-                                if (componentProperty != null)
+                                if (componentProperty is not null)
                                 {
                                     componentType = componentProperty.ComponentType;
                                 }
@@ -160,7 +160,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                             {
                                 //
 
-                                //if (helpAttribute != null && !helpAttribute.IsDefaultAttribute()) {
+                                //if (helpAttribute is not null && !helpAttribute.IsDefaultAttribute()) {
                                 //    typeName = helpAttribute.HelpKeyword;
                                 //}
                                 //else {
@@ -288,7 +288,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (_propertyInfo != null)
+                if (_propertyInfo is not null)
                 {
                     return _propertyInfo.Name;
                 }
@@ -316,7 +316,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     object objRet = GetPropertyValueCore(GetValueOwner());
 
-                    if (_exceptionConverter != null)
+                    if (_exceptionConverter is not null)
                     {
                         // undo the exception converter
                         SetFlagsAndExceptionInfo(0, null, null);
@@ -375,7 +375,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     Type propType = PropertyType;
 
-                    if (propType != null && (propType.IsArray || propType.IsValueType || propType.IsPrimitive))
+                    if (propType is not null && (propType.IsArray || propType.IsValueType || propType.IsPrimitive))
                     {
                         SetFlag(FLAG_READONLY_EDITABLE, false);
                         SetFlag(FLAG_RENDER_READONLY, true);
@@ -402,7 +402,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (_exceptionConverter != null)
+                if (_exceptionConverter is not null)
                 {
                     return _exceptionConverter;
                 }
@@ -423,7 +423,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (_exceptionEditor != null)
+                if (_exceptionEditor is not null)
                 {
                     return _exceptionEditor;
                 }
@@ -444,16 +444,16 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (!IsValueEditable)
             {
                 RefreshPropertiesAttribute refreshAttr = (RefreshPropertiesAttribute)_propertyInfo.Attributes[typeof(RefreshPropertiesAttribute)];
-                if ((refreshAttr != null && !refreshAttr.RefreshProperties.Equals(RefreshProperties.None)))
+                if ((refreshAttr is not null && !refreshAttr.RefreshProperties.Equals(RefreshProperties.None)))
                 {
-                    GridEntryHost.Refresh(refreshAttr != null && refreshAttr.Equals(RefreshPropertiesAttribute.All));
+                    GridEntryHost.Refresh(refreshAttr is not null && refreshAttr.Equals(RefreshPropertiesAttribute.All));
                 }
             }
         }
 
         internal override Point GetLabelToolTipLocation(int mouseX, int mouseY)
         {
-            if (_pvUIItems != null)
+            if (_pvUIItems is not null)
             {
                 for (int i = 0; i < _pvUIItems.Length; i++)
                 {
@@ -495,7 +495,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             _isSerializeContentsProp = (_propertyInfo.SerializationVisibility == DesignerSerializationVisibility.Content);
 
-            Debug.Assert(propInfo != null, "Can't create propEntry because of null prop info");
+            Debug.Assert(propInfo is not null, "Can't create propEntry because of null prop info");
 
             if (!_activeXHide && IsPropertyReadOnly)
             {
@@ -511,7 +511,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         protected virtual void NotifyParentChange(GridEntry ge)
         {
             // now see if we need to notify the parent(s) up the chain
-            while (ge != null &&
+            while (ge is not null &&
                    ge is PropertyDescriptorGridEntry &&
                    ((PropertyDescriptorGridEntry)ge)._propertyInfo.Attributes.Contains(NotifyParentPropertyAttribute.Yes))
             {
@@ -534,13 +534,13 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
 
                 // fire the change on that owner
-                if (ge != null)
+                if (ge is not null)
                 {
                     owner = ge.GetValueOwner();
 
                     IComponentChangeService changeService = ComponentChangeService;
 
-                    if (changeService != null)
+                    if (changeService is not null)
                     {
                         changeService.OnComponentChanging(owner, ((PropertyDescriptorGridEntry)ge)._propertyInfo);
                         changeService.OnComponentChanged(owner, ((PropertyDescriptorGridEntry)ge)._propertyInfo, null, null);
@@ -548,7 +548,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     ge.ClearCachedValues(false); //clear the value so it paints correctly next time.
                     PropertyGridView gv = GridEntryHost;
-                    if (gv != null)
+                    if (gv is not null)
                     {
                         gv.InvalidateGridEntryValue(ge);
                     }
@@ -568,7 +568,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 case NOTIFY_RESET:
 
                     SetPropertyValue(obj, null, true, string.Format(SR.PropertyGridResetValue, PropertyName));
-                    if (_pvUIItems != null)
+                    if (_pvUIItems is not null)
                     {
                         for (int i = 0; i < _pvUIItems.Length; i++)
                         {
@@ -580,7 +580,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 case NOTIFY_CAN_RESET:
                     try
                     {
-                        return _propertyInfo.CanResetValue(obj) || (_pvUIItems != null && _pvUIItems.Length > 0);
+                        return _propertyInfo.CanResetValue(obj) || (_pvUIItems is not null && _pvUIItems.Length > 0);
                     }
                     catch
                     {
@@ -616,10 +616,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                     {
                         _eventBindings = (IEventBindingService)GetService(typeof(IEventBindingService));
                     }
-                    if (_eventBindings != null)
+                    if (_eventBindings is not null)
                     {
                         EventDescriptor descriptor = _eventBindings.GetEvent(_propertyInfo);
-                        if (descriptor != null)
+                        if (descriptor is not null)
                         {
                             return ViewEvent(obj, null, null, true);
                         }
@@ -639,7 +639,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         public override bool OnMouseClick(int x, int y, int count, MouseButtons button)
         {
-            if (_pvUIItems != null && count == 2 && ((button & MouseButtons.Left) == MouseButtons.Left))
+            if (_pvUIItems is not null && count == 2 && ((button & MouseButtons.Left) == MouseButtons.Left))
             {
                 for (int i = 0; i < _pvUIItems.Length; i++)
                 {
@@ -666,7 +666,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             _pvUIItems = propValSvc.GetPropertyUIValueItems(this, _propertyInfo);
 
-            if (_pvUIItems != null)
+            if (_pvUIItems is not null)
             {
                 if (_uiItemRects is null || _uiItemRects.Length != _pvUIItems.Length)
                 {
@@ -699,7 +699,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 object oldValue = GetPropertyValueCore(obj);
 
-                if (objVal != null && objVal.Equals(oldValue))
+                if (objVal is not null && objVal.Equals(oldValue))
                 {
                     return objVal;
                 }
@@ -708,7 +708,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 IDesignerHost host = DesignerHost;
 
-                if (host != null)
+                if (host is not null)
                 {
                     string text = (undoText ?? string.Format(SR.PropertyGridSetValue, _propertyInfo.Name));
                     trans = host.CreateTransaction(text);
@@ -725,7 +725,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     try
                     {
-                        if (ComponentChangeService != null)
+                        if (ComponentChangeService is not null)
                         {
                             ComponentChangeService.OnComponentChanging(obj, _propertyInfo);
                         }
@@ -748,7 +748,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
 
                 RefreshPropertiesAttribute refreshAttr = (RefreshPropertiesAttribute)_propertyInfo.Attributes[typeof(RefreshPropertiesAttribute)];
-                bool needsRefresh = wasExpanded || (refreshAttr != null && !refreshAttr.RefreshProperties.Equals(RefreshProperties.None));
+                bool needsRefresh = wasExpanded || (refreshAttr is not null && !refreshAttr.RefreshProperties.Equals(RefreshProperties.None));
 
                 if (needsRefresh)
                 {
@@ -762,13 +762,13 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 // This is possibly an event.  Check it out.
                 //
-                if (obj != null && objVal is string)
+                if (obj is not null && objVal is string)
                 {
                     if (_eventBindings is null)
                     {
                         _eventBindings = (IEventBindingService)GetService(typeof(IEventBindingService));
                     }
-                    if (_eventBindings != null)
+                    if (_eventBindings is not null)
                     {
                         eventDesc = _eventBindings.GetEvent(_propertyInfo);
                     }
@@ -802,7 +802,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     {
                         _propertyInfo.ResetValue(obj);
                     }
-                    else if (eventDesc != null)
+                    else if (eventDesc is not null)
                     {
                         ViewEvent(obj, (string)objVal, eventDesc, false);
                     }
@@ -815,7 +815,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     // Now notify the change service that the change was successful.
                     //
-                    if (needChangeNotify && ComponentChangeService != null)
+                    if (needChangeNotify && ComponentChangeService is not null)
                     {
                         ComponentChangeService.OnComponentChanged(obj, _propertyInfo, null, objVal);
                     }
@@ -828,19 +828,19 @@ namespace System.Windows.Forms.PropertyGridInternal
                     // 1) if this property has the refreshpropertiesattribute, or
                     // 2) it's got expanded sub properties
                     //
-                    if (needsRefresh && GridEntryHost != null)
+                    if (needsRefresh && GridEntryHost is not null)
                     {
                         RecreateChildren(childCount);
                         if (setSuccessful)
                         {
-                            GridEntryHost.Refresh(refreshAttr != null && refreshAttr.Equals(RefreshPropertiesAttribute.All));
+                            GridEntryHost.Refresh(refreshAttr is not null && refreshAttr.Equals(RefreshPropertiesAttribute.All));
                         }
                     }
                 }
             }
             catch (CheckoutException checkoutEx)
             {
-                if (trans != null)
+                if (trans is not null)
                 {
                     trans.Cancel();
                     trans = null;
@@ -854,7 +854,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             catch
             {
-                if (trans != null)
+                if (trans is not null)
                 {
                     trans.Cancel();
                     trans = null;
@@ -864,7 +864,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             finally
             {
-                if (trans != null)
+                if (trans is not null)
                 {
                     trans.Commit();
                 }
@@ -898,13 +898,13 @@ namespace System.Windows.Forms.PropertyGridInternal
                 //
                 bool treatAsValueType = false;
 
-                if (ParentGridEntry != null)
+                if (ParentGridEntry is not null)
                 {
                     Type propType = ParentGridEntry.PropertyType;
                     treatAsValueType = propType.IsValueType || propType.IsArray;
                 }
 
-                if (target != null)
+                if (target is not null)
                 {
                     _propertyInfo.SetValue(target, value);
 
@@ -918,7 +918,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     if (treatAsValueType)
                     {
                         GridEntry parent = ParentGridEntry;
-                        if (parent != null && parent.IsValueEditable)
+                        if (parent is not null && parent.IsValueEditable)
                         {
                             parent.PropertyValue = obj;
                         }
@@ -942,7 +942,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             string handler = value as string;
 
-            if (handler is null && value != null && TypeConverter != null && TypeConverter.CanConvertTo(typeof(string)))
+            if (handler is null && value is not null && TypeConverter is not null && TypeConverter.CanConvertTo(typeof(string)))
             {
                 handler = TypeConverter.ConvertToString(value);
             }
@@ -984,7 +984,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     _eventBindings = (IEventBindingService)GetService(typeof(IEventBindingService));
                 }
-                if (_eventBindings != null)
+                if (_eventBindings is not null)
                 {
                     eventdesc = _eventBindings.GetEvent(_propertyInfo);
                 }
@@ -1002,32 +1002,32 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return false;
                 }
 
-                if (host != null)
+                if (host is not null)
                 {
-                    string compName = component.Site != null ? component.Site.Name : component.GetType().Name;
+                    string compName = component.Site is not null ? component.Site.Name : component.GetType().Name;
                     trans = DesignerHost.CreateTransaction(string.Format(SR.WindowsFormsSetEvent, compName + "." + PropertyName));
                 }
 
                 if (_eventBindings is null)
                 {
                     ISite site = component.Site;
-                    if (site != null)
+                    if (site is not null)
                     {
                         _eventBindings = (IEventBindingService)site.GetService(typeof(IEventBindingService));
                     }
                 }
 
-                if (newHandler is null && _eventBindings != null)
+                if (newHandler is null && _eventBindings is not null)
                 {
                     newHandler = _eventBindings.CreateUniqueMethodName(component, eventdesc);
                 }
 
-                if (newHandler != null)
+                if (newHandler is not null)
                 {
                     // now walk through all the matching methods to see if this one exists.
                     // if it doesn't we'll wanna show code.
                     //
-                    if (_eventBindings != null)
+                    if (_eventBindings is not null)
                     {
                         bool methodExists = false;
                         foreach (string methodName in _eventBindings.GetCompatibleMethods(eventdesc))
@@ -1050,13 +1050,13 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
                     catch (InvalidOperationException ex)
                     {
-                        if (trans != null)
+                        if (trans is not null)
                         {
                             trans.Cancel();
                             trans = null;
                         }
 
-                        if (GridEntryHost != null && GridEntryHost is PropertyGridView)
+                        if (GridEntryHost is not null && GridEntryHost is PropertyGridView)
                         {
                             PropertyGridView pgv = GridEntryHost as PropertyGridView;
                             pgv.ShowInvalidMessage(newHandler, obj, ex);
@@ -1066,7 +1066,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
                 }
 
-                if (alwaysNavigate && _eventBindings != null)
+                if (alwaysNavigate && _eventBindings is not null)
                 {
                     s_targetBindingService = _eventBindings;
                     s_targetComponent = component;
@@ -1076,7 +1076,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             catch
             {
-                if (trans != null)
+                if (trans is not null)
                 {
                     trans.Cancel();
                     trans = null;
@@ -1085,7 +1085,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             finally
             {
-                if (trans != null)
+                if (trans is not null)
                 {
                     trans.Commit();
                 }
@@ -1100,7 +1100,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         static private void ShowCodeIdle(object sender, EventArgs e)
         {
             Application.Idle -= new EventHandler(PropertyDescriptorGridEntry.ShowCodeIdle);
-            if (s_targetBindingService != null)
+            if (s_targetBindingService is not null)
             {
                 s_targetBindingService.ShowCode(s_targetComponent, s_targetEventdesc);
                 s_targetBindingService = null;
@@ -1188,7 +1188,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         return propertyGridView.DropDownListBoxAccessibleObject;
                     }
 
-                    if (propertyGridView.DropDownVisible && propertyGridView.DropDownControlHolder != null)
+                    if (propertyGridView.DropDownVisible && propertyGridView.DropDownControlHolder is not null)
                     {
                         return propertyGridView.DropDownControlHolder.AccessibilityObject;
                     }
@@ -1302,7 +1302,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
 
                     if (_owningPropertyDescriptorGridEntry == propertyGridView.SelectedGridEntry &&
-                        ((_owningPropertyDescriptorGridEntry != null && _owningPropertyDescriptorGridEntry.InternalExpanded)
+                        ((_owningPropertyDescriptorGridEntry is not null && _owningPropertyDescriptorGridEntry.InternalExpanded)
                          || propertyGridView.DropDownVisible))
                     {
                         return UiaCore.ExpandCollapseState.Expanded;
@@ -1349,7 +1349,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     if (value is Exception ex)
                     {
-                        if (ex.InnerException != null)
+                        if (ex.InnerException is not null)
                         {
                             ex = ex.InnerException;
                         }
@@ -1372,12 +1372,12 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     IUIService uis = null;
 
-                    if (context != null)
+                    if (context is not null)
                     {
                         uis = (IUIService)context.GetService(typeof(IUIService));
                     }
 
-                    if (uis != null)
+                    if (uis is not null)
                     {
                         uis.ShowError(except);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.DropDownHolder.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.DropDownHolder.cs
@@ -69,7 +69,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     cp.Style |= unchecked((int)(User32.WS.POPUP | User32.WS.BORDER));
                     cp.ExStyle |= (int)User32.WS_EX.TOOLWINDOW;
                     cp.ClassStyle |= (int)User32.CS.DROPSHADOW;
-                    if (gridView != null)
+                    if (gridView is not null)
                     {
                         cp.Parent = gridView.ParentInternal.Handle;
                     }
@@ -148,7 +148,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             protected override void Dispose(bool disposing)
             {
-                if (disposing && createNewLink != null)
+                if (disposing && createNewLink is not null)
                 {
                     createNewLink.Dispose();
                     createNewLink = null;
@@ -193,7 +193,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 // check the property type itself.  this is the default path.
                 //
                 PropertyDescriptor pd = entry.PropertyDescriptor;
-                if (pd != null)
+                if (pd is not null)
                 {
                     editor = pd.GetEditor(typeof(InstanceCreationEditor)) as InstanceCreationEditor;
                 }
@@ -203,7 +203,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (editor is null)
                 {
                     UITypeEditor ute = entry.UITypeEditor;
-                    if (ute != null && ute.GetEditStyle() == UITypeEditorEditStyle.DropDown)
+                    if (ute is not null && ute.GetEditStyle() == UITypeEditorEditStyle.DropDown)
                     {
                         editor = (InstanceCreationEditor)TypeDescriptor.GetEditor(ute, typeof(InstanceCreationEditor));
                     }
@@ -218,7 +218,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             /// </summary>
             private Bitmap GetSizeGripGlyph(Graphics g)
             {
-                if (sizeGripGlyph != null)
+                if (sizeGripGlyph is not null)
                 {
                     return sizeGripGlyph;
                 }
@@ -252,13 +252,13 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             public virtual bool GetUsed()
             {
-                return (currentControl != null);
+                return (currentControl is not null);
             }
 
             public virtual void FocusComponent()
             {
                 Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "DropDownHolder:FocusComponent()");
-                if (currentControl != null && Visible)
+                if (currentControl is not null && Visible)
                 {
                     currentControl.Focus();
                 }
@@ -297,7 +297,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             private void OnCurrentControlResize(object o, EventArgs e)
             {
-                if (currentControl != null && !resizing)
+                if (currentControl is not null && !resizing)
                 {
                     int oldWidth = Width;
                     Size newSize = new Size(2 * DropDownHolderBorder + currentControl.Width, 2 * DropDownHolderBorder + currentControl.Height);
@@ -337,17 +337,17 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 InstanceCreationEditor ice = e.Link.LinkData as InstanceCreationEditor;
 
-                Debug.Assert(ice != null, "How do we have a link without the InstanceCreationEditor?");
-                if (ice != null && gridView?.SelectedGridEntry != null)
+                Debug.Assert(ice is not null, "How do we have a link without the InstanceCreationEditor?");
+                if (ice is not null && gridView?.SelectedGridEntry is not null)
                 {
                     Type createType = gridView.SelectedGridEntry.PropertyType;
-                    if (createType != null)
+                    if (createType is not null)
                     {
                         gridView.CloseDropDown();
 
                         object newValue = ice.CreateInstance(gridView.SelectedGridEntry, createType);
 
-                        if (newValue != null)
+                        if (newValue is not null)
                         {
                             // make sure we got what we asked for.
                             //
@@ -557,7 +557,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         case Keys.Return:
                             // make sure the return gets forwarded to the control that
                             // is being displayed
-                            if (gridView.UnfocusSelection() && gridView.SelectedGridEntry != null)
+                            if (gridView.UnfocusSelection() && gridView.SelectedGridEntry is not null)
                             {
                                 gridView.SelectedGridEntry.OnValueReturnKey();
                             }
@@ -579,7 +579,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 // clear any existing control we have
                 //
-                if (currentControl != null)
+                if (currentControl is not null)
                 {
                     currentControl.Resize -= new EventHandler(OnCurrentControlResize);
                     Controls.Remove(currentControl);
@@ -588,14 +588,14 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 // remove the InstanceCreationEditor link
                 //
-                if (createNewLink != null && createNewLink.Parent == this)
+                if (createNewLink is not null && createNewLink.Parent == this)
                 {
                     Controls.Remove(createNewLink);
                 }
 
                 // now set up the new control, top to bottom
                 //
-                if (ctl != null)
+                if (ctl is not null)
                 {
                     currentControl = ctl;
                     Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "DropDownHolder:SetComponent(" + (ctl.GetType().Name) + ")");
@@ -626,7 +626,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                         // now check for an editor, and show the link if there is one.
                         //
-                        if (editor != null)
+                        if (editor is not null)
                         {
                             // set up the link.
                             //
@@ -673,7 +673,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         ctl.Dock = DockStyle.Fill;
                         ctl.Visible = true;
 
-                        if (editor != null)
+                        if (editor is not null)
                         {
                             CreateNewLink.Dock = DockStyle.Bottom;
                             Controls.Add(CreateNewLink);
@@ -688,7 +688,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     //
                     currentControl.Resize += new EventHandler(OnCurrentControlResize);
                 }
-                Enabled = currentControl != null;
+                Enabled = currentControl is not null;
             }
 
             protected override void WndProc(ref Message m)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewEdit.GridViewEditAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewEdit.GridViewEditAccessibleObject.cs
@@ -50,7 +50,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 /// <returns>Returns the element in the specified direction.</returns>
                 internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
                 {
-                    if (direction == UiaCore.NavigateDirection.Parent && _owningPropertyGridView.SelectedGridEntry != null)
+                    if (direction == UiaCore.NavigateDirection.Parent && _owningPropertyGridView.SelectedGridEntry is not null)
                     {
                         return _owningPropertyGridView.SelectedGridEntry.AccessibilityObject;
                     }
@@ -137,14 +137,14 @@ namespace System.Windows.Forms.PropertyGridInternal
                     get
                     {
                         string name = Owner.AccessibleName;
-                        if (name != null)
+                        if (name is not null)
                         {
                             return name;
                         }
                         else
                         {
                             GridEntry selectedGridEntry = _owningPropertyGridView.SelectedGridEntry;
-                            if (selectedGridEntry != null)
+                            if (selectedGridEntry is not null)
                             {
                                 return selectedGridEntry.AccessibilityObject.Name;
                             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewEdit.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewEdit.cs
@@ -221,7 +221,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (!Focused)
                 {
                     Graphics g = CreateGraphics();
-                    if (psheet.SelectedGridEntry != null &&
+                    if (psheet.SelectedGridEntry is not null &&
                         ClientRectangle.Width <= psheet.SelectedGridEntry.GetValueTextWidth(Text, g, Font))
                     {
                         psheet.ToolTip.ToolTip = PasswordProtect ? "" : Text;
@@ -287,7 +287,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                             // if this is just the delete key and we're on a non-text editable property that is resettable,
                             // reset it now.
                             //
-                            if (psheet.SelectedGridEntry != null && !psheet.SelectedGridEntry.Enumerable && !psheet.SelectedGridEntry.IsTextEditable && psheet.SelectedGridEntry.CanResetPropertyValue())
+                            if (psheet.SelectedGridEntry is not null && !psheet.SelectedGridEntry.Enumerable && !psheet.SelectedGridEntry.IsTextEditable && psheet.SelectedGridEntry.CanResetPropertyValue())
                             {
                                 object oldValue = psheet.SelectedGridEntry.PropertyValue;
                                 psheet.SelectedGridEntry.ResetPropertyValue();
@@ -314,7 +314,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     {
                         case Keys.Return:
                             bool fwdReturn = !psheet.NeedsCommit;
-                            if (psheet.UnfocusSelection() && fwdReturn && psheet.SelectedGridEntry != null)
+                            if (psheet.UnfocusSelection() && fwdReturn && psheet.SelectedGridEntry is not null)
                             {
                                 psheet.SelectedGridEntry.OnValueReturnKey();
                             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewListBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewListBoxAccessibleObject.cs
@@ -41,7 +41,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             /// <returns>Returns the element in the specified direction.</returns>
             internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
             {
-                if (direction == UiaCore.NavigateDirection.Parent && _owningPropertyGridView.SelectedGridEntry != null)
+                if (direction == UiaCore.NavigateDirection.Parent && _owningPropertyGridView.SelectedGridEntry is not null)
                 {
                     return _owningPropertyGridView.SelectedGridEntry.AccessibilityObject;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewListBoxItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewListBoxItemAccessibleObject.cs
@@ -62,7 +62,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 get
                 {
-                    if (_owningGridViewListBox != null)
+                    if (_owningGridViewListBox is not null)
                     {
                         return _owningItem.ToString();
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -199,7 +199,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     string val = selectedGridEntry.GetPropertyTextValue();
 
-                    return val != null && val.Length > 0;
+                    return val is not null && val.Length > 0;
                 }
 
                 return true;
@@ -212,7 +212,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return CanCopy && selectedGridEntry != null && selectedGridEntry.IsTextEditable;
+                return CanCopy && selectedGridEntry is not null && selectedGridEntry.IsTextEditable;
             }
         }
 
@@ -222,7 +222,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return selectedGridEntry != null && selectedGridEntry.IsTextEditable; // return gridView.CanPaste;
+                return selectedGridEntry is not null && selectedGridEntry.IsTextEditable; // return gridView.CanPaste;
             }
         }
 
@@ -313,7 +313,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             if ((b.Size.Width != iconsWidth || b.Size.Height != iconsHeight))
             {
                 Bitmap scaledBitmap = DpiHelper.CreateResizedBitmap(b, desiredSize);
-                if (scaledBitmap != null)
+                if (scaledBitmap is not null)
                 {
                     b.Dispose();
                     b = scaledBitmap;
@@ -419,7 +419,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (edit != null && edit.IsHandleCreated)
+                if (edit is not null && edit.IsHandleCreated)
                 {
                     int exStyle = unchecked((int)((long)User32.GetWindowLong(edit, User32.GWL.EXSTYLE)));
                     return (exStyle & (int)User32.WS_EX.RTLREADING) != 0;
@@ -437,7 +437,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return dropDownHolder != null && dropDownHolder.Visible;
+                return dropDownHolder is not null && dropDownHolder.Visible;
             }
         }
 
@@ -445,7 +445,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return (ContainsFocus || (dropDownHolder != null && dropDownHolder.ContainsFocus));
+                return (ContainsFocus || (dropDownHolder is not null && dropDownHolder.ContainsFocus));
             }
         }
 
@@ -508,7 +508,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return topLevelGridEntries != null && topLevelGridEntries.Count > 0;
+                return topLevelGridEntries is not null && topLevelGridEntries.Count > 0;
             }
         }
 
@@ -550,7 +550,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 text = Edit.Text;
 
                 if (((text is null || text.Length == 0) && (originalTextValue is null || originalTextValue.Length == 0)) ||
-                    (text != null && originalTextValue != null && text.Equals(originalTextValue)))
+                    (text is not null && originalTextValue is not null && text.Equals(originalTextValue)))
                 {
                     return false;
                 }
@@ -617,7 +617,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             set
             {
-                if (allGridEntries != null)
+                if (allGridEntries is not null)
                 {
                     foreach (GridEntry e in allGridEntries)
                     {
@@ -631,7 +631,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 GridEntry gr = FindEquivalentGridEntry(new GridEntryCollection(null, new GridEntry[] { value }));
 
-                if (gr != null)
+                if (gr is not null)
                 {
                     SelectGridEntry(gr, true);
                     return;
@@ -659,7 +659,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     topHelpService = null;
 
-                    if (helpService != null && helpService is IDisposable)
+                    if (helpService is not null && helpService is IDisposable)
                     {
                         ((IDisposable)helpService).Dispose();
                     }
@@ -818,7 +818,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             for (int i = startIndex; i < (startIndex + count); i++)
             {
-                if (ipeArray[i] != null)
+                if (ipeArray[i] is not null)
                 {
                     GridEntry ge = ipeArray.GetEntry(i);
                     ge.AddOnValueClick(ehValueClick);
@@ -876,7 +876,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             for (int i = startIndex; i < (startIndex + count); i++)
             {
-                if (ipeArray[i] != null)
+                if (ipeArray[i] is not null)
                 {
                     GridEntry ge = ipeArray.GetEntry(i);
                     ge.RemoveOnValueClick(ehValueClick);
@@ -930,7 +930,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             try
             {
                 SetFlag(FlagDropDownClosing, true);
-                if (dropDownHolder != null && dropDownHolder.Visible)
+                if (dropDownHolder is not null && dropDownHolder.Visible)
                 {
                     if (dropDownHolder.Component == DropDownListBox && GetFlag(FlagDropDownCommit))
                     {
@@ -974,7 +974,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     if (selectedRow != -1)
                     {
                         var gridEntry = GetGridEntryFromRow(selectedRow);
-                        if (gridEntry != null)
+                        if (gridEntry is not null)
                         {
                             gridEntry.AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
                             gridEntry.AccessibilityObject.RaiseAutomationPropertyChangedEvent(
@@ -1064,7 +1064,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:CommonEditorUse");
             Debug.WriteLineIf(GridViewDebugPaint.TraceVerbose, "Showing common editors");
 
-            Debug.Assert(ctl != null, "Null control passed to CommonEditorUse");
+            Debug.Assert(ctl is not null, "Null control passed to CommonEditorUse");
 
             Rectangle rectCur = ctl.Bounds;
 
@@ -1170,17 +1170,17 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (disposing)
             {
                 Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:Dispose");
-                if (scrollBar != null)
+                if (scrollBar is not null)
                 {
                     scrollBar.Dispose();
                 }
 
-                if (listBox != null)
+                if (listBox is not null)
                 {
                     listBox.Dispose();
                 }
 
-                if (dropDownHolder != null)
+                if (dropDownHolder is not null)
                 {
                     dropDownHolder.Dispose();
                 }
@@ -1196,38 +1196,38 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 topHelpService = null;
 
-                if (helpService != null && helpService is IDisposable)
+                if (helpService is not null && helpService is IDisposable)
                 {
                     ((IDisposable)helpService).Dispose();
                 }
 
                 helpService = null;
 
-                if (edit != null)
+                if (edit is not null)
                 {
                     edit.Dispose();
                     edit = null;
                 }
 
-                if (_fontBold != null)
+                if (_fontBold is not null)
                 {
                     _fontBold.Dispose();
                     _fontBold = null;
                 }
 
-                if (btnDropDown != null)
+                if (btnDropDown is not null)
                 {
                     btnDropDown.Dispose();
                     btnDropDown = null;
                 }
 
-                if (btnDialog != null)
+                if (btnDialog is not null)
                 {
                     btnDialog.Dispose();
                     btnDialog = null;
                 }
 
-                if (toolTip != null)
+                if (toolTip is not null)
                 {
                     toolTip.Dispose();
                     toolTip = null;
@@ -1245,7 +1245,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     Edit.Copy();
                 }
-                else if (selectedGridEntry != null)
+                else if (selectedGridEntry is not null)
                 {
                     Clipboard.SetDataObject(selectedGridEntry.GetPropertyTextValue());
                 }
@@ -1275,10 +1275,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                 else
                 {
                     IDataObject dataObj = Clipboard.GetDataObject();
-                    if (dataObj != null)
+                    if (dataObj is not null)
                     {
                         string data = (string)dataObj.GetData(typeof(string));
-                        if (data != null)
+                        if (data is not null)
                         {
                             Edit.Focus();
                             Edit.Text = data;
@@ -1301,7 +1301,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             Type propType = entry.PropertyType;
 
-            if (entry.PropertyValue != null)
+            if (entry.PropertyValue is not null)
             {
                 propType = entry.PropertyValue.GetType();
             }
@@ -1311,7 +1311,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                                      ", TypeConverter=" + (entry.TypeConverter is null ? "(null)" : entry.TypeConverter.GetType().FullName) + ", UITypeEditor=" + ((entry.UITypeEditor is null ? "(null)" : entry.UITypeEditor.GetType().FullName)));
             GridEntryCollection children = entry.Children;
 
-            if (children != null)
+            if (children is not null)
             {
                 foreach (GridEntry g in children)
                 {
@@ -1645,7 +1645,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         // for qa automation
         internal int GetPropertyLocation(string propName, bool getXY, bool rowValue)
         {
-            if (allGridEntries != null && allGridEntries.Count > 0)
+            if (allGridEntries is not null && allGridEntries.Count > 0)
             {
                 for (int i = 0; i < allGridEntries.Count; i++)
                 {
@@ -1681,7 +1681,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 return this;
             }
-            if (ServiceProvider != null)
+            if (ServiceProvider is not null)
             {
                 return serviceProvider.GetService(classService);
             }
@@ -1772,7 +1772,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             SelectEdit(false);
 
             var gridEntry = GetGridEntryFromRow(selectedRow);
-            if (gridEntry != null)
+            if (gridEntry is not null)
             {
                 gridEntry.AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
                 gridEntry.AccessibilityObject.RaiseAutomationPropertyChangedEvent(
@@ -1806,7 +1806,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         public virtual void DropDownUpdate()
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "DropDownHolder:DropDownUpdate");
-            if (dropDownHolder != null && dropDownHolder.GetUsed())
+            if (dropDownHolder is not null && dropDownHolder.GetUsed())
             {
                 int row = selectedRow;
                 GridEntry gridEntry = GetGridEntryFromRow(row);
@@ -1823,10 +1823,10 @@ namespace System.Windows.Forms.PropertyGridInternal
         private bool FilterEditWndProc(ref Message m)
         {
             // if it's the TAB key, we keep it since we'll give them focus with it.
-            if (dropDownHolder != null && dropDownHolder.Visible && m.Msg == (int)User32.WM.KEYDOWN && (int)m.WParam != (int)Keys.Tab)
+            if (dropDownHolder is not null && dropDownHolder.Visible && m.Msg == (int)User32.WM.KEYDOWN && (int)m.WParam != (int)Keys.Tab)
             {
                 Control ctl = dropDownHolder.Component;
-                if (ctl != null)
+                if (ctl is not null)
                 {
                     m.Result = User32.SendMessageW(ctl, (User32.WM)m.Msg, m.WParam, m.LParam);
                     return true;
@@ -1848,7 +1848,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     object valueCur = values[(i + index + 1) % values.Length];
                     string text = gridEntry.GetPropertyTextValue(valueCur);
-                    if (text != null && text.Length > 0 && string.Compare(text.Substring(0, 1), letter, true, CultureInfo.InvariantCulture) == 0)
+                    if (text is not null && text.Length > 0 && string.Compare(text.Substring(0, 1), letter, true, CultureInfo.InvariantCulture) == 0)
                     {
                         CommitValue(valueCur);
                         if (Edit.Focused)
@@ -1880,7 +1880,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             // for the tree.
             //
 
-            if (selectedGridEntry != null)
+            if (selectedGridEntry is not null)
             {
                 switch (charPressed)
                 {
@@ -1936,7 +1936,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 // if we've got one above, and it's expandable,
                 // expand it
-                if (targetEntry != null)
+                if (targetEntry is not null)
                 {
                     // how many do we have?
                     int items = rgipes.Count;
@@ -2019,7 +2019,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return null;
             }
 
-            if (allGridEntries != null && !fUpdateCache)
+            if (allGridEntries is not null && !fUpdateCache)
             {
                 return allGridEntries;
             }
@@ -2051,7 +2051,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 object value = gridEntry.PropertyValue;
                 string textValue = gridEntry.TypeConverter.ConvertToString(gridEntry, value);
 
-                if (values != null && values.Length > 0)
+                if (values is not null && values.Length > 0)
                 {
                     string itemTextValue;
                     int stringMatch = -1;
@@ -2067,7 +2067,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                             stringMatch = i;
                         }
                         // now try .equals if they are both non-null
-                        if (value != null && curValue != null && curValue.Equals(value))
+                        if (value is not null && curValue is not null && curValue.Equals(value))
                         {
                             equalsMatch = i;
                         }
@@ -2103,13 +2103,13 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private IHelpService GetHelpService()
         {
-            if (helpService is null && ServiceProvider != null)
+            if (helpService is null && ServiceProvider is not null)
             {
                 topHelpService = (IHelpService)ServiceProvider.GetService(typeof(IHelpService));
-                if (topHelpService != null)
+                if (topHelpService is not null)
                 {
                     IHelpService localHelpService = topHelpService.CreateLocalContext(HelpContextType.ToolWindowSelection);
-                    if (localHelpService != null)
+                    if (localHelpService is not null)
                     {
                         helpService = localHelpService;
                     }
@@ -2144,7 +2144,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 GridEntry[] entries = new GridEntry[depth + 1];
 
-                while (gridEntry != null && depth >= 0)
+                while (gridEntry is not null && depth >= 0)
                 {
                     entries[depth] = gridEntry;
                     gridEntry = gridEntry.ParentGridEntry;
@@ -2163,7 +2163,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         private /*protected virtual*/ GridEntry GetGridEntryFromOffset(int offset)
         {
             GridEntryCollection rgipesAll = GetAllGridEntries();
-            if (rgipesAll != null)
+            if (rgipesAll is not null)
             {
                 if (offset >= 0 && offset < rgipesAll.Count)
                 {
@@ -2201,7 +2201,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (ipeCur.InternalExpanded)
                 {
                     GridEntryCollection subGridEntry = ipeCur.Children;
-                    if (subGridEntry != null && subGridEntry.Count > 0)
+                    if (subGridEntry is not null && subGridEntry.Count > 0)
                     {
                         cCur = GetGridEntriesFromOutline(subGridEntry,
                                                   cCur + 1, cTarget, rgipeTarget);
@@ -2342,7 +2342,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             Rectangle rect = ClientRectangle;
             Size sizeWindow = new Size(rect.Width, rect.Height);
 
-            if (scrollBar != null)
+            if (scrollBar is not null)
             {
                 Rectangle boundsScroll = ScrollBar.Bounds;
                 boundsScroll.X = sizeWindow.Width - boundsScroll.Width - 1;
@@ -2431,7 +2431,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             Control cParent = c.ParentInternal;
 
-            while (cParent != null)
+            while (cParent is not null)
             {
                 if (cParent == this)
                 {
@@ -2468,7 +2468,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             Control parent1 = c1.ParentInternal;
             Control parent2 = c2.ParentInternal;
 
-            while (parent2 != null)
+            while (parent2 is not null)
             {
                 if (parent1 == parent2)
                 {
@@ -2565,7 +2565,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             base.OnGotFocus(e);
 
-            if (e != null && !GetInPropertySet())
+            if (e is not null && !GetInPropertySet())
             {
                 if (!Commit())
                 {
@@ -2574,7 +2574,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
             }
 
-            if (selectedGridEntry != null && GetRowFromGridEntry(selectedGridEntry) != -1)
+            if (selectedGridEntry is not null && GetRowFromGridEntry(selectedGridEntry) != -1)
             {
                 selectedGridEntry.Focus = true;
                 SelectGridEntry(selectedGridEntry, false);
@@ -2584,7 +2584,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 SelectRow(0);
             }
 
-            if (selectedGridEntry != null && selectedGridEntry.GetValueOwner() != null)
+            if (selectedGridEntry is not null && selectedGridEntry.GetValueOwner() is not null)
             {
                 UpdateHelpAttributes(null, selectedGridEntry);
             }
@@ -2615,7 +2615,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             SystemEvents.UserPreferenceChanged -= new UserPreferenceChangedEventHandler(OnSysColorChange);
             // We can leak this if we aren't disposed.
             //
-            if (toolTip != null && !RecreatingHandle)
+            if (toolTip is not null && !RecreatingHandle)
             {
                 toolTip.Dispose();
                 toolTip = null;
@@ -2660,7 +2660,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 // don't need the commit because we're committing anyway.
                 //
                 SetFlag(FlagDropDownCommit, false);
-                if (value != null && !CommitText((string)value))
+                if (value is not null && !CommitText((string)value))
                 {
                     SetCommitError(ERROR_NONE);
                     SelectRow(selectedRow);
@@ -2713,7 +2713,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (ke.KeyCode == Keys.Return)
             {
                 OnListClick(null, null);
-                if (selectedGridEntry != null)
+                if (selectedGridEntry is not null)
                 {
                     selectedGridEntry.OnValueReturnKey();
                 }
@@ -2727,7 +2727,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:OnLostFocus");
             Debug.WriteLineIf(GridViewDebugPaint.TraceVerbose, "PropertyGridView lost focus");
 
-            if (e != null)
+            if (e is not null)
             {
                 base.OnLostFocus(e);
             }
@@ -2739,7 +2739,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
 
             GridEntry gridEntry = GetGridEntryFromRow(selectedRow);
-            if (gridEntry != null)
+            if (gridEntry is not null)
             {
                 Debug.WriteLineIf(GridViewDebugPaint.TraceVerbose, "removing gridEntry focus");
                 gridEntry.Focus = false;
@@ -2781,7 +2781,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (!Edit.InSetText())
             {
                 GridEntry gridEntry = GetGridEntryFromRow(selectedRow);
-                if (gridEntry != null && (gridEntry.Flags & GridEntry.FLAG_IMMEDIATELY_EDITABLE) != 0)
+                if (gridEntry is not null && (gridEntry.Flags & GridEntry.FLAG_IMMEDIATELY_EDITABLE) != 0)
                 {
                     Commit();
                 }
@@ -2816,7 +2816,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     break;
             }
 
-            if (selectedGridEntry != null && GetRowFromGridEntry(selectedGridEntry) != -1)
+            if (selectedGridEntry is not null && GetRowFromGridEntry(selectedGridEntry) != -1)
             {
                 Debug.WriteLineIf(GridViewDebugPaint.TraceVerbose, "adding gridEntry focus");
                 selectedGridEntry.Focus = true;
@@ -2835,19 +2835,19 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             object value = gridEntry.PropertyValue;
             object[] rgvalues = gridEntry.GetPropertyValueList();
-            if (rgvalues != null)
+            if (rgvalues is not null)
             {
                 for (int i = 0; i < rgvalues.Length; i++)
                 {
                     object rgvalue = rgvalues[i];
-                    if (value != null && rgvalue != null && value.GetType() != rgvalue.GetType() && gridEntry.TypeConverter.CanConvertTo(gridEntry, value.GetType()))
+                    if (value is not null && rgvalue is not null && value.GetType() != rgvalue.GetType() && gridEntry.TypeConverter.CanConvertTo(gridEntry, value.GetType()))
                     {
                         rgvalue = gridEntry.TypeConverter.ConvertTo(gridEntry, CultureInfo.CurrentCulture, rgvalue, value.GetType());
                     }
 
-                    bool equal = (value == rgvalue) || (value != null && value.Equals(rgvalue));
+                    bool equal = (value == rgvalue) || (value is not null && value.Equals(rgvalue));
 
-                    if (!equal && value is string && rgvalue != null)
+                    if (!equal && value is string && rgvalue is not null)
                     {
                         equal = 0 == string.Compare((string)value, rgvalue.ToString(), true, CultureInfo.CurrentCulture);
                     }
@@ -2938,7 +2938,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             // check to see if the focus is on the drop down or one of it's children
             // if so, return;
-            if (dropDownHolder != null && dropDownHolder.Visible)
+            if (dropDownHolder is not null && dropDownHolder.Visible)
             {
                 bool found = false;
                 for (IntPtr hwnd = User32.GetForegroundWindow();
@@ -3058,7 +3058,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     Edit.Text = originalTextValue;
                     bool needReset = true;
 
-                    if (selectedGridEntry != null)
+                    if (selectedGridEntry is not null)
                     {
                         string curTextValue = selectedGridEntry.GetPropertyTextValue();
                         needReset = originalTextValue != curTextValue && !(string.IsNullOrEmpty(originalTextValue) && string.IsNullOrEmpty(curTextValue));
@@ -3142,7 +3142,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return;
             }
 
-            if (keyCode == Keys.Up && fAlt && DropDownButton.Visible && (dropDownHolder != null) && dropDownHolder.Visible)
+            if (keyCode == Keys.Up && fAlt && DropDownButton.Visible && (dropDownHolder is not null) && dropDownHolder.Visible)
             {
                 UnfocusSelection();
                 return;
@@ -3338,7 +3338,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
             }
 
-            if (gridEntry != null && ke.KeyData == (Keys.C | Keys.Alt | Keys.Shift | Keys.Control))
+            if (gridEntry is not null && ke.KeyData == (Keys.C | Keys.Alt | Keys.Shift | Keys.Control))
             {
                 Clipboard.SetDataObject(gridEntry.GetTestingInfo());
                 return;
@@ -3357,7 +3357,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                    string strCh = (new string(new char[] {(char)ke.KeyCode})).ToLower(CultureInfo.InvariantCulture);
 
                    int cCur = -1;
-                   if (gridEntry != null)
+                   if (gridEntry is not null)
                        for (int i = 0; i < cLength; i++) {
                            if (rgipes[i] == gridEntry) {
                                cCur = i;
@@ -3380,8 +3380,8 @@ namespace System.Windows.Forms.PropertyGridInternal
                }
             */
 
-            if (selectedGridEntry != null && selectedGridEntry.Enumerable &&
-                dropDownHolder != null && dropDownHolder.Visible &&
+            if (selectedGridEntry is not null && selectedGridEntry.Enumerable &&
+                dropDownHolder is not null && dropDownHolder.Visible &&
                 (keyCode == Keys.Up || keyCode == Keys.Down))
             {
                 ProcessEnumUpAndDown(selectedGridEntry, keyCode, false);
@@ -3440,7 +3440,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             // it's coords first...we really  just need the x, y
             GridEntry gridEntry = GetGridEntryFromRow(pos.Y);
 
-            if (gridEntry != null)
+            if (gridEntry is not null)
             {
                 // get the origin of this pe
                 Rectangle r = GetRectangle(pos.Y, ROWLABEL);
@@ -3516,7 +3516,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 string tip = string.Empty;
                 tipInfo = -1;
 
-                if (gridItem != null)
+                if (gridItem is not null)
                 {
                     Rectangle itemRect = GetRectangle(pt.Y, pt.X);
                     if (onLabel && gridItem.GetLabelToolTipLocation(me.X - itemRect.X, me.Y - itemRect.Y) != InvalidPoint)
@@ -3600,7 +3600,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             // we use the mouse wheel to change the values in the dropdown if it's
             // an enumerable value.
             //
-            if (selectedGridEntry != null && selectedGridEntry.Enumerable && Edit.Focused && selectedGridEntry.IsValueEditable)
+            if (selectedGridEntry is not null && selectedGridEntry.Enumerable && Edit.Focused && selectedGridEntry.IsValueEditable)
             {
                 int index = GetCurrentValueIndex(selectedGridEntry);
                 if (index != -1)
@@ -3962,7 +3962,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             UpdateUIBasedOnFont(true);
             base.OnFontChanged(e);
 
-            if (selectedGridEntry != null)
+            if (selectedGridEntry is not null)
             {
                 SelectGridEntry(selectedGridEntry, true);
             }
@@ -3975,14 +3975,14 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return;
             }
 
-            if (Visible && ParentInternal != null)
+            if (Visible && ParentInternal is not null)
             {
                 SetConstants();
-                if (selectedGridEntry != null)
+                if (selectedGridEntry is not null)
                 {
                     SelectGridEntry(selectedGridEntry, true);
                 }
-                if (toolTip != null)
+                if (toolTip is not null)
                 {
                     ToolTip.Font = Font;
                 }
@@ -4099,7 +4099,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             LayoutWindow(false);
 
-            bool selectionVisible = (selectedGridEntry != null && selectedRow >= 0 && selectedRow <= visibleRows);
+            bool selectionVisible = (selectedGridEntry is not null && selectedRow >= 0 && selectedRow <= visibleRows);
             SelectGridEntry(selectedGridEntry, selectionVisible);
             lastClientRect = newRect;
         }
@@ -4117,14 +4117,14 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             int oldRow = -1;
             GridEntry oldGridEntry = selectedGridEntry;
-            if (selectedGridEntry != null)
+            if (selectedGridEntry is not null)
             {
                 oldRow = GetRowFromGridEntry(oldGridEntry);
                 Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "OnScroll: SelectedGridEntry=" + oldGridEntry.PropertyLabel);
             }
 
             ScrollBar.Value = se.NewValue;
-            if (oldGridEntry != null)
+            if (oldGridEntry is not null)
             {
                 // we need to zero out the selected row so we don't try to commit again...since selectedRow is now bogus.
                 selectedRow = -1;
@@ -4153,9 +4153,9 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:PopupDialog");
             GridEntry gridEntry = GetGridEntryFromRow(row);
-            if (gridEntry != null)
+            if (gridEntry is not null)
             {
-                if (dropDownHolder != null && dropDownHolder.GetUsed())
+                if (dropDownHolder is not null && dropDownHolder.GetUsed())
                 {
                     CloseDropDown();
                     return;
@@ -4187,7 +4187,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         using var fontSelection = new Gdi32.SelectObjectScope(hdc, hFont);
 
                         iSel = GetCurrentValueIndex(gridEntry);
-                        if (rgItems != null && rgItems.Length > 0)
+                        if (rgItems is not null && rgItems.Length > 0)
                         {
                             string s;
                             Size textSize = new Size();
@@ -4389,7 +4389,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                             OnBtnClick((DialogButton.Focused ? DialogButton : DropDownButton), EventArgs.Empty);
                             return true;
                         }
-                        else if (selectedGridEntry != null && selectedGridEntry.Expandable)
+                        else if (selectedGridEntry is not null && selectedGridEntry.Expandable)
                         {
                             SetExpand(selectedGridEntry, !selectedGridEntry.InternalExpanded);
                             return true;
@@ -4422,7 +4422,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             SetExpand(gridEntry, expand);
 
             GridEntryCollection rgipes = gridEntry.Children;
-            if (rgipes != null)
+            if (rgipes is not null)
             {
                 for (int i = 0; i < rgipes.Count; i++)
                 {
@@ -4445,7 +4445,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             //resetting gridoutline rect to recalculate before repaint when viewsort property changed. This is necessary especially when user
             // changes sort and move to a secondary monitor with different DPI and change view sort back to original.
-            if (topLevelGridEntries != null && DpiHelper.IsScalingRequirementMet)
+            if (topLevelGridEntries is not null && DpiHelper.IsScalingRequirementMet)
             {
                 var outlineRectIconSize = GetOutlineIconSize();
                 foreach (GridEntry gridentry in topLevelGridEntries)
@@ -4531,7 +4531,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     SetConstants();
 
-                    if (positionData != null)
+                    if (positionData is not null)
                     {
                         gridEntry = positionData.Restore(this);
 
@@ -4584,7 +4584,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             InvalidateRows(rowStart, rowEnd);
 
-            if (gridEntry != null)
+            if (gridEntry is not null)
             {
                 SelectGridEntry(gridEntry, pageInGridEntry);
             }
@@ -4676,7 +4676,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             SetScrollOffset(newOffset);
 
-            if (ipeCur != null)
+            if (ipeCur is not null)
             {
                 int curRow = GetRowFromGridEntry(ipeCur);
                 if (curRow >= 0 && curRow < visibleRows - 1)
@@ -4702,7 +4702,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private void SelectEdit(bool caretAtEnd)
         {
-            if (edit != null)
+            if (edit is not null)
             {
                 Edit.SelectAll();
             }
@@ -4804,7 +4804,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             UpdateHelpAttributes(selectedGridEntry, gridEntry);
 
             // tell the old selection it's not focused any more
-            if (selectedGridEntry != null)
+            if (selectedGridEntry is not null)
             {
                 selectedGridEntry.Focus = false;
             }
@@ -4877,7 +4877,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 rect.Width -= EDIT_INDENT + 1;
             }
 
-            if ((GetFlag(FlagIsNewSelection) || !Edit.Focused) && (s != null && !s.Equals(Edit.Text)))
+            if ((GetFlag(FlagIsNewSelection) || !Edit.Focused) && (s is not null && !s.Equals(Edit.Text)))
             {
                 Edit.Text = s;
                 originalTextValue = s;
@@ -4934,7 +4934,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             OwnerGrid.SetStatusBox(gridEntry.PropertyLabel, gridEntry.PropertyDescription);
 
             // tell the new focused item that it now has focus
-            if (selectedGridEntry != null)
+            if (selectedGridEntry is not null)
             {
                 selectedGridEntry.Focus = FocusInside;
             }
@@ -4985,7 +4985,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             bool adjustWidth = SetScrollbarLength();
             GridEntryCollection rgipesAll = GetAllGridEntries();
-            if (rgipesAll != null)
+            if (rgipesAll is not null)
             {
                 int scroll = GetScrollOffset();
                 if ((scroll + visibleRows) >= rgipesAll.Count)
@@ -5055,7 +5055,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         internal /*public virtual*/ void SetExpand(GridEntry gridEntry, bool value)
         {
-            if (gridEntry != null && gridEntry.Expandable)
+            if (gridEntry is not null && gridEntry.Expandable)
             {
                 int row = GetRowFromGridEntry(gridEntry);
                 int countFromEnd = visibleRows - row;
@@ -5085,7 +5085,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 GridEntry ipeSelect = selectedGridEntry;
                 if (!value)
                 {
-                    for (GridEntry ipeCur = ipeSelect; ipeCur != null; ipeCur = ipeCur.ParentGridEntry)
+                    for (GridEntry ipeCur = ipeSelect; ipeCur is not null; ipeCur = ipeCur.ParentGridEntry)
                     {
                         if (ipeCur.Equals(gridEntry))
                         {
@@ -5240,7 +5240,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     //we'll want to close the drop down (like true/false).  Otherwise, if we're
                     //working with Anchor for ex., then we should be able to select different values
                     //from the editor, without having it close every time.
-                    if (ipeCur != null &&
+                    if (ipeCur is not null &&
                         ipeCur.Enumerable &&
                         closeDropDown)
                     {
@@ -5295,14 +5295,14 @@ namespace System.Windows.Forms.PropertyGridInternal
             // in case this guy got disposed...
             if (ipeCur.Disposed)
             {
-                bool editfocused = (edit != null && edit.Focused);
+                bool editfocused = (edit is not null && edit.Focused);
 
                 // reselect the row to find the replacement.
                 //
                 SelectGridEntry(ipeCur, true);
                 ipeCur = selectedGridEntry;
 
-                if (editfocused && edit != null)
+                if (editfocused && edit is not null)
                 {
                     edit.Focus();
                 }
@@ -5428,9 +5428,9 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (dialog.StartPosition == FormStartPosition.CenterScreen)
             {
                 Control topControl = this;
-                if (topControl != null)
+                if (topControl is not null)
                 {
-                    while (topControl.ParentInternal != null)
+                    while (topControl.ParentInternal is not null)
                     {
                         topControl = topControl.ParentInternal;
                     }
@@ -5449,7 +5449,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             IUIService service = (IUIService)GetService(typeof(IUIService));
             DialogResult result;
-            if (service != null)
+            if (service is not null)
             {
                 result = service.ShowDialog(dialog);
             }
@@ -5529,7 +5529,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             ErrorDialog.Text = SR.PBRSErrorTitle;
             ErrorDialog.Details = exMessage;
 
-            if (uiSvc != null)
+            if (uiSvc is not null)
             {
                 revert = (DialogResult.Cancel == uiSvc.ShowDialog(ErrorDialog));
             }
@@ -5611,7 +5611,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             ErrorDialog.Text = SR.PBRSErrorTitle;
             ErrorDialog.Details = exMessage;
 
-            if (uiSvc != null)
+            if (uiSvc is not null)
             {
                 revert = (DialogResult.Cancel == uiSvc.ShowDialog(ErrorDialog));
             }
@@ -5652,12 +5652,12 @@ namespace System.Windows.Forms.PropertyGridInternal
                 Edit.Focus();
                 SelectEdit(false);
             }
-            else if (dropDownHolder != null && dropDownHolder.Visible)
+            else if (dropDownHolder is not null && dropDownHolder.Visible)
             {
                 dropDownHolder.FocusComponent();
                 return;
             }
-            else if (currentEditor != null)
+            else if (currentEditor is not null)
             {
                 currentEditor.Focus();
             }
@@ -5681,16 +5681,16 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
 
             GridEntry temp = oldEntry;
-            if (oldEntry != null && !oldEntry.Disposed)
+            if (oldEntry is not null && !oldEntry.Disposed)
             {
-                while (temp != null)
+                while (temp is not null)
                 {
                     hsvc.RemoveContextAttribute("Keyword", temp.HelpKeyword);
                     temp = temp.ParentGridEntry;
                 }
             }
 
-            if (newEntry != null)
+            if (newEntry is not null)
             {
                 temp = newEntry;
 
@@ -5707,7 +5707,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             UpdateHelpAttributes(helpSvc, entry.ParentGridEntry, false);
             string helpKeyword = entry.HelpKeyword;
-            if (helpKeyword != null)
+            if (helpKeyword is not null)
             {
                 helpSvc.AddContextAttribute("Keyword", helpKeyword, addAsF1 ? HelpKeywordType.F1Keyword : HelpKeywordType.GeneralKeyword);
             }
@@ -5719,12 +5719,12 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 try
                 {
-                    if (listBox != null)
+                    if (listBox is not null)
                     {
                         DropDownListBox.ItemHeight = RowHeight + 2;
                     }
 
-                    if (btnDropDown != null)
+                    if (btnDropDown is not null)
                     {
                         var isScalingRequirementMet = DpiHelper.IsScalingRequirementMet;
                         if (isScalingRequirementMet)
@@ -5736,7 +5736,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                             btnDropDown.Size = new Size(SystemInformation.VerticalScrollBarArrowHeight, RowHeight);
                         }
 
-                        if (btnDialog != null)
+                        if (btnDialog is not null)
                         {
                             DialogButton.Size = DropDownButton.Size;
                             if (isScalingRequirementMet)
@@ -5785,10 +5785,10 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (totalProps > 0)
             {
                 IMenuCommandService mcs = (IMenuCommandService)GetService(typeof(IMenuCommandService));
-                if (mcs != null)
+                if (mcs is not null)
                 {
                     MenuCommand reset = mcs.FindCommand(PropertyGridCommands.Reset);
-                    if (reset != null)
+                    if (reset is not null)
                     {
                         reset.Enabled = gridEntry is null ? false : gridEntry.CanResetPropertyValue();
                     }
@@ -5934,7 +5934,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     int flags = (int)(User32.DLGC.WANTCHARS | User32.DLGC.WANTARROWS);
 
-                    if (selectedGridEntry != null)
+                    if (selectedGridEntry is not null)
                     {
                         if ((ModifierKeys & Keys.Shift) == 0)
                         {
@@ -6003,7 +6003,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 outlineSize = LogicalToDeviceUnits(OUTLINE_SIZE);
                 maxListBoxHeight = LogicalToDeviceUnits(MAX_LISTBOX_HEIGHT);
                 offset_2Units = LogicalToDeviceUnits(OFFSET_2PIXELS);
-                if (topLevelGridEntries != null)
+                if (topLevelGridEntries is not null)
                 {
                     foreach (GridEntry t in topLevelGridEntries)
                     {
@@ -6144,7 +6144,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (nCode == User32.HC.ACTION)
                 {
                     User32.MOUSEHOOKSTRUCT* mhs = (User32.MOUSEHOOKSTRUCT*)lparam;
-                    if (mhs != null)
+                    if (mhs is not null)
                     {
                         switch (unchecked((User32.WM)(long)wparam))
                         {
@@ -6265,7 +6265,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     try
                     {
                         MouseHook control = (MouseHook)reference.Target;
-                        if (control != null)
+                        if (control is not null)
                         {
                             ret = control.MouseHookProc(nCode, wparam, lparam);
                         }
@@ -6322,7 +6322,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     _parentPropertyGrid.AccessibilityObject is PropertyGridAccessibleObject propertyGridAccessibleObject)
                 {
                     UiaCore.IRawElementProviderFragment navigationTarget = propertyGridAccessibleObject.ChildFragmentNavigate(this, direction);
-                    if (navigationTarget != null)
+                    if (navigationTarget is not null)
                     {
                         return navigationTarget;
                     }
@@ -6406,7 +6406,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 get
                 {
                     string name = Owner.AccessibleName;
-                    if (name != null)
+                    if (name is not null)
                     {
                         return name;
                     }
@@ -6435,7 +6435,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 int row = ((PropertyGridView)Owner).GetRowFromGridEntry(current);
                 GridEntry nextEntry = ((PropertyGridView)Owner).GetGridEntryFromRow(++row);
-                if (nextEntry != null)
+                if (nextEntry is not null)
                 {
                     return nextEntry.AccessibilityObject;
                 }
@@ -6489,7 +6489,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     {
                         // Set to true to return the previous iterable element.
                         currentGridEntryFound = true;
-                        if (previousGridEntry != null)
+                        if (previousGridEntry is not null)
                         {
                             // In the current iteration return previous entry if the current entry == iterated grid entry.
                             return previousGridEntry.AccessibilityObject;
@@ -6505,7 +6505,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         if (gridEntry.ChildCount > 0)
                         {
                             AccessibleObject foundChild = GetPreviousGridEntry(currentGridEntry, gridEntry.Children, out currentGridEntryFound);
-                            if (foundChild != null)
+                            if (foundChild is not null)
                             {
                                 // Return some down-level child if found.
                                 return foundChild;
@@ -6549,7 +6549,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     else if (gridEntry.ChildCount > 0)
                     {
                         AccessibleObject foundChild = GetNextGridEntry(currentGridEntry, gridEntry.Children, out currentGridEntryFound);
-                        if (foundChild != null)
+                        if (foundChild is not null)
                         {
                             // Return some down-level child if found.
                             return foundChild;
@@ -6575,7 +6575,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (current.ChildCount > 0)
                 {
                     GridEntryCollection subGridEntry = current.Children;
-                    if (subGridEntry != null && subGridEntry.Count > 0)
+                    if (subGridEntry is not null && subGridEntry.Count > 0)
                     {
                         GridEntry[] targetEntries = new GridEntry[1];
                         try
@@ -6604,7 +6604,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (current.ChildCount > 0)
                 {
                     GridEntryCollection subGridEntry = current.Children;
-                    if (subGridEntry != null && subGridEntry.Count > 0)
+                    if (subGridEntry is not null && subGridEntry.Count > 0)
                     {
                         GridEntry[] targetEntries = new GridEntry[1];
                         try
@@ -6642,7 +6642,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         return nextEntry.AccessibilityObject;
                     }
                 }
-                while (nextEntry != null);
+                while (nextEntry is not null);
 
                 return null;
             }
@@ -6651,7 +6651,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 int row = ((PropertyGridView)Owner).GetRowFromGridEntry(current);
                 GridEntry prevEntry = ((PropertyGridView)Owner).GetGridEntryFromRow(--row);
-                if (prevEntry != null)
+                if (prevEntry is not null)
                 {
                     return prevEntry.AccessibilityObject;
                 }
@@ -6677,7 +6677,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         return previousEntry.AccessibilityObject;
                     }
                 }
-                while (previousEntry != null);
+                while (previousEntry is not null);
 
                 return null;
             }
@@ -6690,7 +6690,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             public override AccessibleObject GetChild(int index)
             {
                 GridEntryCollection properties = ((PropertyGridView)Owner).AccessibilityGetGridEntries();
-                if (properties != null && index >= 0 && index < properties.Count)
+                if (properties is not null && index >= 0 && index < properties.Count)
                 {
                     return properties.GetEntry(index).AccessibilityObject;
                 }
@@ -6709,7 +6709,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 GridEntryCollection properties = ((PropertyGridView)Owner).AccessibilityGetGridEntries();
 
-                if (properties != null)
+                if (properties is not null)
                 {
                     return properties.Count;
                 }
@@ -6725,7 +6725,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             public override AccessibleObject GetFocused()
             {
                 GridEntry gridEntry = ((PropertyGridView)Owner).SelectedGridEntry;
-                if (gridEntry != null && gridEntry.Focus)
+                if (gridEntry is not null && gridEntry.Focus)
                 {
                     return gridEntry.AccessibilityObject;
                 }
@@ -6738,7 +6738,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             public override AccessibleObject GetSelected()
             {
                 GridEntry gridEntry = ((PropertyGridView)Owner).SelectedGridEntry;
-                if (gridEntry != null)
+                if (gridEntry is not null)
                 {
                     return gridEntry.AccessibilityObject;
                 }
@@ -6767,7 +6767,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (pos != PropertyGridView.InvalidPosition)
                 {
                     GridEntry gridEntry = ((PropertyGridView)Owner).GetGridEntryFromRow(pos.Y);
-                    if (gridEntry != null)
+                    if (gridEntry is not null)
                     {
                         // Return the accessible object for this grid entry
                         //
@@ -6855,7 +6855,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 gridView.RestoreHierarchyState(expandedState);
                 GridEntry entry = gridView.FindEquivalentGridEntry(selectedItemTree);
 
-                if (entry != null)
+                if (entry is not null)
                 {
                     gridView.SelectGridEntry(entry, true);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/SingleSelectRootGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/SingleSelectRootGridEntry.cs
@@ -28,7 +28,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         internal SingleSelectRootGridEntry(PropertyGridView gridEntryHost, object value, GridEntry parent, IServiceProvider baseProvider, IDesignerHost host, PropertyTab tab, PropertySort sortType)
         : base(gridEntryHost.OwnerGrid, parent)
         {
-            Debug.Assert(value != null, "Can't browse a null object!");
+            Debug.Assert(value is not null, "Can't browse a null object!");
             this.host = host;
             this.gridEntryHost = gridEntryHost;
             this.baseProvider = baseProvider;
@@ -69,7 +69,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 bool same = true;
 
-                if (browsableAttributes != null && value != null && browsableAttributes.Count == value.Count)
+                if (browsableAttributes is not null && value is not null && browsableAttributes.Count == value.Count)
                 {
                     Attribute[] attr1 = new Attribute[browsableAttributes.Count];
                     Attribute[] attr2 = new Attribute[value.Count];
@@ -95,7 +95,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 browsableAttributes = value;
 
-                if (!same && Children != null && Children.Count > 0)
+                if (!same && Children is not null && Children.Count > 0)
                 {
                     DisposeChildren();
                 }
@@ -165,13 +165,13 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (!forceReadOnlyChecked)
                 {
                     ReadOnlyAttribute readOnlyAttr = (ReadOnlyAttribute)TypeDescriptor.GetAttributes(objValue)[typeof(ReadOnlyAttribute)];
-                    if ((readOnlyAttr != null && !readOnlyAttr.IsDefaultAttribute()) || TypeDescriptor.GetAttributes(objValue).Contains(InheritanceAttribute.InheritedReadOnly))
+                    if ((readOnlyAttr is not null && !readOnlyAttr.IsDefaultAttribute()) || TypeDescriptor.GetAttributes(objValue).Contains(InheritanceAttribute.InheritedReadOnly))
                     {
                         flags |= FLAG_FORCE_READONLY;
                     }
                     forceReadOnlyChecked = true;
                 }
-                return base.ForceReadOnly || (GridEntryHost != null && !GridEntryHost.Enabled);
+                return base.ForceReadOnly || (GridEntryHost is not null && !GridEntryHost.Enabled);
             }
         }
 
@@ -205,7 +205,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 HelpKeywordAttribute helpAttribute = (HelpKeywordAttribute)TypeDescriptor.GetAttributes(objValue)[typeof(HelpKeywordAttribute)];
 
-                if (helpAttribute != null && !helpAttribute.IsDefaultAttribute())
+                if (helpAttribute is not null && !helpAttribute.IsDefaultAttribute())
                 {
                     return helpAttribute.HelpKeyword;
                 }
@@ -229,7 +229,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return site.Name;
                 }
 
-                if (objValue != null)
+                if (objValue is not null)
                 {
                     return objValue.ToString();
                 }
@@ -284,11 +284,11 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             object service = null;
 
-            if (host != null)
+            if (host is not null)
             {
                 service = host.GetService(serviceType);
             }
-            if (service is null && baseProvider != null)
+            if (service is null && baseProvider is not null)
             {
                 service = baseProvider.GetService(serviceType);
             }
@@ -320,7 +320,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
 
                 // recreate the children
-                if (Expandable && ChildCollection != null)
+                if (Expandable && ChildCollection is not null)
                 {
                     CreateChildren();
                 }
@@ -344,8 +344,8 @@ namespace System.Windows.Forms.PropertyGridInternal
                     for (int i = 0; i < childEntries.Length; i++)
                     {
                         GridEntry pe = childEntries[i];
-                        Debug.Assert(pe != null);
-                        if (pe != null)
+                        Debug.Assert(pe is not null);
+                        if (pe is not null)
                         {
                             string category = pe.PropertyCategory;
                             ArrayList bin = (ArrayList)bins[category];
@@ -368,7 +368,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     while (enumBins.MoveNext())
                     {
                         ArrayList bin = (ArrayList)enumBins.Value;
-                        if (bin != null)
+                        if (bin is not null)
                         {
                             string category = (string)enumBins.Key;
                             if (bin.Count > 0)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyManager.cs
@@ -29,7 +29,7 @@ namespace System.Windows.Forms
 
         private protected override void SetDataSource(object dataSource)
         {
-            if (_dataSource != null && !string.IsNullOrEmpty(_propName))
+            if (_dataSource is not null && !string.IsNullOrEmpty(_propName))
             {
                 _propInfo.RemoveValueChanged(_dataSource, new EventHandler(PropertyChanged));
                 _propInfo = null;
@@ -37,7 +37,7 @@ namespace System.Windows.Forms
 
             _dataSource = dataSource;
 
-            if (_dataSource != null && !string.IsNullOrEmpty(_propName))
+            if (_dataSource is not null && !string.IsNullOrEmpty(_propName))
             {
                 _propInfo = TypeDescriptor.GetProperties(dataSource).Find(_propName, true);
                 if (_propInfo is null)
@@ -179,7 +179,7 @@ namespace System.Windows.Forms
 
         internal override object DataSource => _dataSource;
 
-        internal override bool IsBinding => _dataSource != null;
+        internal override bool IsBinding => _dataSource is not null;
 
         /// <summary>
         ///  Gets the position in the underlying list that controls bound to this data source point to.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyStore.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyStore.cs
@@ -353,7 +353,7 @@ namespace System.Windows.Forms
         [MemberNotNullWhen(true, nameof(_objEntries))]
         private bool LocateObjectEntry(short entryKey, out int index)
         {
-            if (_objEntries != null)
+            if (_objEntries is not null)
             {
                 int length = _objEntries.Length;
                 Debug.Assert(length > 0);
@@ -695,7 +695,7 @@ namespace System.Windows.Forms
             if (!LocateIntegerEntry(entryKey, out int index))
             {
                 // We must allocate a new entry.
-                if (_intEntries != null)
+                if (_intEntries is not null)
                 {
                     IntegerEntry[] newEntries = new IntegerEntry[_intEntries.Length + 1];
 
@@ -756,7 +756,7 @@ namespace System.Windows.Forms
             if (!LocateObjectEntry(entryKey, out int index))
             {
                 // We must allocate a new entry.
-                if (_objEntries != null)
+                if (_objEntries is not null)
                 {
                     ObjectEntry[] newEntries = new ObjectEntry[_objEntries.Length + 1];
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RadioButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RadioButton.cs
@@ -465,7 +465,7 @@ namespace System.Windows.Forms
                 if (isChecked)
                 {
                     Control parent = ParentInternal;
-                    if (parent != null)
+                    if (parent is not null)
                     {
                         ControlCollection children = parent.Controls;
                         for (int i = 0; i < children.Count; i++)
@@ -492,7 +492,7 @@ namespace System.Windows.Forms
         private void WipeTabStops(bool tabbedInto)
         {
             Control parent = ParentInternal;
-            if (parent != null)
+            if (parent is not null)
             {
                 ControlCollection children = parent.Controls;
                 for (int i = 0; i < children.Count; i++)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RelatedCurrencyManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RelatedCurrencyManager.cs
@@ -29,7 +29,7 @@ namespace System.Windows.Forms
 
         internal void Bind(BindingManagerBase parentManager, string dataField)
         {
-            Debug.Assert(parentManager != null, "How could this be a null parentManager.");
+            Debug.Assert(parentManager is not null, "How could this be a null parentManager.");
 
             // Unwire previous BindingManagerBase
             UnwireParentManager(this.parentManager);
@@ -51,7 +51,7 @@ namespace System.Windows.Forms
 
         private void UnwireParentManager(BindingManagerBase bmb)
         {
-            if (bmb != null)
+            if (bmb is not null)
             {
                 bmb.CurrentItemChanged -= new EventHandler(ParentManager_CurrentItemChanged);
 
@@ -64,7 +64,7 @@ namespace System.Windows.Forms
 
         private void WireParentManager(BindingManagerBase bmb)
         {
-            if (bmb != null)
+            if (bmb is not null)
             {
                 bmb.CurrentItemChanged += new EventHandler(ParentManager_CurrentItemChanged);
 
@@ -79,7 +79,7 @@ namespace System.Windows.Forms
         {
             PropertyDescriptor[] accessors;
 
-            if (listAccessors != null && listAccessors.Length > 0)
+            if (listAccessors is not null && listAccessors.Length > 0)
             {
                 accessors = new PropertyDescriptor[listAccessors.Length + 1];
                 listAccessors.CopyTo(accessors, 1);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RelatedPropertyManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RelatedPropertyManager.cs
@@ -23,7 +23,7 @@ namespace System.Windows.Forms
 
         private void Bind(BindingManagerBase parentManager, string dataField)
         {
-            Debug.Assert(parentManager != null, "How could this be a null parentManager.");
+            Debug.Assert(parentManager is not null, "How could this be a null parentManager.");
             this.parentManager = parentManager;
             this.dataField = dataField;
             fieldInfo = parentManager.GetItemProperties().Find(dataField, true);
@@ -56,7 +56,7 @@ namespace System.Windows.Forms
         {
             PropertyDescriptor[] accessors;
 
-            if (listAccessors != null && listAccessors.Length > 0)
+            if (listAccessors is not null && listAccessors.Length > 0)
             {
                 accessors = new PropertyDescriptor[listAccessors.Length + 1];
                 listAccessors.CopyTo(accessors, 1);
@@ -97,7 +97,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                return (DataSource != null) ? fieldInfo.GetValue(DataSource) : null;
+                return (DataSource is not null) ? fieldInfo.GetValue(DataSource) : null;
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -321,8 +321,8 @@ namespace System.Windows.Forms
                     string path = pathBuilder.ToString();
                     FileVersionInfo versionInfo = FileVersionInfo.GetVersionInfo(path);
 
-                    Debug.Assert(versionInfo != null && !string.IsNullOrEmpty(versionInfo.ProductVersion), "Couldn't get the version info for the richedit dll");
-                    if (versionInfo != null && !string.IsNullOrEmpty(versionInfo.ProductVersion))
+                    Debug.Assert(versionInfo is not null && !string.IsNullOrEmpty(versionInfo.ProductVersion), "Couldn't get the version info for the richedit dll");
+                    if (versionInfo is not null && !string.IsNullOrEmpty(versionInfo.ProductVersion))
                     {
                         //Note: this only allows for one digit version
                         if (int.TryParse(versionInfo.ProductVersion[0].ToString(), out int parsedValue))
@@ -679,7 +679,7 @@ namespace System.Windows.Forms
                 {
                     return StreamOut(SF.RTF);
                 }
-                else if (textPlain != null)
+                else if (textPlain is not null)
                 {
                     ForceHandleCreate();
                     return StreamOut(SF.RTF);
@@ -1293,7 +1293,7 @@ namespace System.Windows.Forms
             set
             {
                 // Verify the argument, and throw an error if is bad
-                if (value != null && value.Length > MAX_TAB_STOPS)
+                if (value is not null && value.Length > MAX_TAB_STOPS)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), SR.SelTabCountRange);
                 }
@@ -1413,7 +1413,7 @@ namespace System.Windows.Forms
 
                 if (!IsHandleCreated && textRtf is null)
                 {
-                    if (textPlain != null)
+                    if (textPlain is not null)
                     {
                         return textPlain;
                     }
@@ -1812,7 +1812,7 @@ namespace System.Windows.Forms
                             // However, the user said that his app is not using LoadFile method.
                             // The only possibility left open is that the native Edit control sends random calls into EditStreamProc.
                             // We have to guard against this.
-                            if (editStream != null)
+                            if (editStream is not null)
                             {
                                 transferred = editStream.Read(bytes, 0, cb);
 
@@ -2540,14 +2540,14 @@ namespace System.Windows.Forms
             try
             {
                 SuppressTextChangedEvent = true;
-                if (textRtf != null)
+                if (textRtf is not null)
                 {
                     // setting RTF calls back on Text, which relies on textRTF being null
                     string text = textRtf;
                     textRtf = null;
                     Rtf = text;
                 }
-                else if (textPlain != null)
+                else if (textPlain is not null)
                 {
                     string text = textPlain;
                     textPlain = null;
@@ -2942,7 +2942,7 @@ namespace System.Windows.Forms
             try
             {
                 editStream = data;
-                Debug.Assert(data != null, "StreamIn passed a null stream");
+                Debug.Assert(data is not null, "StreamIn passed a null stream");
 
                 // If SF_RTF is requested then check for the RTF tag at the start
                 // of the file.  We don't load if the tag is not there.
@@ -3731,13 +3731,13 @@ namespace System.Windows.Forms
                 }
 
                 Ole32.ILockBytes pLockBytes = Ole32.CreateILockBytesOnHGlobal(IntPtr.Zero, BOOL.TRUE);
-                Debug.Assert(pLockBytes != null, "pLockBytes is NULL!");
+                Debug.Assert(pLockBytes is not null, "pLockBytes is NULL!");
 
                 storage = Ole32.StgCreateDocfileOnILockBytes(
                     pLockBytes,
                     Ole32.STGM.SHARE_EXCLUSIVE | Ole32.STGM.CREATE | Ole32.STGM.READWRITE,
                     0);
-                Debug.Assert(storage != null, "storage is NULL!");
+                Debug.Assert(storage is not null, "storage is NULL!");
 
                 return HRESULT.S_OK;
             }
@@ -3923,7 +3923,7 @@ namespace System.Windows.Forms
                         // We only care about the drag.
                         //
                         // When we drop, lastEffect will have the right state
-                        if (fDrag.IsFalse() && lastDataObject != null && grfKeyState != (User32.MK)0)
+                        if (fDrag.IsFalse() && lastDataObject is not null && grfKeyState != (User32.MK)0)
                         {
                             DragEventArgs e = new DragEventArgs(lastDataObject,
                                                                 (int)grfKeyState,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.cs
@@ -524,7 +524,7 @@ namespace System.Windows.Forms
         /// </summary>
         protected override void OnMouseWheel(MouseEventArgs e)
         {
-            if (e != null)
+            if (e is not null)
             {
                 _wheelDelta += e.Delta;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollProperties.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollProperties.cs
@@ -46,7 +46,7 @@ namespace System.Windows.Forms
             get => _enabled;
             set
             {
-                if (_parent != null && _parent.AutoScroll)
+                if (_parent is not null && _parent.AutoScroll)
                 {
                     return;
                 }
@@ -54,7 +54,7 @@ namespace System.Windows.Forms
                 if (value != _enabled)
                 {
                     _enabled = value;
-                    if (_parent != null)
+                    if (_parent is not null)
                     {
                         User32.EnableScrollBar(
                             _parent,
@@ -112,7 +112,7 @@ namespace System.Windows.Forms
             get => _maximum;
             set
             {
-                if (_parent != null && _parent.AutoScroll)
+                if (_parent is not null && _parent.AutoScroll)
                 {
                     return;
                 }
@@ -147,7 +147,7 @@ namespace System.Windows.Forms
             get => _minimum;
             set
             {
-                if (_parent != null && _parent.AutoScroll)
+                if (_parent is not null && _parent.AutoScroll)
                 {
                     return;
                 }
@@ -252,7 +252,7 @@ namespace System.Windows.Forms
             get => _visible;
             set
             {
-                if (_parent != null && _parent.AutoScroll)
+                if (_parent is not null && _parent.AutoScroll)
                 {
                     return;
                 }
@@ -269,7 +269,7 @@ namespace System.Windows.Forms
 
         internal void UpdateScrollInfo()
         {
-            if (_parent != null && _parent.IsHandleCreated && _visible)
+            if (_parent is not null && _parent.IsHandleCreated && _visible)
             {
                 var si = new User32.SCROLLINFO
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollableControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollableControl.cs
@@ -357,7 +357,7 @@ namespace System.Windows.Forms
                 // things.)
                 _scrollMargin = _requestedScrollMargin;
 
-                if (dockPadding != null)
+                if (dockPadding is not null)
                 {
                     _scrollMargin.Height += Padding.Bottom;
                     _scrollMargin.Width += Padding.Right;
@@ -376,7 +376,7 @@ namespace System.Windows.Forms
                     // In addition, this is the more correct thing, because
                     // we want to layout the children with respect to their
                     // "local" visibility, not the hierarchy.
-                    if (current != null && current.DesiredVisibility)
+                    if (current is not null && current.DesiredVisibility)
                     {
                         switch (((Control)current).Dock)
                         {
@@ -427,7 +427,7 @@ namespace System.Windows.Forms
 
                     // Same logic as the margin calc - you need to see if the
                     // control *will* be visible...
-                    if (current != null && current.DesiredVisibility)
+                    if (current is not null && current.DesiredVisibility)
                     {
                         if (defaultLayoutEngine)
                         {
@@ -603,7 +603,7 @@ namespace System.Windows.Forms
             // thus require a new layout. The result is that when you
             // affect a control's layout, we are forced to layout twice. There
             // isn't any noticible flicker, but this could be a perf problem...
-            if (levent != null && levent.AffectedControl != null && AutoScroll)
+            if (levent is not null && levent.AffectedControl is not null && AutoScroll)
             {
                 base.OnLayout(levent);
             }
@@ -674,7 +674,7 @@ namespace System.Windows.Forms
                 throw new ArgumentNullException(nameof(e));
 
             if ((HScroll || VScroll) &&
-                BackgroundImage != null &&
+                BackgroundImage is not null &&
                 (BackgroundImageLayout == ImageLayout.Zoom || BackgroundImageLayout == ImageLayout.Stretch || BackgroundImageLayout == ImageLayout.Center))
             {
                 if (ControlPaint.IsImageTransparent(BackgroundImage))
@@ -806,7 +806,7 @@ namespace System.Windows.Forms
             for (int i = 0; i < Controls.Count; i++)
             {
                 Control ctl = Controls[i];
-                if (ctl != null && ctl.IsHandleCreated)
+                if (ctl is not null && ctl.IsHandleCreated)
                 {
                     ctl.UpdateBounds();
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SelectionRangeConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SelectionRangeConverter.cs
@@ -131,7 +131,7 @@ namespace System.Windows.Forms
                 {
                     ConstructorInfo ctor = typeof(SelectionRange).GetConstructor(new Type[] {
                         typeof(DateTime), typeof(DateTime)});
-                    if (ctor != null)
+                    if (ctor is not null)
                     {
                         return new InstanceDescriptor(ctor, new object[] { range.Start, range.End });
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.cs
@@ -314,7 +314,7 @@ namespace System.Windows.Forms
             if (s_hhook != IntPtr.Zero)
             {
                 s_stopHook = false;
-                if (s_events != null)
+                if (s_events is not null)
                 {
                     s_events.Clear();
                 }
@@ -927,13 +927,13 @@ namespace System.Windows.Forms
 
             // For SendInput only, see AddCancelModifiersForPreviousEvents for details.
             SKEvent[] previousEvents = null;
-            if ((s_events != null) && (s_events.Count != 0))
+            if ((s_events is not null) && (s_events.Count != 0))
             {
                 previousEvents = s_events.ToArray();
             }
 
             // Generate the list of events that we're going to fire off with the hook.
-            ParseKeys(keys, (control != null) ? control.Handle : IntPtr.Zero);
+            ParseKeys(keys, (control is not null) ? control.Handle : IntPtr.Zero);
 
             // If there weren't any events posted as a result, we're done!
             if (s_events is null)
@@ -986,7 +986,7 @@ namespace System.Windows.Forms
         ///  Sends the given keys to the active application, and then waits for the messages to be processed.
         /// </summary>
         /// <remarks>
-        ///  WARNING: this method will never work if control != null, because while Windows journaling *looks* like it
+        ///  WARNING: this method will never work if control is not null, because while Windows journaling *looks* like it
         ///  can be directed to a specific HWND, it can't.
         /// </remarks>
         private static void SendWait(string keys, Control control)
@@ -1000,7 +1000,7 @@ namespace System.Windows.Forms
         public static void Flush()
         {
             Application.DoEvents();
-            while (s_events != null && s_events.Count > 0)
+            while (s_events is not null && s_events.Count > 0)
             {
                 Application.DoEvents();
             }
@@ -1117,7 +1117,7 @@ namespace System.Windows.Forms
                     case User32.HC.SKIP:
                         if (_gotNextEvent)
                         {
-                            if (s_events != null && s_events.Count > 0)
+                            if (s_events is not null && s_events.Count > 0)
                             {
                                 s_events.Dequeue();
                             }
@@ -1130,7 +1130,7 @@ namespace System.Windows.Forms
                         _gotNextEvent = true;
 
                         Debug.Assert(
-                            s_events != null && s_events.Count > 0 && !s_stopHook,
+                            s_events is not null && s_events.Count > 0 && !s_stopHook,
                             "HC_GETNEXT when queue is empty!");
 
                         SKEvent evt = (SKEvent)s_events.Peek();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
@@ -256,7 +256,7 @@ namespace System.Windows.Forms
                     _borderStyle = value;
                     Invalidate();
                     SetInnerMostBorder(this);
-                    if (ParentInternal != null)
+                    if (ParentInternal is not null)
                     {
                         if (ParentInternal is SplitterPanel)
                         {
@@ -318,7 +318,7 @@ namespace System.Windows.Forms
             set
             {
                 base.Dock = value;
-                if (ParentInternal != null)
+                if (ParentInternal is not null)
                 {
                     if (ParentInternal is SplitterPanel)
                     {
@@ -1171,7 +1171,7 @@ namespace System.Windows.Forms
                     // Focus the current splitter OnMouseDown.
                     _splitterFocused = true;
                     IContainerControl c = ParentInternal.GetContainerControl();
-                    if (c != null)
+                    if (c is not null)
                     {
                         if (!(c is ContainerControl cc))
                         {
@@ -1560,7 +1560,7 @@ namespace System.Windows.Forms
         private bool ProcessArrowKey(bool forward)
         {
             Control group = this;
-            if (ActiveControl != null)
+            if (ActiveControl is not null)
             {
                 group = ActiveControl.ParentInternal;
             }
@@ -1575,7 +1575,7 @@ namespace System.Windows.Forms
             if (IsHandleCreated)
             {
                 Graphics g = CreateGraphicsInternal();
-                if (BackgroundImage != null)
+                if (BackgroundImage is not null)
                 {
                     using TextureBrush textureBrush = new TextureBrush(BackgroundImage, WrapMode.Tile);
                     g.FillRectangle(textureBrush, ClientRectangle);
@@ -1803,7 +1803,7 @@ namespace System.Windows.Forms
                 {
                     Control parent = ParentInternal;
                     _selectNextControl = true;
-                    while (parent != null)
+                    while (parent is not null)
                     {
                         if (parent.SelectNextControl(this, forward, true, true, parent.ParentInternal is null))
                         {
@@ -1841,13 +1841,13 @@ namespace System.Windows.Forms
                 if (ctl is SplitterPanel panel && panel.Visible)
                 {
                     //We have crossed over to the second Panel...
-                    if (firstPanel != null)
+                    if (firstPanel is not null)
                     {
                         break;
                     }
                     firstPanel = panel;
                 }
-                if (!forward && firstPanel != null && ctl.ParentInternal != firstPanel)
+                if (!forward && firstPanel is not null && ctl.ParentInternal != firstPanel)
                 {
                     //goback to start correct re-ordering ....
                     ctl = firstPanel;
@@ -1872,13 +1872,13 @@ namespace System.Windows.Forms
                         return true;
                     }
                 }
-            } while (ctl != null);
-            if (ctl != null && TabStop)
+            } while (ctl is not null);
+            if (ctl is not null && TabStop)
             {
                 //we are on Splitter.....Focus it
                 _splitterFocused = true;
                 IContainerControl c = ParentInternal.GetContainerControl();
-                if (c != null)
+                if (c is not null)
                 {
                     if (!(c is ContainerControl cc))
                     {
@@ -1900,7 +1900,7 @@ namespace System.Windows.Forms
                 if (!selected)
                 {
                     Control parent = ParentInternal;
-                    if (parent != null)
+                    if (parent is not null)
                     {
                         try
                         {
@@ -1953,7 +1953,7 @@ namespace System.Windows.Forms
                         return true;
                     }
                 }
-            } while (ctl != null);
+            } while (ctl is not null);
 
             //If CTL is null .. we r out of the Current SplitContainer...
             if (ctl is null || (ctl is SplitterPanel && !ctl.Visible))
@@ -1990,10 +1990,10 @@ namespace System.Windows.Forms
             if (ctl is ContainerControl container)
             {
                 bool correctParentActiveControl = true;
-                if (container.ParentInternal != null)
+                if (container.ParentInternal is not null)
                 {
                     IContainerControl c = container.ParentInternal.GetContainerControl();
-                    if (c != null)
+                    if (c is not null)
                     {
                         c.ActiveControl = container;
                         correctParentActiveControl = (c.ActiveControl == container);
@@ -2128,7 +2128,7 @@ namespace System.Windows.Forms
         private void SplitEnd(bool accept)
         {
             DrawSplitBar(DrawEnd);
-            if (_splitContainerMessageFilter != null)
+            if (_splitContainerMessageFilter is not null)
             {
                 Application.RemoveMessageFilter(_splitContainerMessageFilter);
                 _splitContainerMessageFilter = null;
@@ -2355,7 +2355,7 @@ namespace System.Windows.Forms
                 return base.ProcessTabKey(forward);
             }
 
-            if (_nextActiveControl != null)
+            if (_nextActiveControl is not null)
             {
                 SetActiveControl(_nextActiveControl);
                 _nextActiveControl = null;
@@ -2379,7 +2379,7 @@ namespace System.Windows.Forms
                     //We are om Splitter ......
                     _splitterFocused = true;
                     IContainerControl c = ParentInternal.GetContainerControl();
-                    if (c != null)
+                    if (c is not null)
                     {
                         if (!(c is ContainerControl cc))
                         {
@@ -2399,7 +2399,7 @@ namespace System.Windows.Forms
         protected override void OnMouseCaptureChanged(EventArgs e)
         {
             base.OnMouseCaptureChanged(e);
-            if (_splitContainerMessageFilter != null)
+            if (_splitContainerMessageFilter is not null)
             {
                 Application.RemoveMessageFilter(_splitContainerMessageFilter);
                 _splitContainerMessageFilter = null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.cs
@@ -632,7 +632,7 @@ namespace System.Windows.Forms
             SplitData spd = new SplitData();
             Control target = FindTarget();
             spd.target = target;
-            if (target != null)
+            if (target is not null)
             {
                 switch (target.Dock)
                 {
@@ -797,7 +797,7 @@ namespace System.Windows.Forms
         protected override void OnKeyDown(KeyEventArgs e)
         {
             base.OnKeyDown(e);
-            if (splitTarget != null && e.KeyCode == Keys.Escape)
+            if (splitTarget is not null && e.KeyCode == Keys.Escape)
             {
                 SplitEnd(false);
             }
@@ -815,7 +815,7 @@ namespace System.Windows.Forms
         protected override void OnMouseMove(MouseEventArgs e)
         {
             base.OnMouseMove(e);
-            if (splitTarget != null)
+            if (splitTarget is not null)
             {
                 int x = e.X + Left;
                 int y = e.Y + Top;
@@ -829,7 +829,7 @@ namespace System.Windows.Forms
         protected override void OnMouseUp(MouseEventArgs e)
         {
             base.OnMouseUp(e);
-            if (splitTarget != null)
+            if (splitTarget is not null)
             {
                 int x = e.X + Left;
                 int y = e.Y + Top;
@@ -849,7 +849,7 @@ namespace System.Windows.Forms
         {
             ((SplitterEventHandler)Events[EVENT_MOVING])?.Invoke(this, sevent);
 
-            if (splitTarget != null)
+            if (splitTarget is not null)
             {
                 SplitMove(sevent.SplitX, sevent.SplitY);
             }
@@ -864,7 +864,7 @@ namespace System.Windows.Forms
         {
             ((SplitterEventHandler)Events[EVENT_MOVED])?.Invoke(this, sevent);
 
-            if (splitTarget != null)
+            if (splitTarget is not null)
             {
                 SplitMove(sevent.SplitX, sevent.SplitY);
             }
@@ -897,13 +897,13 @@ namespace System.Windows.Forms
         private void SplitBegin(int x, int y)
         {
             SplitData spd = CalcSplitBounds();
-            if (spd.target != null && (minSize < maxSize))
+            if (spd.target is not null && (minSize < maxSize))
             {
                 anchor = new Point(x, y);
                 splitTarget = spd.target;
                 splitSize = GetSplitSize(x, y);
 
-                if (splitterMessageFilter != null)
+                if (splitterMessageFilter is not null)
                 {
                     splitterMessageFilter = new SplitterMessageFilter(this);
                 }
@@ -922,7 +922,7 @@ namespace System.Windows.Forms
             DrawSplitBar(DRAW_END);
             splitTarget = null;
             Capture = false;
-            if (splitterMessageFilter != null)
+            if (splitterMessageFilter is not null)
             {
                 Application.RemoveMessageFilter(splitterMessageFilter);
                 splitterMessageFilter = null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusStrip.StatusStripAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusStrip.StatusStripAccessibleObject.cs
@@ -43,7 +43,7 @@ namespace System.Windows.Forms
                         for (int i = 0; i < GetChildCount(); i++)
                         {
                             firstChild = GetChild(i);
-                            if (firstChild != null && !(firstChild is ControlAccessibleObject))
+                            if (firstChild is not null && !(firstChild is ControlAccessibleObject))
                             {
                                 return firstChild;
                             }
@@ -55,7 +55,7 @@ namespace System.Windows.Forms
                         for (int i = GetChildCount() - 1; i >= 0; i--)
                         {
                             lastChild = GetChild(i);
-                            if (lastChild != null && !(lastChild is ControlAccessibleObject))
+                            if (lastChild is not null && !(lastChild is ControlAccessibleObject))
                             {
                                 return lastChild;
                             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusStrip.cs
@@ -256,7 +256,7 @@ namespace System.Windows.Forms
         {
             if (disposing)
             {
-                if (rtlLayoutGrip != null)
+                if (rtlLayoutGrip is not null)
                 {
                     rtlLayoutGrip.Dispose();
                     rtlLayoutGrip = null;
@@ -279,7 +279,7 @@ namespace System.Windows.Forms
                     }
                 }
             }
-            else if (rtlLayoutGrip != null)
+            else if (rtlLayoutGrip is not null)
             {
                 if (Controls.Contains(rtlLayoutGrip))
                 {
@@ -333,7 +333,7 @@ namespace System.Windows.Forms
             bool inDisplayedItemCollecton = false;
             ToolStripItem item = levent.AffectedComponent as ToolStripItem;
             int itemCount = DisplayedItems.Count;
-            if (item != null)
+            if (item is not null)
             {
                 inDisplayedItemCollecton = DisplayedItems.Contains(item);
             }
@@ -344,7 +344,7 @@ namespace System.Windows.Forms
             }
             base.OnLayout(levent);
 
-            if (itemCount != DisplayedItems.Count || (item != null && (inDisplayedItemCollecton != DisplayedItems.Contains(item))))
+            if (itemCount != DisplayedItems.Count || (item is not null && (inDisplayedItemCollecton != DisplayedItems.Contains(item))))
             {
                 // calling OnLayout has changed the displayed items collection
                 // the SpringTableLayoutCore requires the count of displayed items to
@@ -392,7 +392,7 @@ namespace System.Windows.Forms
                             item.SetPlacement(ToolStripItemPlacement.None);
                         }
                     }
-                    else if (lastItem != null && (lastItemBounds.IntersectsWith(item.Bounds)))
+                    else if (lastItem is not null && (lastItemBounds.IntersectsWith(item.Bounds)))
                     {
                         // if it overlaps the previous element, set the location to nomansland.
                         SetItemLocation(item, noMansLand);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StringSource.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StringSource.cs
@@ -34,7 +34,7 @@ namespace System.Windows.Forms
         {
             Array.Clear(strings, 0, size);
 
-            if (strings != null)
+            if (strings is not null)
             {
                 this.strings = strings;
             }
@@ -78,7 +78,7 @@ namespace System.Windows.Forms
 
         public void ReleaseAutoComplete()
         {
-            if (_autoCompleteObject2 != null)
+            if (_autoCompleteObject2 is not null)
             {
                 Marshal.ReleaseComObject(_autoCompleteObject2);
                 _autoCompleteObject2 = null;
@@ -89,7 +89,7 @@ namespace System.Windows.Forms
         {
             Array.Clear(strings, 0, size);
 
-            if (strings != null)
+            if (strings is not null)
             {
                 strings = newSource;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.ControlCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.ControlCollection.cs
@@ -53,7 +53,7 @@ namespace System.Windows.Forms
 
                 // Site the tabPage if necessary.
                 ISite site = _owner.Site;
-                if (site != null)
+                if (site is not null)
                 {
                     ISite siteTab = tabPage.Site;
                     if (siteTab is null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -466,14 +466,14 @@ namespace System.Windows.Forms
                     EventHandler recreateHandler = new EventHandler(ImageListRecreateHandle);
                     EventHandler disposedHandler = new EventHandler(DetachImageList);
 
-                    if (_imageList != null)
+                    if (_imageList is not null)
                     {
                         _imageList.RecreateHandle -= recreateHandler;
                         _imageList.Disposed -= disposedHandler;
                     }
 
                     _imageList = value;
-                    IntPtr handle = (value != null) ? value.Handle : IntPtr.Zero;
+                    IntPtr handle = (value is not null) ? value.Handle : IntPtr.Zero;
                     if (IsHandleCreated)
                     {
                         User32.SendMessageW(this, (User32.WM)ComCtl32.TCM.SETIMAGELIST, IntPtr.Zero, handle);
@@ -485,7 +485,7 @@ namespace System.Windows.Forms
                         tabPage.ImageIndexer.ImageList = value;
                     }
 
-                    if (value != null)
+                    if (value is not null)
                     {
                         value.RecreateHandle += recreateHandler;
                         value.Disposed += disposedHandler;
@@ -1041,7 +1041,7 @@ namespace System.Windows.Forms
         {
             if (disposing)
             {
-                if (_imageList != null)
+                if (_imageList is not null)
                 {
                     _imageList.Disposed -= new EventHandler(DetachImageList);
                 }
@@ -1065,7 +1065,7 @@ namespace System.Windows.Forms
 
         internal int FindTabPage(TabPage tabPage)
         {
-            if (_tabPages != null)
+            if (_tabPages is not null)
             {
                 for (int i = 0; i < _tabPageCount; i++)
                 {
@@ -1202,7 +1202,7 @@ namespace System.Windows.Forms
         /// </summary>
         private void InsertItem(int index, TabPage tabPage)
         {
-            if (index < 0 || ((_tabPages != null) && index > _tabPageCount))
+            if (index < 0 || ((_tabPages is not null) && index > _tabPageCount))
             {
                 throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
             }
@@ -1271,7 +1271,7 @@ namespace System.Windows.Forms
             base.OnHandleCreated(e);
             _cachedDisplayRect = Rectangle.Empty;
             ApplyItemSize();
-            if (_imageList != null)
+            if (_imageList is not null)
             {
                 User32.SendMessageW(this, (User32.WM)ComCtl32.TCM.SETIMAGELIST, IntPtr.Zero, _imageList.Handle);
             }
@@ -1363,7 +1363,7 @@ namespace System.Windows.Forms
         protected override void OnEnter(EventArgs e)
         {
             base.OnEnter(e);
-            if (SelectedTab != null)
+            if (SelectedTab is not null)
             {
                 SelectedTab.FireEnter(e);
             }
@@ -1385,7 +1385,7 @@ namespace System.Windows.Forms
         /// </summary>
         protected override void OnLeave(EventArgs e)
         {
-            if (SelectedTab != null)
+            if (SelectedTab is not null)
             {
                 SelectedTab.FireLeave(e);
             }
@@ -1488,7 +1488,7 @@ namespace System.Windows.Forms
             ((TabControlEventHandler)Events[s_selectedEvent])?.Invoke(this, e);
 
             // Raise the enter event for this tab.
-            if (SelectedTab != null)
+            if (SelectedTab is not null)
             {
                 SelectedTab.FireEnter(EventArgs.Empty);
             }
@@ -1510,7 +1510,7 @@ namespace System.Windows.Forms
             ((TabControlEventHandler)Events[s_deselectedEvent])?.Invoke(this, e);
 
             // Raise the Leave event for this tab.
-            if (SelectedTab != null)
+            if (SelectedTab is not null)
             {
                 SelectedTab.FireLeave(EventArgs.Empty);
             }
@@ -1685,7 +1685,7 @@ namespace System.Windows.Forms
         public void SelectTab(int index)
         {
             TabPage t = GetTabPage(index);
-            if (t != null)
+            if (t is not null)
             {
                 SelectedTab = t;
             }
@@ -1806,7 +1806,7 @@ namespace System.Windows.Forms
         public override string ToString()
         {
             string s = base.ToString();
-            if (TabPages != null)
+            if (TabPages is not null)
             {
                 s += ", TabPages.Count: " + TabPages.Count.ToString(CultureInfo.CurrentCulture);
                 if (TabPages.Count > 0)
@@ -1872,13 +1872,13 @@ namespace System.Windows.Forms
                                 if (!ContainsFocus)
                                 {
                                     IContainerControl c = GetContainerControl();
-                                    if (c != null)
+                                    if (c is not null)
                                     {
                                         while (c.ActiveControl is ContainerControl)
                                         {
                                             c = (IContainerControl)c.ActiveControl;
                                         }
-                                        if (c.ActiveControl != null)
+                                        if (c.ActiveControl is not null)
                                         {
                                             c.ActiveControl.Focus();
                                         }
@@ -1888,7 +1888,7 @@ namespace System.Windows.Forms
                             else
                             {
                                 IContainerControl c = GetContainerControl();
-                                if (c != null && !DesignMode)
+                                if (c is not null && !DesignMode)
                                 {
                                     if (c is ContainerControl)
                                     {
@@ -1992,7 +1992,7 @@ namespace System.Windows.Forms
         private bool WmSelChanging()
         {
             IContainerControl c = GetContainerControl();
-            if (c != null && !DesignMode)
+            if (c is not null && !DesignMode)
             {
                 if (c is ContainerControl)
                 {
@@ -2118,7 +2118,7 @@ namespace System.Windows.Forms
             var tcitem = new ComCtl32.TCITEMW();
             string text = tabPage.Text;
             PrefixAmpersands(ref text);
-            if (text != null)
+            if (text is not null)
             {
                 tcitem.mask |= ComCtl32.TCIF.TEXT;
                 tcitem.cchTextMax = text.Length;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
@@ -393,7 +393,7 @@ namespace System.Windows.Forms
         /// </summary>
         internal override void AssignParent(Control value)
         {
-            if (value != null && !(value is TabControl))
+            if (value is not null && !(value is TabControl))
             {
                 throw new ArgumentException(string.Format(SR.TabControlTabPageNotOnTabControl, value.GetType().FullName));
             }
@@ -412,7 +412,7 @@ namespace System.Windows.Forms
                 return null;
             }
 
-            while (c != null && !(c is TabPage))
+            while (c is not null && !(c is TabPage))
             {
                 c = c.ParentInternal;
             }
@@ -505,7 +505,7 @@ namespace System.Windows.Forms
 
                 // TabRenderer does not support painting the background image on the panel, so
                 // draw it ourselves.
-                if (BackgroundImage != null)
+                if (BackgroundImage is not null)
                 {
                     ControlPaint.DrawBackgroundImage(e.Graphics, BackgroundImage, bkcolor, BackgroundImageLayout, inflateRect, inflateRect, DisplayRectangle.Location);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutPanel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutPanel.cs
@@ -48,7 +48,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value != null && value.IsStub)
+                if (value is not null && value.IsStub)
                 {
                     // WINRES only scenario.
                     // we only support table layout settings that have been created from a type converter.
@@ -198,7 +198,7 @@ namespace System.Windows.Forms
         private bool ShouldSerializeControls()
         {
             TableLayoutControlCollection collection = Controls;
-            return collection != null && collection.Count > 0;
+            return collection is not null && collection.Count > 0;
         }
 
         #region Extended Properties

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutSettings.TableLayoutSettingsStub.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutSettings.TableLayoutSettingsStub.cs
@@ -34,7 +34,7 @@ namespace System.Windows.Forms
             {
                 // apply row,column,rowspan,colspan
                 TableLayout.ContainerInfo containerInfo = TableLayout.GetContainerInfo(settings.Owner);
-                if (containerInfo.Container is Control appliedControl && _controlsInfo != null)
+                if (containerInfo.Container is Control appliedControl && _controlsInfo is not null)
                 {
                     // we store the control names, look up the controls
                     // in the appliedControl's control collection and apply the row,column settings.
@@ -47,11 +47,11 @@ namespace System.Windows.Forms
                         // because the Name property is shadowed at design time
                         foreach (Control tableControl in appliedControl.Controls)
                         {
-                            if (tableControl != null)
+                            if (tableControl is not null)
                             {
                                 string name = null;
                                 PropertyDescriptor prop = TypeDescriptor.GetProperties(tableControl)["Name"];
-                                if (prop != null && prop.PropertyType == typeof(string))
+                                if (prop is not null && prop.PropertyType == typeof(string))
                                 {
                                     name = prop.GetValue(tableControl) as string;
                                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutSettings.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutSettings.cs
@@ -218,7 +218,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (_stub != null)
+                if (_stub is not null)
                 {
                     return true;
                 }
@@ -281,7 +281,7 @@ namespace System.Windows.Forms
             else
             {
                 IArrangedElement element = LayoutEngine.CastToArrangedElement(control);
-                if (element.Container != null)
+                if (element.Container is not null)
                 {
                     TableLayout.ClearCachedAssignments(TableLayout.GetContainerInfo(element.Container));
                 }
@@ -327,7 +327,7 @@ namespace System.Windows.Forms
             else
             {
                 IArrangedElement element = LayoutEngine.CastToArrangedElement(control);
-                if (element.Container != null)
+                if (element.Container is not null)
                 {
                     TableLayout.ClearCachedAssignments(TableLayout.GetContainerInfo(element.Container));
                 }
@@ -480,7 +480,7 @@ namespace System.Windows.Forms
             else
             {
                 IArrangedElement element = LayoutEngine.CastToArrangedElement(control);
-                if (element.Container != null)
+                if (element.Container is not null)
                 {
                     TableLayout.ClearCachedAssignments(TableLayout.GetContainerInfo(element.Container));
                 }
@@ -544,7 +544,7 @@ namespace System.Windows.Forms
                         // We need to go through the PropertyDescriptor for the Name property
                         // since it is shadowed.
                         PropertyDescriptor prop = TypeDescriptor.GetProperties(c)["Name"];
-                        if (prop != null && prop.PropertyType == typeof(string))
+                        if (prop is not null && prop.PropertyType == typeof(string))
                         {
                             controlInfo.Name = prop.GetValue(c);
                         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutSettingsTypeConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutSettingsTypeConverter.cs
@@ -137,7 +137,7 @@ namespace System.Windows.Forms.Layout
         private string GetAttributeValue(XmlNode node, string attribute)
         {
             XmlAttribute attr = node.Attributes[attribute];
-            if (attr != null)
+            if (attr is not null)
             {
                 return attr.Value;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutStyle.cs
@@ -26,7 +26,7 @@ namespace System.Windows.Forms
                 if (_sizeType != value)
                 {
                     _sizeType = value;
-                    if (Owner != null)
+                    if (Owner is not null)
                     {
                         LayoutTransaction.DoLayout(Owner, Owner, PropertyNames.Style);
                         if (Owner is Control owner)
@@ -50,7 +50,7 @@ namespace System.Windows.Forms
                 if (_size != value)
                 {
                     _size = value;
-                    if (Owner != null)
+                    if (Owner is not null)
                     {
                         LayoutTransaction.DoLayout(Owner, Owner, PropertyNames.Style);
                         if (Owner is Control owner)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutStyleCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutStyleCollection.cs
@@ -133,7 +133,7 @@ namespace System.Windows.Forms
 
         private void EnsureNotOwned(TableLayoutStyle style)
         {
-            if (style.Owner != null)
+            if (style.Owner is not null)
             {
                 throw new ArgumentException(string.Format(SR.OnlyOneControl, style.GetType().Name), nameof(style));
             }
@@ -148,7 +148,7 @@ namespace System.Windows.Forms
         }
         private void PerformLayoutIfOwned()
         {
-            if (Owner != null)
+            if (Owner is not null)
             {
                 LayoutTransaction.DoLayout(Owner, Owner, PropertyName);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialog.cs
@@ -811,7 +811,7 @@ namespace System.Windows.Forms
             ComCtl32.TDN notification,
             IntPtr wParam)
         {
-            Debug.Assert(_boundPage != null);
+            Debug.Assert(_boundPage is not null);
 
             // Set the hWnd as this may be the first time that we get it.
             bool isFirstNotification = _handle == IntPtr.Zero;
@@ -1010,7 +1010,7 @@ namespace System.Windows.Forms
                             // override the previously set result, which would mean the
                             // button returned from Show() would not match one specified
                             // in the "Closing" event's args.
-                            if (_resultButton != null)
+                            if (_resultButton is not null)
                             {
                                 applyButtonResult = false;
                             }
@@ -1125,7 +1125,7 @@ namespace System.Windows.Forms
             // the dialog was closed abnormally without a prior TDN_BUTTON_CLICKED
             // notification (e.g. when closing the main application window while a modeless
             // task dialog is showing).
-            if (_resultButton != null || _receivedDestroyedNotification)
+            if (_resultButton is not null || _receivedDestroyedNotification)
             {
                 throw new InvalidOperationException(SR.TaskDialogCannotNavigateClosedDialog);
             }
@@ -1148,7 +1148,7 @@ namespace System.Windows.Forms
                     // button click that closed the dialog.
                     // TODO: Another option would be to disallow button clicks while
                     // within the event handler.
-                    if (_resultButton != null)
+                    if (_resultButton is not null)
                     {
                         throw new InvalidOperationException(SR.TaskDialogCannotNavigateClosedDialog);
                     }
@@ -1471,7 +1471,7 @@ namespace System.Windows.Forms
 
         private void SubclassWindow()
         {
-            if (_windowSubclassHandler != null)
+            if (_windowSubclassHandler is not null)
             {
                 throw new InvalidOperationException();
             }
@@ -1483,7 +1483,7 @@ namespace System.Windows.Forms
 
         private void UnsubclassWindow()
         {
-            if (_windowSubclassHandler != null)
+            if (_windowSubclassHandler is not null)
             {
                 try
                 {
@@ -1503,7 +1503,7 @@ namespace System.Windows.Forms
 
         private void DenyIfBound()
         {
-            if (_boundPage != null)
+            if (_boundPage is not null)
             {
                 throw new InvalidOperationException(SR.TaskDialogCannotSetPropertyOfShownDialog);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogButton.cs
@@ -302,7 +302,7 @@ namespace System.Windows.Forms
 
         internal override bool IsCreatable => base.IsCreatable && _visible;
 
-        internal bool IsStandardButton => _standardButtonResult != null;
+        internal bool IsStandardButton => _standardButtonResult is not null;
 
         internal TaskDialogResult StandardButtonResult => _standardButtonResult ?? throw new InvalidOperationException();
 
@@ -384,7 +384,7 @@ namespace System.Windows.Forms
 
         internal ComCtl32.TDF Bind(TaskDialogPage page, int customButtonID)
         {
-            if (_standardButtonResult != null)
+            if (_standardButtonResult is not null)
                 throw new InvalidOperationException();
 
             ComCtl32.TDF result = Bind(page);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogButtonCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogButtonCollection.cs
@@ -157,7 +157,7 @@ namespace System.Windows.Forms
 
         private void DenyIfHasOtherCollection(TaskDialogButton item)
         {
-            if (item.Collection != null && item.Collection != this)
+            if (item.Collection is not null && item.Collection != this)
                 throw new InvalidOperationException(SR.TaskDialogControlIsPartOfOtherCollection);
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogCommandLinkButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogCommandLinkButton.cs
@@ -62,7 +62,7 @@ namespace System.Windows.Forms
         {
             string? text = base.GetResultingText();
 
-            if (text != null && _descriptionText != null)
+            if (text is not null && _descriptionText is not null)
             {
                 text += '\n' + _descriptionText;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogControl.cs
@@ -146,7 +146,7 @@ namespace System.Windows.Forms
 
         private protected void DenyIfBoundAndNotCreated()
         {
-            if (BoundPage != null && !IsCreated)
+            if (BoundPage is not null && !IsCreated)
             {
                 throw new InvalidOperationException(SR.TaskDialogControlNotCreated);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogExpander.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogExpander.cs
@@ -79,7 +79,7 @@ namespace System.Windows.Forms
             {
                 DenyIfBoundAndNotCreated();
 
-                if (BoundPage != null)
+                if (BoundPage is not null)
                 {
                     // If we are bound but waiting for initialization (e.g. immediately after
                     // starting a navigation), we buffer the change until we apply the

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogFootnote.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogFootnote.cs
@@ -65,7 +65,7 @@ namespace System.Windows.Forms
             {
                 DenyIfBoundAndNotCreated();
 
-                if (BoundPage != null)
+                if (BoundPage is not null)
                 {
                     // If we are bound but waiting for initialization (e.g. immediately after
                     // starting a navigation), we buffer the change until we apply the
@@ -117,7 +117,7 @@ namespace System.Windows.Forms
                 // while waiting for the initialization.
                 DenyIfWaitingForInitialization();
 
-                if (BoundPage != null)
+                if (BoundPage is not null)
                 {
                     (ComCtl32.TASKDIALOGCONFIG.IconUnion icon, bool? iconIsFromHandle) =
                         TaskDialogPage.GetIconValue(value);
@@ -125,7 +125,7 @@ namespace System.Windows.Forms
                     // The native task dialog icon cannot be updated from a handle
                     // type to a non-handle type and vice versa, so we need to throw
                     // in such a case.
-                    if (iconIsFromHandle != null && iconIsFromHandle != _boundIconIsFromHandle)
+                    if (iconIsFromHandle is not null && iconIsFromHandle != _boundIconIsFromHandle)
                     {
                         throw new InvalidOperationException(SR.TaskDialogCannotUpdateIconType);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogIcon.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogIcon.cs
@@ -182,9 +182,9 @@ namespace System.Windows.Forms
 
         internal TaskDialogStandardIcon StandardIcon => _standardIcon ?? throw new InvalidOperationException();
 
-        internal bool IsStandardIcon => _standardIcon != null;
+        internal bool IsStandardIcon => _standardIcon is not null;
 
-        internal bool IsHandleIcon => _iconHandle != null;
+        internal bool IsHandleIcon => _iconHandle is not null;
 
         private static Icon BitmapToIcon(Bitmap bitmap)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogPage.cs
@@ -317,7 +317,7 @@ namespace System.Windows.Forms
             get => _heading;
             set
             {
-                if (BoundDialog != null)
+                if (BoundDialog is not null)
                 {
                     // If we are bound but waiting for initialization (e.g. immediately after
                     // starting a navigation), we buffer the change until we apply the
@@ -353,7 +353,7 @@ namespace System.Windows.Forms
             get => _text;
             set
             {
-                if (BoundDialog != null)
+                if (BoundDialog is not null)
                 {
                     if (WaitingForInitialization)
                     {
@@ -402,7 +402,7 @@ namespace System.Windows.Forms
                 // that seems like an overkill.
                 DenyIfWaitingForInitialization();
 
-                if (BoundDialog != null)
+                if (BoundDialog is not null)
                 {
                     (ComCtl32.TASKDIALOGCONFIG.IconUnion icon, bool? iconIsFromHandle) =
                         GetIconValue(value);
@@ -410,7 +410,7 @@ namespace System.Windows.Forms
                     // The native task dialog icon cannot be updated from a handle
                     // type to a non-handle type and vice versa, so we need to throw
                     // throw in such a case.
-                    if (iconIsFromHandle != null && iconIsFromHandle != _boundIconIsFromHandle)
+                    if (iconIsFromHandle is not null && iconIsFromHandle != _boundIconIsFromHandle)
                     {
                         throw new InvalidOperationException(SR.TaskDialogCannotUpdateIconType);
                     }
@@ -540,7 +540,7 @@ namespace System.Windows.Forms
         ///   started navigation to this page but navigation did not yet complete
         ///   (in which case we cannot modify the dialog even though we are bound).
         /// </summary>
-        internal bool WaitingForInitialization => BoundDialog != null && !_appliedInitialization;
+        internal bool WaitingForInitialization => BoundDialog is not null && !_appliedInitialization;
 
         /// <summary>
         ///  Shows the new content in the current task dialog.
@@ -624,7 +624,7 @@ namespace System.Windows.Forms
 
         internal void DenyIfBound()
         {
-            if (BoundDialog != null)
+            if (BoundDialog is not null)
             {
                 throw new InvalidOperationException(SR.TaskDialogCannotSetPropertyOfBoundPage);
             }
@@ -680,7 +680,7 @@ namespace System.Windows.Forms
         internal void Validate()
         {
             // Check that this page instance is not already bound to a TaskDialog instance.
-            if (BoundDialog != null)
+            if (BoundDialog is not null)
             {
                 throw new InvalidOperationException(string.Format(
                     SR.TaskDialogPageIsAlreadyBound,
@@ -690,8 +690,8 @@ namespace System.Windows.Forms
 
             // We also need to check the controls (and collections) since they could also be
             // bound to a TaskDialogPage at the same time.
-            if (_buttons.BoundPage != null ||
-                _radioButtons.BoundPage != null)
+            if (_buttons.BoundPage is not null ||
+                _radioButtons.BoundPage is not null)
             {
                 throw new InvalidOperationException(string.Format(
                     SR.TaskDialogCollectionAlreadyBound,
@@ -704,7 +704,7 @@ namespace System.Windows.Forms
                 .Append(_expander)
                 .Append(_footnote)
                 .Append(_progressBar)
-                .Any(c => c?.BoundPage != null))
+                .Any(c => c?.BoundPage is not null))
             {
                 throw new InvalidOperationException(string.Format(
                     SR.TaskDialogControlAlreadyBound,
@@ -761,7 +761,7 @@ namespace System.Windows.Forms
             }
 
             // Ensure the default button is part of the button collection.
-            if (DefaultButton != null && !_buttons.Contains(DefaultButton))
+            if (DefaultButton is not null && !_buttons.Contains(DefaultButton))
             {
                 throw new InvalidOperationException(SR.TaskDialogDefaultButtonMustExistInCollection);
             }
@@ -778,7 +778,7 @@ namespace System.Windows.Forms
             out int defaultButtonID,
             out int defaultRadioButtonID)
         {
-            if (BoundDialog != null)
+            if (BoundDialog is not null)
             {
                 throw new InvalidOperationException();
             }
@@ -830,7 +830,7 @@ namespace System.Windows.Forms
                 flags |= customButton.Bind(this, CustomButtonStartID + i);
             }
 
-            if (DefaultButton != null)
+            if (DefaultButton is not null)
             {
                 // Retrieve the button from the collection, to handle the case for standard buttons
                 // when the user set an equal (but not same) instance as default button.
@@ -867,17 +867,17 @@ namespace System.Windows.Forms
             if (_boundCustomButtons.Any(e => e.IsCreated && e is TaskDialogCommandLinkButton))
                 flags |= ComCtl32.TDF.USE_COMMAND_LINKS;
 
-            if (_checkBox != null)
+            if (_checkBox is not null)
             {
                 flags |= _checkBox.Bind(this);
             }
 
-            if (_expander != null)
+            if (_expander is not null)
             {
                 flags |= _expander.Bind(this);
             }
 
-            if (_footnote != null)
+            if (_footnote is not null)
             {
                 flags |= _footnote.Bind(this, out footnoteIcon);
             }
@@ -886,7 +886,7 @@ namespace System.Windows.Forms
                 footnoteIcon = default;
             }
 
-            if (_progressBar != null)
+            if (_progressBar is not null)
             {
                 flags |= _progressBar.Bind(this);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogProgressBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogProgressBar.cs
@@ -79,7 +79,7 @@ namespace System.Windows.Forms
 
                 DenyIfBoundAndNotCreated();
 
-                if (BoundPage != null && value == TaskDialogProgressBarState.None)
+                if (BoundPage is not null && value == TaskDialogProgressBarState.None)
                 {
                     throw new InvalidOperationException(
                         SR.TaskDialogCannotRemoveProgressBarWhileDialogIsShown);
@@ -351,7 +351,7 @@ namespace System.Windows.Forms
 
         private void UpdateState(TaskDialogProgressBarState previousState, bool isInitialization = false)
         {
-            Debug.Assert(BoundPage != null);
+            Debug.Assert(BoundPage is not null);
 
             TaskDialog taskDialog = BoundPage.BoundDialog!;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogRadioButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogRadioButton.cs
@@ -139,7 +139,7 @@ namespace System.Windows.Forms
                     // all other buttons to False.
                     // Note that this does not handle buttons that are added later
                     // to the collection.
-                    if (_collection != null && value)
+                    if (_collection is not null && value)
                     {
                         foreach (TaskDialogRadioButton radioButton in _collection)
                         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogRadioButtonCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogRadioButtonCollection.cs
@@ -156,7 +156,7 @@ namespace System.Windows.Forms
 
         private void DenyIfHasOtherCollection(TaskDialogRadioButton item)
         {
-            if (item.Collection != null && item.Collection != this)
+            if (item.Collection is not null && item.Collection != this)
             {
                 throw new InvalidOperationException(SR.TaskDialogControlIsPartOfOtherCollection);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
@@ -196,14 +196,14 @@ namespace System.Windows.Forms
             {
                 if (autoCompleteCustomSource != value)
                 {
-                    if (autoCompleteCustomSource != null)
+                    if (autoCompleteCustomSource is not null)
                     {
                         autoCompleteCustomSource.CollectionChanged -= new CollectionChangeEventHandler(OnAutoCompleteCustomSourceChanged);
                     }
 
                     autoCompleteCustomSource = value;
 
-                    if (value != null)
+                    if (value is not null)
                     {
                         autoCompleteCustomSource.CollectionChanged += new CollectionChangeEventHandler(OnAutoCompleteCustomSourceChanged);
                     }
@@ -505,11 +505,11 @@ namespace System.Windows.Forms
                 // so this will undo it, but on a dispose we'll be Destroying the window anyay.
 
                 ResetAutoComplete(true);
-                if (autoCompleteCustomSource != null)
+                if (autoCompleteCustomSource is not null)
                 {
                     autoCompleteCustomSource.CollectionChanged -= new CollectionChangeEventHandler(OnAutoCompleteCustomSourceChanged);
                 }
-                if (stringSource != null)
+                if (stringSource is not null)
                 {
                     stringSource.ReleaseAutoComplete();
                     stringSource = null;
@@ -627,7 +627,7 @@ namespace System.Windows.Forms
 
         protected override void OnHandleDestroyed(EventArgs e)
         {
-            if (stringSource != null)
+            if (stringSource is not null)
             {
                 stringSource.ReleaseAutoComplete();
                 stringSource = null;
@@ -762,7 +762,7 @@ namespace System.Windows.Forms
 
                 if (AutoCompleteSource == AutoCompleteSource.CustomSource)
                 {
-                    if (IsHandleCreated && AutoCompleteCustomSource != null)
+                    if (IsHandleCreated && AutoCompleteCustomSource is not null)
                     {
                         if (AutoCompleteCustomSource.Count == 0)
                         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -662,7 +662,7 @@ namespace System.Windows.Forms
             set
             {
                 //unparse this string list...
-                if (value != null && value.Length > 0)
+                if (value is not null && value.Length > 0)
                 {
                     // Using a StringBuilder instead of a String
                     // speeds things up approx 150 times
@@ -1547,7 +1547,7 @@ namespace System.Windows.Forms
         /// </summary>
         protected override void OnMouseUp(MouseEventArgs mevent)
         {
-            if (mevent != null)
+            if (mevent is not null)
             {
                 Point pt = PointToScreen(mevent.Location);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ThreadExceptionDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ThreadExceptionDialog.cs
@@ -189,7 +189,7 @@ namespace System.Windows.Forms
 
                 try
                 {
-                    if (name.EscapedCodeBase != null && name.EscapedCodeBase.Length > 0)
+                    if (name.EscapedCodeBase is not null && name.EscapedCodeBase.Length > 0)
                     {
                         Uri codeBase = new Uri(name.EscapedCodeBase);
                         if (codeBase.Scheme == "file")
@@ -357,13 +357,13 @@ namespace System.Windows.Forms
 
         private void ThreadExceptionDialog_DpiChanged(object sender, DpiChangedEventArgs e)
         {
-            if (expandImage != null)
+            if (expandImage is not null)
             {
                 expandImage.Dispose();
             }
             expandImage = DpiHelper.GetBitmapFromIcon(GetType(), DownBitmapName);
 
-            if (collapseImage != null)
+            if (collapseImage is not null)
             {
                 collapseImage.Dispose();
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Timer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Timer.cs
@@ -157,7 +157,7 @@ namespace System.Windows.Forms
                         if (Enabled)
                         {
                             // Change the timer value, don't tear down the timer itself.
-                            if (!DesignMode && _timerWindow != null)
+                            if (!DesignMode && _timerWindow is not null)
                             {
                                 _timerWindow.RestartTimer(value);
                             }


### PR DESCRIPTION
Contributes to https://github.com/dotnet/winforms/issues/3459

## Proposed changes

- Use 'is not null' in some System.Windows.Forms files.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4385)