### PR TITLE
Enable nullability in DragEventArgs and ItemDragEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -9819,8 +9819,8 @@ System.Windows.Forms.DateBoldEventArgs.DaysToBold.set -> void
 ~System.Windows.Forms.DomainUpDown.OnSelectedItemChanged(object source, System.EventArgs e) -> void
 ~System.Windows.Forms.DomainUpDown.SelectedItem.get -> object
 ~System.Windows.Forms.DomainUpDown.SelectedItem.set -> void
-~System.Windows.Forms.DragEventArgs.Data.get -> System.Windows.Forms.IDataObject
-~System.Windows.Forms.DragEventArgs.DragEventArgs(System.Windows.Forms.IDataObject data, int keyState, int x, int y, System.Windows.Forms.DragDropEffects allowedEffect, System.Windows.Forms.DragDropEffects effect) -> void
+System.Windows.Forms.DragEventArgs.Data.get -> System.Windows.Forms.IDataObject?
+System.Windows.Forms.DragEventArgs.DragEventArgs(System.Windows.Forms.IDataObject? data, int keyState, int x, int y, System.Windows.Forms.DragDropEffects allowedEffect, System.Windows.Forms.DragDropEffects effect) -> void
 ~System.Windows.Forms.DrawItemEventArgs.DrawItemEventArgs(System.Drawing.Graphics graphics, System.Drawing.Font font, System.Drawing.Rectangle rect, int index, System.Windows.Forms.DrawItemState state) -> void
 ~System.Windows.Forms.DrawItemEventArgs.DrawItemEventArgs(System.Drawing.Graphics graphics, System.Drawing.Font font, System.Drawing.Rectangle rect, int index, System.Windows.Forms.DrawItemState state, System.Drawing.Color foreColor, System.Drawing.Color backColor) -> void
 ~System.Windows.Forms.DrawItemEventArgs.Font.get -> System.Drawing.Font
@@ -10102,8 +10102,8 @@ System.Windows.Forms.InputLanguageCollection.IndexOf(System.Windows.Forms.InputL
 System.Windows.Forms.InputLanguageCollection.this[int index].get -> System.Windows.Forms.InputLanguage!
 ~System.Windows.Forms.ItemCheckedEventArgs.Item.get -> System.Windows.Forms.ListViewItem
 ~System.Windows.Forms.ItemCheckedEventArgs.ItemCheckedEventArgs(System.Windows.Forms.ListViewItem item) -> void
-~System.Windows.Forms.ItemDragEventArgs.Item.get -> object
-~System.Windows.Forms.ItemDragEventArgs.ItemDragEventArgs(System.Windows.Forms.MouseButtons button, object item) -> void
+System.Windows.Forms.ItemDragEventArgs.Item.get -> object?
+System.Windows.Forms.ItemDragEventArgs.ItemDragEventArgs(System.Windows.Forms.MouseButtons button, object? item) -> void
 ~System.Windows.Forms.KeysConverter.Compare(object a, object b) -> int
 ~System.Windows.Forms.Label.CalcImageRenderBounds(System.Drawing.Image image, System.Drawing.Rectangle r, System.Drawing.ContentAlignment align) -> System.Drawing.Rectangle
 ~System.Windows.Forms.Label.DrawImage(System.Drawing.Graphics g, System.Drawing.Image image, System.Drawing.Rectangle r, System.Drawing.ContentAlignment align) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DragEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DragEventArgs.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System.Runtime.InteropServices;
-
 namespace System.Windows.Forms
 {
     /// <summary>
@@ -17,7 +13,13 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Initializes a new instance of the <see cref='DragEventArgs'/> class.
         /// </summary>
-        public DragEventArgs(IDataObject data, int keyState, int x, int y, DragDropEffects allowedEffect, DragDropEffects effect)
+        public DragEventArgs(
+            IDataObject? data,
+            int keyState,
+            int x,
+            int y,
+            DragDropEffects allowedEffect,
+            DragDropEffects effect)
         {
             Data = data;
             KeyState = keyState;
@@ -31,7 +33,7 @@ namespace System.Windows.Forms
         ///  The <see cref='IDataObject'/> that contains the data associated
         ///  with this event.
         /// </summary>
-        public IDataObject Data { get; }
+        public IDataObject? Data { get; }
 
         /// <summary>
         ///  Gets the current state of the SHIFT, CTRL, and ALT keys.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ItemDragEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ItemDragEventArgs.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System.Runtime.InteropServices;
-
 namespace System.Windows.Forms
 {
     /// <summary>
@@ -13,11 +9,12 @@ namespace System.Windows.Forms
     /// </summary>
     public class ItemDragEventArgs : EventArgs
     {
-        public ItemDragEventArgs(MouseButtons button) : this(button, null)
+        public ItemDragEventArgs(MouseButtons button)
+            : this(button, null)
         {
         }
 
-        public ItemDragEventArgs(MouseButtons button, object item)
+        public ItemDragEventArgs(MouseButtons button, object? item)
         {
             Button = button;
             Item = item;
@@ -25,6 +22,6 @@ namespace System.Windows.Forms
 
         public MouseButtons Button { get; }
 
-        public object Item { get; }
+        public object? Item { get; }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in DragEventArgs and ItemDragEventArgs.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4423)