### PR TITLE
Adding the ability to get keyboard toolTips for TabPages of a TabControl

### DIFF
--- a/Winforms.sln
+++ b/Winforms.sln
@@ -145,6 +145,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Windows.Forms.Source
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Windows.Forms.Primitives.TestUtilities.Tests", "src\System.Windows.Forms.Primitives\tests\TestUtilities.Tests\System.Windows.Forms.Primitives.TestUtilities.Tests.csproj", "{6EE57002-9965-46E7-A48B-B449969738BB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MauiTabControlTests", "src\System.Windows.Forms\tests\IntegrationTests\MauiTests\MauiTabControlTests\MauiTabControlTests.csproj", "{B8FD66E7-BD6F-4E6F-8199-7CE6149FBE48}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -315,6 +317,10 @@ Global
 		{6EE57002-9965-46E7-A48B-B449969738BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6EE57002-9965-46E7-A48B-B449969738BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6EE57002-9965-46E7-A48B-B449969738BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B8FD66E7-BD6F-4E6F-8199-7CE6149FBE48}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8FD66E7-BD6F-4E6F-8199-7CE6149FBE48}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8FD66E7-BD6F-4E6F-8199-7CE6149FBE48}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B8FD66E7-BD6F-4E6F-8199-7CE6149FBE48}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -364,6 +370,7 @@ Global
 		{3BB220A9-7BC9-4D45-9DC7-B5A1D659B478} = {77FEDB47-F7F6-490D-AF7C-ABB4A9E0B9D7}
 		{1976540D-65A6-45D7-95D2-13106DE6D5BB} = {583F1292-AE8D-4511-B8D8-A81FE4642DDC}
 		{6EE57002-9965-46E7-A48B-B449969738BB} = {583F1292-AE8D-4511-B8D8-A81FE4642DDC}
+		{B8FD66E7-BD6F-4E6F-8199-7CE6149FBE48} = {8F20A905-BD37-4D80-B8DF-FA45276FC23F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7B1B0433-F612-4E5A-BE7E-FCF5B9F6E136}

--- a/src/System.Windows.Forms.Primitives/src/Properties/AssemblyInfo.cs
+++ b/src/System.Windows.Forms.Primitives/src/Properties/AssemblyInfo.cs
@@ -22,6 +22,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("System.Windows.Forms.Maui.IntegrationTests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("MauiMonthCalendarTests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("MauiTestsHelper, PublicKey=00000000000000000400000000000000")]
+[assembly: InternalsVisibleTo("MauiTabControlTests, PublicKey=00000000000000000400000000000000")]
 
 // This is needed in order to Moq internal interfaces for testing
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]

--- a/src/System.Windows.Forms/src/Properties/AssemblyInfo.cs
+++ b/src/System.Windows.Forms/src/Properties/AssemblyInfo.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("System.Windows.Forms.Tests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("MauiPropertyGridViewTests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("MauiMonthCalendarTests, PublicKey=00000000000000000400000000000000")]
+[assembly: InternalsVisibleTo("MauiTabControlTests, PublicKey=00000000000000000400000000000000")]
 
 // This is needed in order to Moq internal interfaces for testing
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 ~override System.Windows.Forms.ListView.OnLostFocus(System.EventArgs e) -> void
+~override System.Windows.Forms.TabControl.OnGotFocus(System.EventArgs e) -> void
+~override System.Windows.Forms.TabControl.OnLostFocus(System.EventArgs e) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -3042,6 +3042,11 @@ namespace System.Windows.Forms
         {
         }
 
+        internal virtual void RemoveToolTip(ToolTip toolTip)
+        {
+            // Control doesn't have a specific logic after a toolTip is removed
+        }
+
         private Control ReflectParent
         {
             get => _reflectParent;
@@ -10744,6 +10749,11 @@ namespace System.Windows.Forms
             // WARNING: if we ever add argument checking to "flag", we will need
             // to move private styles like Layered to State.
             _controlStyle = value ? _controlStyle | flag : _controlStyle & ~flag;
+        }
+
+        internal virtual void SetToolTip(ToolTip toolTip)
+        {
+            // Control doesn't have a specific logic after a toolTip is set
         }
 
         protected void SetTopLevel(bool value)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -2541,6 +2541,8 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.ControlHandleCreatedDescr))]
         public bool IsHandleCreated => _window.Handle != IntPtr.Zero;
 
+        private protected virtual bool IsHoveredWithMouse() => ClientRectangle.Contains(PointToClient(MousePosition));
+
         /// <summary>
         ///  Determines if layout is currently suspended.
         /// </summary>
@@ -5591,6 +5593,15 @@ namespace System.Windows.Forms
             return (ctl == this) ? null : ctl;
         }
 
+        private protected virtual string GetCaptionForTool(ToolTip toolTip)
+        {
+            IKeyboardToolTip host = ToolStripControlHost;
+
+            return host is null
+                ? toolTip.GetCaptionForTool(this)
+                : host.GetCaptionForTool(toolTip);
+        }
+
         /// <summary>
         ///  Retrieves the child control that is located at the specified client
         ///  coordinates.
@@ -5845,6 +5856,9 @@ namespace System.Windows.Forms
 
             return found;
         }
+
+        private protected virtual IList<Rectangle> GetNeighboringToolsRectangles()
+            => ((IKeyboardToolTip)ToolStripControlHost)?.GetNeighboringToolsRectangles() ?? GetOwnNeighboringToolsRectangles();
 
         /// <summary>
         ///  Retrieves the next control in the tab order of child controls.
@@ -13917,20 +13931,9 @@ namespace System.Windows.Forms
 
         Rectangle IKeyboardToolTip.GetNativeScreenRectangle() => GetToolNativeScreenRectangle();
 
-        IList<Rectangle> IKeyboardToolTip.GetNeighboringToolsRectangles()
-        {
-            IKeyboardToolTip host = ToolStripControlHost;
-            if (host is null)
-            {
-                return GetOwnNeighboringToolsRectangles();
-            }
-            else
-            {
-                return host.GetNeighboringToolsRectangles();
-            }
-        }
+        IList<Rectangle> IKeyboardToolTip.GetNeighboringToolsRectangles() => GetNeighboringToolsRectangles();
 
-        bool IKeyboardToolTip.IsHoveredWithMouse() => ClientRectangle.Contains(PointToClient(MousePosition));
+        bool IKeyboardToolTip.IsHoveredWithMouse() => IsHoveredWithMouse();
 
         bool IKeyboardToolTip.HasRtlModeEnabled()
         {
@@ -13950,18 +13953,7 @@ namespace System.Windows.Forms
 
         void IKeyboardToolTip.OnUnhooked(ToolTip toolTip) => OnKeyboardToolTipUnhook(toolTip);
 
-        string IKeyboardToolTip.GetCaptionForTool(ToolTip toolTip)
-        {
-            IKeyboardToolTip host = ToolStripControlHost;
-            if (host is null)
-            {
-                return toolTip.GetCaptionForTool(this);
-            }
-            else
-            {
-                return host.GetCaptionForTool(toolTip);
-            }
-        }
+        string IKeyboardToolTip.GetCaptionForTool(ToolTip toolTip) => GetCaptionForTool(toolTip);
 
         bool IKeyboardToolTip.ShowsOwnToolTip()
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
@@ -1453,12 +1453,18 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Called by ToolTip to poke in that Tooltip into this ComCtl so that the Native ChildToolTip is not exposed.
         /// </summary>
-        internal void SetToolTip(ToolTip toolTip)
+        internal override void SetToolTip(ToolTip toolTip)
         {
-            if (toolTip != null && !_controlToolTip)
+            if (toolTip is null || _controlToolTip)
             {
-                _controlToolTip = true;
+                return;
             }
+
+            // Label now has its own Tooltip for AutoEllipsis.
+            // So this control too falls in special casing.
+            // We need to disable the LABEL AutoEllipsis tooltip and show
+            // this tooltip always.
+            _controlToolTip = true;
         }
 
         internal override bool SupportsUiaProviders => true;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -5320,9 +5320,14 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Called by ToolTip to poke in that Tooltip into this ComCtl so that the Native ChildToolTip is not exposed.
         /// </summary>
-        internal void SetToolTip(ToolTip toolTip, string toolTipCaption)
+        internal override void SetToolTip(ToolTip toolTip)
         {
-            this.toolTipCaption = toolTipCaption;
+            if (toolTip is null)
+            {
+                return;
+            }
+
+            toolTipCaption = toolTip.GetToolTip(this);
 
             // native ListView expects tooltip HWND as a wParam and ignores lParam
             IntPtr oldHandle = User32.SendMessageW(this, (User32.WM)LVM.SETTOOLTIPS, toolTip.Handle, IntPtr.Zero);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -1680,11 +1680,16 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Called by ToolTip to poke in that Tooltip into this ComCtl so that the Native ChildToolTip is not exposed.
         /// </summary>
-        internal void SetToolTip(ToolTip toolTip, string controlToolTipText)
+        internal override void SetToolTip(ToolTip toolTip)
         {
+            if (toolTip is null || !ShowToolTips)
+            {
+                return;
+            }
+
             User32.SendMessageW(this, (User32.WM)ComCtl32.TCM.SETTOOLTIPS, toolTip.Handle);
             GC.KeepAlive(toolTip);
-            _controlTipText = controlToolTipText;
+            _controlTipText = toolTip.GetToolTip(this);
         }
 
         private void SetTabPage(int index, TabPage value)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -1243,6 +1243,29 @@ namespace System.Windows.Forms
             return base.IsInputKey(keyData);
         }
 
+        private void NotifyAboutFocusState(TabPage selectedTab, bool focused)
+        {
+            if (selectedTab is null)
+            {
+                return;
+            }
+
+            if (focused)
+            {
+                KeyboardToolTipStateMachine.Instance.NotifyAboutGotFocus(selectedTab);
+            }
+            else
+            {
+                KeyboardToolTipStateMachine.Instance.NotifyAboutLostFocus(selectedTab);
+            }
+        }
+
+        protected override void OnGotFocus(EventArgs e)
+        {
+            NotifyAboutFocusState(SelectedTab, focused: true);
+            base.OnGotFocus(e);
+        }
+
         /// <summary>
         ///  This is a notification that the handle has been created.
         ///  We do some work here to configure the handle.
@@ -1392,6 +1415,12 @@ namespace System.Windows.Forms
             base.OnLeave(e);
         }
 
+        protected override void OnLostFocus(EventArgs e)
+        {
+            NotifyAboutFocusState(SelectedTab, focused: false);
+            base.OnLostFocus(e);
+        }
+
         /// <summary>
         ///  We override this to get tabbing functionality.
         ///  If overriding this, remember to call base.onKeyDown.
@@ -1470,6 +1499,8 @@ namespace System.Windows.Forms
             UpdateTabSelection(GetState(State.UISelection));
             SetState(State.UISelection, false);
             _onSelectedIndexChanged?.Invoke(this, e);
+            KeyboardToolTipStateMachine.Instance.NotifyAboutLostFocus(this);
+            NotifyAboutFocusState(SelectedTab, focused: true);
         }
 
         /// <summary>
@@ -1512,6 +1543,7 @@ namespace System.Windows.Forms
             // Raise the Leave event for this tab.
             if (SelectedTab is not null)
             {
+                NotifyAboutFocusState(SelectedTab, focused: false);
                 SelectedTab.FireLeave(EventArgs.Empty);
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
@@ -4,7 +4,9 @@
 
 #nullable disable
 
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Design;
 using System.Windows.Forms.Layout;
@@ -27,6 +29,9 @@ namespace System.Windows.Forms
         private bool _enterFired;
         private bool _leaveFired;
         private bool _useVisualStyleBackColor;
+        private List<ToolTip> _associatedToolTips;
+        private ToolTip _externalToolTip;
+        private readonly ToolTip _internalToolTip = new ToolTip();
 
         /// <summary>
         ///  Constructs an empty TabPage.
@@ -44,6 +49,9 @@ namespace System.Windows.Forms
         {
             Text = text;
         }
+
+        internal override bool AllowsKeyboardToolTip()
+            => ParentInternal is TabControl tabControl && tabControl.ShowToolTips;
 
         /// <summary>
         ///  Allows the control to optionally shrink when AutoSize is true.
@@ -127,6 +135,74 @@ namespace System.Windows.Forms
         ///  Constructs the new instance of the Controls collection objects.
         /// </summary>
         protected override ControlCollection CreateControlsInstance() => new TabPageControlCollection(this);
+
+        private protected override string GetCaptionForTool(ToolTip toolTip)
+        {
+            // Return the internal toolTip text if it is set
+            if (!string.IsNullOrEmpty(_toolTipText))
+            {
+                return _toolTipText;
+            }
+
+            // Return the external toolTip text for this page
+            return toolTip.GetCaptionForTool(this);
+        }
+
+        private protected override IList<Rectangle> GetNeighboringToolsRectangles()
+        {
+            List<Rectangle> neighbors = new List<Rectangle>();
+
+            if (ParentInternal is not TabControl tabControl)
+            {
+                return neighbors;
+            }
+
+            int currentIndex = tabControl.TabPages.IndexOf(this);
+            if (currentIndex == -1)
+            {
+                return neighbors;
+            }
+
+            // Get the previous tab rectangle
+            if (currentIndex > 0)
+            {
+                neighbors.Add(tabControl.RectangleToScreen(tabControl.GetTabRect(currentIndex - 1)));
+            }
+
+            // Get the next tab rectangle
+            if (currentIndex < tabControl.TabCount - 1)
+            {
+                neighbors.Add(tabControl.RectangleToScreen(tabControl.GetTabRect(currentIndex + 1)));
+            }
+
+            return neighbors;
+        }
+
+        private protected override bool IsHoveredWithMouse()
+        {
+            if (ParentInternal is not TabControl tabControl)
+            {
+                return false;
+            }
+
+            // Check if any tab contains the mouse
+            for (int i = 0; i < tabControl.TabCount; i++)
+            {
+                if (tabControl.RectangleToScreen(tabControl.GetTabRect(i)).Contains(MousePosition))
+                {
+                    return true;
+                }
+            }
+
+            // Check if the selected page contains the mouse
+            TabPage selectedTab = tabControl.SelectedTab;
+            if (selectedTab is not null)
+            {
+                return selectedTab.AccessibilityObject.Bounds.Contains(MousePosition);
+            }
+
+            return false;
+        }
 
         internal ImageList.Indexer ImageIndexer => _imageIndexer ??= new ImageList.Indexer();
 
@@ -368,6 +444,11 @@ namespace System.Windows.Forms
 
                 _toolTipText = value;
                 UpdateParent();
+
+                if (_externalToolTip is null && _associatedToolTips is null)
+                {
+                    _internalToolTip.SetToolTip(this, value);
+                }
             }
         }
 
@@ -418,6 +499,21 @@ namespace System.Windows.Forms
             }
 
             return (TabPage)c;
+        }
+
+        internal override Rectangle GetToolNativeScreenRectangle()
+        {
+            // Check SelectedIndex of the parental TabControl instead of SelectedTab
+            // because it is used in GetTabRect next.
+            // So check this to make sure that the value is correct
+            // to avoid ArgumentOutOfRangeException in GetTabRect.
+            if (ParentInternal is TabControl tabControl && tabControl.SelectedIndex >= 0)
+            {
+                Rectangle rect = tabControl.GetTabRect(tabControl.SelectedIndex);
+                return tabControl.RectangleToScreen(rect);
+            }
+
+            return Rectangle.Empty;
         }
 
         /// <summary>
@@ -513,6 +609,81 @@ namespace System.Windows.Forms
             else
             {
                 base.OnPaintBackground(e);
+            }
+        }
+
+        internal void OnToolTipRemoved(ToolTip toolTip)
+        {
+            if (toolTip is null)
+            {
+                return;
+            }
+
+            // If a user used one ToolTIp instance to set a toolTip text before.
+            if (_associatedToolTips is null)
+            {
+                Debug.Assert(_externalToolTip == toolTip, "RemoveToolTip should remove a toolTip that was set.");
+                _externalToolTip = null;
+                _internalToolTip.SetToolTip(this, ToolTipText);
+                return;
+            }
+
+            if (_associatedToolTips.Contains(toolTip))
+            {
+                _associatedToolTips.Remove(toolTip);
+            }
+            else
+            {
+                Debug.Fail("RemoveToolTip should remove a toolTip that was set.");
+            }
+
+            // If there is only one associated toolTip set it as _externalToolTip
+            // and remove the List collection to improve performance.
+            if (_associatedToolTips.Count == 1)
+            {
+                _externalToolTip = _associatedToolTips[0];
+                _associatedToolTips = null;
+            }
+        }
+
+        /// <summary>
+        ///  Usually users create one ToolTip instance and set toolTip texts for several controls using this instance.
+        ///  This method will store the link to this ToolTip instance in _externalToolTip
+        ///  to use it as a base for a keyboard toolTip instead _internalToolTip instance.
+        ///  That is strange and unexpected but a user can set several toolTip instances for this TabPage,
+        ///  in this case, we have to check all associated toolTips.
+        ///  Because of that, create a new List collection to do that.
+        /// </summary>
+        internal void OnToolTipSet(ToolTip toolTip)
+        {
+            // "_externalToolTip == toolTip" condition means a user just set a new text using a ToolTip instance
+            // that was already set for this TabPage.
+            if (toolTip is null || _externalToolTip == toolTip)
+            {
+                return;
+            }
+
+            // If a user sets toolTip text using a ToolTip instance first time.
+            // In this case, use external ToolTip instance to show keyboard toolTip instead internal one.
+            if (_externalToolTip is null)
+            {
+                _externalToolTip = toolTip;
+                _internalToolTip.RemoveAll();
+                return;
+            }
+
+            // If a user sets a toolTip text for this TabPage using one more ToolTip instance.
+            // Use the List collection to track all associated toolTips.
+            // In this case, the keyboard toolTip will show the text of the latest toolTip instance that was set.
+            if (_associatedToolTips is null)
+            {
+                _associatedToolTips = new List<ToolTip>() { _externalToolTip, toolTip };
+                return;
+            }
+
+            if (!_associatedToolTips.Contains(toolTip))
+            {
+                _associatedToolTips.Add(toolTip);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
@@ -612,7 +612,7 @@ namespace System.Windows.Forms
             }
         }
 
-        internal void OnToolTipRemoved(ToolTip toolTip)
+        internal override void RemoveToolTip(ToolTip toolTip)
         {
             if (toolTip is null)
             {
@@ -654,7 +654,7 @@ namespace System.Windows.Forms
         ///  in this case, we have to check all associated toolTips.
         ///  Because of that, create a new List collection to do that.
         /// </summary>
-        internal void OnToolTipSet(ToolTip toolTip)
+        internal override void SetToolTip(ToolTip toolTip)
         {
             // "_externalToolTip == toolTip" condition means a user just set a new text using a ToolTip instance
             // that was already set for this TabPage.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -639,56 +639,9 @@ namespace System.Windows.Forms
 
             Control control = (Control)sender;
             CreateRegion(control);
-            CheckNativeToolTip(control);
-            CheckCompositeControls(control);
+            SetToolTipToControl(control);
 
             KeyboardToolTipStateMachine.Instance.Hook(control, this);
-        }
-
-        private void CheckNativeToolTip(Control associatedControl)
-        {
-            // Wait for the Handle Creation.
-            if (!GetHandleCreated())
-            {
-                return;
-            }
-
-            if (associatedControl is TreeView treeView && treeView.ShowNodeToolTips)
-            {
-                treeView.SetToolTip(this, GetToolTip(associatedControl));
-            }
-
-            if (associatedControl is TabControl tabControl && tabControl.ShowToolTips)
-            {
-                tabControl.SetToolTip(this, GetToolTip(associatedControl));
-            }
-
-            if (associatedControl is TabPage tabPage)
-            {
-                tabPage.OnToolTipSet(this);
-            }
-
-            if (associatedControl is ListView listView)
-            {
-                listView.SetToolTip(this, GetToolTip(associatedControl));
-            }
-
-            // Label now has its own Tooltip for AutoEllipsis.
-            // So this control too falls in special casing.
-            // We need to disable the LABEL AutoEllipsis tooltip and show
-            // this tooltip always.
-            if (associatedControl is Label label)
-            {
-                label.SetToolTip(this);
-            }
-        }
-
-        private void CheckCompositeControls(Control associatedControl)
-        {
-            if (associatedControl is UpDownBase upDownBase)
-            {
-                upDownBase.SetToolTip(this, GetToolTip(associatedControl));
-            }
         }
 
         private void HandleDestroyed(object sender, EventArgs eventargs)
@@ -928,11 +881,7 @@ namespace System.Windows.Forms
             {
                 new ToolInfoWrapper<Control>(ctl).SendMessage(this, (User32.WM)TTM.DELTOOLW);
                 _created.Remove(ctl);
-
-                if (ctl is TabPage tabPage)
-                {
-                    tabPage.OnToolTipRemoved(this);
-                }
+                ctl.RemoveToolTip(this);
             }
         }
 
@@ -1262,8 +1211,7 @@ namespace System.Windows.Forms
                 {
                     ToolInfoWrapper<Control> toolInfo = GetTOOLINFO(control, info.Caption);
                     toolInfo.SendMessage(this, (User32.WM)TTM.SETTOOLINFOW);
-                    CheckNativeToolTip(control);
-                    CheckCompositeControls(control);
+                    SetToolTipToControl(control);
                 }
                 else if (empty && exists && !DesignMode)
                 {
@@ -1277,6 +1225,14 @@ namespace System.Windows.Forms
 
                     _created.Remove(control);
                 }
+            }
+        }
+
+        private void SetToolTipToControl(Control associatedControl)
+        {
+            if (GetHandleCreated())
+            {
+                associatedControl.SetToolTip(this);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -663,6 +663,11 @@ namespace System.Windows.Forms
                 tabControl.SetToolTip(this, GetToolTip(associatedControl));
             }
 
+            if (associatedControl is TabPage tabPage)
+            {
+                tabPage.OnToolTipSet(this);
+            }
+
             if (associatedControl is ListView listView)
             {
                 listView.SetToolTip(this, GetToolTip(associatedControl));
@@ -923,6 +928,11 @@ namespace System.Windows.Forms
             {
                 new ToolInfoWrapper<Control>(ctl).SendMessage(this, (User32.WM)TTM.DELTOOLW);
                 _created.Remove(ctl);
+
+                if (ctl is TabPage tabPage)
+                {
+                    tabPage.OnToolTipRemoved(this);
+                }
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -1698,14 +1698,16 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Called by ToolTip to poke in that Tooltip into this ComCtl so that the Native ChildToolTip is not exposed.
         /// </summary>
-        internal void SetToolTip(ToolTip toolTip, string toolTipText)
+        internal override void SetToolTip(ToolTip toolTip)
         {
-            if (toolTip != null)
+            if (toolTip is null || !ShowNodeToolTips)
             {
-                User32.SendMessageW(toolTip, (User32.WM)TTM.SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
-                User32.SendMessageW(this, (User32.WM)TVM.SETTOOLTIPS, toolTip.Handle);
-                controlToolTipText = toolTipText;
+                return;
             }
+
+            User32.SendMessageW(toolTip, (User32.WM)TTM.SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
+            User32.SendMessageW(this, (User32.WM)TVM.SETTOOLTIPS, toolTip.Handle);
+            controlToolTipText = toolTip.GetToolTip(this);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
@@ -958,8 +958,14 @@ namespace System.Windows.Forms
             }
         }
 
-        internal void SetToolTip(ToolTip toolTip, string caption)
+        internal override void SetToolTip(ToolTip toolTip)
         {
+            if (toolTip is null)
+            {
+                return;
+            }
+
+            string caption = toolTip.GetToolTip(this);
             toolTip.SetToolTip(_upDownEdit, caption);
             toolTip.SetToolTip(_upDownButtons, caption);
         }

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiTabControlTests/MauiTabControlTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiTabControlTests/MauiTabControlTests.cs
@@ -1,0 +1,84 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using System.Threading;
+using System.Windows.Forms.IntegrationTests.Common;
+using ReflectTools;
+using WFCTestLib.Log;
+using static Interop;
+
+namespace System.Windows.Forms.IntegrationTests.MauiTests
+{
+    public class MauiTabControlTests : ReflectBase
+    {
+        private readonly TabControl _tabControl;
+        private readonly TabPage _tabPage1;
+        private readonly TabPage _tabPage2;
+
+        public MauiTabControlTests(string[] args) : base(args)
+        {
+            this.BringToForeground();
+            _tabControl = new TabControl() { Location = new Point(0, 0) };
+            _tabPage1 = new TabPage();
+            _tabPage2 = new TabPage();
+            _tabControl.TabPages.Add(_tabPage1);
+            _tabControl.TabPages.Add(_tabPage2);
+            Controls.Add(_tabControl);
+        }
+
+        static void Main(string[] args)
+        {
+            Thread.CurrentThread.SetCulture("en-US");
+            Application.Run(new MauiTabControlTests(args));
+        }
+
+        [Scenario(true)]
+        public ScenarioResult TabPage_IsHoveredWithMouse_IsTrue_WhenMouseIsOn_FirstTab(TParams p)
+            => new ScenarioResult(IsHoveredWithMouse(_tabControl, 10, 10));
+
+        [Scenario(true)]
+        public ScenarioResult TabPage_IsHoveredWithMouse_IsTrue_WhenMouseIsOn_SecondTab(TParams p)
+            => new ScenarioResult(IsHoveredWithMouse(_tabControl, 60, 10));
+
+        [Scenario(true)]
+        public ScenarioResult TabPage_IsHoveredWithMouse_IsTrue_WhenMouseIsOn_SelectedPage(TParams p)
+            => new ScenarioResult(IsHoveredWithMouse(_tabControl, 50, 50));
+
+        [Scenario(true)]
+        public ScenarioResult TabPage_IsHoveredWithMouse_IsFalse_WhenMouseIs_OutsideControl(TParams p)
+            => new ScenarioResult(!IsHoveredWithMouse(_tabControl, 300, 300));
+
+        [Scenario(true)]
+        public ScenarioResult TabPage_IsHoveredWithMouse_IsFalse_WhenMouseIs_OutsideMainScreen(TParams p)
+            => new ScenarioResult(!IsHoveredWithMouse(_tabControl, -1000, -1000));
+
+        private bool IsHoveredWithMouse(TabControl tabControl, int mousePositionX, int mousePositionY)
+        {
+            Point previousPosition = new Point();
+            BOOL setOldCursorPosition = User32.GetPhysicalCursorPos(ref previousPosition);
+
+            try
+            {
+                // Offset the mouse cursor relative to the test app window
+                Point pt = tabControl.PointToScreen(new Point(mousePositionX, mousePositionY));
+                MouseHelper.ChangeMousePosition(pt.X, pt.Y);
+
+                bool resultOfPage1 = ((IKeyboardToolTip)tabControl.TabPages[0]).IsHoveredWithMouse();
+                bool resultOfPage2 = ((IKeyboardToolTip)tabControl.TabPages[1]).IsHoveredWithMouse();
+
+                return resultOfPage1 && resultOfPage2;
+            }
+            finally
+            {
+                if (setOldCursorPosition.IsTrue())
+                {
+                    // Move cursor to old position
+                    MouseHelper.ChangeMousePosition(previousPosition.X, previousPosition.Y);
+                    Application.DoEvents();
+                }
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiTabControlTests/MauiTabControlTests.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiTabControlTests/MauiTabControlTests.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\References.targets"/>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MauiTestsHelper\MauiTestsHelper.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.Maui.IntegrationTests/WinformsMauiTabControlTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.Maui.IntegrationTests/WinformsMauiTabControlTests.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Windows.Forms.Maui.IntegrationTests
+{
+    /// <summary>
+    ///  This class runs a maui executable, which contains one or more scenarios.
+    ///
+    ///  We want to be able to represent each scenario as a seperate xUnit test, but it's not
+    ///  possible to run them independently. The workaround is to have a MauiTestRunner execute all
+    ///  the scenarios once and store the results, then feed the scenario names in as member data.
+    ///
+    ///  However, MemberData is resolved before any constructors (even static) are called.
+    ///  This means the scenario names will not be available yet.
+    ///
+    ///  The solution to this is to inherit from MemberDataAttribute and execute custom code
+    ///  (running the maui test) before returning the expected data. See MauiMemberDataAttribute.cs for more info.
+    ///
+    ///  Also [Collection("Maui")] is used put all maui tests in the same collection, which makes them run sequentially
+    ///  instead of in parallel. This is to migitate race conditions of multiple forms open at once.
+    /// </summary>
+    [Collection("Maui")]
+    public class WinformsMauiTabControlTests
+    {
+        private const string ProjectName = "MauiTabControlTests";
+
+        [Theory]
+        [MauiData(ProjectName)]
+        public void MauiTabControlTests(string scenarioName)
+        {
+            MauiTestHelper.ValidateScenarioPassed(ProjectName, scenarioName);
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LabelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LabelTests.cs
@@ -223,6 +223,25 @@ namespace System.Windows.Forms.Tests
             Assert.True(label.SupportsUiaProviders);
         }
 
+        [WinFormsFact]
+        public void Label_Invokes_SetToolTip_IfExternalToolTipIsSet()
+        {
+            using Label label = new Label();
+            using ToolTip toolTip = new ToolTip();
+            label.CreateControl();
+
+            dynamic labelDynamic = label.TestAccessor().Dynamic;
+            bool actual = labelDynamic._controlToolTip;
+
+            Assert.False(actual);
+            Assert.NotEqual(IntPtr.Zero, toolTip.Handle); // A workaroung to create the toolTip native window Handle
+
+            toolTip.SetToolTip(label, "Some test text"); // Invokes Label's SetToolTip inside
+            actual = labelDynamic._controlToolTip;
+
+            Assert.True(actual);
+        }
+
         public class SubLabel : Label
         {
             public new bool CanEnableIme => base.CanEnableIme;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -5004,6 +5004,7 @@ namespace System.Windows.Forms.Tests
             ListView_FindNearestItem_Check_Result(listItems, listViewItemToTest, SearchDirectionHint.Right, rightitem);
             ListView_FindNearestItem_Check_Result(listItems, listViewItemToTest, SearchDirectionHint.Down, downitem);
         }
+
         [WinFormsTheory]
         [MemberData(nameof(ListView_FindNearestItem_Invoke_TestData))]
         public void ListView_FindNearestItem_With_Images(int item, int? leftitem, int? upitem, int? rightitem, int? downitem)
@@ -5066,6 +5067,26 @@ namespace System.Windows.Forms.Tests
             {
                 Assert.Equal(listItems[resultItem.Value], item.FindNearestItem(direction));
             }
+        }
+
+        [WinFormsFact]
+        public void ListView_Invokes_SetToolTip_IfExternalToolTipIsSet()
+        {
+            using ListView listView = new ListView();
+            using ToolTip toolTip = new ToolTip();
+            listView.CreateControl();
+
+            dynamic listViewDynamic = listView.TestAccessor().Dynamic;
+            string actual = listViewDynamic.toolTipCaption;
+
+            Assert.Empty(actual);
+            Assert.NotEqual(IntPtr.Zero, toolTip.Handle); // A workaroung to create the toolTip native window Handle
+
+            string text = "Some test text";
+            toolTip.SetToolTip(listView, text); // Invokes ListView's SetToolTip inside
+            actual = listViewDynamic.toolTipCaption;
+
+            Assert.Equal(text, actual);
         }
 
         private class SubListViewItem : ListViewItem

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
@@ -5659,6 +5659,26 @@ namespace System.Windows.Forms.Tests
             Assert.Equal("System.Windows.Forms.TabControl, TabPages.Count: 2, TabPages[0]: TabPage: {text1}", control.ToString());
         }
 
+        [WinFormsFact]
+        public void TabControl_Invokes_SetToolTip_IfExternalToolTipIsSet()
+        {
+            using TabControl control = new TabControl() { ShowToolTips = true };
+            using ToolTip toolTip = new ToolTip();
+            control.CreateControl();
+
+            dynamic tabControl = control.TestAccessor().Dynamic;
+            string actual = tabControl._controlTipText;
+
+            Assert.Empty(actual);
+            Assert.NotEqual(IntPtr.Zero, toolTip.Handle); // A workaroung to create the toolTip native window Handle
+
+            string text = "Some test text";
+            toolTip.SetToolTip(control, text); // Invokes TabControl's SetToolTip inside
+            actual = tabControl._controlTipText;
+
+            Assert.Equal(text, actual);
+        }
+
         private class SubTabPage : TabPage
         {
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -6785,6 +6785,27 @@ namespace System.Windows.Forms.Tests
             Assert.False(accessor.IsToolTracked(treeSubNodeLevel2));
         }
 
+        [WinFormsFact]
+        public void TreeView_Invokes_SetToolTip_IfExternalToolTipIsSet()
+        {
+            using TreeView treeView = new TreeView();
+            treeView.ShowNodeToolTips = true;
+            using ToolTip toolTip = new ToolTip();
+            treeView.CreateControl();
+
+            dynamic listViewDynamic = treeView.TestAccessor().Dynamic;
+            string actual = listViewDynamic.controlToolTipText;
+
+            Assert.Null(actual);
+            Assert.NotEqual(IntPtr.Zero, toolTip.Handle); // A workaroung to create the toolTip native window Handle
+
+            string text = "Some test text";
+            toolTip.SetToolTip(treeView, text); // Invokes TreeView's SetToolTip inside
+            actual = listViewDynamic.controlToolTipText;
+
+            Assert.Equal(text, actual);
+        }
+
         private class SubTreeView : TreeView
         {
             public new bool CanEnableIme => base.CanEnableIme;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBaseTests.cs
@@ -3012,6 +3012,29 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, createdCallCount);
         }
 
+        [WinFormsFact]
+        public void UpDownBase_Invokes_SetToolTip_IfExternalToolTipIsSet()
+        {
+            using UpDownBase upDownBase = new SubUpDownBase();
+            using ToolTip toolTip = new ToolTip();
+            upDownBase.CreateControl();
+
+            string actualEditToolTipText = toolTip.GetToolTip(upDownBase._upDownEdit);
+            string actualButtonsToolTipText = toolTip.GetToolTip(upDownBase._upDownButtons);
+
+            Assert.Empty(actualEditToolTipText);
+            Assert.Empty(actualButtonsToolTipText);
+            Assert.NotEqual(IntPtr.Zero, toolTip.Handle); // A workaroung to create the toolTip native window Handle
+
+            string text = "Some test text";
+            toolTip.SetToolTip(upDownBase, text); // Invokes UpDownBase's SetToolTip inside
+            actualEditToolTipText = toolTip.GetToolTip(upDownBase._upDownEdit);
+            actualButtonsToolTipText = toolTip.GetToolTip(upDownBase._upDownButtons);
+
+            Assert.Equal(text, actualEditToolTipText);
+            Assert.Equal(text, actualButtonsToolTipText);
+        }
+
         private class CustomValidateUpDownBase : UpDownBase
         {
             public new bool ChangingText


### PR DESCRIPTION
Fixes #2717
Related Issue #4305
Based on PR #2719. But the changes were significantly reworked so I have created this new PR
Most of review points from #2719 were fixed here

## Proposed changes

- Notify `KeyboardToolTipStateMachine` about getting and losing a focus
- Inverted incorrect dependencies inside `ToolTip` class

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A user can see a TabPage toolTip when using a keyboard

## Regression? 

- No

## Risk

- Minimal


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
- TabControl shows mouse toolTips only:
![before](https://user-images.githubusercontent.com/49272759/110465292-48ab8b00-80e5-11eb-85d5-ce41aaf25c08.gif)



### After
- Keyboard toolTips are available for TabControl:
![after](https://user-images.githubusercontent.com/49272759/110465331-53662000-80e5-11eb-8107-3090f75002f9.gif)



## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Unit tests
- CTI

## Test environment(s) <!-- Remove any that don't apply -->
- .NET Version: 6.0.0-alpha.1.20554.7
- Microsoft Windows [Version 10.0.19042.685]


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4421)