### PR TITLE
Fix #4385 for VB and fixed constant name from Framework

### DIFF
--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Helpers/NativeTypes.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Helpers/NativeTypes.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
             Implements IDisposable
 
             Friend Sub New()
-                nLength = System.Runtime.InteropServices.Marshal.SizeOf(GetType(SECURITY_ATTRIBUTES))
+                nLength = Marshal.SizeOf(GetType(SECURITY_ATTRIBUTES))
             End Sub
 
             Public nLength As Integer
@@ -127,19 +127,19 @@ Namespace Microsoft.VisualBasic.CompilerServices
 
                         Const STARTF_USESTDHANDLES As Integer = 256 'Defined in windows.h
                         If (dwFlags And STARTF_USESTDHANDLES) <> 0 Then
-                            If hStdInput <> IntPtr.Zero AndAlso hStdInput <> NativeTypes.INVALID_HANDLE Then
+                            If hStdInput <> IntPtr.Zero AndAlso hStdInput <> s_invalidHandle Then
                                 NativeMethods.CloseHandle(hStdInput)
-                                hStdInput = NativeTypes.INVALID_HANDLE
+                                hStdInput = s_invalidHandle
                             End If
 
-                            If hStdOutput <> IntPtr.Zero AndAlso hStdOutput <> NativeTypes.INVALID_HANDLE Then
+                            If hStdOutput <> IntPtr.Zero AndAlso hStdOutput <> s_invalidHandle Then
                                 NativeMethods.CloseHandle(hStdOutput)
-                                hStdOutput = NativeTypes.INVALID_HANDLE
+                                hStdOutput = s_invalidHandle
                             End If
 
-                            If hStdError <> IntPtr.Zero AndAlso hStdError <> NativeTypes.INVALID_HANDLE Then
+                            If hStdError <> IntPtr.Zero AndAlso hStdError <> s_invalidHandle Then
                                 NativeMethods.CloseHandle(hStdError)
-                                hStdError = NativeTypes.INVALID_HANDLE
+                                hStdError = s_invalidHandle
                             End If
                         End If 'Me.dwFlags and STARTF_USESTDHANDLES
 
@@ -156,8 +156,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
         End Class
 
         ' Handle Values
-        <Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification:="Came from Framework")>
-        Friend Shared ReadOnly INVALID_HANDLE As IntPtr = New IntPtr(-1)
+        Friend Shared ReadOnly s_invalidHandle As IntPtr = New IntPtr(-1)
 
         ' GetWindow() Constants
         Friend Const GW_HWNDFIRST As Integer = 0

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Helpers/NativeTypes.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Helpers/NativeTypes.vb
@@ -156,6 +156,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
         End Class
 
         ' Handle Values
+        <Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification:="Came from Framework")>
         Friend Shared ReadOnly INVALID_HANDLE As IntPtr = New IntPtr(-1)
 
         ' GetWindow() Constants

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Interaction.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Interaction.vb
@@ -2,7 +2,6 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Runtime.CompilerServices
 Imports System.Runtime.InteropServices
 Imports System.Security
 Imports System.Text
@@ -48,10 +47,10 @@ Namespace Microsoft.VisualBasic
                 If ok = 0 Then
                     ErrorCode = Marshal.GetLastWin32Error()
                 End If
-                If ProcessInfo.hProcess <> IntPtr.Zero AndAlso ProcessInfo.hProcess <> NativeTypes.INVALID_HANDLE Then
+                If ProcessInfo.hProcess <> IntPtr.Zero AndAlso ProcessInfo.hProcess <> NativeTypes.s_invalidHandle Then
                     safeProcessHandle.InitialSetHandle(ProcessInfo.hProcess)
                 End If
-                If ProcessInfo.hThread <> IntPtr.Zero AndAlso ProcessInfo.hThread <> NativeTypes.INVALID_HANDLE Then
+                If ProcessInfo.hThread <> IntPtr.Zero AndAlso ProcessInfo.hThread <> NativeTypes.s_invalidHandle Then
                     safeThreadHandle.InitialSetHandle(ProcessInfo.hThread)
                 End If
 

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Interaction.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Interaction.vb
@@ -357,7 +357,7 @@ Namespace Microsoft.VisualBasic
             Dim ParentWindow As Windows.Forms.IWin32Window = Nothing
 
             vbhost = CompilerServices.HostServices.VBHost
-            If Not vbhost Is Nothing Then
+            If vbhost IsNot Nothing Then
                 ParentWindow = vbhost.GetParentWindow()
             End If
 
@@ -372,7 +372,7 @@ Namespace Microsoft.VisualBasic
             End If
 
             Try
-                If Not Prompt Is Nothing Then
+                If Prompt IsNot Nothing Then
                     sPrompt = DirectCast(Conversions.ChangeType(Prompt, GetType(String)), String)
                 End If
             Catch ex As StackOverflowException


### PR DESCRIPTION
Fixes #4385 for VB


## Proposed changes

- Change Not "Is" tp IsNot for VB
- Ignore IDE1006 for 1 constant that came from Framework
- This cleans up all Code Cleanup issues for VB

## Customer Impact

- Cleans up issue for VB Source, no impact on Binaries
- 

## Regression? 

- No

## Risk

- Minimal added attribute and used equivalent comparison in VB that makes code easier to understand


## Test methodology <!-- How did you ensure quality? -->

- Runs existing test, this is more about IDE issues not runtime
-  

## Test environment(s) <!-- Remove any that don't apply -->

- N/A All existing test should see no impact



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4389)