### PR TITLE
Use generic lists in LinkLabel

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.LinkCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.LinkCollection.cs
@@ -323,7 +323,7 @@ namespace System.Windows.Forms
 
             void ICollection.CopyTo(Array dest, int index)
             {
-                _owner._links.CopyTo(dest, index);
+                ((ICollection)_owner._links).CopyTo(dest, index);
             }
 
             public IEnumerator GetEnumerator()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.LinkComparer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.LinkComparer.cs
@@ -2,23 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace System.Windows.Forms
 {
     public partial class LinkLabel
     {
-        private class LinkComparer : IComparer
+        private class LinkComparer : IComparer<Link>
         {
-            int IComparer.Compare(object link1, object link2)
+            public int Compare(Link? link1, Link? link2)
             {
-                Debug.Assert(link1 is not null && link2 is not null, "Null objects sent for comparison");
-
-                int pos1 = ((Link)link1).Start;
-                int pos2 = ((Link)link2).Start;
+                int pos1 = link1?.Start ?? -1;
+                int pos2 = link2?.Start ?? -1;
 
                 return pos1 - pos2;
             }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LinkLabel.LinkComparerTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LinkLabel.LinkComparerTests.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    public class LinkLabel_LinkComparerTests : IClassFixture<ThreadExceptionFixture>
+    {
+        public static IEnumerable<object[]> LinkCompare_Return_IsExpected_TestData()
+        {
+            yield return new object[] { null, null, 0 };
+            yield return new object[] { null, new LinkLabel.Link(0, 1), -1 };
+            yield return new object[] { new LinkLabel.Link(0, 1), null, 1 };
+            yield return new object[] { new LinkLabel.Link(0, 1), new LinkLabel.Link(0, 1), 0 };
+            yield return new object[] { new LinkLabel.Link(1, 5), new LinkLabel.Link(2, 5), -1 };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(LinkCompare_Return_IsExpected_TestData))]
+        public void LinkCompare_Return_IsExpected(object link1, object link2, int expectedValue)
+        {
+            using var linkLabel = new LinkLabel();
+            var comparer = linkLabel.TestAccessor().Dynamic.s_linkComparer;
+            var compareMethod = comparer.GetType().GetMethod("Compare");
+            Assert.Equal(expectedValue, compareMethod.Invoke(comparer, new object[] { link1, link2 }));
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

- Use generic lists in LinkLabel.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4424)